### PR TITLE
Fix repo urls to use read-only access

### DIFF
--- a/plugin_config.yml
+++ b/plugin_config.yml
@@ -1,23 +1,23 @@
 ---
 plugins/chiliproject_activity_module:
-  repository: "git@github.com:finnlabs/chiliproject_activity_module.git"
+  repository: "git://github.com/finnlabs/chiliproject_activity_module.git"
   branch: master
 plugins/help_link:
-  repository: "git@github.com:finnlabs/help_link.git"
+  repository: "git://github.com/finnlabs/help_link.git"
   branch: master
 plugins/numbered_headings:
-  repository: "git@github.com:finnlabs/numbered_headings.git"
+  repository: "git://github.com/finnlabs/numbered_headings.git"
   branch: master
 plugins/redmine_checkout:
-  repository: "git@github.com:finnlabs/redmine_checkout.git"
+  repository: "git://github.com/finnlabs/redmine_checkout.git"
   branch: master
 plugins/customize_modules:
-  repository: "git@github.com:finnlabs/customize_modules.git"
+  repository: "git://github.com/finnlabs/customize_modules.git"
   branch: master
 plugins/redmine_favicon:
-  repository: "git@github.com:finnlabs/redmine_favicon.git"
+  repository: "git://github.com/finnlabs/redmine_favicon.git"
   branch: master
 plugins/memcached_passenger:
-  repository: "git@github.com:finnlabs/memcached_passenger.git"
+  repository: "git://github.com/finnlabs/memcached_passenger.git"
   branch: master
 

--- a/plugin_config.yml
+++ b/plugin_config.yml
@@ -1,23 +1,23 @@
 ---
 plugins/chiliproject_activity_module:
-  repository: "git://github.com/finnlabs/chiliproject_activity_module.git"
+  repository: "https://github.com/finnlabs/chiliproject_activity_module.git"
   branch: master
 plugins/help_link:
-  repository: "git://github.com/finnlabs/help_link.git"
+  repository: "https://github.com/finnlabs/help_link.git"
   branch: master
 plugins/numbered_headings:
-  repository: "git://github.com/finnlabs/numbered_headings.git"
+  repository: "https://github.com/finnlabs/numbered_headings.git"
   branch: master
 plugins/redmine_checkout:
-  repository: "git://github.com/finnlabs/redmine_checkout.git"
+  repository: "https://github.com/finnlabs/redmine_checkout.git"
   branch: master
 plugins/customize_modules:
-  repository: "git://github.com/finnlabs/customize_modules.git"
+  repository: "https://github.com/finnlabs/customize_modules.git"
   branch: master
 plugins/redmine_favicon:
-  repository: "git://github.com/finnlabs/redmine_favicon.git"
+  repository: "https://github.com/finnlabs/redmine_favicon.git"
   branch: master
 plugins/memcached_passenger:
-  repository: "git://github.com/finnlabs/memcached_passenger.git"
+  repository: "https://github.com/finnlabs/memcached_passenger.git"
   branch: master
 


### PR DESCRIPTION
Makes the setup.rb use the read only github urls that do not require a ssh key / repo access. Since those repos are usually cloned for read only purpose on production machines it should be sufficient this way. 
