### PR TITLE
Being more defensive when trying to delete membership after last role was removed

### DIFF
--- a/app/models/member_role.rb
+++ b/app/models/member_role.rb
@@ -35,7 +35,7 @@ class MemberRole < ActiveRecord::Base
   private
 
   def remove_member_if_empty
-    if member.roles.empty?
+    if member and member.roles.empty?
       member.destroy
     end
   end


### PR DESCRIPTION
In certain scenarios - when programmatically interacting with roles and memberships - it is possible, that the member was already deleted. In this case, the code raised a NullPointerException. The proposed fix is more defensive when trying to delete the member. There is no reason to 'freak out' when there is no member present.

Thanks for taking a look.

Gregor
