### PR TITLE
Feature/reset sort when clear

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -14,6 +14,7 @@
 
 class IssuesController < ApplicationController
   EXPORT_FORMATS = %w[atom rss api xls csv pdf]
+  DEFAULT_SORT_ORDER = ['parent', 'desc']
 
   menu_item :new_issue, :only => [:new, :create]
   menu_item :view_all_issues, :only => [:all]
@@ -55,7 +56,7 @@ class IssuesController < ApplicationController
   verify :method => :put, :only => :update, :render => {:nothing => true, :status => :method_not_allowed }
 
   def index
-    sort_init(@query.sort_criteria.empty? ? [['parent', 'desc']] : @query.sort_criteria)
+    sort_init(@query.sort_criteria.empty? ? [DEFAULT_SORT_ORDER] : @query.sort_criteria)
     sort_update(@query.sortable_columns)
 
     if @query.valid?

--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -55,7 +55,7 @@
                        }, :class => 'icon icon-checked' %>
 
     <%= link_to_remote l(:button_clear),
-                       { :url => { :set_filter => 1, :project_id => @project },
+                       { :url => { :set_filter => 1, :sort => 'parent:desc', :project_id => @project },
                          :method => :get,
                          :update => "content",
                        }, :class => 'icon icon-reload'  %>

--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -55,7 +55,7 @@
                        }, :class => 'icon icon-checked' %>
 
     <%= link_to_remote l(:button_clear),
-                       { :url => { :set_filter => 1, :sort => 'parent:desc', :project_id => @project },
+                       { :url => { :set_filter => 1, :sort => IssuesController::DEFAULT_SORT_ORDER.join(':'), :project_id => @project },
                          :method => :get,
                          :update => "content",
                        }, :class => 'icon icon-reload'  %>


### PR DESCRIPTION
this is a mirror + additional code from https://github.com/finnlabs/chiliproject/pull/22

see discussion there for reference.

basically this just removes the duplication which defines the default sort order.

explanation: in order to clear the sort we have to pass in some value for :sort, otherwise it will take it from the session. we could pass ":sort => :clear" which then would end up removing the :sort from the session. This would require more complicated refactoring for a minor reason, therefore I think it's fine to directly pass :sort => [:parent, :desc] when it comes from a single code location.
