### PR TITLE
Feature/issue description diffs

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -12,6 +12,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'diff'
+
 class JournalsController < ApplicationController
   before_filter :find_journal, :only => [:edit, :diff]
   before_filter :find_issue, :only => [:new]
@@ -84,6 +86,21 @@ class JournalsController < ApplicationController
     end
   end
 
+  def diff
+    if valid_field?(params[:field])
+      from = @journal.changes[params[:field]][0]
+      to = @journal.changes[params[:field]][1]
+
+      @diff = Redmine::Helpers::Diff.new(to, from)
+      @issue = @journal.journaled
+      respond_to do |format|
+        format.html { }
+      end
+    else
+      render_404
+    end
+  end
+  
   private
 
   def find_journal
@@ -99,5 +116,10 @@ class JournalsController < ApplicationController
     @project = @issue.project
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  # Is this a valid field for diff'ing?
+  def valid_field?(field)
+    field.to_s.strip == "description"
   end
 end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -95,12 +95,13 @@ class JournalsController < ApplicationController
       @issue = @journal.journaled
       respond_to do |format|
         format.html { }
+        format.js { render :partial => 'diff', :locals => { :diff => @diff } }
       end
     else
       render_404
     end
   end
-  
+
   private
 
   def find_journal

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -52,7 +52,10 @@ class Issue < ActiveRecord::Base
   register_on_journal_formatter(:fraction, 'estimated_hours')
   register_on_journal_formatter(:decimal, 'done_ratio')
   register_on_journal_formatter(:datetime, 'due_date', 'start_date')
-  register_on_journal_formatter(:plaintext, 'subject', 'description')
+  register_on_journal_formatter(:plaintext, 'subject')
+  register_on_journal_formatter(:diff, 'description')
+  register_on_journal_formatter(:attachment, /attachments_?\d+/)
+  register_on_journal_formatter(:custom_field, /custom_values\d+/)
 
   acts_as_searchable :columns => ['subject', "#{table_name}.description", "#{Journal.table_name}.notes"],
                      :include => [:project, :journals],

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -13,6 +13,10 @@
 #++
 
 require_dependency 'journal_formatter'
+require_dependency 'redmine/acts/journalized/format_hooks'
+require_dependency 'open_project/journal_formatter/diff'
+require_dependency 'open_project/journal_formatter/attachment'
+require_dependency 'open_project/journal_formatter/custom_field'
 
 # The ActiveRecord model representing journals.
 class Journal < ActiveRecord::Base
@@ -21,6 +25,7 @@ class Journal < ActiveRecord::Base
   include Comparable
   include JournalFormatter
   include JournalDeprecated
+  include FormatHooks
 
   # Make sure each journaled model instance only has unique version ids
   validates_uniqueness_of :version, :scope => [:journaled_id, :type]
@@ -33,6 +38,10 @@ class Journal < ActiveRecord::Base
   belongs_to :user
 
   #attr_protected :user_id
+
+  register_journal_formatter :diff, OpenProject::JournalFormatter::Diff
+  register_journal_formatter :attachment, OpenProject::JournalFormatter::Attachment
+  register_journal_formatter :custom_field, OpenProject::JournalFormatter::CustomField
 
   # "touch" the journaled object on creation
   after_create :touch_journaled_after_creation

--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -137,3 +137,11 @@
 <% end %>
 <div id="context-menu" style="display: none;"></div>
 <%= javascript_tag "new ContextMenu('#{issues_context_menu_path}')" %>
+<%= javascript_tag "jQuery('document').ready(function () {
+      jQuery.ajaxAppend({
+        'dom_identifier': { 'trigger_class': 'description-details',
+                            'indicator_class': 'ajax-indicator' },
+        'i18n': { 'hide': '" + l(:label_hide) + "'}
+      } );
+  });"
+%>

--- a/app/views/journals/_diff.html.erb
+++ b/app/views/journals/_diff.html.erb
@@ -1,0 +1,3 @@
+<div class="text-diff">
+  <%= simple_format_without_paragraph diff.to_html %>
+</div>

--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -1,0 +1,9 @@
+<p><%= authoring @journal.created_at, @journal.user, :label => :label_updated_time_by %></p>
+
+<div class="text-diff">
+<%= simple_format_without_paragraph @diff.to_html %>
+</div>
+
+<p><%= link_to(l(:button_back), issue_path(@issue)) %></p>
+
+<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>

--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -1,8 +1,7 @@
 <p><%= authoring @journal.created_at, @journal.user, :label => :label_updated_time_by %></p>
 
-<div class="text-diff">
-<%= simple_format_without_paragraph @diff.to_html %>
-</div>
+<%= render :partial => 'diff',
+           :locals => { :diff => @diff } %>
 
 <p><%= link_to(l(:button_back), issue_path(@issue)) %></p>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -526,6 +526,7 @@ de:
   label_login: Anmelden
   label_logout: Abmelden
   label_help: Hilfe
+  label_hide: Verbergen
   label_reported_issues: Gemeldete Tickets
   label_assigned_to_me_issues: Mir zugewiesen
   label_last_login: Letzte Anmeldung
@@ -927,8 +928,11 @@ de:
   text_are_you_sure: Sind Sie sicher?
   text_are_you_sure_with_children: "Lösche Aufgabe und alle Unteraufgaben?"
   text_journal_changed: "%{label} wurde von %{old} zu %{new} geändert"
+  text_journal_changed_with_diff: "%{label} geändert (%{link})"
   text_journal_set_to: "%{label} wurde auf %{value} gesetzt"
+  text_journal_set_with_diff: "%{label} gesetzt (%{link})"
   text_journal_deleted: "%{label} %{old} wurde gelöscht"
+  text_journal_deleted_with_diff: "%{label} wurde gelöscht (%{link})"
   text_journal_added: "%{label} %{value} wurde hinzugefügt"
   text_tip_issue_begin_day: Aufgabe, die an diesem Tag beginnt
   text_tip_issue_end_day: Aufgabe, die an diesem Tag endet

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,6 +523,7 @@ en:
   label_login: Sign in
   label_logout: Sign out
   label_help: Help
+  label_hide: Hide
   label_reported_issues: Reported issues
   label_assigned_to_me_issues: Issues assigned to me
   label_last_login: Last connection
@@ -943,9 +944,12 @@ en:
   text_are_you_sure: Are you sure?
   text_are_you_sure_with_children: "Delete issue and all child issues?"
   text_journal_changed: "%{label} changed from %{old} to %{new}"
+  text_journal_changed_with_diff: "%{label} changed (%{link})"
   text_journal_changed_no_detail: "%{label} updated"
   text_journal_set_to: "%{label} set to %{value}"
+  text_journal_set_with_diff: "%{label} set (%{link})"
   text_journal_deleted: "%{label} deleted (%{old})"
+  text_journal_deleted_with_diff: "%{label} deleted (%{link})"
   text_journal_added: "%{label} %{value} added"
   text_tip_issue_begin_day: issue beginning this day
   text_tip_issue_end_day: issue ending this day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,8 @@ ActionController::Routing::Routes.draw do |map|
   map.bulk_update_issue 'issues/bulk_edit', :controller => 'issues', :action => 'bulk_update', :conditions => { :method => :post }
   map.quoted_issue '/issues/:id/quoted', :controller => 'journals', :action => 'new', :id => /\d+/, :conditions => { :method => :post }
   map.connect '/issues/:id/destroy', :controller => 'issues', :action => 'destroy', :conditions => { :method => :post } # legacy
-
+  map.journal_diff '/journals/:id/diff/:field', :controller => 'journals', :action => 'diff', :conditions => { :method => :get }
+  
   map.resource :gantt, :path_prefix => '/issues', :controller => 'gantts', :only => [:show, :update]
   map.resource :gantt, :path_prefix => '/projects/:project_id/issues', :controller => 'gantts', :only => [:show, :update]
   map.resource :calendar, :path_prefix => '/issues', :controller => 'calendars', :only => [:show, :update]

--- a/lib/open_project/journal_formatter/attachment.rb
+++ b/lib/open_project/journal_formatter/attachment.rb
@@ -1,0 +1,35 @@
+class OpenProject::JournalFormatter::Attachment < ::JournalFormatter::Base
+  unloadable
+
+  include ApplicationHelper
+
+  def self.default_url_options
+    { :only_path => true }
+  end
+
+  def render(key, values, no_html = false)
+    label, old_value, value = format_details(key.sub("attachments", ""), values)
+
+    unless no_html
+      label, old_value, value = *format_html_details(label, old_value, value)
+
+      value = format_html_attachment_detail(key.sub("attachments", ""), value)
+    end
+
+    render_binary_detail_text(label, value, old_value)
+  end
+
+  private
+
+  def label(key)
+    l(:label_attachment)
+  end
+
+  def format_html_attachment_detail(key, value)
+    if !value.blank? && a = Attachment.find_by_id(key.to_i)
+      link_to_attachment(a)
+    else
+      value if value.present?
+    end
+  end
+end

--- a/lib/open_project/journal_formatter/custom_field.rb
+++ b/lib/open_project/journal_formatter/custom_field.rb
@@ -1,0 +1,25 @@
+class OpenProject::JournalFormatter::CustomField < ::JournalFormatter::Base
+  unloadable
+
+  include CustomFieldsHelper
+
+  private
+
+  def format_details(key, values)
+
+    custom_field = CustomField.find_by_id(key.sub("custom_values", "").to_i)
+
+    if custom_field
+      label = custom_field.name
+      old_value = format_value(values.first, custom_field.field_format) if values.first
+      value = format_value(values.last, custom_field.field_format) if values.last
+    else
+      label = l(:label_deleted_custom_field)
+      old_value = values.first
+      value = values.last
+    end
+
+    [label, old_value, value]
+  end
+
+end

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -1,0 +1,52 @@
+require_dependency 'journal_formatter/base'
+
+class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
+  unloadable
+
+  def render(key, values, no_html = false)
+    label = label(key)
+
+    render_ternary_detail_text(label, values.last, values.first, no_html)
+  end
+
+  private
+
+  def format_html_detail(label)
+    content_tag('strong', label)
+  end
+
+  def render_ternary_detail_text(label, value, old_value, no_html)
+    link = link(label, no_html)
+
+    label = format_html_detail(label) unless no_html
+
+    if value.blank?
+      l(:text_journal_deleted_with_diff, :label => label, :link => link)
+    else
+      unless old_value.blank?
+        l(:text_journal_changed_with_diff, :label => label, :link => link)
+      else
+        l(:text_journal_set_with_diff, :label => label, :link => link)
+      end
+    end
+  end
+
+  def link(label, no_html)
+    url_attr = { :controller => 'journals',
+                 :action => 'diff',
+                 :id => @journal.id,
+                 :field => label.downcase,
+                 :only_path => false,
+                 :protocol => Setting.protocol,
+                 :host => Setting.host_name }
+
+    if no_html
+      url_for url_attr
+    else
+      link_to(l(:label_details),
+                url_attr,
+                :class => 'description-details')
+    end
+  end
+end
+

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -4,21 +4,23 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   unloadable
 
   def render(key, values, no_html = false)
-    label = label(key)
-
-    render_ternary_detail_text(label, values.last, values.first, no_html)
+    render_ternary_detail_text(key, values.last, values.first, no_html)
   end
 
   private
 
-  def format_html_detail(label)
-    content_tag('strong', label)
+  def label(key, no_html)
+    label = super key
+
+    no_html ?
+      label :
+      content_tag('strong', label)
   end
 
-  def render_ternary_detail_text(label, value, old_value, no_html)
-    link = link(label, no_html)
+  def render_ternary_detail_text(key, value, old_value, no_html)
+    link = link(key, no_html)
 
-    label = format_html_detail(label) unless no_html
+    label = label(key, no_html)
 
     if value.blank?
       l(:text_journal_deleted_with_diff, :label => label, :link => link)
@@ -31,11 +33,11 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
     end
   end
 
-  def link(label, no_html)
+  def link(key, no_html)
     url_attr = { :controller => 'journals',
                  :action => 'diff',
                  :id => @journal.id,
-                 :field => label.downcase,
+                 :field => key.downcase,
                  :only_path => false,
                  :protocol => Setting.protocol,
                  :host => Setting.host_name }

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -757,6 +757,120 @@ $(window).bind('resizeEnd', function() {
         }
 });
 
+/* this could and should be moved into separate file once the asset pipeline
+   is in place */
+
+(function ($) {
+  var append_href,
+      close,
+      dom_identifier = { 'indicator_class': 'ajax_indicator',
+                         'window_class': 'ajax_appended_information',
+                         'trigger_class': 'ajax_append' },
+      i18n = { 'hide': 'Hide' },
+      merge_with_defaults,
+      replace_with_loading,
+      replace_with_close,
+      replace_with_open,
+      slideIn,
+      init;
+
+  close = function () {
+    var close_link = $(this),
+        information_window = close_link.siblings('.' + dom_identifier.window_class);
+
+    replace_with_open(close_link);
+
+    information_window.slideUp();
+  };
+
+  append_href = function (link) {
+    var container,
+        url = link.attr('href');
+
+    container = link.siblings('.' + dom_identifier.window_class);
+
+    if (container.size() > 0) {
+      container.slideDown();
+
+      replace_with_close(link, true);
+    }
+    else {
+      container = $('<div style="display:none" class="' + dom_identifier.window_class + '"></div>'),
+
+      $.ajax({ url: url,
+               headers: { Accept: 'text/javascript' },
+               complete: function (jqXHR) {
+                           container.html(jqXHR.responseText);
+                           slideIn(container);
+                         }
+             });
+
+
+      link.parent().append(container);
+
+      replace_with_loading(link);
+    }
+  };
+
+  replace_with_loading = function (link) {
+    var loading = $('<span class="' + dom_identifier.indicator_class + '"></span>');
+
+    link.hide();
+
+    link.after(loading);
+  };
+
+  replace_with_close = function (to_replace, hide) {
+    var close_link = $('<a href="javascript:void(0)">' + i18n.hide + '</a>');
+
+    to_replace.after(close_link);
+
+    if (hide) {
+      to_replace.hide();
+    }
+    else {
+      to_replace.remove();
+    }
+
+
+    close_link.click(close);
+  };
+
+  replace_with_open = function(to_replace) {
+    var load_link = to_replace.siblings('.' + dom_identifier.trigger_class);
+
+    to_replace.remove();
+
+    /* this link is never removed, only hidden */
+    load_link.show();
+  };
+
+  slideIn = function (container) {
+    container.slideDown();
+
+    replace_with_close(container.siblings('.' + dom_identifier.indicator_class));
+  };
+
+  merge_with_defaults = function (options) {
+    $.extend(dom_identifier, options.dom_identifier);
+    $.extend(i18n, options.i18n);
+  };
+
+  if ($.ajaxAppend) {
+    return;
+  };
+
+  $.ajaxAppend = function (options) {
+    merge_with_defaults(options);
+
+    $('.' + dom_identifier.trigger_class).click(function(link) {
+      append_href($(this));
+
+      return false;
+    });
+  };
+}(jQuery));
+
 var Administration = (function ($) {
   var update_default_language_options,
       init_language_selection_handling,

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -610,6 +610,14 @@ padding-left: 26px;
 vertical-align: bottom;
 }
 
+.ajax-indicator {
+  background-position: 0% 40%;
+  background-repeat: no-repeat;
+  background-image: url(../images/loading.gif);
+  padding-left: 16px;
+  vertical-align: bottom;
+}
+
 /***** Calendar *****/
 table.cal {border-collapse: collapse; width: 100%; margin: 0px 0 6px 0;border: 1px solid #d7d7d7;}
 table.cal thead th {width: 14%; background-color:#EEEEEE; padding: 4px; }

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -109,6 +109,10 @@ class RoutingTest < ActionController::IntegrationTest
     should_route :post, "/issues/bulk_edit", :controller => 'issues', :action => 'bulk_update'
   end
 
+  context "journals" do
+    should_route :get, "/journals/100/diff/description", :controller => 'journals', :action => 'diff', :id => '100', :field => 'description'
+  end
+  
   context "issue categories" do
     should_route :get, "/projects/test/issue_categories/new", :controller => 'issue_categories', :action => 'new', :project_id => 'test'
 

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -28,6 +28,7 @@ module JournalFormatter
   include CustomFieldsHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::TextHelper
   include ActionController::UrlWriter
   extend Redmine::I18n
 
@@ -122,6 +123,16 @@ module JournalFormatter
     [label, old_value, value]
   end
 
+  # Formats a detail to be used with a Journal diff
+  #
+  # Truncates the content. Adds a link to view a diff.
+  def format_html_diff_detail(key, label, old_value, value)
+    link = link_to(l(:label_more), {:controller => 'journals', :action => 'diff', :id => id, :field => key.to_s})
+    old_value = truncate(old_value, :length => 80)
+    value = truncate(value, :length => 80) + " " + link
+    [old_value, value]
+  end
+  
   def property(detail)
     key = prop_key(detail)
     if key.start_with? "custom_values"
@@ -186,6 +197,9 @@ module JournalFormatter
     unless no_html
       label, old_value, value = *format_html_detail(label, old_value, value)
       value = format_html_attachment_detail(key.sub("attachments", ""), value) if attachment_detail
+      if property(detail) == :attribute && key == "description"
+        old_value, value = *format_html_diff_detail(key, label, old_value, value)
+      end
     end
 
     unless value.blank?

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -21,25 +21,10 @@
 # This module holds the formatting methods that each journal has.
 # It provides the hooks to apply different formatting to the details
 # of a specific journal.
+
 module JournalFormatter
   unloadable
   mattr_accessor :formatters, :registered_fields
-  include ApplicationHelper
-  include CustomFieldsHelper
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::UrlHelper
-  include ActionView::Helpers::TextHelper
-  include ActionController::UrlWriter
-  extend Redmine::I18n
-
-  def self.included(base)
-    base.class_eval do
-      # Required to use any link_to in the formatters
-      def self.default_url_options
-        {:only_path => true }
-      end
-    end
-  end
 
   def self.register(hash)
     if hash[:class]
@@ -53,121 +38,16 @@ module JournalFormatter
 
   # TODO: Document Formatters (can take up to three params, value, journaled, field ...)
   def self.default_formatters
-    { :plaintext => (Proc.new {|v,*| v.try(:to_s) }),
-      :datetime => (Proc.new {|v,*| format_date(v.to_date) }),
-      :named_association => (Proc.new do |value, journaled, field|
-        association = journaled.class.reflect_on_association(field.to_sym)
-        if association
-          record = association.class_name.constantize.find_by_id(value.to_i)
-          record.name if record
-        end
-      end),
-      :fraction => (Proc.new {|v,*| "%0.02f" % v.to_f }),
-      :decimal => (Proc.new {|v,*| v.to_i.to_s }),
-      :id => (Proc.new {|v,*| "##{v}" }) }
+    { :plaintext => JournalFormatter::Plaintext,
+      :datetime => JournalFormatter::Datetime,
+      :named_association => JournalFormatter::NamedAssociation,
+      :fraction => JournalFormatter::Fraction,
+      :decimal => JournalFormatter::Decimal,
+      :id => JournalFormatter::Id }
   end
 
   self.formatters = default_formatters
   self.registered_fields = {}
-
-  def format_attribute_detail(key, values, no_html=false)
-    field = key.to_s.gsub(/\_id$/, "")
-    label = l(("field_" + field).to_sym)
-
-    if format = JournalFormatter.registered_fields[self.class.name.to_sym][key]
-      formatter = JournalFormatter.formatters[format]
-      old_value = formatter.call(values.first, journaled, field) if values.first
-      value = formatter.call(values.last, journaled, field) if values.last
-      [label, old_value, value]
-    else
-      return nil
-    end
-  end
-
-  def format_custom_value_detail(custom_field, values, no_html)
-    if custom_field
-      label = custom_field.name
-      old_value = format_value(values.first, custom_field.field_format) if values.first
-      value = format_value(values.last, custom_field.field_format) if values.last
-    else
-      label = l(:label_deleted_custom_field)
-      old_value = values.first
-      value = values.last
-    end
-
-    [label, old_value, value]
-  end
-
-  def format_attachment_detail(key, values, no_html)
-    label = l(:label_attachment)
-    old_value = values.first
-    value = values.last
-
-    [label, old_value, value]
-  end
-
-  def format_html_attachment_detail(key, value)
-    if !value.blank? && a = Attachment.find_by_id(key.to_i)
-      link_to_attachment(a)
-    else
-      content_tag("i", h(value)) if value.present?
-    end
-  end
-
-  def format_html_detail(label, old_value, value)
-    label = content_tag('strong', label)
-    old_value = content_tag("i", h(old_value)) if old_value && !old_value.blank?
-    old_value = content_tag("strike", old_value) if old_value and value.blank?
-    value = content_tag("i", h(value)) if value.present?
-    value ||= ""
-    [label, old_value, value]
-  end
-
-  # Formats a detail to be used with a Journal diff
-  #
-  # Truncates the content. Adds a link to view a diff.
-  def format_html_diff_detail(key, label, old_value, value)
-    link = link_to(l(:label_more), {:controller => 'journals', :action => 'diff', :id => id, :field => key.to_s})
-    old_value = truncate(old_value, :length => 80)
-    value = truncate(value, :length => 80) + " " + link
-    [old_value, value]
-  end
-  
-  def property(detail)
-    key = prop_key(detail)
-    if key.start_with? "custom_values"
-      :custom_field
-    elsif key.start_with? "attachments"
-      :attachment
-    elsif journaled.class.columns.collect(&:name).include? key
-      :attribute
-    end
-  end
-
-  def prop_key(detail)
-    if detail.respond_to? :to_ary
-      detail.first
-    else
-      detail
-    end
-  end
-
-  def values(detail)
-    key = prop_key(detail)
-    if detail != key
-      detail.last
-    else
-      details[key.to_s]
-    end
-  end
-
-  def old_value(detail)
-    values(detail).first
-  end
-
-  def value(detail)
-    values(detail).last
-  end
 
   def render_detail(detail, no_html=false)
     if detail.respond_to? :to_ary
@@ -178,51 +58,14 @@ module JournalFormatter
       values = details[key.to_s]
     end
 
-    case property(detail)
-    when :attribute
-      attr_detail = format_attribute_detail(key, values, no_html)
-    when :custom_field
-      custom_field = CustomField.find_by_id(key.sub("custom_values", "").to_i)
-      cv_detail = format_custom_value_detail(custom_field, values, no_html)
-    when :attachment
-      attachment_detail = format_attachment_detail(key.sub("attachments", ""), values, no_html)
-    end
+    # this is plain ugly but needed for attachments and custom_values as each instance has it's own association of the format
+    # attachments[n], custom_values[n]
+    formatter_key = JournalFormatter.registered_fields[self.class.name.to_sym].keys.detect{ |k| key.start_with?(k) }
 
-    label, old_value, value = attr_detail || cv_detail || attachment_detail
-    Redmine::Hook.call_hook :helper_issues_show_detail_after_setting, { :detail => JournalDetail.new(label, old_value, value),
-                                                                        :label => label,
-                                                                        :value => value,
-                                                                        :old_value => old_value }
-    return nil unless label || old_value || value # print nothing if there are no values
-    label, old_value, value = [label, old_value, value].collect(&:to_s)
+    formatter = JournalFormatter.formatters[JournalFormatter.registered_fields[self.class.name.to_sym][formatter_key]]
 
-    unless no_html
-      label, old_value, value = *format_html_detail(label, old_value, value)
-      value = format_html_attachment_detail(key.sub("attachments", ""), value) if attachment_detail
-    end
+    formatter_instance = formatter.new(self)
 
-    unless value.blank?
-      if attr_detail || cv_detail
-
-        unless old_value.blank?
-          if property(detail) == :attribute && key == "description"
-            link = link_to(l(:label_more), { :controller => 'journals',
-                                             :action => 'diff',
-                                             :id => id,
-                                             :field => key.to_s },
-                                             :class => 'lightbox-ajax')
-            l(:text_journal_changed_with_diff, :label => label, :link => link)
-          else
-            l(:text_journal_changed, :label => label, :old => old_value, :new => value)
-          end
-        else
-          l(:text_journal_set_to, :label => label, :value => value)
-        end
-      elsif attachment_detail
-        l(:text_journal_added, :label => label, :value => value)
-      end
-    else
-      l(:text_journal_deleted, :label => label, :old => old_value)
-    end
+    formatter_instance.render(key, values, no_html)
   end
 end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -189,8 +189,10 @@ module JournalFormatter
     end
 
     label, old_value, value = attr_detail || cv_detail || attachment_detail
-    Redmine::Hook.call_hook :helper_issues_show_detail_after_setting, {:detail => JournalDetail.new(label, old_value, value),
-        :label => label, :value => value, :old_value => old_value }
+    Redmine::Hook.call_hook :helper_issues_show_detail_after_setting, { :detail => JournalDetail.new(label, old_value, value),
+                                                                        :label => label,
+                                                                        :value => value,
+                                                                        :old_value => old_value }
     return nil unless label || old_value || value # print nothing if there are no values
     label, old_value, value = [label, old_value, value].collect(&:to_s)
 

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -197,15 +197,22 @@ module JournalFormatter
     unless no_html
       label, old_value, value = *format_html_detail(label, old_value, value)
       value = format_html_attachment_detail(key.sub("attachments", ""), value) if attachment_detail
-      if property(detail) == :attribute && key == "description"
-        old_value, value = *format_html_diff_detail(key, label, old_value, value)
-      end
     end
 
     unless value.blank?
       if attr_detail || cv_detail
+
         unless old_value.blank?
-          l(:text_journal_changed, :label => label, :old => old_value, :new => value)
+          if property(detail) == :attribute && key == "description"
+            link = link_to(l(:label_more), { :controller => 'journals',
+                                             :action => 'diff',
+                                             :id => id,
+                                             :field => key.to_s },
+                                             :class => 'lightbox-ajax')
+            l(:text_journal_changed_with_diff, :label => label, :link => link)
+          else
+            l(:text_journal_changed, :label => label, :old => old_value, :new => value)
+          end
         else
           l(:text_journal_set_to, :label => label, :value => value)
         end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/attribute.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/attribute.rb
@@ -1,0 +1,17 @@
+class JournalFormatter::Attribute < JournalFormatter::Base
+  unloadable
+
+  private
+
+  def format_details(key, values)
+    label = label(key)
+
+    old_value, value = *format_values(values)
+
+    [label, old_value, value]
+  end
+
+  def format_values(values)
+    values.map{ |v| v.try(:to_s) }
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -1,0 +1,81 @@
+class JournalFormatter::Base
+  unloadable
+
+  include Redmine::I18n
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::TextHelper
+  include ActionController::UrlWriter
+
+  def initialize(journal)
+    @journal = journal
+  end
+
+  def render(key, values, no_html = false)
+
+    label, old_value, value = format_details(key, values)
+
+    unless no_html
+      label, old_value, value = *format_html_details(label, old_value, value)
+    end
+
+    render_ternary_detail_text(label, value, old_value)
+  end
+
+  private
+
+  def format_details(key, values)
+    label = label(key)
+
+    old_value = values.first
+    value = values.last
+
+    [label, old_value, value]
+  end
+
+  def format_html_details(label, old_value, value)
+    label = content_tag('strong', label)
+    old_value = content_tag("i", h(old_value)) if old_value && !old_value.blank?
+    old_value = content_tag("strike", old_value) if old_value and value.blank?
+    value = content_tag("i", h(value)) if value.present?
+    value ||= ""
+
+    [label, old_value, value]
+  end
+
+  def label(key)
+    field = key.to_s.gsub(/\_id$/, "")
+    l(("field_" + field).to_sym)
+  end
+
+  def render_ternary_detail_text(label, value, old_value)
+    unless value.blank?
+      unless old_value.blank?
+
+        l(:text_journal_changed, :label => label, :old => old_value, :new => value)
+
+      else
+
+        l(:text_journal_set_to, :label => label, :value => value)
+
+      end
+    else
+
+      l(:text_journal_deleted, :label => label, :old => old_value)
+
+    end
+
+  end
+
+  def render_binary_detail_text(label, value, old_value)
+    if value.blank?
+
+      l(:text_journal_deleted, :label => label, :old => old_value)
+
+    else
+
+      l(:text_journal_added, :label => label, :value => value)
+
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/datetime.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/datetime.rb
@@ -1,0 +1,11 @@
+class JournalFormatter::Datetime < JournalFormatter::Attribute
+  unloadable
+
+  def format_values(values)
+    values.map do |v|
+      v.nil? ?
+        nil :
+        format_date(v.to_date)
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/decimal.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/decimal.rb
@@ -1,0 +1,7 @@
+class JournalFormatter::Decimal < JournalFormatter::Attribute
+  unloadable
+
+  def format_values(values)
+    values.map{ |v| v.to_i.to_s }
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/fraction.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/fraction.rb
@@ -1,0 +1,11 @@
+class JournalFormatter::Fraction < JournalFormatter::Attribute
+  unloadable
+
+  def format_values(values)
+    values.map do |v|
+      v.nil? ?
+        nil :
+        "%0.02f" % v.to_f
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/id.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/id.rb
@@ -1,0 +1,7 @@
+class JournalFormatter::Id < JournalFormatter::Attribute
+  unloadable
+
+  def format_values(values)
+    values.map{ |v| "##{v}" }
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -1,0 +1,26 @@
+class JournalFormatter::NamedAssociation < JournalFormatter::Attribute
+  unloadable
+
+  private
+
+  def format_details(key, values)
+    label = label(key)
+
+    old_value, value = *format_values(values, key)
+
+    [label, old_value, value]
+  end
+
+  def format_values(values, key)
+    field = key.to_s.gsub(/\_id$/, "").to_sym
+
+    association = @journal.journaled.class.reflect_on_association(field)
+
+    values.map do |value|
+      if association
+        record = association.class_name.constantize.find_by_id(value.to_i)
+        record.name if record
+      end
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/plaintext.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/plaintext.rb
@@ -1,0 +1,7 @@
+class JournalFormatter::Plaintext < JournalFormatter::Attribute
+  unloadable
+
+  def format_values(values)
+    values.map{ |v| v.try(:to_s) }
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/proc.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/proc.rb
@@ -1,0 +1,25 @@
+class JournalFormatter::Proc < JournalFormatter::Attribute
+  unloadable
+
+  class << self
+    attr_accessor :proc
+  end
+
+  private
+
+  def format_details(key, values)
+    label = label(key)
+
+    old_value, value = *format_values(values, key)
+
+    [label, old_value, value]
+  end
+
+  def format_values(values, key)
+    field = key.to_s.gsub(/\_id$/, "")
+
+    values.map do |value|
+      self.class.proc.call value, @journal.journaled, field
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/format_hooks.rb
+++ b/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/format_hooks.rb
@@ -28,8 +28,8 @@ module Redmine::Acts::Journalized
       # Shortcut to register a formatter for a number of fields
       def register_on_journal_formatter(formatter, *field_names)
         formatter = formatter.to_sym
-        field_names.collect(&:to_s).each do |field|
-          JournalFormatter.register :class => self.journal_class.name.to_sym, field => formatter
+        field_names.each do |field|
+          JournalFormatter.register_formatted_field(self.journal_class.name.to_sym, field, formatter)
         end
       end
 

--- a/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/format_hooks.rb
+++ b/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/format_hooks.rb
@@ -35,8 +35,16 @@ module Redmine::Acts::Journalized
 
       # Shortcut to register a new proc as a named formatter. Overwrites
       # existing formatters with the same name
-      def register_journal_formatter(formatter)
-        JournalFormatter.register formatter.to_sym => Proc.new
+      def register_journal_formatter(formatter, klass = nil, &block)
+        if block_given?
+          klass = Class.new(JournalFormatter::Proc) do
+                    @proc = block
+                  end
+        end
+
+        raise ArgumentError "Provide either a class or a block defining the value formatting" if klass.nil?
+
+        JournalFormatter.register formatter.to_sym => klass
       end
     end
   end


### PR DESCRIPTION
This alters displaying a change in an issue description from a long text of the schema:

<pre>
Description changed from Lorem Ipsum to Lorem Ipsum new
</pre>


to 

<pre>
Description changed (Details)
</pre>


Where Details is a link that when clicked loads a diff view from the server. The diff view is equal to that displayed for a wiki.

A lot of work has gone into refactoring the journal formatters. The OpenProject specific code has been factored out of the acts_as_journalized plugin and moved into lib. In addition, modifying the way a journal entry is formatted should now be easy. 
