### PR TITLE
changed ssl option handling for receive imap

### DIFF
--- a/lib/redmine/imap.rb
+++ b/lib/redmine/imap.rb
@@ -20,7 +20,7 @@ module Redmine
       def check(imap_options={}, options={})
         host = imap_options[:host] || '127.0.0.1'
         port = imap_options[:port] || '143'
-        ssl = !imap_options[:ssl].nil?
+        ssl = imap_options[:ssl] || false
         folder = imap_options[:folder] || 'INBOX'
 
         imap = Net::IMAP.new(host, port, ssl)

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -134,9 +134,11 @@ Examples:
 END_DESC
 
     task :receive_imap => :environment do
+      ssl = ENV['ssl']
+      ssl = ssl.nil? ? false : ((ssl == "1" || ssl == "true") ? true : false)
       imap_options = {:host => ENV['host'],
                       :port => ENV['port'],
-                      :ssl => ENV['ssl'],
+                      :ssl => ssl,
                       :username => ENV['username'],
                       :password => ENV['password'],
                       :folder => ENV['folder'],


### PR DESCRIPTION
- redmine/imap lib uses the content of given ssl option and not only checking if key exists
- email.rake sets ssl option always true or false
