### PR TITLE
fixes issue diff link when having a relative_url_root defined

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem "rails", "2.3.15"
+gem "rails", "2.3.16"
 
 gem "coderay", "~> 0.9.7"
 gem "i18n", "> 0.4"

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,7 +19,7 @@
 # ENV['RAILS_ENV'] ||= 'production'
 
 # Specifies gem version of Rails to use when vendor/rails is not present
-RAILS_GEM_VERSION = '2.3.15' unless defined? RAILS_GEM_VERSION
+RAILS_GEM_VERSION = '2.3.16' unless defined? RAILS_GEM_VERSION
 
 if RUBY_VERSION >= '1.9'
   Encoding.default_external = 'UTF-8'

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -40,7 +40,12 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
                  :field => key.downcase,
                  :only_path => false,
                  :protocol => Setting.protocol,
-                 :host => Setting.host_name }
+    # the link params should better be defined with the
+    # skip_relative_url_root => true
+    # option. But this method is flawed in 2.3
+    # revise when on 3.2
+                 :host => Setting.host_name.gsub(Redmine::Utils.relative_url_root, "") }
+
 
     if no_html
       url_for url_attr


### PR DESCRIPTION
Because relative_url_root gets applied along with Setting.host_name having the same root when constructing the link the root is included two times in the resulting link. This is accounted for with this fix. There is a better method of doing so but this would require OpenProject to use rails 3.2 and we are not there yet.
