### PR TITLE
Perf/journal caching

### DIFF
--- a/app/helpers/journals_helper.rb
+++ b/app/helpers/journals_helper.rb
@@ -44,10 +44,11 @@ module JournalsHelper
       </h4>
     HTML
 
+
     if journal.details.any?
       details = content_tag "ul", :class => "details journal-attributes" do
         journal.details.collect do |detail|
-          if d = journal.render_detail(detail)
+          if d = journal.render_detail(detail, :cache => options[:cache])
             content_tag("li", d)
           end
         end.compact.join(' ')

--- a/app/views/mailer/issue_edit.text.html.rhtml
+++ b/app/views/mailer/issue_edit.text.html.rhtml
@@ -2,7 +2,7 @@
 
 <ul>
 <% for detail in @journal.details %>
-    <li><%= @journal.render_detail(detail, true) %></li>
+  <li><%= @journal.render_detail(detail, :no_html => true) %></li>
 <% end %>
 </ul>
 

--- a/app/views/mailer/issue_edit.text.plain.rhtml
+++ b/app/views/mailer/issue_edit.text.plain.rhtml
@@ -1,7 +1,7 @@
 <%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @journal.user) %>
 
 <% for detail in @journal.details -%>
-<%= @journal.render_detail(detail, true) %>
+  <%= @journal.render_detail(detail, :no_html => true) %>
 <% end -%>
 
 <%= @journal.notes if @journal.notes? %>

--- a/lib/open_project/journal_formatter/attachment.rb
+++ b/lib/open_project/journal_formatter/attachment.rb
@@ -7,10 +7,10 @@ class OpenProject::JournalFormatter::Attachment < ::JournalFormatter::Base
     { :only_path => true }
   end
 
-  def render(key, values, no_html = false)
+  def render(key, values, options = { :no_html => false })
     label, old_value, value = format_details(key.sub("attachments", ""), values)
 
-    unless no_html
+    unless options[:no_html]
       label, old_value, value = *format_html_details(label, old_value, value)
 
       value = format_html_attachment_detail(key.sub("attachments", ""), value)

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -3,8 +3,8 @@ require_dependency 'journal_formatter/base'
 class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   unloadable
 
-  def render(key, values, no_html = false)
-    render_ternary_detail_text(key, values.last, values.first, no_html)
+  def render(key, values, options = { :no_html => false })
+    render_ternary_detail_text(key, values.last, values.first, options[:no_html])
   end
 
   private

--- a/vendor/plugins/acts_as_journalized/lib/acts/journalized/journal_object_cache.rb
+++ b/vendor/plugins/acts_as_journalized/lib/acts/journalized/journal_object_cache.rb
@@ -1,0 +1,18 @@
+module Acts
+  module Journalized
+    class JournalObjectCache
+      unloadable
+
+      def fetch(klass, id, &block)
+
+        @cache ||= Hash.new do |klass_hash, klass_key|
+          klass_hash[klass_key] = Hash.new do |id_hash, id_key|
+                                    id_hash[id_key] = yield klass_key, id_key
+                                  end
+        end
+
+        @cache[klass][id]
+      end
+    end
+  end
+end

--- a/vendor/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/vendor/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -115,6 +115,9 @@ module Redmine
               c.class_eval("belongs_to :journaled, :class_name => '#{name}' #{include_option}")
               c.class_eval("belongs_to :#{name.gsub("::", "_").underscore},
                   :foreign_key => 'journaled_id' #{include_option}")
+              c.class_eval("def self.journaled_class
+                              #{self}
+                            end")
             end
           end
         end

--- a/vendor/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/vendor/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -20,6 +20,7 @@
 
 
 Dir[File.expand_path("../redmine/acts/journalized/*.rb", __FILE__)].each{|f| require f }
+Dir[File.expand_path("../acts/journalized/*.rb", __FILE__)].each{|f| require f }
 require "ar_condition"
 
 module Redmine

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -42,7 +42,6 @@ module JournalFormatter
     registered_fields[klass].merge!(field => formatter)
   end
 
-  # TODO: Document Formatters (can take up to three params, value, journaled, field ...)
   def self.default_formatters
     { :plaintext => JournalFormatter::Plaintext,
       :datetime => JournalFormatter::Datetime,

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -56,7 +56,7 @@ module JournalFormatter
     hash[klass] = {}
   end
 
-  def render_detail(detail, no_html=false)
+  def render_detail(detail, options = { :no_html => false })
     if detail.respond_to? :to_ary
       key = detail.first
       values = detail.last
@@ -69,7 +69,7 @@ module JournalFormatter
 
     return nil if formatter.nil?
 
-    formatter.render(key, values, no_html)
+    formatter.render(key, values, options)
   end
 
   def formatter_instance(formatter_key)

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -11,11 +11,11 @@ class JournalFormatter::Base
     @journal = journal
   end
 
-  def render(key, values, no_html = false)
+  def render(key, values, options = { :no_html => false })
 
     label, old_value, value = format_details(key, values)
 
-    unless no_html
+    unless options[:no_html]
       label, old_value, value = *format_html_details(label, old_value, value)
     end
 
@@ -24,7 +24,7 @@ class JournalFormatter::Base
 
   private
 
-  def format_details(key, values)
+  def format_details(key, values, options = {})
     label = label(key)
 
     old_value = values.first

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -1,26 +1,56 @@
 class JournalFormatter::NamedAssociation < JournalFormatter::Attribute
   unloadable
 
+  def render(key, values, options = { :no_html => false })
+
+    label, old_value, value = format_details(key, values, options)
+
+    unless options[:no_html]
+      label, old_value, value = *format_html_details(label, old_value, value)
+    end
+
+    render_ternary_detail_text(label, value, old_value)
+  end
+
   private
 
-  def format_details(key, values)
+  def format_details(key, values, options = {})
     label = label(key)
 
-    old_value, value = *format_values(values, key)
+    old_value, value = *format_values(values, key, options)
 
     [label, old_value, value]
   end
 
-  def format_values(values, key)
+  def format_values(values, key, options)
     field = key.to_s.gsub(/\_id$/, "").to_sym
-
-    association = @journal.journaled.class.reflect_on_association(field)
+    klass = class_from_field(field)
 
     values.map do |value|
-      if association
-        record = association.class_name.constantize.find_by_id(value.to_i)
+      if klass
+        record = associated_object(klass, value.to_i, options)
         record.name if record
       end
+    end
+  end
+
+  def associated_object(klass, id, options = {})
+    cache = options[:cache]
+
+    if cache && cache.is_a?(Acts::Journalized::JournalObjectCache)
+      cache.fetch(klass, id) do |k, i|
+        k.find_by_id(i)
+      end
+    else
+      klass.find_by_id(id)
+    end
+  end
+
+  def class_from_field(field)
+    association = @journal.class.journaled_class.reflect_on_association(field)
+
+    if association
+      association.class_name.constantize
     end
   end
 end


### PR DESCRIPTION
Extends the journal formatter's render method to be able to receive arbitrary options. The first application for this versatility is being able to pass a simple cache to the named association formatter.

The association formatter is used to render changes in associated objects. E.g. for an issue a change in priority is handled by this formatter. In order to be able to render the name (or similar identifier) of the associated object, it has to load it. This is done by using [Model-Constant].find_by_id.

As the formatters are independent instances for each change, each change in an associated object will lead to calling a find_by_id (Two calls to be percise - former value and new value). It is not necessary for each formatter to access the db. Rails SQL caching prevents the worst here. But when using an external caching like memcached, every find_by_id leads to an IPC-call. The performance overhead suffered can be circumvented when reusing loaded objects.

Therefore a simple cache is added that stores all loaded objects in the process itself. The result is a two-level caching. Objects are looked up in the in-process-cache. When no hit is made, the block provided is executed. For the named association formatter the fallback is still calling the find_by_id method. And this method is cached by the Rails SQL cache.

This pull request does not yet use the cache. This will be done by a separate pull request in order to keep it clean.

It might be desirable to optimize the caching strategy for some object types later on. One idea would be to always load all of the priorities. As there should always be just a few priority instances, instantiating them all should be cheaper than additional db-requests.  
