### PR TITLE
refactors querying for assignable users

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,6 +28,10 @@ class Project < ActiveRecord::Base
   # Specific overidden Activities
   has_many :time_entry_activities
   has_many :members, :include => [:user, :roles], :conditions => "#{User.table_name}.type='User' AND #{User.table_name}.status=#{User::STATUS_ACTIVE}"
+  has_many :assignable_members,
+           :class_name => 'Member',
+           :include => [:user, :roles],
+           :conditions => "#{User.table_name}.type='User' AND #{User.table_name}.status=#{User::STATUS_ACTIVE} AND roles.assignable = 1"
   has_many :memberships, :class_name => 'Member'
   has_many :member_principals, :class_name => 'Member',
                                :include => :principal,
@@ -428,7 +432,7 @@ class Project < ActiveRecord::Base
 
   # Users issues can be assigned to
   def assignable_users
-    members.select {|m| m.roles.detect {|role| role.assignable?}}.collect {|m| m.user}.sort
+    assignable_members.map(&:user).sort
   end
 
   # Returns the mail adresses of users that should be always notified on project events


### PR DESCRIPTION
It is still not as fast as it should be. Even after refactoring it takes 1-2 seconds before the answer is calculated (used to be 5-6).

It might be desirable to switch behavior depending on whether all associated objects are already loaded and how much of them exist. When they are all loaded and when there are but a few it might be faster to do this in ruby itself. 
