### PR TITLE
Perf/issue show without edit

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -106,7 +106,6 @@ class IssuesController < ApplicationController
     @journals.reverse! if User.current.wants_comments_in_reverse_order?
     @changesets = @issue.changesets.visible.all(:include => [{ :repository => {:project => :enabled_modules} }, :user])
     @changesets.reverse! if User.current.wants_comments_in_reverse_order?
-    @allowed_statuses = @issue.new_statuses_allowed_to(User.current)
 
     @relations = @issue.relations(:include => { :other_issue => [:status,
                                                                  :priority,
@@ -127,8 +126,8 @@ class IssuesController < ApplicationController
                                                                :priority,
                                                                :fixed_version,
                                                                :project])
+
     @edit_allowed = User.current.allowed_to?(:edit_issues, @project)
-    @priorities = IssuePriority.all
     @time_entry = TimeEntry.new(:issue => @issue, :project => @issue.project)
     respond_to do |format|
       format.html { render :template => 'issues/show.rhtml' }

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -178,6 +178,7 @@ class IssuesController < ApplicationController
     @journal = @issue.current_journal
 
     respond_to do |format|
+      format.js { render :partial => 'edit' }
       format.html { }
       format.xml  { }
     end

--- a/app/views/issues/_action_menu.rhtml
+++ b/app/views/issues/_action_menu.rhtml
@@ -1,5 +1,9 @@
 <% content_for :action_menu_main do %>
-  <%= li_unless_nil(link_to_if_authorized(l(:button_update), {:controller => 'issues', :action => 'edit', :id => @issue }, :onclick => 'showAndScrollTo("update", "notes"); return false;', :class => 'icon icon-edit', :accesskey => accesskey(:edit))) %>
+  <%= li_unless_nil(link_to_if_authorized(l(:button_update), { :controller => 'issues',
+                                                               :action => 'edit',
+                                                               :id => @issue },
+                                                               :class => 'edit icon icon-edit',
+                                                               :accesskey => accesskey(:edit))) %>
   <%= li_unless_nil(watcher_link(@issue,
                        User.current,
                        { :class => 'watcher_link',

--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -137,11 +137,3 @@
 <% end %>
 <div id="context-menu" style="display: none;"></div>
 <%= javascript_tag "new ContextMenu('#{issues_context_menu_path}')" %>
-<%= javascript_tag "jQuery('document').ready(function () {
-      jQuery.ajaxAppend({
-        'dom_identifier': { 'trigger_class': 'description-details',
-                            'indicator_class': 'ajax-indicator' },
-        'i18n': { 'hide': '" + l(:label_hide) + "'}
-      } );
-  });"
-%>

--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -108,7 +108,7 @@
 <div style="clear: both;"></div>
 
 <div class="title-bar" id="lower-title-bar">
-  <%= javascript_include_tag 'copy_issue_actions' %>
+  <%= render :partial => 'layouts/action_menu' %>
 </div>
 
 <div style="clear: both;"></div>

--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -113,8 +113,7 @@
 
 <div style="clear: both;"></div>
 <% if authorize_for('issues', 'edit') %>
-<div id="update" style="display:none;">
-  <%= render :partial => 'edit' %>
+  <div id="update">
   </div>
 <% end %>
 

--- a/app/views/layouts/_action_menu.html.erb
+++ b/app/views/layouts/_action_menu.html.erb
@@ -1,0 +1,13 @@
+<% if @content_for_action_menu_main %>
+  <ul class="action_menu_main">
+    <%= yield :action_menu_main %>
+    <% if @content_for_action_menu_more %>
+      <li class="drop-down">
+        <a href="javascript:" class="icon icon-more"><%= l(:more_actions) %></a>
+        <ul class="action_menu_more" style="display:none;">
+          <%= yield :action_menu_more %>
+        </ul>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/layouts/base.rhtml
+++ b/app/views/layouts/base.rhtml
@@ -103,19 +103,7 @@
       <%= render_flash_messages %>
 
       <!-- Action menu -->
-      <% if @content_for_action_menu_main %>
-        <ul class="action_menu_main">
-          <%= yield :action_menu_main %>
-          <% if @content_for_action_menu_more %>
-            <li class="drop-down">
-              <a href="javascript:" class="icon icon-more"><%= l(:more_actions) %></a>
-              <ul class="action_menu_more" style="display:none;">
-                <%= yield :action_menu_more %>
-              </ul>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+      <%= render :partial => 'layouts/action_menu' %>
 
       <%= yield %>
       <%= call_hook :view_layouts_base_content %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1133,3 +1133,4 @@ de:
         zero: Sie dürfen keine Elemente auswählen
     ajax:
       loading: Lädt ...
+      hide: Verbergen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1131,3 +1131,5 @@ de:
         one: Sie dürfen nur ein Element auswählen
         other: Sie dürfen nur {{limit}} Elemente auswählen
         zero: Sie dürfen keine Elemente auswählen
+    ajax:
+      loading: Lädt ...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1113,3 +1113,4 @@ en:
         zero: You cannot select any items
     ajax:
       loading: Loading ...
+      hide: Hide

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1111,3 +1111,5 @@ en:
         one: You can only select one item
         other: You can only select {{limit}} items
         zero: You cannot select any items
+    ajax:
+      loading: Loading ...

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -1484,6 +1484,13 @@ Issue.Show = (function($) {
                 $("#notes").focus();
       }
     });
+
+    $.ajaxAppend({
+      trigger: '.description-details',
+      indicator_class: 'ajax-indicator',
+      loading_class: 'text-diff',
+      hide_text: I18n.t("js.ajax.hide")
+    } );
   };
 
   $('document').ready(function () {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -1458,3 +1458,37 @@ var SubmitConfirm = (function($) {
     init: init
   };
 })(jQuery);
+
+var Issue = Issue || {};
+
+Issue.Show = (function($) {
+  var init;
+
+  init = function () {
+    $.ajaxAppend({
+      trigger: '.action_menu_main .edit',
+      indicator_class: 'ajax-indicator',
+      load_target: '#update',
+      loading_text: I18n.t("js.ajax.loading"),
+      loading_class: 'box loading',
+      loading: function(update) {
+                 $('html, body').animate({
+                   scrollTop: $(update).offset().top
+                 }, 200);
+               },
+      loaded: function(update) {
+                $('html, body').animate({
+                  scrollTop: $(update).offset().top
+                }, 200);
+
+                $("#notes").focus();
+      }
+    });
+  };
+
+  $('document').ready(function () {
+    if ($('body.controller-issues.action-show').size() > 0) {
+     init();
+    };
+  });
+})(jQuery);

--- a/public/javascripts/copy_issue_actions.js
+++ b/public/javascripts/copy_issue_actions.js
@@ -1,5 +1,0 @@
-jQuery(document).ready(function(){
-  var clone = jQuery('.action_menu_main').clone();
-  jQuery('#lower-title-bar').append(clone);
-  clone.onClickDropDown();
-});

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -626,6 +626,15 @@ vertical-align: bottom;
   vertical-align: bottom;
 }
 
+.ajax_appended_information.loading .ajax-indicator {
+  padding-left: 22px;
+  display: block;
+  width: 0em;
+  margin-left: auto;
+  margin-right: auto;
+  white-space: nowrap;
+}
+
 /***** Calendar *****/
 table.cal {border-collapse: collapse; width: 100%; margin: 0px 0 6px 0;border: 1px solid #d7d7d7;}
 table.cal thead th {width: 14%; background-color:#EEEEEE; padding: 4px; }


### PR DESCRIPTION
Implements loading the issue's edit form asynchronously on demand instead of each time an issue's show action is called. 

Especially for larger projects, with a lot of members and other defined fields, loading the edit form later speeds up the initial loading time considerably.

Beware: This pull request is not base on the master but on https://github.com/opf/openproject/pull/28. This was done because https://github.com/opf/openproject/pull/28 changes eager loaded objects and as such is a prerequisite for this pull request. 

The implementation is based on reusing ajaxAppend, a javascript function already part of OpenProject. ajaxAppend needed to first be extended in order for it to offer the flexibility needed. This extra work should pay of in the long run.   
