### PR TITLE
prevents exploiting implicit mysql typecasting

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -37,7 +37,7 @@ class AccountController < ApplicationController
   def lost_password
     redirect_to(home_url) && return unless Setting.lost_password?
     if params[:token]
-      @token = Token.find_by_action_and_value("recovery", params[:token])
+      @token = Token.find_by_action_and_value("recovery", params[:token].to_s)
       redirect_to(home_url) && return unless @token and !@token.expired?
       @user = @token.user
       if request.post?
@@ -109,7 +109,7 @@ class AccountController < ApplicationController
   # Token based account activation
   def activate
     redirect_to(home_url) && return unless Setting.self_registration? && params[:token]
-    token = Token.find_by_action_and_value('register', params[:token])
+    token = Token.find_by_action_and_value('register', params[:token].to_s)
     redirect_to(home_url) && return unless token and !token.expired?
     user = token.user
     redirect_to(home_url) && return unless user.registered?


### PR DESCRIPTION
This should prevent an attacker from issuing a request where he sends a token param casted to integer. MySql would cast the value attribute of Token to integer which is either the integer at the beginning of the value or, in absence of such, 0.
