### PR TITLE
Fixes problem with other urls passed into the function.

### DIFF
--- a/public/javascripts/openproject.js
+++ b/public/javascripts/openproject.js
@@ -54,7 +54,7 @@ window.OpenProject = (function ($) {
       }
 
       if (!url) {
-        url = "/projects/level_list.json";
+        url = this.getFullUrl("/projects/level_list.json");
       }
 
       if (this.projects) {
@@ -63,7 +63,7 @@ window.OpenProject = (function ($) {
       }
 
       jQuery.getJSON(
-        this.getFullUrl(url),
+        url,
         jQuery.proxy(function (data, textStatus, jqXHR) {
           this.projects = augment(this, data.projects);
           this.fetchProjects.apply(this, fetchArgs);


### PR DESCRIPTION
When urls are passed into this function, they originate from Rails.
Rails already knows the full path, so the expansion only should happen
on the default project list.
