### PR TITLE
include calendar js files in case they are needed for edit

### DIFF
--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -137,3 +137,6 @@
 <% end %>
 <div id="context-menu" style="display: none;"></div>
 <%= javascript_tag "new ContextMenu('#{issues_context_menu_path}')" %>
+
+<% #include calendar js files in case they are needed for edit
+  include_calendar_headers_tags -%>


### PR DESCRIPTION
The edit form requires Calendar.js. As the form is loaded asynchronously now and thus without html-header, the required files where no longer included in the page once an edit is desired. This might not be an optimal solution as the files are loaded regardless of whether they are actually used or not. Given the migration to rails 3, I consider it a practical solution as it solves the problem without creating mechanisms that might later be on hand anyway once the migration is done.
