### PR TITLE
no longer serializes changes as they will be anyway

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -375,7 +375,7 @@ class Issue < ActiveRecord::Base
   def attachment_removed(obj)
     init_journal(User.current)
     create_journal
-    last_journal.update_attribute(:changes, {"attachments_" + obj.id.to_s => [obj.filename, nil]}.to_yaml)
+    last_journal.update_attribute(:changes, { "attachments_#{obj.id}" => [obj.filename, nil] })
   end
 
   # Return true if the issue is closed, otherwise false


### PR DESCRIPTION
Assigning an already serialized attribute to an attribute that will be serialized by active record is disabled due to security issues (rails 2.3.17)

Please see accordingly named branch in tests.
