### PR TITLE
Fixes migrations for MySQL5.

### DIFF
--- a/db/migrate/20110211160100_add_summary_to_projects.rb
+++ b/db/migrate/20110211160100_add_summary_to_projects.rb
@@ -1,6 +1,6 @@
 class AddSummaryToProjects < ActiveRecord::Migration
   def self.up
-    add_column :projects, :summary, :text, :default => ""
+    add_column :projects, :summary, :text
   end
 
   def self.down


### PR DESCRIPTION
This removes the default value on the summary text column. Excerpt from
MySQL 5.0 Reference Manual, 11.1.6.3. The BLOB and TEXT Types: BLOB and
TEXT columns cannot have DEFAULT values [1].

This seems to cause problems on windows boxes since 2008 [2]

[1] http://dev.mysql.com/doc/refman/5.0/en/blob.html
[2] http://stackoverflow.com/a/4553664/1474757
