### PR TITLE
no longer serializes changes as they are declared to be serialized

### DIFF
--- a/db/migrate/20100804112053_merge_wiki_versions_with_journals.rb
+++ b/db/migrate/20100804112053_merge_wiki_versions_with_journals.rb
@@ -37,7 +37,7 @@ class MergeWikiVersionsWithJournals < ActiveRecord::Migration
       changes = {}
       changes["compression"] = wv.compression
       changes["data"] = wv.data
-      journal.update_attribute(:changes, changes.to_yaml)
+      journal.update_attribute(:changes, changes)
       journal.update_attribute(:version, wv.version)
     end
     # drop_table :wiki_content_versions


### PR DESCRIPTION
As of rails 2.3.17, assigning a serialized object to an AR attribute declared as serialized is not permitted.
