### PR TITLE
fixes builtin role migration by reloading Roles' table information

### DIFF
--- a/db/migrate/062_insert_builtin_roles.rb
+++ b/db/migrate/062_insert_builtin_roles.rb
@@ -14,6 +14,7 @@
 
 class InsertBuiltinRoles < ActiveRecord::Migration
   def self.up
+    Role.connection.schema_cache.clear!
     Role.reset_column_information
     nonmember = Role.new(:name => 'Non member', :position => 0)
     nonmember.builtin = Role::BUILTIN_NON_MEMBER


### PR DESCRIPTION
Had this issue while migrating the test db, development was fine. Setting config.cache_classes to false was of no use, so I assume this isn't just an issue with my config.

Sorry Tessi, had to assign somebody so this doesn't get lost somehow and I know you're working on rails3 stuff.
