### PR TITLE
Speeds up level_list view of projects.

### DIFF
--- a/app/views/projects/level_list.api.rsb
+++ b/app/views/projects/level_list.api.rsb
@@ -7,7 +7,7 @@ api.array :projects, api_meta(:size => @elements.size) do
       api.name(project.name)
       api.identifier(project.identifier)
 
-      api.has_children(project.children.present?)
+      api.has_children(!project.leaf?)
 
       api.level(element[:level])
 


### PR DESCRIPTION
projects.children fetches those children from the DB. this caused the
retrieval of ~2000 projects to take upward of 10 seconds. Asking for
'leaf?' operates on nested set lft and rgt and does not require a
database query.
