### PR TITLE
adapts calling render_details to changes signature

### DIFF
--- a/lib/redmine/export/pdf.rb
+++ b/lib/redmine/export/pdf.rb
@@ -414,7 +414,7 @@ module Redmine
           pdf.Ln
           pdf.SetFontStyle('I',8)
           for detail in journal.details
-            pdf.RDMMultiCell(190,5, "- " + journal.render_detail(detail, true))
+            pdf.RDMMultiCell(190,5, "- " + journal.render_detail(detail, :no_html => true))
             pdf.Ln
           end
           if journal.notes?


### PR DESCRIPTION
The signature of the render_detail method on journals changed from (detail, no_html = true) to (detail, :options => { :no_html => false }).

Pleas also consider the accordingly named branch in the tests plugin.
