### PR TITLE
generalizes routes for watching

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
+
 OpenProject::Application.routes.draw do
   root :to => 'welcome#index', :as => 'home'
 
@@ -34,10 +35,12 @@ OpenProject::Application.routes.draw do
   post  'projects/:id/wiki' => 'wikis#edit'
   match 'projects/:id/wiki/destroy' => 'wikis#destroy'
 
-  # generic route for adding/removing watchers
-  # looks to be ressourceful
-  scope ':object_type/:object_id', :constraints => { :object_type => /issues|messages|boards|wikis|wiki_pages|news/,
-                                                     :object_id => /\d+/ } do
+  # generic route for adding/removing watchers.
+  # Models declared as acts_as_watchable will be automatically added to
+  # OpenProject::Acts::Watchable::Routes.watched
+  scope ':object_type/:object_id', :constraints => lambda { |req|
+                                                     OpenProject::Acts::Watchable::Routes.watched?(req.path_parameters[:object_type]) &&
+                                                     /\d+/.match(req.path_parameters[:object_id]) } do
     resources :watchers, :only => [:new]
 
     match '/watch' => 'watchers#watch', :via => :post

--- a/lib/plugins/acts_as_watchable/init.rb
+++ b/lib/plugins/acts_as_watchable/init.rb
@@ -1,4 +1,6 @@
 #-- encoding: UTF-8
 # Include hook code here
 require File.dirname(__FILE__) + '/lib/acts_as_watchable'
+require File.dirname(__FILE__) + '/lib/acts_as_watchable/routes.rb'
+
 ActiveRecord::Base.send(:include, Redmine::Acts::Watchable)

--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
@@ -8,6 +8,21 @@ module Redmine
       end
 
       module ClassMethods
+        # Marks an ActiveRecord::Model as watchable
+        # A watchable model has association with users (watchers) who wish to be informed of changes on it.
+        #
+        # This also creates the routes necessary for watching/unwatching by adding the model's name to routes. This
+        # e.g leads to the following routes when marking issues as watchable:
+        #   POST:     issues/1/watch
+        #   DELETE:   issues/1/unwatch
+        #   GET/POST: issues/1/watchers/new
+        #   DELETE:   issues/1/watchers/1
+        # Use the :route_prefix option to change the model prefix, e.g. from issues to tickets
+        #
+        # params:
+        #   options:
+        #     route_prefix: overrides the route calculation which would normally use the models name.
+
         def acts_as_watchable(options = {})
           return if self.included_modules.include?(Redmine::Acts::Watchable::InstanceMethods)
           class_eval do

--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
@@ -22,6 +22,8 @@ module Redmine
           end
           send :include, Redmine::Acts::Watchable::InstanceMethods
           alias_method_chain :watcher_user_ids=, :uniq_ids
+
+          OpenProject::Acts::Watchable::Routes.add_watched(options[:route_prefix] || self.to_s.underscore.pluralize)
         end
       end
 

--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable/routes.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable/routes.rb
@@ -1,0 +1,21 @@
+module OpenProject
+  module Acts
+    module Watchable
+      module Routes
+        mattr_accessor :models
+
+        def self.watched?(object)
+          @watchregexp.present? && @watchregexp.match(object).present?
+        end
+
+        def self.add_watched(watched)
+          self.models ||= []
+
+          self.models << watched.to_s unless self.models.include?(watched.to_s)
+
+          @watchregexp = Regexp.new(self.models.join("|"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a Routes module to acts_as_watchable. This module is used in routes.rb to dynamically determine whether a requested route is one where acts_as_watchable is involved. By defining a model as acts_as_watchable, it is automatically added to the watchable routes.
