### PR TITLE
enable testing plugins from OpenProject core

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,9 @@ module OpenProject
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # initialize variable for register plugin tests
+    config.plugins_to_test_paths = []
   end
 
   def self.preload_circular_dependencies

--- a/lib/tasks/plugin_tests.rake
+++ b/lib/tasks/plugin_tests.rake
@@ -1,0 +1,36 @@
+#  This task will run all plugin specs separated by plugin.
+#  A plugin must register for tests via config variable 'plugins_to_test_paths'
+#
+#  e.g.
+#  class Engine < ::Rails::Engine
+#    initializer 'register_path_to_rspec' do |app|
+#      app.config.plugins_to_test_paths << self.root
+#    end
+#  end
+#
+
+desc "Run plugin tests"
+namespace :openproject do
+  namespace :plugins do
+    namespace :test do
+      desc "Run specs for all test registered plugins"
+      task :rspec => :environment do
+        get_plugins_to_test.each do |plugin_path|
+          puts "run specs for #{plugin_path.split('/').last} plugin"
+          ENV['SPEC'] = "#{plugin_path}/spec/"
+          Rake::Task["spec"].execute
+        end
+      end
+    end
+  end
+end
+
+def get_plugins_to_test
+  plugin_paths = []
+  Rails.application.config.plugins_to_test_paths.each do |dir|
+    if File.directory?( dir )
+      plugin_paths << File.join(dir).to_s
+    end
+  end
+  plugin_paths
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,12 @@ Spork.prefork do
 
     config.treat_symbols_as_metadata_keys_with_true_values = true
     config.run_all_when_everything_filtered = true
+
+    config.after(:suite) do
+      [User, Project, Issue].each do |cls|
+        raise "your specs leave a #{cls} in the DB\ndid you use before(:all) instead of before or forget to kill the instances in a after(:all)?" if cls.count > 0
+    end
+  end
   end
 end
 


### PR DESCRIPTION
- created rake task to run plugin specs
- added config variable where plugins can register for tests
- added after(:suite) block in spec_helper to check for wrong used before(:all)
