### PR TITLE
Removed the after_initialize callback in old syntax

### DIFF
--- a/app/models/wiki_menu_item.rb
+++ b/app/models/wiki_menu_item.rb
@@ -19,10 +19,6 @@ class WikiMenuItem < ActiveRecord::Base
 
   validates_presence_of :name
 
-  def after_initialize
-    self.options ||= Hash.new
-  end
-
   def item_class
     title.dasherize
   end


### PR DESCRIPTION
as specifying the class name as second parameter in
"serialize options, Hash" causes options to always
have the default value of hash (an empty hash)
- see API documentation of ActiveRecord::Base -
  so there is no need to call after_initialize
  to create an empty hash if none is present.
