### PR TITLE
Gemfile: Use https URLs for GitHub repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
-gem "rails", :git => "git://github.com/rails/rails.git", :branch => "3-2-13"
+gem "rails", :git => "https://github.com/rails/rails.git", :branch => "3-2-13"
 # be careful when updating past 3-2-13
 # rails commit 9bd5c86c3bdc70bf29be7f756d1dec2fdd4eaaf0 resultsin a bug, when creating WikiContent Objects via FactoryGirl.
 # So we use the commit before that for now.
-# gem "rails", :git => "git://github.com/rails/rails.git", :ref => "bb0007f70420445f140004587aa1228895ab6653"
+# gem "rails", :git => "https://github.com/rails/rails.git", :ref => "bb0007f70420445f140004587aa1228895ab6653"
 
-gem "sprockets", :git => "git://github.com/tessi/sprockets.git", :branch => "2_2_1-backport"
+gem "sprockets", :git => "https://github.com/tessi/sprockets.git", :branch => "2_2_1-backport"
 
 gem "coderay", "~> 1.0.5"
 gem "rubytree", "~> 0.8.3"
@@ -14,7 +14,7 @@ gem "rdoc", ">= 2.4.2"
 # Needed only on RUBY_VERSION = 1.8, ruby 1.9+ compatible interpreters should bring their csv
 gem "fastercsv", "~> 1.5.0", :platforms => [:ruby_18, :jruby, :mingw_18]
 # master includes the uniqueness validator, formerly patched in config/initializers/globalize3_patch.rb
-gem 'globalize3', :git => 'git://github.com/svenfuchs/globalize3.git'
+gem 'globalize3', :git => 'https://github.com/svenfuchs/globalize3.git'
 gem "delayed_job_active_record" # that's how delayed job's readme recommends it
 
 # TODO: adds #auto_link which was deprecated in rails 3.1
@@ -42,11 +42,11 @@ end
 
 gem "prototype-rails"
 gem 'jquery-rails', '~> 2.0.3'
-gem "i18n-js", :git => "git://github.com/fnando/i18n-js.git", :branch => "rewrite"
+gem "i18n-js", :git => "https://github.com/fnando/i18n-js.git", :branch => "rewrite"
 
 group :test do
   gem 'shoulda', '~> 3.1.1'
-  gem 'object-daddy', :git => 'git://github.com/awebneck/object_daddy.git'
+  gem 'object-daddy', :git => 'https://github.com/awebneck/object_daddy.git'
   gem 'mocha', '~> 0.13.1', :require => false
   gem "launchy", "~> 2.1.0"
   gem "factory_girl_rails", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
-  remote: git://github.com/awebneck/object_daddy.git
+  remote: https://github.com/awebneck/object_daddy.git
   revision: cf5abf001cdbd14b47a3b51421446717a3183f0a
   specs:
     object-daddy (1.1.0)
 
 GIT
-  remote: git://github.com/fnando/i18n-js.git
+  remote: https://github.com/fnando/i18n-js.git
   revision: 8801f8d17ef96c48a7a0269e251fcf1648c8f441
   branch: rewrite
   specs:
@@ -13,7 +13,7 @@ GIT
       i18n
 
 GIT
-  remote: git://github.com/rails/rails.git
+  remote: https://github.com/rails/rails.git
   revision: 488699166c3558963fa82d4689a35f8c3fd93f47
   branch: 3-2-13
   specs:
@@ -61,7 +61,7 @@ GIT
       thor (>= 0.14.6, < 2.0)
 
 GIT
-  remote: git://github.com/svenfuchs/globalize3.git
+  remote: https://github.com/svenfuchs/globalize3.git
   revision: ee44def9b244f02a41c3687a73cf7c0165667e3d
   specs:
     globalize3 (0.3.0)
@@ -70,7 +70,7 @@ GIT
       paper_trail (~> 2)
 
 GIT
-  remote: git://github.com/tessi/sprockets.git
+  remote: https://github.com/tessi/sprockets.git
   revision: f8cf7a6d158f000096a94fb4be74195e8459d0fd
   branch: 2_2_1-backport
   specs:


### PR DESCRIPTION
HTTPs provides server authentication in contrast to the plain git protocol [1].

[1] http://git-scm.com/book/ch4-1.html#The-Git-Protocol
