### PR TITLE
fixes regression in using an attribute introduces in 318e93a

### DIFF
--- a/db/migrate/20100804112053_merge_wiki_versions_with_journals.rb
+++ b/db/migrate/20100804112053_merge_wiki_versions_with_journals.rb
@@ -34,10 +34,14 @@ class MergeWikiVersionsWithJournals < ActiveRecord::Migration
     WikiContent::Version.find_by_sql("SELECT * FROM wiki_content_versions").each do |wv|
       journal = WikiContentJournal.create!(:journaled_id => wv.wiki_content_id, :user_id => wv.author_id,
         :notes => wv.comments, :created_at => wv.updated_on, :activity_type => "wiki_edits")
-      changes = {}
-      changes["compression"] = wv.compression
-      changes["data"] = wv.data
-      journal.update_attribute(:changes, changes)
+      changed_data = {}
+      changed_data["compression"] = wv.compression
+      changed_data["data"] = wv.data
+      if journal.has_attribute? :changes
+        journal.update_attribute(:changes, changed_data)
+      else
+        journal.update_attribute(:changed_data, changed_data)
+      end
       journal.update_attribute(:version, wv.version)
     end
     # drop_table :wiki_content_versions


### PR DESCRIPTION
A fix for serializing an attribute declared as serializable intended for the rails 2.3 branch was applied without taking note of the altered attribute name introduced in the rails 3 branch. The purpose of the serialization fix is still valid though. So this commit fixes both, the serialization bug 318e93a intended to fix as well as the regression introduced by 318e93a.

Please see the diff with 3586197ef0da8a461bd3b5cee0cebaab80ec5b97 as it will ease reviewing.
