### PR TITLE
Feature/rails3 redmine i18n

### DIFF
--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -21,11 +21,11 @@ module ActiveRecord
     # Translate attribute names for validation errors display
     def self.human_attribute_name(attr, options = {})
       begin
-        options = options.merge({:raise => true})
-        super(attr, options)
+        options_with_raise = options.merge({:raise => true})
+        super(attr, options_with_raise)
       rescue I18n::MissingTranslationData => e
         warn "[DEPRECATION] Relying on Redmine::I18n addition of `field_` to your translation keys is deprecated. Please use proper ActiveRecord i18n!"
-        l("field_#{attr.to_s.gsub(/_id$/, '')}")
+        l("field_#{attr.to_s.gsub(/_id$/, '')}", options)
       end
     end
   end

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -24,6 +24,7 @@ module ActiveRecord
         options = options.merge({:raise => true})
         super(attr, options)
       rescue I18n::MissingTranslationData => e
+        warn "[DEPRECATION] Relying on Redmine::I18n addition of `field_` to your translation keys is deprecated. Please use proper ActiveRecord i18n!"
         l("field_#{attr.to_s.gsub(/_id$/, '')}")
       end
     end

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -20,7 +20,12 @@ module ActiveRecord
 
     # Translate attribute names for validation errors display
     def self.human_attribute_name(attr, options = {})
-      l("field_#{attr.to_s.gsub(/_id$/, '')}")
+      begin
+        options = options.merge({:raise => true})
+        super(attr, options)
+      rescue I18n::MissingTranslationData => e
+        l("field_#{attr.to_s.gsub(/_id$/, '')}")
+      end
     end
   end
 end


### PR DESCRIPTION
Recreates the original i18n behavior e.g. for looking up active_record attributes and deprecates the "field_" prefix custom lookup.
