### PR TITLE
fix missing translations in settings/issue tracking

### DIFF
--- a/app/views/settings/_issues.html.erb
+++ b/app/views/settings/_issues.html.erb
@@ -14,7 +14,7 @@
 
 <fieldset class="box settings"><legend><%= l(:setting_column_options) %></legend>
 <%= settings_multiselect([:issue_list_default_columns, :issue_list_summable_columns],
-  Query.new.available_columns.collect {|c| [c.caption, c.name.to_s]}, :label_choices => :label_columns) %>
+  Query.new.available_columns.collect {|c| [c.caption, c.name.to_s]}, :label_choices => :setting_issue_properties) %>
 </fieldset>
 
 <%= submit_tag l(:button_save) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -353,6 +353,7 @@ de:
   setting_time_format: Zeitformat
   setting_cross_project_issue_relations: Ticket-Beziehungen zwischen Projekten erlauben
   setting_column_options: Anpassen der Darstellung der Ticketlisten
+  setting_issue_properties: Ticket Eigenschaften
   setting_issue_list_default_columns: Standardmäßig anzeigen
   setting_issue_list_summable_columns: Summierbar
   setting_repositories_encodings: Kodierungen der Projektarchive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,6 +345,7 @@ en:
   setting_time_format: Time format
   setting_cross_project_issue_relations: Allow cross-project issue relations
   setting_column_options: Customize the appearance of the issue lists
+  setting_issue_properties: Issue properties
   setting_issue_list_default_columns: Display by default
   setting_issue_list_summable_columns: Summable
   setting_repositories_encodings: Repositories encodings


### PR DESCRIPTION
There was a missing translation in the settings dialog.

see: https://www.openproject.org/issues/429
