### PR TITLE
Feature/rails3 broken links in deep neested pages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -483,6 +483,11 @@ class User < Principal
   # * nil with options[:global] set : check if user has at least one role allowed for this action,
   #   or falls back to Non Member / Anonymous permissions depending if the user is logged
   def allowed_to?(action, context, options={})
+    if action.is_a?(Hash) && action[:controller] && action[:controller].starts_with?("/")
+      action = action.dup
+      action[:controller] = action[:controller][1..-1]
+    end
+
     if context.is_a?(Project)
       allowed_to_in_project?(action, context, options)
     elsif context.is_a?(Array)

--- a/features/issues/issue.feature
+++ b/features/issues/issue.feature
@@ -54,3 +54,10 @@ Feature: Issue textile quickinfo links
     Then I should see a quickinfo link with description for "issue1" within "div.wiki"
     When I follow the issue link with 3 hash for "issue1"
     Then I should be on the page of the issue "issue1"
+
+  Scenario: Navigating from issue reports back to issue overview
+    When I go to the issues/report page of the project called "parent"
+    And I follow "Issue" within "#main-menu"
+    Then I should be on the overall issues page
+    And I should have the following query string:
+      | project_id | parent |

--- a/features/issues/issue.feature
+++ b/features/issues/issue.feature
@@ -58,6 +58,4 @@ Feature: Issue textile quickinfo links
   Scenario: Navigating from issue reports back to issue overview
     When I go to the issues/report page of the project called "parent"
     And I follow "Issue" within "#main-menu"
-    Then I should be on the overall issues page
-    And I should have the following query string:
-      | project_id | parent |
+    Then I should be on the issues index page of the project called "parent"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -63,9 +63,6 @@ module NavigationHelpers
       issue = Issue.find_by_subject($1)
       "/issues/#{issue.id}"
 
-    when /^the overall issues page$/
-      "/issues"
-
     when /^the edit page (?:for|of) the issue "([^\"]+)"$/
       issue = Issue.find_by_subject($1)
       "/issues/#{issue.id}/edit"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -63,6 +63,9 @@ module NavigationHelpers
       issue = Issue.find_by_subject($1)
       "/issues/#{issue.id}"
 
+    when /^the overall issues page$/
+      "/issues"
+
     when /^the edit page (?:for|of) the issue "([^\"]+)"$/
       issue = Issue.find_by_subject($1)
       "/issues/#{issue.id}/edit"

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -72,14 +72,14 @@ Redmine::AccessControl.map do |map|
     # Issue categories
     map.permission :manage_categories, {:projects => :settings, :issue_categories => [:new, :create, :edit, :update, :destroy]}, :require => :member
     # Issues
-    map.permission :view_issues, {:issues => [:index, :all, :show],
+    map.permission :view_issues, {:'issues' => [:index, :all, :show],
                                   :auto_complete => [:issues],
                                   :context_menus => [:issues],
                                   :versions => [:index, :show, :status_by],
                                   :journals => [:index, :diff],
                                   :queries => :index,
                                   :'issues/reports' => [:report, :report_details]}
-    map.permission :export_issues, {:issues => [:index, :all]}
+    map.permission :export_issues, {:'issues' => [:index, :all]}
     map.permission :add_issues, {:issues => [:new, :create, :update_form],
                                  :'issues/previews' => :create}
     map.permission :edit_issues, {:issues => [:edit, :update, :bulk_edit, :bulk_update, :update_form],
@@ -163,14 +163,14 @@ end
 
 Redmine::MenuManager.map :top_menu do |menu|
   menu.push :home, :home_path
-  menu.push :my_page, { :controller => 'my', :action => 'page' }, :if => Proc.new { User.current.logged? }
-  menu.push :projects, { :controller => 'projects', :action => 'index' }, :caption => :label_project_plural # menu-item projects will be overwritten by base.rhtml
-  menu.push :administration, { :controller => 'admin', :action => 'projects' }, :if => Proc.new { User.current.admin? }, :last => true
+  menu.push :my_page, { :controller => '/my', :action => 'page' }, :if => Proc.new { User.current.logged? }
+  menu.push :projects, { :controller => '/projects', :action => 'index' }, :caption => :label_project_plural # menu-item projects will be overwritten by base.rhtml
+  menu.push :administration, { :controller => '/admin', :action => 'projects' }, :if => Proc.new { User.current.admin? }, :last => true
   menu.push :help, Redmine::Info.help_url, :last => true, :caption => "?", :html => { :accesskey => Redmine::AccessKeys.key_for(:help) }
 end
 
 Redmine::MenuManager.map :account_menu do |menu|
-  menu.push :my_account, { :controller => 'my', :action => 'account' }, :if => Proc.new { User.current.logged? }
+  menu.push :my_account, { :controller => '/my', :action => 'account' }, :if => Proc.new { User.current.logged? }
   menu.push :logout, :signout_path, :if => Proc.new { User.current.logged? }
 end
 
@@ -179,8 +179,8 @@ Redmine::MenuManager.map :application_menu do |menu|
 end
 
 Redmine::MenuManager.map :my_menu do |menu|
-  menu.push :account, {:controller => 'my', :action => 'account'}, :caption => :label_my_account
-  menu.push :password, {:controller => 'my', :action => 'password'}, :caption => :button_change_password, :if => Proc.new { User.current.change_password_allowed? }
+  menu.push :account, {:controller => '/my', :action => 'account'}, :caption => :label_my_account
+  menu.push :password, {:controller => '/my', :action => 'password'}, :caption => :button_change_password, :if => Proc.new { User.current.change_password_allowed? }
   menu.push :delete_account, :deletion_info_path,
                              :caption => I18n.t('account.delete'),
                              :param => :user_id,
@@ -188,46 +188,46 @@ Redmine::MenuManager.map :my_menu do |menu|
 end
 
 Redmine::MenuManager.map :admin_menu do |menu|
-  menu.push :projects, {:controller => 'admin', :action => 'projects'}, :caption => :label_project_plural
-  menu.push :users, {:controller => 'users'}, :caption => :label_user_plural
-  menu.push :groups, {:controller => 'groups'}, :caption => :label_group_plural
-  menu.push :roles, {:controller => 'roles'}, :caption => :label_role_and_permissions
-  menu.push :trackers, {:controller => 'trackers'}, :caption => :label_tracker_plural
-  menu.push :issue_statuses, {:controller => 'issue_statuses'}, :caption => :label_issue_status_plural,
+  menu.push :projects, {:controller => '/admin', :action => 'projects'}, :caption => :label_project_plural
+  menu.push :users, {:controller => '/users'}, :caption => :label_user_plural
+  menu.push :groups, {:controller => '/groups'}, :caption => :label_group_plural
+  menu.push :roles, {:controller => '/roles'}, :caption => :label_role_and_permissions
+  menu.push :trackers, {:controller => '/trackers'}, :caption => :label_tracker_plural
+  menu.push :issue_statuses, {:controller => '/issue_statuses'}, :caption => :label_issue_status_plural,
             :html => {:class => 'issue_statuses'}
-  menu.push :workflows, {:controller => 'workflows', :action => 'edit'}, :caption => :label_workflow
-  menu.push :custom_fields, {:controller => 'custom_fields'},  :caption => :label_custom_field_plural,
+  menu.push :workflows, {:controller => '/workflows', :action => 'edit'}, :caption => :label_workflow
+  menu.push :custom_fields, {:controller => '/custom_fields'},  :caption => :label_custom_field_plural,
             :html => {:class => 'custom_fields'}
-  menu.push :enumerations, {:controller => 'enumerations'}
-  menu.push :settings, {:controller => 'settings'}
-  menu.push :ldap_authentication, {:controller => 'ldap_auth_sources', :action => 'index'},
+  menu.push :enumerations, {:controller => '/enumerations'}
+  menu.push :settings, {:controller => '/settings'}
+  menu.push :ldap_authentication, {:controller => '/ldap_auth_sources', :action => 'index'},
             :html => {:class => 'server_authentication'}
-  menu.push :plugins, {:controller => 'admin', :action => 'plugins'}, :last => true
-  menu.push :info, {:controller => 'admin', :action => 'info'}, :caption => :label_information_plural, :last => true
+  menu.push :plugins, {:controller => '/admin', :action => 'plugins'}, :last => true
+  menu.push :info, {:controller => '/admin', :action => 'info'}, :caption => :label_information_plural, :last => true
 end
 
 Redmine::MenuManager.map :project_menu do |menu|
-  menu.push :overview, { :controller => 'projects', :action => 'show' }
-  menu.push :activity, { :controller => 'activities', :action => 'index' }, :param => :project_id
-  menu.push :roadmap, { :controller => 'versions', :action => 'index' }, :param => :project_id,
+  menu.push :overview, { :controller => '/projects', :action => 'show' }
+  menu.push :activity, { :controller => '/activities', :action => 'index' }, :param => :project_id
+  menu.push :roadmap, { :controller => '/versions', :action => 'index' }, :param => :project_id,
               :if => Proc.new { |p| p.shared_versions.any? }
 
-  menu.push :issues, { :controller => 'issues', :action => 'index' }, :param => :project_id, :caption => :label_issue_plural
-  menu.push :new_issue, { :controller => 'issues', :action => 'new' }, :param => :project_id, :caption => :label_issue_new, :parent => :issues,
+  menu.push :issues, { :controller => '/issues', :action => 'index' }, :param => :project_id, :caption => :label_issue_plural
+  menu.push :new_issue, { :controller => '/issues', :action => 'new' }, :param => :project_id, :caption => :label_issue_new, :parent => :issues,
               :html => { :accesskey => Redmine::AccessKeys.key_for(:new_issue) }
-  menu.push :view_all_issues, { :controller => 'issues', :action => 'all' }, :param => :project_id, :caption => :label_issue_view_all, :parent => :issues
-  menu.push :summary_field, {:controller => 'issues/reports', :action => 'report'}, :param => :project_id, :caption => :field_summary, :parent => :issues
-  menu.push :calendar, { :controller => 'calendars', :action => 'show' }, :param => :project_id, :caption => :label_calendar
-  menu.push :news, { :controller => 'news', :action => 'index' }, :param => :project_id, :caption => :label_news_plural
-  menu.push :new_news, { :controller => 'news', :action => 'new' }, :param => :project_id, :caption => :label_news_new, :parent => :news,
+  menu.push :view_all_issues, { :controller => '/issues', :action => 'all' }, :param => :project_id, :caption => :label_issue_view_all, :parent => :issues
+  menu.push :summary_field, {:controller => '/issues/reports', :action => 'report'}, :param => :project_id, :caption => :field_summary, :parent => :issues
+  menu.push :calendar, { :controller => '/calendars', :action => 'show' }, :param => :project_id, :caption => :label_calendar
+  menu.push :news, { :controller => '/news', :action => 'index' }, :param => :project_id, :caption => :label_news_plural
+  menu.push :new_news, { :controller => '/news', :action => 'new' }, :param => :project_id, :caption => :label_news_new, :parent => :news,
               :if => Proc.new { |p| User.current.allowed_to?(:manage_news, p.project) }
-  menu.push :documents, { :controller => 'documents', :action => 'index' }, :param => :project_id, :caption => :label_document_plural
-  menu.push :boards, { :controller => 'boards', :action => 'index', :id => nil }, :param => :project_id,
+  menu.push :documents, { :controller => '/documents', :action => 'index' }, :param => :project_id, :caption => :label_document_plural
+  menu.push :boards, { :controller => '/boards', :action => 'index', :id => nil }, :param => :project_id,
               :if => Proc.new { |p| p.boards.any? }, :caption => :label_board_plural
-  menu.push :files, { :controller => 'files', :action => 'index' }, :caption => :label_file_plural, :param => :project_id
-  menu.push :repository, { :controller => 'repositories', :action => 'show' },
+  menu.push :files, { :controller => '/files', :action => 'index' }, :caption => :label_file_plural, :param => :project_id
+  menu.push :repository, { :controller => '/repositories', :action => 'show' },
               :if => Proc.new { |p| p.repository && !p.repository.new_record? }
-  menu.push :settings, { :controller => 'projects', :action => 'settings' }, :caption => :label_project_settings, :last => true
+  menu.push :settings, { :controller => '/projects', :action => 'settings' }, :caption => :label_project_settings, :last => true
 end
 
 Redmine::Activity.map do |activity|

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -33,19 +33,19 @@ module Redmine::MenuManager::MenuHelper
     WikiMenuItem.main_items(project_wiki).each do |main_item|
       Redmine::MenuManager.loose :project_menu do |menu|
         menu.push "#{main_item.item_class}".to_sym,
-          { :controller => 'wiki', :action => 'show', :id => h(main_item.title) },
+          { :controller => '/wiki', :action => 'show', :id => h(main_item.title) },
             :param => :project_id, :caption => main_item.name
 
-        menu.push :"#{main_item.item_class}_new_page", {:action=>"new_child", :controller=>"wiki", :id => h(main_item.title) },
+        menu.push :"#{main_item.item_class}_new_page", {:action=>"new_child", :controller=>"/wiki", :id => h(main_item.title) },
           :param => :project_id, :caption => :create_child_page,
           :parent => "#{main_item.item_class}".to_sym if main_item.new_wiki_page and
             WikiPage.find_by_wiki_id_and_title(project_wiki.id, main_item.title)
 
-        menu.push :"#{main_item.item_class}_toc", {:action => 'index', :controller => 'wiki', :id => h(main_item.title)}, :param => :project_id, :caption => :label_table_of_contents, :parent => "#{main_item.item_class}".to_sym if main_item.index_page
+        menu.push :"#{main_item.item_class}_toc", {:action => 'index', :controller => '/wiki', :id => h(main_item.title)}, :param => :project_id, :caption => :label_table_of_contents, :parent => "#{main_item.item_class}".to_sym if main_item.index_page
 
         main_item.children.each do |child|
           menu.push "#{child.item_class}".to_sym,
-            { :controller => 'wiki', :action => 'show', :id => h(child.title) },
+            { :controller => '/wiki', :action => 'show', :id => h(child.title) },
               :param => :project_id, :caption => child.name, :parent => "#{main_item.item_class}".to_sym
         end
       end


### PR DESCRIPTION
When the user navigates into nested pages (e.g. /projects/foo/issues/report) the menu links were broken. See [openproject.org issue #426](https://www.openproject.org/issues/426)

This is now tested in a cuke, fixed, and ready for review.
