### PR TITLE
Allow plugins to disable core specs via rspec-example_disabler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
   gem 'database_cleaner'
   gem "cucumber-rails-training-wheels" # http://aslakhellesoy.com/post/11055981222/the-training-wheels-came-off
   gem "rspec-rails", "~> 2.0", :group => :development
+  gem 'rspec-example_disabler', :git => 'https://github.com/finnlabs/rspec-example_disabler.git'
   gem 'capybara'
   gem 'selenium-webdriver'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,12 @@ GIT
     object-daddy (1.1.0)
 
 GIT
+  remote: https://github.com/finnlabs/rspec-example_disabler.git
+  revision: 05b1af7d349865b3af39d603016803c958e0b95b
+  specs:
+    rspec-example_disabler (0.0.1)
+
+GIT
   remote: https://github.com/fnando/i18n-js.git
   revision: 8801f8d17ef96c48a7a0269e251fcf1648c8f441
   ref: 8801f8d17ef96c48a7a0269e251fcf1648c8f441
@@ -386,6 +392,7 @@ DEPENDENCIES
   rb-readline
   rdoc (>= 2.4.2)
   rmagick (>= 1.15.17)
+  rspec-example_disabler!
   rspec-rails (~> 2.0)
   ruby-openid (~> 2.1.4)
   ruby-prof

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 
 require 'rspec/autorun'
+require 'rspec/example_disabler'
 require 'capybara/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
@@ -51,3 +52,11 @@ RSpec.configure do |config|
   end
 end
 
+# load disable_specs.rbs from plugins
+Rails.application.config.plugins_to_test_paths.each do |dir|
+  disable_specs_file = File.join(dir, 'spec', 'disable_specs.rb')
+  if File.exists?(disable_specs_file)
+    puts 'Loading ' + disable_specs_file
+    require disable_specs_file
+  end
+end


### PR DESCRIPTION
Plugins can create a spec/disable_specs.rb and call
RSpec::ExampleDisabler.disable_example from there.

Also see https://github.com/finnlabs/rspec-example_disabler
