### PR TITLE
fix for not beeing able to add related issues (#384)

### DIFF
--- a/app/views/issue_relations/_form.html.erb
+++ b/app/views/issue_relations/_form.html.erb
@@ -1,14 +1,15 @@
 <%= error_messages_for 'relation' %>
 
-<p><%= f.select :relation_type, collection_for_relation_type_select, {}, :onchange => "setPredecessorFieldsVisibility();" %>
-<%= l(:label_issue) %> #<%= f.text_field :issue_to_id, :size => 10 %>
-<div id="related_issue_candidates" class="autocomplete"></div>
-<%= javascript_tag "observeRelatedIssueField('#{issues_auto_complete_path(:id => @issue, :project_id => @project, :escape => false) }')" %>
-<span id="predecessor_fields" style="display:none;">
-<%= l(:field_delay) %>: <%= f.text_field :delay, :size => 3 %> <%= l(:label_day_plural) %>
-</span>
-<%= submit_tag l(:button_add) %>
-<%= toggle_link l(:button_cancel), 'new-relation-form'%>
+<p>
+  <%= f.select :relation_type, collection_for_relation_type_select, {}, :onchange => "setPredecessorFieldsVisibility();" %>
+  <%= l(:label_issue) %> #<%= f.text_field :issue_to_id, :size => 10 %>
+  <div id="related_issue_candidates" class="autocomplete"></div>
+  <%= javascript_tag "observeRelatedIssueField('#{issues_auto_complete_path(:id => @issue, :project_id => @project, :escape => false) }')" %>
+  <span id="predecessor_fields" style="display:none;">
+    <%= l(:field_delay) %>: <%= f.text_field :delay, :size => 3 %> <%= l(:label_day_plural) %>
+  </span>
+  <%= submit_tag l(:button_add) %>
+  <%= toggle_link l(:button_cancel), 'new-relation-form'%>
 </p>
 
 <%= javascript_tag "setPredecessorFieldsVisibility();" %>

--- a/app/views/issues/_relations.html.erb
+++ b/app/views/issues/_relations.html.erb
@@ -5,11 +5,11 @@
   <% end %>
 </p>
 
-<% if @relations.present? %>
 <table style="width:100%">
-  <%= render :partial => 'issues/relation', :collection => @relations, :as => :relation %>
+  <tbody>
+    <%= render :partial => 'issues/relation', :collection => @relations, :as => :relation -%>
+  </tbody>
 </table>
-<% end %>
 
 <%= form_for(@issue.new_relation,
              :as => :relation,

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -21,66 +21,65 @@
 
   <div class="meta">
     <table class="attributes">
-    <tr>
+      <tr>
         <th class="status"><%=l(:field_status)%>:</th><td class="status"><%= h(@issue.status.name) %></td>
         <th class="start-date"><%=l(:field_start_date)%>:</th><td class="start-date"><%= format_date(@issue.start_date) %></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <th class="priority"><%=l(:field_priority)%>:</th><td class="priority"><%= h(@issue.priority.name) %></td>
         <th class="due-date"><%=l(:field_due_date)%>:</th><td class="due-date"><%= format_date(@issue.due_date) %></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <th class="assigned-to"><%=l(:field_assigned_to)%>:</th><td class="assigned-to"><%= avatar(@issue.assigned_to, :size => "14") %><%= @issue.assigned_to ? link_to_user(@issue.assigned_to) : "-" %></td>
         <th class="progress"><%=l(:field_done_ratio)%>:</th><td class="progress"><%= progress_bar @issue.done_ratio, :width => '80px', :legend => "#{@issue.done_ratio}%" %></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <th class="category"><%=l(:field_category)%>:</th><td class="category"><%=h(@issue.category ? @issue.category.name : "-") %></td>
         <% if User.current.allowed_to?(:view_time_entries, @project) %>
-        <th class="spent-time"><%=l(:label_spent_time)%>:</th>
-        <td class="spent-time"><%= @issue.spent_hours > 0 ? (link_to l_hours(@issue.spent_hours), issue_time_entries_path(@issue)) : "-" %></td>
+          <th class="spent-time"><%=l(:label_spent_time)%>:</th>
+          <td class="spent-time"><%= @issue.spent_hours > 0 ? (link_to l_hours(@issue.spent_hours), issue_time_entries_path(@issue)) : "-" %></td>
         <% end %>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <th class="fixed-version"><%=l(:field_fixed_version)%>:</th><td class="fixed-version"><%= @issue.fixed_version ? link_to_version(@issue.fixed_version) : "-" %></td>
         <% if @issue.estimated_hours %>
-        <th class="estimated-hours"><%=l(:field_estimated_hours)%>:</th><td class="estimated-hours"><%= l_hours(@issue.estimated_hours) %></td>
+          <th class="estimated-hours"><%=l(:field_estimated_hours)%>:</th><td class="estimated-hours"><%= l_hours(@issue.estimated_hours) %></td>
         <% end %>
-    </tr>
-    <%= render_custom_fields_rows(@issue) %>
-    <%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
+      </tr>
+      <%= render_custom_fields_rows(@issue) %>
+      <%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
     </table>
   </div><!-- .meta -->
 
-<% if @issue.description? %>
+  <% if @issue.description? %>
+    <div class="description">
+      <hr />
+      <div class="contextual">
+        <%= link_to_remote_if_authorized(l(:button_quote), { :url => {:controller => '/journals', :action => 'new', :id => @issue} }, :class => 'icon icon-comment') %>
+      </div>
+      <p><strong><%=l(:field_description)%></strong></p>
+      <div class="wiki">
+        <%= textilizable @issue, :description, :attachments => @issue.attachments %>
+      </div>
+    </div>
+  <% end %>
 
-  <div class="description">
-    <hr />
-	  <div class="contextual">
-	    <%= link_to_remote_if_authorized(l(:button_quote), { :url => {:controller => '/journals', :action => 'new', :id => @issue} }, :class => 'icon icon-comment') %>
-	  </div>
+  <% if @issue.attachments.any? -%>
+    <%= link_to_attachments @issue %>
+  <% end -%>
 
-        <p><strong><%=l(:field_description)%></strong></p>
-        <div class="wiki">
-          <%= textilizable @issue, :description, :attachments => @issue.attachments %>
-        </div>
-</div>
-<% end %>
+  <%= call_hook(:view_issues_show_description_bottom, :issue => @issue) %>
 
-<% if @issue.attachments.any? -%>
-<%= link_to_attachments @issue %>
-<% end -%>
+  <hr />
 
-<%= call_hook(:view_issues_show_description_bottom, :issue => @issue) %>
+  <%= render :partial => 'subissues_paragraph' %>
 
-<hr />
+  <% if authorize_for('issue_relations', 'create') || @relations.present? %>
+    <div id="relations">
+      <%= render :partial => 'relations' %>
+    </div>
+  <% end %>
 
-<%= render :partial => 'subissues_paragraph' %>
-
-<% if authorize_for('issue_relations', 'create') || @relations.present? %>
-<div id="relations">
-<%= render :partial => 'relations' %>
-</div>
-<% end %>
   <% if User.current.allowed_to?(:add_issue_watchers, @project) ||
     (@issue.watchers.present? && User.current.allowed_to?(:view_issue_watchers, @project)) %>
     <div id="watchers">
@@ -91,17 +90,17 @@
 <div style="clear: both;"></div>
 
 <% if @changesets.present? %>
-<div id="issue-changesets">
-<h3><%=l(:label_associated_revisions)%></h3>
-<%= render :partial => 'changesets', :locals => { :changesets => @changesets} %>
-</div>
+  <div id="issue-changesets">
+    <h3><%=l(:label_associated_revisions)%></h3>
+    <%= render :partial => 'changesets', :locals => { :changesets => @changesets} %>
+  </div>
 <% end %>
 
 <% if @journals.present? %>
-<div id="history">
-<h3><%=l(:label_history)%></h3>
-<%= render :partial => 'history', :locals => { :issue => @issue, :journals => @journals } %>
-</div>
+  <div id="history">
+    <h3><%=l(:label_history)%></h3>
+    <%= render :partial => 'history', :locals => { :issue => @issue, :journals => @journals } %>
+  </div>
 <% end %>
 
 
@@ -129,8 +128,8 @@
 <% end %>
 
 <% content_for :header_tags do %>
-    <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.rss_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
-    <%= stylesheet_link_tag 'context_menu_rtl' if l(:direction) == 'rtl' %>
+  <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.rss_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
+  <%= stylesheet_link_tag 'context_menu_rtl' if l(:direction) == 'rtl' %>
 <% end %>
 <div id="context-menu" style="display: none;"></div>
 <%= javascript_tag "new ContextMenu('#{issues_context_menu_path}')" %>

--- a/features/issues/relations.feature
+++ b/features/issues/relations.feature
@@ -1,0 +1,31 @@
+Feature: Relating issues to each other
+
+  Background:
+    Given there is 1 user with the following:
+      | login | bob |
+    And there is a role "member"
+    And the role "member" may have the following rights:
+      | view_issues   |
+    And there is 1 project with the following:
+      | name       | project1 |
+      | identifier | project1 |
+    And the project "project1" has the following trackers:
+      | name | position |
+      | Bug  |     1    |
+    And the user "bob" is a "member" in the project "project1"
+    And the user "bob" has 1 issue with the following:
+      | subject | Some Issue |
+    And the user "bob" has 1 issue with the following:
+      | subject | Another Issue |
+    And I am logged in as "admin"
+
+  @javascript
+  Scenario: Adding a relation will add it to the list of related issues through AJAX instantly
+    When I go to the page of the issue "Some Issue"
+    And I click on "Add related issue"
+    And I fill in "relation_issue_to_id" with "2"
+    And I press "Add"
+    And I wait for the AJAX requests to finish
+    Then I should be on the page of the issue "Some Issue"
+    And I should see "related to Bug #2: Another Issue"
+


### PR DESCRIPTION
always render the table, even if it's empty. this allows jquery to have an anchor to put content in. also explicitly add the <tbody> tag since the corresponding jquery code uses that one. this worked before because (at least) chrome adds implicit <tbody> tags if missing and the table isn't empty. fixes #384.
