### PR TITLE
improves deprecation warning message and allows passing default values

### DIFF
--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -21,11 +21,11 @@ module ActiveRecord
     # Translate attribute names for validation errors display
     def self.human_attribute_name(attr, options = {})
       begin
-        options_with_raise = options.merge({:raise => true, :default => false})
+        options_with_raise = {:raise => true, :default => false}.merge options
         super(attr, options_with_raise)
       rescue I18n::MissingTranslationData => e
         # TODO: remove this method once no warning is displayed when running a server/console/tests/tasks etc.
-        warn "[DEPRECATION] Relying on Redmine::I18n addition of `field_` to your translation keys is deprecated. Please use proper ActiveRecord i18n!"
+        warn "[DEPRECATION] Relying on Redmine::I18n addition of `field_` to your translation key \"#{attr}\" on the \"#{self}\" model is deprecated. Please use proper ActiveRecord i18n!"
         l("field_#{attr.to_s.gsub(/_id$/, '')}", options)
       end
     end


### PR DESCRIPTION
- states the key and model for which the human_attribute_name is
  inquired
- have the raise and default option only as a fallback when nothing else
  is supplied. Doing this allows for model classes to pass additional
  attributes.
