### PR TITLE
Improves check for api requests.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -514,7 +514,11 @@ class ApplicationController < ActionController::Base
   end
 
   def api_request?
-    %w(xml json).include? params[:format]
+    if params[:format].nil?
+      %w(application/xml application/json).include? request.format.to_s
+    else
+      %w(xml json).include? params[:format]
+    end
   end
 
   # Returns the API key present in the request


### PR DESCRIPTION
Timelines introduces a case where the json format is negotiated
but not represented in the format parameter via routes (i.e., the
extension ".json"). This change adds support for Accept-header content
negotiation, which results in the format field of the request. For
consistency, xml was also added.

This is tested via an application_controller spec in the rails2-core, the test breaks in rails3 and is therefore replaced with a proper new spec in the timelines domain. You can find the original pull request at https://github.com/opf/openproject/pull/86 and the original test at https://github.com/finnlabs/core_tests/commit/d61686a0ccaab8ac9ddf2087d6157c0e36ec5a0f.
