### PR TITLE
fixes estimated_hours validation on issues 

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -265,7 +265,8 @@ class Issue < ActiveRecord::Base
   alias_method_chain(:attributes=, :tracker_first) unless method_defined?(:attributes_without_tracker_first=)
 
   def estimated_hours=(h)
-    write_attribute :estimated_hours, (h.is_a?(String) ? h.to_hours : h)
+    converted_hours = (h.is_a?(String) ? h.to_hours : h)
+    write_attribute :estimated_hours, !!converted_hours ? converted_hours : h
   end
 
   safe_attributes 'tracker_id',

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -78,6 +78,16 @@ describe Issue do
 
         initial_journal.should be_identical(recreated_journal)
       end
+
+      it "should not validate with oddly set estimated_hours" do
+        @issue.estimated_hours = "this should not work"
+        @issue.should_not be_valid
+      end
+
+      it "should validate with sane estimated_hours" do
+        @issue.estimated_hours = "13h"
+        @issue.should be_valid
+      end
     end
   end
 end


### PR DESCRIPTION
... by explicitly making it fail on invalid input strings
