### PR TITLE
[OPF #478] fixes wiki page renaming

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -198,7 +198,7 @@ class WikiController < ApplicationController
     @page.redirect_existing_links = true
     # used to display the *original* title if some AR validation errors occur
     @original_title = @page.pretty_title
-    if request.post? && @page.update_attributes(params[:wiki_page])
+    if request.put? && @page.update_attributes(params[:wiki_page])
       flash[:notice] = l(:notice_successful_update)
       redirect_to :action => 'show', :project_id => @project, :id => @page.title
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ OpenProject::Application.routes.draw do
         get '/diff/:version/vs/:version_from' => 'wiki#diff', :as => 'wiki_diff'
         get '/diff(/:version)' => 'wiki#diff', :as => 'wiki_diff'
         get '/annotate/:version' => 'wiki#annotate', :as => 'wiki_annotate'
-        match :rename, :via => [:get, :post]
+        match :rename, :via => [:get, :put]
         get :history
         post :preview
         post :protect

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -283,9 +283,9 @@ class WikiControllerTest < ActionController::TestCase
 
   def test_rename_with_redirect
     @request.session[:user_id] = 2
-    post :rename, :project_id => 1, :id => 'Another_page',
-                            :wiki_page => { :title => 'Another renamed page',
-                                            :redirect_existing_links => 1 }
+    put :rename, :project_id => 1, :id => 'Another_page',
+                 :wiki_page => { :title => 'Another renamed page',
+                                 :redirect_existing_links => 1 }
     assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_renamed_page'
     wiki = Project.find(1).wiki
     # Check redirects
@@ -295,9 +295,9 @@ class WikiControllerTest < ActionController::TestCase
 
   def test_rename_without_redirect
     @request.session[:user_id] = 2
-    post :rename, :project_id => 1, :id => 'Another_page',
-                            :wiki_page => { :title => 'Another renamed page',
-                                            :redirect_existing_links => "0" }
+    put :rename, :project_id => 1, :id => 'Another_page',
+                 :wiki_page => { :title => 'Another renamed page',
+                                 :redirect_existing_links => "0" }
     assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_renamed_page'
     wiki = Project.find(1).wiki
     # Check that there's no redirects
@@ -306,16 +306,20 @@ class WikiControllerTest < ActionController::TestCase
 
   def test_rename_with_parent_assignment
     @request.session[:user_id] = 2
-    post :rename, :project_id => 1, :id => 'Another_page',
-      :wiki_page => { :title => 'Another page', :redirect_existing_links => "0", :parent_id => '4' }
+    put :rename, :project_id => 1, :id => 'Another_page',
+                 :wiki_page => { :title => 'Another page',
+                                 :redirect_existing_links => "0",
+                                 :parent_id => '4' }
     assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_page'
     assert_equal WikiPage.find(4), WikiPage.find_by_title('Another_page').parent
   end
 
   def test_rename_with_parent_unassignment
     @request.session[:user_id] = 2
-    post :rename, :project_id => 1, :id => 'Child_1',
-      :wiki_page => { :title => 'Child 1', :redirect_existing_links => "0", :parent_id => '' }
+    put :rename, :project_id => 1, :id => 'Child_1',
+                 :wiki_page => { :title => 'Child 1',
+                                 :redirect_existing_links => "0",
+                                 :parent_id => '' }
     assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Child_1'
     assert_nil WikiPage.find_by_title('Child_1').parent
   end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -974,7 +974,7 @@ class RoutingTest < ActionDispatch::IntegrationTest
                                                                                    :action => 'preview',
                                                                                    :project_id => '567',
                                                                                    :id => 'CookBook_documentation' )
-      should route(:post, "/projects/22/wiki/ladida/rename").to( :controller => 'wiki',
+      should route(:put, "/projects/22/wiki/ladida/rename").to( :controller => 'wiki',
                                                                  :action => 'rename',
                                                                  :project_id => '22',
                                                                 :id => 'ladida' )


### PR DESCRIPTION
- changed wiki#rename routes to rails default 'put'
- adapted tests
