### PR TITLE
html mails show a link to an updated attachment instead of just the name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -153,12 +153,16 @@ module ApplicationHelper
   def link_to_attachment(attachment, options={})
     text = options.delete(:text) || attachment.filename
     action = options.delete(:download) ? 'download' : 'show'
+    only_path = options.delete(:only_path) { true }
 
     link_to h(text),
             {:controller => '/attachments',
              :action => action,
              :id => attachment,
-             :filename => attachment.filename },
+             :filename => attachment.filename,
+             :host => Setting.host_name,
+             :protocol => Setting.protocol,
+             :only_path => only_path },
             options
   end
 

--- a/app/views/user_mailer/issue_updated.html.erb
+++ b/app/views/user_mailer/issue_updated.html.erb
@@ -2,7 +2,7 @@
 
 <ul>
 <% @journal.details.each do |detail| %>
-  <li><%= @journal.render_detail(detail, :no_html => true) %></li>
+  <li><%= @journal.render_detail(detail) %></li>
 <% end %>
 </ul>
 

--- a/lib/open_project/journal_formatter/attachment.rb
+++ b/lib/open_project/journal_formatter/attachment.rb
@@ -33,7 +33,7 @@ class OpenProject::JournalFormatter::Attachment < ::JournalFormatter::Base
 
   def format_html_attachment_detail(key, value)
     if !value.blank? && a = Attachment.find_by_id(key.to_i)
-      link_to_attachment(a)
+      link_to_attachment(a, :only_path => false )
     else
       value if value.present?
     end

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -69,7 +69,7 @@ module JournalFormatter
 
     return nil if formatter.nil?
 
-    formatter.render(key, values, options)
+    formatter.render(key, values, options).html_safe
   end
 
   def formatter_instance(formatter_key)

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -913,6 +913,9 @@ class IssuesControllerTest < ActionController::TestCase
   end
 
   def test_put_update_with_attachment_only
+    Setting.host_name = 'mydomain.foo'
+    Setting.protocol = 'https'
+
     set_tmp_attachments_directory
 
     # anonymous user
@@ -928,7 +931,8 @@ class IssuesControllerTest < ActionController::TestCase
     assert_equal User.anonymous, j.user
 
     mail = ActionMailer::Base.deliveries.last
-    assert mail.body.encoded.include?('testfile.txt')
+    assert mail.text_part.body.encoded.include?('testfile.txt')
+    assert mail.html_part.body.encoded =~ /<a href="https:\/\/mydomain.foo\/attachments\/\d+\/testfile.txt">testfile.txt<\/a>/
   end
 
   def test_put_update_with_attachment_that_fails_to_save

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -67,8 +67,10 @@ class UserMailerTest < ActionMailer::TestCase
                     "https://mydomain.foo/issues/#{issue.id}",
                     :text => "My Tracker ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li',
-                    :text => "Description changed (https://mydomain.foo/journals/#{journal.id}/diff/description)"
+      assert_select 'li', :text => /Description changed/
+      assert_select 'li>a[href=?]',
+                    "https://mydomain.foo/journals/#{journal.id}/diff/description",
+                    :text => "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "https://mydomain.foo/issues/#{related_issue.id}",
@@ -103,8 +105,10 @@ class UserMailerTest < ActionMailer::TestCase
                     "http://mydomain.foo/rdm/issues/#{issue.id}",
                     :text => "My Tracker ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li',
-                    :text => "Description changed (http://mydomain.foo/rdm/journals/#{journal.id}/diff/description)"
+      assert_select 'li', :text => /Description changed/
+      assert_select 'li>a[href=?]',
+                    "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
+                    :text => "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/issues/#{related_issue.id}",
@@ -142,8 +146,10 @@ class UserMailerTest < ActionMailer::TestCase
                     "http://mydomain.foo/rdm/issues/#{issue.id}",
                     :text => "My Tracker ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li',
-                    :text => "Description changed (http://mydomain.foo/rdm/journals/#{journal.id}/diff/description)"
+      assert_select 'li', :text => /Description changed/
+      assert_select 'li>a[href=?]',
+                    "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
+                    :text => "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/issues/#{related_issue.id}",


### PR DESCRIPTION
fix for issue #366
