### PR TITLE
removes cuke step conflicting with within

### DIFF
--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -4,12 +4,6 @@ Then /^I should (not )?see "([^"]*)"\s*\#.*$/ do |negative, name|
   }
 end
 
-Then /^I should (not )?see "([^"]*)" within "([^"]*)"\s*\#.*$/ do |negative, name, scope|
-  steps %Q{
-    Then I should #{negative}see "#{name}" within "#{scope}"
-  }
-end
-
 When /^I click(?:| on) "([^"]*)"$/ do |name|
   click_link_or_button name
 end


### PR DESCRIPTION
As "within" is used by a general step to scope another step, the step removed here is no longer needed and in fact leads to an ambiguous step error.
