### PR TITLE
Fixes Members Edit Button

### DIFF
--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -25,7 +25,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="splitcontentleft">
 <% if @members.any? %>
-  <% authorized = authorize_for('members', 'edit') %>
+  <% authorized = authorize_for('members', 'update') %>
 <table class="list members">
 	<thead><tr>
 	  <th><%= User.model_name.human %> / <%= Group.model_name.human %></th>
@@ -41,7 +41,10 @@ See doc/COPYRIGHT.rdoc for more details.
   <td class="roles">
     <span id="member-<%= member.id %>-roles"><%=h member.roles.sort.collect(&:to_s).join(', ') %></span>
     <% if authorized %>
-      <%= form_for(member, :url => {:controller => '/members', :action => 'edit', :id => member, :page => params[:page]},
+      <%= form_for(member, :url => {:controller => '/members',
+                                    :action => 'update',
+                                    :id => member,
+                                    :page => params[:page]},
                            :method => :put,
                            :remote => true,
                            :html => { :id => "member-#{member.id}-roles-form", :class => 'hol', :style => 'display:none' }) do |f| %>

--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -56,15 +56,15 @@ See doc/COPYRIGHT.rdoc for more details.
         <p><%= submit_tag l(:button_change), :class => "small" %>
         <%= link_to_function l(:button_cancel), "$('member-#{member.id}-roles').show(); $('member-#{member.id}-roles-form').hide(); return false;" %></p>
       <% end %>
+      <td class="buttons">
+          <%= link_to_function l(:button_edit), "$('member-#{member.id}-roles').hide(); $('member-#{member.id}-roles-form').show(); return false;", :class => 'icon icon-edit' %>
+          <%= link_to(l(:button_delete), {:controller => '/members', :action => 'destroy', :id => member, :page => params[:page]},
+                :method => :delete,
+                :remote => true,
+                :confirm => ((!User.current.admin? && member.include?(User.current)) ? l(:text_own_membership_delete_confirmation) : nil),
+                :title => l(:button_delete), :class => 'icon icon-del') if member.deletable? %>
+      </td>
     <% end %>
-  </td>
-  <td class="buttons">
-      <%= link_to_function l(:button_edit), "$('member-#{member.id}-roles').hide(); $('member-#{member.id}-roles-form').show(); return false;", :class => 'icon icon-edit' %>
-      <%= link_to(l(:button_delete), {:controller => '/members', :action => 'destroy', :id => member, :page => params[:page]},
-            :method => :delete,
-            :remote => true,
-            :confirm => ((!User.current.admin? && member.include?(User.current)) ? l(:text_own_membership_delete_confirmation) : nil),
-            :title => l(:button_delete), :class => 'icon icon-del') if member.deletable? %>
   </td>
   <%= call_hook(:view_projects_settings_members_table_row, { :project => @project, :member => member}) %>
 	</tr>

--- a/features/groups/group_memberships.feature
+++ b/features/groups/group_memberships.feature
@@ -66,7 +66,7 @@ Feature: Group Memberships
      Then I should see "Successful creation." within ".flash.notice"
 
       And I check "A-Team"
-      And I check "Developer"
+      And I check "Developer" within "#principals"
       And I press "Add"
       And I wait for the AJAX requests to finish
      Then I should see "Successful creation." within ".flash.notice"

--- a/features/groups/group_memberships.feature
+++ b/features/groups/group_memberships.feature
@@ -45,9 +45,8 @@ Feature: Group Memberships
 
      When I go to the settings page of the project called "Project1"
       And I click on "tab-members"
-      And I check "A-Team"
-      And I check "Manager"
-      And I press "Add"
+      And I add the principal "A-Team" as a member with the roles:
+        | Manager |
      Then I should be on the settings page of the project called "Project1"
       And I should see "A-Team" within ".members"
       And I should see "Bob Bobbit" within ".members"
@@ -59,15 +58,13 @@ Feature: Group Memberships
 
      When I go to the settings page of the project called "Project1"
       And I click on "tab-members"
-      And I check "Bob Bobbit"
-      And I check "Manager"
-      And I press "Add"
+      And I add the principal "Bob Bobbit" as a member with the roles:
+        | Manager |
       And I wait for the AJAX requests to finish
      Then I should see "Successful creation." within ".flash.notice"
 
-      And I check "A-Team"
-      And I check "Developer" within "#principals"
-      And I press "Add"
+      And I add the principal "A-Team" as a member with the roles:
+        | Developer |
       And I wait for the AJAX requests to finish
      Then I should see "Successful creation." within ".flash.notice"
 
@@ -86,9 +83,8 @@ Feature: Group Memberships
 
      When I go to the settings page of the project called "Project1"
       And I click on "tab-members"
-      And I check "A-Team"
-      And I check "Manager"
-      And I press "Add"
+      And I add the principal "A-Team" as a member with the roles:
+        | Manager |
 
      Then I should be on the settings page of the project called "Project1"
       And I wait for the AJAX requests to finish

--- a/features/projects/settings.feature
+++ b/features/projects/settings.feature
@@ -1,0 +1,47 @@
+Feature: Project Settings
+  Background:
+    Given there is 1 project with the following:
+      | name        | project1 |
+      | identifier  | project1 |
+    And there is 1 user with the following:
+      | login     | bob        |
+      | firstname | Bob        |
+      | Lastname  | Bobbit     |
+    And there is 1 user with the following:
+      | login     | alice      |
+      | firstname | Alice      |
+      | Lastname  | Alison     |
+    And there is a role "alpha"
+    And there is a role "beta"
+    And the user "bob" is a "alpha" in the project "project1"
+    And the user "alice" is a "beta" in the project "project1"
+
+  @javascript
+  Scenario: Adding a Role to a Member
+    Given I am logged in as "admin"
+    When I go to the members tab of the settings page of the project "project1"
+    When I click on "Edit" within "#member-1"
+    And I check "beta" within "#member-1-roles-form"
+    And I click "Change" within "#member-1-roles-form"
+    Then I should see "alpha" within "#member-1-roles"
+    And I should see "beta" within "#member-1-roles"
+
+@javascript
+  Scenario: Removing one Role from while adding another Role to a Member
+    Given I am logged in as "admin"
+    When I go to the members tab of the settings page of the project "project1"
+    When I click on "Edit" within "#member-1"
+    And I uncheck "alpha" within "#member-1-roles-form"
+    And I check "beta" within "#member-1-roles-form"
+    And I click "Change" within "#member-1-roles-form"
+    Then I should see "beta" within "#member-1-roles"
+    And I should not see "alpha" within "#member-1-roles"
+
+@javascript
+  Scenario: Removing the last Role of a Member
+    Given I am logged in as "admin"
+    When I go to the members tab of the settings page of the project "project1"
+    When I click on "Edit" within "#member-1"
+    And I uncheck "alpha" within "#member-1-roles-form"
+    And I click "Change" within "#member-1-roles-form"
+    Then I should not see "Bob Bobbit" within ".list.members"

--- a/features/step_definitions/group_steps.rb
+++ b/features/step_definitions/group_steps.rb
@@ -52,11 +52,6 @@ Given /^there is a group named "(.*?)" with the following members:$/ do |name, t
   end
 end
 
-When /^I delete the "([^"]*)" membership$/ do |group_name|
-  membership = member_for_login(group_name)
-  step %Q(I follow "Delete" within "#member-#{membership.id}")
-end
-
 When /^I delete "([^"]*)" from the group$/ do |login|
   user = User.find_by_login!(login)
   step %Q(I follow "Delete" within "#user-#{user.id}")

--- a/features/step_definitions/project_member_steps.rb
+++ b/features/step_definitions/project_member_steps.rb
@@ -80,6 +80,11 @@ When /^I filter for the user "(.+?)"$/ do |login|
   filter_user_by_login login
 end
 
+When /^I delete the "([^"]*)" membership$/ do |group_name|
+  membership = member_for_login(group_name)
+  step %Q(I follow "Delete" within "#member-#{membership.id}")
+end
+
 def member_for_login principal_name
   principal = InstanceFinder.find(Principal, principal_name)
 


### PR DESCRIPTION
The edit button inside Member-Tab project's settings was broken, all it did was hide the text of a user's assigned roles. The only way to assign more/less roles to a user was to delete his/her membership and create a new one with the respective values.

The url for the editing a user's value was changed somewhere from #edit to #update, and this was not reflected in the code.
