### PR TITLE
Use thin instead of WEBrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :development do
   gem 'guard-spork'
   gem 'rb-fsevent', :group => :test
   gem 'rack-mini-profiler'
+  gem 'thin'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
       rails (~> 3.0)
     cucumber-rails-training-wheels (1.0.0)
       cucumber-rails (>= 1.1.1)
+    daemons (1.1.9)
     dalli (2.6.2)
     database_cleaner (0.9.1)
     debug_inspector (0.0.2)
@@ -139,6 +140,7 @@ GEM
       delayed_job (~> 3.0)
     diff-lcs (1.2.4)
     erubis (2.7.0)
+    eventmachine (1.0.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (4.2.0)
@@ -318,6 +320,10 @@ GEM
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.18.1)
     tilt (1.4.0)
     tinymce-rails (3.5.8.2)
@@ -405,6 +411,7 @@ DEPENDENCIES
   sqlite3-ruby (< 1.3)
   strong_parameters
   therubyracer
+  thin
   tinymce-rails
   tinymce-rails-langs
   uglifier (>= 1.0.3)


### PR DESCRIPTION
Use thin instead of WEBrick, to get rid of the 'WARN Could not determine content-length of response body' Errors (a bug in WEBrick)

see: http://stackoverflow.com/questions/9612618/warn-could-not-determine-content-length-of-response-body-set-content-length-of
