### PR TITLE
adds a step for using the action menu

### DIFF
--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -9,3 +9,33 @@ end
 Then /^there should be no menu item selected$/ do
   page.should_not have_css("#main-menu .selected")
 end
+
+When /^I select "(.+?)" from the action menu$/ do |entry_name|
+  within(action_menu_selector) do
+    if !find_link(entry_name).visible?
+      click_link(I18n.t(:more_actions))
+    end
+
+    click_link(entry_name, :visible => false)
+  end
+end
+
+Then /^there should not be a "(.+?)" entry in the action menu$/ do |entry_name|
+  within(action_menu_selector) do
+    should_not have_link(entry_name)
+  end
+end
+
+def action_menu_selector
+  # supports both the old and the new selector for the action menu
+  # please note that using this with the old .contextual selector takes longer
+  # as capybara waits for the new .action_menu_main selector to appear
+
+  if has_css?(".action_menu_main", :visible => true)
+    all(".action_menu_main", :visible => true).first
+  elsif has_css?(".contextual", :visible => true)
+    all(".contextual", :visible => true).first
+  else
+    raise "No action menu on the current page"
+  end
+end

--- a/features/users/deleting.feature
+++ b/features/users/deleting.feature
@@ -28,7 +28,7 @@ Feature: User deletion
       | login     | bob |
     And I am already logged in as "admin"
     When I go to the edit page of the user "bob"
-    And I follow "Delete" within ".contextual"
+    And I select "Delete" from the action menu
     And I press "Delete"
     And I accept the alert dialog
     Then I should see "Account successfully deleted"
@@ -40,7 +40,7 @@ Feature: User deletion
       | login     | bob |
     And I am already logged in as "admin"
     And I go to the edit page of the user "bob"
-    Then I should not see "Delete" within ".contextual"
+    Then there should not be a "Delete" entry in the action menu
 
   Scenario: Deletablilty settings can be set in the users tab of the settings
     Given I am already logged in as "admin"


### PR DESCRIPTION
Uses it for the user deletion step which breaks once a plugin adds another (invisible) contextual div
