### PR TITLE
removes i18n currency fields for de causing havoc in rails internals

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -78,9 +78,6 @@ de:
       format:
         unit: '€'
         format: '%n %u'
-        separator:
-        delimiter:
-        precision:
     percentage:
       format:
         delimiter: ""


### PR DESCRIPTION
Having the currency fields (i.e. precision) set to nil causes errors in the NumberHelper#number_to_currency method
