### PR TITLE
fix update_journals_for_acts_as_journalized down migration

### DIFF
--- a/db/migrate/20100714111652_update_journals_for_acts_as_journalized.rb
+++ b/db/migrate/20100714111652_update_journals_for_acts_as_journalized.rb
@@ -50,7 +50,6 @@ class UpdateJournalsForActsAsJournalized < ActiveRecord::Migration
       t.string :journalized_type, :limit => 30, :default => "", :null => false
     end
 
-    custom_field_names = CustomField.all.group_by(&:type)[IssueCustomField].collect(&:name)
     Journal.all.each do |j|
       # Can't used j.journalized.class.name because the model changes make it nil
       j.update_attribute(:journalized_type, j.type.to_s.sub("Journal","")) if j.type.present?


### PR DESCRIPTION
This is completely based on a PR by @marutosi. Kudos to him.

The only liberty I took was to change the commit message as the original one was not written for the OpenProject context.
