### PR TITLE
Fixes waiting for Ajax in Cucumber

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -535,6 +535,16 @@ jQuery.viewportHeight = function() {
 
 /* TODO: integrate with existing code and/or refactor */
 jQuery(document).ready(function($) {
+  document.ajaxActive = false;
+
+
+  $(document).ajaxStart(function () {
+    document.ajaxActive = true;
+  });
+
+  $(document).ajaxStop(function () {
+    document.ajaxActive = false;
+  });
 
     var propagateOpenClose = function () {
       if ($(this).is(":visible")) {

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -257,24 +257,27 @@ end
 
 When /^I wait(?: (\d+) seconds)? for(?: the)? [Aa][Jj][Aa][Xx](?: requests?(?: to finish)?)?$/ do |timeout|
   ajax_done = lambda do
-    page.evaluate_script(%Q{
-      (function (){
-        var done = true;
+    is_done = false
+    while (!is_done) do
+      is_done = page.evaluate_script(%Q{
+        (function (){
+          var done = true;
 
-        if (window.jQuery) {
-          if (!window.jQuery.isReady || window.jQuery.active != 0) {
-            done = false;
+          if (window.jQuery) {
+            if (document.ajaxActive) {
+              done = false;
+            }
           }
-        }
-        if (window.Prototype && window.Ajax) {
-          if (window.Ajax.activeRequestCount != 0) {
-            done = false;
+          if (window.Prototype && window.Ajax) {
+            if (window.Ajax.activeRequestCount != 0) {
+              done = false;
+            }
           }
-        }
 
-        return done;
-      }())
-    }.gsub("\n", ''))
+          return done;
+        }())
+      }.gsub("\n", ''))
+    end
   end
 
   timeout = timeout.present? ?


### PR DESCRIPTION
- old implementation did not actually wait,
  but just checked once whether jQuery or Prototype provided
  any signs of ajaxy activity. It did not actually do anything
  with this information.
- the new implementation waits (busily!) 'til PT and jQuery
  have no signs of ajax anymore. If that takes to long,
  it'll raise Timeout::Error.
