### PR TITLE
reenable calendar menu item

### DIFF
--- a/features/menu_items.feature
+++ b/features/menu_items.feature
@@ -1,0 +1,18 @@
+Feature: Menu items
+  Background:
+    Given there is 1 project with the following:
+      | name            | Awesome Project      |
+      | identifier      | awesome-project      |
+    And project "Awesome Project" uses the following modules:
+      | calendar |
+    And there is a role "member"
+    And the role "member" may have the following rights:
+      | view_calendar  |
+    And there is 1 user with the following:
+      | login | bob |
+    And the user "bob" is a "member" in the project "Awesome Project"
+    And I am logged in as "bob"
+
+  Scenario: Calendar menu should be visible when calendar is activated
+    When I go to the overview page of the project "Awesome Project"
+    Then I should see "Calendar" within "#main-menu"

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -216,7 +216,7 @@ Redmine::MenuManager.map :project_menu do |menu|
               :html => { :accesskey => Redmine::AccessKeys.key_for(:new_issue) }
   menu.push :view_all_issues, { :controller => '/issues', :action => 'all' }, :param => :project_id, :caption => :label_issue_view_all, :parent => :issues
   menu.push :summary_field, {:controller => '/issues/reports', :action => 'report'}, :param => :project_id, :caption => :label_workflow_summary, :parent => :issues
-  menu.push :calendar, { :controller => '/calendars', :action => 'show' }, :param => :project_id, :caption => :label_calendar
+  menu.push :calendar, { :controller => '/issues/calendars', :action => 'index' }, :param => :project_id, :caption => :label_calendar
   menu.push :news, { :controller => '/news', :action => 'index' }, :param => :project_id, :caption => :label_news_plural
   menu.push :new_news, { :controller => '/news', :action => 'new' }, :param => :project_id, :caption => :label_news_new, :parent => :news,
               :if => Proc.new { |p| User.current.allowed_to?(:manage_news, p.project) }


### PR DESCRIPTION
The "Calendar" menu item was gone, because the URL in the menu definition was erroneous. Made the allowed_to? call return false every time.
