### PR TITLE
Increase default minimum password length to 10

### DIFF
--- a/config/initializers/reduce_password_requirements.rb
+++ b/config/initializers/reduce_password_requirements.rb
@@ -1,0 +1,3 @@
+if Rails.env == 'test'
+  Setting.password_min_length = 4
+end

--- a/config/initializers/reduce_password_requirements.rb
+++ b/config/initializers/reduce_password_requirements.rb
@@ -1,3 +1,6 @@
 if Rails.env == 'test'
-  Setting.password_min_length = 4
+  puts 'Reducing minimum password length to 4 characters for test environment'
+  # Set default minimum length to 4, this doesn't require writing to the database.
+  # Migrations might not have run here.
+  Setting.available_settings['password_min_length'] = 4
 end

--- a/config/initializers/reduce_password_requirements.rb
+++ b/config/initializers/reduce_password_requirements.rb
@@ -2,5 +2,5 @@ if Rails.env == 'test'
   puts 'Reducing minimum password length to 4 characters for test environment'
   # Set default minimum length to 4, this doesn't require writing to the database.
   # Migrations might not have run here.
-  Setting.available_settings['password_min_length'] = 4
+  Setting.available_settings['password_min_length']['default'] = 4
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,7 @@ lost_password:
   default: 1
 password_min_length:
   format: int
-  default: 4
+  default: 10
 attachment_max_size:
   format: int
   default: 5120


### PR DESCRIPTION
Hashes of eight-character password can be cracked with relatively cheap hardware/cloud in reasonable time. Use 10 to have a little margin.

See http://arstechnica.com/security/2013/05/how-crackers-make-minced-meat-out-of-your-passwords/
