### PR TITLE
Feature/rails3 fix breadcrumb translations

### DIFF
--- a/app/controllers/issues/calendars_controller.rb
+++ b/app/controllers/issues/calendars_controller.rb
@@ -46,4 +46,10 @@ class Issues::CalendarsController < ApplicationController
 
     render :layout => !request.xhr?
   end
+
+private
+
+  def default_breadcrumb
+    l(:label_calendar)
+  end
 end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -342,4 +342,8 @@ private
   def load_pages_for_index
     @pages = @wiki.pages.with_updated_on.all(:order => 'title', :include => {:wiki => :project})
   end
+
+  def default_breadcrumb
+    Wiki.name.humanize
+  end
 end


### PR DESCRIPTION
"/wiki -> edit" and "issues/calendar -> show" have missing translations in their breadcrumbs. See:
- https://www.openproject.org/issues/738
- https://www.openproject.org/issues/774
