### PR TITLE
Fixes database index on postgres.

### DIFF
--- a/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
+++ b/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
@@ -19,7 +19,7 @@ class CreateTimelinesAvailableProjectStatuses < ActiveRecord::Migration
     end
 
     add_index :timelines_available_project_statuses, :project_type_id
-    add_index :timelines_available_project_statuses, :reported_project_status_id, :name => "index_timelines_avail_project_statuses_on_rep_project_status_id"
+    add_index :timelines_available_project_statuses, :reported_project_status_id, :name => "index_avail_project_statuses_on_rep_project_status_id"
   end
 
   def self.down

--- a/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
+++ b/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
@@ -19,7 +19,7 @@ class CreateTimelinesEnabledPlanningElementTypes < ActiveRecord::Migration
     end
 
     add_index :timelines_enabled_planning_element_types, :project_id
-    add_index :timelines_enabled_planning_element_types, :planning_element_type_id, :name => "index_enabled_planning_element_types_on_planning_element_type_id"
+    add_index :timelines_enabled_planning_element_types, :planning_element_type_id, :name => "index_enabled_pe_types_on_pe_type_id"
   end
 
   def self.down

--- a/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
+++ b/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
@@ -18,8 +18,8 @@ class CreateTimelinesDefaultPlanningElementTypes < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :timelines_default_planning_element_types, :project_type_id, :name => "index_default_planning_element_types_on_project_type_id"
-    add_index :timelines_default_planning_element_types, :planning_element_type_id, :name => "index_default_planning_element_types_on_planning_element_type_id"
+    add_index :timelines_default_planning_element_types, :project_type_id, :name => "index_default_pe_types_on_project_type_id"
+    add_index :timelines_default_planning_element_types, :planning_element_type_id, :name => "index_default_pe_types_on_pe_type_id"
 
   end
 


### PR DESCRIPTION
According to 4.1.1. Identifiers and Key Words [1] of the PostgreSQL
9.2.4 Documentation, NAMEDATALEN is 64 so the maximum identifier length
is 63 bytes.

[1] http://www.postgresql.org/docs/current/interactive/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
