### PR TITLE
Custom fields validation double errors (#709)

### DIFF
--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -24,10 +24,11 @@ module Redmine
           has_many :custom_values, :as => :customized,
                                    :include => :custom_field,
                                    :order => "#{CustomField.table_name}.position",
-                                   :dependent => :delete_all
+                                   :dependent => :delete_all,
+                                   :validate => false
           before_validation { |customized| customized.custom_field_values if customized.new_record? }
           # Trigger validation only if custom values were changed
-          validates_associated :custom_values, :on => :update, :if => Proc.new { |customized| customized.custom_field_values_changed? }
+          validates_associated :custom_values, :if => Proc.new { |customized| customized.custom_field_values_changed? }
           send :include, Redmine::Acts::Customizable::InstanceMethods
           # Save custom values when saving the customized object
           after_save :save_custom_field_values

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -27,8 +27,8 @@ module Redmine
                                    :dependent => :delete_all,
                                    :validate => false
           before_validation { |customized| customized.custom_field_values if customized.new_record? }
-          # Trigger validation only if custom values were changed
-          validates_associated :custom_values, :if => Proc.new { |customized| customized.custom_field_values_changed? }
+          # always trigger validation
+          validates_associated :custom_values
           send :include, Redmine::Acts::Customizable::InstanceMethods
           # Save custom values when saving the customized object
           after_save :save_custom_field_values

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
     visible true
     field_format "bool"
 
-    factory :user_custom_field do
+    factory :user_custom_field, :class => UserCustomField do
       sequence(:name) { |n| "User Custom Field #{n}" }
       type "UserCustomField"
 
@@ -63,7 +63,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :issue_custom_field do
+    factory :issue_custom_field, :class => IssueCustomField do
       sequence(:name) { |n| "Issue Custom Field #{n}" }
       type "WorkPackageCustomField"
 

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -63,7 +63,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :issue_custom_field, :class => IssueCustomField do
+    factory :issue_custom_field, :class => WorkPackageCustomField do
       sequence(:name) { |n| "Issue Custom Field #{n}" }
       type "WorkPackageCustomField"
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -131,7 +131,7 @@ describe Issue do
       cf2 = FactoryGirl.create(:issue_custom_field, :is_required => true)
 
       issue = FactoryGirl.create :issue
-      issue.project.issue_custom_fields << cf1
+      issue.project.work_package_custom_fields << cf1
       issue.tracker.custom_fields << cf1
 
       # allow active record to run validations
@@ -142,7 +142,7 @@ describe Issue do
 
       expect(issue).to be_valid
 
-      issue.project.issue_custom_fields << cf2
+      issue.project.work_package_custom_fields << cf2
       issue.tracker.custom_fields << cf2
       issue.custom_field_values # custom_field_values needs to be touched
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -130,22 +130,24 @@ describe Issue do
       cf1 = FactoryGirl.create(:issue_custom_field, :is_required => true)
       cf2 = FactoryGirl.create(:issue_custom_field, :is_required => true)
 
+      # create issue with one required custom field
       issue = FactoryGirl.create :issue
       issue.project.work_package_custom_fields << cf1
       issue.tracker.custom_fields << cf1
 
-      # allow active record to run validations
-      issue.stubs(:custom_field_values_changed?).returns(true)
-
+      # set that custom field with a value, should be fine
       issue.custom_field_values = {cf1.id => 'test'}
       issue.save!; issue.reload
 
+      # is it fine?
       expect(issue).to be_valid
 
+      # now give the issue another required custom field, but don't assign a value
       issue.project.work_package_custom_fields << cf2
       issue.tracker.custom_fields << cf2
-      issue.custom_field_values # custom_field_values needs to be touched
+      issue.custom_field_values # #custom_field_values needs to be touched
 
+      # that should not be valid
       expect(issue).to_not be_valid
 
       # assert that there is only one error

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -758,8 +758,6 @@ class IssueTest < ActiveSupport::TestCase
   end
 
   def test_journalized_description
-    WorkPackageCustomField.delete_all
-
     i = Issue.first
     old_description = i.description
     new_description = "This is the new description"

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -263,7 +263,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_rebuild_should_sort_children_alphabetically
-    ProjectCustomField.delete_all
+    CustomField.destroy_all
     parent = Project.create!(:name => 'Parent', :identifier => 'parent')
     Project.create!(:name => 'Project C', :identifier => 'project-c').move_to_child_of(parent)
     Project.create!(:name => 'Project B', :identifier => 'project-b').move_to_child_of(parent)


### PR DESCRIPTION
fixes the display of multiple error messages of the same attribute for the same custom field (fixes #709)
