### PR TITLE
Improve password complexity requirements

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -169,7 +169,7 @@ class AccountController < ApplicationController
           user.login = registration['nickname'] unless registration['nickname'].nil?
           user.mail = registration['email'] unless registration['email'].nil?
           user.firstname, user.lastname = registration['fullname'].split(' ') unless registration['fullname'].nil?
-          user.random_password
+          user.random_password!
           user.register
 
           case Setting.self_registration

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1293,7 +1293,13 @@ module ApplicationHelper
   end
 
   def password_complexity_requirements
-    raw "<em>" + l(:text_caracters_minimum, :count => Setting.password_min_length) + "</em>"
+    rules = OpenProject::Passwords::Evaluator.rules_description
+    # use 0..0, so this doesn't fail if rules is an empty string
+    rules[0] = rules[0..0].upcase
+
+    s = raw "<em>" + OpenProject::Passwords::Evaluator.min_length_description + "</em>"
+    s += raw "<br /><em>" + rules + "</em>" unless rules.empty?
+    s
   end
 
 end

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -342,7 +342,7 @@ class MailHandler < ActionMailer::Base
     user = User.new
     user.mail = email_address
     user.login = user.mail
-    user.password = SecureRandom.hex [Setting.password_min_length.to_i, 10].max
+    user.random_password!
     user.language = Setting.default_language
 
     names = fullname.blank? ? email_address.gsub(/@.*$/, '').split('.') : fullname.split

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -24,6 +24,10 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p><%= setting_text_field :password_min_length, :size => 6 %></p>
 
+<p><%= setting_multiselect :password_active_rules, OpenProject::Passwords::Evaluator.known_rules.map {|r| [l("label_password_rule_#{r}"), r] } %></p>
+
+<p><%= setting_text_field :password_min_adhered_rules, :size => 6 %></p>
+
 <p><%= setting_check_box :lost_password, :label => :label_password_lost %></p>
 
 <p><%= setting_check_box :openid, :disabled => !Object.const_defined?(:OpenID) %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -202,6 +202,15 @@ de:
               cannot_be_in_recycle_bin : "darf nicht im Papierkorb liegen"
         "timelines/project_association":
           project_association_not_allowed: "erlaubt keine Projekt-Abhängigkeiten"
+        user:
+          attributes:
+            password:
+              weak: "muss Zeichen aus folgenden Klassen beinhalten (mindestens %{min_count} von %{all_count}): %{rules}"
+              lowercase: "Kleinbuchstaben (z.B. 'a')"
+              uppercase: "Großbuchstaben (z.B. 'A')"
+              numeric: "Ziffern (z.B. '1')"
+              special: "Sonderzeichen (z.B. '%')"
+              reused: "darf nicht eines der %{count} zuletzt genutzten sein."
       template:
         body: "Bitte überprüfen Sie die folgenden Felder:"
         header:
@@ -774,6 +783,10 @@ de:
   label_overall_spent_time: "Aufgewendete Zeit aller Projekte anzeigen"
   label_overview: "Übersicht"
   label_password_lost: "Kennwort vergessen"
+  label_password_rule_lowercase: "Kleinbuchstaben"
+  label_password_rule_numeric: "Ziffern"
+  label_password_rule_special: "Sonderzeichen"
+  label_password_rule_uppercase: "Großbuchstaben"
   label_path_encoding: "Path encoding"
   label_per_page: "Pro Seite"
   label_permissions: "Berechtigungen"
@@ -1152,7 +1165,9 @@ de:
   setting_mail_handler_body_delimiters: "Schneide E-Mails nach einer dieser Zeilen ab"
   setting_new_project_user_role_id: "Rolle, die einem Nicht-Administrator zugeordnet wird, der ein Projekt erstellt"
   setting_openid: "Erlaube OpenID-Anmeldung und -Registrierung"
+  setting_password_active_rules: "Aktive Passwortregeln"
   setting_password_min_length: "Mindestlänge des Kennworts"
+  setting_password_min_adhered_rules: "Mindestanzahl zu erfüllender Regeln"
   setting_per_page_options: "Objekte pro Seite"
   setting_plain_text_mail: "Nur reinen Text (kein HTML) senden"
   setting_protocol: "Protokoll"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,15 @@ en:
               cannot_be_in_recycle_bin : "cannot be in recycle bin."
         "timelines/project_association":
           project_association_not_allowed: "does not allow associations"
+        user:
+          attributes:
+            password:
+              weak: "must contain characters of the following classes (at least %{min_count} of %{all_count}): %{rules}"
+              lowercase: "lowercase (e.g. 'a')"
+              uppercase: "uppercase (e.g. 'A')"
+              numeric: "numeric (e.g. '1')"
+              special: "special (e.g. '%')"
+              reused: "must not be one of the last %{count} used"
       template:
         body: "Please check the following fields:"
         header:
@@ -760,6 +769,10 @@ en:
   label_overall_spent_time: "Overall spent time"
   label_overview: "Overview"
   label_password_lost: "Lost password"
+  label_password_rule_lowercase: "Lowercase"
+  label_password_rule_numeric: "Numeric Characters"
+  label_password_rule_special: "Special Characters"
+  label_password_rule_uppercase: "Uppercase"
   label_path_encoding: "Path encoding"
   label_per_page: "Per page"
   label_permissions: "Permissions"
@@ -1135,7 +1148,9 @@ en:
   setting_mail_handler_body_delimiters: "Truncate emails after one of these lines"
   setting_new_project_user_role_id: "Role given to a non-admin user who creates a project"
   setting_openid: "Allow OpenID login and registration"
+  setting_password_active_rules: "Active password rules"
   setting_password_min_length: "Minimum password length"
+  setting_password_min_adhered_rules: "Minimum number of rules to adhere to"
   setting_per_page_options: "Objects per page options"
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,20 @@ lost_password:
   default: 1
 password_min_length:
   format: int
-  default: 4
+  default: 10
+password_active_rules:
+  serialized: true
+  default:
+    - lowercase
+    - uppercase
+    - numeric
+    - special
+password_min_adhered_rules:
+  format: int
+  default: 0
+password_days_valid:
+  format: int
+  default: 0
 attachment_max_size:
   format: int
   default: 5120

--- a/features/step_definitions/error_steps.rb
+++ b/features/step_definitions/error_steps.rb
@@ -1,0 +1,20 @@
+#encoding: utf-8
+
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Then /^there should be an error message$/ do
+  should have_selector('#errorExplanation')
+end
+
+Then /^I should see an error explanation stating "([^"]*)"$/ do |message|
+  page.all(:css, ".errorExplanation li, .errorExplanation li *", :text => message).should_not be_empty
+end

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -391,7 +391,7 @@ end
 
 When /^(?:|I )login as (.+)(?: with password (.+))?$/ do |username, password|
   username = username.gsub("\"", "")
-  password = password.nil? ? "admin" : password.gsub("\"", "")
+  password = password.nil? ? "adminADMIN!" : password.gsub("\"", "")
   login(username, password)
 end
 

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -26,6 +26,11 @@ Before do |scenario|
   end
 end
 
+Given /^I am logged in$/ do
+  @user = FactoryGirl.create :user
+  page.set_rack_session(:user_id => @user.id)
+end
+
 Given /^(?:|I )am not logged in$/ do
   User.current = AnonymousUser.first
 end
@@ -33,7 +38,7 @@ end
 Given /^(?:|I )am [aA]dmin$/ do
   FactoryGirl.create :admin unless User.where(:login => 'admin').any?
   FactoryGirl.create :anonymous unless AnonymousUser.count > 0
-  login('admin', 'admin')
+  login('admin', 'adminADMIN!')
 end
 
 Given /^I am already logged in as "(.+?)"$/ do |login|
@@ -45,7 +50,7 @@ end
 Given /^(?:|I )am logged in as "([^\"]*)"$/ do |username|
   FactoryGirl.create :admin unless User.where(:login => 'admin').any?
   FactoryGirl.create :anonymous unless AnonymousUser.count > 0
-  login(username, 'admin')
+  login(username, 'adminADMIN!')
 end
 
 Given /^there is 1 [pP]roject with(?: the following)?:$/ do |table|

--- a/features/step_definitions/password_steps.rb
+++ b/features/step_definitions/password_steps.rb
@@ -1,3 +1,16 @@
+#encoding: utf-8
+
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 def parse_password_rules(str)
   str.sub(', and ', ', ').split(', ')
 end
@@ -23,22 +36,20 @@ Given /^I try to set my new password to "(.+)"$/ do |password|
   @new_password = password
 end
 
-Given /^there should be an error describing the password complexity is too low$/ do
-  should have_selector('#errorExplanation')
-end
-
-Given /^the password change should succeed$/ do
+Then /^the password change should succeed$/ do
   find('.notice').should have_content('success')
 end
 
-Given /^I should be able to login using the new password$/ do
+Then /^I should be able to login using the new password$/ do
   visit('/logout')
   login(@user.login, @new_password)
 end
 
-Given /^I activate the ([a-z, ]+) password rules$/ do |rules|
+When /^I activate the ([a-z, ]+) password rules$/ do |rules|
   rules = parse_password_rules(rules)
+  # ensure checkboxes are loaded, 'all' doesn't wait
   should have_selector(:xpath, "//input[@id='settings_password_active_rules_' and @value='#{rules.first}']")
+
   all(:xpath, "//input[@id='settings_password_active_rules_']").each do |checkbox|
     checkbox.set(false)
   end

--- a/features/step_definitions/password_steps.rb
+++ b/features/step_definitions/password_steps.rb
@@ -1,0 +1,48 @@
+def parse_password_rules(str)
+  str.sub(', and ', ', ').split(', ')
+end
+
+Given /^passwords must contain ([0-9]+) of ([a-z, ]+) characters$/ do |minimum_rules, rules|
+  rules = parse_password_rules(rules)
+  Setting.password_active_rules = rules
+  Setting.password_min_adhered_rules = minimum_rules.to_i
+end
+
+Given /^passwords have a minimum length of ([0-9]+) characters$/ do |minimum_length|
+  Setting.password_min_length = minimum_length
+end
+
+Given /^I try to set my new password to "(.+)"$/ do |password|
+  visit "/my/password"
+  # use find and set with id to prevent ambigious match
+  find('#password').set('adminADMIN!')
+
+  fill_in('new_password', :with => password)
+  fill_in('new_password_confirmation', :with => password)
+  click_link_or_button 'Apply'
+  @new_password = password
+end
+
+Given /^there should be an error describing the password complexity is too low$/ do
+  should have_selector('#errorExplanation')
+end
+
+Given /^the password change should succeed$/ do
+  find('.notice').should have_content('success')
+end
+
+Given /^I should be able to login using the new password$/ do
+  visit('/logout')
+  login(@user.login, @new_password)
+end
+
+Given /^I activate the ([a-z, ]+) password rules$/ do |rules|
+  rules = parse_password_rules(rules)
+  should have_selector(:xpath, "//input[@id='settings_password_active_rules_' and @value='#{rules.first}']")
+  all(:xpath, "//input[@id='settings_password_active_rules_']").each do |checkbox|
+    checkbox.set(false)
+  end
+  rules.each do |rule|
+    find(:xpath, "//input[@id='settings_password_active_rules_' and @value='#{rule}']").set(true)
+  end
+end

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -40,14 +40,6 @@ Then /^the "(.+?)" setting should be (true|false)$/ do |name, trueish|
   Setting.send((name + "?").to_sym).should == (trueish == "true")
 end
 
-When /^I visit the ([^ ]+) settings page$/ do |tab|
-  visit("/settings?tab=#{tab}")
-  @settings_tab = tab
-end
-
 Given /^I save the settings$/ do
-  within("#tab-content-#{@settings_tab}") do
-    click_button('Save')
-  end
-  @settings_tab = nil
+  click_button('Save', :visible => true)
 end

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -39,3 +39,15 @@ end
 Then /^the "(.+?)" setting should be (true|false)$/ do |name, trueish|
   Setting.send((name + "?").to_sym).should == (trueish == "true")
 end
+
+When /^I visit the ([^ ]+) settings page$/ do |tab|
+  visit("/settings?tab=#{tab}")
+  @settings_tab = tab
+end
+
+Given /^I save the settings$/ do
+  within("#tab-content-#{@settings_tab}") do
+    click_button('Save')
+  end
+  @settings_tab = nil
+end

--- a/features/step_definitions/timelines_then_steps.rb
+++ b/features/step_definitions/timelines_then_steps.rb
@@ -132,10 +132,6 @@ Then /^I should see an? (notice|warning|error) flash stating "([^"]*)"$/ do |cla
   page.all(:css, ".flash.#{class_name}, .flash.#{class_name} *", :text => message).should_not be_empty
 end
 
-Then /^I should see an error explanation stating "([^"]*)"$/ do |message|
-  page.all(:css, ".errorExplanation li, .errorExplanation li *", :text => message).should_not be_empty
-end
-
 Then /^I should see a planning element named "([^"]*)"$/ do |name|
   cells = page.all(:css, "table td.timelines-pe-name *", :text => name)
   cells.should_not be_empty

--- a/features/users/password_complexity_checks.feature
+++ b/features/users/password_complexity_checks.feature
@@ -1,23 +1,36 @@
+#encoding: utf-8
+
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 Feature: Password Complexity Checks
     Scenario: A user changing the password including attempts to set not complex enough passwords
         Given passwords must contain 2 of lowercase, uppercase, and numeric characters
         And passwords have a minimum length of 4 characters
         And I am logged in
         And I try to set my new password to "password"
-        Then there should be an error describing the password complexity is too low
+        Then there should be an error message
         When I try to set my new password to "Password"
         Then the password change should succeed
         And I should be able to login using the new password
 
     Scenario: An admin can change the password complexity requirements and they are effective
         Given I am admin
-        When I visit the authentication settings page
+        When I go to the authentication tab of the settings page
         And I activate the lowercase, uppercase, and special password rules
         And I fill in "Minimum number of rules to adhere to" with "3"
         And I save the settings
         And I try to set my new password to "adminADMIN"
-        Then there should be an error describing the password complexity is too low
+        Then there should be an error message
         And I try to set my new password to "adminADMIN123"
-        Then there should be an error describing the password complexity is too low
+        Then there should be an error message
         And I try to set my new password to "adminADMIN!"
         Then the password change should succeed

--- a/features/users/password_complexity_checks.feature
+++ b/features/users/password_complexity_checks.feature
@@ -1,0 +1,23 @@
+Feature: Password Complexity Checks
+    Scenario: A user changing the password including attempts to set not complex enough passwords
+        Given passwords must contain 2 of lowercase, uppercase, and numeric characters
+        And passwords have a minimum length of 4 characters
+        And I am logged in
+        And I try to set my new password to "password"
+        Then there should be an error describing the password complexity is too low
+        When I try to set my new password to "Password"
+        Then the password change should succeed
+        And I should be able to login using the new password
+
+    Scenario: An admin can change the password complexity requirements and they are effective
+        Given I am admin
+        When I visit the authentication settings page
+        And I activate the lowercase, uppercase, and special password rules
+        And I fill in "Minimum number of rules to adhere to" with "3"
+        And I save the settings
+        And I try to set my new password to "adminADMIN"
+        Then there should be an error describing the password complexity is too low
+        And I try to set my new password to "adminADMIN123"
+        Then there should be an error describing the password complexity is too low
+        And I try to set my new password to "adminADMIN!"
+        Then the password change should succeed

--- a/lib/open_project/passwords.rb
+++ b/lib/open_project/passwords.rb
@@ -1,3 +1,16 @@
+#encoding: utf-8
+
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 module OpenProject
   ##
   # Evaluate and generate passwords

--- a/lib/open_project/passwords.rb
+++ b/lib/open_project/passwords.rb
@@ -1,0 +1,131 @@
+module OpenProject
+  ##
+  # Evaluate and generate passwords
+  #
+  module Passwords
+    ##
+    # Evaluates passwords and generates error messages for the evaluated
+    # passwords based on password complexity settings like minimum password
+    # length and other complexity rules.
+    #
+    module Evaluator
+      RULES = {'uppercase' => /.*[A-Z].*/u,
+               'lowercase' => /.*[a-z].*/u,
+               'special'   => /.*[^\da-zA-Z].*/u,
+               'numeric'   => /.*\d.*/u}
+      # Check whether password conforms to password complexity settings.
+      # Checks complexity rules and password length.
+      def self.conforming?(password)
+        password_long_enough(password) and password_conforms_to_rules(password)
+      end
+
+      # Returns corresponding error messages if +password+ doesn't conform to
+      # password complexity settings.
+      def self.errors_for_password(password)
+        errors = []
+        unless password_conforms_to_rules(password)
+          errors << rules_description
+        end
+        unless password_long_enough(password)
+          errors << I18n.t(:too_short,
+                           :scope => [:activerecord, :errors, :messages],
+                           :count => OpenProject::Passwords::Evaluator.min_length)
+        end
+        errors
+      end
+
+      # Returns the names of known rules, e.g. ['uppercase'].
+      def self.known_rules
+        RULES.keys
+      end
+
+      # Returns the names of rules activated in settings.
+      def self.active_rules
+        Setting.password_active_rules
+      end
+
+      # Checks whether password adheres to complexity rules.
+      # Does not check length.
+      def self.password_conforms_to_rules(password)
+        size_active_rules_adhered_by(password) >= min_adhered_rules
+      end
+
+      # Checks whether password matches minimum length specified in settings.
+      def self.password_long_enough(password)
+        password.length >= min_length
+      end
+
+      # Returns the minimum number of rules passwords must adhere to
+      # to be accepted, as specified in settings and checked to be within
+      # reasonable bounds (>= 0, <= number of active rules).
+      def self.min_adhered_rules
+        min = Setting.password_min_adhered_rules.to_i
+        # ensure value is in interval [0, active_rules.size]
+        [[0, min].max, active_rules.size].min
+      end
+
+      # Returns the minimum password length as specified in settings.
+      def self.min_length
+        Setting.password_min_length.to_i
+      end
+
+      # Returns a text describing the active password complexity rules,
+      # the minimum number of rules to adhere to and the total number of rules.
+      def self.rules_description
+        return '' if min_adhered_rules == 0
+
+        rules = active_rules.map do |rule|
+          I18n.t(rule.to_sym,
+                 :scope => [:activerecord, :errors, :models, :user, :attributes, :password])
+        end
+
+        I18n.t(:weak,
+          :scope => [:activerecord, :errors, :models, :user, :attributes, :password],
+          :rules => rules.join(", "),
+          :min_count => min_adhered_rules,
+          :all_count => active_rules.size)
+      end
+
+      # Returns a text describing the minimum length of a password.
+      def self.min_length_description
+        I18n.t(:text_caracters_minimum,
+               :count => OpenProject::Passwords::Evaluator.min_length)
+      end
+
+    private
+
+      # Returns the number of active rules password adheres to.
+      def self.size_active_rules_adhered_by(password)
+        active_rules.count do |name|
+          password =~ RULES[name] ? true : false
+        end
+      end
+    end
+
+    ##
+    # Generates random passwords that conform to password complexity settings
+    #
+    module Generator
+      RANDOM_PASSWORD_MIN_LENGTH = 15
+
+      # Generates a random password with a minimum length of 15 or the minimum
+      # password length, whichever is higher.
+      # The generated password conforms to the active password rules.
+      def self.random_password
+        chars = ("a".."z").to_a +
+                ("A".."Z").to_a +
+                ("0".."9").to_a +
+                ["!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+",
+                  ",", "-", ".", "/", ":", ";", "<", "=", ">", "?", "@", "[", "\\",
+                   "]", "^", "_", "`", "{", "|", "}", "~"]
+
+        begin
+           password = ''
+           length = [RANDOM_PASSWORD_MIN_LENGTH, Evaluator.min_length].max
+           length.times { |i| password << chars[SecureRandom.random_number(chars.size-1)] }
+        end while not Evaluator.conforming? password
+        password
+      end
+    end
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -20,8 +20,8 @@ FactoryGirl.define do
     lastname 'Bobbit'
     sequence(:login) { |n| "bob#{n}" }
     sequence(:mail) {|n| "bob#{n}.bobbit@bob.com" }
-    password 'admin'
-    password_confirmation 'admin'
+    password 'adminADMIN!'
+    password_confirmation 'adminADMIN!'
 
     mail_notification(Redmine::VERSION::MAJOR > 0 ? 'all' : true)
 
@@ -45,8 +45,6 @@ FactoryGirl.define do
       firstname 'Redmine'
       lastname 'Admin'
       login 'admin'
-      password 'admin'
-      password_confirmation 'admin'
       mail 'admin@example.com'
       admin true
       first_login false if User.table_exists? and User.columns.map(&:name).include? 'first_login'

--- a/spec/lib/open_project/passwords_spec.rb
+++ b/spec/lib/open_project/passwords_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'open_project/passwords'
+
+describe OpenProject::Passwords::Generator do
+  describe :random_password do
+    it "should create a valid password" do
+      with_settings :password_active_rules => ['lowercase', 'uppercase', 'numeric', 'special'],
+                    :password_min_adhered_rules => 3,
+                    :password_min_length => 4 do
+       pwd = OpenProject::Passwords::Generator.random_password
+       OpenProject::Passwords::Evaluator.conforming?(pwd).should == true
+     end
+   end
+  end
+end
+
+describe OpenProject::Passwords::Evaluator do
+  it "should correctly evaluate passwords" do
+    with_settings :password_active_rules => ['lowercase', 'uppercase', 'numeric'],
+                  :password_min_adhered_rules => 3,
+                  :password_min_length => 4 do
+      OpenProject::Passwords::Evaluator.conforming?('abCD').should == false
+      OpenProject::Passwords::Evaluator.conforming?('ab12').should == false
+      OpenProject::Passwords::Evaluator.conforming?('12CD').should == false
+      OpenProject::Passwords::Evaluator.conforming?('12CD*').should == false
+      OpenProject::Passwords::Evaluator.conforming?('aB1').should == false
+      OpenProject::Passwords::Evaluator.conforming?('abCD12').should == true
+      OpenProject::Passwords::Evaluator.conforming?('aB123').should == true
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,7 +130,7 @@ describe User do
       @u = User.new
       @u.password.should be_nil
       @u.password_confirmation.should be_nil
-      @u.random_password
+      @u.random_password!
     end
 
     it { @u.password.should_not be_blank }

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -1,0 +1,10 @@
+##
+# Runs block with settings specified in options.
+# The original settings are restored afterwards.
+def with_settings(options, &block)
+  saved_settings = options.keys.inject({}) {|h, k| h[k] = Setting[k].dup; h}
+  options.each {|k, v| Setting[k] = v}
+  yield
+ensure
+  saved_settings.each {|k, v| Setting[k] = v}
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -23,9 +23,9 @@ users_001:
   status: 1
   last_login_on: 2006-07-19 22:57:52 +02:00
   language: en
-  # password = admin
-  salt: 82090c953c4a0000a7db253b0691a6b4
-  hashed_password: b5b6ff9543bf1387374cdfa27a54c96d236a7150
+  # password = adminADMIN!
+  salt: a19f9743f4b7b043a2fd07b8eb13a1df
+  hashed_password: b4596ce83c0e154e5ce9d3dd5636fde4d6f38b75
   updated_on: 2006-07-19 22:57:52 +02:00
   admin: true
   mail: admin@somenet.foo

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -211,8 +211,8 @@ class AccountControllerTest < ActionController::TestCase
         Setting.self_registration = '3'
         post :register, :user => {
           :login => 'register',
-          :password => 'test',
-          :password_confirmation => 'test',
+          :password => 'adminADMIN!',
+          :password_confirmation => 'adminADMIN!',
           :firstname => 'John',
           :lastname => 'Doe',
           :mail => 'register@example.com'

--- a/test/functional/my_controller_test.rb
+++ b/test/functional/my_controller_test.rb
@@ -102,10 +102,10 @@ class MyControllerTest < ActionController::TestCase
 
     # good password
     post :password, :password => 'jsmith',
-                    :new_password => 'hello',
-                    :new_password_confirmation => 'hello'
+                    :new_password => 'newpassPASS!',
+                    :new_password_confirmation => 'newpassPASS!'
     assert_redirected_to '/my/account'
-    assert User.try_to_login('jsmith', 'hello')
+    assert User.try_to_login('jsmith', 'newpassPASS!')
   end
 
   def test_page_layout

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -157,8 +157,8 @@ class UsersControllerTest < ActionController::TestCase
             :firstname => 'John',
             :lastname => 'Doe',
             :login => 'jdoe',
-            :password => 'secret',
-            :password_confirmation => 'secret',
+            :password => 'adminADMIN!',
+            :password_confirmation => 'adminADMIN!',
             :mail => 'jdoe@gmail.com',
             :mail_notification => 'none'
           },
@@ -174,12 +174,12 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal 'jdoe', user.login
     assert_equal 'jdoe@gmail.com', user.mail
     assert_equal 'none', user.mail_notification
-    assert user.check_password?('secret')
+    assert user.check_password?('adminADMIN!')
 
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail
     assert_equal [user.mail], mail.to
-    assert mail.body.encoded.include?('secret')
+    assert mail.body.encoded.include?('adminADMIN!')
   end
 
   def test_create_with_failure
@@ -250,14 +250,14 @@ class UsersControllerTest < ActionController::TestCase
     ActionMailer::Base.deliveries.clear
     Setting.bcc_recipients = '1'
 
-    put :update, :id => 2, :user => {:password => 'newpass', :password_confirmation => 'newpass'}, :send_information => '1'
+    put :update, :id => 2, :user => {:password => 'newpassPASS!', :password_confirmation => 'newpassPASS!'}, :send_information => '1'
     u = User.find(2)
-    assert u.check_password?('newpass')
+    assert u.check_password?('newpassPASS!')
 
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail
     assert_equal [u.mail], mail.to
-    assert mail.body.encoded.include?('newpass')
+    assert mail.body.encoded.include?('newpassPASS!')
   end
 
   test "put :update with a password change to an AuthSource user switching to Internal authentication" do
@@ -266,10 +266,10 @@ class UsersControllerTest < ActionController::TestCase
     u.auth_source = AuthSource.find(1)
     u.save!
 
-    put :update, :id => u.id, :user => {:auth_source_id => '', :password => 'newpass'}, :password_confirmation => 'newpass'
+    put :update, :id => u.id, :user => {:auth_source_id => '', :password => 'newpassPASS!'}, :password_confirmation => 'newpassPASS!'
 
     assert_equal nil, u.reload.auth_source
-    assert u.check_password?('newpass')
+    assert u.check_password?('newpassPASS!')
   end
 
   def test_edit_membership

--- a/test/integration/account_test.rb
+++ b/test/integration/account_test.rb
@@ -46,7 +46,7 @@ class AccountTest < ActionDispatch::IntegrationTest
     Token.delete_all
 
     # User logs in with 'autologin' checked
-    post '/login', :username => user.login, :password => 'admin', :autologin => 1
+    post '/login', :username => user.login, :password => 'adminADMIN!', :autologin => 1
     assert_redirected_to '/my/page'
     token = Token.find :first
     assert_not_nil token
@@ -91,11 +91,11 @@ class AccountTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "account/password_recovery"
 
-    post "account/lost_password", :token => token.value, :new_password => 'newpass', :new_password_confirmation => 'newpass'
+    post "account/lost_password", :token => token.value, :new_password => 'newpassPASS!', :new_password_confirmation => 'newpassPASS!'
     assert_redirected_to "/login"
     assert_equal 'Password was successfully updated.', flash[:notice]
 
-    log_user('jsmith', 'newpass')
+    log_user('jsmith', 'newpassPASS!')
     assert_equal 0, Token.count
   end
 
@@ -107,7 +107,7 @@ class AccountTest < ActionDispatch::IntegrationTest
     assert_template 'account/register'
 
     post 'account/register', :user => {:login => "newuser", :language => "en", :firstname => "New", :lastname => "User", :mail => "newuser@foo.bar"},
-                             :password => "newpass", :password_confirmation => "newpass"
+                             :password => "newpassPASS!", :password_confirmation => "newpassPASS!"
     assert_redirected_to '/my/account'
     follow_redirect!
     assert_response :success
@@ -132,7 +132,7 @@ class AccountTest < ActionDispatch::IntegrationTest
     Setting.self_registration = '1'
     Token.delete_all
 
-    post 'account/register', :user => {:login => "newuser", :language => "en", :firstname => "New", :lastname => "User", :mail => "newuser@foo.bar", :password => "newpass", :password_confirmation => "newpass"}
+    post 'account/register', :user => {:login => "newuser", :language => "en", :firstname => "New", :lastname => "User", :mail => "newuser@foo.bar", :password => "newpassPASS!", :password_confirmation => "newpassPASS!"}
     assert_redirected_to '/login'
     assert !User.find_by_login('newuser').active?
 
@@ -143,7 +143,7 @@ class AccountTest < ActionDispatch::IntegrationTest
 
     get 'account/activate', :token => token.value
     assert_redirected_to '/login'
-    log_user('newuser', 'newpass')
+    log_user('newuser', 'newpassPASS!')
   end
 
   should_eventually "login after losing password should redirect back to home" do

--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -15,28 +15,29 @@ class AdminTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def test_add_user
-    log_user("admin", "admin")
+    log_user("admin", "adminADMIN!")
     get new_user_path
     assert_response :success
     assert_template "users/new"
-    post users_path, :user => { :login => "psmith", :firstname => "Paul", :lastname => "Smith", :mail => "psmith@somenet.foo", :language => "en", :password => "psmith09", :password_confirmation => "psmith09" }
+    post users_path, :user => { :login => "psmith", :firstname => "Paul", :lastname => "Smith", :mail => "psmith@somenet.foo", :language => "en", :password => "psmithPSMITH09", :password_confirmation => "psmithPSMITH09" }
 
     user = User.find_by_login("psmith")
+
     assert_kind_of User, user
     assert_redirected_to edit_user_path(user)
 
-    logged_user = User.try_to_login("psmith", "psmith09")
+    logged_user = User.try_to_login("psmith", "psmithPSMITH09")
     assert_kind_of User, logged_user
     assert_equal "Paul", logged_user.firstname
 
     put user_path(user), :id => user.id, :user => { :status => User::STATUS_LOCKED }
     assert_redirected_to edit_user_path(user)
-    locked_user = User.try_to_login("psmith", "psmith09")
+    locked_user = User.try_to_login("psmith", "psmithPSMITH09")
     assert_equal nil, locked_user
   end
 
   test "Add a user as an anonymous user should fail" do
-    post users_path, :user => { :login => 'psmith', :firstname => 'Paul'}, :password => "psmith09", :password_confirmation => "psmith09"
+    post users_path, :user => { :login => 'psmith', :firstname => 'Paul'}, :password => "psmithPSMITH09", :password_confirmation => "psmithPSMITH09"
     assert_response :redirect
     assert_redirected_to "/login?back_url=http%3A%2F%2Fwww.example.com%2Fusers"
   end

--- a/test/integration/api_test/disabled_rest_api_test.rb
+++ b/test/integration/api_test/disabled_rest_api_test.rb
@@ -45,8 +45,8 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
 
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'my_password', :password_confirmation => 'my_password')
-          @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'my_password')
+          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
+          @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
           get "/news.xml", nil, :authorization => @authorization
         end
 
@@ -90,8 +90,8 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
 
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'my_password', :password_confirmation => 'my_password')
-          @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'my_password')
+          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
+          @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
           get "/news.json", nil, :authorization => @authorization
         end
 

--- a/test/integration/api_test/users_test.rb
+++ b/test/integration/api_test/users_test.rb
@@ -65,13 +65,13 @@ class ApiTest::UsersTest < ActionDispatch::IntegrationTest
   context "POST /users" do
     context "with valid parameters" do
       setup do
-        @parameters = {:user => {:login => 'foo', :firstname => 'Firstname', :lastname => 'Lastname', :mail => 'foo@example.net', :password => 'secret', :mail_notification => 'only_assigned'}}
+        @parameters = {:user => {:login => 'foo', :firstname => 'Firstname', :lastname => 'Lastname', :mail => 'foo@example.net', :password => 'adminADMIN!', :mail_notification => 'only_assigned'}}
       end
 
       context ".xml" do
         should_allow_api_authentication(:post,
           '/users.xml',
-          {:user => {:login => 'foo', :firstname => 'Firstname', :lastname => 'Lastname', :mail => 'foo@example.net', :password => 'secret'}},
+          {:user => {:login => 'foo', :firstname => 'Firstname', :lastname => 'Lastname', :mail => 'foo@example.net', :password => 'adminADMIN!'}},
           {:success_code => :created})
 
         should "create a user with the attributes" do
@@ -86,7 +86,7 @@ class ApiTest::UsersTest < ActionDispatch::IntegrationTest
           assert_equal 'foo@example.net', user.mail
           assert_equal 'only_assigned', user.mail_notification
           assert !user.admin?
-          assert user.check_password?('secret')
+          assert user.check_password?('adminADMIN!')
 
           assert_response :created
           assert_equal 'application/xml', @response.content_type

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -25,9 +25,9 @@ class LayoutTest < ActionDispatch::IntegrationTest
   end
 
   test "browsing to an unauthorized page should render the base layout" do
-    change_user_password('miscuser9', 'test')
+    change_user_password('miscuser9', 'testTestTest!')
 
-    log_user('miscuser9','test')
+    log_user('miscuser9','testTestTest!')
 
     get "/admin"
     assert_response :forbidden

--- a/test/integration/projects_test.rb
+++ b/test/integration/projects_test.rb
@@ -16,7 +16,7 @@ class ProjectsTest < ActionDispatch::IntegrationTest
 
   def test_archive_project
     subproject = Project.find(1).children.first
-    log_user("admin", "admin")
+    log_user("admin", "adminADMIN!")
     get "admin/projects"
     assert_response :success
     assert_template "admin/projects"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -260,7 +260,10 @@ class ActiveSupport::TestCase
   end
 
   def credentials(login, password = nil)
-    { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(login, password || login) }
+    if password.nil?
+      password = (login == 'admin' ? 'adminADMIN!' : login)
+    end
+    { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(login, password) }
   end
 
 
@@ -297,9 +300,9 @@ class ActiveSupport::TestCase
     context "should allow http basic auth using a username and password for #{http_method} #{url}" do
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'my_password', :password_confirmation => 'my_password', :admin => true) # Admin so they can access the project
+          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!', :admin => true) # Admin so they can access the project
 
-          send(http_method, url, parameters, credentials(@user.login, 'my_password'))
+          send(http_method, url, parameters, credentials(@user.login, 'adminADMIN!'))
         end
 
         should respond_with success_code

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -331,7 +331,9 @@ class ProjectTest < ActiveSupport::TestCase
   def test_children
     c = Project.find(1).children
     assert c.first.is_a?(Project)
-    assert_equal [3, 4, 5], c.collect(&:id)
+    # ignore ordering, since it depends on database collation configuration
+    # and may order lowercase/uppercase chars in a different order
+    assert_equal [3, 4, 5], c.collect(&:id).sort!
   end
 
   def test_descendants

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -43,18 +43,18 @@ class UserTest < ActiveSupport::TestCase
     user = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
 
     user.login = "jsmith"
-    user.password, user.password_confirmation = "password", "password"
+    user.password, user.password_confirmation = "adminADMIN!", "adminADMIN!"
     # login uniqueness
     assert !user.save
     assert_equal 1, user.errors.count
 
     user.login = "newuser"
-    user.password, user.password_confirmation = "passwd", "password"
+    user.password, user.password_confirmation = "adminADMIN!", "NOTadminADMIN!"
     # password confirmation
     assert !user.save
     assert_equal 1, user.errors.count
 
-    user.password, user.password_confirmation = "password", "password"
+    user.password, user.password_confirmation = "adminADMIN!", "adminADMIN!"
     assert user.save
   end
 
@@ -74,12 +74,12 @@ class UserTest < ActiveSupport::TestCase
     should "be case-insensitive." do
       u = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
       u.login = 'newuser'
-      u.password, u.password_confirmation = "password", "password"
+      u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
       assert u.save
 
       u = User.new(:firstname => "Similar", :lastname => "User", :mail => "similaruser@somenet.foo")
       u.login = 'NewUser'
-      u.password, u.password_confirmation = "password", "password"
+      u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
       assert !u.save
       assert_include u.errors[:login], I18n.translate('activerecord.errors.messages.taken')
     end
@@ -88,12 +88,12 @@ class UserTest < ActiveSupport::TestCase
   def test_mail_uniqueness_should_not_be_case_sensitive
     u = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
     u.login = 'newuser1'
-    u.password, u.password_confirmation = "password", "password"
+    u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
     assert u.save
 
     u = User.new(:firstname => "new", :lastname => "user", :mail => "newUser@Somenet.foo")
     u.login = 'newuser2'
-    u.password, u.password_confirmation = "password", "password"
+    u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
     assert !u.save
     assert_include u.errors[:mail], I18n.translate('activerecord.errors.messages.taken')
   end
@@ -127,17 +127,17 @@ class UserTest < ActiveSupport::TestCase
 
   context "User#try_to_login" do
     should "fall-back to case-insensitive if user login is not found as-typed." do
-      user = User.try_to_login("AdMin", "admin")
+      user = User.try_to_login("AdMin", "adminADMIN!")
       assert_kind_of User, user
       assert_equal "admin", user.login
     end
 
     should "select the exact matching user first" do
-      case_sensitive_user = User.generate_with_protected!(:login => 'changed', :password => 'admin', :password_confirmation => 'admin')
+      case_sensitive_user = User.generate_with_protected!(:login => 'changed', :password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
       # bypass validations to make it appear like existing data
       case_sensitive_user.update_attribute(:login, 'ADMIN')
 
-      user = User.try_to_login("ADMIN", "admin")
+      user = User.try_to_login("ADMIN", "adminADMIN!")
       assert_kind_of User, user
       assert_equal "ADMIN", user.login
 
@@ -145,13 +145,13 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_password
-    user = User.try_to_login("admin", "admin")
+    user = User.try_to_login("admin", "adminADMIN!")
     assert_kind_of User, user
     assert_equal "admin", user.login
-    user.password = "hello"
+    user.password = "newpassPASS!"
     assert user.save
 
-    user = User.try_to_login("admin", "hello")
+    user = User.try_to_login("admin", "newpassPASS!")
     assert_kind_of User, user
     assert_equal "admin", user.login
   end
@@ -178,7 +178,7 @@ class UserTest < ActiveSupport::TestCase
   context ".try_to_login" do
     context "with good credentials" do
       should "return the user" do
-        user = User.try_to_login("admin", "admin")
+        user = User.try_to_login("admin", "adminADMIN!")
         assert_kind_of User, user
         assert_equal "admin", user.login
       end


### PR DESCRIPTION
Add a new Passwords module, which evaluates and generates passwords.

In addition to checking the length, the module verifies that a password contains a certain number of character classes like uppercase/lowercase.

This pull request also increases the default password requirements from 4 to 10.

Also see #160.
