### PR TITLE
Adds a test and validations for circular structures.

### DIFF
--- a/app/models/timelines/planning_element.rb
+++ b/app/models/timelines/planning_element.rb
@@ -201,7 +201,9 @@ class Timelines::PlanningElement < ActiveRecord::Base
       errors.add :parent, :cannot_be_milestone if parent.is_milestone?
       errors.add :parent, :cannot_be_in_another_project if parent.project != project
       errors.add :parent, :cannot_be_in_recycle_bin if parent.deleted?
+      errors.add :parent, :circular_dependency if ancestors.include?(self)
     end
+
   end
 
   def leaf?

--- a/spec/models/timelines/planning_element_spec.rb
+++ b/spec/models/timelines/planning_element_spec.rb
@@ -620,6 +620,21 @@ describe Timelines::PlanningElement do
         changes.size.should == 1
         changes.should include("start_date")
       end
+
+      it 'disallows circular structures' do
+        child_pe # trigger creation of child and parent
+
+        # create a circular structure
+        pe.parent_id = child_pe.id
+
+        # ensure it is not valid
+        pe.should_not be_valid
+
+        pe.errors[:parent].should be_present
+        pe.errors[:parent].should == ["This relation would create a circular dependency"]
+
+      end
+
     end
 
     describe "a planning elements' journals includes changes to associated alternate dates start/end date" do


### PR DESCRIPTION
Acts_as_tree does not check for circular structures in the models it is invoked on. With this fix, infinite tree fetching no more.
