### PR TITLE
[OPF #907] special version instead of sha1 on admin info page

### DIFF
--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -15,12 +15,12 @@ See doc/COPYRIGHT.rdoc for more details.
 <p><strong><%= Redmine::Info.versioned_name %></strong> (<%= @db_adapter_name %>)</p>
 
 <table class="list">
-<% @checklist.each do |label, result| %>
-	<tr class="<%= cycle 'odd', 'even' %>">
-		<td><%= l(label) %></td>
-		<td width="30px"><%= image_tag((result ? 'check.png' : 'error.png'), :style => "vertical-align:bottom;", :alt => (result ? l(:general_text_Yes) : l(:general_text_No))) %></td>
-	</tr>
-<% end %>
+  <% @checklist.each do |label, result| %>
+    <tr class="<%= cycle 'odd', 'even' %>">
+      <td><%= l(label) %></td>
+      <td width="30px"><%= image_tag((result ? 'check.png' : 'error.png'), :style => "vertical-align:bottom;", :alt => (result ? l(:general_text_Yes) : l(:general_text_No))) %></td>
+    </tr>
+  <% end %>
 </table>
 
 <% html_title(l(:label_information_plural)) -%>

--- a/lib/chili_project/version.rb
+++ b/lib/chili_project/version.rb
@@ -10,48 +10,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'rexml/document'
-
 module ChiliProject
-  module VERSION #:nodoc:
-
-    MAJOR = 3
-    MINOR = 0
-    PATCH = 0
-    TINY  = PATCH # Redmine compat
-
-    # Used by semver to define the special version (if any).
-    # A special version "satify but have a lower precedence than the associated
-    # normal version". So 2.0.0RC1 would be part of the 2.0.0 series but
-    # be considered to be an older version.
-    #
-    #   1.4.0 < 2.0.0RC1 < 2.0.0RC2 < 2.0.0 < 2.1.0
-    #
-    # This method may be overridden by third party code to provide vendor or
-    # distribution specific versions. They may or may not follow semver.org:
-    #
-    #   2.0.0debian-2
-    def self.special
-      'beta1'
-    end
-
-    def self.revision
-      revision = `git rev-parse HEAD`
-      if revision.present?
-        revision.strip[0..8]
-      else
-        nil
-      end
-    end
-
-    REVISION = self.revision
-    ARRAY = [MAJOR, MINOR, PATCH, REVISION].compact
-    STRING = ARRAY.join('.')
-
-    def self.to_a; ARRAY end
-    def self.to_s; STRING end
-    def self.to_semver
-      [MAJOR, MINOR, PATCH].join('.') + special
-    end
-  end
+  # THIS IS A ChiliProject COMPATIBILITY INTERFACE
+  VERSION = OpenProject::VERSION
 end

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -32,7 +32,7 @@ module OpenProject
     #
     #   2.0.0debian-2
     def self.special
-      'beta1'
+      'beta2'
     end
 
     def self.revision

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -1,0 +1,57 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'rexml/document'
+
+module OpenProject
+  module VERSION #:nodoc:
+
+    MAJOR = 3
+    MINOR = 0
+    PATCH = 0
+    TINY  = PATCH # Redmine compat
+
+    # Used by semver to define the special version (if any).
+    # A special version "satify but have a lower precedence than the associated
+    # normal version". So 2.0.0RC1 would be part of the 2.0.0 series but
+    # be considered to be an older version.
+    #
+    #   1.4.0 < 2.0.0RC1 < 2.0.0RC2 < 2.0.0 < 2.1.0
+    #
+    # This method may be overridden by third party code to provide vendor or
+    # distribution specific versions. They may or may not follow semver.org:
+    #
+    #   2.0.0debian-2
+    def self.special
+      'beta1'
+    end
+
+    def self.revision
+      revision = `git rev-parse HEAD`
+      if revision.present?
+        revision.strip[0..8]
+      else
+        nil
+      end
+    end
+
+    REVISION = self.revision
+    ARRAY = [MAJOR, MINOR, PATCH, REVISION].compact
+    STRING = ARRAY.join('.')
+
+    def self.to_a; ARRAY end
+    def self.to_s; STRING end
+    def self.to_semver
+      [MAJOR, MINOR, PATCH].join('.') + special
+    end
+  end
+end

--- a/lib/redmine/info.rb
+++ b/lib/redmine/info.rb
@@ -18,7 +18,7 @@ module Redmine
       def help_url
         "https://www.openproject.org/projects/support"
       end
-      def versioned_name; "#{app_name} #{Redmine::VERSION}" end
+      def versioned_name; "#{app_name} #{Redmine::VERSION.to_semver}" end
 
       # Creates the url string to a specific Redmine issue
       def issue(issue_id)

--- a/lib/redmine/version.rb
+++ b/lib/redmine/version.rb
@@ -12,5 +12,5 @@
 
 module Redmine
   # THIS IS A REDMINE COMPATIBILITY INTERFACE
-  VERSION = ChiliProject::VERSION
+  VERSION = OpenProject::VERSION
 end


### PR DESCRIPTION
- moved ChiliProject::Info in OpenProject namespace

see: https://www.openproject.org/issues/907
