### PR TITLE
Feature/user current laziness warning

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -18,6 +18,7 @@ describe UsersController do
 
   let(:user) { FactoryGirl.create(:user) }
   let(:admin) { FactoryGirl.create(:admin) }
+  let(:anonymous) { FactoryGirl.create(:anonymous) }
 
   describe "GET deletion_info" do
 
@@ -26,10 +27,11 @@ describe UsersController do
       let(:params) { { "id" => user.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(user)
         Setting.stub!(:users_deletable_by_self?).and_return(true)
 
-        get :deletion_info, params
+        as_logged_in_user user do
+          get :deletion_info, params
+        end
       end
 
       it { response.should be_success }
@@ -42,22 +44,23 @@ describe UsersController do
       let(:params) { { "id" => user.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(user)
         Setting.stub!(:users_deletable_by_self?).and_return(false)
 
-        get :deletion_info, params
+        as_logged_in_user user do
+          get :deletion_info, params
+        end
       end
 
       it { response.response_code.should == 404 }
     end
 
     describe "WHEN the current user is the anonymous user" do
-      let(:params) { { "id" => User.anonymous.id.to_s } }
+      let(:params) { { "id" => anonymous.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(User.anonymous)
-
-        get :deletion_info, params
+        as_logged_in_user anonymous do
+          get :deletion_info, params
+        end
       end
 
       it { response.should redirect_to({ :controller => 'account',
@@ -68,14 +71,14 @@ describe UsersController do
 
     describe "WHEN the current user is admin
               WHEN the setting users_deletable_by_admins is set to true" do
-      let(:admin) { FactoryGirl.create(:admin) }
       let(:params) { { "id" => user.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(admin)
         Setting.stub!(:users_deletable_by_admins?).and_return(true)
 
-        get :deletion_info, params
+        as_logged_in_user admin do
+          get :deletion_info, params
+        end
       end
 
       it { response.should be_success }
@@ -85,14 +88,14 @@ describe UsersController do
 
     describe "WHEN the current user is admin
               WHEN the setting users_deletable_by_admins is set to false" do
-      let(:admin) { FactoryGirl.create(:admin) }
       let(:params) { { "id" => user.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(admin)
         Setting.stub!(:users_deletable_by_admins?).and_return(false)
 
-        get :deletion_info, params
+        as_logged_in_user admin do
+          get :deletion_info, params
+        end
       end
 
       it { response.response_code.should == 404 }
@@ -106,10 +109,11 @@ describe UsersController do
 
       before do
         @controller.instance_eval{ flash.stub!(:sweep) }
-        @controller.stub!(:find_current_user).and_return(user)
         Setting.stub!(:users_deletable_by_self?).and_return(true)
 
-        post :destroy, params
+        as_logged_in_user user do
+          post :destroy, params
+        end
       end
 
       it { response.should redirect_to({ :controller => 'account', :action => 'login' }) }
@@ -122,10 +126,11 @@ describe UsersController do
 
       before do
         @controller.instance_eval{ flash.stub!(:sweep) }
-        @controller.stub!(:find_current_user).and_return(user)
         Setting.stub!(:users_deletable_by_self?).and_return(false)
 
-        post :destroy, params
+        as_logged_in_user user do
+          post :destroy, params
+        end
       end
 
       it { response.response_code.should == 404 }
@@ -133,13 +138,15 @@ describe UsersController do
 
     describe "WHEN the current user is the anonymous user
               EVEN when the setting login_required is set to false" do
-      let(:params) { { "id" => User.anonymous.id.to_s } }
+      let(:params) { { "id" => anonymous.id.to_s } }
 
       before do
-        @controller.stub!(:find_current_user).and_return(User.anonymous)
+        @controller.stub!(:find_current_user).and_return(anonymous)
         Setting.stub!(:login_required?).and_return(false)
 
-        post :destroy, params
+        as_logged_in_user anonymous do
+          post :destroy, params
+        end
       end
 
       # redirecting post is not possible for now
@@ -153,10 +160,11 @@ describe UsersController do
 
       before do
         @controller.instance_eval{ flash.stub!(:sweep) }
-        @controller.stub!(:find_current_user).and_return(admin)
         Setting.stub!(:users_deletable_by_admins?).and_return(true)
 
-        post :destroy, params
+        as_logged_in_user admin do
+          post :destroy, params
+        end
       end
 
       it { response.should redirect_to({ :controller => 'users', :action => 'index' }) }
@@ -170,10 +178,11 @@ describe UsersController do
 
       before do
         @controller.instance_eval{ flash.stub!(:sweep) }
-        @controller.stub!(:find_current_user).and_return(admin)
         Setting.stub!(:users_deletable_by_admins).and_return(false)
 
-        post :destroy, params
+        as_logged_in_user admin do
+          post :destroy, params
+        end
       end
 
       it { response.response_code.should == 404 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,31 +63,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.after(:each) do
-    # Using the hacky way of getting current_user to avoid under the hood creation of AnonymousUser
-    unless User.instance_variable_get(:@current_user).nil?
-      warn <<-DOC
-
-              ============================================================================================
-              #{ example.full_description }
-              ============================================================================================
-              This spec leaves User.current in an unclean state, creating a dependency to other specs.
-
-              It sets User.current to a value other than User.anonymous but does not clean up after the
-              spec is run. User.current saves this value in an instance variable of the User class.
-              This class instance variable is not removed between tests.
-
-              So please go ahead and set User.current to nil afterwards.
-              ============================================================================================
-
-              #{ example.metadata[:caller].join("\n              ") }
-
-              ============================================================================================
-
-
-      DOC
-
-      User.current = nil
-    end
+    OpenProject::RSpecLazinessWarn.warn_if_user_current_set(example)
   end
 
   config.after(:suite) do
@@ -104,4 +80,69 @@ Rails.application.config.plugins_to_test_paths.each do |dir|
     puts 'Loading ' + disable_specs_file
     require disable_specs_file
   end
+end
+
+module OpenProject::RSpecLazinessWarn
+
+  def self.warn_if_user_current_set(example)
+    # Using the hacky way of getting current_user to avoid under the hood creation of AnonymousUser
+    # which might break other tests and at least leaves this user in the db after the test is run.
+    unless User.instance_variable_get(:@current_user).nil?
+
+      # we only want an abbreviated_stacktrace because the logfiles
+      # might otherwise not be capable to show all the warnings.
+      # Thus we only take the callers that are part of the user code.
+      file_roots = Rails::Application::Railties.engines.map { |e| e.root.to_s } << Rails.root.to_s
+      abbreviated_stacktrace = example.metadata[:caller].select { |s| file_roots.any?{ |root| s.include?(root) } }
+
+      # we only want to show the more verbose warning once
+      if self.warned
+        warn <<-DOC
+
+              ============================================================================================
+              #{ example.full_description }
+              ============================================================================================
+              This spec also leaves User.current in an unclean state.
+              ============================================================================================
+              #{ abbreviated_stacktrace.join("\n              ") }
+              ============================================================================================
+        DOC
+      else
+        warn <<-DOC
+
+                ============================================================================================
+                #{ example.full_description }
+                ============================================================================================
+                This spec leaves User.current in an unclean state, creating a dependency to other specs.
+
+                It sets User.current to a value other than User.anonymous but does not clean up after the
+                spec is run. User.current saves this value in an instance variable of the User class.
+                This class instance variable is not removed between tests.
+
+                So please go ahead and set User.current to nil afterwards.
+                ============================================================================================
+
+                Abbreviated stacktrace:
+
+                #{ abbreviated_stacktrace.join("\n              ") }
+
+                ============================================================================================
+
+
+        DOC
+
+        self.warned = true
+      end
+
+      User.current = nil
+    end
+  end
+
+
+  protected
+
+  class << self
+    attr_accessor :warned
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@
 #++
 
 require 'rubygems'
-require 'pp'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'

--- a/spec/support/shared/as_user.rb
+++ b/spec/support/shared/as_user.rb
@@ -1,0 +1,16 @@
+# Method for controller tests where you want to do everything in the context of the
+# provided user without the hassle of locking in the user and cleaning up User.current
+# afterwards
+#
+# Example usage:
+#
+#   as_logged_in_user admin do
+#     post :create, { :name => "foo" }
+#   end
+
+def as_logged_in_user(user, &block)
+  @controller.stub!(:user_setup).and_return(user)
+  User.stub!(:current).and_return(user)
+
+  yield
+end


### PR DESCRIPTION
When User.current is set by a spec, an instance variable of the class
gets set to the provided value. This instance variable is not reset
between specs, the next spec will "profit" as well.

This commit implements cleaning up after such lazy specs.

The lazy specs should be improved so that this cleanup is no longer
required. However I do not have the time to do this right now. As a
reminder I implemented a very verbose warning which should give us
enough of an encouragement that we will improve the specs eventually.
