### PR TITLE
fixes timelines modal changed dialog

### DIFF
--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -485,7 +485,7 @@ var ModalHelper = (function() {
 
       // close when body is clicked
       body.click(function(e) {
-        if (modalDiv.data('changed') !== true || confirm(I18n.t('js.timelines.really_close_dialog'))) {
+        if (modalDiv.data('changed') !== undefined && (modalDiv.data('changed') !== true || confirm(I18n.t('js.timelines.really_close_dialog')))) {
           modalDiv.data('changed', false);
           modalDiv.dialog('close');
         } else {


### PR DESCRIPTION
It should only appear when properly initialized. Problem was a javascript error thrown because of a call of close() on uninitialized dialog.
