### PR TITLE
Removed function to preload circular dependencies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,6 @@ require 'cgi'
 
 class ApplicationController < ActionController::Base
   # ensure the OpenProject models are required in the right order (as they have circular dependencies)
-  OpenProject.preload_circular_dependencies
 
   class_attribute :_model_object
   class_attribute :_model_scope

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -10,6 +10,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require_dependency 'project'
+
 class Principal < ActiveRecord::Base
   extend Pagination::Model
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require_dependency 'issue'
+
 class Project < ActiveRecord::Base
   include Redmine::SafeAttributes
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require_dependency 'principal'
 require "digest/sha1"
 
 class User < Principal

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,13 +87,4 @@ module OpenProject
     # initialize variable for register plugin tests
     config.plugins_to_test_paths = []
   end
-
-  def self.preload_circular_dependencies
-    # preload circular dependencies. this should be used to ensure the correct load
-    # order when loading core classes from plugins.
-    require_dependency 'issue'
-    require_dependency 'project'
-    require_dependency 'user'
-    require_dependency 'principal'
-  end
 end

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -369,5 +369,3 @@ Redmine::WikiFormatting.map do |format|
 end
 
 ActionView::Template.register_template_handler :rsb, Redmine::Views::ApiTemplateHandler
-
-OpenProject.preload_circular_dependencies


### PR DESCRIPTION
since it is not always running first to load the dependencies (see Bundler.require in application.rb),
therefore explicitely requiring the dependencies in the files loads classes
in the correct order no matter which is loaded first
