### PR TITLE
Gemfile: Remove pry from test group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ rvm:
   - 1.9.3
 env:
   # mysql2
-  - "TEST_SUITE=test:units       RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite"
-  - "TEST_SUITE=test:functionals RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite"
-  - "TEST_SUITE=test:integration RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite"
-  - "TEST_SUITE=spec             RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite"
-  - "TEST_SUITE=cucumber         RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite"
+  - "TEST_SUITE=cucumber         RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+  - "TEST_SUITE=test:units       RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+  - "TEST_SUITE=test:functionals RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+  - "TEST_SUITE=test:integration RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+  - "TEST_SUITE=spec             RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
   # postgres
-  - "TEST_SUITE=test:units       RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite"
-  - "TEST_SUITE=test:functionals RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite"
-  - "TEST_SUITE=test:integration RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite"
-  - "TEST_SUITE=spec             RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite"
-  - "TEST_SUITE=cucumber         RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite"
+  - "TEST_SUITE=cucumber         RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
+  - "TEST_SUITE=test:units       RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
+  - "TEST_SUITE=test:functionals RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
+  - "TEST_SUITE=test:integration RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
+  - "TEST_SUITE=spec             RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
 script: "bundle exec rake $TEST_SUITE"
 before_install:
   - "sudo apt-get update -qq"

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,8 @@ group :test do
   gem 'rack_session_access'
   gem 'database_cleaner'
   gem "cucumber-rails-training-wheels" # http://aslakhellesoy.com/post/11055981222/the-training-wheels-came-off
-  gem "rspec-rails", "~> 2.0", :group => :development
+  gem 'rspec', '~> 2.0'
+  gem "rspec-rails", "~> 2.0"
   gem 'rspec-example_disabler', :git => 'https://github.com/finnlabs/rspec-example_disabler.git'
   gem 'capybara'
   gem 'capybara-screenshot'
@@ -91,20 +92,17 @@ group :development do
   gem 'rails-footnotes', '>= 3.7.5.rc4'
   gem 'bullet'
   gem 'letter_opener', '~> 1.0.0'
+  gem 'pry-rails'
+  gem 'pry-stack_explorer'
+  gem 'pry-rescue'
+  gem 'pry-debugger'
+  gem 'pry-doc'
   gem 'rails-dev-tweaks', '~> 0.6.1'
   gem 'guard-rspec'
   gem 'guard-cucumber'
   gem 'rb-fsevent', :group => :test
   gem 'rack-mini-profiler'
   gem 'thin'
-end
-
-group :development, :test do
-  gem 'pry-rails'
-  gem 'pry-stack_explorer'
-  gem 'pry-rescue'
-  gem 'pry-debugger'
-  gem 'pry-doc'
 end
 
 group :tools do

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -360,6 +360,7 @@ end
 
 Given /^I start debugging$/ do
   save_and_open_page
+  require 'pry'
   binding.pry
   true
 end


### PR DESCRIPTION
Travis fails to install debugger, which regularly has to be updated
for new Ruby versions. Travis told us to remove debugger from the test
group, which not only saves installing it when running tests on CI,
but also should make debugger not break our CI runs in the future.

The only downside I see is, that running pry from tests might require
loading pry before using it, so 'binding.pry' becomes
'require "pry"; binding.pry'.

OpenProject Issue: https://www.openproject.org/issues/1262
