### PR TITLE
Refactor user status

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -99,7 +99,7 @@ module Api
           @user.password, @user.password_confirmation = params[:user][:password], params[:user][:password_confirmation]
         end
         # Was the account actived ? (do it before User#save clears the change)
-        was_activated = (@user.status_change == [User::STATUS_REGISTERED, User::STATUS_ACTIVE])
+        was_activated = (@user.status_change == [User::STATUSES[:registered], User::STATUSES[:active]])
         if @user.save
           # TODO: Similar to My#account
           @user.pref.attributes = params[:pref]
@@ -134,7 +134,7 @@ module Api
       def destroy
         # as destroying users is a lengthy process we handle it in the background
         # and lock the account now so that no action can be performed with it
-        @user.status = User::STATUS_LOCKED
+        @user.status = User::STATUSES[:locked]
         @user.save
 
         # TODO: use Delayed::Worker.delay_jobs = false in test environment as soon as

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -136,7 +136,8 @@ class UsersController < ApplicationController
       @user.password, @user.password_confirmation = params[:user][:password], params[:user][:password_confirmation]
     end
     # Was the account actived ? (do it before User#save clears the change)
-    was_activated = (@user.status_change == [User::STATUS_REGISTERED, User::STATUS_ACTIVE])
+    was_activated = (@user.status_change == [User::STATUSES[:registered],
+                                             User::STATUSES[:active]])
     if @user.save
       # TODO: Similar to My#account
       @user.pref.attributes = params[:pref]
@@ -196,7 +197,7 @@ class UsersController < ApplicationController
   def destroy
     # as destroying users is a lengthy process we handle it in the background
     # and lock the account now so that no action can be performed with it
-    @user.status = User::STATUS_LOCKED
+    @user.status = User::STATUSES[:locked]
     @user.save
 
     # TODO: use Delayed::Worker.delay_jobs = false in test environment as soon as

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,25 +94,11 @@ module ApplicationHelper
 
   #returns a class name based on the user's status
   def user_status_class(user)
-    case user.status
-      when User::STATUS_ACTIVE
-        "status_active"
-      when User::STATUS_REGISTERED
-        "status_registered"
-      when User::STATUS_LOCKED
-        "status_locked"
-    end
+    'status_' + user.status_name.to_s
   end
 
   def user_status_i18n(user)
-    case user.status
-      when User::STATUS_ACTIVE
-        l(:status_active)
-      when User::STATUS_REGISTERED
-        l(:status_registered)
-      when User::STATUS_LOCKED
-        l(:status_locked)
-    end
+    l(('status_' + user.status_name.to_s).to_sym)
   end
 
   # Displays a link to +issue+ with its subject.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,11 +94,11 @@ module ApplicationHelper
 
   #returns a class name based on the user's status
   def user_status_class(user)
-    'status_' + user.status_name.to_s
+    'status_' + user.status_name
   end
 
   def user_status_i18n(user)
-    l(('status_' + user.status_name.to_s).to_sym)
+    l(('status_' + user.status_name).to_sym)
   end
 
   # Displays a link to +issue+ with its subject.

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -36,11 +36,11 @@ module UsersHelper
     url = {:controller => '/users', :action => 'update', :id => user, :page => params[:page], :status => params[:status], :tab => nil}
 
     if user.locked?
-      link_to l(:button_unlock), url.merge(:user => {:status => User::STATUS_ACTIVE}), :method => :put, :class => 'icon icon-unlock'
+      link_to l(:button_unlock), url.merge(:user => {:status => User::STATUSES[:active]}), :method => :put, :class => 'icon icon-unlock'
     elsif user.registered?
-      link_to l(:button_activate), url.merge(:user => {:status => User::STATUS_ACTIVE}), :method => :put, :class => 'icon icon-unlock'
+      link_to l(:button_activate), url.merge(:user => {:status => User::STATUSES[:active]}), :method => :put, :class => 'icon icon-unlock'
     elsif user != User.current
-      link_to l(:button_lock), url.merge(:user => {:status => User::STATUS_LOCKED}), :method => :put, :class => 'icon icon-lock'
+      link_to l(:button_lock), url.merge(:user => {:status => User::STATUSES[:locked]}), :method => :put, :class => 'icon icon-lock'
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -13,10 +13,13 @@
 module UsersHelper
   def users_status_options_for_select(selected)
     user_count_by_status = User.count(:group => 'status').to_hash
-    options_for_select([[l(:label_all), ''],
-                        ["#{l(:status_active)} (#{user_count_by_status[1].to_i})", 1],
-                        ["#{l(:status_registered)} (#{user_count_by_status[2].to_i})", 2],
-                        ["#{l(:status_locked)} (#{user_count_by_status[3].to_i})", 3]], selected)
+    statuses = User::STATUSES.reject{|n,i| n == :builtin}.map do |name, index|
+      ["#{translate_user_status(name)} (#{user_count_by_status[index].to_i})"]
+    end
+  end
+
+  def translate_user_status(status_name)
+    I18n.t(('status_' + status_name.to_s).to_sym)
   end
 
   # Options for the new membership projects combo-box

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -14,12 +14,14 @@ module UsersHelper
   def users_status_options_for_select(selected)
     user_count_by_status = User.count(:group => 'status').to_hash
     statuses = User::STATUSES.reject{|n,i| n == :builtin}.map do |name, index|
-      ["#{translate_user_status(name)} (#{user_count_by_status[index].to_i})"]
+      ["#{translate_user_status(name.to_s)} (#{user_count_by_status[index].to_i})",
+       index]
     end
+    options_for_select([[I18n.t(:label_all), '']] + statuses, selected)
   end
 
   def translate_user_status(status_name)
-    I18n.t(('status_' + status_name.to_s).to_sym)
+    I18n.t(('status_' + status_name).to_sym)
   end
 
   # Options for the new membership projects combo-box

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -221,7 +221,7 @@ class UserMailer < ActionMailer::Base
     @user           = user
     @activation_url = url_for(:controller => '/users',
                               :action     => :index,
-                              :status     => User::STATUS_REGISTERED,
+                              :status     => User::STATUSES[:registered],
                               :sort       => 'created_at:desc')
 
     open_project_headers 'Type' => 'Account'

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -66,6 +66,15 @@ class Principal < ActiveRecord::Base
     active_or_registered.like(query)
   end
 
+  def status_name
+    # Only Users should have another status than active.
+    # User defines the status values and other classes like Principal
+    # shouldn't know anything about them. Nevertheless, some functions
+    # want to know the status for other Principals than User.
+    raise "Principal has status other than active" unless self.status == 1
+    :active
+  end
+
   def <=>(principal)
     if self.class.name == principal.class.name
       self.to_s.downcase <=> principal.to_s.downcase

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -72,7 +72,7 @@ class Principal < ActiveRecord::Base
     # shouldn't know anything about them. Nevertheless, some functions
     # want to know the status for other Principals than User.
     raise "Principal has status other than active" unless self.status == 1
-    :active
+    'active'
   end
 
   def <=>(principal)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,18 +25,21 @@ class Project < ActiveRecord::Base
 
   # Specific overidden Activities
   has_many :time_entry_activities
-  has_many :members, :include => [:user, :roles], :conditions => "#{User.table_name}.type='User' AND #{User.table_name}.status=#{User::STATUS_ACTIVE}"
+  has_many :members, :include => [:user, :roles], :conditions => "#{User.table_name}.type='User' AND #{User.table_name}.status=#{User::STATUSES[:active]}"
   has_many :assignable_members,
            :class_name => 'Member',
            :include => [:user, :roles],
            :conditions => ["#{User.table_name}.type=? AND #{User.table_name}.status=? AND roles.assignable = ?",
                            'User',
-                           User::STATUS_ACTIVE,
+                           User::STATUSES[:active],
                            true]
   has_many :memberships, :class_name => 'Member'
   has_many :member_principals, :class_name => 'Member',
                                :include => :principal,
-                               :conditions => "#{Principal.table_name}.type='Group' OR (#{Principal.table_name}.type='User' AND (#{Principal.table_name}.status=#{User::STATUS_ACTIVE} OR #{Principal.table_name}.status=#{User::STATUS_REGISTERED}))"
+                               :conditions => "#{Principal.table_name}.type='Group' OR " +
+                                              "(#{Principal.table_name}.type='User' AND " +
+                                              "(#{Principal.table_name}.status=#{User::STATUSES[:active]} OR " +
+                                              "#{Principal.table_name}.status=#{User::STATUSES[:registered]}))"
   has_many :users, :through => :members
   has_many :principals, :through => :member_principals, :source => :principal
 

--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -46,13 +46,13 @@ class SystemUser < User
 
   def grant_privileges
     self.admin = true
-    self.status = STATUS_BUILTIN
+    self.status = STATUSES[:builtin]
     self.save
   end
 
   def remove_privileges
     self.admin = false
-    self.status = User::STATUS_LOCKED
+    self.status = STATUSES[:locked]
     self.save
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,10 +16,13 @@ class User < Principal
   include Redmine::SafeAttributes
 
   # Account statuses
-  STATUS_BUILTIN    = 0
-  STATUS_ACTIVE     = 1
-  STATUS_REGISTERED = 2
-  STATUS_LOCKED     = 3
+  # Code accessing the keys assumes they are ordered, which they are since Ruby 1.9
+  STATUSES = {
+    :builtin => 0,
+    :active => 1,
+    :registered => 2,
+    :locked => 3
+  }
 
   USER_FORMATS_STRUCTURE = {
     :firstname_lastname => [:firstname, :lastname],
@@ -82,8 +85,10 @@ class User < Principal
   has_many :projects, :through => :memberships
 
   # Active non-anonymous users scope
-  scope :active, :conditions => "#{User.table_name}.status = #{STATUS_ACTIVE}"
-  scope :active_or_registered, :conditions => "#{User.table_name}.status = #{STATUS_ACTIVE} or #{User.table_name}.status = #{STATUS_REGISTERED}"
+  scope :active, :conditions => "#{User.table_name}.status = #{STATUSES[:active]}"
+  scope :active_or_registered, :conditions =>
+          "#{User.table_name}.status = #{STATUSES[:active]} or " + 
+          "#{User.table_name}.status = #{STATUSES[:registered]}"
 
   acts_as_customizable
 
@@ -251,40 +256,44 @@ class User < Principal
     end
   end
 
+  def status_name
+    STATUSES.keys[self.status]
+  end
+
   def active?
-    self.status == STATUS_ACTIVE
+    self.status == STATUSES[:active]
   end
 
   def registered?
-    self.status == STATUS_REGISTERED
+    self.status == STATUSES[:registered]
   end
 
   def locked?
-    self.status == STATUS_LOCKED
+    self.status == STATUSES[:locked]
   end
 
   def activate
-    self.status = STATUS_ACTIVE
+    self.status = STATUSES[:active]
   end
 
   def register
-    self.status = STATUS_REGISTERED
+    self.status = STATUSES[:registered]
   end
 
   def lock
-    self.status = STATUS_LOCKED
+    self.status = STATUSES[:locked]
   end
 
   def activate!
-    update_attribute(:status, STATUS_ACTIVE)
+    update_attribute(:status, STATUSES[:active])
   end
 
   def register!
-    update_attribute(:status, STATUS_REGISTERED)
+    update_attribute(:status, STATUSES[:registered])
   end
 
   def lock!
-    update_attribute(:status, STATUS_LOCKED)
+    update_attribute(:status, STATUSES[:locked])
   end
 
   # Returns true if +clear_password+ is the correct user's password, otherwise false
@@ -631,7 +640,7 @@ class User < Principal
         u.firstname = ''
         u.mail = ''
         u.admin = false
-        u.status = User::STATUS_LOCKED
+        u.status = User::STATUSES[:locked]
         u.first_login = false
         u.random_password!
       end).save
@@ -777,7 +786,7 @@ class DeletedUser < User
   end
 
   def self.first
-    find_or_create_by_type_and_status(self.to_s, User::STATUS_BUILTIN)
+    find_or_create_by_type_and_status(self.to_s, STATUSES[:builtin])
   end
 
   # Overrides a few properties

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,7 +257,7 @@ class User < Principal
   end
 
   def status_name
-    STATUSES.keys[self.status]
+    STATUSES.keys[self.status].to_s
   end
 
   def active?

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -27,6 +27,10 @@ Given /^the [Uu]ser "([^\"]*)" has:$/ do |user, table|
   modify_user(u, table)
 end
 
+Given /^the user "([^\"]*)" is locked$/ do |user|
+  User.find_by_login(user).lock!
+end
+
 Given /^there are the following users:$/ do |table|
   table.raw.flatten.each do |login|
     FactoryGirl.create(:user, :login => login)
@@ -50,4 +54,12 @@ Then /^there should be a user with the following:$/ do |table|
   expected.each do |key, value|
     user.send(key).should == value
   end
+end
+
+##
+# admin users list
+#
+When /^I filter the users list by status "([^\"]+)"$/ do |status|
+  visit('/users')
+  select(status, :from => 'Status:')
 end

--- a/features/users/status.feature
+++ b/features/users/status.feature
@@ -1,0 +1,11 @@
+Feature: User Status
+  Background:
+    Given I am already logged in as "admin"
+
+  @javascript
+  Scenario: Users can be filtered by status
+    Given there is a user named "bobby"
+    And the user "bobby" is locked
+    Then I should not see "bobby"
+    And I filter the users list by status "locked (1)"
+    Then I should see "bobby"

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -26,7 +26,7 @@ FactoryGirl.define do
     mail_notification(Redmine::VERSION::MAJOR > 0 ? 'all' : true)
 
     language 'en'
-    status User::STATUS_ACTIVE
+    status User::STATUSES[:active]
     admin false
     first_login false if User.table_exists? and User.columns.map(&:name).include? 'first_login'
 
@@ -51,12 +51,12 @@ FactoryGirl.define do
     end
 
     factory :anonymous, :class => AnonymousUser do
-      status User::STATUS_BUILTIN
+      status User::STATUSES[:builtin]
       initialize_with { User.anonymous }
     end
 
     factory :deleted_user, :class => DeletedUser do
-      status User::STATUS_BUILTIN
+      status User::STATUSES[:builtin]
     end
   end
 end

--- a/spec/models/system_user_spec.rb
+++ b/spec/models/system_user_spec.rb
@@ -6,7 +6,7 @@ describe SystemUser do
   describe '#grant_privileges' do
     before do
       system_user.admin.should be_false
-      system_user.status.should == User::STATUS_LOCKED
+      system_user.status.should == User::STATUSES[:locked]
       system_user.grant_privileges
     end
 
@@ -15,14 +15,14 @@ describe SystemUser do
     end
 
     it 'unlocks the user' do
-      system_user.status.should == User::STATUS_BUILTIN
+      system_user.status.should == User::STATUSES[:builtin]
     end
   end
 
   describe '#remove_privileges' do
     before do
       system_user.admin = true
-      system_user.status = User::STATUS_ACTIVE
+      system_user.status = User::STATUSES[:active]
       system_user.save
       system_user.remove_privileges
     end
@@ -32,7 +32,7 @@ describe SystemUser do
     end
 
     it 'locks the user' do
-      system_user.status.should == User::STATUS_LOCKED
+      system_user.status.should == User::STATUSES[:locked]
     end
   end
 

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -94,7 +94,7 @@ class AccountControllerTest < ActionController::TestCase
                              :lastname => 'User',
                              :mail => 'user@somedomain.com',
                              :identity_url => 'http://openid.example.com/good_user',
-                             :status => User::STATUS_REGISTERED)
+                             :status => User::STATUSES[:registered])
     existing_user.login = 'cool_user'
     assert existing_user.save!
 
@@ -141,7 +141,7 @@ class AccountControllerTest < ActionController::TestCase
     assert_redirected_to '/login'
     user = User.find_by_login('cool_user')
     assert user
-    assert_equal User::STATUS_REGISTERED, user.status
+    assert_equal User::STATUSES[:registered], user.status
   end
 
   def test_login_with_openid_with_new_user_with_conflict_should_register
@@ -228,7 +228,7 @@ class AccountControllerTest < ActionController::TestCase
       should 'set the user status to active' do
         user = User.last(:conditions => {:login => 'register'})
         assert user
-        assert_equal User::STATUS_ACTIVE, user.status
+        assert_equal User::STATUSES[:active], user.status
       end
     end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -231,12 +231,12 @@ class UsersControllerTest < ActionController::TestCase
     Setting.available_languages = [:en, :fr]
     u = User.new(:firstname => 'Foo', :lastname => 'Bar', :mail => 'foo.bar@somenet.foo', :language => 'fr')
     u.login = 'foo'
-    u.status = User::STATUS_REGISTERED
+    u.status = User::STATUSES[:registered]
     u.save!
     ActionMailer::Base.deliveries.clear
     Setting.bcc_recipients = '1'
 
-    put :update, :id => u.id, :user => {:status => User::STATUS_ACTIVE}
+    put :update, :id => u.id, :user => {:status => User::STATUSES[:active]}
     assert u.reload.active?
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail

--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -30,7 +30,7 @@ class AdminTest < ActionDispatch::IntegrationTest
     assert_kind_of User, logged_user
     assert_equal "Paul", logged_user.firstname
 
-    put user_path(user), :id => user.id, :user => { :status => User::STATUS_LOCKED }
+    put user_path(user), :id => user.id, :user => { :status => User::STATUSES[:locked] }
     assert_redirected_to edit_user_path(user)
     locked_user = User.try_to_login("psmith", "psmithPSMITH09")
     assert_equal nil, locked_user

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -168,7 +168,7 @@ class UserTest < ActiveSupport::TestCase
     user = User.try_to_login("jsmith", "jsmith")
     assert_equal @jsmith, user
 
-    @jsmith.status = User::STATUS_LOCKED
+    @jsmith.status = User::STATUSES[:locked]
     assert @jsmith.save
 
     user = User.try_to_login("jsmith", "jsmith")
@@ -287,7 +287,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return nil if the key is found for an inactive user" do
-      user = User.generate_with_protected!(:status => User::STATUS_LOCKED)
+      user = User.generate_with_protected!(:status => User::STATUSES[:locked])
       token = Token.generate!(:action => 'api')
       user.api_token = token
       user.save
@@ -296,7 +296,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return the user if the key is found for an active user" do
-      user = User.generate_with_protected!(:status => User::STATUS_ACTIVE)
+      user = User.generate_with_protected!(:status => User::STATUSES[:active])
       token = Token.generate!(:action => 'api')
       user.api_token = token
       user.save


### PR DESCRIPTION
User status numbers were defined only as constants, which made handling them difficult. Multiple helpers had knowledge of the different numbers' meaning.

Now, User has a status_name method, which returns a symbol describing the user's status. The helpers now use this status_name instead of the numbers. Unfortunately, the helpers are also used for principals, which are not users, so this adds a method to principal always returning active, which is the default by schema.rb.

OpenProject Issue: https://www.openproject.org/issues/1299
