### PR TITLE
Reduce number of warnings for specs that don't reset User.current

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,8 +86,8 @@ module OpenProject::RSpecLazinessWarn
   def self.warn_if_user_current_set(example)
     # Using the hacky way of getting current_user to avoid under the hood creation of AnonymousUser
     # which might break other tests and at least leaves this user in the db after the test is run.
-    unless User.instance_variable_get(:@current_user).nil?
-
+    user = User.instance_variable_get(:@current_user)
+    unless user.nil? or user.is_a? AnonymousUser
       # we only want an abbreviated_stacktrace because the logfiles
       # might otherwise not be capable to show all the warnings.
       # Thus we only take the callers that are part of the user code.


### PR DESCRIPTION
Don't show the warning if User.current is an AnonymousUser.

Any access to User.current sets the current user to an AnonymousUser,
so without this change, the warning about User.current not being reset
is issued falsely for any test that runs code accessing User.current.
While it probably is a good idea to remove User.current everywhere,
issuing way too many warnings during specs won't accomplish this.
