### PR TITLE
Feature/rails3 fix pagination

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -39,7 +39,7 @@ module PaginationHelper
     links = Setting.per_page_options_array.collect do |n|
       n == selected ?
               content_tag(:span, n, :class => 'current') :
-              link_to_content_update(n, params.merge(:per_page => n))
+              link_to_content_update(n, params.merge(:page => 1, :per_page => n))
     end
     content_tag :span, :class => 'per_page_options' do
       links.size > 1 ? l(:label_display_per_page, links.join(', ')).html_safe : nil

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -25,7 +25,7 @@ module PaginationHelper
 
       html << content_tag(:span, "(#{paginator.offset + 1} - #{paginator.offset + paginator.length}/#{paginator.total_entries})", :class => 'range')
 
-      if per_page_links && links = per_page_links(paginator.per_page)
+      if per_page_links && links = per_page_links(paginator.per_page, merged_options[:params] || params)
         html << links
       end
     end
@@ -35,11 +35,11 @@ module PaginationHelper
       html
   end
 
-  def per_page_links(selected=nil)
+  def per_page_links(selected=nil, options = params)
     links = Setting.per_page_options_array.collect do |n|
       n == selected ?
               content_tag(:span, n, :class => 'current') :
-              link_to_content_update(n, params.merge(:page => 1, :per_page => n))
+              link_to_content_update(n, options.merge(:page => 1, :per_page => n))
     end
     content_tag :span, :class => 'per_page_options' do
       links.size > 1 ? l(:label_display_per_page, links.join(', ')).html_safe : nil

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* `#1409` Changing pagination limit on members view looses members tab
+* `#1371` Changing pagination per_page_param does not change page
 * `#1314` Always set last activity timestamp and check session expiry if ttl-setting is enabled
 * `#1414` Remove start & due date requirement from planning elements
 

--- a/features/issues/index_pagination.feature
+++ b/features/issues/index_pagination.feature
@@ -44,7 +44,7 @@ Feature: Paginated issue index list
     Then I should be on the global index page of issues
     And I should see 1 issue
 
-  Scenario: Chaning issues per page
+  Scenario: Changing issues per page
     When I go to the issues index page of the project "project1"
     Then I follow "2" within ".pagination"
     Then I should see 1 issue

--- a/features/issues/index_pagination.feature
+++ b/features/issues/index_pagination.feature
@@ -43,3 +43,10 @@ Feature: Paginated issue index list
     When I follow "2" within ".pagination"
     Then I should be on the global index page of issues
     And I should see 1 issue
+
+  Scenario: Chaning issues per page
+    When I go to the issues index page of the project "project1"
+    Then I follow "2" within ".pagination"
+    Then I should see 1 issue
+    Then I follow "50" within ".per_page_options"
+    Then I should see 26 issues

--- a/features/projects/settings.feature
+++ b/features/projects/settings.feature
@@ -45,3 +45,11 @@ Feature: Project Settings
     And I uncheck "alpha" within "#member-1-roles-form"
     And I click "Change" within "#member-1-roles-form"
     Then I should not see "Bob Bobbit" within ".list.members"
+
+@javascript
+  Scenario: Changing members per page keeps us on the members tab
+    Given I am logged in as "admin"
+    When I go to the settings page of the project "project1"
+    And I follow "Members" within ".tabs"
+    And I follow "50" within ".per_page_options" within "#tab-content-members"
+    Then I should be on the members tab of the settings page of the project "project1"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -211,7 +211,7 @@ module NavigationHelpers
         "/settings/edit?tab=#{$1}"
       end
 
-    when /^the(?: (.+?) tab of the) settings page (?:of|for) the project "(.+?)"$/
+    when /^the(?: (.+?) tab of the)? settings page (?:of|for) the project "(.+?)"$/
       if $1.nil?
         "/projects/#{$2}/settings"
       else

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -77,7 +77,7 @@ describe PaginationHelper do
     end
 
     it "should have different urls if the params are specified as options" do
-      params = { :tab => 'lorem' }
+      params = { :controller => 'issues', :action => 'index' }
 
       pagination = helper.pagination_links_full(paginator, { :params => params })
 

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -96,7 +96,7 @@ describe PaginationHelper do
       pagination.should have_selector("span.per_page_options")
 
       pagination.should have_selector(".per_page_options span.current", :text => per_page)
-      pagination.should have_selector(".per_page_options a[href='#{issues_path(:per_page => Setting.per_page_options_array.last)}']")
+      pagination.should have_selector(".per_page_options a[href='#{issues_path(:page => current_page, :per_page => Setting.per_page_options_array.last)}']")
 
       Setting.per_page_options = ar
     end


### PR DESCRIPTION
fixes #1371 and #1409 on openproject.org
- #1371 - when changing items per page in the pagination links, page is now set to 1 (so we dont land on an empty or unexpected page)
- #1409 - when coming from the projects setting page and clicking on members and then chaning pagination, we now get a new page on the members tab (not the general settings tab anymore)
- added/fixed a possible path for our cukes to reach the general project settings page
