### PR TITLE
Changed default capybara behaviour to ignore hidden elements removing

### DIFF
--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -16,7 +16,7 @@ Then /^I should (not )?see "([^"]*)"\s*\#.*$/ do |negative, name|
 end
 
 When /^I click(?:| on) "([^"]*)"$/ do |name|
-  click_link_or_button(name, {:visible => true })
+  click_link_or_button(name)
 end
 
 When /^(?:|I )jump to [Pp]roject "([^\"]*)"$/ do |project|

--- a/features/step_definitions/i18n_steps.rb
+++ b/features/step_definitions/i18n_steps.rb
@@ -79,11 +79,11 @@ end
 
 def update_localization(container, language, value)
   new_value = container.find(:css, "input[type=text], textarea")
-  new_locale = container.find(:css, ".locale_selector")
+  new_locale = container.find(:css, ".locale_selector", :visible => false)
 
   new_value.set(value.gsub("\\n", "\n"))
 
-  locale_name = new_locale.all(:css, "option").detect{|o| o.value == locale_for_language(language)}
+  locale_name = new_locale.all(:css, "option", :visible => false).detect{|o| o.value == locale_for_language(language)}
   new_locale.select(locale_name.text) if locale_name
 end
 
@@ -96,7 +96,7 @@ Then /^there should be the following localizations:$/ do |table|
 
   page.should have_selector(:xpath, '(//*[contains(@name, "translations_attributes") and not(contains(@disabled,"disabled"))])[1]')
 
-  attributes = page.all(:css, "[name*=\"translations_attributes\"]:not([disabled=disabled])")
+  attributes = page.all(:css, "[name*=\"translations_attributes\"]:not([disabled=disabled])", :visible => false)
 
   name_regexp = /\[(\d)+\]\[(\w+)\]$/
 
@@ -134,7 +134,7 @@ end
 Then /^the delete link for the (.+) localization of the "(.+)" attribute should not be visible$/ do |locale, attribute_name|
   attribute_span = span_for_localization locale, attribute_name
 
-  attribute_span.find(:css, "a.destroy_locale").should_not be_visible
+  attribute_span.find(:css, "a.destroy_locale", :visible => false).should_not be_visible
 end
 
 def span_for_localization language, attribute
@@ -143,7 +143,7 @@ def span_for_localization language, attribute
   attribute_spans = page.all(:css, "span.#{attribute}_translation")
 
   attribute_spans.detect do |attribute_span|
-    attribute_span.find(:css, ".locale_selector")["value"] == locale &&
+    attribute_span.find(:css, ".locale_selector", :visible => false)["value"] == locale &&
     attribute_span.visible?
   end
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -23,7 +23,7 @@ end
 
 When /^I select "(.+?)" from the action menu$/ do |entry_name|
   within(action_menu_selector) do
-    if !find_link(entry_name).visible?
+    if !find_link(entry_name, :visible => false).visible?
       click_link(I18n.t(:more_actions))
     end
 
@@ -42,10 +42,10 @@ def action_menu_selector
   # please note that using this with the old .contextual selector takes longer
   # as capybara waits for the new .action_menu_main selector to appear
 
-  if has_css?(".action_menu_main", :visible => true)
-    all(".action_menu_main", :visible => true).first
-  elsif has_css?(".contextual", :visible => true)
-    all(".contextual", :visible => true).first
+  if has_css?(".action_menu_main")
+    all(".action_menu_main").first
+  elsif has_css?(".contextual")
+    all(".contextual").first
   else
     raise "No action menu on the current page"
   end

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -41,7 +41,7 @@ Then /^the "(.+?)" setting should be (true|false)$/ do |name, trueish|
 end
 
 Given /^I save the settings$/ do
-  click_button('Save', :visible => true)
+  click_button('Save')
 end
 
 Given /^users are blocked for ([0-9]+) minutes after ([0-9]+) failed login attempts$/ do |duration, attempts|

--- a/features/step_definitions/timelines_then_steps.rb
+++ b/features/step_definitions/timelines_then_steps.rb
@@ -14,7 +14,7 @@ Then /^I should see the planning element edit modal$/ do
  steps 'Then I should see a modal window with selector "#planningElementDialog"'
 end
 Then /^I should see a modal window with selector "(.*?)"$/ do |selector|
-  page.should have_selector(selector, visible: true)
+  page.should have_selector(selector)
   dialog = find(selector)
 
   dialog["class"].include?("ui-dialog-content").should be_true

--- a/features/step_definitions/timelines_when_steps.rb
+++ b/features/step_definitions/timelines_when_steps.rb
@@ -26,7 +26,7 @@ When(/^I hide empty projects for the timeline "([^"]*?)" of the project called "
     When I go to the edit page of the timeline "#{timeline_name}" of the project called "#{project_name}"
   }
 
-  page.should have_selector("#timeline_options_exclude_empty")
+  page.should have_selector("#timeline_options_exclude_empty", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_exclude_empty').prop('checked', true)")
   page.execute_script("jQuery('#content form').submit()")
@@ -37,7 +37,7 @@ When(/^I make the planning element "([^"]*?)" vertical for the timeline "([^"]*?
   }
   planning_element = PlanningElement.find_by_subject(planning_element_subject)
 
-  page.should have_selector("#timeline_options_vertical_planning_elements")
+  page.should have_selector("#timeline_options_vertical_planning_elements", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_vertical_planning_elements').val('#{planning_element.id}')")
   page.execute_script("jQuery('#content form').submit()")
@@ -48,7 +48,7 @@ When(/^I set the first level grouping criteria to "(.*?)" for the timeline "(.*?
   }
   grouping_project = Project.find_by_name(grouping_project_name)
 
-  page.should have_selector("#timeline_options_grouping_one_enabled")
+  page.should have_selector("#timeline_options_grouping_one_enabled", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_grouping_one_enabled').prop('checked', true)")
   page.execute_script("jQuery('#timeline_options_grouping_one_selection').val('#{grouping_project.id}')")
@@ -61,7 +61,7 @@ When(/^I show only projects which have a planning element which lies between "(.
     When I go to the edit page of the timeline "#{timeline_name}" of the project called "#{project_name}"
   }
 
-  page.should have_selector("#timeline_options_planning_element_time_types")
+  page.should have_selector("#timeline_options_planning_element_time_types", :visible => false)
 
   planning_element_type = PlanningElementType.find_by_name(type)
   page.execute_script("jQuery('#timeline_options_planning_element_time_types').val('#{planning_element_type.id}')")
@@ -76,7 +76,7 @@ When(/^I set the second level grouping criteria to "(.*?)" for the timeline "(.*
   }
   project_type = ProjectType.find_by_name(project_type_name)
 
-  page.should have_selector("#timeline_options_grouping_two_enabled")
+  page.should have_selector("#timeline_options_grouping_two_enabled", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_grouping_two_enabled').prop('checked', true)")
   page.execute_script("jQuery('#timeline_options_grouping_two_selection').val('#{project_type.id}')")
@@ -98,7 +98,7 @@ When(/^I set the first level grouping criteria to:$/) do |table|
   results = result.join(",");
 
   #we need to wait for our submit form to load ...
-  page.should have_selector("#timeline_options_grouping_one_enabled")
+  page.should have_selector("#timeline_options_grouping_one_enabled", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_grouping_one_enabled').prop('checked', true)")
   page.execute_script("jQuery('#timeline_options_grouping_one_selection').val('#{results}')")
@@ -112,7 +112,7 @@ When(/^I set the sortation of the first level grouping criteria to explicit orde
     When I go to the edit page of the timeline "#{timeline_name}" of the project called "#{project_name}"
   }
 
-  page.should have_selector("#timeline_options_grouping_one_sort")
+  page.should have_selector("#timeline_options_grouping_one_sort", :visible => false)
 
   page.execute_script("jQuery('#timeline_options_grouping_one_sort').val('1')")
   page.execute_script("jQuery('#content form').submit()")
@@ -148,16 +148,16 @@ When /^I wait (\d+) seconds?$/ do |seconds|
   sleep seconds.to_i
 end
 When /^I wait for the modal to show$/ do
-  page.should have_selector('#planningElementDialog', visible: true)
+  page.should have_selector('#planningElementDialog')
 end
 When /^I wait for the modal to close$/ do
-  page.should have_no_selector('#planningElementDialog', visible: true)
+  page.should have_no_selector('#planningElementDialog')
 end
 When (/^I set duedate to "([^"]*)"$/) do |value|
   fill_in 'planning_element_due_date', :with => value
 end
 When /^I wait for timeline to load table$/ do
-  page.should have_selector('.tl-left-main', visible: true)
+  page.should have_selector('.tl-left-main')
 end
 When (/^I open a modal for planning element "([^"]*)" of project "([^"]*)"$/) do |planning_element_subject, project_name|
   planning_element = PlanningElement.find_by_subject(planning_element_subject)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -36,7 +36,7 @@ When /^I check the assign random password to user field$/ do
 end
 
 Given /^I save the user$/ do
-  click_button('Save', :visible => true)
+  click_button('Save')
 end
 
 Given /^I save the new user$/ do

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -309,20 +309,20 @@ Then /^there should be a( disabled)? "(.+)" field( visible| invisible)?(?: withi
   if plugin_name.nil? || Redmine::Plugin.installed?(plugin_name)
     with_scope(selector) do
       if defined?(Spec::Rails::Matchers)
-        find_field(fieldname).should_not be_nil
+        find_field(fieldname, :visible => false).should_not be_nil
         if visible && visible == " visible"
-          find_field(fieldname).should be_visible
+          find_field(fieldname, :visible => false).should be_visible
         elsif visible && visible == " invisible"
-          find_field(fieldname).should_not be_visible
+          find_field(fieldname, :visible => false).should_not be_visible
         end
 
         if disabled
-          find_field(fieldname)[:disabled].should == "disabled"
+          find_field(fieldname, :visible => false)[:disabled].should == "disabled"
         else
-          find_field(fieldname)[:disabled].should == nil
+          find_field(fieldname, :visible => false)[:disabled].should == nil
         end
       else
-        assert_not_nil find_field(fieldname)
+        assert_not_nil find_field(fieldname, :visible => false)
       end
     end
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -36,7 +36,7 @@ Capybara.configure do |config|
     config.default_selector = :css
     config.default_wait_time = 10
     config.exact_options = true
-    config.ignore_hidden_elements = false
+    config.ignore_hidden_elements = true
     config.match = :one
     config.visible_text_only = true
 end


### PR DESCRIPTION
as it is the more natural behaviour and helps reduce the number of ambigious matches, especially related to ticket https://www.openproject.org/issues/1063 (fixing the cukes in the impermanent memberships plugin)
