### PR TITLE
Remove coveralls for now (was: Run coverage reporting only on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 before_script:
   - "RAILS_ENV=production bundle exec rake ci:travis:prepare"
-after_success:
-  - "RAILS_ENV=production bundle exec rake coveralls:push"
 branches:
   only:
     - feature/rails3

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ group :test do
   # why in Gemfile? see: https://github.com/guard/guard-test
   gem 'ruby-prof'
   gem 'simplecov', ">= 0.8.pre"
-  gem 'coveralls', :require => false
 end
 
 group :openid do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,14 +116,7 @@ GEM
       execjs
     coffee-script-source (1.6.2)
     color-tools (1.3.0)
-    colorize (0.5.8)
     columnize (0.3.6)
-    coveralls (0.6.7)
-      colorize
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      thor
     cucumber (1.3.2)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -271,8 +264,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
     rmagick (2.13.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -375,7 +366,6 @@ DEPENDENCIES
   coderay (~> 1.0.5)
   coffee-rails (~> 3.2.1)
   color-tools (~> 1.3.0)
-  coveralls
   cucumber-rails
   cucumber-rails-training-wheels
   dalli

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,6 @@
 
 {<img src="https://travis-ci.org/opf/openproject.png?branch=feature/rails3" alt="Build Status" />}[https://travis-ci.org/opf/openproject]
 {<img src="https://gemnasium.com/opf/openproject.png" alt="Dependency Status" />}[https://gemnasium.com/opf/openproject]
-{<img src="https://coveralls.io/repos/opf/openproject/badge.png?branch=feature%2Frails3" alt="Coverage Status" />}[https://coveralls.io/r/opf/openproject?branch=feature%2Frails3]
 
 == This is a beta-Release Branch
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,13 +15,6 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
-# Run coverage reporting only on Travis
-if ENV['TRAVIS']
-  require 'coveralls'
-  require 'simplecov_openproject_profile'
-  Coveralls.wear_merged!('openproject')
-end
-
 require 'cucumber/rails'
 require 'capybara-screenshot/cucumber'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,9 +15,13 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
-require 'coveralls'
-require 'simplecov_openproject_profile'
-Coveralls.wear_merged!('openproject')
+# Run coverage reporting only on Travis
+if ENV['TRAVIS']
+  require 'coveralls'
+  require 'simplecov_openproject_profile'
+  Coveralls.wear_merged!('openproject')
+end
+
 require 'cucumber/rails'
 require 'capybara-screenshot/cucumber'
 

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -10,11 +10,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-if Rails.env.test?
-  require 'coveralls/rake/task'
-  Coveralls::RakeTask.new
-end
-
 namespace :test do
   desc 'Run unit and functional scm tests'
   task :scm do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,12 @@ require 'rubygems'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 
-require 'coveralls'
-require 'simplecov_openproject_profile'
-Coveralls.wear_merged!('openproject')
+# Run coverage reporting only on Travis
+if ENV['TRAVIS']
+  require 'coveralls'
+  require 'simplecov_openproject_profile'
+  Coveralls.wear_merged!('openproject')
+end
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,6 @@ require 'rubygems'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 
-# Run coverage reporting only on Travis
-if ENV['TRAVIS']
-  require 'coveralls'
-  require 'simplecov_openproject_profile'
-  Coveralls.wear_merged!('openproject')
-end
-
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,9 +12,12 @@
 
 ENV["RAILS_ENV"] = "test"
 
-require 'coveralls'
-require 'simplecov_openproject_profile'
-Coveralls.wear_merged!('openproject')
+# Run coverage reporting only on Travis
+if ENV['TRAVIS']
+  require 'coveralls'
+  require 'simplecov_openproject_profile'
+  Coveralls.wear_merged!('openproject')
+end
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,13 +12,6 @@
 
 ENV["RAILS_ENV"] = "test"
 
-# Run coverage reporting only on Travis
-if ENV['TRAVIS']
-  require 'coveralls'
-  require 'simplecov_openproject_profile'
-  Coveralls.wear_merged!('openproject')
-end
-
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'fileutils'


### PR DESCRIPTION
Coveralls/simplecov make our specs, cukes and test unit tests take 20-30 seconds more after the actual tests are finished. We only use the output on Travis, so using it there should be enough.

Update: Seems to be broken for months, so removing it for now.
