### PR TITLE
Feature/work package on page diff

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,6 +41,7 @@
 //= require calendar
 //= require ajaxappender
 //= require issues
+//= require work_packages
 //= require settings
 
 //source: http://stackoverflow.com/questions/8120065/jquery-and-prototype-dont-work-together-with-array-prototype-reverse

--- a/app/assets/javascripts/work_packages.js.erb
+++ b/app/assets/javascripts/work_packages.js.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is a project management system.
+
+Copyright (C) 2012-2013 the OpenProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+var WorkPackage = WorkPackage || {};
+
+WorkPackage.Show = (function($) {
+  var init;
+
+  init = function () {
+    $.ajaxAppend({
+      trigger: '.description-details',
+      indicator_class: 'ajax-indicator',
+      loading_class: 'text-diff',
+      hide_text: I18n.t("js.ajax.hide")
+    } );
+  };
+
+  $('document').ready(function () {
+    if ($('body.controller-work_packages.action-show').size() > 0) {
+     init();
+    }
+  });
+})(jQuery);

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -67,7 +67,7 @@ class JournalsController < ApplicationController
       to = @journal.changed_data[params[:field]][1]
 
       @diff = Redmine::Helpers::Diff.new(to, from)
-      @issue = @journal.journaled
+      @journaled = @journal.journaled
       respond_to do |format|
         format.html { }
         format.js { render :partial => 'diff', :locals => { :diff => @diff } }

--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -15,6 +15,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= render :partial => 'diff',
            :locals => { :diff => @diff } %>
 
-<p><%= link_to(l(:button_back), issue_path(@issue)) %></p>
+<p><%= link_to(l(:button_back), polymorphic_path(@journaled)) %></p>
 
-<% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
+<% html_title "#{ @journaled.to_s }" %>

--- a/app/views/user_mailer/issue_updated.html.erb
+++ b/app/views/user_mailer/issue_updated.html.erb
@@ -14,7 +14,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <ul>
 <% @journal.details.each do |detail| %>
-  <li><%= @journal.render_detail(detail) %></li>
+  <li><%= @journal.render_detail(detail, :only_path => false) %></li>
 <% end %>
 </ul>
 

--- a/app/views/user_mailer/issue_updated.text.erb
+++ b/app/views/user_mailer/issue_updated.text.erb
@@ -1,7 +1,7 @@
 <%= t(:text_issue_updated, :id => "##{@issue.id}", :author => @journal.user) %>
 
 <% @journal.details.each do |detail| %>
-  <%= @journal.render_detail(detail, :no_html => true) %>
+  <%= @journal.render_detail(detail, :no_html => true, :only_path => false) %>
 <% end %>
 
 <%= @journal.notes if @journal.notes? %>

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* `#1420` Allow for seeing work package description changes inside of the page
 * `#1488` Fixes multiple and missing error messages on project settings' member tab
 * `#377`  Some usability fixes for members selection with select2
 * `#1406` Creating a work package w/o responsible or assignee results in 500

--- a/features/step_definitions/diff_steps.rb
+++ b/features/step_definitions/diff_steps.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Please note that this is zero based
+When(/^I follow the link to see the diff in the (.+?) journal$/) do |nth|
+  within all(".journal .details")[nth.to_i] do
+    click_link I18n.t(:label_details)
+  end
+end
+
+When(/^I should see the following inline diff(?: on (.+?)):$/) do |page, table|
+  if page
+    step %Q{I should be on #{page}}
+  end
+
+  table.rows_hash.each do |key, value|
+    case key
+    when "new"
+      find "ins.diffmod", :text => value
+    when "old"
+      find "del.diffmod", :text => value
+    when "unchanged"
+      find ".text-diff", :text => value
+    else
+      raise ArgumentError, "#{ key } is not supported. 'new', 'old', 'unchanged' is."
+    end
+  end
+end
+

--- a/features/step_definitions/work_package_steps.rb
+++ b/features/step_definitions/work_package_steps.rb
@@ -15,7 +15,7 @@ require "rack_session_access/capybara"
 
 Given /^the work package "(.*?)" has the following children:$/ do |work_package_subject, table|
   parent = WorkPackage.find_by_subject(work_package_subject)
-  
+
   table.raw.flatten.each do |child_subject|
     child = WorkPackage.find_by_subject(child_subject)
 
@@ -41,4 +41,10 @@ Given /^user is already watching "(.*?)"$/  do |work_package_subject|
   user = User.find(page.get_rack_session["user_id"])
 
   work_package.add_watcher user
+end
+
+Given(/^the work_package "(.+?)" is updated with the following:$/) do |subject, table|
+  work_package = WorkPackage.find_by_subject(subject)
+
+  send_table_to_object(work_package, table)
 end

--- a/features/work_packages/diff_on_show.feature
+++ b/features/work_packages/diff_on_show.feature
@@ -1,0 +1,49 @@
+#-- copyright
+#
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Having an inline diff view for work package description changes
+  Background:
+    Given there is 1 project with the following:
+      | name        | parent      |
+      | identifier  | parent      |
+    And I am working in project "parent"
+    And the project "parent" has the following trackers:
+      | name | position |
+      | Bug  |     1    |
+    And there is a default issuepriority with:
+      | name   | Normal |
+    And there is a role "member"
+    And the role "member" may have the following rights:
+      | view_work_packages |
+    And there is 1 user with the following:
+      | login     | bob    |
+      | firstname | Bob    |
+      | lastname  | Bobbit |
+      | admin     | true   |
+    And the user "bob" is a "member" in the project "parent"
+    Given the user "bob" has 1 issue with the following:
+      | subject     | wp1                 |
+      | description | Initial description |
+    And I am already logged in as "bob"
+
+  @javascript
+  Scenario: A work package with a changed description has a callable diff showing the changes inline
+    Given the work_package "wp1" is updated with the following:
+      | description | Altered description |
+
+    When I go to the page of the work package "wp1"
+
+    Then I follow the link to see the diff in the 1 journal
+    And I should see the following inline diff on the page of the work package "wp1":
+      | new       | Altered     |
+      | old       | Initial     |
+      | unchanged | description |

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -14,8 +14,11 @@ require_dependency 'journal_formatter/base'
 class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   # unloadable
 
-  def render(key, values, options = { :no_html => false })
-    render_ternary_detail_text(key, values.last, values.first, options[:no_html])
+  def render(key, values, options = { })
+    merge_options = { :only_path => true,
+                      :no_html => false }.merge(options)
+
+    render_ternary_detail_text(key, values.last, values.first, merge_options)
   end
 
   private
@@ -28,10 +31,10 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
       content_tag('strong', label)
   end
 
-  def render_ternary_detail_text(key, value, old_value, no_html)
-    link = link(key, no_html)
+  def render_ternary_detail_text(key, value, old_value, options)
+    link = link(key, options)
 
-    label = label(key, no_html)
+    label = label(key, options[:no_html])
 
     if value.blank?
       l(:text_journal_deleted_with_diff, :label => label, :link => link)
@@ -48,12 +51,12 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   # see: http://stackoverflow.com/questions/3659455/is-there-a-new-syntax-for-url-for-in-rails-3
   def controller; @controller; end
 
-  def link(key, no_html)
+  def link(key, options)
     url_attr = { :controller => '/journals',
                  :action => 'diff',
                  :id => @journal.id,
                  :field => key.downcase,
-                 :only_path => false,
+                 :only_path => options[:only_path],
                  :protocol => Setting.protocol,
     # the link params should better be defined with the
     # skip_relative_url_root => true
@@ -61,7 +64,7 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
     # revise when on 3.2
                  :host => Setting.host_name.gsub(Redmine::Utils.relative_url_root.to_s, "") }
 
-    if no_html
+    if options[:no_html]
       url_for url_attr
     else
       link_to(l(:label_details),

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -67,7 +67,9 @@ module JournalFormatter
     hash[klass] = {}
   end
 
-  def render_detail(detail, options = { :no_html => false })
+  def render_detail(detail, options = { })
+    merge_options = { :no_html => false, :only_path => true }.merge(options)
+
     if detail.respond_to? :to_ary
       key = detail.first
       values = detail.last
@@ -80,7 +82,7 @@ module JournalFormatter
 
     return nil if formatter.nil?
 
-    formatter.render(key, values, options).html_safe
+    formatter.render(key, values, merge_options).html_safe
   end
 
   def formatter_instance(formatter_key)

--- a/lib/redmine/export/pdf.rb
+++ b/lib/redmine/export/pdf.rb
@@ -410,7 +410,7 @@ module Redmine
           pdf.Ln
           pdf.SetFontStyle('I',8)
           for detail in journal.details
-            pdf.RDMMultiCell(190,5, "- " + journal.render_detail(detail, :no_html => true))
+            pdf.RDMMultiCell(190,5, "- " + journal.render_detail(detail, :no_html => true, :only_path => false))
             pdf.Ln
           end
           if journal.notes?

--- a/spec/lib/journal_formatter/diff_spec.rb
+++ b/spec/lib/journal_formatter/diff_spec.rb
@@ -17,7 +17,10 @@ describe OpenProject::JournalFormatter::Diff do
   # WARNING: the order of the modules is important to ensure that url_for of
   # ActionController::UrlWriter is called and not the one of ActionView::Helpers::UrlHelper
   include ActionView::Helpers::UrlHelper
-  include Rails.application.routes.url_helpers
+
+  def url_helper
+    Rails.application.routes.url_helpers
+  end
 
   Struct.new("TestJournal", :id, :journaled)
 
@@ -28,22 +31,16 @@ describe OpenProject::JournalFormatter::Diff do
   end
   let(:instance) { klass.new(journal) }
   let(:key) { "description" }
-  
-  # FIXME
-  # calling a helper method (link_to in this case) doesn't work always here
-  # with rspec-core 2.13.0 in combination with rspec-rails
-  # see https://github.com/rspec/rspec-core/issues/817
-  # 
-  #let(:url) { { :controller => 'journals',
-  #              :action => 'diff',
-  #              :id => journal.id,
-  #              :field => key.downcase,
-  #              :protocol => Setting.protocol,
-  #              :host => Setting.host_name } }
-  #
-  # Setting the url by hand is just a workaround until rspec bug is fixed
-  let(:url) {"#{Setting.protocol}://#{Setting.host_name}/journals/#{journal.id}/diff/description"}
+
+  let(:url) {  url_helper.journal_diff_path(:id => journal.id,
+                                            :field => key.downcase)}
+  let(:full_url) { url_helper.journal_diff_url(:id => journal.id,
+                                               :field => key.downcase,
+                                               :protocol => Setting.protocol,
+                                               :host => Setting.host_name) }
   let(:link) { link_to(I18n.t(:label_details), url, :class => 'description-details') }
+  let(:full_url_link) { link_to(I18n.t(:label_details), full_url, :class => 'description-details') }
+
   describe :render do
     describe "WITH the first value beeing nil, and the second a string" do
       let(:expected) { I18n.t(:text_journal_set_with_diff,
@@ -91,7 +88,7 @@ describe OpenProject::JournalFormatter::Diff do
               WITH specifying not to output html" do
       let(:expected) { I18n.t(:text_journal_set_with_diff,
                               :label => key.camelize,
-                              :link => url_for(url)) }
+                              :link => url) }
 
       it { instance.render(key, [nil, "new value"], :no_html => true).should == expected }
     end
@@ -100,18 +97,26 @@ describe OpenProject::JournalFormatter::Diff do
               WITH specifying not to output html" do
       let(:expected) { I18n.t(:text_journal_changed_with_diff,
                               :label => key.camelize,
-                              :link => url_for(url)) }
+                              :link => url) }
 
       it { instance.render(key, ["old value", "new value"], :no_html => true).should == expected }
+    end
+
+    describe "WITH the first value beeing a string, and the second a string
+              WITH specifying to output a full url" do
+      let(:expected) { I18n.t(:text_journal_changed_with_diff,
+                              :label => "<strong>#{key.camelize}</strong>",
+                              :link => full_url_link) }
+
+      it { instance.render(key, ["old value", "new value"], :only_path => false).should == expected }
     end
 
     describe "WITH the first value beeing a string, and the second nil" do
       let(:expected) { I18n.t(:text_journal_deleted_with_diff,
                               :label => key.camelize,
-                              :link => url_for(url)) }
+                              :link => url) }
 
       it { instance.render(key, ["old_value", nil], :no_html => true).should == expected }
     end
-
   end
 end


### PR DESCRIPTION
The functionality itself is adapted from issue#show.

On the other hand, the diff is no longer rendered with the full url as the
link's href. Using the full url caused problems with selenium tests that
ran into problems with cross domain requests. This could have been fixed
by setting the application's host and protocol setting accordingly.
However, it is much cleaner to use a relative url. So for rendering the
diff inside the application the behaviour was alterd to use relative
url. The full url is now only used where it is absolutely necessary
(pdf, email).

Issue on OP: https://www.openproject.org/issues/1420
