### PR TITLE
Measure and display time for three things during the Rails boot process

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,13 +11,31 @@
 
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require 'benchmark'
+module SimpleBenchmark
+  #
+  # Measure execution of block and display result
+  #
+  # Time is measured by Benchmark module, displayed time is total
+  # (user cpu time + system cpu time + user and system cpu time of children)
+  # This is not wallclock time.
+  def self.bench(title)
+    print "#{title}... "
+    result = Benchmark.measure do
+      yield
+    end
+    print "%.03fs\n" % result.total
+  end
+end
+
+SimpleBenchmark.bench "require 'rails/all'" do
+  require 'rails/all'
+end
 
 if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  #Bundler.require(*Rails.groups(:assets => %w(development test)))
-  # If you want your assets lazily compiled in production, use this line
-  Bundler.require(:default, :assets, :opf_plugins, Rails.env)
+  SimpleBenchmark.bench 'Bundler.require' do
+    Bundler.require(:default, :assets, :opf_plugins, Rails.env)
+  end
 end
 
 module OpenProject

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -12,5 +12,7 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
-# Initialize the rails application
-OpenProject::Application.initialize!
+SimpleBenchmark.bench 'Application.initialize!' do
+  # Initialize the rails application
+  OpenProject::Application.initialize!
+end


### PR DESCRIPTION
The goal of this change is to increase visibility of boot times, so each
developer can see when they increase. It might also improve the waiting time
by letting the developer know what happens during the waiting time.

Measured things:
- require 'rails/all'
- Bundler.require
- OpenProject::Application.initialize!

Examples:

```
$ bundle exec rspec spec/models/user_spec.rb 
require 'rails/all'... 0.850s
Bundler.require... 3.240s
Application.initialize!... 6.120s
.................

Finished in 3.53 seconds
17 examples, 0 failures

Randomized with seed 23695
```

```
$ bundle exec rails server
require 'rails/all'... 0.740s
Bundler.require... 4.030s
=> Booting Thin
=> Rails 3.2.13 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
Application.initialize!... 3.960s
>> Thin web server (v1.5.1 codename Straight Razor)
>> Maximum connections set to 1024
>> Listening on 0.0.0.0:3000, CTRL+C to stop
```

```
$ cuke features/users/random_password_assignment.feature 
require 'rails/all'... 0.840s
Bundler.require... 3.920s
Application.initialize!... 3.980s
ruby -S bundle exec cucumber -r features features/users/random_password_assignment.feature
require 'rails/all'... 0.520s
Bundler.require... 3.290s
Application.initialize!... 6.380s
Using the default profile...
Feature: User Status

  Background: ...
```

(yes, cukes load everything two times, we should improve this)
