### PR TITLE
Removes the rack-mini-profiler.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-cucumber'
   gem 'rb-fsevent', :group => :test
-  gem 'rack-mini-profiler'
   gem 'thin'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,8 +245,6 @@ GEM
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-mini-profiler (0.1.26)
-      rack (>= 1.1.3)
     rack-ssl (1.3.3)
       rack
     rack-test (0.6.2)
@@ -408,7 +406,6 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
-  rack-mini-profiler
   rack_session_access
   rails!
   rails-dev-tweaks (~> 0.6.1)


### PR DESCRIPTION
This thing is regularly obstructing my views as well as slowing things down quite a bit in dev environment. I see that when looking into performance issues, one can readily use this profiler, but forcing it into every development environment that does not remove it from the Gemfile is just annoying.
