### PR TITLE
Improve cucumber task startup time

### DIFF
--- a/doc/RUNNING_TESTS.md
+++ b/doc/RUNNING_TESTS.md
@@ -22,16 +22,25 @@ executing scenarios by name, e.g. `"cucumber:all[-n 'Adding an issue link']"`.
 Like with spaces in `cucumber:custom` arguments, task name and arguments
 have to be enclosed in quotation marks.
 
+### Shortcuts
+
 Here are two bash functions which allow using shorter commands for running
 cucumber features:
 
     # Run OpenProject cucumber features (like arguments to the cucumber command)
     # Example: cuke features/issues/issue.feature
-    cuke() { bundle exec rake "cucumber:custom[$*]"; }
+    cuke() { RAILS_ENV=test bundle exec rake "cucumber:custom[$*]"; }
 
     # Run OpenProject cucumber scenarios by name
     # Example: cuken Adding an issue link
-    cuken() { bundle exec rake "cucumber:all[-n '$*']"; }
+    cuken() { RAILS_ENV=test bundle exec rake "cucumber:all[-n '$*']"; }
+
+Setting `RAILS_ENV=test` allows the cucumber rake tasks to run the features
+directly in the same process, so this reduces the time until the features are
+running a bit (5-10 seconds) due to the Rails environment only being loaded
+once.
+
+### JavaScript and Firebug
 
 To activate selenium as test driver to test javascript on web pages, you can add
 @javascript above the scenario like the following example shows:

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -39,7 +39,7 @@ begin
       Rails.application.config.plugins_to_test_paths.each do |dir|
         if File.directory?( dir )
           feature_dir = Shellwords.escape(File.join(dir, 'features'))
-          features << prefix + feature_dir
+          features += [prefix, feature_dir]
         end
       end
       features
@@ -66,10 +66,14 @@ begin
           opts += args[:options].split(/\s+/) if args[:options]
 
           # load feature support files from Rails root
-          support_files = ['-r ' + Shellwords.escape(File.join(Rails.root, 'features'))]
-          support_files += get_plugin_features(prefix=' -r ')
+          support_files = ['-r', Shellwords.escape(File.join(Rails.root, 'features'))]
+          support_files += get_plugin_features(prefix='-r')
 
           t.cucumber_opts = opts + support_files + features
+
+          # If we are not in the test environment, the test gems are not loaded
+          # by Bundler.require in application.rb, so we need to fork.
+          t.fork = Rails.env != 'test'
         end
         Rake::Task['cucumber_run'].invoke
       end


### PR DESCRIPTION
OpenProject Issue: https://www.openproject.org/issues/1442
Depends on #263 

Allow running cucumber in the same process as Rake. This saves about
10 seconds on my machine for loading the Rails environment a second
time.

Setting RAILS_ENV=test is required, so Bundler loads Gems from the
test group. This happens in  application.rb and before the Rake tasks
are loaded. So setting the environment in the Rake task would be too
late.
