### PR TITLE
Authentication Settings: Add option to set password validity period

### DIFF
--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -31,6 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   [l("label_password_rule_#{r}"), r]
                 end %></p>
       <p><%= setting_text_field :password_min_adhered_rules, :size => 6 %></p>
+      <p><%= setting_text_field :password_days_valid, :size => 6 %></p>
       <p><%= setting_text_field :password_count_former_banned, :size => 6 %></p>
       <p><%= setting_check_box :lost_password, :label => :label_password_lost %></p>
     </fieldset>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1194,6 +1194,7 @@ de:
   setting_openid: "Erlaube OpenID-Anmeldung und -Registrierung"
   setting_password_active_rules: "Aktive Zeichenklassen"
   setting_password_count_former_banned: "Anzahl zuletzt benutzter Passwörter, die nicht wiederverwendet werden dürfen"
+  setting_password_days_valid: "Anzahl von Tagen, nach denen ein Passwortwechsel erwzwungen wird (deaktivieren mit 0)"
   setting_password_min_length: "Mindestlänge"
   setting_password_min_adhered_rules: "Mindestanzahl zu verwendender Zeichenklassen"
   setting_per_page_options: "Objekte pro Seite"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1174,6 +1174,7 @@ en:
   setting_openid: "Allow OpenID login and registration"
   setting_password_active_rules: "Active character classes"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"
+  setting_password_days_valid: "Number of days, after which to enforce a password change (disable with 0)"
   setting_password_min_length: "Minimum length"
   setting_password_min_adhered_rules: "Minimum number of required classes"
   setting_per_page_options: "Objects per page options"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,8 +7,10 @@ app_subtitle:
   default: Project management
 brute_force_block_minutes:
   default: 30
+  format: int
 brute_force_block_after_failed_logins:
   default: 20
+  format: int
 welcome_text:
   default:
 login_required:


### PR DESCRIPTION
https://www.openproject.org/issues/1347
This only adds the options to the settings, but doesn't enforce expiry.

Integration tests will come with the actual checks, unit tests don't make sense for this.

This also fixes https://www.openproject.org/issues/1400
