### PR TITLE
Feature/rails3 do not remove member when last role was removed

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -55,24 +55,23 @@ JS
   end
 
   def update
-    if member = update_member_from_params and
-      member.save
+    member = update_member_from_params
+    member.save
 
-  	 respond_to do |format|
-        format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project, :page => params[:page] }
-        format.js {
-          render(:update) { |page|
-            if params[:membership]
-              @user = member.user
-              page.replace_html "tab-content-memberships", :partial => 'users/memberships'
-            else
-              page.replace_html "tab-content-members", :partial => 'projects/settings/members'
-            end
-            page << TAB_SCRIPTS
-            page.visual_effect(:highlight, "member-#{@member.id}") unless Member.find_by_id(@member.id).nil?
-          }
+    respond_to do |format|
+      format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project, :page => params[:page] }
+      format.js {
+        render(:update) { |page|
+          if params[:membership]
+            @user = member.user
+            page.replace_html "tab-content-memberships", :partial => 'users/memberships'
+          else
+            page.replace_html "tab-content-members", :partial => 'projects/settings/members'
+          end
+          page << TAB_SCRIPTS
+          page.visual_effect(:highlight, "member-#{@member.id}") unless Member.find_by_id(@member.id).nil?
         }
-      end
+      }
     end
   end
 
@@ -106,7 +105,7 @@ JS
     end
 
     respond_to do |format|
-      format.json 
+      format.json
       format.html {
         if request.xhr?
           partial = "members/autocomplete_for_member"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -82,7 +82,11 @@ class Member < ActiveRecord::Base
   protected
 
   def validate_presence_of_role
-    errors.add_on_empty :roles if member_roles.empty? && roles.empty? || !member_roles.empty? && member_roles.all?(&:marked_for_destruction?)
+    if member_roles.empty?
+      errors.add :roles, :empty if roles.empty?
+    else
+      errors.add :roles, :empty if member_roles.all?(&:marked_for_destruction?)
+    end
   end
 
   private

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* `#1505` Removing all roles from a membership removes the project membership
 * `#1405` Incorrect message when trying to login with a permanently blocked account
 * `#1409` Changing pagination limit on members view looses members tab
 * `#1371` Changing pagination per_page_param does not change page

--- a/features/projects/settings.feature
+++ b/features/projects/settings.feature
@@ -44,7 +44,8 @@ Feature: Project Settings
     When I click on "Edit" within "#member-1"
     And I uncheck "alpha" within "#member-1-roles-form"
     And I click "Change" within "#member-1-roles-form"
-    Then I should not see "Bob Bobbit" within ".list.members"
+    Then there should be an error message
+    And I should see "Bob Bobbit" within ".list.members"
 
 @javascript
   Scenario: Changing members per page keeps us on the members tab

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,26 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Member do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:role) { FactoryGirl.create(:role) }
+  let(:member) { FactoryGirl.build(:member, :user => user) }
+
+  it "fails to save members without roles" do
+    member.role_ids = [role.id]
+    member.save!
+    member.member_roles.each(&:mark_for_destruction)
+    member.should_not be_valid
+    member.errors[:roles].should include "can't be empty"
+  end
+end


### PR DESCRIPTION
fixes https://www.openproject.org/issues/1505

You cannot delete all roles of a project member anymore.

Please don't be scared: most of the changes in members_controllers is due to indentation (its only the if statement at the beginning which is different)
