### PR TITLE
Feature/rails3 activity module

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -12,7 +12,7 @@
 
 class ActivitiesController < ApplicationController
   menu_item :activity
-  before_filter :find_optional_project
+  before_filter :find_optional_project, :verify_activities_module_activated
   accept_key_auth :index
 
   def index
@@ -67,6 +67,10 @@ class ActivitiesController < ApplicationController
     authorize
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  def verify_activities_module_activated
+    render_403 if @project && !@project.module_enabled?("activity")
   end
 
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -34,26 +34,7 @@ class ActivitiesController < ApplicationController
     @activity.scope = (@author.nil? ? :default : :all) if @activity.scope.empty?
 
     events = @activity.events(@date_from, @date_to)
-
-    # Do not show events, which are associated with projects where activities are disabled.
-    # In a better world this would be implemented (with better performance) in SQL.
-    # TODO: make the world a better place.
-    allowed_project_ids = EnabledModule.where(:name => 'activity').map(&:project_id)
-    events.select! do |event|
-      project_ids = []
-      if event.respond_to?(:changed_data) and event.changed_data['project_id']
-        project_ids = event.changed_data['project_id']
-      elsif event.respond_to?(:project_id)
-        project_ids = [ event.project_id ]
-      end
-      if project_ids.empty?
-        # show this event if it is not associated with a project
-        true
-      else
-        # show this event if the activity module is enabled in any of the associated projects
-        project_ids.any? { |id| allowed_project_ids.include? id }
-      end
-    end
+    censor_events_from_projects_with_disabled_activity!(events) unless @project
 
     if events.empty? || stale?(:etag => [@activity.scope, @date_to, @date_from, @with_subprojects, @author, events.first, User.current, current_language])
       respond_to do |format|
@@ -93,4 +74,25 @@ class ActivitiesController < ApplicationController
     render_403 if @project && !@project.module_enabled?("activity")
   end
 
+  # Do not show events, which are associated with projects where activities are disabled.
+  # In a better world this would be implemented (with better performance) in SQL.
+  # TODO: make the world a better place.
+  def censor_events_from_projects_with_disabled_activity!(events)
+    allowed_project_ids = EnabledModule.where(:name => 'activity').map(&:project_id)
+    events.select! do |event|
+      project_ids = []
+      if event.respond_to?(:changed_data) and event.changed_data['project_id']
+        project_ids = event.changed_data['project_id']
+      elsif event.respond_to?(:project_id)
+        project_ids = [ event.project_id ]
+      end
+      if project_ids.empty?
+        # show this event if it is not associated with a project
+        true
+      else
+        # show this event if the activity module is enabled in any of the associated projects
+        project_ids.any? { |id| allowed_project_ids.include? id }
+      end
+    end
+  end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -35,6 +35,26 @@ class ActivitiesController < ApplicationController
 
     events = @activity.events(@date_from, @date_to)
 
+    # Do not show events, which are associated with projects where activities are disabled.
+    # In a better world this would be implemented (with better performance) in SQL.
+    # TODO: make the world a better place.
+    allowed_project_ids = EnabledModule.where(:name => 'activity').map(&:project_id)
+    events.select! do |event|
+      project_ids = []
+      if event.respond_to?(:changed_data) and event.changed_data['project_id']
+        project_ids = event.changed_data['project_id']
+      elsif event.respond_to?(:project_id)
+        project_ids = [ event.project_id ]
+      end
+      if project_ids.empty?
+        # show this event if it is not associated with a project
+        true
+      else
+        # show this event if the activity module is enabled in any of the associated projects
+        project_ids.any? { |id| allowed_project_ids.include? id }
+      end
+    end
+
     if events.empty? || stale?(:etag => [@activity.scope, @date_to, @date_from, @with_subprojects, @author, events.first, User.current, current_language])
       respond_to do |format|
         format.html {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -388,8 +388,8 @@ module ApplicationHelper
 
   def time_tag(time)
     text = distance_of_time_in_words(Time.now, time)
-    if @project
-      link_to(text, {:controller => '/activities', :action => 'index', :id => @project, :from => time.to_date}, :title => format_time(time))
+    if @project and @project.module_enabled?("activity")
+      link_to(text, {:controller => '/activities', :action => 'index', :project_id => @project, :from => time.to_date}, :title => format_time(time))
     else
       content_tag('label', text, :title => format_time(time), :class => "timestamp")
     end

--- a/app/helpers/timelines_journals_helper.rb
+++ b/app/helpers/timelines_journals_helper.rb
@@ -32,8 +32,8 @@ module TimelinesJournalsHelper
 
   def timelines_time_tag(time)
     text = format_time(time)
-    if @project
-      link_to(text, {:controller => '/activities', :action => 'index', :id => @project, :from => time.to_date}, :title => format_time(time))
+    if @project and @project.module_enabled?("activity")
+      link_to(text, {:controller => '/activities', :action => 'index', :project_id => @project, :from => time.to_date}, :title => format_time(time))
     else
       content_tag('label', text, :title => format_time(time), :class => "timestamp")
     end

--- a/db/migrate/20130723092240_add_activity_module.rb
+++ b/db/migrate/20130723092240_add_activity_module.rb
@@ -1,0 +1,21 @@
+class AddActivityModule < ActiveRecord::Migration
+  def up
+    # activate activity module for all projects
+    Project.all.each do |project|
+      project.enabled_module_names = ["activity"] | project.enabled_module_names
+    end
+
+    # add activity module from default settings
+    Setting["default_projects_modules"] = ["activity"] | Setting.default_projects_modules
+  end
+
+  def down
+    # deactivate activity module for all projects
+    Project.all.each do |project|
+      project.enabled_module_names = project.enabled_module_names - ["activity"]
+    end
+
+    # remove activity module from default settings
+    Setting["default_projects_modules"] = Setting.default_projects_modules - ["activity"]
+  end
+end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * `#1517` Journal changed_data cannot contain the changes of a wiki_content content
 * `#779`  Integrate password expiration
+* `#1461` Integration Activity Plugin
 * `#1505` Removing all roles from a membership removes the project membership
 * `#1405` Incorrect message when trying to login with a permanently blocked account
 * `#1488` Fixes multiple and missing error messages on project settings' member tab (now with support for success messages)

--- a/features/activities/index.feature
+++ b/features/activities/index.feature
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Activities
+
+  Background:
+    Given there is 1 project with the following:
+      | Name | project1 |
+    And the project "project1" has the following trackers:
+      | name | position |
+      | Bug  |     1    |
+    And the project "project1" has 1 issue with the following:
+      |  subject | issue1 |
+    And there is 1 project with the following:
+      | Name | project2 |
+    And the project "project2" has the following trackers:
+      | name | position |
+      | Bug  |     1    |
+    And the project "project2" does not use the following modules:
+      | activity |
+    And the project "project2" has 1 issue with the following:
+      |  subject | issue2 |
+    And I am already logged in as "admin"
+
+Scenario: Hide activity from Projects with disabled activity module
+    When I go to the overall activity page
+    Then I should see "project1" within "#activity"
+    And I should not see "project2" within "#activity"

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -101,6 +101,13 @@ Given /^(?:the )?[pP]roject "([^\"]*)" uses the following [mM]odules:$/ do |proj
   p.reload
 end
 
+Given /^(?:the )?[pP]roject "([^\"]*)" does not use the following [mM]odules:$/ do |project, table|
+  p = Project.find_by_name(project)
+
+  p.enabled_module_names -= table.raw.map { |row| row.first }
+  p.reload
+end
+
 Given /^the [Uu]ser "([^\"]*)" is a "([^\"]*)" (?:in|of) the [Pp]roject "([^\"]*)"$/ do |user, role, project|
   u = User.find_by_login(user)
   r = Role.find_by_name(role)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -77,6 +77,9 @@ module NavigationHelpers
       project_identifier = Project.find_by_name(project_identifier).identifier.gsub(' ', '%20')
       "/projects/#{project_identifier}/activity"
 
+    when /^the overall activity page$/
+      "/activity"
+
     when /^the page (?:for|of) the issue "([^\"]+)"$/
       issue = Issue.find_by_subject($1)
       "/work_packages/#{issue.id}"

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -278,7 +278,8 @@ end
 
 Redmine::MenuManager.map :project_menu do |menu|
   menu.push :overview, { :controller => '/projects', :action => 'show' }
-  menu.push :activity, { :controller => '/activities', :action => 'index' }, :param => :project_id
+  menu.push :activity, { :controller => '/activities', :action => 'index' }, :param => :project_id,
+              :if => Proc.new { |p| p.module_enabled?("activity") }
   menu.push :roadmap, { :controller => '/versions', :action => 'index' }, :param => :project_id,
               :if => Proc.new { |p| p.shared_versions.any? }
 

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -368,3 +368,5 @@ Redmine::WikiFormatting.map do |format|
 end
 
 ActionView::Template.register_template_handler :rsb, Redmine::Views::ApiTemplateHandler
+
+Redmine::AccessControl.available_project_modules << :activity

--- a/lib/redmine/activity/fetcher.rb
+++ b/lib/redmine/activity/fetcher.rb
@@ -40,7 +40,7 @@ module Redmine
                 p.activity_provider_options[o].try(:[], :permission)
               end.compact
               return @user.allowed_to?("view_#{o}".to_sym, @project) if permissions.blank?
-              permissions.all? {|p| @user.allowed_to?(p, @project) } if @project
+              permissions.all? {|p| @user.allowed_to?(p, @project) }
             end
           end
         end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,0 +1,51 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ActivitiesController do
+  before :each do
+    @controller.stub!(:set_localization)
+
+    admin = FactoryGirl.create(:admin)
+    User.stub!(:current).and_return admin
+
+    @params = {}
+  end
+
+  describe 'index' do
+    describe 'with activated activity module' do
+      before do
+        @project = FactoryGirl.create(:project, :enabled_module_names => %w[activity wiki])
+        @params[:project_id] = @project.id
+      end
+
+      it 'renders activity' do
+        get 'index', @params
+        response.should be_success
+        response.should render_template 'index'
+      end
+    end
+
+    describe 'without activated activity module' do
+      before do
+        @project = FactoryGirl.create(:project, :enabled_module_names => %w[wiki])
+        @params[:project_id] = @project.id
+      end
+
+      it 'renders 403' do
+        get 'index', @params
+        response.status.should == 403
+        response.should render_template 'common/error'
+      end
+    end
+  end
+end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -13,10 +13,10 @@ require 'spec_helper'
 
 describe ActivitiesController do
   before :each do
-    @controller.stub!(:set_localization)
+    @controller.stub(:set_localization)
 
     admin = FactoryGirl.create(:admin)
-    User.stub!(:current).and_return admin
+    User.stub(:current).and_return admin
 
     @params = {}
   end

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -13,11 +13,11 @@ require 'spec_helper'
 
 describe SettingsController do
   before :each do
-    @controller.stub!(:set_localization)
+    @controller.stub(:set_localization)
     @params = {}
 
     @user = FactoryGirl.create(:admin)
-    User.stub!(:current).and_return @user
+    User.stub(:current).and_return @user
   end
 
   describe 'edit' do

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -1,0 +1,106 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe SettingsController do
+  before :each do
+    @controller.stub!(:set_localization)
+    @params = {}
+
+    @user = FactoryGirl.create(:admin)
+    User.stub!(:current).and_return @user
+  end
+
+  describe 'edit' do
+    render_views
+
+    def clear_settings_cache
+      Rails.cache.clear
+    end
+
+    # this is the base method for get, post, etc.
+    def process(*args)
+      clear_settings_cache
+      result = super
+      clear_settings_cache
+      result
+    end
+
+    before(:all) do
+      @previous_projects_modules = Setting.default_projects_modules
+    end
+
+    after(:all) do
+      Setting.default_projects_modules = @previous_projects_modules
+    end
+
+    it 'contains a check box for the activity module on the projects tab' do
+      get 'edit', :tab => 'projects'
+
+      response.should be_success
+      response.should render_template 'edit'
+      response.body.should have_selector "input[@name='settings[default_projects_modules][]'][@value='activity']"
+    end
+
+    it 'does not store the activity in the default_projects_modules if unchecked' do
+      post 'edit', :tab => 'projects', :settings => {
+        :default_projects_modules => ['wiki']
+      }
+
+      response.should be_redirect
+      response.should redirect_to :action => 'edit', :tab => 'projects'
+
+      Setting.default_projects_modules.should == ['wiki']
+    end
+
+    it 'stores the activity in the default_projects_modules if checked' do
+      post 'edit', :tab => 'projects', :settings => {
+        :default_projects_modules => ['activity', 'wiki']
+      }
+
+      response.should be_redirect
+      response.should redirect_to :action => 'edit', :tab => 'projects'
+
+      Setting.default_projects_modules.should == ['activity', 'wiki']
+    end
+
+    describe 'with activity in Setting.default_projects_modules' do
+      before do
+        Setting.default_projects_modules = %w[activity wiki]
+      end
+
+      it 'contains a checked checkbox for activity' do
+        get 'edit', :tab => 'projects'
+
+        response.should be_success
+        response.should render_template 'edit'
+
+        response.body.should have_selector "input[@name='settings[default_projects_modules][]'][@value='activity'][@checked='checked']"
+      end
+    end
+
+    describe 'without activated activity module' do
+      before do
+        Setting.default_projects_modules = %w[wiki]
+      end
+
+      it 'contains an unchecked checkbox for activity' do
+        get 'edit', :tab => 'projects'
+
+        response.should be_success
+        response.should render_template 'edit'
+
+        response.body.should_not have_selector "input[@name='settings[default_projects_modules][]'][@value='activity'][@checked='checked']"
+      end
+    end
+  end
+end

--- a/test/fixtures/enabled_modules.yml
+++ b/test/fixtures/enabled_modules.yml
@@ -83,3 +83,23 @@ enabled_modules_025:
   name: news
   project_id: 2
   id: 25
+enabled_modules_026:
+  name: activity
+  project_id: 1
+  id: 26
+enabled_modules_027:
+  name: activity
+  project_id: 2
+  id: 27
+enabled_modules_028:
+  name: activity
+  project_id: 3
+  id: 28
+enabled_modules_029:
+  name: activity
+  project_id: 4
+  id: 29
+enabled_modules_030:
+  name: activity
+  project_id: 5
+  id: 30


### PR DESCRIPTION
integrate the activity_module plugin in the core

added some additional features/bugfixes:
- the overall activity page only shows activity from projects, where the module is activated
- links to activity are not rendered, if the module is disabled
- links to activity page ("1 hour ago" in issues#show for example) do not point to the projects activity page (not to the overall activity page anymore)

see: https://www.openproject.org/issues/1461
