### PR TITLE
Adds .ruby-gemset to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@
 /Gemfile.plugins
 /.rvmrc*
 /.ruby-version
+/.ruby-gemset
 


### PR DESCRIPTION
It corresponds to .ruby-version and is created by default when migrating to new rvm.
