### PR TITLE
Feature/better defaults

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -25,6 +25,10 @@ class TypesController < ApplicationController
     render :action => "index", :layout => false if request.xhr?
   end
 
+  def type
+    @type
+  end
+
   def new
     @type = Type.new(params[:type])
     @types = Type.find(:all, :order => 'position')
@@ -32,7 +36,7 @@ class TypesController < ApplicationController
   end
 
   def create
-    @type = Type.new(params[:type])
+    @type = Type.new(permitted_params.type)
     if @type.save
       # workflow copy
       if !params[:copy_workflow_from].blank? && (copy_from = Type.find_by_id(params[:copy_workflow_from]))

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -58,7 +58,8 @@ class TypesController < ApplicationController
 
   def update
     @type = Type.find(params[:id])
-    if @type.update_attributes(params[:type])
+
+    if @type.update_attributes(permitted_params.type)
       redirect_to types_path, :notice => t(:notice_successful_update)
     else
       @projects = Project.all
@@ -84,6 +85,7 @@ class TypesController < ApplicationController
     # put that into the model and do a `if @type.destroy`
     if @type.issues.empty?
       @type.destroy
+      flash[:notice] = l(:notice_successful_delete)
     else
       flash[:error] = t(:error_can_not_delete_type)
     end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -66,6 +66,18 @@ class TypesController < ApplicationController
     end
   end
 
+  def move
+    @type = Type.find(params[:id])
+
+    if @type.update_attributes(permitted_params.type_move)
+      flash[:notice] = l(:notice_successful_update)
+    else
+      flash.now[:error] = l('type_could_not_be_saved')
+      render :action => 'edit'
+    end
+    redirect_to types_path
+  end
+
   def destroy
     @type = Type.find(params[:id])
     # types cannot be deleted when they have issue

--- a/app/helpers/timelines_helper.rb
+++ b/app/helpers/timelines_helper.rb
@@ -22,25 +22,6 @@ module TimelinesHelper
     content_tag(:span, " ", options)
   end
 
-  def icon_for_planning_element_type(type)
-    return unless type
-
-    if type.is_milestone?
-      css_class = 'timelines-milestone'
-    else
-      css_class = 'timelines-phase'
-    end
-    if type.color.present?
-      color = type.color.hexcode
-    else
-      color = "#CCC"
-    end
-
-    content_tag(:span, " ",
-                :class => css_class,
-                :style => "background-color: #{color}")
-  end
-
   def parent_id_select_tag(form, planning_element)
     available_parents = planning_element.project.planning_elements.without_deleted.find(:all, :order => "COALESCE(parent_id, id), parent_id")
     available_parents -= [planning_element]

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -11,4 +11,23 @@
 #++
 
 module TypesHelper
+
+  def icon_for_type(type)
+    return unless type
+
+    if type.is_milestone?
+      css_class = 'timelines-milestone'
+    else
+      css_class = 'timelines-phase'
+    end
+    if type.color.present?
+      color = type.color.hexcode
+    else
+      color = "#CCC"
+    end
+
+    content_tag(:span, " ",
+                :class => css_class,
+                :style => "background-color: #{color}")
+  end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -105,6 +105,10 @@ class PermittedParams < Struct.new(:params, :user)
     end
   end
 
+  def type
+    params.require(:type).permit(*self.class.permitted_attributes[:type])
+  end
+
   def work_package
     params.require(:work_package).permit(:subject,
                                          :description,
@@ -196,8 +200,15 @@ class PermittedParams < Struct.new(:params, :user)
                                :scenario => [
                                               :name,
                                               :description
-                                            ]
-
+                                            ],
+                               :type => [
+                                          :name,
+                                          :is_in_roadmap,
+                                          :in_aggregation,
+                                          :is_milestone,
+                                          :is_default,
+                                          :color_id
+                                        ]
                             }
   end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -109,6 +109,10 @@ class PermittedParams < Struct.new(:params, :user)
     params.require(:type).permit(*self.class.permitted_attributes[:type])
   end
 
+  def type_move
+    params.require(:type).permit(*self.class.permitted_attributes[:type_move])
+  end
+
   def work_package
     params.require(:work_package).permit(:subject,
                                          :description,
@@ -208,7 +212,8 @@ class PermittedParams < Struct.new(:params, :user)
                                           :is_milestone,
                                           :is_default,
                                           :color_id
-                                        ]
+                                        ],
+                               :type_move => [:move_to]
                             }
   end
 end

--- a/app/models/planning_element_type.rb
+++ b/app/models/planning_element_type.rb
@@ -9,62 +9,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class PlanningElementType < ActiveRecord::Base
-  unloadable
-
+class PlanningElementType < Type
   self.table_name = 'planning_element_types'
-
-  acts_as_list
-  default_scope :order => 'position ASC'
-
-  extend Pagination::Model
-
-  has_many :default_planning_element_types, :class_name  => 'DefaultPlanningElementType',
-                                            :foreign_key => 'planning_element_type_id',
-                                            :dependent   => :delete_all
-  has_many :project_types, :through => :default_planning_element_types
-
-  has_many :enabled_planning_element_types, :class_name  => 'EnabledPlanningElementType',
-                                            :foreign_key => 'planning_element_type_id',
-                                            :dependent   => :delete_all
-  has_many :projects, :through => :enabled_planning_element_types
-
-  belongs_to :color, :class_name  => 'PlanningElementTypeColor',
-                     :foreign_key => 'color_id'
-
-  has_many :planning_elements, :class_name  => 'PlanningElement',
-                               :foreign_key => 'planning_element_type_id',
-                               :dependent   => :nullify
-
-  include ActiveModel::ForbiddenAttributesProtection
-
-  validates_presence_of :name
-  validates_inclusion_of :in_aggregation, :is_default, :is_milestone, :in => [true, false]
-
-  validates_length_of :name, :maximum => 255, :unless => lambda { |e| e.name.blank? }
-
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-    :order => "name" }
-  }
-
-  def self.search_scope(query)
-    like(query)
-  end
-
-  def enabled_in?(object)
-    case object
-    when ProjectType
-      object.planning_element_types.include?(self)
-    when Project
-      object.planning_element_types.include?(self)
-    else
-      false
-    end
-  end
-
-  def available_colors
-    PlanningElementTypeColor.all
-  end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -11,7 +11,13 @@
 #++
 
 class Type < ActiveRecord::Base
+
+  extend Pagination::Model
+
+  include ActiveModel::ForbiddenAttributesProtection
+
   before_destroy :check_integrity
+
   has_many :issues
   has_many :workflows, :dependent => :delete_all do
     def copy(source_type)
@@ -20,12 +26,47 @@ class Type < ActiveRecord::Base
   end
 
   has_and_belongs_to_many :projects
-  has_and_belongs_to_many :custom_fields, :class_name => 'WorkPackageCustomField', :join_table => "#{table_name_prefix}custom_fields_types#{table_name_suffix}", :association_foreign_key => 'custom_field_id'
+
+  has_and_belongs_to_many :custom_fields,
+                          :class_name => 'WorkPackageCustomField',
+                          :join_table => "#{table_name_prefix}custom_fields_types#{table_name_suffix}",
+                          :association_foreign_key => 'custom_field_id'
+
+  has_many :default_planning_element_types, :class_name  => 'DefaultPlanningElementType',
+                                            :foreign_key => 'planning_element_type_id',
+                                            :dependent   => :delete_all
+
+  has_many :project_types, :through => :default_planning_element_types
+
+  has_many :enabled_planning_element_types, :class_name  => 'EnabledPlanningElementType',
+                                            :foreign_key => 'planning_element_type_id',
+                                            :dependent   => :delete_all
+
+  has_many :projects, :through => :enabled_planning_element_types
+
+  belongs_to :color, :class_name  => 'PlanningElementTypeColor',
+                     :foreign_key => 'color_id'
+
+  has_many :planning_elements, :class_name  => 'PlanningElement',
+                               :foreign_key => 'planning_element_type_id',
+                               :dependent   => :nullify
   acts_as_list
 
-  validates_presence_of :name
+  validates_presence_of   :name
   validates_uniqueness_of :name
-  validates_length_of :name, :maximum => 30
+  validates_length_of     :name,
+                          :maximum => 255,
+                          :unless => lambda { |e| e.name.blank? }
+
+  validates_inclusion_of :in_aggregation, :is_default, :is_milestone, :in => [true, false]
+
+  default_scope :order => 'position ASC'
+
+  scope :like, lambda { |q|
+    s = "%#{q.to_s.strip.downcase}%"
+    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
+    :order => "name" }
+  }
 
   def to_s; name end
 
@@ -52,6 +93,25 @@ class Type < ActiveRecord::Base
             uniq
 
     @issue_statuses = IssueStatus.find_all_by_id(ids).sort
+  end
+
+  def self.search_scope(query)
+    like(query)
+  end
+
+  def enabled_in?(object)
+    case object
+    when ProjectType
+      object.planning_element_types.include?(self)
+    when Project
+      object.planning_element_types.include?(self)
+    else
+      false
+    end
+  end
+
+  def available_colors
+    PlanningElementTypeColor.all
   end
 
 private

--- a/app/views/planning_elements/_planning_element.html.erb
+++ b/app/views/planning_elements/_planning_element.html.erb
@@ -65,7 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
           </label>
         </th>
         <td class="planning-element-type">
-          <%= icon_for_planning_element_type(planning_element.planning_element_type) %>
+          <%= icon_for_type(planning_element.planning_element_type) %>
           <%= h planning_element.planning_element_type.try(:name) %>&nbsp;
         </td>
       </tr>

--- a/app/views/planning_elements/_table_row.html.erb
+++ b/app/views/planning_elements/_table_row.html.erb
@@ -16,7 +16,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= link_to_planning_element(planning_element, :include_name => false) %>
   </td>
   <td class="timelines-pe-type">
-    <%= icon_for_planning_element_type(planning_element.planning_element_type) %>
+    <%= icon_for_type(planning_element.planning_element_type) %>
     <%=h planning_element.planning_element_type.try(:name) %>
   </td>
   <td class="timelines-pe-name">

--- a/app/views/projects/settings/_timelines.html.erb
+++ b/app/views/projects/settings/_timelines.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
           </td>
           <td>
             <label for="project_planning_element_type_ids_<%= type.id %>">
-              <%= icon_for_planning_element_type(type) %>
+              <%= icon_for_type(type) %>
               <%=h type.name %>
             </label>
           </td>

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -35,20 +35,20 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= hidden_field_tag 'type[custom_field_ids][]', '' %>
 <% end %>
 
-<% if @type.new_record? && @types.any? %>
+<% if controller.type.new_record? && @types.any? %>
 <p><label for="copy_workflow_from"><%= l(:label_copy_workflow_from) %></label>
 <%= select_tag(:copy_workflow_from, content_tag("option") + options_from_collection_for_select(@types, :id, :name)) %></p>
 <% end %>
 <!--[eoform:type]-->
 </div>
-<%= submit_tag l(@type.new_record? ? :button_create : :button_save) %>
+<%= submit_tag l(controller.type.new_record? ? :button_create : :button_save) %>
 </div>
 
 <div class="splitcontentright">
 <% if @projects.any? %>
 <fieldset class="box" id="type_project_ids"><legend><%= l(:label_project_plural) %></legend>
 <%= project_nested_ul(@projects) do |p|
-  content_tag('label', check_box_tag('type[project_ids][]', p.id, @type.projects.include?(p), :id => nil) + ' ' + h(p))
+  content_tag('label', check_box_tag('type[project_ids][]', p.id, controller.type.projects.include?(p), :id => nil) + ' ' + h(p))
 end %>
 <%= hidden_field_tag('type[project_ids][]', '', :id => nil) %>
 <p><%= check_all_links 'type_project_ids' %></p>

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -17,6 +17,10 @@ See doc/COPYRIGHT.rdoc for more details.
 <!--[form:type]-->
 <p><%= f.text_field :name, :required => true %></p>
 <p><%= f.check_box :is_in_roadmap %></p>
+<p><%= f.select :color_id, options_for_colors(controller.type) %></p>
+<p><%= f.check_box :in_aggregation %></p>
+<p><%= f.check_box :is_default %></p>
+<p><%= f.check_box :is_milestone %></p>
 
 <% if WorkPackageCustomField.all.any? %>
 <p>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -50,7 +50,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <td class="timelines-pet-is_default"><%= checked_image(type.is_default) %></td>
     <td class="timelines-pet-in_aggregation"><%= checked_image(type.in_aggregation) %></td>
     <td class="timelines-pet-is_milestone"><%= checked_image(type.is_milestone) %></td>
-    <td align="center" style="width:15%;"><%= reorder_links('type', {:action => 'update', :id => type}, :method => :put) %></td>
+    <td class="timelines-pet-reorder"><%= reorder_links('type', {:action => 'move', :id => type}) %></td>
     <td class="buttons">
       <%= link_to t(:button_delete), type, :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon icon-del' %>
     </td>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -10,28 +10,50 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= header_tags %>
+
 <div class="contextual">
 <%= link_to l(:label_type_new), {:action => 'new'}, :class => 'icon icon-add' %>
 </div>
 
 <h2><%=l(:label_type_plural)%></h2>
 
-<table class="list">
-  <thead><tr>
-  <th><%= Type.model_name.human %></th>
-  <th></th>
-  <th><%=l(:button_sort)%></th>
-  <th></th>
-  </tr></thead>
+<table class="list timelines-pet">
+  <thead>
+    <tr>
+      <th class="timelines-pet-name">
+        <%= Type.human_attribute_name(:name) %>
+      </th>
+      <th></th> <!-- Missing workflow warning -->
+      <th class="timelines-pet-color">
+        <%= Type.human_attribute_name(:color) %>
+      </th>
+      <th class="timelines-pet-is_default">
+        <%= Type.human_attribute_name(:is_default) %>
+      </th>
+      <th class="timelines-pet-in_aggregation" title="<%= l('timelines.planning_elements_are_displayed_in_aggregations') %>">
+        <%= Type.human_attribute_name(:in_aggregation) %>
+      </th>
+      <th class="timelines-pet-is_milestone">
+        <%= Type.human_attribute_name(:is_milestone) %>
+      </th>
+      <th><%=l(:button_sort)%></th>
+      <th></th>
+  </tr>
+  </thead>
   <tbody>
 <% for type in @types %>
   <tr class="<%= cycle("odd", "even") %>">
-  <td><%= link_to type.name, edit_type_path(type) %></td>
-  <td align="center"><% if type.workflows.empty? %><span class="icon icon-warning"><%= l(:text_type_no_workflow) %> (<%= link_to l(:button_edit), {:controller => '/workflows', :action => 'edit', :type_id => type} %>)</span><% end %></td>
-  <td align="center" style="width:15%;"><%= reorder_links('type', {:action => 'update', :id => type}, :method => :put) %></td>
-  <td class="buttons">
-    <%= link_to t(:button_delete), type, :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon icon-del' %>
-  </td>
+    <td><%= link_to type.name, edit_type_path(type) %></td>
+    <td align="center"><% if type.workflows.empty? %><span class="icon icon-warning"><%= l(:text_type_no_workflow) %> (<%= link_to l(:button_edit), {:controller => '/workflows', :action => 'edit', :type_id => type} %>)</span><% end %></td>
+    <td class="timelines-pet-color"><%= icon_for_type type %></td>
+    <td class="timelines-pet-is_default"><%= checked_image(type.is_default) %></td>
+    <td class="timelines-pet-in_aggregation"><%= checked_image(type.in_aggregation) %></td>
+    <td class="timelines-pet-is_milestone"><%= checked_image(type.is_milestone) %></td>
+    <td align="center" style="width:15%;"><%= reorder_links('type', {:action => 'update', :id => type}, :method => :put) %></td>
+    <td class="buttons">
+      <%= link_to t(:button_delete), type, :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon icon-del' %>
+    </td>
   </tr>
 <% end %>
   </tbody>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <tbody>
 <% for type in @types %>
   <tr class="<%= cycle("odd", "even") %>">
-    <td><%= link_to type.name, edit_type_path(type) %></td>
+    <td class="timelines-pet-name"><%= link_to type.name, edit_type_path(type) %></td>
     <td align="center"><% if type.workflows.empty? %><span class="icon icon-warning"><%= l(:text_type_no_workflow) %> (<%= link_to l(:button_edit), {:controller => '/workflows', :action => 'edit', :type_id => type} %>)</span><% end %></td>
     <td class="timelines-pet-color"><%= icon_for_type type %></td>
     <td class="timelines-pet-is_default"><%= checked_image(type.is_default) %></td>
@@ -52,7 +52,10 @@ See doc/COPYRIGHT.rdoc for more details.
     <td class="timelines-pet-is_milestone"><%= checked_image(type.is_milestone) %></td>
     <td class="timelines-pet-reorder"><%= reorder_links('type', {:action => 'move', :id => type}) %></td>
     <td class="buttons">
-      <%= link_to t(:button_delete), type, :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon icon-del' %>
+      <%= link_to type, :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon icon-del' do %>
+        <%= t(:button_delete) %>
+        <span class="hidden-for-sighted"><%=h type.name %></span>
+      <% end %>
     </td>
   </tr>
 <% end %>

--- a/app/views/types/new.html.erb
+++ b/app/views/types/new.html.erb
@@ -12,6 +12,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <h2><%= link_to t(:label_type_plural), types_path %> &#187; <%= t(:label_type_new) %></h2>
 
-<%= form_for @type, :builder => TabularFormBuilder do |f| %>
+<%= form_for controller.type, :builder => TabularFormBuilder do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -421,6 +421,8 @@ de:
   default_type_bug: "Fehler"
   default_type_feature: "Feature"
   default_type_support: "Unterstützung"
+  default_type_phase: "Phase"
+  default_type_milestone: "Meilenstein"
 
   description_active: "Aktiv?"
   description_attachment_toggle: "Dateien aus/einblenden"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1467,6 +1467,7 @@ de:
     project_association_with_other: "Projekt-Abhängigkeit zwischen “%{project_a}” und “%{project_b}”"
     project_association_of_type: "Projekt-Abhängigkeit zu Projekt des Typs “%{type}”"
     project_type_could_not_be_saved: "Projekt-Typ konnte nicht gespeichert werden."
+    type_could_not_be_saved: "Typ konnte nicht gespeichert werden."
     properties: "Eigenschaften"
     reporting_could_not_be_saved: "Statusbericht konnte nicht gespeichert werden."
     reporting_for_project:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,6 +425,8 @@ en:
   default_type_bug: "Bug"
   default_type_feature: "Feature"
   default_type_support: "Support"
+  default_type_phase: "Phase"
+  default_type_milestone: "Milestone"
 
   description_active: "Active?"
   description_attachment_toggle: "Show/Hide attachments"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1447,6 +1447,7 @@ en:
     project_association_with_other: "Project dependency between “%{project_a}” and “%{project_b}”"
     project_association_of_type: "Dependency to project of type “%{type}”"
     project_type_could_not_be_saved: "Project type could not be saved"
+    type_could_not_be_saved: "Type could not be saved"
     reporting_could_not_be_saved: "Reporting could not be saved"
     properties: "Properties"
     really_delete_color: >

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -155,15 +155,16 @@ default_projects_public:
 default_projects_modules:
   serialized: true
   default:
-  - issue_tracking
-  - time_tracking
-  - news
-  - documents
-  - files
-  - wiki
-  - repository
   - boards
   - calendar
+  - documents
+  - files
+  - issue_tracking
+  - news
+  - repository
+  - time_tracking
+  - timelines
+  - wiki
 # Role given to a non-admin user who creates a project
 new_project_user_role_id:
   format: int

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,7 +48,7 @@ activity_days_default:
   format: int
   default: 30
 per_page_options:
-  default: '25,50,100'
+  default: '100, 500, 1000'
 mail_from:
   default: openproject@example.net
 bcc_recipients:

--- a/db/migrate/20130724143418_add_planning_element_type_properties_to_type.rb
+++ b/db/migrate/20130724143418_add_planning_element_type_properties_to_type.rb
@@ -1,0 +1,54 @@
+class AddPlanningElementTypePropertiesToType < ActiveRecord::Migration
+
+  # create_table "planning_element_types", :force => true do |t|
+  #   t.string   "name",                              :null => false
+  #   t.boolean  "in_aggregation", :default => true,  :null => false
+  #   t.boolean  "is_milestone",   :default => false, :null => false
+  #   t.boolean  "is_default",     :default => false, :null => false
+  #   t.integer  "position",       :default => 1
+  #   t.integer  "color_id"
+  #   t.datetime "created_at",                        :null => false
+  #   t.datetime "updated_at",                        :null => false
+  # end
+
+  # add_index "planning_element_types", ["color_id"], :name => "index_timelines_planning_element_types_on_color_id"
+
+  # create_table "types", :force => true do |t|
+  #   t.string  "name",          :limit => 30, :default => "",    :null => false
+  #   t.boolean "is_in_chlog",                 :default => false, :null => false
+  #   t.integer "position",                    :default => 1
+  #   t.boolean "is_in_roadmap",               :default => true,  :null => false
+  # end
+
+  def up
+
+    add_column :types, :in_aggregation, :boolean, :default => true,  :null => false
+    add_column :types, :is_milestone,   :boolean, :default => false, :null => false
+    add_column :types, :is_default,     :boolean, :default => false, :null => false
+
+    add_column :types, :color_id,   :integer
+    add_column :types, :created_at, :datetime, :null => false
+    add_column :types, :updated_at, :datetime, :null => false
+
+    change_column :types, :name, :string, :default => "", :null => false
+
+    add_index :types, [:color_id], :name => :index_types_on_color_id
+
+  end
+
+  def down
+
+    remove_column :types, :in_aggregation
+    remove_column :types, :is_milestone
+    remove_column :types, :is_default
+
+    remove_column :types, :color_id
+    remove_column :types, :created_at
+    remove_column :types, :updated_at
+
+    change_column :types, :name, :string, :limit => 30, :default => "", :null => false
+
+    remove_index :types, :name => :index_types_on_color_id
+  end
+
+end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* `#1437` Update seed data
+
 ## 3.0.0pre9
 
 * `#1517` Journal changed_data cannot contain the changes of a wiki_content content

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -282,12 +282,14 @@ Given /^the [pP]roject "([^\"]*)" has 1 [sS]ubproject with the following:$/ do |
 end
 
 Given /^there are the following types:$/ do |table|
-
+  table.map_headers! { |header| header.underscore.gsub(' ', '_') }
   table.hashes.each_with_index do |t, i|
     type = Type.find_by_name(t['name'])
     type = Type.new :name => t['name'] if type.nil?
     type.position = t['position'] ? t['position'] : i
     type.is_in_roadmap = t['is_in_roadmap'] ? t['is_in_roadmap'] : true
+    type.is_milestone = t['is_milestone'] ? t['is_milestone'] : true
+    type.in_aggregation = t['in_aggregation'] ? t['in_aggregation'] : true
     type.save!
   end
 end

--- a/features/step_definitions/timelines_then_steps.rb
+++ b/features/step_definitions/timelines_then_steps.rb
@@ -110,10 +110,6 @@ Then /^I should see that "([^"]*)" is a color$/ do |name|
   cell.should_not be_empty
 end
 
-Then /^I should not see the "([^"]*)" planning element type$/ do |name|
-  page.all(:css, '.timelines-pet-name', :text => name).should be_empty
-end
-
 Then /^I should not see the "([^"]*)" color$/ do |name|
   cell = page.all(:css, ".timelines-color-name", :text => name)
   cell.should be_empty

--- a/features/step_definitions/type_steps.rb
+++ b/features/step_definitions/type_steps.rb
@@ -11,6 +11,10 @@
 
 # change from symbol to constant once namespace is removed
 
-InstanceFinder.register(:planning_element_type, Proc.new { |name| PlanningElementType.find_by_name(name) })
+InstanceFinder.register(:type, Proc.new { |name| Type.find_by_name(name) })
 
-RouteMap.register(PlanningElementType, "/planning_element_types")
+RouteMap.register(Type, "/types")
+
+Then /^I should not see the "([^"]*)" type$/ do |name|
+  page.all(:css, '.timelines-pet-name', :text => name).should be_empty
+end

--- a/features/types/types_adminstration.feature
+++ b/features/types/types_adminstration.feature
@@ -9,67 +9,66 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-Feature: Planning Element Type Adminstration
-  As a ChiliProject Admin
-  I want to configure which planning element types are available
+Feature: Type Adminstration
+  As an OpenProject Admin
+  I want to configure which types are available
   So that I can support my teams with useful settings while still controlling
-  the total number of available planning element types
+  the total number of available types
   So that my teams can work effectively
 
   Background:
-    Given there are the following planning element types:
+    Given there are the following types:
           | Name            | Is Milestone | In aggregation |
           | Phase           | false        | true           |
           | Milestone       | true         | true           |
           | Minor Phase     | false        | false          |
           | Minor Milestone | true         | false          |
 
-      And I am logged in as "admin"
+      And I am admin
 
-  Scenario: The admin may see all planning element types within the admin UI
+  Scenario: The admin may see all types within the admin UI
      When I go to the admin page
-      And I follow "Planning element types"
+      And I follow "Types"
      Then I should see that "Phase" is not a milestone and shown in aggregation
       And I should see that "Milestone" is a milestone and shown in aggregation
       And I should see that "Minor Phase" is not a milestone and not shown in aggregation
       And I should see that "Minor Milestone" is a milestone and not shown in aggregation
 
-  Scenario: The admin may create a planning element type
+  Scenario: The admin may create a type
      When I go to the admin page
-      And I follow "Planning element types"
-      And I follow "New planning element type"
+      And I follow "Types"
+      And I follow "New type"
       And I fill in "New Phase" for "Name"
-      And I press "Save"
+      And I press "Create"
      Then I should see a notice flash stating "Successful creation."
       And I should see that "New Phase" is not a milestone and shown in aggregation
       And "New Phase" should be the last element in the list
 
   Scenario: Nice error messages help fixing them
      When I go to the admin page
-      And I follow "Planning element types"
-      And I follow "New planning element type"
+      And I follow "Types"
+      And I follow "New type"
       And I fill in "" for "Name"
-      And I press "Save"
+      And I press "Create"
      Then I should see an error explanation stating "Name can't be blank"
 
-  Scenario: The admin may edit a planning element type
-     When I go to the edit page of the planning element type called "Phase"
+  Scenario: The admin may edit a type
+     When I go to the edit page of the type called "Phase"
       And I fill in "Updated Phase" for "Name"
       And I press "Save"
      Then I should see a notice flash stating "Successful update."
       And I should see that "Updated Phase" is not a milestone and shown in aggregation
 
-  Scenario: The admin may delete a planning element type
+  Scenario: The admin may delete a type
      When I go to the admin page
-      And I follow "Planning element types"
+      And I follow "Types"
       And I follow "Delete Minor Phase"
-      And I press "Delete"
      Then I should see a notice flash stating "Successful deletion."
-      And I should not see the "Minor Phase" planning element type
+      And I should not see the "Minor Phase" type
 
-  Scenario: The admin may reorder planning element types
+  Scenario: The admin may reorder types
      When I go to the admin page
-      And I follow "Planning element types"
+      And I follow "Types"
       And I move "Minor Phase" to the top
      Then "Minor Phase" should be the first element in the list
 

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -114,6 +114,13 @@ module Redmine
                                                            :browse_repository,
                                                            :view_changesets]
 
+            # Colors
+            colors = PlanningElementTypeColor.ms_project_colors
+            color_map = Hash[*(colors.map do |color|
+              color.save
+              [color.name, color.id]
+            end).flatten]
+
             # Types
             Type.create! :name           => l(:default_type_bug),
                          :is_in_chlog    => true,

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -115,14 +115,16 @@ module Redmine
                                                            :view_changesets]
 
             # Colors
-            colors = PlanningElementTypeColor.ms_project_colors
-            color_map = Hash[*(colors.map do |color|
+            colors_list = PlanningElementTypeColor.ms_project_colors
+            colors = Hash[*(colors_list.map do |color|
               color.save
-              [color.name, color.id]
+              color.reload
+              [color.name.to_sym, color.id]
             end).flatten]
 
             # Types
             Type.create! :name           => l(:default_type_bug),
+                         :color_id       => colors[:pjRed],
                          :is_in_chlog    => true,
                          :is_in_roadmap  => false,
                          :in_aggregation => true,
@@ -130,6 +132,7 @@ module Redmine
                          :position       => 1
 
             Type.create! :name           => l(:default_type_feature),
+                         :color_id       => colors[:pjLime],
                          :is_in_chlog    => true,
                          :is_in_roadmap  => true,
                          :in_aggregation => true,
@@ -137,6 +140,7 @@ module Redmine
                          :position       => 2
 
             Type.create! :name           => l(:default_type_support),
+                         :color_id       => colors[:pjBlue],
                          :is_in_chlog    => false,
                          :is_in_roadmap  => false,
                          :in_aggregation => true,
@@ -144,6 +148,7 @@ module Redmine
                          :position       => 3
 
             Type.create! :name           => l(:default_type_phase),
+                         :color_id       => colors[:pjSilver],
                          :is_in_chlog    => false,
                          :is_in_roadmap  => false,
                          :in_aggregation => true,
@@ -151,6 +156,7 @@ module Redmine
                          :position       => 4
 
             Type.create! :name           => l(:default_type_milestone),
+                         :color_id       => colors[:pjPurple],
                          :is_in_chlog    => false,
                          :is_in_roadmap  => true,
                          :in_aggregation => true,
@@ -158,8 +164,8 @@ module Redmine
                          :position       => 5
 
             # Issue statuses
-            new       = IssueStatus.create!(:name => l(:default_issue_status_new), :is_closed => false, :is_default => true, :position => 1)
-            in_progress  = IssueStatus.create!(:name => l(:default_issue_status_in_progress), :is_closed => false, :is_default => false, :position => 2)
+            new      = IssueStatus.create!(:name => l(:default_issue_status_new), :is_closed => false, :is_default => true, :position => 1)
+            in_progress  = IssueStatus.create!(:name => l(:default_issue_status_in_progress), :is_closed => false, :is_default => false, :position => 3)
             resolved  = IssueStatus.create!(:name => l(:default_issue_status_resolved), :is_closed => false, :is_default => false, :position => 3)
             feedback  = IssueStatus.create!(:name => l(:default_issue_status_feedback), :is_closed => false, :is_default => false, :position => 4)
             closed    = IssueStatus.create!(:name => l(:default_issue_status_closed), :is_closed => true, :is_default => false, :position => 5)

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -115,9 +115,40 @@ module Redmine
                                                            :view_changesets]
 
             # Types
-            Type.create!(:name => l(:default_type_bug),     :is_in_chlog => true,  :is_in_roadmap => false, :position => 1)
-            Type.create!(:name => l(:default_type_feature), :is_in_chlog => true,  :is_in_roadmap => true,  :position => 2)
-            Type.create!(:name => l(:default_type_support), :is_in_chlog => false, :is_in_roadmap => false, :position => 3)
+            Type.create! :name           => l(:default_type_bug),
+                         :is_in_chlog    => true,
+                         :is_in_roadmap  => false,
+                         :in_aggregation => true,
+                         :is_milestone   => false,
+                         :position       => 1
+
+            Type.create! :name           => l(:default_type_feature),
+                         :is_in_chlog    => true,
+                         :is_in_roadmap  => true,
+                         :in_aggregation => true,
+                         :is_milestone   => false,
+                         :position       => 2
+
+            Type.create! :name           => l(:default_type_support),
+                         :is_in_chlog    => false,
+                         :is_in_roadmap  => false,
+                         :in_aggregation => true,
+                         :is_milestone   => false,
+                         :position       => 3
+
+            Type.create! :name           => l(:default_type_phase),
+                         :is_in_chlog    => false,
+                         :is_in_roadmap  => false,
+                         :in_aggregation => true,
+                         :is_milestone   => false,
+                         :position       => 4
+
+            Type.create! :name           => l(:default_type_milestone),
+                         :is_in_chlog    => false,
+                         :is_in_roadmap  => true,
+                         :in_aggregation => true,
+                         :is_milestone   => true,
+                         :position       => 5
 
             # Issue statuses
             new       = IssueStatus.create!(:name => l(:default_issue_status_new), :is_closed => false, :is_default => true, :position => 1)

--- a/lib/tasks/load_default_data.rake
+++ b/lib/tasks/load_default_data.rake
@@ -40,7 +40,8 @@ namespace :redmine do
     rescue Redmine::DefaultData::DataAlreadyLoaded => error
       puts error
     rescue => error
-      puts "Error: " + error
+      puts "Error: " + error.message
+      puts error.backtrace.join("\n")
       puts "Default configuration data was not loaded."
     end
   end


### PR DESCRIPTION
Better defaults for the new core;
- 100, 500, 1000 pagination options.
- Adds default colors
- Adds phase and milestone types
- Adds colors to types
- Makes timelines a default module
- Improves error verbosity of load_default_data rake task

Only merge after https://github.com/opf/openproject/pull/281
