### PR TITLE
Removed the requirement of attachment containers having

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -44,7 +44,12 @@ class AttachmentsController < ApplicationController
     @attachment.container.attachments.delete(@attachment)
     redirect_to :back
   rescue ::ActionController::RedirectBackError
-    redirect_to :controller => '/projects', :action => 'show', :id => @project
+    # we cannot be sure the container actually has a project (example: LandingPage)
+    if @project
+      redirect_to :controller => '/projects', :action => 'show', :id => @project
+    else
+      redirect_to home_url
+    end
   end
 
 private

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -144,7 +144,8 @@ class Attachment < ActiveRecord::Base
   end
 
   def project
-    container.project
+    #not every container has a project (example: LandingPage)
+    container.respond_to?(:project)? container.project : nil
   end
 
   def visible?(user=User.current)


### PR DESCRIPTION
a project since it is not true for e.g. the Landing Page
plugin

Implements https://www.openproject.org/issues/1538
