### PR TITLE
Removed clearing of caches by regexp matchers

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -129,7 +129,7 @@ class Setting < ActiveRecord::Base
   def self.[]=(name, v)
     setting = find_or_default(name)
     setting.value = (v ? v : "")
-    Rails.cache.delete_matched(Regexp.compile(base_cache_key(name, '.+')))
+    Rails.cache.delete(cache_key(name))
     setting.save
     setting.value
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,4 +48,7 @@ OpenProject::Application.configure do
 
   # Send mails to browser window
   config.action_mailer.delivery_method = :letter_opener
+
+  # we use per process memory for caching in development
+  config.cache_store = :memory_store
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,7 @@ OpenProject::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # we use per process memory for caching in the test environment
+  config.cache_store = :memory_store
 end


### PR DESCRIPTION
since it is not supported by memcached

This issue came up while fixing https://www.openproject.org/issues/1537
