### PR TITLE
better censorship of overall journals

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -86,7 +86,7 @@ class ActivitiesController < ApplicationController
       elsif event.respond_to?(:project_id) or event.journaled.respond_to?(:project_id)
         # if possible access project_id (its faster)
         project_ids = [ event.project_id ]
-      elsif event.respond_to?(:project_) or event.journaled.respond_to?(:project)
+      elsif event.respond_to?(:project) or event.journaled.respond_to?(:project)
         # sometimes (e.g.) for wikis, we have no :project_id, but a :project method.
         project_ids = [ event.project.id ]
       end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -84,7 +84,11 @@ class ActivitiesController < ApplicationController
       if event.respond_to?(:changed_data) and event.changed_data['project_id']
         project_ids = event.changed_data['project_id']
       elsif event.respond_to?(:project_id) or event.journaled.respond_to?(:project_id)
+        # if possible access project_id (its faster)
         project_ids = [ event.project_id ]
+      elsif event.respond_to?(:project_) or event.journaled.respond_to?(:project)
+        # sometimes (e.g.) for wikis, we have no :project_id, but a :project method.
+        project_ids = [ event.project.id ]
       end
       if project_ids.empty?
         # show this event if it is not associated with a project

--- a/features/activities/index.feature
+++ b/features/activities/index.feature
@@ -34,3 +34,14 @@ Scenario: Hide activity from Projects with disabled activity module
     When I go to the overall activity page
     Then I should see "project1" within "#activity"
     And I should not see "project2" within "#activity"
+
+Scenario: Hide wiki activity from Projects with disabled activity module
+    Given the project "project1" has 1 wiki page with the following:
+      | title | Project1Wiki |
+    Given the project "project2" has 1 wiki page with the following:
+      | title | Project2Wiki |
+    When I go to the overall activity page
+    And I check "Wiki edits" within "#menu-sidebar"
+    And I press "Apply" within "#menu-sidebar"
+    Then I should see "project1" within "#activity"
+    And I should not see "project2" within "#activity"


### PR DESCRIPTION
Sometimes journal_events have a :project method, but no :project_id method.
We still use event.project_id if possible (it's faster) and fallback to
event.project.id.

see: https://www.openproject.org/issues/1461
