### PR TITLE
Disables the timelines/comparisons partial.

### DIFF
--- a/app/views/timelines/_form.html.erb
+++ b/app/views/timelines/_form.html.erb
@@ -24,7 +24,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <%= render :partial => "timelines/general", :locals => {:timeline => @timeline, :f => f}%>
 
-  <%= render :partial => "timelines/comparison", :locals => {:timeline => @timeline}%>
+  <%# render :partial => "timelines/comparison", :locals => {:timeline => @timeline}%>
 
   <%= render :partial => "timelines/vertical_planning_elements", :locals => {:timeline => @timeline}%>
 

--- a/app/views/timelines/_form.html.erb
+++ b/app/views/timelines/_form.html.erb
@@ -24,7 +24,13 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <%= render :partial => "timelines/general", :locals => {:timeline => @timeline, :f => f}%>
 
-  <%# render :partial => "timelines/comparison", :locals => {:timeline => @timeline}%>
+  <%# comparisons were removed so that they don't break for everyone once the
+      journalization changes start.
+
+        render :partial => "timelines/comparison", :locals => {:timeline => @timeline}
+
+      TODO enable comparisons once journalization is done.
+  %>
 
   <%= render :partial => "timelines/vertical_planning_elements", :locals => {:timeline => @timeline}%>
 


### PR DESCRIPTION
Comparisons will break when journalization will be changed.

OP issue: https://www.openproject.org/issues/1607
