### PR TITLE
Fix/type switching

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -12,7 +12,6 @@
 class WorkPackagesController < ApplicationController
   unloadable
 
-  include ExtendedHTTP
   include Redmine::Export::PDF
 
   current_menu_item do |controller|
@@ -29,8 +28,6 @@ class WorkPackagesController < ApplicationController
       :issues
     end
   end
-
-  model_object WorkPackage
 
   before_filter :disable_api
   before_filter :not_found_unless_work_package,
@@ -169,7 +166,8 @@ class WorkPackagesController < ApplicationController
 
   def new_work_package
     @new_work_package ||= begin
-      project = find_project_by_project_id
+      project = Project.visible.find_by_id(params[:project_id])
+      return nil unless project
 
       permitted = if params[:work_package]
                     permitted_params.new_work_package(:project => project)

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -206,48 +206,21 @@ class WorkPackagesController < ApplicationController
   end
 
   def ancestors
-    @ancestors ||= begin
-                     case work_package
-                     when PlanningElement
-                       # Right now all planning_elements of a tree are part of the same project.
-                       # That means that a user can either see all planning_elements or none.
-                       # Thus, after access to a planning element is established (work_package) we
-                       # currently need no extra check for the ancestors/descendants
-                       work_package.ancestors
-                     when Issue
-                       work_package.ancestors.visible.includes(:type,
+    @ancestors ||= work_package.ancestors.visible.includes(:type,
+                                                           :assigned_to,
+                                                           :status,
+                                                           :priority,
+                                                           :fixed_version,
+                                                           :project)
+  end
+
+  def descendants
+    @descendants ||= work_package.descendants.visible.includes(:type,
                                                                :assigned_to,
                                                                :status,
                                                                :priority,
                                                                :fixed_version,
                                                                :project)
-                     else
-                       []
-                     end
-                   end
-
-  end
-
-  def descendants
-    @descendants ||= begin
-                       case work_package
-                       when PlanningElement
-                         # Right now all planning_elements of a tree are part of the same project.
-                         # That means that a user can either see all planning_elements or none.
-                         # Thus, after access to a planning element is established (work_package) we
-                         # currently need no extra check for the ancestors/descendants
-                         work_package.descendants
-                       when Issue
-                         work_package.descendants.visible.includes(:type,
-                                                                   :assigned_to,
-                                                                   :status,
-                                                                   :priority,
-                                                                   :fixed_version,
-                                                                   :project)
-                       else
-                         []
-                       end
-                     end
 
   end
 

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -166,7 +166,7 @@ class WorkPackagesController < ApplicationController
 
   def new_work_package
     @new_work_package ||= begin
-      project = Project.visible.find_by_id(params[:project_id])
+      project = Project.find_visible(current_user, params[:project_id])
       return nil unless project
 
       permitted = if params[:work_package]

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -84,7 +84,7 @@ class PermittedParams < Struct.new(:params, :user)
   def new_work_package(args = {})
     permitted = permitted_attributes(:new_work_package, args)
 
-    permitted_params = params[:work_package].permit(*permitted)
+    permitted_params = params.require(:work_package).permit(*permitted)
 
     permitted_params.merge!(custom_field_values(:work_package))
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -84,28 +84,30 @@ class PermittedParams < Struct.new(:params, :user)
   def new_work_package(args = {})
     permitted = permitted_attributes(:new_work_package, args)
 
-    params[:work_package].permit(*permitted)
+    permitted_params = params[:work_package].permit(*permitted)
+
+    permitted_params.merge!(custom_field_values(:work_package))
+
+    permitted_params
   end
 
-  def update_work_package(args = {})
-    permitted = permitted_attributes(:new_work_package, args)
-
-    params[:work_package].permit(*permitted)
-  end
+  alias :update_work_package :new_work_package
 
   def user_update_as_admin
     if user.admin?
-      params.require(:user).permit(:firstname,
-                                   :lastname,
-                                   :mail,
-                                   :mail_notification,
-                                   :language,
-                                   :custom_field_values,
-                                   :custom_fields,
-                                   :identity_url,
-                                   :auth_source_id,
-                                   :force_password_change,
-                                   :group_ids => [])
+      permitted_params = params.require(:user).permit(:firstname,
+                                                      :lastname,
+                                                      :mail,
+                                                      :mail_notification,
+                                                      :language,
+                                                      :custom_fields,
+                                                      :identity_url,
+                                                      :auth_source_id,
+                                                      :force_password_change,
+                                                      :group_ids => [])
+      permitted_params.merge!(custom_field_values(:user))
+
+      permitted_params
     else
       params.require(:user).permit()
     end
@@ -133,6 +135,20 @@ class PermittedParams < Struct.new(:params, :user)
   end
 
   protected
+
+  def custom_field_values(key)
+    # a hash of arbitrary values is not supported by strong params
+    # thus we do it by hand
+    values = params.require(key)[:custom_field_values] || {}
+
+    # only permit values following the schema
+    # 'id as string' => 'value as string'
+    values.reject!{ |k, v| k.to_i < 1 || !v.is_a?(String) }
+
+    values.empty? ?
+      {} :
+      { "custom_field_values" => values }
+  end
 
   def permitted_attributes(key, additions = {})
     merged_args = { :params => params, :user => user }.merge(additions)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -410,6 +410,12 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def self.find_visible(user, *args)
+    with_scope(:find => where(Project.visible_by(user))) do
+      find(*args)
+    end
+  end
+
   def to_param
     # id is used for projects with a numeric identifier (compatibility)
     @to_param ||= (identifier.to_s =~ %r{^\d*$} ? id : identifier)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -313,19 +313,27 @@ class WorkPackage < ActiveRecord::Base
 
   # TODO: move into Business Object and rename to update
   # update for now is a private method defined by AR
-  def update_by(user, attributes)
-    init_journal(user, attributes.delete(:notes)) if attributes[:notes]
-
+  def update_by!(user, attributes)
     raw_attachments = attributes.delete(:attachments)
-    add_time_entry_for(user, attributes.delete(:time_entry))
 
-    if update_attributes(attributes)
+    update_by(user, attributes)
+
+    if save
       # as attach_files always saves an attachment right away
       # it is not possible to stage attaching and check for
       # valid. If this would be possible, we could check
       # for this along with update_attributes
       attachments = Attachment.attach_files(self, raw_attachments)
     end
+  end
+
+  def update_by(user, attributes)
+    init_journal(user, attributes.delete(:notes)) if attributes[:notes]
+
+    add_time_entry_for(user, attributes.delete(:time_entry))
+    attributes.delete(:attachments)
+
+    self.attributes = attributes
   end
 
   def is_milestone?

--- a/app/views/work_packages/_edit.html.erb
+++ b/app/views/work_packages/_edit.html.erb
@@ -21,7 +21,7 @@ See doc/COPYRIGHT.rdoc for more details.
                                         :multipart => true
                                        } do |f| %>
 
-  <%= error_messages_for 'work_package' %>
+  <%= error_messages_for work_package %>
 
   <div class="box">
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* `#1598` Switching type of work package looses inserted data
+
 ## 3.0.0pre10
 
 * `#1536` Fixed bug: Reposman.rb receives xml response for json request

--- a/features/work_packages/editable_fields.feature
+++ b/features/work_packages/editable_fields.feature
@@ -25,6 +25,7 @@ Feature: Fields editable on work package edit
       | name | prio1 |
     And the role "manager" may have the following rights:
       | edit_work_packages |
+      | view_work_packages |
       | manage_subtasks    |
     And the project "ecookbook" has 1 version with:
       | name | version1 |
@@ -57,6 +58,7 @@ Feature: Fields editable on work package edit
   Scenario: Going to the page and viewing timelog fields if this module is enabled
     Given the role "manager" may have the following rights:
       | edit_work_packages |
+      | view_work_packages |
       | log_time           |
 
     And there are the following planning elements in project "ecookbook":

--- a/features/work_packages/error_on_update.feature
+++ b/features/work_packages/error_on_update.feature
@@ -10,7 +10,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-Feature: Logging time on work package update
+Feature: Error messages are displayed
+
   Background:
     Given there is 1 user with:
       | login     | manager |
@@ -33,7 +34,7 @@ Feature: Logging time on work package update
     And I am already logged in as "manager"
 
   @javascript
-  Scenario: Logging time
+  Scenario: Inserting a blank subject results in an error beeing shown
     When I go to the edit page of the work package called "pe1"
      And I follow "More"
      And I fill in the following:

--- a/features/work_packages/navigate_to_edit.feature
+++ b/features/work_packages/navigate_to_edit.feature
@@ -6,6 +6,7 @@ Feature: Navigating to the work package edit page
     And there is a role "manager"
     And the role "manager" may have the following rights:
       | edit_work_packages |
+      | view_work_packages |
 
     And there is 1 project with the following:
       | identifier | ecookbook |

--- a/features/work_packages/switch_type.feature
+++ b/features/work_packages/switch_type.feature
@@ -43,6 +43,33 @@ Feature: Switching types of work packages
       | Responsible | Bob Bobbit |
     And I follow "More"
     And I select "Feature" from "Type"
+
     Then I should be on the edit page of the work package "wp1"
     And I should see the following fields:
       | Responsible | Bob Bobbit |
+
+  @javascript
+  Scenario: Switching type should update the presented custom fields
+    Given the following work package custom fields are defined:
+      | name      | type |
+      | cfBug     | int  |
+      | cfFeature | int  |
+      | cfAll     | int  |
+    And the custom field "cfBug" is activated for type "Bug"
+    And the custom field "cfFeature" is activated for type "Feature"
+    And the custom field "cfAll" is activated for type "Bug"
+    And the custom field "cfAll" is activated for type "Feature"
+
+    When I go to the edit page of the work package "wp1"
+    And I follow "More"
+    And I fill in the following:
+      | cfAll | 5 |
+    And I select "Feature" from "Type"
+
+    Then I should be on the edit page of the work package "wp1"
+    And I should see the following fields:
+      | cfFeature |   |
+      | cfAll     | 5 |
+
+
+

--- a/features/work_packages/switch_type.feature
+++ b/features/work_packages/switch_type.feature
@@ -1,0 +1,48 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Switching types of work packages
+  Background:
+    Given there is 1 project with the following:
+      | name        | project1 |
+      | identifier  | project1 |
+    And I am working in project "project1"
+    And the project "project1" has the following types:
+      | name    | position |
+      | Bug     | 1        |
+      | Feature | 2        |
+    And there is a default issuepriority with:
+      | name   | Normal |
+    And there is a role "member"
+    And the role "member" may have the following rights:
+      | view_work_packages |
+      | edit_work_packages |
+    And there is 1 user with the following:
+      | login     | bob    |
+      | firstname | Bob    |
+      | lastname  | Bobbit |
+    And the user "bob" is a "member" in the project "project1"
+    Given the user "bob" has 1 issue with the following:
+      | subject     | wp1                 |
+      | description | Initial description |
+      | type        | Bug                 |
+    And I am already logged in as "bob"
+
+  @javascript
+  Scenario: Switching type should keep the inserted value
+    When I go to the edit page of the work package "wp1"
+    And I fill in the following:
+      | Responsible | Bob Bobbit |
+    And I follow "More"
+    And I select "Feature" from "Type"
+    Then I should be on the edit page of the work package "wp1"
+    And I should see the following fields:
+      | Responsible | Bob Bobbit |

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -343,9 +343,7 @@ describe WorkPackagesController do
       let(:params) { { :project_id => stub_project.id } }
 
       before do
-        projects = [stub_project]
-        Project.stub(:visible).and_return projects
-        projects.stub(:find_by_id).and_return(stub_project)
+        Project.stub(:find_visible).and_return stub_project
       end
 
       describe 'when the type is "PlanningElement"' do

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -592,12 +592,17 @@ describe WorkPackagesController do
   end
 
   describe :new_work_package do
+    let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
+
     describe 'when the type is "PlanningElement"' do
       before do
         controller.params = { :sti_type => 'PlanningElement',
                               :work_package => {} }
-        controller.stub!(:find_project_by_project_id).and_return(project)
-        controller.stub!(:current_user).and_return(stub_user)
+        controller.stub(:find_project_by_project_id).and_return(project)
+        controller.stub(:current_user).and_return(stub_user)
+        controller.send(:permitted_params).should_receive(:new_work_package)
+                                          .with(:project => project)
+                                          .and_return(wp_params)
 
         project.should_receive(:add_planning_element) do |args|
 
@@ -623,8 +628,11 @@ describe WorkPackagesController do
         controller.params = { :sti_type => 'Issue',
                               :work_package => {} }
 
-        controller.stub!(:find_project_by_project_id).and_return(project)
-        controller.stub!(:current_user).and_return(stub_user)
+        controller.stub(:find_project_by_project_id).and_return(project)
+        controller.stub(:current_user).and_return(stub_user)
+        controller.send(:permitted_params).should_receive(:new_work_package)
+                                          .with(:project => project)
+                                          .and_return(wp_params)
 
         project.should_receive(:add_issue) do |args|
 

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -98,10 +98,10 @@ describe WorkPackagesController do
       describe 'w/o being a member or administrator' do
         become_non_member
 
-        it 'renders a 403 Forbidden page' do
+        it 'renders a 404 Not Found' do
           get 'show', :id => planning_element.id
 
-          response.response_code.should == 403
+          response.response_code.should == 404
         end
       end
 
@@ -154,11 +154,11 @@ describe WorkPackagesController do
       describe 'w/o being a member or administrator' do
         become_non_member
 
-        it 'renders a 403 Forbidden page' do
+        it 'renders a 404 Not Found' do
           get 'show', :format => 'pdf',
                       :id => planning_element.id
 
-          response.response_code.should == 403
+          response.response_code.should == 404
         end
       end
 
@@ -344,19 +344,20 @@ describe WorkPackagesController do
     describe 'w/ beeing a member
               w/ having the necessary permissions
               w/ having an successful save' do
-      let(:params) { { :project_id => project.id, :work_package => { } } }
+      let(:params) { { :project_id => planning_element.project.id,
+                       :work_package => { } } }
 
       become_member_with_permissions [:add_work_packages]
 
       before do
-        controller.stub!(:new_work_package).and_return(stub_issue)
-        stub_issue.should_receive(:save).and_return(true)
+        controller.stub!(:new_work_package).and_return(planning_element)
+        planning_element.should_receive(:save).and_return(true)
       end
 
       it 'redirect to show' do
         post 'create', params
 
-        response.should redirect_to(work_package_path(stub_issue))
+        response.should redirect_to(work_package_path(planning_element))
       end
 
       it 'should show a flash message' do
@@ -370,7 +371,7 @@ describe WorkPackagesController do
       it 'should attach attachments if those are provided' do
         params[:attachments] = 'attachment-blubs-data'
 
-        Attachment.should_receive(:attach_files).with(stub_issue, params[:attachments])
+        Attachment.should_receive(:attach_files).with(planning_element, params[:attachments])
         controller.stub!(:render_attachment_warning_if_needed)
 
         post 'create', params
@@ -383,8 +384,8 @@ describe WorkPackagesController do
       become_member_with_permissions [:add_work_packages]
 
       before do
-        controller.stub!(:new_work_package).and_return(stub_issue)
-        stub_issue.should_receive(:save).and_return(false)
+        controller.stub!(:new_work_package).and_return(planning_element)
+        planning_element.should_receive(:save).and_return(false)
 
         post 'create', :project_id => project.id
       end
@@ -441,10 +442,10 @@ describe WorkPackagesController do
       describe 'w/o being a member or administrator' do
         become_non_member
 
-        it 'renders a 403 Forbidden page' do
+        it 'renders a 404 Not Found' do
           get 'edit', :id => planning_element.id
 
-          response.response_code.should == 403
+          response.response_code.should == 404
         end
       end
 

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -63,153 +63,78 @@ describe WorkPackagesController do
   let(:stub_project) { FactoryGirl.build_stubbed(:project, :identifier => 'test_project', :is_public => false) }
   let(:stub_issue) { FactoryGirl.build_stubbed(:issue, :project_id => stub_project.id) }
   let(:stub_user) { FactoryGirl.build_stubbed(:user) }
+  let(:stub_work_package) { double("work_package", :id => 1337, :project => stub_project).as_null_object }
 
   let(:current_user) { FactoryGirl.create(:user) }
 
-  describe 'show.html' do
-    become_admin
+  def self.requires_permission_in_project(&block)
+    describe 'w/o the permission to see the project/work_package' do
+      before do
+        controller.stub(:work_package).and_return(nil)
 
-    describe 'w/o a valid planning element id' do
-
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 page' do
-          get 'show', :id => '1337'
-
-          response.response_code.should === 404
-        end
+        call_action
       end
 
-      describe 'w/ the current user being a member' do
-        become_member_with_view_planning_element_permissions
-
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          get 'show', :id => '1337'
-
-          response.response_code.should === 404
-        end
+      it 'should render a 404' do
+        response.response_code.should === 404
       end
     end
 
-    describe 'w/ a valid planning element id' do
-      become_admin
+    describe 'w/ the permission to see the project
+              w/ having the necessary permissions' do
 
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 Not Found' do
-          get 'show', :id => planning_element.id
-
-          response.response_code.should == 404
-        end
+      before do
+        controller.stub(:work_package).and_return(stub_work_package)
+        controller.should_receive(:authorize).and_return(true)
       end
 
-      describe 'w/ the current user being a member' do
-        become_member_with_view_planning_element_permissions
+      instance_eval(&block)
+    end
+  end
 
-        before do
-          get 'show', :id => planning_element.id
-        end
 
-        it 'renders the show builder template' do
-          response.should render_template('work_packages/show', :formats => ["html"], :layout => :base)
-        end
+  describe 'show.html' do
+    let(:call_action) { get('show', :id => '1337') }
+
+    requires_permission_in_project do
+      it 'renders the show builder template' do
+        call_action
+
+        response.should render_template('work_packages/show', :formats => ["html"],
+                                                              :layout => :base)
       end
     end
   end
+
 
   describe 'show.pdf' do
+    let(:call_action) { get('show', :format => 'pdf', :id => '1337') }
 
-    become_admin
+    requires_permission_in_project do
+      it 'respond with a pdf' do
+        pdf = double('pdf')
 
-    describe 'w/o a valid planning element id' do
-
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 page' do
-          get 'show', :format => 'pdf',
-                      :id => '1337'
-
-          response.response_code.should === 404
-        end
-      end
-
-      describe 'w/ the current user being a member' do
-        become_member_with_view_planning_element_permissions
-
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          get 'show', :format => 'pdf',
-                      :id => '1337'
-
-          response.response_code.should === 404
-        end
-      end
-    end
-
-    describe 'w/ a valid planning element id' do
-      become_admin
-
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 Not Found' do
-          get 'show', :format => 'pdf',
-                      :id => planning_element.id
-
-          response.response_code.should == 404
-        end
-      end
-
-      describe 'w/ the current user being a member' do
-        become_member_with_view_planning_element_permissions
-
-        it "should respond with a pdf" do
-          pdf = double('pdf')
-
-          expected_name = "#{planning_element.project.identifier}-#{planning_element.id}.pdf"
-          controller.stub!(:issue_to_pdf).and_return(pdf)
-          controller.should_receive(:send_data).with(pdf,
-                                                     :type => 'application/pdf',
-                                                     :filename => expected_name).and_call_original
-          get 'show', :format => 'pdf',
-                      :id => planning_element.id
-        end
+        expected_name = "#{stub_work_package.project.identifier}-#{stub_work_package.id}.pdf"
+        controller.stub!(:issue_to_pdf).and_return(pdf)
+        controller.should_receive(:send_data).with(pdf,
+                                                   :type => 'application/pdf',
+                                                   :filename => expected_name).and_call_original
+        call_action
       end
     end
   end
+
 
   describe 'new.html' do
-    describe 'w/o specifying a project_id' do
+    let(:call_action) { get('new', :format => 'html', :project_id => 5) }
+
+    requires_permission_in_project do
       before do
-        get 'new'
-      end
-
-      it 'should return 404 Not found' do
-        response.response_code.should == 404
-      end
-    end
-
-    describe 'w/o being a member' do
-      before do
-        get 'new', :project_id => project.id
-      end
-
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions' do
-      become_member_with_permissions [:add_work_packages]
-
-      before do
-        get 'new', :project_id => project.id
+        call_action
       end
 
       it 'renders the new builder template' do
+
         response.should render_template('work_packages/new', :formats => ["html"])
       end
 
@@ -217,58 +142,21 @@ describe WorkPackagesController do
         response.response_code.should == 200
       end
     end
-
-    describe 'w/ beeing a member
-              w/o having the necessary permissions' do
-      become_member_with_permissions []
-
-      before do
-        get 'new', :project_id => project.id
-      end
-
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
-      end
-    end
   end
+
 
   describe 'new_type.js' do
-
     let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
+    let(:call_action) { xhr :get, :new_type, :project_id => 5 }
 
-    describe 'w/o specifying a project_id or an id' do
+    requires_permission_in_project do
       before do
-        xhr :get, :new_type
-      end
-
-      it 'should return 404 Not found' do
-        response.response_code.should == 404
-      end
-    end
-
-    describe 'w/o being a member' do
-      before do
-        xhr :get, :new_type, :project_id => project.id
-      end
-
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ specifying a project_id' do
-      become_member_with_permissions [:add_work_packages]
-
-      before do
-        controller.stub!(:new_work_package).and_return(planning_element)
         controller.send(:permitted_params).should_receive(:update_work_package)
-                                          .with(:project => planning_element.project)
+                                          .with(:project => stub_project)
                                           .and_return(wp_params)
-        planning_element.should_receive(:update_by).with(current_user, wp_params).and_return(true)
+        stub_work_package.should_receive(:update_by).with(current_user, wp_params).and_return(true)
 
-        xhr :get, :new_type, :project_id => project.id
+        call_action
       end
 
       it 'renders the new builder template' do
@@ -277,389 +165,275 @@ describe WorkPackagesController do
 
       it 'should respond with 200 OK' do
         response.response_code.should == 200
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ specifying an id' do
-      become_member_with_permissions [:view_work_packages,
-                                      :edit_work_packages]
-
-
-      before do
-        controller.stub(:existing_work_package).and_return(planning_element)
-        controller.send(:permitted_params).should_receive(:update_work_package)
-                                          .with(:project => project)
-                                          .and_return(wp_params)
-        planning_element.should_receive(:update_by).with(current_user, wp_params).and_return(true)
-
-        xhr :get, :new_type, :id => planning_element.id
-      end
-
-      it 'renders the new builder template' do
-        response.should render_template('work_packages/new_type', :formats => ["html"])
-      end
-
-      it 'should respond with 200 OK' do
-        response.response_code.should == 200
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/o having the necessary permissions' do
-      become_member_with_permissions []
-
-      before do
-        xhr :get, :new_type, :project_id => project.id
-      end
-
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
       end
     end
   end
 
+
   describe 'create.html' do
-    describe 'w/o specifying a project_id' do
-      before do
-        post 'create'
+    let(:params) { { :project_id => stub_work_package.project.id,
+                     :work_package => { } } }
+
+    let(:call_action) { post 'create', params }
+
+    requires_permission_in_project do
+
+      describe 'w/ having a successful save' do
+        before do
+          stub_work_package.should_receive(:save).and_return(true)
+        end
+
+        it 'redirect to show' do
+          call_action
+
+          response.should redirect_to(work_package_path(stub_work_package))
+        end
+
+        it 'should show a flash message' do
+          disable_flash_sweep
+
+          call_action
+
+          flash[:notice].should == I18n.t(:notice_successful_create)
+        end
+
+        it 'should attach attachments if those are provided' do
+          params[:attachments] = 'attachment-blubs-data'
+
+          Attachment.should_receive(:attach_files).with(stub_work_package, params[:attachments])
+          controller.stub!(:render_attachment_warning_if_needed)
+
+          call_action
+        end
       end
 
-      it 'should return 404 Not found' do
-        response.response_code.should == 404
-      end
-    end
+      describe 'w/ having an unsuccessful save' do
 
-    describe 'w/o being a member' do
-      before do
-        post 'create', :project_id => project.id
-      end
+        before do
+          stub_work_package.should_receive(:save).and_return(false)
 
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
-      end
-    end
+          call_action
+        end
 
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ having an successful save' do
-      let(:params) { { :project_id => planning_element.project.id,
-                       :work_package => { } } }
-
-      become_member_with_permissions [:add_work_packages]
-
-      before do
-        controller.stub!(:new_work_package).and_return(planning_element)
-        planning_element.should_receive(:save).and_return(true)
-      end
-
-      it 'redirect to show' do
-        post 'create', params
-
-        response.should redirect_to(work_package_path(planning_element))
-      end
-
-      it 'should show a flash message' do
-        disable_flash_sweep
-
-        post 'create', params
-
-        flash[:notice].should == I18n.t(:notice_successful_create)
-      end
-
-      it 'should attach attachments if those are provided' do
-        params[:attachments] = 'attachment-blubs-data'
-
-        Attachment.should_receive(:attach_files).with(planning_element, params[:attachments])
-        controller.stub!(:render_attachment_warning_if_needed)
-
-        post 'create', params
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ having an unsuccessful save' do
-      become_member_with_permissions [:add_work_packages]
-
-      before do
-        controller.stub!(:new_work_package).and_return(planning_element)
-        planning_element.should_receive(:save).and_return(false)
-
-        post 'create', :project_id => project.id
-      end
-
-      it 'renders the new template' do
-        response.should render_template('work_packages/new', :formats => ["html"])
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/o having the necessary permissions' do
-      become_member_with_permissions []
-
-      before do
-        get 'new', :project_id => project.id
-      end
-
-      it 'should return 403 Forbidden' do
-        response.response_code.should == 403
+        it 'renders the new template' do
+          response.should render_template('work_packages/new', :formats => ["html"])
+        end
       end
     end
   end
 
   describe 'edit.html' do
+    let(:call_action) { get 'edit', :id => stub_work_package.id }
 
-    become_admin
+    requires_permission_in_project do
+      it 'renders the show builder template' do
+        call_action
 
-    describe 'w/o a valid work_package id' do
-
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 page' do
-          get 'edit', :id => '1337'
-
-          response.response_code.should === 404
-        end
-      end
-
-      describe 'w/ the current user being a member' do
-        become_member_with_view_planning_element_permissions
-
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          get 'edit', :id => '1337'
-
-          response.response_code.should === 404
-        end
-      end
-    end
-
-    describe 'w/ a valid work package id' do
-      become_admin
-
-      describe 'w/o being a member or administrator' do
-        become_non_member
-
-        it 'renders a 404 Not Found' do
-          get 'edit', :id => planning_element.id
-
-          response.response_code.should == 404
-        end
-      end
-
-      describe 'w/ the current user being a member' do
-        become_member_with_permissions [:edit_work_packages,
-                                        :view_work_packages]
-
-        before do
-          get 'edit', :id => planning_element.id
-        end
-
-        it 'renders the show builder template' do
-          response.should render_template('work_packages/edit', :formats => ["html"], :layout => :base)
-        end
+        response.should render_template('work_packages/edit', :formats => ["html"], :layout => :base)
       end
     end
   end
 
   describe 'update.html' do
-    describe 'w/o being a member' do
+    let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
+    let(:params) { { :id => stub_work_package.id, :work_package => wp_params } }
+    let(:call_action) { put 'update', params }
+
+    requires_permission_in_project do
       before do
-        put 'update'
-      end
-
-      it 'should return 404 Not Found' do
-        response.response_code.should == 404
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ a valid wp id
-              w/ having a successful save' do
-      let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
-      let(:params) { { :id => planning_element.id, :work_package => wp_params } }
-
-      become_member_with_permissions [:edit_work_packages]
-
-      before do
-        controller.stub!(:work_package).and_return(planning_element)
+        controller.stub(:work_package).and_return(stub_work_package)
         controller.send(:permitted_params).should_receive(:update_work_package)
-                                          .with(:project => planning_element.project)
+                                          .with(:project => stub_work_package.project)
                                           .and_return(wp_params)
-        planning_element.should_receive(:update_by!).with(current_user, wp_params).and_return(true)
       end
 
-      it 'should respond with 200 OK' do
-        put 'update', params
+      describe 'w/ having a successful save' do
+        before do
+          stub_work_package.should_receive(:update_by!)
+                           .with(current_user, wp_params)
+                           .and_return(true)
+        end
 
-        response.response_code.should == 200
+        it 'should respond with 200 OK' do
+          call_action
+
+          response.response_code.should == 200
+        end
+
+        it 'should show a flash message' do
+          disable_flash_sweep
+
+          call_action
+
+          flash[:notice].should == I18n.t(:notice_successful_update)
+        end
       end
 
-      it 'should show a flash message' do
-        disable_flash_sweep
+      describe 'w/ having an unsuccessful save' do
+        before do
+          stub_work_package.should_receive(:update_by!)
+                           .with(current_user, wp_params)
+                           .and_return(false)
+        end
 
-        put 'update', params
+        it 'render the edit action' do
+          call_action
 
-        flash[:notice].should == I18n.t(:notice_successful_update)
-      end
-    end
-
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ a valid wp id
-              w/ having an unsuccessful save' do
-      let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
-      let(:params) { { :id => planning_element.id, :work_package => wp_params } }
-
-      become_member_with_permissions [:edit_work_packages]
-
-      before do
-        controller.stub!(:work_package).and_return(planning_element)
-        controller.send(:permitted_params).should_receive(:update_work_package)
-                                          .with(:project => planning_element.project)
-                                          .and_return(wp_params)
-        planning_element.should_receive(:update_by!).with(current_user, wp_params).and_return(false)
+          response.should render_template('work_packages/edit', :formats => ["html"], :layout => :base)
+        end
       end
 
-      it 'render the edit action' do
-        put 'update', params
+      describe 'w/ having a successful save
+                w/ having a faulty attachment' do
 
-        response.should render_template('work_packages/edit', :formats => ["html"], :layout => :base)
-      end
-    end
+        before do
+          stub_work_package.should_receive(:update_by!)
+                           .with(current_user, wp_params)
+                           .and_return(true)
+          stub_work_package.stub(:unsaved_attachments)
+                           .and_return([double('unsaved_attachment')])
+        end
 
-    describe 'w/ beeing a member
-              w/ having the necessary permissions
-              w/ a valid wp id
-              w/ having a successful save
-              w/ having a faulty attachment' do
-      let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
-      let(:params) { { :id => planning_element.id, :work_package => wp_params } }
+        it 'should respond with 200 OK' do
+          call_action
 
-      become_member_with_permissions [:edit_work_packages]
+          response.response_code.should == 200
+        end
 
-      before do
-        controller.stub!(:work_package).and_return(planning_element)
-        controller.send(:permitted_params).should_receive(:update_work_package)
-                                          .with(:project => planning_element.project)
-                                          .and_return(wp_params)
-        planning_element.should_receive(:update_by).with(current_user, wp_params).and_return(true)
-        planning_element.stub(:unsaved_attachments).and_return([double('unsaved_attachment')])
-      end
+        it 'should show a flash message' do
+          disable_flash_sweep
 
-      it 'should respond with 200 OK' do
-        put 'update', params
+          call_action
 
-        response.response_code.should == 200
-      end
-
-      it 'should show a flash message' do
-        disable_flash_sweep
-
-        put 'update', params
-
-        flash[:warning].should == I18n.t(:warning_attachments_not_saved, :count => 1)
+          flash[:warning].should == I18n.t(:warning_attachments_not_saved, :count => 1)
+        end
       end
     end
   end
 
   describe :work_package do
-    describe 'when beeing allowed to see the work_package' do
-      become_member_with_view_planning_element_permissions
+    describe 'when providing an id (wanting to see an existing wp)' do
+      describe 'when beeing allowed to see the work_package' do
+        become_member_with_view_planning_element_permissions
 
-      it 'should return the work_package' do
-        controller.params = { id: planning_element.id }
+        it 'should return the work_package' do
+          controller.params = { id: planning_element.id }
 
-        controller.work_package.should == planning_element
+          controller.work_package.should == planning_element
+        end
+
+        it 'should return nil for non existing work_packages' do
+          controller.params = { id: 0 }
+
+          controller.work_package.should be_nil
+        end
       end
 
-      it 'should return nil for non existing work_packages' do
-        controller.params = { id: 0 }
+      describe 'when not beeing allowed to see the work_package' do
+        it 'should return nil' do
+          controller.params = { id: planning_element.id }
+
+          controller.work_package.should be_nil
+        end
+      end
+    end
+
+    describe 'when providing a project_id (wanting to build a new wp)' do
+      let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
+      let(:params) { { :project_id => stub_project.id } }
+
+      before do
+        projects = [stub_project]
+        Project.stub(:visible).and_return projects
+        projects.stub(:find_by_id).and_return(stub_project)
+      end
+
+      describe 'when the type is "PlanningElement"' do
+        before do
+          controller.params = { :sti_type => 'PlanningElement',
+                                :work_package => {} }.merge(params)
+
+          controller.stub(:current_user).and_return(stub_user)
+          controller.send(:permitted_params).should_receive(:new_work_package)
+                                            .with(:project => stub_project)
+                                            .and_return(wp_params)
+
+          stub_project.should_receive(:add_planning_element) do |args|
+
+            expect(args[:author]).to eql stub_user
+
+          end.and_return(stub_planning_element)
+        end
+
+        it 'should return a new planning element on the project' do
+          controller.work_package.should == stub_planning_element
+        end
+
+        it 'should copy over attributes from another work_package provided as the source' do
+          controller.params[:copy_from] = 2
+          stub_planning_element.should_receive(:copy_from).with(2, :exclude => [:project_id])
+
+          controller.work_package
+        end
+      end
+
+      describe 'when the type is "Issue"' do
+        before do
+          controller.params = { :sti_type => 'Issue',
+                                :work_package => {} }.merge(params)
+
+          controller.stub(:current_user).and_return(stub_user)
+          controller.send(:permitted_params).should_receive(:new_work_package)
+                                            .with(:project => stub_project)
+                                            .and_return(wp_params)
+
+          stub_project.should_receive(:add_issue) do |args|
+
+            expect(args[:author]).to eql stub_user
+
+          end.and_return(stub_issue)
+        end
+
+        it 'should return a new issue on the project' do
+          controller.work_package.should == stub_issue
+        end
+
+        it 'should copy over attributes from another work_package provided as the source' do
+          controller.params[:copy_from] = 2
+          stub_issue.should_receive(:copy_from).with(2, :exclude => [:project_id])
+
+          controller.work_package
+        end
+      end
+
+      describe 'if the project is not visible for the current_user' do
+        before do
+          projects = [stub_project]
+          Project.stub(:visible).and_return projects
+          projects.stub(:find_by_id).and_return(stub_project)
+        end
+
+        it 'should return nil' do
+          controller.work_package.should be_nil
+
+        end
+      end
+
+      describe 'when the sti_type is "Project"' do
+        it "should raise not allowed" do
+          controller.params = { :sti_type => 'Project',
+                                :project_id => stub_project.id }.merge(params)
+
+          expect { controller.work_package }.to raise_error ArgumentError
+        end
+      end
+    end
+
+    describe 'when providing neither id nor project_id (error)' do
+      it "should return nil" do
+        controller.params = {}
 
         controller.work_package.should be_nil
-      end
-    end
-
-    describe 'when not beeing allowed to see the work_package' do
-      it 'should return nil' do
-        controller.params = { id: planning_element.id }
-
-        controller.work_package.should be_nil
-      end
-    end
-  end
-
-  describe :new_work_package do
-    let(:wp_params) { { :wp_attribute => double('wp_attribute') } }
-
-    describe 'when the type is "PlanningElement"' do
-      before do
-        controller.params = { :sti_type => 'PlanningElement',
-                              :work_package => {} }
-        controller.stub(:find_project_by_project_id).and_return(project)
-        controller.stub(:current_user).and_return(stub_user)
-        controller.send(:permitted_params).should_receive(:new_work_package)
-                                          .with(:project => project)
-                                          .and_return(wp_params)
-
-        project.should_receive(:add_planning_element) do |args|
-
-          expect(args[:author]).to eql stub_user
-
-        end.and_return(stub_planning_element)
-      end
-
-      it 'should return a new planning element on the project' do
-        controller.new_work_package.should == stub_planning_element
-      end
-
-      it 'should copy over attributes from another work_package provided as the source' do
-        controller.params[:copy_from] = 2
-        stub_planning_element.should_receive(:copy_from).with(2, :exclude => [:project_id])
-
-        controller.new_work_package
-      end
-    end
-
-    describe 'when the type is "Issue"' do
-      before do
-        controller.params = { :sti_type => 'Issue',
-                              :work_package => {} }
-
-        controller.stub(:find_project_by_project_id).and_return(project)
-        controller.stub(:current_user).and_return(stub_user)
-        controller.send(:permitted_params).should_receive(:new_work_package)
-                                          .with(:project => project)
-                                          .and_return(wp_params)
-
-        project.should_receive(:add_issue) do |args|
-
-          expect(args[:author]).to eql stub_user
-
-        end.and_return(stub_issue)
-      end
-
-      it 'should return a new issue on the project' do
-        controller.new_work_package.should == stub_issue
-      end
-
-      it 'should copy over attributes from another work_package provided as the source' do
-        controller.params[:copy_from] = 2
-        stub_issue.should_receive(:copy_from).with(2, :exclude => [:project_id])
-
-        controller.new_work_package
-      end
-    end
-
-    describe 'when the sti_type is "Project"' do
-      it "should raise not allowed" do
-        controller.stub(:find_project_by_project_id).and_return(stub_project)
-        controller.params = { :sti_type => 'Project' }
-
-        expect { controller.new_work_package }.to raise_error ArgumentError
       end
     end
   end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -403,6 +403,22 @@ describe PermittedParams do
 
       PermittedParams.new(params, user).new_work_package(:project => project).should == {}
     end
+
+    it "should permit custom field values" do
+      hash = { "custom_field_values" => { "1" => "5" } }
+
+      params = ActionController::Parameters.new(:work_package => hash)
+
+      PermittedParams.new(params, user).new_work_package.should == hash
+    end
+
+    it "should remove custom field values that do not follow the schema 'id as string' => 'value as string'" do
+      hash = { "custom_field_values" => { "blubs" => "5", "5" => {"1" => "2"} } }
+
+      params = ActionController::Parameters.new(:work_package => hash)
+
+      PermittedParams.new(params, user).new_work_package.should == {}
+    end
   end
 
   describe :update_work_package do
@@ -571,6 +587,22 @@ describe PermittedParams do
 
       PermittedParams.new(params, user).update_work_package(:project => project).should == {}
     end
+
+    it "should permit custom field values" do
+      hash = { "custom_field_values" => { "1" => "5" } }
+
+      params = ActionController::Parameters.new(:work_package => hash)
+
+      PermittedParams.new(params, user).new_work_package.should == hash
+    end
+
+    it "should remove custom field values that do not follow the schema 'id as string' => 'value as string'" do
+      hash = { "custom_field_values" => { "blubs" => "5", "5" => {"1" => "2"} } }
+
+      params = ActionController::Parameters.new(:work_package => hash)
+
+      PermittedParams.new(params, user).new_work_package.should == {}
+    end
   end
 
   describe :user do
@@ -579,7 +611,6 @@ describe PermittedParams do
                          'mail',
                          'mail_notification',
                          'language',
-                         'custom_field_values',
                          'custom_fields',
                          'identity_url',
                          'auth_source_id',
@@ -608,6 +639,22 @@ describe PermittedParams do
       params = ActionController::Parameters.new(:user => hash)
 
       PermittedParams.new(params, admin).user_update_as_admin.should == hash
+    end
+
+    it "should permit custom field values" do
+      hash = { "custom_field_values" => { "1" => "5" } }
+
+      params = ActionController::Parameters.new(:user => hash)
+
+      PermittedParams.new(params, admin).user_update_as_admin.should == hash
+    end
+
+    it "should remove custom field values that do not follow the schema 'id as string' => 'value as string'" do
+      hash = { "custom_field_values" => { "blubs" => "5", "5" => {"1" => "2"} } }
+
+      params = ActionController::Parameters.new(:user => hash)
+
+      PermittedParams.new(params, admin).user_update_as_admin.should == {}
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -10,10 +10,14 @@
 #++
 
 require 'spec_helper'
+require File.expand_path('../../support/shared/become_member', __FILE__)
 
 describe Project do
+  include BecomeMember
+
   let(:project) { FactoryGirl.build(:project) }
   let(:admin) { FactoryGirl.create(:admin) }
+  let(:user) { FactoryGirl.create(:user) }
 
   describe Project::STATUS_ACTIVE do
     it "equals 1" do
@@ -128,6 +132,28 @@ describe Project do
       Issue.stub!(:new).and_yield(new_issue)
 
       project.add_issue(attributes)
+    end
+  end
+
+  describe :find_visible do
+    it 'should find the project by id if the user is project member' do
+      become_member_with_permissions(project, user, :view_work_packages)
+
+      Project.find_visible(user, project.id).should == project
+    end
+
+    it 'should find the project by identifier if the user is project member' do
+      become_member_with_permissions(project, user, :view_work_packages)
+
+      Project.find_visible(user, project.identifier).should == project
+    end
+
+    it 'should not find the project by identifier if the user is no project member' do
+      expect { Project.find_visible(user, project.identifier) }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it 'should not find the project by id if the user is no project member' do
+      expect { Project.find_visible(user, project.id) }.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -198,7 +198,7 @@ describe WorkPackage do
     end
   end
 
-  describe :update_with do
+  describe :update_by! do
     #TODO remove once only WP exists
     [:issue, :planning_element].each do |subclass|
 
@@ -206,17 +206,17 @@ describe WorkPackage do
         let(:instance) { send(subclass) }
 
         it "should return true" do
-          instance.update_by(user, {}).should be_true
+          instance.update_by!(user, {}).should be_true
         end
 
         it "should set the values" do
-          instance.update_by(user, { :subject => "New subject" })
+          instance.update_by!(user, { :subject => "New subject" })
 
           instance.subject.should == "New subject"
         end
 
         it "should create a journal with the journal's 'notes' attribute set to the supplied" do
-          instance.update_by(user, { :notes => "blubs" })
+          instance.update_by!(user, { :notes => "blubs" })
 
           instance.journals.last.notes.should == "blubs"
         end
@@ -229,7 +229,7 @@ describe WorkPackage do
                     .with(instance, raw_attachments)
                     .and_return(attachment)
 
-          instance.update_by(user, { :attachments => raw_attachments })
+          instance.update_by!(user, { :attachments => raw_attachments })
         end
 
         it "should only attach the attachment when saving was successful" do
@@ -238,13 +238,13 @@ describe WorkPackage do
 
           Attachment.should_not_receive(:attach_files)
 
-          instance.update_by(user, { :subject => "", :attachments => raw_attachments })
+          instance.update_by!(user, { :subject => "", :attachments => raw_attachments })
         end
 
         it "should add a time entry" do
           activity = FactoryGirl.create(:time_entry_activity)
 
-          instance.update_by(user, { :time_entry => { "hours" => "5",
+          instance.update_by!(user, { :time_entry => { "hours" => "5",
                                                       "activity_id" => activity.id.to_s,
                                                       "comments" => "blubs" } } )
 
@@ -262,7 +262,7 @@ describe WorkPackage do
         it "should not persist the time entry if the #{subclass}'s update fails" do
           activity = FactoryGirl.create(:time_entry_activity)
 
-          instance.update_by(user, { :subject => '',
+          instance.update_by!(user, { :subject => '',
                                      :time_entry => { "hours" => "5",
                                                       "activity_id" => activity.id.to_s,
                                                       "comments" => "blubs" } } )
@@ -279,7 +279,7 @@ describe WorkPackage do
                               "activity_id" => "",
                               "comments" => "" }
 
-          instance.update_by(user, :time_entry => time_attributes)
+          instance.update_by!(user, :time_entry => time_attributes)
 
           instance.should have(0).time_entries
         end

--- a/spec/permissions/add_work_packages_spec.rb
+++ b/spec/permissions/add_work_packages_spec.rb
@@ -1,0 +1,21 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../spec_helper', __FILE__)
+require File.expand_path('../../support/permission_specs', __FILE__)
+
+describe WorkPackagesController, "add_work_packages permission", :type => :controller do
+  include PermissionSpecs
+
+  check_permission_required_for('work_packages#new', :add_work_packages)
+  check_permission_required_for('work_packages#new_type', :add_work_packages)
+  check_permission_required_for('work_packages#create', :add_work_packages)
+end

--- a/spec/permissions/edit_work_packages_spec.rb
+++ b/spec/permissions/edit_work_packages_spec.rb
@@ -1,0 +1,21 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../spec_helper', __FILE__)
+require File.expand_path('../../support/permission_specs', __FILE__)
+
+describe WorkPackagesController, "edit_work_packages permission", :type => :controller do
+  include PermissionSpecs
+
+  check_permission_required_for('work_packages#edit', :edit_work_packages)
+  check_permission_required_for('work_packages#update', :edit_work_packages)
+  check_permission_required_for('work_packages#new_type', :edit_work_packages)
+end

--- a/spec/permissions/view_work_packages_spec.rb
+++ b/spec/permissions/view_work_packages_spec.rb
@@ -1,0 +1,19 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../spec_helper', __FILE__)
+require File.expand_path('../../support/permission_specs', __FILE__)
+
+describe WorkPackagesController, "view_work_packages permission", :type => :controller do
+  include PermissionSpecs
+
+  check_permission_required_for('work_packages#show', :view_work_packages)
+end

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module PermissionSpecs
+  def self.included(base)
+    base.class_eval do
+      let(:project) { FactoryGirl.create(:project, :is_public => false) }
+      let(:current_user) { FactoryGirl.create(:user) }
+
+      def become_member_with_permissions(permissions = [])
+        permissions = Array(permissions)
+
+        role = FactoryGirl.create(:role, :permissions => permissions)
+
+        member = FactoryGirl.build(:member, :user => current_user, :project => project)
+        member.roles = [role]
+        member.save!
+      end
+
+      def self.check_permission_required_for(controller_action, permission)
+        controller_name, action_name = controller_action.split('#')
+
+        it "should allow calling #{controller_action} when having the permission #{permission} permission" do
+          become_member_with_permissions(permission)
+
+          controller.send(:authorize, controller_name, action_name).should be_true
+        end
+
+        it "should prevent calling #{controller_action} when not having the permission #{permission} permission" do
+          become_member_with_permissions
+
+          controller.send(:authorize, controller_name, action_name).should be_false
+        end
+      end
+
+      before do
+        # As failures generate a response we need to prevent calls to nil
+        controller.response = ActionController::TestResponse.new
+
+        User.stub(:current).and_return(current_user)
+
+        controller.instance_variable_set(:@project, project)
+      end
+    end
+  end
+end
+

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -10,33 +10,27 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require File.expand_path('../shared/become_member', __FILE__)
+
 module PermissionSpecs
   def self.included(base)
     base.class_eval do
       let(:project) { FactoryGirl.create(:project, :is_public => false) }
       let(:current_user) { FactoryGirl.create(:user) }
 
-      def become_member_with_permissions(permissions = [])
-        permissions = Array(permissions)
-
-        role = FactoryGirl.create(:role, :permissions => permissions)
-
-        member = FactoryGirl.build(:member, :user => current_user, :project => project)
-        member.roles = [role]
-        member.save!
-      end
+      include BecomeMember
 
       def self.check_permission_required_for(controller_action, permission)
         controller_name, action_name = controller_action.split('#')
 
         it "should allow calling #{controller_action} when having the permission #{permission} permission" do
-          become_member_with_permissions(permission)
+          become_member_with_permissions(project, current_user, permission)
 
           controller.send(:authorize, controller_name, action_name).should be_true
         end
 
         it "should prevent calling #{controller_action} when not having the permission #{permission} permission" do
-          become_member_with_permissions
+          become_member_with_permissions(project, current_user)
 
           controller.send(:authorize, controller_name, action_name).should be_false
         end

--- a/spec/support/shared/become_member.rb
+++ b/spec/support/shared/become_member.rb
@@ -1,0 +1,29 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module BecomeMember
+  def self.included(base)
+    base.send(:include, InstanceMethods)
+  end
+
+  module InstanceMethods
+    def become_member_with_permissions(project, user, permissions = [])
+      permissions = Array(permissions)
+
+      role = FactoryGirl.create(:role, :permissions => permissions)
+
+      member = FactoryGirl.build(:member, :user => user, :project => project)
+      member.roles = [role]
+      member.save!
+    end
+  end
+end


### PR DESCRIPTION
Fixes switching the type of work_packages (new and existing).

Additionally:
- it cleans up the work package controller to always use work_package as an entry point.
- it changes ancestors/descendants presentation for a work package to use the same that was formerly only used for issues.
- enables setting custom fields
- speeds up specs.

OP issue: https://www.openproject.org/issues/1598
