### PR TITLE
Fix/arbitrary failing cuke timelines navigation

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * `#1541` Use Rails 3.2.14 instead of Git Branch
 * `#1598` Switching type of work package looses inserted data
+* `#1648` Arbitrarily failing cuke: Navigating to the timeline page
 
 ## 3.0.0pre10
 

--- a/features/session/user_session.feature
+++ b/features/session/user_session.feature
@@ -11,17 +11,8 @@
 
 Feature: User session
   Background:
-    Given there is 1 project with the following:
-      | name            | Awesome Project      |
-      | identifier      | awesome-project      |
-    And project "Awesome Project" uses the following modules:
-      | calendar |
-    And there is a role "member"
-    And the role "member" may have the following rights:
-      | view_calendar  |
-    And there is 1 user with the following:
+    Given there is 1 user with the following:
       | login | bob |
-    And the user "bob" is a "member" in the project "Awesome Project"
 
   Scenario: A user can log in
     When I login as "bob"

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -11,10 +11,14 @@
 
 Given /^the rest api is enabled$/ do
   Setting.rest_api_enabled = "1"
+
+  Support::Cleanup.to_clean Support::ClearCache.clear
 end
 
 Given /^the following languages are available:$/ do |table|
   Setting.available_languages += table.raw.map(&:first)
+
+  Support::Cleanup.to_clean Support::ClearCache.clear
 end
 
 #Given /^the "(.+?)" setting is set to (true|false)$/ do |name, trueish|
@@ -34,6 +38,8 @@ Given /^the "(.+?)" setting is set to (.+)$/ do |name, value|
   value = value.to_i if Setting.available_settings[name]["format"] == "int"
 
   Setting[name.to_sym] = value
+
+  Support::ClearCache.clear_after
 end
 
 Then /^the "(.+?)" setting should be (true|false)$/ do |name, trueish|
@@ -42,6 +48,8 @@ end
 
 Given /^I save the settings$/ do
   click_button('Save')
+
+  Support::ClearCache.clear_after
 end
 
 ##
@@ -54,10 +62,14 @@ end
 Given /^users are blocked for ([0-9]+) minutes after ([0-9]+) failed login attempts$/ do |duration, attempts|
   Setting.brute_force_block_minutes = duration
   Setting.brute_force_block_after_failed_logins = attempts
+
+  Support::ClearCache.clear_after
 end
 
 Given /^we paginate after (\d+) items$/ do |per_page_param|
   Setting.per_page_options = "#{per_page_param}, 50, 100"
+
+  Support::ClearCache.clear_after
 end
 
 #
@@ -67,5 +79,16 @@ Given /^I set passwords to expire after ([0-9]+) days$/ do |days|
   visit '/settings?tab=authentication'
   fill_in('settings_password_days_valid', :with => days.to_s)
   step 'I save the settings'
+
+  Support::ClearCache.clear_after
 end
 
+module Support
+  module ClearCache
+    def self.clear_after
+      Support::Cleanup.to_clean do
+        Rails.cache.clear
+      end
+    end
+  end
+end

--- a/features/step_definitions/timecop_steps.rb
+++ b/features/step_definitions/timecop_steps.rb
@@ -13,13 +13,26 @@
 
 Given /^the time is ([0-9]+) minutes later$/ do |duration|
   Timecop.travel(Time.now + duration.to_i.minutes)
+
+  # Ensure timecop returns after each scenario
+  Support::ResetTimecop.reset_after
 end
 
 Given /^the time is ([0-9]+) days later$/ do |duration|
   Timecop.travel(Time.now + duration.to_i.days)
+
+  # Ensure timecop returns after each scenario
+  Support::ResetTimecop.reset_after
 end
 
-# Ensure timecop returns after each scenario
-After do
-  Timecop.return
+module Support
+  module ResetTimecop
+    def self.reset_after
+      Support::Cleanup.to_clean do
+        Proc.new do
+          Timecop.return
+        end
+      end
+    end
+  end
 end

--- a/features/support/cleanup.rb
+++ b/features/support/cleanup.rb
@@ -1,0 +1,32 @@
+module Support
+  module Cleanup
+    def self.to_clean(&block)
+      cleanings << block
+    end
+
+    def self.cleanup
+      cleanings.each do |block|
+        block.call
+      end
+
+      reset_cleanings
+    end
+
+    private
+
+    def self.cleanings
+      @cleanings ||= []
+    end
+
+    def self.reset_cleanings
+      @cleanings = []
+    end
+  end
+end
+
+After do
+  Support::Cleanup.cleanup
+end
+
+
+


### PR DESCRIPTION
This should prevent cukes to fail because of settings being cached between scenarios.

I ran this about 10 times on our internal CI - never failed for me.

OP issue: https://www.openproject.org/issues/1648
