### PR TITLE
Updated cucumber and selenium-webdriver.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.14)
       actionpack (= 3.2.14)
@@ -97,11 +96,12 @@ GEM
     coffee-script-source (1.6.2)
     color-tools (1.3.0)
     columnize (0.3.6)
-    cucumber (1.3.2)
+    cucumber (1.3.5)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12.0)
-      multi_json (~> 1.3)
+      multi_json (~> 1.7.5)
+      multi_test (>= 0.0.2)
     cucumber-rails (1.3.1)
       capybara (>= 1.1.2)
       cucumber (>= 1.2.0)
@@ -135,7 +135,7 @@ GEM
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
     fastercsv (1.5.5)
-    ffi (1.8.1)
+    ffi (1.9.0)
     formatador (0.2.4)
     gherkin (2.12.0)
       multi_json (~> 1.3)
@@ -186,7 +186,8 @@ GEM
     mime-types (1.23)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.7.4)
+    multi_json (1.7.8)
+    multi_test (0.0.2)
     mysql (2.9.1)
     mysql2 (0.3.11)
     nokogiri (1.5.9)
@@ -287,7 +288,7 @@ GEM
     select2-rails (3.3.2)
       sass-rails (>= 3.2)
       thor (~> 0.14)
-    selenium-webdriver (2.32.1)
+    selenium-webdriver (2.34.0)
       childprocess (>= 0.2.5)
       multi_json (~> 1.0)
       rubyzip


### PR DESCRIPTION
Updates cucumber to 1.3.5 and selenium-webdriver to 2.34.0. The previous
1.3.2 and 2.32.1 don't work with Firefox 23.
