### PR TITLE
Moved routing-tests from test/unit into specs

### DIFF
--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -1,0 +1,64 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ProjectsController do
+
+  describe "index" do
+    it { get("/projects").should      route_to( :controller => 'projects', :action => 'index')}
+    it { get("/projects.atom").should route_to( :controller => 'projects', :action => 'index', :format => 'atom')}
+    it { get("/projects.xml").should  route_to( :controller => 'projects', :action => 'index', :format => 'xml')}
+  end
+
+
+  describe "show" do
+    it{ get("/projects/1").should       route_to( :controller => 'projects', :action => 'show', :id => '1' )}
+    it{ get("/projects/1.xml").should   route_to( :controller => 'projects', :action => 'show', :id => '1', :format =>"xml")}
+    it{ get("/projects/test").should    route_to( :controller => 'projects', :action => 'show', :id => 'test' )}
+  end
+
+  describe "new" do
+    it { get("/projects/new").should route_to(:controller => 'projects', :action => 'new' )}
+
+  end
+
+  describe "create" do
+    it { post("/projects").should     route_to( :controller => 'projects', :action => 'create')}
+    it { post("/projects.xml").should route_to( :controller => 'projects', :action => 'create', :format => "xml")}
+  end
+
+  describe "update" do
+    it { put("/projects/123").should      route_to(:controller => 'projects', :action => "update", :id => "123")}
+    it { put("/projects/123.xml").should  route_to(:controller => 'projects', :action => "update", :id => "123", :format => "xml")}
+  end
+
+  describe "destroy_info" do
+    it { get("/projects/123/destroy_info").should  route_to(:controller => 'projects', :action => "destroy_info", :id => "123")}
+  end
+
+  describe "delete" do
+    it{ delete("/projects/123").should     route_to(:controller => 'projects', :action => "destroy", :id => "123")}
+    it{ delete("/projects/123.xml").should route_to(:controller => 'projects', :action => "destroy", :id => "123", :format => "xml")}
+  end
+
+  describe "miscellanous" do
+    it { get("/projects/123/settings").should         route_to(:controller => 'projects', :action =>"settings",   :id =>"123")}
+    it { get("/projects/123/settings/members").should route_to(:controller => 'projects', :action =>"settings",   :id =>"123", :tab => "members")}
+    it { put("projects/123/modules").should           route_to(:controller => 'projects', :action =>"modules",    :id =>"123")}
+    it { put("projects/123/archive").should           route_to(:controller => 'projects', :action =>"archive",    :id =>"123")}
+    it { put("projects/123/unarchive").should         route_to(:controller => 'projects', :action =>"unarchive",  :id =>"123")}
+    it { get("projects/123/copy").should              route_to(:controller => 'projects', :action =>"copy",       :id =>"123")}
+    it { post("projects/123/copy").should             route_to(:controller => 'projects', :action =>"copy",       :id =>"123")}
+  end
+end
+
+

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -545,89 +545,6 @@ class RoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
-
-  context "projects" do
-    should route(:get, "/projects").to( :controller => 'projects',
-                                        :action => 'index')
-
-    should route(:get, "/projects.atom").to( :controller => 'projects',
-                                             :action => 'index',
-                                             :format => 'atom' )
-
-    should route(:get, "/projects.xml").to( :controller => 'projects',
-                                            :action => 'index',
-                                            :format => 'xml' )
-
-    should route(:get, "/projects/new").to( :controller => 'projects',
-                                            :action => 'new' )
-
-    should route(:get, "/projects/test").to( :controller => 'projects',
-                                             :action => 'show',
-                                             :id => 'test' )
-
-    should route(:get, "/projects/1.xml").to( :controller => 'projects',
-                                              :action => 'show',
-                                              :id => '1',
-                                              :format => 'xml' )
-
-    should route(:post, "/projects").to( :controller => 'projects',
-                                         :action => 'create' )
-
-    should route(:post, "/projects.xml").to( :controller => 'projects',
-                                             :action => 'create',
-                                             :format => 'xml' )
-
-    should route(:put, "/projects/4223").to( :controller => 'projects',
-                                             :action => 'update',
-                                             :id => '4223' )
-
-    should route(:put, "/projects/1.xml").to( :controller => 'projects',
-                                              :action => 'update',
-                                              :id => '1',
-                                              :format => 'xml' )
-
-    should route(:get, "/projects/64/destroy_info").to( :controller => 'projects',
-                                                         :action => 'destroy_info',
-                                                         :id => '64' )
-
-    should route(:delete, "/projects/64").to( :controller => 'projects',
-                                              :action => 'destroy',
-                                              :id => '64' )
-
-    should route(:delete, "/projects/1.xml").to( :controller => 'projects',
-                                                 :action => 'destroy',
-                                                 :id => '1',
-                                                 :format => 'xml' )
-
-    should route(:get, "/projects/4223/settings").to( :controller => 'projects',
-                                                      :action => 'settings',
-                                                      :id => '4223' )
-
-    should route(:get, "/projects/4223/settings/members").to( :controller => 'projects',
-                                                              :action => 'settings',
-                                                              :id => '4223',
-                                                              :tab => 'members' )
-
-    should route(:put, "/projects/64/modules").to( :controller => 'projects',
-                                                   :action => 'modules',
-                                                   :id => '64' )
-
-    should route(:put, "/projects/64/archive").to( :controller => 'projects',
-                                                    :action => 'archive',
-                                                    :id => '64' )
-
-    should route(:put, "/projects/64/unarchive").to( :controller => 'projects',
-                                                      :action => 'unarchive',
-                                                      :id => '64' )
-
-    should route(:get, "/projects/64/copy").to( :controller => 'projects',
-                                                :action => 'copy',
-                                                :id => '64' )
-
-    should route(:post, "/projects/64/copy").to( :controller => 'projects',
-                                                 :action => 'copy',
-                                                 :id => '64' )
-#  end
 #
 #  context "repositories" do
 #    should route(:get, "/projects/redmine/repository").to( :controller => 'repositories', :action => 'show', :id => 'redmine')
@@ -650,7 +567,6 @@ class RoutingTest < ActionDispatch::IntegrationTest
 #
 #
 #    should route(:post, "/projects/redmine/repository/edit").to( :controller => 'repositories', :action => 'edit', :id => 'redmine')
-  end
 
   context "timelogs" do
     should route(:get, "/time_entries").to( :controller => 'timelog',


### PR DESCRIPTION
I need to disable/change the show-routes for the projects-controller for the openproject-my_project_page-plugin, this doesn't really work for test/unit, so I started moving the tests into a separate spec.
