### PR TITLE
Gemfile: Use rspec-example_disabler from Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :test do
   gem 'rspec', '~> 2.0'
   # also add to development group, so "spec" rake task gets loaded
   gem "rspec-rails", "~> 2.0", :group => :development
-  gem 'rspec-example_disabler', :git => 'https://github.com/finnlabs/rspec-example_disabler.git'
+  gem 'rspec-example_disabler'
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,6 @@ GIT
     object-daddy (1.1.0)
 
 GIT
-  remote: https://github.com/finnlabs/rspec-example_disabler.git
-  revision: 05b1af7d349865b3af39d603016803c958e0b95b
-  specs:
-    rspec-example_disabler (0.0.1)
-
-GIT
   remote: https://github.com/fnando/i18n-js.git
   revision: 8801f8d17ef96c48a7a0269e251fcf1648c8f441
   ref: 8801f8d17ef96c48a7a0269e251fcf1648c8f441
@@ -264,6 +258,7 @@ GEM
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
     rspec-core (2.13.1)
+    rspec-example_disabler (0.0.1)
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
@@ -402,7 +397,7 @@ DEPENDENCIES
   rdoc (>= 2.4.2)
   rmagick (>= 1.15.17)
   rspec (~> 2.0)
-  rspec-example_disabler!
+  rspec-example_disabler
   rspec-rails (~> 2.0)
   ruby-openid (~> 2.2.3)
   ruby-prof


### PR DESCRIPTION
Published rspec-example_disabler on RubyGems, so we can now use it from there.
