### PR TITLE
Fix/accessibility members form

### DIFF
--- a/app/assets/stylesheets/default/application.css.erb
+++ b/app/assets/stylesheets/default/application.css.erb
@@ -600,7 +600,9 @@ input#user_search {width: 100%}
 
 * html div#tab-content-members fieldset div { height: 450px; }
 
-div#tab-content-members fieldset div.select-boxes label {
+div#tab-content-members fieldset div.select-boxes label,
+div#tab-content-members fieldset div#principal_results div.roles,
+div#tab-content-members fieldset div#principal_results div.principals {
   display: inline-block;
   width: 350px; /* max-width of select2boxes */
 }

--- a/app/views/members/_autocomplete_for_member.html.erb
+++ b/app/views/members/_autocomplete_for_member.html.erb
@@ -9,17 +9,22 @@ modify it under the terms of the GNU General Public License version 3.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
-<div class="principals splitcontentleft">
-  <% if principals.size > 20 %>
-    <p><%= simple_format(l('notice_to_many_principals_to_display'))%></p>
+<div style="display:inline-block;">
+  <div class="principals splitcontentleft">
+    <% if principals.size > 20 %>
+      <p><%= simple_format(l('notice_to_many_principals_to_display'))%></p>
+  </div>
 </div>
-  <% elsif principals.size == 0 %>
-    <p><%= l('notice_no_principals_found')%></p>
+    <% elsif principals.size == 0 %>
+      <p><%= l('notice_no_principals_found')%></p>
+  </div>
 </div>
-  <% else %>
-    <%= principals_check_box_tags 'member[user_ids][]', principals %>
-</div>
+    <% else %>
+      <p>
+        <%= "#{l(:label_user_plural)}/#{l(:label_group_plural)}" %>:
+        <%= principals_check_box_tags 'member[user_ids][]', principals %>
+      </p>
+  </div>
 
   <div class="roles splitcontentright">
     <p><%= l(:label_role_plural) %>:
@@ -30,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <% end %>
     </p>
   </div>
-
+</div>
   <p><%= submit_tag l(:button_add), :id => 'member-add-submit' %></p>
 <% end %>
 

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -12,13 +12,11 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% if User.current.impaired? %>
   <% partial = "members/member_form_impaired" %>
-  <% locals = { :members => @project.member_principals.find(:all, :include => [:roles, :principal, :member_roles]) }%>
+  <% locals = { :principals => @project.possible_members("", 21) }%>
 <% else %>
   <% partial = "members/member_form_non_impaired" %>
   <% locals = {} %>
 <% end %>
 
 <%= render :partial => partial,
-           :locals => locals.merge!({ :project => project,
-                        :roles => roles,
-                        :principals => principals }) %>
+           :locals => locals.merge!({ :project => project, :roles => roles }) %>

--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -13,8 +13,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= error_messages_for 'member' %>
 <% roles = Role.find_all_givable
-   available_principals = Principal.possible_members("", 100)
-
+   # Check if there is at least one principal that can be added to the project
+   principals_available = @project.possible_members("", 1)
    member_per_page = 20
 
    @members = @project.member_principals.includes(:roles, :principal, :member_roles)
@@ -23,12 +23,11 @@ See doc/COPYRIGHT.rdoc for more details.
                                         .per_page(per_page_param)
 %>
 <div>
-  <% if roles.any? && available_principals.any? %>
+  <% if roles.any? && principals_available.any? %>
     <%= render :partial => "members/member_form",
               :locals => { :project => @project,
                            :members => members,
-                           :roles => roles,
-                           :principals => available_principals } %>
+                           :roles => roles } %>
 
   <% end %>
 </div>

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,6 +13,7 @@ See doc/COPYRIGHT.rdoc for more details.
 # Changelog
 
 * `#1418` Additional changes: Change links to issues/planning elements to use work_packages controller
+* `#1504` Initial selection of possible project members wrong (accessibility mode)
 * `#1898` Separate action for changing wiki parent page (was same as rename before)
 * `#1923` Add permission that allows hiding repository statistics on commits per author
 * `#1850` Disable atom feeds via setting

--- a/features/members/membership.feature
+++ b/features/members/membership.feature
@@ -74,6 +74,15 @@ Feature: Membership
      When I am impaired
       And I go to the members tab of the settings page of the project "project1"
       And I add the principal "A-Team" as "Manager"
+      And I go to the members tab of the settings page of the project "project1"
+      Then I should not see "A-Team" within "#principal_results"
+      And I should see "A-Team" within ".members"
+
+  @javascript
+  Scenario: User should not appear in members form if he/she is already a member of the project, impaired
+     When I am impaired
+      And I go to the members tab of the settings page of the project "project1"
+      And I add the principal "A-Team" as "Manager"
      Then I should be on the members tab of the settings page of the project "project1"
       And I should see "Successful creation." within ".flash.notice"
       And I should see "A-Team" within ".members"


### PR DESCRIPTION
We had some problems regarding the accessibility members form, described here: https://www.openproject.org/issues/1504. This PR should fix that, and even makes the form a little prettier to look at.
