### PR TITLE
removed bullet&footnotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,8 +94,6 @@ group :openid do
 end
 
 group :development do
-  gem 'rails-footnotes', '>= 3.7.5.rc4'
-  gem 'bullet'
   gem 'letter_opener', '~> 1.0.0'
   gem 'pry-rails'
   gem 'pry-stack_explorer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,6 @@ GEM
     bourne (1.4.0)
       mocha (~> 0.13.2)
     builder (3.0.4)
-    bullet (4.6.0)
-      uniform_notifier
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -232,8 +230,6 @@ GEM
     rails-dev-tweaks (0.6.1)
       actionpack (~> 3.1)
       railties (~> 3.1)
-    rails-footnotes (3.7.9)
-      rails (>= 3.0.0)
     rails_autolink (1.1.0)
       rails (> 3.1)
     railties (3.2.14)
@@ -334,7 +330,6 @@ GEM
     uglifier (2.1.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    uniform_notifier (1.2.0)
     websocket (1.0.7)
     will_paginate (3.0.4)
     xpath (2.0.0)
@@ -350,7 +345,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   acts_as_list (~> 0.2.0)
   awesome_nested_set
-  bullet
   capybara
   capybara-screenshot
   coderay (~> 1.0.5)
@@ -392,7 +386,6 @@ DEPENDENCIES
   rack_session_access
   rails (~> 3.2.14)
   rails-dev-tweaks (~> 0.6.1)
-  rails-footnotes (>= 3.7.5.rc4)
   rails_autolink
   rb-fsevent
   rb-readline


### PR DESCRIPTION
especially footnotes takes up a lot of processing-time: If you really
want to look into the performamce of the app, move the dependencies
into your Gemfile.local
