### PR TITLE
Add environment-specific seeds and load plugin-seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,28 +17,6 @@
 #
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Emanuel', :city => cities.first)
-
-
-
-#-- encoding: UTF-8
-#-- copyright
-# OpenProject is a project management system.
-#
-# Copyright (C) 2012-2013 the OpenProject Team
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License version 3.
-#
-# See doc/COPYRIGHT.rdoc for more details.
-#++
-
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
-#   Mayor.create(:name => 'Emanuel', :city => cities.first)
 #
 # loads environment-specific seeds. The assumed directory structure in db/ is like this:
 #|___seeds

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,13 +18,45 @@
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Emanuel', :city => cities.first)
 
-Type.connection.schema_cache.clear!
-Type.reset_column_information
-Type.create!(name: 'none',
-             color_id: '#000000',
-             is_standard: true,
-             is_default: true,
-             is_in_chlog: true,
-             is_in_roadmap: true,
-             in_aggregation: true,
-             is_milestone: false)
+
+
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+#
+# Examples:
+#
+#   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
+#   Mayor.create(:name => 'Emanuel', :city => cities.first)
+#
+# loads environment-specific seeds. The assumed directory structure in db/ is like this:
+#|___seeds
+#| |___all.rb
+#| |___development.rb
+#| |___staging.rb
+#| |___production.rb
+#|___seeds.rb
+#
+['all', Rails.env].each do |seed|
+  seed_file = "#{Rails.root}/db/seeds/#{seed}.rb"
+  if File.exists?(seed_file)
+    puts "*** Loading #{seed} seed data"
+    require seed_file
+  end
+end
+
+Rails::Application::Railties.engines.each do |engine|
+  puts "*** Loading #{engine.engine_name} seed data"
+  engine.load_seed
+end

--- a/db/seeds/all.rb
+++ b/db/seeds/all.rb
@@ -1,0 +1,13 @@
+# add seeds here, that need to be available in all environments
+unless Type.exists?(name: "none")
+  Type.connection.schema_cache.clear!
+  Type.reset_column_information
+  Type.create!(name: 'none',
+               color_id: '#000000',
+               is_standard: true,
+               is_default: true,
+               is_in_chlog: true,
+               is_in_roadmap: true,
+               in_aggregation: true,
+               is_milestone: false)
+end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,0 +1,1 @@
+# add seeds specific for the development-environment here

--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -1,0 +1,1 @@
+# add seeds specific for the production-environment here

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -1,0 +1,1 @@
+# add seeds specific for the test-environment here


### PR DESCRIPTION
The commit adds a mechanism to load seeds that are specific for the
given environment. The seeds are stored in db/seeds/<environment>.rb
and should be written idempotent, to make sure, they don't
destroy/overwrite anything when being run multiple times.

The seeding now also loads the seeds for the plugins, which allows
plugins to add plugin-specific constants to the database.
