### PR TITLE
Fix 'I should see an image' cucumber step

### DIFF
--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -19,11 +19,9 @@ Then /^I should not see the "(.+)" image(?: within "([^\"]*)")?$/ do |image, sel
   page.should have_no_xpath(search_string)
 end
 
-Then /^I should see an image(?: within "(.+?)")$/ do |selector|
-  with_scope(selector) do
-    img = find :css, 'img'
-    img.should be_present
-    img.should be_visible
-  end
+Then /^I should see an image$/ do
+  img = find :css, 'img'
+  img.should be_present
+  img.should be_visible
 end
 


### PR DESCRIPTION
Wie have a "… within …" step definition which acts as a scope, so using this step definition resulted an ambiguous step error, so it couldn't be used.
