### PR TITLE
Add a sample project to the development-seed.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
   gem 'object-daddy', :git => 'https://github.com/awebneck/object_daddy.git'
   gem 'mocha', '~> 0.13.1', :require => false
   gem "launchy", "~> 2.3.0"
-  gem "factory_girl_rails", "~> 4.0"
+  gem "factory_girl_rails", "~> 4.0", :group => :development
   gem 'cucumber-rails', :require => false
   gem 'rack_session_access'
   gem 'database_cleaner'

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development do
   gem 'guard-cucumber'
   gem 'rb-fsevent', :group => :test
   gem 'thin'
+  gem 'faker'
 end
 
 group :tools do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,18 @@ GIT
       activerecord (>= 3.0.0)
       paper_trail (~> 2)
 
+PATH
+  remote: ~/workspace/openproject-plugins/openproject-documents
+  specs:
+    openproject-documents (1.0.0.pre1)
+      rails (~> 3.2.9)
+
+PATH
+  remote: ~/workspace/openproject-plugins/openproject-video_upload
+  specs:
+    openproject-video_upload (1.0.0.pre2)
+      rails (~> 3.2.9)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,6 +72,7 @@ GEM
     acts_as_list (0.2.0)
       activerecord (>= 3.0)
     addressable (2.3.4)
+    ansi (1.4.3)
     arel (3.0.2)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
@@ -146,6 +159,7 @@ GEM
     guard-test (1.0.0)
       guard (>= 1.8)
       test-unit (~> 2.2)
+    hashie (2.0.5)
     hike (1.2.3)
     htmldiff (0.0.1)
     i18n (0.6.4)
@@ -176,6 +190,12 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.1)
     mime-types (1.23)
+    minitest (4.7.5)
+    minitest-reporters (0.14.20)
+      ansi
+      builder
+      minitest (>= 2.12, < 5.0)
+      powerbar
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.7.9)
@@ -189,6 +209,9 @@ GEM
       railties (~> 3.0)
     pg (0.15.1)
     polyglot (0.3.3)
+    powerbar (1.0.11)
+      ansi (~> 1.4.0)
+      hashie (>= 1.1.0)
     prototype-rails (3.2.1)
       rails (~> 3.2)
     pry (0.9.12.2)
@@ -370,11 +393,14 @@ DEPENDENCIES
   launchy (~> 2.3.0)
   letter_opener (~> 1.0.0)
   loofah
+  minitest-reporters
   mocha (~> 0.13.1)
   mysql
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)
   object-daddy!
+  openproject-documents!
+  openproject-video_upload!
   pg
   prototype-rails
   prototype_legacy_helper (= 0.0.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,18 +27,6 @@ GIT
       activerecord (>= 3.0.0)
       paper_trail (~> 2)
 
-PATH
-  remote: ~/workspace/openproject-plugins/openproject-documents
-  specs:
-    openproject-documents (1.0.0.pre1)
-      rails (~> 3.2.9)
-
-PATH
-  remote: ~/workspace/openproject-plugins/openproject-video_upload
-  specs:
-    openproject-video_upload (1.0.0.pre2)
-      rails (~> 3.2.9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -72,7 +60,6 @@ GEM
     acts_as_list (0.2.0)
       activerecord (>= 3.0)
     addressable (2.3.4)
-    ansi (1.4.3)
     arel (3.0.2)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
@@ -139,6 +126,8 @@ GEM
     factory_girl_rails (4.2.1)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
+    faker (1.2.0)
+      i18n (~> 0.5)
     fastercsv (1.5.5)
     ffi (1.9.0)
     formatador (0.2.4)
@@ -159,7 +148,6 @@ GEM
     guard-test (1.0.0)
       guard (>= 1.8)
       test-unit (~> 2.2)
-    hashie (2.0.5)
     hike (1.2.3)
     htmldiff (0.0.1)
     i18n (0.6.4)
@@ -190,12 +178,6 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.1)
     mime-types (1.23)
-    minitest (4.7.5)
-    minitest-reporters (0.14.20)
-      ansi
-      builder
-      minitest (>= 2.12, < 5.0)
-      powerbar
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.7.9)
@@ -209,9 +191,6 @@ GEM
       railties (~> 3.0)
     pg (0.15.1)
     polyglot (0.3.3)
-    powerbar (1.0.11)
-      ansi (~> 1.4.0)
-      hashie (>= 1.1.0)
     prototype-rails (3.2.1)
       rails (~> 3.2)
     pry (0.9.12.2)
@@ -380,6 +359,7 @@ DEPENDENCIES
   delayed_job_active_record
   execjs
   factory_girl_rails (~> 4.0)
+  faker
   fastercsv (~> 1.5.0)
   globalize3!
   guard-cucumber
@@ -393,14 +373,11 @@ DEPENDENCIES
   launchy (~> 2.3.0)
   letter_opener (~> 1.0.0)
   loofah
-  minitest-reporters
   mocha (~> 0.13.1)
   mysql
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)
   object-daddy!
-  openproject-documents!
-  openproject-video_upload!
   pg
   prototype-rails
   prototype_legacy_helper (= 0.0.0)!

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,1 +1,76 @@
 # add seeds specific for the development-environment here
+
+puts "Creating seeded project..."
+if delete_me=Project.find_by_identifier("seeded_project")
+  delete_me.destroy
+end
+
+project = FactoryGirl.create(:public_project, name: "Seeded Project", identifier: "seeded_project", description: Faker::Lorem.paragraph(5))
+project.types << Type.all
+project.save
+
+# this will fail rather miserably, when there are no statuses present
+statuses = IssueStatus.all
+types = project.types.all
+puts "Creating seeded project...done."
+
+puts "Creating issues ..."
+20.times do |count|
+  login = "#{Faker::Name.first_name}#{rand(10000)}"
+
+  user = User.find_by_login(login)
+
+  unless user
+    user = FactoryGirl.create(:user,
+                              login: login,
+                              firstname: Faker::Name.first_name,
+                              lastname: Faker::Name.last_name,
+                              mail: Faker::Internet.email)
+  end
+
+  ## let every user about 5 issues...
+
+  rand(30).times do
+    print "."
+    issue = Issue.create!(project: project,
+                          author: user,
+                          status: statuses.sample,
+                          subject: Faker::Lorem.words(8).join(" "),
+                          description: Faker::Lorem.paragraph(5, true,3),
+                          type: types.sample
+    )
+
+  end
+
+  rand(20).times do
+    start_date = rand(20).days.from_now
+    due_date   = start_date + rand(20).days
+
+    element = PlanningElement.create!(project: project,
+                                      author: user,
+                                      status: statuses.sample,
+                                      subject: Faker::Lorem.words(5).join(" "),
+                                      description: Faker::Lorem.paragraph(5, true,3),
+                                      type: types.sample,
+                                      start_date: start_date,
+                                      due_date: due_date)
+    rand(5).times do
+      offset = start_date
+      element = PlanningElement.create!(project: project,
+                                        author: user,
+                                        status: statuses.sample,
+                                        subject: Faker::Lorem.words(5).join(" "),
+                                        description: Faker::Lorem.paragraph(5, true,3),
+                                        type: types.sample,
+                                        start_date: start_date,
+                                        due_date: due_date)
+    end
+
+
+  end
+
+
+end
+
+puts "\n"
+puts "#{project.work_packages.count} issues created."

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,4 +1,4 @@
-# only seed a new project, if it hasn't already run
+# Careful: The seeding recreates the seeded project before it runs, so any changes on the seeded project will be lost.
 puts "Creating seeded project..."
 if delete_me=Project.find_by_identifier("seeded_project")
   delete_me.destroy

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,20 +1,23 @@
-# add seeds specific for the development-environment here
-
+# only seed a new project, if it hasn't already run
 puts "Creating seeded project..."
 if delete_me=Project.find_by_identifier("seeded_project")
   delete_me.destroy
 end
 
-project = FactoryGirl.create(:public_project, name: "Seeded Project", identifier: "seeded_project", description: Faker::Lorem.paragraph(5))
-project.types << Type.all
-project.save
+project = FactoryGirl.create(:public_project, name: "Seeded Project", identifier: "seeded_project", description: Faker::Lorem.paragraph(5), types: Type.all)
 
 # this will fail rather miserably, when there are no statuses present
 statuses = IssueStatus.all
 types = project.types.all
-puts "Creating seeded project...done."
 
-puts "Creating issues ..."
+# create a default timeline that shows all our planning elements
+timeline = FactoryGirl.build(:timeline, project: project)
+timeline.options.merge!({zoom_factor: ["4"]})
+timeline.save
+
+
+
+print "Creating issues and planning-elements..."
 20.times do |count|
   login = "#{Faker::Name.first_name}#{rand(10000)}"
 
@@ -28,9 +31,9 @@ puts "Creating issues ..."
                               mail: Faker::Internet.email)
   end
 
-  ## let every user about 5 issues...
+  ## let every user create some issues...
 
-  rand(30).times do
+  rand(10).times do
     print "."
     issue = Issue.create!(project: project,
                           author: user,
@@ -42,9 +45,12 @@ puts "Creating issues ..."
 
   end
 
-  rand(20).times do
-    start_date = rand(20).days.from_now
-    due_date   = start_date + rand(20).days
+
+
+  rand(30).times do
+    print "."
+    start_date = rand(90).days.from_now
+    due_date   = start_date + 5.day + rand(30).days
 
     element = PlanningElement.create!(project: project,
                                       author: user,
@@ -55,22 +61,28 @@ puts "Creating issues ..."
                                       start_date: start_date,
                                       due_date: due_date)
     rand(5).times do
-      offset = start_date
-      element = PlanningElement.create!(project: project,
-                                        author: user,
-                                        status: statuses.sample,
-                                        subject: Faker::Lorem.words(5).join(" "),
-                                        description: Faker::Lorem.paragraph(5, true,3),
-                                        type: types.sample,
-                                        start_date: start_date,
-                                        due_date: due_date)
+      print "."
+      sub_start_date = rand(start_date..due_date)
+      sub_due_date   = rand(sub_start_date..due_date)
+      child_element = PlanningElement.create!(project: project,
+                                              parent: element,
+                                              author: user,
+                                              status: statuses.sample,
+                                              subject: Faker::Lorem.words(5).join(" "),
+                                              description: Faker::Lorem.paragraph(5, true,3),
+                                              type: types.sample,
+                                              start_date: sub_start_date,
+                                              due_date: sub_due_date)
     end
 
 
   end
 
 
-end
 
+end
+print "done."
 puts "\n"
-puts "#{project.work_packages.count} issues created."
+puts "#{PlanningElement.where(:project_id => project.id).count} planning_elements created."
+puts "#{Issue.where(:project_id => project.id).count} issues created."
+puts "Creating seeded project...done."


### PR DESCRIPTION
Using `RAILS_ENV=development rake db:seed`, you can now generates a sample project: The project contains several issues, a timeline and lots of planning-elements to play with. Feel free to add some more sample data
to this pet-project.

The project is re-generated every time you seed the database, so every changes to the seeded project will be lost.

The ci is currently skipped, as travis currently does not run the seeding, so there is nothing to test there.
