### PR TITLE
Stop replacing links inside macros

### DIFF
--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -39,6 +39,8 @@ module Redmine
       end
 
       def to_html(format, text, options = {}, &block)
+        puts "---   -----------------       Formatting....            -------------------------------------------"
+
         edit = !!options.delete(:edit)
         text = if Setting.cache_formatted_text? && text.size > 2.kilobyte && cache_store && cache_key = cache_key_for(format, options[:object], options[:attribute, options[:edit]])
           # Text retrieved from the cache store may be frozen
@@ -47,9 +49,11 @@ module Redmine
             formatter_for(format).new(text).to_html edit ? :edit : nil
           end.dup
         else
+          puts "---   -----------------       formatter....            -------------------------------------------"
           formatter_for(format).new(text).to_html edit ? :edit : nil
         end
         if block_given? and !edit
+          puts "---   -----------------       Executing macros....            -------------------------------------------"
           execute_macros(text, block)
         end
         text

--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -39,8 +39,6 @@ module Redmine
       end
 
       def to_html(format, text, options = {}, &block)
-        puts "---   -----------------       Formatting....            -------------------------------------------"
-
         edit = !!options.delete(:edit)
         text = if Setting.cache_formatted_text? && text.size > 2.kilobyte && cache_store && cache_key = cache_key_for(format, options[:object], options[:attribute, options[:edit]])
           # Text retrieved from the cache store may be frozen
@@ -49,11 +47,9 @@ module Redmine
             formatter_for(format).new(text).to_html edit ? :edit : nil
           end.dup
         else
-          puts "---   -----------------       formatter....            -------------------------------------------"
           formatter_for(format).new(text).to_html edit ? :edit : nil
         end
         if block_given? and !edit
-          puts "---   -----------------       Executing macros....            -------------------------------------------"
           execute_macros(text, block)
         end
         text

--- a/lib/redmine/wiki_formatting/textile/formatter.rb
+++ b/lib/redmine/wiki_formatting/textile/formatter.rb
@@ -61,6 +61,7 @@ module Redmine
                         (                          # leading text
                           <\w+.*?>|                # leading HTML tag, or
                           [^=<>!:'"/]|             # leading punctuation, or
+                          \{\{\w+\(|               # inside a macro?
                           ^                        # beginning of line
                         )
                         (
@@ -80,7 +81,7 @@ module Redmine
         def inline_auto_link(text)
           text.gsub!(AUTO_LINK_RE) do
             all, leading, proto, url, post = $&, $1, $2, $3, $6
-            if leading =~ /<a\s/i || leading =~ /![<>=]?/
+            if leading =~ /<a\s/i || leading =~ /![<>=]?/ || leading =~ /\{\{\w+\(/
               # don't replace URL's that are already linked
               # and URL's prefixed with ! !> !< != (textile images)
               all

--- a/test/unit/lib/redmine/wiki_formatting/textile_formatter_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/textile_formatter_test.rb
@@ -87,6 +87,22 @@ class Redmine::WikiFormatting::TextileFormatterTest < HelperTestCase
     )
   end
 
+  def test_inline_auto_link
+    assert_html_output(
+        'Autolink to http://www.google.com'=>
+        'Autolink to <a class="external" href="http://www.google.com">http://www.google.com</a>'
+    )
+  end
+
+  def test_ignore_links_inside_macros
+    assert_html_output(
+        '{{embed_youtube(http://www.google.com)}}'=>
+        '{{embed_youtube(http://www.google.com)}}'
+    )
+  end
+
+
+
   def test_blockquote
     # orig raw text
     raw = <<-RAW


### PR DESCRIPTION
The textile-formatter runs before the macros: If a macro uses a url as a parameter (e.g. to {{embed_youtube(http://www.youtube.com/watch?v=bqzQ2qrtBeg)}} then these urls are replaced with an inline link (rendering them unusable: e.g. {{embed_youtube(<a href="..." ) - the commit makes sure, that urls inside macros remain untouched.
