### PR TITLE
Fix mail interceptors in dev env being registered multiple times

### DIFF
--- a/config/initializers/register_mail_interceptors.rb
+++ b/config/initializers/register_mail_interceptors.rb
@@ -1,0 +1,7 @@
+# Register interceptors defined in app/mailers/user_mailer.rb
+# Do this here, so they aren't registered multiple times due to reloading in development mode.
+
+UserMailer.register_interceptor(DefaultHeadersInterceptor)
+UserMailer.register_interceptor(RemoveSelfNotificationsInterceptor)
+# following needs to be the last interceptor
+UserMailer.register_interceptor(DoNotSendMailsWithoutReceiverInterceptor)


### PR DESCRIPTION
This resulted e.g. in mail headers being added multiple times.
