### PR TITLE
Add option to create PDFs from issue lists with a description

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -72,7 +72,10 @@ class IssuesController < ApplicationController
         format.csv  { send_data(issues_to_csv(@issues, @project), :type => 'text/csv; header=present', :filename => 'export.csv') }
         format.html { render :template => 'issues/index', :layout => !request.xhr? }
         format.atom { render_feed(@issues, :title => "#{@project || Setting.app_title}: #{l(:label_issue_plural)}") }
-        format.pdf  { send_data(issues_to_pdf(@issues, @project, @query), :type => 'application/pdf', :filename => 'export.pdf') }
+        format.pdf  { send_data(issues_to_pdf(@issues, @project, @query,
+                                              :show_descriptions => params[:show_descriptions]),
+                                :type => 'application/pdf',
+                                :filename => 'export.pdf') }
       end
     else
       # Send html if the query is not valid

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -96,6 +96,9 @@ See doc/COPYRIGHT.rdoc for more details.
 	<%= f.link_to 'Atom', :url => { :project_id => @project, :query_id => (@query.new_record? ? nil : @query), :key => User.current.rss_key } %>
 	<%= f.link_to 'CSV', :url => { :project_id => @project } %>
 	<%= f.link_to 'PDF', :url => { :project_id => @project } %>
+    <%= f.link_to I18n.t(:label_pdf_with_descriptions), :url => { :project_id => @project,
+                                                                  :show_descriptions => true,
+                                                                  :format => 'pdf' } %>
 <% end if User.current.allowed_to? :export_issues, @project, :global => @project.nil? %>
 
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -798,6 +798,7 @@ de:
   label_password_rule_special: "Sonderzeichen"
   label_password_rule_uppercase: "Großbuchstaben"
   label_path_encoding: "Path encoding"
+  label_pdf_with_descriptions: "PDF mit Beschreibungen"
   label_per_page: "Pro Seite"
   label_permissions: "Berechtigungen"
   label_permissions_report: "Berechtigungsübersicht"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -780,6 +780,7 @@ en:
   label_password_rule_special: "Special Characters"
   label_password_rule_uppercase: "Uppercase"
   label_path_encoding: "Path encoding"
+  label_pdf_with_descriptions: "PDF with Descriptions"
   label_per_page: "Per page"
   label_permissions: "Permissions"
   label_permissions_report: "Permissions report"


### PR DESCRIPTION
This adds an additional link below the issue list, called "PDF with Descriptions"

There was no option to create a PDF from an issue list with descriptions before.

This also fixes creating more than one PDF per server start in development mode.
