### PR TITLE
Fixing a ci-issue with factory-girls in development.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
   gem 'object-daddy', :git => 'https://github.com/awebneck/object_daddy.git'
   gem 'mocha', '~> 0.13.1', :require => false
   gem "launchy", "~> 2.3.0"
-  gem "factory_girl_rails", "~> 4.0", :group => :development
+  gem "factory_girl_rails", "~> 4.0"
   gem 'cucumber-rails', :require => false
   gem 'rack_session_access'
   gem 'database_cleaner'


### PR DESCRIPTION
The rake db:migrate, that is used on jenkins, uses the
development-environment: The latest change to add sample-data for the
development-environment added a :group => :development to the
factorygirls-gem, which in turn loads the factories, which crashes in
planning_element_type_color.rb, when the ms_project_colors are loaded.

The short-term fix for this:
- removed the factory_girls-gem from :development
- removed the dependency from seeds/deveopment
