### PR TITLE
Use pry-byebug on Ruby 2.0, keep pry-debugger for 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,8 @@ group :development do
   gem 'pry-rails'
   gem 'pry-stack_explorer'
   gem 'pry-rescue'
-  gem 'pry-debugger'
+  gem 'pry-byebug', :platforms => :mri_20
+  gem 'pry-debugger', :platforms => :mri_19
   gem 'pry-doc'
   gem 'rails-dev-tweaks', '~> 0.6.1'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
     bourne (1.4.0)
       mocha (~> 0.13.2)
     builder (3.0.4)
+    byebug (1.8.2)
+      columnize (~> 0.3.6)
+      debugger-linecache (~> 1.2.0)
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -197,6 +200,9 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-byebug (1.1.2)
+      byebug (~> 1.6)
+      pry (~> 0.9.12)
     pry-debugger (0.2.2)
       debugger (~> 1.3)
       pry (~> 0.9.10)
@@ -381,6 +387,7 @@ DEPENDENCIES
   pg
   prototype-rails
   prototype_legacy_helper (= 0.0.0)!
+  pry-byebug
   pry-debugger
   pry-doc
   pry-rails


### PR DESCRIPTION
debugger is buggy on 2.0,  [byebug](https://github.com/deivid-rodriguez/byebug) seems to be the cool new thing
