### PR TITLE
Removed the link_to_issue and replaced references with link_to_workpackage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,12 +114,6 @@ module ApplicationHelper
     l(('status_' + user.status_name).to_sym)
   end
 
-  def link_to_issue(issue, options={})
-    warn "[DEPRECATION] link_to_issue will be removed - use link_to_work_package instead.\n" +
-         "Called from: #{caller[0]}"
-    link_to_work_package(issue, options)
-  end
-
   # Generates a link to an attachment.
   # Options:
   # * :text - Link text (default to attachment filename)

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -41,7 +41,7 @@ module IssuesHelper
     @cached_label_priority ||= Issue.human_attribute_name(:priority)
     @cached_label_project ||= Issue.human_attribute_name(:project)
 
-    (link_to_issue(issue) + "<br /><br />
+    (link_to_work_package(issue) + "<br /><br />
       <strong>#{@cached_label_project}</strong>: #{link_to_project(issue.project)}<br />
       <strong>#{@cached_label_status}</strong>: #{h(issue.status.name)}<br />
       <strong>#{@cached_label_start_date}</strong>: #{format_date(issue.start_date)}<br />

--- a/app/helpers/timelog_helper.rb
+++ b/app/helpers/timelog_helper.rb
@@ -19,7 +19,7 @@ module TimelogHelper
     links << link_to(h(@project), {:project_id => @project, :work_package_id => nil}) if @project
     if @issue
       if @issue.visible?
-        links << link_to_issue(@issue, :subject => false)
+        links << link_to_work_package(@issue, :subject => false)
       else
         links << "##{@issue.id}".html_safe
       end

--- a/app/views/common/_calendar.html.erb
+++ b/app/views/common/_calendar.html.erb
@@ -37,7 +37,7 @@ while day <= calendar.enddt %>
                                     :class => "imgtag-icon") %>
   <% end %>
 
-  <%= link_to_issue i, :truncate => 30, :before_text => date_img %>
+  <%= link_to_work_package i, :truncate => 30, :before_text => date_img %>
   <span class="tip"><%= render_issue_tooltip i %></span>
   </div>
   <% else %>

--- a/app/views/issues/_relation.html.erb
+++ b/app/views/issues/_relation.html.erb
@@ -14,7 +14,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <td>
     <%= l(relation.label_for(@issue)) %> <%= "(#{l('datetime.distance_in_words.x_days', :count => relation.delay)})" if relation.delay && relation.delay != 0 %>
     <%= h(relation.other_issue(@issue).project) + ' - ' if Setting.cross_project_issue_relations? %>
-    <%= link_to_issue(relation.other_issue(@issue), :truncate => 60) %>
+    <%= link_to_work_package(relation.other_issue(@issue), :truncate => 60) %>
   </td>
   <% if not relation.other_issue(@issue).kind.nil? %>
     <td>

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -43,7 +43,7 @@ entries_by_day = entries.group_by(&:spent_on)
     <% entries_by_day[day].each do |entry| -%>
     <tr class="time-entry" style="border-bottom: 1px solid #f5f5f5;">
     <td class="activity"><%=h entry.activity %></td>
-    <td class="subject"><%=h entry.project %> <%= ' - '.html_safe + link_to_issue(entry.work_package, :truncate => 50) if entry.work_package%></td>
+    <td class="subject"><%=h entry.project %> <%= ' - '.html_safe + link_to_work_package(entry.work_package, :truncate => 50) if entry.work_package%></td>
     <td class="comments"><%=h entry.comments %></td>
     <td class="hours"><%= html_hours("%.2f" % entry.hours) %></td>
     <td align="center">

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <td class="project"><%= link_to_project(entry.project) %></td>
 <td class="subject">
 <% if entry.work_package -%>
-<%= entry.work_package.visible? ? link_to_issue(entry.work_package, :truncate => 50) : "##{entry.work_package.id}" -%>
+<%= entry.work_package.visible? ? link_to_work_package(entry.work_package, :truncate => 50) : "##{entry.work_package.id}" -%>
 <% end -%>
 </td>
 <td class="comments"><%=h entry.comments %></td>

--- a/app/views/work_packages/_relation.html.erb
+++ b/app/views/work_packages/_relation.html.erb
@@ -14,7 +14,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <td>
     <%= l(relation.label_for(work_package)) %> <%= "(#{l('datetime.distance_in_words.x_days', :count => relation.delay)})" if relation.delay && relation.delay != 0 %>
     <%= h(relation.other_issue(work_package).project) + ' - ' if Setting.cross_project_issue_relations? %>
-    <%= link_to_issue(relation.other_issue(work_package), :truncate => 60) %>
+    <%= link_to_work_package(relation.other_issue(work_package), :truncate => 60) %>
   </td>
   <% unless relation.other_issue(work_package).type.is_standard %>
     <td>


### PR DESCRIPTION
This is only the first part of the cleanup-task https://www.openproject.org/issues/1753: There is a lengthy discussion in the ticket (https://www.openproject.org/issues/1418) that outlines which parts are affected by the issues -> work_package change. The #1753-Ticket is an initial try to break this down into manageable tasks. 

This commit here __only_ does the link_to_issue -> link_to_work_package, the rest will eventually end up in sub-tickets of #1753. 
