### PR TITLE
Fixing workpackage-ajax-update (#1823, #1422)

### DIFF
--- a/app/assets/javascripts/issues.js.erb
+++ b/app/assets/javascripts/issues.js.erb
@@ -10,12 +10,13 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-var Issue = Issue || {};
+var WorkPackage = WorkPackage || {};
 
-Issue.Show = (function($) {
+WorkPackage.Show = (function($) {
   var init;
 
   init = function () {
+    
     $.ajaxAppend({
       trigger: '.action_menu_main .edit',
       indicator_class: 'ajax-indicator',
@@ -23,7 +24,7 @@ Issue.Show = (function($) {
       loading_text: I18n.t("js.ajax.loading"),
       loading_class: 'box loading',
       loading: function(update) {
-                 $('html, body').animate({
+                $('html, body').animate({
                    scrollTop: $(update).offset().top
                  }, 200);
                },
@@ -31,7 +32,7 @@ Issue.Show = (function($) {
                 $('html, body').animate({
                   scrollTop: $(update).offset().top
                 }, 200);
-                $("#notes").focus();
+                $("#work_package_notes").focus();
       }
     });
 
@@ -76,7 +77,7 @@ Issue.Show = (function($) {
   };
 
   $('document').ready(function () {
-    if ($('body.controller-issues.action-show').size() > 0) {
+    if ($('body.controller-work_packages.action-show').size() > 0) {
      init();
     }
   });

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -123,14 +123,19 @@ class WorkPackagesController < ApplicationController
   end
 
   def edit
+    locals =   { :work_package => work_package,
+                 :allowed_statuses => allowed_statuses,
+                 :project => project,
+                 :priorities => priorities,
+                 :time_entry => time_entry,
+                 :user => current_user }
+
     respond_to do |format|
       format.html do
-        render :edit, :locals => { :work_package => work_package,
-                                   :allowed_statuses => allowed_statuses,
-                                   :project => project,
-                                   :priorities => priorities,
-                                   :time_entry => time_entry,
-                                   :user => current_user }
+        render :edit, :locals => locals
+      end
+      format.js do
+        render :partial => "edit", :locals => locals
       end
     end
   end

--- a/app/views/work_packages/_form.html.erb
+++ b/app/views/work_packages/_form.html.erb
@@ -52,4 +52,4 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= call_hook(:view_issues_form_details_bottom, { :issue => work_package, :form => f }) %>
 
-<%= wikitoolbar_for 'issue_description' %>
+<%= wikitoolbar_for 'work_package_description' %>


### PR DESCRIPTION
The ajax-update-functionality for workpackages wasn't properly wired:
Due to the renaming, some dom-references pointed into nowhere; the
second bug (wiki-toolbar not properly initialised) was also caused by
wrong/changed dom-references.
- wired the listener to the edit-button
- added the js-response to the work_packages_controller
- dom-references fixed for wiki-toolbar-initializers
