### PR TITLE
Previous versions need some more reloads.

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -201,11 +201,15 @@ print "Creating objects for..."
         t.hours = rand(10) if rand(99).even?
       end
 
+      issue.reload
+
       attachments = issue.attachments
 
       attachments.each do |a|
         issue.attachments.delete a if rand(99).even?
       end
+
+      issue.reload
 
       issue.custom_values.each do |cv|
         cv.value = Faker::Code.isbn if rand(99).even?


### PR DESCRIPTION
This is needed to prevent stale object errors in previous versions of
OpenProject (<= 3.0.0pre12).
