### PR TITLE
Moved visibility-tests for issues into spec

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* `#1896` Moved visibility-tests for issues into specs for workpackages
 * `#1766` Fixed bug: Viewing diff of Work Package description results in error 500
 * `#1800` Add settings to change software name and URL and add additional footer content
 * `#1808` Add option to log user for each request

--- a/spec/models/work_package_visibility_spec.rb
+++ b/spec/models/work_package_visibility_spec.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe "WorkPackage-Visibility" do
+
+  let(:admin)    {FactoryGirl.create(:admin)}
+  let(:anonymous){FactoryGirl.create(:anonymous)}
+  let(:user)    {FactoryGirl.create(:user)}
+  let(:public_project) {FactoryGirl.create(:project, is_public: true)}
+  let(:private_project) {FactoryGirl.create(:project, is_public: false)}
+  let(:other_project) {FactoryGirl.create(:project, is_public: true)}
+  let(:view_work_packages) {FactoryGirl.create(:role, :permissions => [:view_work_packages])}
+
+  describe "of public projects" do
+    subject { FactoryGirl.create(:work_package, :project => public_project)}
+
+    it "should be viewable by anonymous users, when the anonymous-role has the permission to view packages" do
+      # it is not really clear, where these kind of "preconditions" belong to: This setting
+      # is a default in Redmine::DefaultData::Loader - but this not loaded in the tests: here we
+      # just make sure, that the workpackage is visible, when this permission is set
+      Role.anonymous.add_permission! :view_work_packages
+      WorkPackage.visible(anonymous).should include subject
+    end
+
+  end
+
+
+  describe "of private projects" do
+    subject { FactoryGirl.create(:work_package, :project => private_project)}
+
+    it "should be visible for the admin, even if the project is private" do
+      WorkPackage.visible(admin).should include subject
+    end
+
+    it "should not be visible for anonymous users, when the project is private" do
+      WorkPackage.visible(anonymous).should_not include subject
+    end
+
+    it "should be visible for members of the project, that are allowed to view workpackages" do
+      member = FactoryGirl.create(:member, user: user, project: private_project, role_ids: [view_work_packages.id])
+      WorkPackage.visible(user).should include subject
+    end
+
+    it "should __not__ be visible for non-members of the project without the permission to view workpackages" do
+      WorkPackage.visible(user).should_not include subject
+    end
+
+    it "should __not__ be visible for members of the project, without the right to view work_packages" do
+      no_permission = FactoryGirl.create(:role, :permissions => [:no_permission])
+      member = FactoryGirl.create(:member, user: user, project: private_project, role_ids: [no_permission.id])
+
+      WorkPackage.visible(user).should_not include subject
+    end
+  end
+
+end
+

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -76,49 +76,6 @@ class IssueTest < ActiveSupport::TestCase
     assert_equal 'PostgreSQL', issue.custom_value_for(field).value
   end
 
-  def test_visible_scope_for_anonymous
-    # Anonymous user should see issues of public projects only
-    issues = Issue.visible(User.anonymous).all
-    assert issues.any?
-    assert_nil issues.detect {|issue| !issue.project.is_public?}
-    # Anonymous user should not see work units without permission
-    Role.anonymous.remove_permission!(:view_work_packages)
-    issues = Issue.visible(User.anonymous).all
-    assert issues.empty?
-  end
-
-  def test_visible_scope_for_user
-    user = User.find(9)
-    assert user.projects.empty?
-    # Non member user should see issues of public projects only
-    issues = Issue.visible(user).all
-    assert issues.any?
-    assert_nil issues.detect {|issue| !issue.project.is_public?}
-    # Non member user should not see issues without permission
-    Role.non_member.remove_permission!(:view_work_packages)
-    user.reload
-    issues = Issue.visible(user).all
-    assert issues.empty?
-    # User should see issues of projects for which he has view_issues permissions only
-    Member.new.tap do |m|
-      m.force_attributes = { :principal => user, :project_id => 2, :role_ids => [1] }
-    end.save!
-    user.reload
-    issues = Issue.visible(user).all
-    assert issues.any?
-    assert_nil issues.detect {|issue| issue.project_id != 2}
-  end
-
-  def test_visible_scope_for_admin
-    user = User.find(1)
-    user.members.each(&:destroy)
-    assert user.projects.empty?
-    issues = Issue.visible(user).all
-    assert issues.any?
-    # Admin should see issues on private projects that he does not belong to
-    assert issues.detect {|issue| !issue.project.is_public?}
-  end
-
   def test_errors_full_messages_should_include_custom_fields_errors
     field = WorkPackageCustomField.find_by_name('Database')
 


### PR DESCRIPTION
straightened out the visibility-tests and moved them into a spec.

https://www.openproject.org/issues/1896
