### PR TITLE
Remove filename column from attachable journals.

### DIFF
--- a/db/migrate/20130903092156_remove_filename_from_attachable_journals.rb
+++ b/db/migrate/20130903092156_remove_filename_from_attachable_journals.rb
@@ -1,0 +1,9 @@
+class RemoveFilenameFromAttachableJournals < ActiveRecord::Migration
+  def up
+    remove_column :attachable_journals, :filename
+  end
+
+  def down
+    add_column :attachable_journals, :filename, :string, :default => "", :null => false
+  end
+end


### PR DESCRIPTION
This filename is redundant.
