### PR TITLE
add news subject to url

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -67,6 +67,10 @@ class News < ActiveRecord::Base
     new_comment(attributes).post!
   end
 
+  def to_param
+    id && "#{id} #{title}".parameterize
+  end
+
   private
 
   def add_author_as_watcher

--- a/test/functional/news/comments_controller_test.rb
+++ b/test/functional/news/comments_controller_test.rb
@@ -22,7 +22,8 @@ class News::CommentsControllerTest < ActionController::TestCase
   def test_add_comment
     @request.session[:user_id] = 2
     post :create, :news_id => 1, :comment => { :comments => 'This is a test comment' }
-    assert_redirected_to '/news/1'
+    news = News.find(1)
+    assert_redirected_to news_path(news)
 
     comment = News.find(1).comments.reorder('created_on DESC').first
     assert_not_nil comment
@@ -34,8 +35,9 @@ class News::CommentsControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     assert_no_difference 'Comment.count' do
       post :create, :news_id => 1, :comment => { :comments => '' }
+      news = News.find(1)
       assert_response :redirect
-      assert_redirected_to '/news/1'
+      assert_redirected_to news_path(news)
     end
   end
 
@@ -46,7 +48,8 @@ class News::CommentsControllerTest < ActionController::TestCase
       delete :destroy, :id => 2
     end
 
-    assert_redirected_to '/news/1'
+    news = News.find(1)
+    assert_redirected_to news_path(news)
     assert_nil Comment.find_by_id(2)
   end
 end

--- a/test/functional/news_controller_test.rb
+++ b/test/functional/news_controller_test.rb
@@ -88,8 +88,8 @@ class NewsControllerTest < ActionController::TestCase
   def test_put_update
     @request.session[:user_id] = 2
     put :update, :id => 1, :news => { :description => 'Description changed by test_post_edit' }
-    assert_redirected_to '/news/1'
     news = News.find(1)
+    assert_redirected_to news_path(news)
     assert_equal 'Description changed by test_post_edit', news.description
   end
 

--- a/test/unit/news_test.rb
+++ b/test/unit/news_test.rb
@@ -62,4 +62,14 @@ class NewsTest < ActiveSupport::TestCase
     10.times { projects(:projects_001).news.create(valid_news) }
     assert_equal 5, News.latest(users(:users_004)).size
   end
+
+  def test_to_param_should_include_id_and_title
+    title = "OpenProject now has a Twitter Account"
+    news  = News.create! valid_news.merge(:title => title)
+    assert_equal news.to_param, "#{news.id}-openproject-now-has-a-twitter-account"
+  end
+
+  def test_to_param_should_return_nil_for_unsaved_news
+    assert_nil News.new.to_param
+  end
 end


### PR DESCRIPTION
I noticed that OpenProject has poor urls for its news. This PR appends the subject to the news link to make them more memorizable and to know what to expect before clicking.

It turns

https://www.openproject.org/news/20

into

https://www.openproject.org/news/20-openproject-now-has-a-twitter-account

Note: both urls work today already. The PR only changes the links rails generates when using its helper methods.
