### PR TITLE
fix the creation of workpackages when a validation-error occurs

### DIFF
--- a/app/controllers/issues/reports_controller.rb
+++ b/app/controllers/issues/reports_controller.rb
@@ -11,7 +11,7 @@
 #++
 
 class Issues::ReportsController < ApplicationController
-  menu_item :summary_field, :only => [:issue_report]
+  menu_item :summary_field, :only => [:report, :report_details]
   before_filter :find_project_by_project_id, :authorize, :find_issue_statuses
 
   def report

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -15,24 +15,13 @@ class WorkPackagesController < ApplicationController
   DEFAULT_SORT_ORDER = ['parent', 'desc']
   EXPORT_FORMATS = %w[atom rss xls csv pdf]
 
+  menu_item :new_work_package, :only => [:new, :create]
+
   include QueriesHelper
   include SortHelper
   include PaginationHelper
 
   accept_key_auth :index, :show, :create, :update, :destroy
-
-  current_menu_item do |controller|
-    begin
-      wp = controller.work_package
-
-      case wp
-      when Issue
-        :issues
-      end
-    rescue
-      :issues
-    end
-  end
 
   before_filter :disable_api
   before_filter :not_found_unless_work_package,
@@ -132,7 +121,10 @@ class WorkPackagesController < ApplicationController
       redirect_to(work_package_path(work_package))
     else
       respond_to do |format|
-        format.html { render :action => 'new' }
+        format.html { render :action => 'new', :locals => { :work_package => work_package,
+                                                            :project => project,
+                                                            :priorities => priorities,
+                                                            :user => current_user } }
       end
     end
   end

--- a/features/work_packages/create.feature
+++ b/features/work_packages/create.feature
@@ -1,0 +1,57 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Creating work packages
+  Background:
+    Given there is 1 user with:
+      | login     | manager |
+      | firstname | the     |
+      | lastname  | manager |
+    And there are the following types:
+      | Name   | Is milestone |
+      | Phase1 | false        |
+      | Phase2 | false        |
+    And there are the following project types:
+      | Name                  |
+      | Standard Project      |
+    And there is 1 project with the following:
+      | identifier | ecookbook |
+      | name       | ecookbook |
+    And the project named "ecookbook" is of the type "Standard Project"
+    And the following types are enabled for projects of type "Standard Project"
+      | Phase1 |
+      | Phase2 |
+    And I am working in project "ecookbook"
+    And there is a role "manager"
+    And the role "manager" may have the following rights:
+      | add_work_packages    |
+      | create_work_packages |
+      | edit_work_packages   |
+      | view_work_packages   |
+      | manage_subtasks      |
+    And the user "manager" is a "manager" in the project "ecookbook"
+    And there are the following priorities:
+      | name  | default |
+      | prio1 | true    |
+      | prio2 |         |
+    And there are the following status:
+      | name    | default |
+      | status1 | true    |
+      | status2 |         |
+    And the type "Phase1" has the default workflow for the role "manager"
+    And the type "Phase2" has the default workflow for the role "manager"
+    And I am already logged in as "manager"
+
+  @javascript
+  Scenario: Creating a new work package without required fields should give an error-message
+    When I go to the new work_package page of the project called "ecookbook"
+    And I submit the form by the "Create" button
+    Then I should see "Subject can't be blank" within "#errorExplanation"

--- a/features/work_packages/reset_filters.feature
+++ b/features/work_packages/reset_filters.feature
@@ -36,14 +36,6 @@ Feature: Resetting filteres on work packages
      And I should see "No data to display"
 
   @javascript
-  Scenario: Clearing filters via the menu
-    When I toggle the "Work packages" submenu
-     And I follow "View all work packages"
-
-    Then I should be on the work package index page of the project called "project1"
-     And I should see "Some issue"
-
-  @javascript
   Scenario: Clearing filters via the filter buttons
     When I follow "Clear"
 

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -273,8 +273,8 @@ Redmine::MenuManager.map :project_menu do |menu|
               :if => Proc.new { |p| p.shared_versions.any? }
 
   menu.push :work_packages, { :controller => '/work_packages', :action => 'index' }, :param => :project_id, :caption => :label_work_package_plural
-  menu.push :new_issue, { :controller => '/work_packages', :action => 'new', :sti_type => 'Issue' }, :param => :project_id, :caption => :label_work_package_new, :parent => :work_packages,
-              :html => { :accesskey => Redmine::AccessKeys.key_for(:new_issue) }
+  menu.push :new_work_package, { :controller => '/work_packages', :action => 'new'}, :param => :project_id, :caption => :label_work_package_new, :parent => :work_packages,
+                                                                                     :html => { :accesskey => Redmine::AccessKeys.key_for(:new_work_package) }
   menu.push :view_all_work_packages, { :controller => '/work_packages', :action => 'index', :set_filter => 1 }, :param => :project_id, :caption => :label_work_package_view_all, :parent => :work_packages
   menu.push :summary_field, {:controller => '/issues/reports', :action => 'report'}, :param => :project_id, :caption => :label_workflow_summary, :parent => :work_packages
   menu.push :calendar, { :controller => '/issues/calendars', :action => 'index' }, :param => :project_id, :caption => :label_calendar

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -275,7 +275,6 @@ Redmine::MenuManager.map :project_menu do |menu|
   menu.push :work_packages, { :controller => '/work_packages', :action => 'index' }, :param => :project_id, :caption => :label_work_package_plural
   menu.push :new_work_package, { :controller => '/work_packages', :action => 'new'}, :param => :project_id, :caption => :label_work_package_new, :parent => :work_packages,
                                                                                      :html => { :accesskey => Redmine::AccessKeys.key_for(:new_work_package) }
-  menu.push :view_all_work_packages, { :controller => '/work_packages', :action => 'index', :set_filter => 1 }, :param => :project_id, :caption => :label_work_package_view_all, :parent => :work_packages
   menu.push :summary_field, {:controller => '/issues/reports', :action => 'report'}, :param => :project_id, :caption => :label_workflow_summary, :parent => :work_packages
   menu.push :calendar, { :controller => '/issues/calendars', :action => 'index' }, :param => :project_id, :caption => :label_calendar
   menu.push :news, { :controller => '/news', :action => 'index' }, :param => :project_id, :caption => :label_news_plural

--- a/test/unit/lib/redmine_test.rb
+++ b/test/unit/lib/redmine_test.rb
@@ -59,7 +59,7 @@ class RedmineTest < ActiveSupport::TestCase
     assert_menu_contains_item_named :project_menu, :activity
     assert_menu_contains_item_named :project_menu, :roadmap
     assert_menu_contains_item_named :project_menu, :work_packages
-    assert_menu_contains_item_named :project_menu, :new_issue
+    assert_menu_contains_item_named :project_menu, :new_work_package
     assert_menu_contains_item_named :project_menu, :calendar
     assert_menu_contains_item_named :project_menu, :news
     assert_menu_contains_item_named :project_menu, :boards
@@ -68,7 +68,7 @@ class RedmineTest < ActiveSupport::TestCase
   end
 
   def test_new_issue_should_have_issues_as_a_parent
-    new_issue = get_menu_item(:project_menu, :new_issue)
-    assert_equal :work_packages, new_issue.parent.name
+    new_work_package = get_menu_item(:project_menu, :new_work_package)
+    assert_equal :work_packages, new_work_package.parent.name
   end
 end


### PR DESCRIPTION
added missing :locals to the render-call of create; fixed the highlighting in the menue for workpackages. (see [#1789](https://www.openproject.org/issues/1789))
