### PR TITLE
Fix/work package queries

### DIFF
--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -41,7 +41,7 @@ class ::Query::Results
 
   # Returns the work package count
   def work_package_count
-    WorkPackage.count(:include => [:status, :project], :conditions => statement)
+    WorkPackage.count(:include => [:status, :project], :conditions => query.statement)
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)
   end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#1978` Migrate legacy issues
 * `#1982` Migrate planning element types
 * `#2019` Migrate auto completes controller tests
+* `#2078` Work package query produces 500 when grouping on exclusively empty values
 
 ## 3.0.0pre16
 

--- a/features/issues/query.feature
+++ b/features/issues/query.feature
@@ -9,9 +9,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-Feature: Watch issues
+Feature: Work Package Query
   Background:
-    Given there are no issues
     And there is 1 project with the following:
       | name       | project |
       | identifier | project |

--- a/features/issues/query.feature
+++ b/features/issues/query.feature
@@ -18,29 +18,10 @@ Feature: Work Package Query
     And the project "project" has the following types:
       | name | position |
       | Bug  |     1    |
-    And there is a role "member_with_privileges"
-    And there is a role "member_without_privileges"
-    And the role "member_with_privileges" may have the following rights:
-      | view_work_packages |
-      | save_queries       |
-    And the role "member_without_privileges" may have the following rights:
-      | view_work_packages |
-    And there is 1 user with the following:
-      | login     | bob    |
-      | firstname | Bob    |
-      | lastname  | Bobbit |
-    And there is 1 user with the following:
-      | login     | alice  |
-      | firstname | Alice  |
-      | lastname  | Alison |
-    And the project "project" has 1 issue with the following:
-      |  subject | issue1 |
-    And the user "bob" is a "member_with_privileges" in the project "project"    
-    And the user "alice" is a "member_without_privileges" in the project "project"    
 
   @javascript
   Scenario: Create a query and give it a name
-    When I am already logged in as "bob"
+    When I am already admin
      And I go to the work packages index page for the project "project"
      And I follow "Save" within "#query_form"
      And I fill in "Query" for "Name"
@@ -50,7 +31,9 @@ Feature: Work Package Query
   
   @javascript
   Scenario: Group on empty Value (Assignee)
-    When I am already logged in as "bob"
+    Given the project "project" has 1 issue with the following:
+      | subject | issue1 |
+     And I am already admin
      And I go to the work packages index page for the project "project"
      And I follow "Options" within "#query_form"
      And I select "Assignee" from "group_by"
@@ -63,11 +46,28 @@ Feature: Work Package Query
      And I should see "None" within "#content"
 
   Scenario: Save Button should be visible for users with the proper rights
+    Given there is 1 user with the following:
+      | login     | bob    |
+      | firstname | Bob    |
+      | lastname  | Bobbit |
+    And there is a role "member_with_privileges"
+    And the role "member_with_privileges" may have the following rights:
+      | view_work_packages |
+      | save_queries       |
+    And the user "bob" is a "member_with_privileges" in the project "project"
     When I am already logged in as "bob"
      And I go to the work packages index page for the project "project"
     Then I should see "Save" within "#query_form"
 
   Scenario: Save Button should be invisible for users without the proper rights
+    Given there is 1 user with the following:
+      | login     | alice  |
+      | firstname | Alice  |
+      | lastname  | Alison |
+    And there is a role "member_without_privileges"
+    And the role "member_without_privileges" may have the following rights:
+      | view_work_packages |
+    And the user "alice" is a "member_without_privileges" in the project "project"
     When I am already logged in as "alice"
      And I go to the work packages index page for the project "project"
     Then I should not see "Save" within "#query_form"

--- a/features/issues/query.feature
+++ b/features/issues/query.feature
@@ -34,6 +34,8 @@ Feature: Watch issues
       | login     | alice  |
       | firstname | Alice  |
       | lastname  | Alison |
+    And the project "project" has 1 issue with the following:
+      |  subject | issue1 |
     And the user "bob" is a "member_with_privileges" in the project "project"    
     And the user "alice" is a "member_without_privileges" in the project "project"    
 
@@ -47,6 +49,20 @@ Feature: Watch issues
     Then I should see "Query" within "#content"
      And I should see "Successful creation."
   
+  @javascript
+  Scenario: Group on empty Value (Assignee)
+    When I am already logged in as "bob"
+     And I go to the work packages index page for the project "project"
+     And I follow "Options" within "#query_form"
+     And I select "Assignee" from "group_by"
+     And I follow "Apply"
+     And I follow "Save"
+     And I fill in "Query" for "Name"
+     And I press "Save"
+    Then I should see "Query" within "#content"
+     And I should see "Successful creation."
+     And I should see "None" within "#content"
+
   Scenario: Save Button should be visible for users with the proper rights
     When I am already logged in as "bob"
      And I go to the work packages index page for the project "project"

--- a/features/issues/query.feature
+++ b/features/issues/query.feature
@@ -1,0 +1,58 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Watch issues
+  Background:
+    Given there are no issues
+    And there is 1 project with the following:
+      | name       | project |
+      | identifier | project |
+    And I am working in project "project"
+    And the project "project" has the following types:
+      | name | position |
+      | Bug  |     1    |
+    And there is a role "member_with_privileges"
+    And there is a role "member_without_privileges"
+    And the role "member_with_privileges" may have the following rights:
+      | view_work_packages |
+      | save_queries       |
+    And the role "member_without_privileges" may have the following rights:
+      | view_work_packages |
+    And there is 1 user with the following:
+      | login     | bob    |
+      | firstname | Bob    |
+      | lastname  | Bobbit |
+    And there is 1 user with the following:
+      | login     | alice  |
+      | firstname | Alice  |
+      | lastname  | Alison |
+    And the user "bob" is a "member_with_privileges" in the project "project"    
+    And the user "alice" is a "member_without_privileges" in the project "project"    
+
+  @javascript
+  Scenario: Create a query and give it a name
+    When I am already logged in as "bob"
+     And I go to the work packages index page for the project "project"
+     And I follow "Save" within "#query_form"
+     And I fill in "Query" for "Name"
+     And I press "Save"
+    Then I should see "Query" within "#content"
+     And I should see "Successful creation."
+  
+  Scenario: Save Button should be visible for users with the proper rights
+    When I am already logged in as "bob"
+     And I go to the work packages index page for the project "project"
+    Then I should see "Save" within "#query_form"
+
+  Scenario: Save Button should be invisible for users without the proper rights
+    When I am already logged in as "alice"
+     And I go to the work packages index page for the project "project"
+    Then I should not see "Save" within "#query_form"


### PR DESCRIPTION
Currently, saving a work package query is broken. This is an impediment for https://www.openproject.org/issues/1967. The corresponding issue is https://www.openproject.org/issues/2078.
