### PR TITLE
Work Package Update: Keep Values on Error

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -398,8 +398,12 @@ class WorkPackagesController < ApplicationController
 
   def time_entry
     attributes = {}
+    permitted = {}
 
-    permitted = permitted_params.update_work_package(:project => project)
+    if params[:work_package]
+      permitted = permitted_params.update_work_package(:project => project)
+    end
+
     if permitted.has_key?("time_entry")
       attributes = permitted["time_entry"]
     end

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -397,7 +397,14 @@ class WorkPackagesController < ApplicationController
   end
 
   def time_entry
-    work_package.add_time_entry
+    attributes = {}
+
+    permitted = permitted_params.update_work_package(:project => project)
+    if permitted.has_key?("time_entry")
+      attributes = permitted["time_entry"]
+    end
+
+    work_package.add_time_entry(attributes)
   end
 
   protected

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -232,11 +232,13 @@ module WorkPackagesHelper
   end
 
   def send_notification_option
+    checked = params["send_notification"] != "0"
+
     content_tag(:label,
                 l(:label_notify_member_plural),
                   :for => 'send_notification') +
     hidden_field_tag('send_notification', '0', :id => nil) +
-    check_box_tag('send_notification', '1', true)
+    check_box_tag('send_notification', '1', checked)
   end
 
   def render_work_package_tree_row(work_package, level, relation)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -326,9 +326,12 @@ class WorkPackage < ActiveRecord::Base
     self.relations_from.build
   end
 
-  def add_time_entry
-    time_entries.build(:project => project,
-                       :work_package => self)
+  def add_time_entry(attributes={})
+    attributes.reverse_merge!({
+        :project => project,
+        :work_package => self
+      })
+    time_entries.build(attributes)
   end
 
   def all_dependent_packages(except=[])

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 # Changelog
 
+* `#1560` WorkPackage/update does not retain some fields when validations fail 
 * `#1946` Modal shown within in Modal
 * `#1949` External links within modals do not work
 * `#1992` Prepare schema migrations table

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -388,6 +388,7 @@ describe WorkPackagesController do
       before do
         controller.stub(:work_package).and_return(stub_work_package)
         controller.send(:permitted_params).should_receive(:update_work_package)
+                                          .at_most(:twice)
                                           .with(:project => stub_work_package.project)
                                           .and_return(wp_params)
       end


### PR DESCRIPTION
Implements [ticket 1560](https://www.openproject.org/issues/1560)

Keeps Time-Entry and Send E-Mail Values if the WP update fails.
