### PR TITLE
Added a test to make sure there are no double validation error

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 # Changelog
 
+* `#709`  Added test for double custom field validation error messages
 * `#902`  Spelling Mistake: Timelines Report Configuration
 * `#959`  Too many available responsibles returned for filtering in Timelines
 * `#1738` Forum problem when no description given.
@@ -38,8 +39,8 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2026` 404 error when letters are entered in category Work Package
 * `#2371` Add support for IE10 to Timelines
 * `#2423` [Issue Tracker] Several Internal Errors when there is no default work package status
-* `#2426` [Core] Enumerations for planning elements 
-* `#2427` [Issue Tracker] Cannot delete work package priority 
+* `#2426` [Core] Enumerations for planning elements
+* `#2427` [Issue Tracker] Cannot delete work package priority
 * `#2433` [Timelines] Empty timeline report not displayed initially
 * `#2448` Accelerate work package updates
 * `#2464` No initial attachment journal for messages

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -39,7 +39,7 @@ FactoryGirl.define do
     visible true
     field_format "bool"
 
-    factory :user_custom_field do
+    factory :user_custom_field, :class => UserCustomField do
       sequence(:name) { |n| "User Custom Field #{n}" }
       type "UserCustomField"
 
@@ -80,7 +80,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :issue_custom_field do
+    factory :issue_custom_field, :class => WorkPackageCustomField do
       sequence(:name) { |n| "Issue Custom Field #{n}" }
       type "WorkPackageCustomField"
 


### PR DESCRIPTION
messages in custom fields and fixed 2 factories

https://www.openproject.org/issues/709 was fixed by some other changes in between, so
https://github.com/opf/openproject/pull/168 should not be necessary anymore. I only added
linki's test to prevent regression.
