### PR TITLE
Used skip_invoke! to get a cleaner skipping of scenarios

### DIFF
--- a/lib/scenario_disabler.rb
+++ b/lib/scenario_disabler.rb
@@ -29,7 +29,7 @@
 class ScenarioDisabler
   def self.empty_if_disabled(scenario)
     if self.disabled?(scenario)
-      scenario.instance_variable_set(:@steps,::Cucumber::Ast::StepCollection.new([])) 
+      scenario.skip_invoke!
       true
     else
       false


### PR DESCRIPTION
not creating problems with standard users that were not
created due to disabled scenarios
