### PR TITLE
introduce plugin hook for global assets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,6 +64,7 @@
 //= require top-shelf
 //= require unsupported-browsers
 //= require_tree ./pages
+//= require openproject_plugins
 
 //source: http://stackoverflow.com/questions/8120065/jquery-and-prototype-dont-work-together-with-array-prototype-reverse
 if (typeof []._reverse == 'undefined') {

--- a/app/assets/javascripts/openproject_plugins.js.erb
+++ b/app/assets/javascripts/openproject_plugins.js.erb
@@ -1,0 +1,7 @@
+<%=
+  Redmine::Plugin.all.collect do |plugin|
+    plugin.registered_global_assets[:js].each do |path|
+      require_asset path
+    end
+  end
+%>

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -43,4 +43,5 @@ See doc/COPYRIGHT.rdoc for more details.
  *= require scm
  *= require top-shelf
  *= require work_packages
+ *= require openproject_plugins
  */

--- a/app/assets/stylesheets/openproject_plugins.css.erb
+++ b/app/assets/stylesheets/openproject_plugins.css.erb
@@ -1,0 +1,7 @@
+<%
+  Redmine::Plugin.all.collect do |plugin|
+    plugin.registered_global_assets[:css].each do |path|
+      require_asset path
+    end
+  end
+%>

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#3030` Users preferences for order of comments is ignored on wp comments
 * `#3032` Fix: Work package comments aren't editable by authors
 * API v2: Improve timelines performance by not filtering statuses by visible projects
+* Add hook so that plugins can register assets, which are loaded on every page
 
 ## 3.0.0pre31
 

--- a/lib/redmine/plugin.rb
+++ b/lib/redmine/plugin.rb
@@ -195,6 +195,24 @@ module Redmine #:nodoc:
       true
     end
 
+    ##
+    # Registers an assets (javascript, css file) to be injected into every page
+    # params: Hash containing associations with
+    #   :type => (symbol): either :js or :css
+    #   :path => (string): path to asset to include, or array with multiple asset paths
+    def global_assets(assets_hash = {})
+      assets_hash.each { |k,v| registered_global_assets[k] = Array(v) }
+    end
+
+    ##
+    # Returns a list of assets for the given type
+    # those assets shall be included into every OpenProject page
+    # params:
+    #   type (symbol): either :css, or :js
+    def registered_global_assets
+      @registered_global_assets ||= Hash.new([])
+    end
+
     # Sets a requirement on a Redmine plugin version
     # Raises a PluginRequirementError exception if the requirement is not met
     #


### PR DESCRIPTION
OpenProject plugins may now register assets to be included globally
on every OpenProject page. This should be usefull for Tracking plugins, AB-Testing, and similar
things.

If you use the openproject-plugins gem, do the following to register
your asset:

<pre>
module OpenProject::MyFancyPlugin
  class Engine &lt; ::Rails::Engine
    engine_name :openproject_my_fancy_plugin

    include OpenProject::Plugins::ActsAsOpEngine

    register 'openproject-MyFancyPlugin',
             :author_url => 'http://openproject.org',
             :requires_openproject => '>= 3.0.0',
             :global_assets => {js:  'fancy.js',
                                css: ['cool.css', 'another.css']}

    initializer 'my_fancy_plugin.precompile_assets' do |app|
      app.config.assets.precompile += ['fancy.js','cool.css','another.css']
    end
  end
end
</pre>
