### PR TITLE
Feature/rails3 fix planning element api

### DIFF
--- a/app/assets/javascripts/timelines.js
+++ b/app/assets/javascripts/timelines.js
@@ -899,7 +899,7 @@ Timeline = {
         }
 
         pe.alternate_start_date = e.start_date;
-        pe.alternate_end_date = e.end_date;
+        pe.alternate_due_date = e.due_date;
       });
 
       dataEnhancer.setElementMap(Timeline.HistoricalPlanningElement, undefined);
@@ -2257,8 +2257,8 @@ Timeline = {
     start: function() {
       var pet = this.getPlanningElementType();
       //if we have got a milestone w/o a start date but with an end date, just set them the same.
-      if (this.start_date === undefined && this.end_date !== undefined && pet && pet.is_milestone) {
-        this.start_date = this.end_date;
+      if (this.start_date === undefined && this.due_date !== undefined && pet && pet.is_milestone) {
+        this.start_date = this.due_date;
       }
       if (this.start_date_object === undefined && this.start_date !== undefined) {
         this.start_date_object = Date.parse(this.start_date);
@@ -2268,13 +2268,13 @@ Timeline = {
     end: function() {
       var pet = this.getPlanningElementType();
       //if we have got a milestone w/o a start date but with an end date, just set them the same.
-      if (this.end_date === undefined && this.start_date !== undefined && pet && pet.is_milestone) {
-        this.end_date = this.start_date;
+      if (this.due_date === undefined && this.start_date !== undefined && pet && pet.is_milestone) {
+        this.due_date = this.start_date;
       }
-      if (this.end_date_object=== undefined && this.end_date !== undefined) {
-        this.end_date_object = Date.parse(this.end_date);
+      if (this.due_date_object=== undefined && this.due_date !== undefined) {
+        this.due_date_object = Date.parse(this.due_date);
       }
-      return this.end_date_object;
+      return this.due_date_object;
     },
     alternate_start: function() {
       if (this.alternate_start_date_object === undefined) {
@@ -2283,19 +2283,19 @@ Timeline = {
       return this.alternate_start_date_object;
     },
     alternate_end: function() {
-      if (this.alternate_end_date_object=== undefined) {
-        this.alternate_end_date_object = Date.parse(this.alternate_end_date);
+      if (this.alternate_due_date_object=== undefined) {
+        this.alternate_due_date_object = Date.parse(this.alternate_due_date);
       }
-      return this.alternate_end_date_object;
+      return this.alternate_due_date_object;
     },
     getSubElements: function() {
       return this.getChildren();
     },
     hasAlternateDates: function() {
       return (this.alternate_start_date !== undefined &&
-              this.alternate_end_date !== undefined &&
+              this.alternate_due_date !== undefined &&
               (!(this.start_date === this.alternate_start_date &&
-                 this.end_date === this.alternate_end_date)) ||
+                 this.due_date === this.alternate_due_date)) ||
               this.is_deleted);
     },
     isDeleted: function() {
@@ -2304,7 +2304,7 @@ Timeline = {
     isNewlyAdded: function() {
       return (this.timeline.isComparing() &&
               this.alternate_start_date === undefined &&
-              this.alternate_end_date === undefined);
+              this.alternate_due_date === undefined);
     },
     getAlternateHorizontalBounds: function(scale, absolute_beginning, milestone) {
       return this.getHorizontalBoundsForDates(
@@ -3684,7 +3684,7 @@ Timeline = {
   getAvailableRows: function() {
     var timeline = this;
     return {
-      all: ['end_date', 'type', 'status', 'responsible', 'start_date'],
+      all: ['due_date', 'type', 'status', 'responsible', 'start_date'],
       type: function (data, pet, pt) {
         var ptName, petName;
         if (pt !== undefined) {
@@ -3743,20 +3743,20 @@ Timeline = {
           return jQuery(result);
         }
       },
-      end_date: function(data) {
+      due_date: function(data) {
         var kind, result = '';
-        if (data.end_date !== undefined) {
-          if (data.alternate_end_date !== undefined && data.end_date !== data.alternate_end_date) {
-            kind = (data.alternate_end_date < data.end_date? 'postponed' : 'preponed');
+        if (data.due_date !== undefined) {
+          if (data.alternate_due_date !== undefined && data.due_date !== data.alternate_due_date) {
+            kind = (data.alternate_due_date < data.due_date? 'postponed' : 'preponed');
             result += '<span class="tl-historical">';
-            result += timeline.escape(data.alternate_end_date);
+            result += timeline.escape(data.alternate_due_date);
             result += '<a href="javascript://" title="%t" class="%c"/>'
               .replace(/%t/, timeline.i18n('timelines.change'))
               .replace(/%c/, 'icon tl-icon-' + kind);
             result += '</span><br/>';
           }
           result += '<span class="tl-column tl-current tl-' + kind + '">' +
-                    timeline.escape(data.end_date) + '</span>';
+                    timeline.escape(data.due_date) + '</span>';
           return jQuery(result);
         }
       }
@@ -4863,9 +4863,9 @@ Timeline = {
     }
     info += "<br/>";
     info += this.escape(renderable.start_date);
-    if (renderable.end_date !== renderable.start_date) {
+    if (renderable.due_date !== renderable.start_date) {
       // only have a second date if it is different.
-      info += "–" + this.escape(renderable.end_date);
+      info += " – " + this.escape(renderable.due_date);
     }
     info += "<br/>";
     if (r && r.name) { // if there is a responsible, show the name.
@@ -4878,9 +4878,9 @@ Timeline = {
     var left = offset.left;
     left -= chart.scrollLeft();
     left += bbox.x;
-    if (renderable.start_date && renderable.end_date) {
+    if (renderable.start_date && renderable.due_date) {
       left += bbox.width / 2;
-    } else if (renderable.end_date) {
+    } else if (renderable.due_date) {
       left += bbox.width - Timeline.HOVER_THRESHOLD;
     } else {
       left += Timeline.HOVER_THRESHOLD;
@@ -4901,9 +4901,9 @@ Timeline = {
     var margin = offset.left;
     margin -= chart.scrollLeft();
     margin += (bbox.x);
-    if (renderable.start_date && renderable.end_date) {
+    if (renderable.start_date && renderable.due_date) {
       margin += bbox.width / 2;
-    } else if (renderable.end_date) {
+    } else if (renderable.due_date) {
       margin += bbox.width - Timeline.HOVER_THRESHOLD;
     } else {
       margin += Timeline.HOVER_THRESHOLD;

--- a/app/assets/javascripts/timelines.js
+++ b/app/assets/javascripts/timelines.js
@@ -1831,18 +1831,20 @@ Timeline = {
           dc = -1;
         }
 
-        if (!a.nameLower) {
-          a.nameLower = a.name.toLowerCase();
+        identifier_methods = [a, b].map(function(e) { return e.hasOwnProperty("subject") ? "subject" : "name" })
+
+        if (!a.identifierLower) {
+          a.identifierLower = a[identifier_methods[0]].toLowerCase();
         }
 
-        if (!b.nameLower) {
-          b.nameLower = b.name.toLowerCase();
+        if (!b.identifierLower) {
+          b.identifierLower = b[identifier_methods[1]].toLowerCase();
         }
 
-        if (a.nameLower < b.nameLower) {
+        if (a.identifierLower < b.identifierLower) {
           nc = -1;
         }
-        if (a.nameLower > b.nameLower) {
+        if (a.identifierLower > b.identifierLower) {
           nc = +1;
         }
 
@@ -2657,7 +2659,7 @@ Timeline = {
         if (!in_aggregation) {
 
           // text rendering in planning elements outside of aggregations
-          text = timeline.getMeasuredPathFromText(this.name);
+          text = timeline.getMeasuredPathFromText(this.subject);
 
           // if this is an expanded planning element w/ children, or if
           // the text would not fit:
@@ -2730,7 +2732,7 @@ Timeline = {
           // the other case is text rendering in planning elements inside
           // of aggregations:
 
-          text = timeline.getMeasuredPathFromText(this.name,
+          text = timeline.getMeasuredPathFromText(this.subject,
                      (label_space.w - Timeline.PE_TEXT_INSIDE_PADDING) / Timeline.PE_TEXT_SCALE);
           label = timeline.paper.path(text.path);
           captionElements.push(label);
@@ -4274,7 +4276,7 @@ Timeline = {
 
       cell.append(contentWrapper);
 
-      text = timeline.escape(data.name);
+      text = timeline.escape(data.subject || data.name);
       if (data.getUrl instanceof Function) {
         text = jQuery('<a href="' + data.getUrl() + '" class="tl-discreet-link" data-modal/>').append(text).attr("title", text);
       }

--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -59,14 +59,7 @@ module Api
       end
 
       def create
-        planning_element_params = permitted_params.planning_element.tap do |p|
-          # map the old planning_element_type_id on the type_id of workpackage
-          p[:type_id] = p[:planning_element_type_id]
-          # and remove it from the params
-          p.except!(:planning_element_type_id)
-        end
-
-        @planning_element = planning_element_scope.new(planning_element_params)
+        @planning_element = planning_element_scope.new(permitted_params.planning_element)
 
         # The planning_element inherits from workpackage, which requires an author.
         # Using the current_user also satisfies this demand for API-calls
@@ -74,7 +67,6 @@ module Api
         successfully_created = @planning_element.save
 
         respond_to do |format|
-
           format.api do
             if successfully_created
               redirect_url = api_v2_project_planning_element_url(

--- a/app/helpers/planning_elements_helper.rb
+++ b/app/helpers/planning_elements_helper.rb
@@ -35,21 +35,21 @@ module PlanningElementsHelper
                   :identifier => planning_element.project.identifier,
                   :name => planning_element.project.name)
 
-      api.name(planning_element.subject)
+      api.subject(planning_element.subject)
 
       api.description(planning_element.description)
 
       api.start_date(planning_element.start_date.to_formatted_s(:db)) unless planning_element.start_date.nil?
-      api.end_date(planning_element.due_date.to_formatted_s(:db)) unless planning_element.due_date.nil?
+      api.due_date(planning_element.due_date.to_formatted_s(:db)) unless planning_element.due_date.nil?
 
       if planning_element.parent
-        api.parent(:id => planning_element.parent_id, :name => planning_element.parent.subject)
+        api.parent(:id => planning_element.parent_id, :subject => planning_element.parent.subject)
       end
 
       if planning_element.children.present?
         api.array(:children, :size => planning_element.children.size) do
           planning_element.children.each do |child|
-            api.child(:id => child.id, :name => child.subject)
+            api.child(:id => child.id, :subject => child.subject)
           end
         end
       end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -224,7 +224,7 @@ class PermittedParams < Struct.new(:params, :user)
                                                       :start_date,
                                                       :due_date,
                                                       :note,
-                                                      :planning_element_type_id,
+                                                      :type_id,
                                                       :planning_element_status_comment,
                                                       :planning_element_status_id,
                                                       :parent_id,

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -138,7 +138,7 @@ class PermittedParams < Struct.new(:params, :user)
     params.require(:work_package).permit(:subject,
                                          :description,
                                          :start_date,
-                                         :end_date,
+                                         :due_date,
                                          :note,
                                          :planning_element_type_id,
                                          :planning_element_status_comment,

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -104,7 +104,7 @@ class Timeline < ActiveRecord::Base
   @@available_columns = [
     "type",
     "start_date",
-    "end_date",
+    "due_date",
     "responsible",
     "status"
   ]

--- a/app/views/api/v2/planning_element_journals/_journal.api.rsb
+++ b/app/views/api/v2/planning_element_journals/_journal.api.rsb
@@ -37,7 +37,7 @@ api.journal do
     journal.changed_data.each do |attribute, changes|
       api.change do
         api.technical do
-          api.name(attribute)
+          api.name(attribute.to_s)
           api.old(changes.first)
           api.new(changes.last)
         end

--- a/app/views/api/v2/planning_element_journals/_journal.api.rsb
+++ b/app/views/api/v2/planning_element_journals/_journal.api.rsb
@@ -51,6 +51,6 @@ api.journal do
     end
   end
 
-  api.created_on(journal.created_at.utc)
+  api.created_on(journal.created_at.utc.iso8601)
 end
 

--- a/app/views/api/v2/project_associations/available_projects.api.rsb
+++ b/app/views/api/v2/project_associations/available_projects.api.rsb
@@ -37,8 +37,8 @@ api.array :projects, api_meta(:size => @elements.size) do
 
       api.level(element[:level])
 
-      api.created_on(project.created_on.utc) if project.created_on
-      api.updated_on(project.updated_on.utc) if project.updated_on
+      api.created_on(project.created_on.utc.iso8601) if project.created_on
+      api.updated_on(project.updated_on.utc.iso8601) if project.updated_on
 
       api.disabled(@disabled.include? project)
     end

--- a/app/views/api/v2/projects/_project.api.rsb
+++ b/app/views/api/v2/projects/_project.api.rsb
@@ -89,6 +89,6 @@ api.project do
     end
   end
 
-  api.created_on(project.created_on.utc) if project.created_on
-  api.updated_on(project.updated_on.utc) if project.updated_on
+  api.created_on(project.created_on.utc.iso8601) if project.created_on
+  api.updated_on(project.updated_on.utc.iso8601) if project.updated_on
 end

--- a/app/views/api/v2/reportings/available_projects.api.rsb
+++ b/app/views/api/v2/reportings/available_projects.api.rsb
@@ -37,8 +37,8 @@ api.array :projects, api_meta(:size => @elements.size) do
 
       api.level(element[:level])
 
-      api.created_on(project.created_on.utc) if project.created_on
-      api.updated_on(project.updated_on.utc) if project.updated_on
+      api.created_on(project.created_on.utc.iso8601) if project.created_on
+      api.updated_on(project.updated_on.utc.iso8601) if project.updated_on
 
       api.disabled(@disabled.include? project)
 

--- a/app/views/timelines/_timeline.html.erb
+++ b/app/views/timelines/_timeline.html.erb
@@ -48,7 +48,7 @@ See doc/COPYRIGHT.rdoc for more details.
                  'timelines.errors.report_timeout',
                  'timelines.errors.not_implemented',
                  'timelines.errors.report_comparison',
-                 'timelines.filter.column.end_date',
+                 'timelines.filter.column.due_date',
                  'timelines.filter.column.name',
                  'timelines.filter.column.type',
                  'timelines.filter.column.status',

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -505,20 +505,6 @@ de:
   error_workflow_copy_source: "Bitte wählen Sie einen Quell-Typ und eine Quell-Rolle."
   error_workflow_copy_target: "Bitte wählen Sie die Ziel-Typ und -Rollen."
 
-  field_responsible: "Planungsverantwortlicher"
-  field_end_date: "Abschlussdatum"
-  field_deleted_at: "Gelöscht am"
-  field_planning_element_status: "Status"
-
-# Overriding definition in core to make field_parent more generic, so that it
-# also works for sub planning elements
-  field_parent: "Unterelement von"
-
-# cannot get rid of these, since I do not want to change the way the project
-# model is internationalized
-  field_project_type: "Projekttyp"
-  field_responsible: "Planungsverantwortlicher"
-
   general_csv_decimal_separator: ","
   general_csv_encoding: "ISO-8859-1"
   general_csv_separator: ";"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1378,7 +1378,7 @@ de:
         default: "Default"
       column:
         type: "Typ"
-        end_date: "Abschlussdatum"
+        due_date: "Abschlussdatum"
         name: "Name"
         status: "Status"
         responsible: "Planungsverantwortlicher"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1353,7 +1353,7 @@ en:
         default: "default"
       column:
         type: "Type"
-        end_date: "End date"
+        due_date: "End date"
         name: "Name"
         status: "Status"
         responsible: "Responsible"

--- a/db/migrate/20130919105841_migrate_settings_to_work_package.rb
+++ b/db/migrate/20130919105841_migrate_settings_to_work_package.rb
@@ -9,8 +9,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'yaml'
-
 require_relative 'migration_utils/utils'
 
 class MigrateSettingsToWorkPackage < ActiveRecord::Migration

--- a/db/migrate/20131015064141_migrate_timelines_end_date_property_in_options.rb
+++ b/db/migrate/20131015064141_migrate_timelines_end_date_property_in_options.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+#
+# Copyright (C) 2012-2013 the OpenProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'yaml'
+
+require_relative 'migration_utils/utils'
+
+class MigrateTimelinesEndDatePropertyInOptions < ActiveRecord::Migration
+  include Migration::Utils
+
+  COLUMN = 'options'
+
+  OPTIONS = {
+    "end_date" => "due_date"
+  }
+
+  def up
+    say_with_time_silently "Update timelines options" do
+      update_column_values('timelines',
+                           [COLUMN],
+                           update_options(OPTIONS),
+                           options_filter(OPTIONS.keys))
+    end
+  end
+
+  def down
+    say_with_time_silently "Restore timelines options" do
+      update_column_values('timelines',
+                           [COLUMN],
+                           update_options(OPTIONS.invert),
+                           options_filter(OPTIONS.invert.keys))
+    end
+  end
+
+  private
+
+  def options_filter(options)
+    filter([COLUMN], options)
+  end
+
+  def update_options(options)
+    Proc.new do |row|
+      timelines_opts = YAML.load(row[COLUMN])
+
+      renamed_options = timelines_opts.each_with_object({}) do |(k, v), h|
+        new_key = (options.has_key? k) ? options[k] : k
+        h[new_key] = update_option_value(v)
+      end
+
+      row[COLUMN] = YAML.dump(renamed_options)
+
+      UpdateResult.new(row, true)
+    end
+  end
+
+  def update_option_value(value)
+    if value.kind_of? Array
+      value.map{|e| (OPTIONS.has_key? e) ? OPTIONS[e] : e}
+    elsif OPTIONS.has_key? value
+      OPTIONS[value]
+    else
+      value
+    end
+  end
+end

--- a/db/migrate/migration_utils/text_references.rb
+++ b/db/migrate/migration_utils/text_references.rb
@@ -236,17 +236,5 @@ module Migration
     def restore_filter(columns)
       filter columns, ['work_package', '#']
     end
-
-    def filter(columns, terms)
-      column_filters = []
-
-      columns.each do |column|
-        filters = terms.map {|term| "#{column} LIKE '%#{term}%'"}
-
-        column_filters << "(#{filters.join(' OR ')})"
-      end
-
-      column_filters.join(' OR ')
-    end
   end
 end

--- a/db/migrate/migration_utils/utils.rb
+++ b/db/migrate/migration_utils/utils.rb
@@ -21,6 +21,18 @@ module Migration
       end
     end
 
+    def filter(columns, terms)
+      column_filters = []
+
+      columns.each do |column|
+        filters = terms.map {|term| "#{column} LIKE '%#{term}%'"}
+
+        column_filters << "(#{filters.join(' OR ')})"
+      end
+
+      column_filters.join(' OR ')
+    end
+
     def update_column_values(table, column_list, updater, conditions)
       update_column_values_and_journals(table, column_list, updater, false, conditions)
     end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 # Changelog
 
 * `#1991` Migrate text references to issues/planning elements
+* `#2297` Fix APIv2 for planning elements
 * `#2304` Introduce keyboard shortcuts
 
 ## 3.0.0pre21

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -31,7 +31,6 @@
 require "benchmark"
 
 When(/^I call the work_package\-api on project "(.*?)" requesting format "(.*?)" without any filters$/) do |project_name, format|
-
   @project = Project.find(project_name)
   @unfiltered_benchmark = Benchmark.measure("Unfiltered Results") do
     visit api_v2_project_planning_elements_path(project_id: project_name, format: format)
@@ -63,12 +62,12 @@ And(/^the json\-response for work_package "(.*?)" should have the responsible "(
 end
 Then(/^the json\-response for work_package "(.*?)" should have the due_date "(.*?)"$/) do |work_package_name, due_date|
   work_package = lookup_work_package(work_package_name)
-  expect(work_package["end_date"]).to eql due_date.gsub('/','-') # normalize the date-format
+  expect(work_package["due_date"]).to eql due_date.gsub('/','-') # normalize the date-format
 end
 
 And(/^the json\-response should say that "(.*?)" is parent of "(.*?)"$/) do |parent_name, child_name|
   child = lookup_work_package(child_name)
-  expect(child["parent"]["name"]).to eql parent_name
+  expect(child["parent"]["subject"]).to eql parent_name
 end
 
 And(/^the json\-response should say that "(.*?)" has no parent$/) do |child_name|
@@ -158,11 +157,11 @@ Then(/^the time to get the filtered results should be faster than the time to ge
 end
 
 def lookup_work_package(work_package_name)
-  work_package = decoded_json["planning_elements"].select {|wp| wp["name"] == work_package_name}.first
+  work_package = decoded_json["planning_elements"].select {|wp| wp["subject"] == work_package_name}.first
 end
 
 def work_package_names
-  decoded_json["planning_elements"].map{|wp| wp["name"]}
+  decoded_json["planning_elements"].map{|wp| wp["subject"]}
 end
 
 def decoded_json

--- a/features/timelines/timeline_view.feature
+++ b/features/timelines/timeline_view.feature
@@ -71,7 +71,7 @@ Feature: Timeline View Tests
       And I set the columns shown in the timeline to:
         | start_date |
         | type       |
-        | end_date   |
+        | due_date   |
       Then I should see the column "Start date" before the column "End date" in the timelines table
         And I should see the column "Start date" before the column "Type" in the timelines table
         And I should see the column "Type" before the column "End date" in the timelines table

--- a/spec/views/api/v2/planning_elements/_planning_element_api_rsb_spec.rb
+++ b/spec/views/api/v2/planning_elements/_planning_element_api_rsb_spec.rb
@@ -48,19 +48,19 @@ describe 'api/v2/planning_elements/_planning_element.api' do
 
   describe 'with an assigned planning element' do
     let(:project) { FactoryGirl.create(:project, :id => 4711,
-                                             :identifier => 'test_project',
-                                             :name => 'Test Project') }
+                                       :identifier => 'test_project',
+                                       :name => 'Test Project') }
     let(:planning_element) { FactoryGirl.build(:work_package,
-                                           :id => 1,
-                                           :project_id => project.id,
-                                           :subject => 'Awesometastic Planning Element',
-                                           :description => 'Description of this planning element',
+                                               :id => 1,
+                                               :project_id => project.id,
+                                               :subject => 'Awesometastic Planning Element',
+                                               :description => 'Description of this planning element',
 
-                                           :start_date => Date.parse('2011-12-06'),
-                                           :due_date   => Date.parse('2011-12-13'),
+                                               :start_date => Date.parse('2011-12-06'),
+                                               :due_date   => Date.parse('2011-12-13'),
 
-                                           :created_at => Time.parse('Thu Jan 06 12:35:00 +0100 2011'),
-                                           :updated_at => Time.parse('Fri Jan 07 12:35:00 +0100 2011')) }
+                                               :created_at => Time.parse('Thu Jan 06 12:35:00 +0100 2011'),
+                                               :updated_at => Time.parse('Fri Jan 07 12:35:00 +0100 2011')) }
 
     it 'renders a planning_element node' do
       render
@@ -80,7 +80,7 @@ describe 'api/v2/planning_elements/_planning_element.api' do
 
       it 'contains an name element containing the planning element name' do
         render
-        response.should have_selector('planning_element name', :text => 'Awesometastic Planning Element')
+        response.should have_selector('planning_element subject', :text => 'Awesometastic Planning Element')
       end
 
       it 'contains an description element containing the planning element description' do
@@ -95,7 +95,7 @@ describe 'api/v2/planning_elements/_planning_element.api' do
 
       it 'contains an due_date element containing the planning element due_date in YYYY-MM-DD' do
         render
-        response.should have_selector('planning_element end_date', :text => '2011-12-13')
+        response.should have_selector('planning_element due_date', :text => '2011-12-13')
       end
 
       it 'does not contain a parent node' do
@@ -136,9 +136,9 @@ describe 'api/v2/planning_elements/_planning_element.api' do
                                             :parent_id  => parent_element.id,
                                             :project_id => project.id) }
 
-    it 'renders a parent node containing the parent\'s id and name' do
+    it 'renders a parent node containing the parent\'s id and subject' do
       render
-      response.should have_selector('planning_element parent[id="1337"][name="Parent Element"]')
+      response.should have_selector('planning_element parent[id="1337"][subject="Parent Element"]')
     end
   end
 
@@ -149,15 +149,15 @@ describe 'api/v2/planning_elements/_planning_element.api' do
                                                 :project_id => project.id) }
     before do
       FactoryGirl.create(:work_package,
-                     :project_id => project.id,
-                     :parent_id  => planning_element.id,
-                     :id         => 1339,
-                     :subject    => 'Child #1')
+                         :project_id => project.id,
+                         :parent_id  => planning_element.id,
+                         :id         => 1339,
+                         :subject    => 'Child #1')
       FactoryGirl.create(:work_package,
-                     :project_id => project.id,
-                     :parent_id  => planning_element.id,
-                     :id         => 1340,
-                     :subject    => 'Child #2')
+                         :project_id => project.id,
+                         :parent_id  => planning_element.id,
+                         :id         => 1340,
+                         :subject    => 'Child #2')
     end
 
     it 'renders a children node containing child nodes for each child planning element' do
@@ -165,10 +165,10 @@ describe 'api/v2/planning_elements/_planning_element.api' do
       response.should have_selector('planning_element children child', :count => 2)
     end
 
-    it 'each child node has an id and name attribute' do
+    it 'each child node has an id and subject attribute' do
       render
-      response.should have_selector('planning_element children child[id="1339"][name="Child #1"]', :count => 1)
-      response.should have_selector('planning_element children child[id="1340"][name="Child #2"]', :count => 1)
+      response.should have_selector('planning_element children child[id="1339"][subject="Child #1"]', :count => 1)
+      response.should have_selector('planning_element children child[id="1340"][subject="Child #2"]', :count => 1)
     end
   end
 


### PR DESCRIPTION
- when reading and writing planning_elements fields were named inconsistently
- the name attribute in planning_element_journals was rendered as a namespace, instead as a name attribute
- times should be in iso8601, but they weren't
  `Time.now.utc #=> 2013-10-07 14:39:32 UTC` <-- **THIS IS NOT ISO8601** <sup>(2013-10-07 14:39:32Z is right)</sup>
  
  ![](http://imgs.xkcd.com/comics/iso_8601.png)
- do not listen for `planning_element_type_id` anymore, it is now named `type_id`

see https://www.openproject.org/issues/2297
