### PR TITLE
Feature/migrate to rabl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,11 @@ gem 'therubyracer'
 
 gem "date_validator"
 
+# replacing rsb with rabl
+gem 'rabl'
+gem 'multi_json'
+gem 'oj'
+
 # will need to be removed once we are on rails4 as it will be part of the rails4 core
 gem 'strong_parameters'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
     mysql2 (0.3.11)
     net-ldap (0.2.2)
     nokogiri (1.5.9)
+    oj (2.1.6)
     paper_trail (2.7.2)
       activerecord (~> 3.0)
       railties (~> 3.0)
@@ -223,6 +224,8 @@ GEM
     pry-stack_explorer (0.4.9)
       binding_of_caller (>= 0.7)
       pry (~> 0.9.11)
+    rabl (0.9.0)
+      activesupport (>= 2.3.14)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -391,10 +394,12 @@ DEPENDENCIES
   letter_opener (~> 1.0.0)
   loofah
   mocha (~> 0.13.1)
+  multi_json
   mysql
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)
   object-daddy!
+  oj
   pg
   prototype-rails
   prototype_legacy_helper (= 0.0.0)!
@@ -404,6 +409,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
+  rabl
   rack_session_access
   rails (~> 3.2.14)
   rails-dev-tweaks (~> 0.6.1)

--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -215,7 +215,7 @@ module Api
       def optimize_planning_elements_for_less_db_queries
         # triggering full load to avoid separate queries for count or related models
         # historical packages are already loaded correctly and only need to be optimised, so they do not need to fetched again, only optimised
-        @planning_elements = @planning_elements.all(:include => [:type, :status, :project]) unless @planning_elements.class == Array
+        @planning_elements = @planning_elements.all(:include => [:type, :status, :project, :responsible]) unless @planning_elements.class == Array
 
         # Replacing association proxies with already loaded instances to avoid
         # further db calls.

--- a/app/views/api/v2/planning_elements/index.api.rabl
+++ b/app/views/api/v2/planning_elements/index.api.rabl
@@ -29,13 +29,12 @@
 collection @planning_elements => :planning_elements
 attributes :id, :subject, :description, :project_id, :parent_id
 
-node :start_date, :if => lambda{|pe| pe.start_date} do |pe|
-  pe.start_date.to_formatted_s(:db)
-end
+node :start_date, :if => lambda{|pe| pe.start_date.present?} { |pe| pe.start_date.to_formatted_s(:db) }
+node :due_date, :if => lambda{|pe| pe.due_date.present?} {|pe| pe.due_date.to_formatted_s(:db) }
 
-node :due_date, :if => lambda{|pe| pe.due_date} do |pe|
-  pe.due_date.to_formatted_s(:db)
-end
+node :created_at, if: lambda{|pe| pe.created_at.present?} {|pe| pe.created_at.utc}
+node :updated_at, if: lambda{|pe| pe.updated_at.present?} {|pe| pe.updated_at.utc}
+
 
 child :project do
   attributes :id, :identifier, :name
@@ -66,3 +65,6 @@ node :assigned_to, if: lambda{|pe| pe.assigned_to.present?} do |pe|
     attributes :id, :name
   end
 end
+
+
+

--- a/app/views/api/v2/planning_elements/index.api.rabl
+++ b/app/views/api/v2/planning_elements/index.api.rabl
@@ -26,8 +26,43 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-api.array :planning_elements, :size => @planning_elements.size do
-  @planning_elements.each do |planning_element|
-    render_planning_element(api, planning_element)
+collection @planning_elements => :planning_elements
+attributes :id, :subject, :description, :project_id, :parent_id
+
+node :start_date, :if => lambda{|pe| pe.start_date} do |pe|
+  pe.start_date.to_formatted_s(:db)
+end
+
+node :due_date, :if => lambda{|pe| pe.due_date} do |pe|
+  pe.due_date.to_formatted_s(:db)
+end
+
+child :project do
+  attributes :id, :identifier, :name
+end
+
+node :parent, if: lambda{|pe| pe.parent.present?} do |pe|
+  child :parent => :parent do
+    attributes :id, :subject
+  end
+end
+
+child :type => :planning_element_type do
+  attributes :id, :name
+end
+
+node :children, unless: lambda{|pe| pe.children.empty?} do |pe|
+  pe.children.to_a.map { |wp| { id: wp.id, subject: wp.subject}}
+end
+
+node :responsible, if: lambda{|pe| pe.responsible.present?} do |pe|
+  child :responsible => :responsible do
+    attributes :id, :name
+  end
+end
+
+node :assigned_to, if: lambda{|pe| pe.assigned_to.present?} do |pe|
+  child(:assigned_to => :assigned_to) do
+    attributes :id, :name
   end
 end

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -16,7 +16,7 @@ Rabl.configure do |config|
   # config.include_xml_root  = false
   # config.include_child_root = true
   # config.enable_json_callbacks = false
-  # config.xml_options = { :dasherize  => true, :skip_types => false }
+  config.xml_options = { :dasherize  => false, :skip_types => false }
   # config.view_paths = []
   # config.raise_on_missing_attribute = true # Defaults to false
   # config.replace_nil_values_with_empty_strings = true # Defaults to false

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -1,0 +1,23 @@
+Rabl.configure do |config|
+  # Commented as these are defaults
+  # config.cache_all_output = false
+  # config.cache_sources = Rails.env != 'development' # Defaults to false
+  # config.cache_engine = Rabl::CacheEngine.new # Defaults to Rails cache
+  # config.perform_caching = false
+  # config.escape_all_output = false
+  config.json_engine = ::Oj # Class with #dump class method (defaults JSON)
+  # config.msgpack_engine = nil # Defaults to ::MessagePack
+  # config.bson_engine = nil # Defaults to ::BSON
+  # config.plist_engine = nil # Defaults to ::Plist::Emit
+  config.include_json_root = false
+  # config.include_msgpack_root = true
+  # config.include_bson_root = true
+  # config.include_plist_root = true
+  # config.include_xml_root  = false
+  # config.include_child_root = true
+  # config.enable_json_callbacks = false
+  # config.xml_options = { :dasherize  => true, :skip_types => false }
+  # config.view_paths = []
+  # config.raise_on_missing_attribute = true # Defaults to false
+  # config.replace_nil_values_with_empty_strings = true # Defaults to false
+end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -103,7 +103,7 @@ repository = Repository::Filesystem.create! project: project,
 
 
 print "Creating objects for..."
-20.times do |count|
+30.times do |count|
   login = "#{Faker::Name.first_name}#{rand(10000)}"
 
   puts
@@ -127,7 +127,7 @@ print "Creating objects for..."
   puts ""
   print "......create issues"
 
-  rand(10).times do
+  rand(50).times do
     print "."
     work_package = WorkPackage.new(project: project,
                                    author: user,

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,8 +36,10 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2334` Deselecting all types in project configuration creates 500
 * `#2336` Cukes for timelines start/end date comparison
 * `#2340` Develop migration mechanism for renamed plugins
+* `#2383` [Performance] planning_elements_controller still has an n+1-query for the responsible
 * `#2384` Replace bundles svg graph with gem
 * `#2386` Remove timelines_journals_helper
+* `#2418` Migrate to RABL
 * Allow using environment variables instead of configuration.yml
 
 ## 3.0.0pre21

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,9 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
 
+  # add helpers to parse json-responses
+  config.include JsonSpec::Helpers
+
   config.after(:each) do
     OpenProject::RSpecLazinessWarn.warn_if_user_current_set(example)
   end

--- a/spec/views/api/v2/planning_elements/index_api_json_spec.rb
+++ b/spec/views/api/v2/planning_elements/index_api_json_spec.rb
@@ -1,0 +1,91 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+
+describe 'api/v2/planning_elements/index.api.rabl' do
+  before do
+    params[:format] = 'json'
+  end
+
+  describe 'with no planning elements available' do
+    before do
+      assign(:planning_elements, [])
+      render
+    end
+
+    it 'renders an empty planning_elements document' do
+      response.body.should have_json_path('planning_elements')
+      response.body.should have_json_size(0).at_path('planning_elements')
+    end
+  end
+
+  describe 'with 3 planning elements available' do
+
+    let(:project){FactoryGirl.build(:project_with_types, name: "Sample Project", identifier: "sample_project")}
+    let(:wp1){FactoryGirl.build(:work_package, subject: "Subject #1", project: project)}
+    let(:wp2){FactoryGirl.build(:work_package, subject: "Subject #2", project: project)}
+    let(:wp3){FactoryGirl.build(:work_package, subject: "Subject #3", project: project)}
+
+    let(:planning_elements) {[wp1, wp2, wp3]}
+
+    before do
+      assign(:planning_elements, planning_elements)
+      render
+    end
+
+    subject do
+      response.body
+    end
+
+    it "should render 3 planning-elements" do
+      should have_json_size(3).at_path("planning_elements")
+    end
+
+    it 'should render the subject' do
+      response.body.should be_json_eql("Subject #1".to_json).at_path("planning_elements/0/subject")
+    end
+
+    it 'should render a planning_element_type' do
+      type = project.types.first
+      expected_json = {name: type.name}.to_json
+
+      should be_json_eql(expected_json).at_path("planning_elements/0/planning_element_type")
+
+    end
+
+    it 'should render a project with name and identifier' do
+      expected_json = {name: "Sample Project", identifier: "sample_project"}.to_json
+
+      should be_json_eql(expected_json).at_path(("planning_elements/0/project"))
+    end
+
+
+
+  end
+end

--- a/spec/views/api/v2/planning_elements/index_api_rsb_spec.rb
+++ b/spec/views/api/v2/planning_elements/index_api_rsb_spec.rb
@@ -28,7 +28,7 @@
 
 require File.expand_path('../../../../../spec_helper', __FILE__)
 
-describe 'api/v2/planning_elements/index.api.rsb' do
+describe 'api/v2/planning_elements/index.json' do
   before do
     view.extend TimelinesHelper
     view.extend PlanningElementsHelper

--- a/spec/views/api/v2/planning_elements/index_api_xml_spec.rb
+++ b/spec/views/api/v2/planning_elements/index_api_xml_spec.rb
@@ -28,7 +28,7 @@
 
 require File.expand_path('../../../../../spec_helper', __FILE__)
 
-describe 'api/v2/planning_elements/index.json' do
+describe 'api/v2/planning_elements/index.api.rsb' do
   before do
     view.extend TimelinesHelper
     view.extend PlanningElementsHelper


### PR DESCRIPTION
Adds rabl/multijson/oj to get some more speed out of the json-rendering. The first view that was converted is the  api/v2/planning_elements/index.api.rabl-view that is used to render the data for timelines. 

The old api-spec was very meager, it basically only tested, that the view is implemented in a certain way. We're now mainly testing the json-version of the api using [json_spec]:https://github.com/collectiveidea/json_spec - it currently contains only some very rough tests: Next step is to check for breaks in timelines/add-ins to get some more cases we need to test. 

If this way of doing the API-views is ok for everybody, we can then proceed with migrating the other views too.
