### PR TITLE
fixes removal of outdated controller action upon redefinition of pagination action

### DIFF
--- a/lib/pagination/controller.rb
+++ b/lib/pagination/controller.rb
@@ -142,7 +142,7 @@ module Pagination::Controller
       controller.pagination.delete(last_action)
 
       # remove old
-      controller.send(:remove_method, last_action) if controller.respond_to? :last_action
+      controller.send(:remove_method, last_action) if controller.respond_to? last_action
     end
 
     def define_action!(block = default_block)


### PR DESCRIPTION
Removing outdated controller pagination methods (e.g. action_for Model, :foo) was impossible due to a faulty check, resulting in 'residue-actions' (e.g. :paginate_model existing alongside :foo for the example above).

There's no ticket for this atm, as I just stumbled upon it.
