### PR TITLE
Fix compatibility with old mail configuration

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,6 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2371` Add support for IE10 to Timelines
 * `#2448` Accelerate work package updates
 * `#2479` Remove TinyMCE spike
+* Fix compatibility with old mail configuration
 
 ## 3.0.0pre22
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -150,14 +150,16 @@ module OpenProject
       # options:
       # disable_deprecation_message - used by testing
       def convert_old_email_settings(config, options={})
-        if config['email_delivery'] and config['email_delivery']['delivery_method']
+        if config['email_delivery']
           unless options[:disable_deprecation_message]
             ActiveSupport::Deprecation.warn 'Deprecated mail delivery settings used. Please ' +
                                             'update them in config/configuration.yml or use ' +
                                             'environment variables. See doc/CONFIGURATION.md for ' +
                                             'more information.'
           end
-          config['email_delivery_method'] = config['email_delivery']['delivery_method']
+
+          config['email_delivery_method'] = config['email_delivery']['delivery_method'] || :smtp
+
           ['sendmail', 'smtp'].each do |settings_type|
             settings_key = "#{settings_type}_settings"
             if config['email_delivery'][settings_key]

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -130,19 +130,36 @@ describe OpenProject::Configuration do
           "domain" => "example.net"
       }}}
     }
-    before do
-      OpenProject::Configuration.send(:convert_old_email_settings, settings,
-                                      :disable_deprecation_message => true)
+
+    context 'with delivery_method' do
+      before do
+        OpenProject::Configuration.send(:convert_old_email_settings, settings,
+                                        :disable_deprecation_message => true)
+      end
+
+      it 'should adopt the delivery method' do
+        settings['email_delivery_method'].should == :smtp
+      end
+
+      it 'should convert smtp settings' do
+        settings['smtp_address'].should == 'smtp.example.net'
+        settings['smtp_port'].should == 25
+        settings['smtp_domain'].should == 'example.net'
+      end
     end
 
-    it 'should adopt the delivery method' do
-      settings['email_delivery_method'].should == :smtp
-    end
+    context 'without delivery_method' do
+      before do
+        settings['email_delivery'].delete('delivery_method')
+        OpenProject::Configuration.send(:convert_old_email_settings, settings,
+                                        :disable_deprecation_message => true)
+      end
 
-    it 'should convert smtp settings' do
-      settings['smtp_address'].should == 'smtp.example.net'
-      settings['smtp_port'].should == 25
-      settings['smtp_domain'].should == 'example.net'
+      it 'should convert smtp settings' do
+        settings['smtp_address'].should == 'smtp.example.net'
+        settings['smtp_port'].should == 25
+        settings['smtp_domain'].should == 'example.net'
+      end
     end
   end
 


### PR DESCRIPTION
Previously, the compatibility code wrongly assumed that
delivery_method was always set when using the old mail configuration
format, although it has the default value :smtp.

No OP ticket for this.
