### PR TITLE
Refactor pagination model

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -80,12 +80,6 @@ class Principal < ActiveRecord::Base
     Principal.active_or_registered_like(criteria).limit(limit)
   end
 
-  def self.paginate_scope!(scope, options = {})
-    limit = options.fetch(:page_limit) || 10
-    page = options.fetch(:page) || 1
-    scope.paginate({ :per_page => limit, :page => page })
-  end
-
   def self.search_scope_without_project(project, query)
     active_or_registered_like(query).not_in_project(project)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,6 +29,7 @@
 
 class Project < ActiveRecord::Base
   include Redmine::SafeAttributes
+  extend Pagination::Model
 
   include Project::Copy
 
@@ -113,14 +114,6 @@ class Project < ActiveRecord::Base
   scope :visible, lambda { { :conditions => Project.visible_by(User.current) } }
 
   # timelines stuff
-
-  extend Pagination::Model
-
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-      :order => "name" }
-  }
 
   scope :selectable_projects
 
@@ -221,6 +214,7 @@ class Project < ActiveRecord::Base
   end
 
   def self.search_scope(query)
+    # overwritten from Pagination::Model
     visible.like(query)
   end
 

--- a/app/models/project_type.rb
+++ b/app/models/project_type.rb
@@ -53,18 +53,6 @@ class ProjectType < ActiveRecord::Base
 
   validates_length_of :name, :maximum => 255, :unless => lambda { |e| e.name.blank? }
 
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-    :order => "name" }
-  }
-
-  def self.search_scope(query)
-    # this should be all project types to which there are projects to
-    # which there are dependencies from projects that the user can see
-    like(query)
-  end
-
   def self.available_grouping_project_types
     # this should be all project types to which there are projects to
     # which there are dependencies from projects that the user can see

--- a/app/models/reported_project_status.rb
+++ b/app/models/reported_project_status.rb
@@ -32,12 +32,6 @@ class ReportedProjectStatus < Enumeration
 
   unloadable
 
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-    :order => "name" }
-  }
-
   has_many :reportings, :class_name  => "Reporting",
                         :foreign_key => 'reported_project_status_id'
 
@@ -53,9 +47,5 @@ class ReportedProjectStatus < Enumeration
 
   def transfer_relations(to)
     reportings.update.all(:reported_project_status_id => to.id)
-  end
-
-  def self.search_scope(query)
-    like(query)
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -28,6 +28,8 @@
 #++
 
 class Role < ActiveRecord::Base
+  extend Pagination::Model
+
   # Built-in roles
   BUILTIN_NON_MEMBER = 1
   BUILTIN_ANONYMOUS  = 2
@@ -36,11 +38,6 @@ class Role < ActiveRecord::Base
   scope :builtin, lambda { |*args|
     compare = 'not' if args.first == true
     { :conditions => "#{compare} builtin = 0" }
-  }
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    {:conditions => ["LOWER(name) LIKE :s", {:s => s}]
-    }
   }
 
   before_destroy :check_deletable
@@ -169,9 +166,7 @@ class Role < ActiveRecord::Base
   end
 
   def self.paginated_search(search, options = {})
-    limit = options.fetch(:page_limit) || 10
-    page = options.fetch(:page) || 1
-    givable.like(search).paginate({ :per_page => limit, :page => page })
+    paginate_scope! givable.like(search), options
   end
 
 private

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -43,12 +43,6 @@ class Status < ActiveRecord::Base
 
   after_save :unmark_old_default_value, :if => :is_default?
 
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-    :order => "name" }
-  }
-
   def unmark_old_default_value
     Status.update_all("is_default=#{connection.quoted_false}", ['id <> ?', id])
   end
@@ -101,10 +95,6 @@ class Status < ActiveRecord::Base
     else
       []
     end
-  end
-
-  def self.search_scope(query)
-    like(query)
   end
 
   def <=>(status)

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -64,12 +64,6 @@ class Type < ActiveRecord::Base
 
   default_scope :order => 'position ASC'
 
-  scope :like, lambda { |q|
-    s = "%#{q.to_s.strip.downcase}%"
-    { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
-    :order => "name" }
-  }
-
   scope :without_standard, conditions: { is_standard: false },
                            order: :position
 
@@ -98,10 +92,6 @@ class Type < ActiveRecord::Base
   def statuses
     return [] if new_record?
     @statuses ||= Type.statuses([id])
-  end
-
-  def self.search_scope(query)
-    like(query)
   end
 
   def enabled_in?(object)

--- a/lib/pagination/model.rb
+++ b/lib/pagination/model.rb
@@ -27,8 +27,8 @@
 #++
 
 # This module includes some boilerplate code for pagination using scopes.
-# #search_scope has to be overridden by the model itself and MUST return an
-# actual scope (i.e. scope in Rails3 or named_scope in Rails2) or its corresponding hash.
+# #search_scope may be overridden by the model to change (restrict) the search scope
+# and MUST return a scope or its corresponding hash.
 
 module Pagination::Model
 
@@ -37,6 +37,12 @@ module Pagination::Model
   end
 
   def self.extended(base)
+    base.scope :like, lambda { |q|
+      s = "%#{q.to_s.strip.downcase}%"
+      { :conditions => ["LOWER(name) LIKE :s", {:s => s}],
+      :order => "name" }
+    }
+
     base.instance_eval do
       unloadable
 
@@ -48,7 +54,7 @@ module Pagination::Model
       end
 
       def search_scope(query)
-        raise NotImplementedError, "Override in subclass #{self.name}"
+        like(query)
       end
     end
   end


### PR DESCRIPTION
When looking at https://codeclimate.com/repos/52330269f3ea006d790604fa/Project we observe that there are a lot of duplicated `:like` scopes in various OpenProject classes.

Those scopes were moved into the `Pagination` module. Also the `search_scope` methods now only needs to be defined if it differs from the default implementation.

Probably needs a good review. The travis-ci errors are due to an unrelated error in mysql-migrations.
