### PR TITLE
Remove unused planning elements routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -447,20 +447,6 @@ OpenProject::Application.routes.draw do
   end
 
   resources :projects, :only => [:index, :show], :controller => 'projects' do
-    resources :planning_elements,      :controller => 'planning_elements' do
-      collection do
-        get :all
-        delete :destroy_all
-        get :confirm_destroy_all
-      end
-
-      member do
-        get :confirm_destroy
-      end
-
-      resources :journals, :controller => 'planning_element_journals',
-                                           :only       => [:index, :create]
-    end
     resources :project_associations,   :controller => 'project_associations' do
       get :confirm_destroy, :on => :member
       get :available_projects, :on => :collection

--- a/spec/controllers/api/v2/planning_elements_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_elements_controller_spec.rb
@@ -384,7 +384,7 @@ describe Api::V2::PlanningElementsController do
       end
 
       def expect_redirect_to
-        Regexp.new(project_planning_elements_path(project))
+        Regexp.new(api_v2_project_planning_elements_path(project))
       end
       let(:permission) { :edit_work_packages }
 


### PR DESCRIPTION
The API v2 has it's own Planning Element routes, another PlanningElementsController doesn't exist any more.
