### PR TITLE
Fix/scope user visibility

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -4,9 +4,10 @@ module Api
     class UsersController < UsersController
       include ::Api::V2::ApiController
 
+      skip_filter :require_admin, :only => :index
 
       def index
-        @users = UserSearchService.new(params).search
+        @users = UserSearchService.new(params).search.visible_by(User.current)
 
         respond_to do |format|
           format.api

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -7,14 +7,13 @@ class UserSearchService
 
   def search
     scope = User
-    search = params[:ids].present? ? ids_search(scope) : query_search(scope)
-
+    params[:ids].present? ? ids_search(scope) : query_search(scope)
   end
 
   def ids_search(scope)
     ids = params[:ids].split(',')
 
-    scope.find(ids)
+    scope.where(:id => ids)
   end
 
   def query_search(scope)
@@ -38,7 +37,7 @@ class UserSearchService
       c << ["LOWER(login) LIKE ? OR LOWER(firstname) LIKE ? OR LOWER(lastname) LIKE ? OR LOWER(mail) LIKE ?", name, name, name, name]
     end
 
-    users = scope.where(c.conditions)
+    scope.where(c.conditions)
                 # currently, the sort/paging-helpers are highly dependent on being included in a controller
                 # and having access to things like the session or the params: this makes it harder
                 # to test outside a controller and especially hard to re-use this functionality

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2574` Fix: Invalid filter options and outdated names in timeline report form
 * `#2613` Old IE versions (IE 7 & IE 8) are presented a message informing about the incompatibilities.
 * `#2615` Fix board edit validations
+* `#2617` Fix: Timelines do not load users for non-admins.
 * `#2618` Fix: When issues are renamed to work packages all watcher assignments are lost
 * `#2623` [Journals] Images in journal notes are not displayed
 * `#2624` [Journals] Work package journals that migrated from legacy planning elements lack default references.


### PR DESCRIPTION
Fixes the problems described here: https://www.openproject.org/issues/2617 by allowing principals to be scoped by visibility, which, as of now, means shared membership in a project or being admin.

Ain't got no specs for the controller at the moment.
