### PR TITLE
remove usage of eval() in User#name

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -50,7 +50,7 @@ class SettingsController < ApplicationController
       redirect_to :action => 'edit', :tab => params[:tab]
     else
       @options = {}
-      @options[:user_format] = User::USER_FORMATS.keys.collect {|f| [User.current.name(f), f.to_s] }
+      @options[:user_format] = User.available_user_formats.collect {|f| [User.current.name(f), f.to_s] }
       @deliveries = ActionMailer::Base.perform_deliveries
 
       @guessed_host_and_path = request.host_with_port.dup + Redmine::Utils.relative_url_root.to_s

--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
    member_per_page = 20
 
    @members = @project.member_principals.includes(:roles, :principal, :member_roles)
-                                        .order(User::USER_FORMATS_STRUCTURE[Setting.user_format].map{|attr| attr.to_s}.join(", "))
+                                        .order(User.user_format_fields(Setting.user_format).map(&:to_s))
                                         .page(params[:page])
                                         .per_page(per_page_param)
 %>

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 # Changelog
 
 * `#2642` [Migration] Empty timelines options cannot be migrated
+* `#2645` Remove usage of  eval()
 
 ## 3.0.0pre25
 


### PR DESCRIPTION
I could not find a security issue with using `eval()` in `User#name`, however we should avoid using `eval()` whenever possible.

see: https://www.openproject.org/issues/2645
