### PR TITLE
Fix work package filter validations

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -115,11 +115,13 @@ class Query < ActiveRecord::Base
     return unless filters
 
     filters.each_key do |field|
-      errors.add label_for(field), :blank unless
-          # filter requires one or more values
-          (values_for(field) and values_for(field).first.present?) or
-          # filter doesn't require any value
-          ["o", "c", "!*", "*", "t", "w"].include? operator_for(field)
+      unless # filter requires one or more values
+            (values_for(field) and values_for(field).first.present?) or
+            # filter doesn't require any value
+            ["o", "c", "!*", "*", "t", "w"].include? operator_for(field)
+        errors.add :base, errors.full_message(WorkPackage.human_attribute_name(field),
+                                              I18n.t('activerecord.errors.messages.invalid'))
+      end
     end
   end
 

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -115,10 +115,11 @@ class Query < ActiveRecord::Base
     return unless filters
 
     filters.each_key do |field|
-      unless # filter requires one or more values
-            (values_for(field) and values_for(field).first.present?) or
-            # filter doesn't require any value
-            ["o", "c", "!*", "*", "t", "w"].include? operator_for(field)
+      unless \
+        # filter requires one or more values
+        (values_for(field) && values_for(field).first.present?) \
+        || ["o", "c", "!*", "*", "t", "w"].include?(operator_for(field))
+        # filter doesn't require any value
         errors.add :base, errors.full_message(WorkPackage.human_attribute_name(field),
                                               I18n.t('activerecord.errors.messages.invalid'))
       end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2586` Query available custom fields in REST API v2
 * `#2637` Migrated timestamps to UTC
 * Reverts `#2645` Remove usage of eval()
+* Fix work package filter query validations
 
 ## 3.0.0pre26
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -29,9 +29,9 @@
 require 'spec_helper'
 
 describe Query do
-  describe 'available_columns' do
-    let(:query) { FactoryGirl.build(:query) }
+  let(:query) { FactoryGirl.build(:query) }
 
+  describe 'available_columns' do
     context 'with work_package_done_ratio NOT disabled' do
       it 'should include the done_ratio column' do
         query.available_columns.find {|column| column.name == :done_ratio}.should be_true
@@ -48,6 +48,20 @@ describe Query do
       end
     end
 
+  end
+
+  describe '#valid?' do
+    context 'with a missing value' do
+      before do
+        query.add_filter('due_date', 't-', [''])
+      end
+
+      it 'should not be valid and create an error' do
+        expect(query.valid?).to be_false
+
+        expect(query.errors[:base].first).to include(I18n.t('activerecord.errors.messages.invalid'))
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Validations didn't work before since adding an error for a inexistent ActiveRecord field is no longer possible in Rails 3.
