### PR TITLE
downgrade delayed_job_active_record gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem "rdoc", ">= 2.4.2"
 gem "fastercsv", "~> 1.5.0", :platforms => [:ruby_18, :jruby, :mingw_18]
 # master includes the uniqueness validator, formerly patched in config/initializers/globalize3_patch.rb
 gem 'globalize3', :git => 'https://github.com/globalize/globalize.git', :branch => '3-0-stable'
-gem "delayed_job_active_record" # that's how delayed job's readme recommends it
 
 gem 'request_store'
 
@@ -71,6 +70,12 @@ gem 'oj'
 
 # will need to be removed once we are on rails4 as it will be part of the rails4 core
 gem 'strong_parameters'
+
+# we need the old Version to be compatible with pgsql 8.4
+# see: http://stackoverflow.com/questions/14862144/rake-jobswork-gives-pgerror-error-select-for-update-share-is-not-allowed-in
+# or: https://github.com/collectiveidea/delayed_job/issues/323
+gem 'delayed_job_active_record', '0.3.3'
+gem 'daemons'
 
 gem 'rack-protection'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     debugger-ruby_core_source (1.2.2)
     delayed_job (3.0.5)
       activesupport (~> 3.0)
-    delayed_job_active_record (0.4.4)
+    delayed_job_active_record (0.3.3)
       activerecord (>= 2.1.0, < 4)
       delayed_job (~> 3.0)
     diff-lcs (1.2.4)
@@ -364,10 +364,11 @@ DEPENDENCIES
   color-tools (~> 1.3.0)
   cucumber-rails
   cucumber-rails-training-wheels
+  daemons
   dalli
   database_cleaner
   date_validator
-  delayed_job_active_record
+  delayed_job_active_record (= 0.3.3)
   execjs
   factory_girl_rails (~> 4.0)
   faker


### PR DESCRIPTION
- to be compatible with pgsql 8.4
- added daemons gem to run delayed job worker
