### PR TITLE
Keyboard shortcuts: Fix j and k (were swapped compared to vim)

### DIFF
--- a/app/assets/javascripts/keyboard_shortcuts.js
+++ b/app/assets/javascripts/keyboard_shortcuts.js
@@ -168,8 +168,8 @@
   Mousetrap.bind('g p',   function(){ go_preview();          return false; });
 
   Mousetrap.bind('n w p', function(){ new_work_package();    return false; });
-  Mousetrap.bind('j',     function(){ focus_previous_item(); return false; });
-  Mousetrap.bind('k',     function(){ focus_next_item();     return false; });
+  Mousetrap.bind('j',     function(){ focus_next_item();     return false; });
+  Mousetrap.bind('k',     function(){ focus_previous_item(); return false; });
   Mousetrap.bind('m',     function(){ open_more_menu();      return false; });
 
   Mousetrap.bind('s p',   function(){ search_project();      return false; });

--- a/app/views/help/keyboard_shortcuts.erb
+++ b/app/views/help/keyboard_shortcuts.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :styles do %>
   body {
     line-height: 2em;
+    font-family: sans-serif;
   }
   kbd {
     background-color: #F2F2F2;

--- a/app/views/help/keyboard_shortcuts.erb
+++ b/app/views/help/keyboard_shortcuts.erb
@@ -72,6 +72,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <li><kbd>g</kbd> <kbd>e</kbd><%= l(:label_keyboard_shortcut_go_edit) %></li>
   <li><kbd>m</kbd><%= l(:label_keyboard_shortcut_open_more_menu) %></li>
   <li><kbd>g</kbd> <kbd>p</kbd><%= l(:label_keyboard_shortcut_go_preview) %></li>
-  <li><kbd>k</kbd><%= l(:label_keyboard_shortcut_focus_next_item) %></li>
-  <li><kbd>j</kbd><%= l(:label_keyboard_shortcut_focus_previous_item) %></li>
+  <li><kbd>j</kbd><%= l(:label_keyboard_shortcut_focus_next_item) %></li>
+  <li><kbd>k</kbd><%= l(:label_keyboard_shortcut_focus_previous_item) %></li>
 </ul>


### PR DESCRIPTION
https://www.openproject.org/issues/2304

Also use a sans-serif font for the preview.
