### PR TITLE
[FIX] Enable API access key auth for custom_field actions

### DIFF
--- a/app/controllers/api/v2/custom_fields_controller.rb
+++ b/app/controllers/api/v2/custom_fields_controller.rb
@@ -32,6 +32,8 @@ module Api
 
       include ::Api::V2::ApiController
 
+      accept_key_auth :index, :show
+
       before_filter :require_permissions
 
       def index

--- a/app/controllers/api/v2/projects_controller.rb
+++ b/app/controllers/api/v2/projects_controller.rb
@@ -36,6 +36,8 @@ module Api
       before_filter :authorize, :only => :show
       before_filter :require_permissions, :only => :planning_element_custom_fields
 
+      accept_key_auth_actions << "planning_element_custom_fields"
+
       def index
         options = {:order => 'lft'}
 

--- a/app/controllers/api/v2/projects_controller.rb
+++ b/app/controllers/api/v2/projects_controller.rb
@@ -36,7 +36,9 @@ module Api
       before_filter :authorize, :only => :show
       before_filter :require_permissions, :only => :planning_element_custom_fields
 
-      accept_key_auth_actions << "planning_element_custom_fields"
+      def self.accept_key_auth_actions
+        super + ["planning_element_custom_fields"]
+      end
 
       def index
         options = {:order => 'lft'}

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2631` Fix: [Timelines] Work package cannot be created out of timeline.
 * `#2686` Fix: [Work package tracking] Work package summary not displayed correctly
 * `#2687` Fix: [Work Package Tracking] No error for parallel editing
+* `#2708` Fix: API key auth does not work for custom_field actions
 * `#2716` Fix: Repository is not auto-created when activated in project settings
 
 ## 3.0.0pre27


### PR DESCRIPTION
Enabled authentication via API access key for:
- `/api/v2/custom_fields.:format`
- `/api/v2/custom_fields/:id.:format`
- `/api/v2/projects/:project_id/planning_element_custom_fields.:format`

Previously only basic auth worked for those.

[Issue #2708](https://www.openproject.org/issues/2708)
