### PR TITLE
Fixed multiple journal entries being created when adding

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -143,8 +143,7 @@ class WorkPackage < ActiveRecord::Base
   # test_destroying_root_projects_should_clear_data #
   # for details.                                    #
   ###################################################
-  acts_as_attachable :after_add => :attachments_changed,
-                     :after_remove => :attachments_changed
+  acts_as_attachable :after_remove => :attachments_changed
 
   after_validation :set_attachments_error_details, if: lambda {|work_package| work_package.errors.messages.has_key? :attachments}
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,6 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2687` Fix: [Work Package Tracking] No error for parallel editing
 * `#2708` Fix: API key auth does not work for custom_field actions
 * `#2716` Fix: Repository is not auto-created when activated in project settings
+* `#2717` Fix: Multiple journal entries when adding multiple attachments in one change
 
 ## 3.0.0pre27
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -166,6 +166,7 @@ describe WorkPackage do
 
       before do
         work_package.attachments << attachment
+        work_package.save!
       end
 
       context "new attachment" do


### PR DESCRIPTION
multiple attachments to a work package in a single
update

Implements https://www.openproject.org/issues/2715
