### PR TITLE
Settings: Cache whether settings table exists

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -37,6 +37,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2708` Fix: API key auth does not work for custom_field actions
 * `#2716` Fix: Repository is not auto-created when activated in project settings
 * `#2717` Fix: Multiple journal entries when adding multiple attachments in one change
+* Improve settings performance by caching whether the settings table exists
 
 ## 3.0.0pre27
 


### PR DESCRIPTION
Before, ActiveRecord executed a SQL query to check whether the table exists on each settings access.

This has a pretty high impact on controller actions accessing settings a lot. The following results show measurements for WorkPackage#index on my MacBook.

40-100 Work Packages shown (not sure any more), Core only, fix enabled around 11:41:

![screen shot 2013-11-08 at 11 50 58](https://f.cloud.github.com/assets/188986/1500060/118fe80a-486c-11e3-994e-bfb12d3a08a3.png)

500 Work Packages shown, openproject.org configuraiton, fix enabled around 12:32:

![screen shot 2013-11-08 at 12 38 32](https://f.cloud.github.com/assets/188986/1500065/36427140-486c-11e3-8a6e-beeff297ffaa.png)

The queries executed for checking whether the settings tables exist are included in the 'SQL - SHOW' time.
