### PR TITLE
do not render success message when we don't actually update a wiki menu item

### DIFF
--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -73,9 +73,12 @@ class WikiMenuItemsController < ApplicationController
       end
     end
 
-    if not @wiki_menu_item.errors.size >= 1 and (@wiki_menu_item.destroyed? or @wiki_menu_item.save)
-      flash[:notice] = l(:notice_successful_update)
-      redirect_back_or_default({ :action => 'edit', :id => @page })
+    changed = @wiki_menu_item.changed? || @wiki_menu_item.destroyed?
+    if @wiki_menu_item.save || changed
+      # we may have just destroyed a new record
+      # e.g. there was no menu_item before, and there is none now
+      flash[:notice] = l(:notice_successful_update) if (!@wiki_menu_item.new_record? && changed)
+      redirect_back_or_default({ :action => 'edit', :id => @page_title })
     else
       respond_to do |format|
         format.html { render :action => 'edit', :id => @page }

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 # Changelog
 
+* `#313`  Fix: Changing the menu title of a menu wiki page does not work
 * `#1368` Fix: Readding project members in user admin view
 * `#2653` Remove relative vertical offset corrections and custom border fixes for IE8.
 * `#2654` Remove custom font rendering/kerning as well as VML from timelines.

--- a/features/wiki_menu_items/wiki_menu_items.feature
+++ b/features/wiki_menu_items/wiki_menu_items.feature
@@ -87,6 +87,15 @@ Feature: Wiki menu items
     Then I should not see "Table of Contents" within "#main-menu"
     Then I should not see "Create new child page" within "#main-menu"
 
+    @javascript
+  Scenario: Do not change existing entry, but saving nonetheless
+    When I go to the wiki page "Wiki" for the project called "Awesome Project"
+    Then I should see "Table of Contents" within "#main-menu"
+    Then I should see "Create new child page" within "#main-menu"
+    When I click on "More functions"
+    And I click on "Configure menu item"
+    And I press "Save"
+    Then I should not see "Successful update."
 
     @javascript
   Scenario: Adding a sub menu entry


### PR DESCRIPTION
https://www.openproject.org/issues/313.
