### PR TITLE
Feature/server side session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'rack-protection'
 gem 'syck', :platforms => [:ruby_20, :mingw_20], :require => false
 
 group :production do
-  # we use dalli as standard memcache client remove this if you don't
+  # we use dalli as standard memcache client
   # requires memcached 1.4+
   # see https://github.com/mperham/dalli
   gem 'dalli'

--- a/Gemfile
+++ b/Gemfile
@@ -202,19 +202,6 @@ platforms :mri, :mingw do
   end
 end
 
-platforms :mri_18, :mingw_18 do
-  group :mysql do
-    gem "mysql"
-    #   gem "ruby-mysql"
-  end
-end
-
-platforms :mri_19, :mingw_19 do
-  group :mysql2 do
-    gem "mysql2", "~> 0.3.11"
-  end
-end
-
 platforms :jruby do
   gem "jruby-openssl"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,6 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.8.2)
     multi_test (0.0.2)
-    mysql (2.9.1)
     mysql2 (0.3.11)
     net-ldap (0.2.2)
     nokogiri (1.5.9)
@@ -387,7 +386,6 @@ DEPENDENCIES
   letter_opener (~> 1.0.0)
   mocha (~> 0.13.1)
   multi_json
-  mysql
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)
   object-daddy (~> 1.1.0)

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -131,6 +131,9 @@ default:
   # see: https://websecuritytool.codeplex.com/wikipage?title=Checks#http-cache-control-header-no-store
   # disable_browser_cache: true
 
+  # use memcache for performance, memcached must be installed
+  # rails_cache_store: :memcache
+
   # Configuration of SCM executable command.
   # Absolute path (e.g. /usr/local/bin/hg) or command name (e.g. hg.exe, bzr.exe)
   # On Windows, *.cmd, *.bat (e.g. hg.cmd, bzr.bat) does not work.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,6 +66,10 @@ OpenProject::Application.configure do
   # Send mails to browser window
   config.action_mailer.delivery_method = :letter_opener
 
-  # we use per process memory for caching in development
-  config.cache_store = :memory_store
+  # default to per process memory for caching in development
+  if OpenProject::Configuration['rails_cache_store'] == :memcache
+    config.cache_store = :dalli_store
+  else
+    config.cache_store = :memory_store
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ OpenProject::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,8 +71,10 @@ OpenProject::Application.configure do
   # Use a different logger for distributed setups
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production
-  config.cache_store = :dalli_store
+  # rails defaults to :file_store, use :dalli when :memcaches is configured in configuration.yml
+  if OpenProject::Configuration['rails_cache_store'] == :memcache
+    config.cache_store = :dalli_store
+  end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -28,8 +28,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-if Rails.env == 'production'
-  OpenProject::Application.config.session_store ActionDispatch::Session::CacheStore
-else
-  OpenProject::Application.config.session_store :cookie_store, :key => '_open_project_session'
-end
+OpenProject::Application.config.session_store ActionDispatch::Session::CacheStore

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -28,9 +28,8 @@
 
 # Be sure to restart your server when you modify this file.
 
-OpenProject::Application.config.session_store :cookie_store, :key => '_open_project_session'
-
-# Use the database for sessions instead of the cookie-based default,
-# which shouldn't be used to store highly confidential information
-# (create the session table with "rails generate session_migration")
-# OpenProject::Application.config.session_store :active_record_store
+if Rails.env == 'production'
+  OpenProject::Application.config.session_store ActionDispatch::Session::CacheStore
+else
+  OpenProject::Application.config.session_store :cookie_store, :key => '_open_project_session'
+end

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -40,6 +40,8 @@ module OpenProject
       'scm_git_command'         => nil,
       'scm_subversion_command'  => nil,
       'disable_browser_cache'   => true,
+      # default cache_store is :file_store in production and :memory_store in development
+      'rails_cache_store'       => :default,
 
       # email configuration
       'email_delivery_method' => nil,


### PR DESCRIPTION
when running a production setup, the default is to use a dalli as a memcache store (for session and everything!)

see: https://www.openproject.org/work_packages/1718
