### PR TITLE
give story_points in the api/v1 if we have them

### DIFF
--- a/app/views/api/v1/issues/index.api.rsb
+++ b/app/views/api/v1/issues/index.api.rsb
@@ -42,10 +42,11 @@ api.array :issues, api_meta(:total_count => @issues.total_entries,
       api.fixed_version(:id => issue.fixed_version_id, :name => issue.fixed_version.name) unless issue.fixed_version.nil?
       api.parent(:id => issue.parent_id) unless issue.parent.nil?
 
-      api.subject 		issue.subject
-      api.description issue.description
-      api.start_date 	issue.start_date
-      api.due_date 		issue.due_date
+      api.subject      issue.subject
+      api.description  issue.description
+      api.start_date   issue.start_date
+      api.due_date     issue.due_date
+      call_hook(:api_issue_index_attributes, :api => api, :issue => issue)
       work_package_api_done_ratio_if_enabled api, issue
       api.estimated_hours issue.estimated_hours
 


### PR DESCRIPTION
Easy and fast way to have story_pints in the API when the backlogs plugin is there.
We actually need a better API with hooks and everything. But before that we need our ci to work again.
