### PR TITLE
API v2: Improve status index performance

### DIFF
--- a/app/controllers/api/v2/statuses_controller.rb
+++ b/app/controllers/api/v2/statuses_controller.rb
@@ -44,15 +44,7 @@ module Api
       accept_key_auth :index, :show
 
       def index
-        if @project
-          @statuses = Type.statuses(@project.types.map(&:id))
-        else
-          visible_type_ids = Project.visible
-                                    .includes(:types)
-                                    .map(&:types).flatten
-                                    .map(&:id)
-          @statuses = Type.statuses(visible_type_ids)
-        end
+        @statuses = Status.all
 
         respond_to do |format|
           format.api

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -31,6 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 * `#3030` Users preferences for order of comments is ignored on wp comments
 * `#3032` Fix: Work package comments aren't editable by authors
+* API v2: Improve timelines performance by not filtering statuses by visible projects
 
 ## 3.0.0pre31
 

--- a/spec/controllers/api/v2/statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/statuses_controller_spec.rb
@@ -52,64 +52,14 @@ describe Api::V2::StatusesController do
   end
 
   describe 'looking up statuses' do
+    let!(:open) {FactoryGirl.create(:status, name: "Open")}
+    let!(:in_progress) {FactoryGirl.create(:status, name: "In Progress")}
+    let!(:closed){FactoryGirl.create(:status, name: "Closed")}
 
-    let(:open) {FactoryGirl.create(:status, name: "Open")}
-    let(:in_progress) {FactoryGirl.create(:status, name: "In Progress")}
-    let(:closed){FactoryGirl.create(:status, name: "Closed")}
-    let(:no_see_status){FactoryGirl.create(:status, name: "You don't see me.")}
+    it "should return all statuses" do
+      get 'index', :format => 'json'
 
-    let(:workflows) do
-      workflows = [FactoryGirl.create(:workflow, old_status: open, new_status: in_progress, role: role),
-                   FactoryGirl.create(:workflow, old_status: in_progress, new_status: closed, role: role)]
-    end
-
-    let(:no_see_workflows) do
-      workflows = [FactoryGirl.create(:workflow, old_status: closed, new_status: no_see_status, role: role)]
-    end
-
-    let(:project) do
-      type = FactoryGirl.create(:type, name: "Standard", workflows: workflows)
-      project = FactoryGirl.create(:project, types: [type])
-    end
-    let(:invisible_project) do
-      invisible_type = FactoryGirl.create(:type, name: "No See", workflows: no_see_workflows)
-      project = FactoryGirl.create(:project, types: [invisible_type], is_public: false)
-    end
-
-    let(:role) { FactoryGirl.create(:role) }
-    let(:member) { FactoryGirl.create(:member, :project => project,
-                                        :user => valid_user,
-                                        :roles => [role]) }
-
-
-    before do
-      member
-      workflows
-    end
-
-    describe 'with project-scope' do
-      it 'with unknown project raises ActiveRecord::RecordNotFound errors' do
-        get 'index', :project_id => '0', :format => 'json'
-        expect(response.response_code).to eql 404
-      end
-
-      it "should return the available statuses _only_ for the given project" do
-        get 'index', :project_id => project.id, :format => 'json'
-        expect(assigns(:statuses)).to include open, in_progress, closed
-        expect(assigns(:statuses)).not_to include no_see_status
-      end
-
-    end
-
-    describe 'without project-scope' do
-      it "should return only status for visible projects" do
-        # create the invisible type/workflow/status
-        invisible_project
-        get 'index', :format => 'json'
-
-        expect(assigns(:statuses)).to include open, in_progress, closed
-        expect(assigns(:statuses)).not_to include no_see_status
-      end
+      expect(assigns(:statuses)).to include open, in_progress, closed
     end
   end
 


### PR DESCRIPTION
Always return all statuses, don't filter by statuses used in visible projects.

According to @apfelfabrik it should be ok to just return all statuses instead of only the visible ones.

![screen shot 2013-11-15 at 16 55 37](https://f.cloud.github.com/assets/188986/1551296/957c88bc-4e11-11e3-8dba-99b067b6955f.png)

The change reduces the duration for a single `/api/v2/statuses.json` request on a test instance from about 6 seconds to 0.13 seconds.
