### PR TITLE
Feature/better error handling for copy project

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -327,7 +327,7 @@ class Query < ActiveRecord::Base
   end
 
   def column_names=(names)
-    if names
+    if names.present?
       names = names.inject([]) { |out, e| out += e.to_s.split(',') }
       names = names.select {|n| n.is_a?(Symbol) || !n.blank? }
       names = names.collect {|n| n.is_a?(Symbol) ? n : n.to_sym }

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -65,6 +65,8 @@ class Timeline < ActiveRecord::Base
     "compare_to_absolute",
     "compare_to_relative",
     "compare_to_relative_unit",
+    "compare_to_historical_one",
+    "compare_to_historical_two",
     "comparison",
     "exclude_empty",
     "exclude_own_planning_elements",

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -93,10 +93,13 @@ de:
       project:
         homepage: "Projekt-Homepage"
         identifier: "Kennung"
-        issues: "Tickets"
+        work_packages: "Arbeitspakete"
         parent: "Unterprojekt von"
         versions: "Versionen"
+        project_type: "Projekttyp"
+        responsible: "Planungsverantwortlicher"
         types: "Typen"
+        queries: "Abfragen"
       query:
         column_names: "Spalten"
         group_by: "Gruppiere Ergebnisse nach"
@@ -204,6 +207,7 @@ de:
         after_or_equal_to: "muss nach oder gleich %{date} sein"
         before: "muss vor %{date} sein"
         before_or_equal_to: "muss vor oder gleich %{date} sein"
+        could_not_be_copied: "konnten nicht (vollständig) kopiert werden"
       models:
         work_package:
           is_not_a_valid_target_for_time_entries: "Arbeitspaket #%{id} ist kein gültiges Ziel für die Zuordnug der Zeiterfassungseinträge."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
         project_type: "Project type"
         responsible: "Responsible"
         types: "Types"
+        queries: "Queries"
       query:
         column_names: "Columns"
         group_by: "Group results by"
@@ -204,6 +205,7 @@ en:
         after_or_equal_to: "must be after or equal to %{date}"
         before: "must be before %{date}"
         before_or_equal_to: "must be before or equal to %{date}"
+        could_not_be_copied: "could not be (fully) copied"
       models:
         project_association:
           identical_projects: "can not be created from one project to itself"

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 # Changelog
 
 * Fix position of 'more functions' menu on wp#show
+* `#3193` Fix: [Bug] Copying the project OpenProject results in 500
 
 ## 3.0.0pre33
 

--- a/lib/copy_model.rb
+++ b/lib/copy_model.rb
@@ -72,11 +72,16 @@ module CopyModel
           to_be_copied.each do |name|
             if (self.respond_to?(:"copy_#{name}") || self.private_methods.include?(:"copy_#{name}"))
               self.reload
-              self.send(:"copy_#{name}", model)
-              # Array(nil) => [], works around nil values of has_one associations
-              (Array(self.send(name)).map do |instance|
-                compiled_errors << instance.errors unless instance.valid?
-              end)
+              begin
+                self.send(:"copy_#{name}", model)
+                # Array(nil) => [], works around nil values of has_one associations
+                (Array(self.send(name)).map do |instance|
+                  compiled_errors << instance.errors unless instance.valid?
+                end)
+              rescue => e
+                errors.add(name, :could_not_be_copied)
+                e.backtrace.join("\n")
+              end
             end
           end
           self


### PR DESCRIPTION
Fixes https://www.openproject.org/work_packages/3193. As its name suggest, it also catches errors and introduces error messages when something goes wrong copying a project.
