### PR TITLE
Fix/multiple opened topmenuitems

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -105,7 +105,7 @@
     },
 
     dropdowns: function () {
-      return this.menu_container.find(" > li.drop-down");
+      return this.menu_container.find("li.drop-down");
     },
 
     withHeadingFoldOutAtBorder: function () {
@@ -261,5 +261,5 @@
 }(jQuery));
 
 jQuery(document).ready(function($) {
-  $(".account-nav").top_menu();
+  $("#top-menu-items").top_menu();
 });

--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -240,9 +240,22 @@
     }
   });
 
+  // this holds all top menus currently active.
+  // if one opens, all others are closed.
+  var top_menus = [];
   $.fn.top_menu = function () {
+    var new_menu;
     $(this).each(function () {
-      new TopMenu($(this));
+      new_menu = new TopMenu($(this));
+      top_menus.each(function (menu) {
+        menu.menu_container.on("openedMenu", function () {
+          new_menu.closing();
+        });
+        new_menu.menu_container.on("openedMenu", function () {
+          menu.closing();
+        });
+      });
+      top_menus.push(new_menu);
     });
   }
 }(jQuery));

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#3202` Fix: Fix: [Bug] Grouping work packages by responsible is broken
 * `#3222` Fix: Validation errors on copying OpenProject
 * `#2395` [Work Package Tracking] Internal Error when entering a character in a number field in a filter
+* Fix: multiple dropdowns in the top menu could be opened
 
 ## 3.0.0pre36
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#3202` Fix: Fix: [Bug] Grouping work packages by responsible is broken
 * `#3222` Fix: Validation errors on copying OpenProject
 * `#2395` [Work Package Tracking] Internal Error when entering a character in a number field in a filter
-* Fix: multiple dropdowns in the top menu could be opened
+* `#3091` Both Top menu sides can be open at the same time
 
 ## 3.0.0pre36
 


### PR DESCRIPTION
This fixes a small regression introduced by the new layout: multiple dropdowns in the top menu could be opened. There's no ticket for this atm.
