### PR TITLE
tells travis to use 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@
 
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.0
 branches:
   only:
     - dev

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 # Changelog
 
+* `#3306` Switch to Ruby 2.0
+
 ## 3.0.0pre38
 
 * `#2399` Fix: Translation missing (en and de) for not_a_valid_parent


### PR DESCRIPTION
Minimal update to ruby 2.0.

Does no longer strive to support 1.9.3.
Does not intend to update gems. See #714 for that.

OP ticket: https://www.openproject.org/work_packages/3306
