### PR TITLE
Fixes a bug with the timelines loader.

### DIFF
--- a/app/assets/javascripts/timelines/model/Project.js
+++ b/app/assets/javascripts/timelines/model/Project.js
@@ -410,7 +410,13 @@ Timeline.Project = {
       return (this.project_type !== undefined) ? this.project_type : null;
     },
     getResponsible: function() {
-      return (this.responsible !== undefined) ? this.responsible : null;
+      if (this.responsible !== undefined) {
+        return this.responsible;
+      } else if (this.responsible_id !== undefined && this.responsible_id !== null) {
+        return { "id": this.responsible_id };
+      } else {
+        return null;
+      }
     },
     getResponsibleName: function()  {
       if (this.responsible && this.responsible.name) {

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 # Changelog
 
 * `#3120` Implement a test suite the spikes can be developed against
+* `#3251` [Timelines] Filtering for Responsible filters everything
 
 ## 3.0.0pre42
 

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -328,6 +328,11 @@ Given /^the [pP]roject uses the following modules:$/ do |table|
   step %Q{the project "#{get_project}" uses the following modules:}, table
 end
 
+Given(/^the user "(.*?)" is responsible$/) do |user|
+  project = get_project
+  project.responsible_id = User.find_by_login(user).id
+  project.save
+end
 
 Given /^the [pP]roject(?: "([^\"]*)")? has the following types:$/ do |project_name, table|
   p = get_project(project_name)

--- a/features/step_definitions/timelines_when_steps.rb
+++ b/features/step_definitions/timelines_when_steps.rb
@@ -128,6 +128,18 @@ When (/^I show only work packages which have the type "(.*?)"$/) do |type|
   JavaScript
 end
 
+When (/^I show only projects which have responsible set to "(.*?)"$/) do |responsible|
+  steps %Q{
+    When I edit the settings of the current timeline
+  }
+
+  page.should have_selector("#timeline_options_project_responsibles", :visible => false)
+
+  responsible = User.find_by_login(responsible)
+  page.execute_script("jQuery('#timeline_options_project_responsibles').val('#{responsible.id}')")
+  page.execute_script("jQuery('#content form').submit()")  
+end
+
 When (/^I show only projects which have a planning element which lies between "(.*?)" and "(.*?)" and has the type "(.*?)"$/) do |start_date, due_date, type|
   steps %Q{
     When I edit the settings of the current timeline

--- a/features/timelines/timeline_view_with_reporters.feature
+++ b/features/timelines/timeline_view_with_reporters.feature
@@ -54,6 +54,11 @@ Feature: Timeline View Tests with reporters
       And there is 1 user with:
           | login | manager |
 
+      And there is 1 user with:
+          | Login     |martymcfly |
+          | Firstname | Marty     |
+          | Lastname  | McFly     |
+
       And there is a role "manager"
       And the role "manager" may have the following rights:
           | view_timelines            |
@@ -69,6 +74,7 @@ Feature: Timeline View Tests with reporters
       And I am working in project "ecookbook"
 
       And the user "manager" is a "manager"
+      And the user "martymcfly" is responsible
 
       And the project uses the following modules:
           | timelines |
@@ -122,6 +128,7 @@ Feature: Timeline View Tests with reporters
       And the project "ecookbook_q3" has the parent "ecookbook13"
       And I am working in project "ecookbook_q3"
       And the user "manager" is a "manager"
+      And the user "martymcfly" is responsible
 
       And the project uses the following modules:
           | timelines |
@@ -201,6 +208,21 @@ Feature: Timeline View Tests with reporters
       And I should see the work package "March" in the timeline
       And I should not see the work package "August" in the timeline
       And I should not see the work package "March13" in the timeline
+
+  @javascript
+  Scenario: Filter projects by responsible
+     Given I am working in the timeline "Testline" of the project called "ecookbook"
+
+     When there is a timeline "Testline" for project "ecookbook"
+      And I show only projects which have responsible set to "martymcfly"
+      And I wait for timeline to load table
+
+     Then I should see the project "ecookbook"
+      And I should see the project "ecookbook_q3"
+      And I should not see the project "ecookbook_empty"
+      And I should not see the project "ecookbook13"
+      And I should see the work package "July" in the timeline
+      And I should see the work package "August" in the timeline
 
   @javascript
   Scenario: First level grouping and sortation


### PR DESCRIPTION
Timelines loading relies on project filtering before fetching planning
elements. It also relies on fetching users based on only the required
ids from projects and planning elements.

This broke when filtering on responsibles of projects, since the filter
on users happened before users were loaded. Now, responsible filtering
of projects has a fallback on filtering based on id only, so the user
needs not be fetched.

This is an untested fix for [`#3251`](https://www.openproject.org/work_packages/3251).
