### PR TITLE
[Fix #3455] fix for missing project types tab

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -42,7 +42,7 @@ module ProjectsHelper
             {:name => 'repository', :action => :manage_repository, :partial => 'projects/settings/repository', :label => :label_repository},
             {:name => 'boards', :action => :manage_boards, :partial => 'projects/settings/boards', :label => :label_board_plural},
             {:name => 'activities', :action => :manage_project_activities, :partial => 'projects/settings/activities', :label => :enumeration_activities},
-            {:name => 'types', :action => :manage_project_configuration, :partial => 'projects/settings/types', :label => :'label_type_plural'}
+            {:name => 'types', :action => :manage_types, :partial => 'projects/settings/types', :label => :'label_type_plural'}
             ]
     tabs.select {|tab| User.current.allowed_to?(tab[:action], @project)}
   end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -31,6 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 * `#3407` Fix: [Roadmap] Missing dropdown menu for displaying work packages by different criteria
 * `#3334` [CodeClimate] Mass Assignment WikiController
+* `#3455` Fix: [Projects] Tab "Types" missing in newly created projects
 
 ## 3.0.0pre40
 * `#3066` [Work package tracking] Bulk edit causes page not found


### PR DESCRIPTION
This PR fixes [`#3455`](https://www.openproject.org/work_packages/3455). Basically just a typo in commit 825f42c.

a new permission/action was introduced for types here https://github.com/opf/openproject/blob/825f42c3b984b33b99d6b4bc5ac112bf431fb416/lib/redmine.rb#L89

but then got forgotten to be used here https://github.com/opf/openproject/blob/825f42c3b984b33b99d6b4bc5ac112bf431fb416/app/helpers/projects_helper.rb#L45
