### PR TITLE
removes no longer required permission

### DIFF
--- a/features/types/types.feature
+++ b/features/types/types.feature
@@ -48,7 +48,6 @@ Feature: Types Settings
       And the role "project admin" may have the following rights:
           | edit_project                 |
           | manage_types                 |
-          | manage_project_configuration |
       And the user "padme" is a "project admin"
 
       And I am already logged in as "padme"

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -199,8 +199,6 @@ Redmine::AccessControl.map do |map|
   map.project_module :activity
 
   map.project_module :timelines do |map|
-    map.permission :manage_project_configuration,
-                   :require => :member
     map.permission :view_project_associations,
                    {:project_associations => [:index, :show]}
     map.permission :edit_project_associations,


### PR DESCRIPTION
#762 fixed the types tab in project settings. It did so by checking for the manage_types permission instead of the manage_project_configuration permission.

As I see it, the managed_project_configuration is no longer required.

Waiting for travis to tell me I am right.
