### PR TITLE
Fix/reduce noise when running tests

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -318,7 +318,7 @@ class WorkPackagesController < ApplicationController
 
       permitted[:author] = current_user
 
-      wp = project.add_issue(permitted)
+      wp = project.add_work_package(permitted)
       wp.copy_from(params[:copy_from], :exclude => [:project_id]) if params[:copy_from]
 
       wp

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -281,11 +281,12 @@ class Query < ActiveRecord::Base
     project_clauses = []
     if project && !project.descendants.active.empty?
       ids = [project.id]
-      if has_filter?("subproject_id")
-        case operator_for("subproject_id")
+      subproject_filter = filter_for 'subproject_id'
+      if subproject_filter
+        case subproject_filter.operator
         when '='
           # include the selected subprojects
-          ids += values_for("subproject_id").each(&:to_i)
+          ids += subproject_filter.values.each(&:to_i)
         when '!*'
           # main project only
         else

--- a/app/views/queries/_filters.html.erb
+++ b/app/views/queries/_filters.html.erb
@@ -117,25 +117,26 @@ Event.observe(document,"dom:loaded", apply_filters_observer);
     </td>
     <td style="width:150px;">
         <%= label_tag "op_#{field}", l(:description_filter), :class => "hidden-for-sighted" %>
-        <%= select_tag "op[#{field}]", options_for_select(operators_for_select(options[:type]), query.operator_for(field)), :id => "operators_#{field}", :onchange => "toggle_operator('#{field}');", :class => "select-small", :style => "vertical-align: top;" %>
+        <%= select_tag "op[#{field}]", options_for_select(operators_for_select(options[:type]), query.filter_for(field).try(:operator)), :id => "operators_#{field}", :onchange => "toggle_operator('#{field}');", :class => "select-small", :style => "vertical-align: top;" %>
     </td>
     <td>
     <div id="div_values_<%= field %>" style="display:none;">
-    <% case options[:type]
+    <% field_values = query.filter_for(field).try(:values) || []
+    case options[:type]
     when :list, :list_optional, :list_status, :list_subprojects %>
-        <select <%= "multiple=true" if query.values_for(field) and query.values_for(field).length > 1 %> name="v[<%= field %>][]" id="values_<%= field %>" class="select-small" style="vertical-align: top;">
-        <%= options_for_select options[:values], query.values_for(field) %>
+        <select <%= "multiple=true" if field_values and field_values.length > 1 %> name="v[<%= field %>][]" id="values_<%= field %>" class="select-small" style="vertical-align: top;">
+        <%= options_for_select options[:values], field_values %>
         </select>
         <%= link_to_function image_tag('bullet_toggle_plus.png'), "toggle_multi_select('#{field}');", :style => "vertical-align: bottom;",
             :title => l(:label_enable_multi_select), :alt => l(:label_enable_multi_select) %>
     <% when :date, :date_past %>
-      <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 3, :class => "select-small" %>
+      <%= text_field_tag "v[#{field}][]", field_values, :id => "values_#{field}", :size => 3, :class => "select-small" %>
       <label for='<%= "values_#{field}" %>'><%= l(:label_day_plural) %></label>
     <% when :string, :text %>
-      <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 30, :class => "select-small" %>
+      <%= text_field_tag "v[#{field}][]", field_values, :id => "values_#{field}", :size => 30, :class => "select-small" %>
       <label for='<%= "values_#{field}" %>' class='hidden-for-sighted' ><%= l(:description_enter_text) %></label>
     <% when :integer %>
-      <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 3, :class => "select-small" %>
+      <%= text_field_tag "v[#{field}][]", field_values, :id => "values_#{field}", :size => 3, :class => "select-small" %>
       <label for='<%= "values_#{field}" %>' class='hidden-for-sighted' ><%= l(:description_enter_number) %></label>
     <% end %>
     </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -78,8 +78,6 @@ de:
         visible: "Sichtbar"
       custom_value:
         value: "Wert"
-      enumeration:
-        active: "Aktiv"
       relation:
         delay: "Pufferzeit"
         from: "Arbeitspaket"
@@ -272,8 +270,8 @@ de:
 
   # common attributes of all models
   attributes:
-    assigned_to: "Zugewiesen an"
     active: "Aktiv"
+    assigned_to: "Zugewiesen an"
     author: "Autor"
     base: "Allgemeiner Fehler:"
     blocks_ids: "Blockiert"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -272,6 +272,7 @@ de:
   attributes:
     active: "Aktiv"
     assigned_to: "Zugewiesen an"
+    attachments: "Anhänge"
     author: "Autor"
     base: "Allgemeiner Fehler:"
     blocks_ids: "Blockiert"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,8 +77,6 @@ en:
         visible: "Visible"
       custom_value:
         value: "Value"
-      enumeration:
-        active: "Active"
       relation:
         delay: "Delay"
         from: "Work Package"
@@ -270,8 +268,8 @@ en:
 
   # common attributes of all models
   attributes:
-    assigned_to: "Assignee"
     active: "Active"
+    assigned_to: "Assignee"
     author: "Author"
     base: "General Error:"
     blocks_ids: "Blocks"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,7 @@ en:
   attributes:
     active: "Active"
     assigned_to: "Assignee"
+    attachments: "Attachments"
     author: "Author"
     base: "General Error:"
     blocks_ids: "Blocks"

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -559,7 +559,7 @@ describe WorkPackagesController do
                                             .with(:project => stub_project)
                                             .and_return(wp_params)
 
-          stub_project.should_receive(:add_issue) do |args|
+          stub_project.should_receive(:add_work_package) do |args|
 
             expect(args[:author]).to eql stub_user
 

--- a/spec/views/api/v2/planning_element_type_colors/show_api_json_spec.rb
+++ b/spec/views/api/v2/planning_element_type_colors/show_api_json_spec.rb
@@ -57,7 +57,6 @@ describe 'api/v2/planning_element_type_colors/show.api.rabl' do
     end
 
     it 'renders the detail information about the color' do
-      puts subject
       expected_json = {name: "Awesometastic color", hexcode: '#FFFFFF', position: 10}.to_json
 
       should be_json_eql(expected_json).at_path('color')

--- a/spec/views/api/v2/project_associations/available_projects_api_json_spec.rb
+++ b/spec/views/api/v2/project_associations/available_projects_api_json_spec.rb
@@ -61,7 +61,6 @@ describe 'api/v2/project_associations/available_projects.api.rabl' do
     subject {response.body}
 
     it 'renders a list of projects available for association' do
-      puts subject
       expected_json = { name: 'Test Project A',
                         identifier: 'test_project_a',
                         level: 1,

--- a/spec/views/api/v2/reportings/index_api_json_spec.rb
+++ b/spec/views/api/v2/reportings/index_api_json_spec.rb
@@ -38,8 +38,6 @@ describe 'api/v2/reportings/index.api.rabl' do
     it 'renders an empty reportings document' do
       assign(:reportings, [])
       render
-
-      puts response.body
       response.should have_json_size(0).at_path 'reportings'
     end
   end

--- a/test/unit/mail_handler_test.rb
+++ b/test/unit/mail_handler_test.rb
@@ -39,7 +39,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     Setting.notified_events = Redmine::Notifiable.all.collect(&:name)
   end
 
-  def test_add_issue
+  def test_add_work_package
     ActionMailer::Base.deliveries.clear
     # This email contains: 'Project: onlinestore'
     issue = submit_email('ticket_on_given_project.eml', :allow_override => 'fixed_version')
@@ -70,7 +70,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert mail.subject.include?('New ticket on a given project')
   end
 
-  def test_add_issue_with_default_type
+  def test_add_work_package_with_default_type
     # This email contains: 'Project: onlinestore'
     issue = submit_email('ticket_on_given_project.eml', :issue => {:type => 'Support request'})
     assert issue.is_a?(WorkPackage)
@@ -79,7 +79,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 'Support request', issue.type.name
   end
 
-  def test_add_issue_with_status
+  def test_add_work_package_with_status
     # This email contains: 'Project: onlinestore' and 'Status: Resolved'
     issue = submit_email('ticket_on_given_project.eml')
     assert issue.is_a?(WorkPackage)
@@ -89,7 +89,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal Status.find_by_name("Resolved"), issue.status
   end
 
-  def test_add_issue_with_attributes_override
+  def test_add_work_package_with_attributes_override
     issue = submit_email('ticket_with_attributes.eml', :allow_override => 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -115,7 +115,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_with_partial_attributes_override
+  def test_add_work_package_with_partial_attributes_override
     issue = submit_email('ticket_with_attributes.eml', :issue => {:priority => 'High'}, :allow_override => ['type'])
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -129,7 +129,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert issue.description.include?('Lorem ipsum dolor sit amet, consectetuer adipiscing elit.')
   end
 
-  def test_add_issue_with_spaces_between_attribute_and_separator
+  def test_add_work_package_with_spaces_between_attribute_and_separator
     issue = submit_email('ticket_with_spaces_between_attribute_and_separator.eml', :allow_override => 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -144,7 +144,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
 
-  def test_add_issue_with_attachment_to_specific_project
+  def test_add_work_package_with_attachment_to_specific_project
     issue = submit_email('ticket_with_attachment.eml', :issue => {:project => 'onlinestore'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -160,7 +160,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 10790, issue.attachments.first.filesize
   end
 
-  def test_add_issue_with_custom_fields
+  def test_add_work_package_with_custom_fields
     issue = submit_email('ticket_with_custom_fields.eml', :issue => {:project => 'onlinestore'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -170,7 +170,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert !issue.description.match(/^searchable field:/i)
   end
 
-  def test_add_issue_should_match_assignee_on_display_name # added from redmine  - not sure if it is ok here
+  def test_add_work_package_should_match_assignee_on_display_name # added from redmine  - not sure if it is ok here
     user = User.generate!(:firstname => 'Foo', :lastname => 'Bar')
     User.add_to_project(user, Project.find(2), Role.generate!(:name => 'Superhero'))
     issue = submit_email('ticket_on_given_project.eml') do |email|
@@ -180,7 +180,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal user, issue.assigned_to
   end
 
-  def test_add_issue_with_cc
+  def test_add_work_package_with_cc
     issue = submit_email('ticket_with_cc.eml', :issue => {:project => 'ecookbook'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -189,13 +189,13 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 1, issue.watcher_user_ids.size
   end
 
-  def test_add_issue_by_unknown_user
+  def test_add_work_package_by_unknown_user
     assert_no_difference 'User.count' do
       assert_equal false, submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'ecookbook'})
     end
   end
 
-  def test_add_issue_by_anonymous_user
+  def test_add_work_package_by_anonymous_user
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
       issue = submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'ecookbook'}, :unknown_user => 'accept')
@@ -204,7 +204,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_by_anonymous_user_with_no_from_address
+  def test_add_work_package_by_anonymous_user_with_no_from_address
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
       issue = submit_email('ticket_by_empty_user.eml', :issue => {:project => 'ecookbook'}, :unknown_user => 'accept')
@@ -213,7 +213,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_by_anonymous_user_on_private_project
+  def test_add_work_package_by_anonymous_user_on_private_project
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
       assert_no_difference 'WorkPackage.count' do
@@ -222,7 +222,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_by_anonymous_user_on_private_project_without_permission_check
+  def test_add_work_package_by_anonymous_user_on_private_project_without_permission_check
     assert_no_difference 'User.count' do
       assert_difference 'WorkPackage.count' do
         issue = submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'onlinestore'}, :no_permission_check => '1', :unknown_user => 'accept')
@@ -235,12 +235,12 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_without_from_header
+  def test_add_work_package_without_from_header
     Role.anonymous.add_permission!(:add_work_packages)
     assert_equal false, submit_email('ticket_without_from_header.eml')
   end
 
-  def test_add_issue_with_invalid_attributes
+  def test_add_work_package_with_invalid_attributes
     issue = submit_email('ticket_with_invalid_attributes.eml', :allow_override => 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
@@ -253,7 +253,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert issue.description.include?('Lorem ipsum dolor sit amet, consectetuer adipiscing elit.')
   end
 
-  def test_add_issue_with_localized_attributes
+  def test_add_work_package_with_localized_attributes
     User.find_by_mail('jsmith@somenet.foo').update_attribute 'language', 'de'
     issue = submit_email('ticket_with_localized_attributes.eml', :allow_override => 'type,category,priority')
     assert issue.is_a?(WorkPackage)
@@ -268,7 +268,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert issue.description.include?('Lorem ipsum dolor sit amet, consectetuer adipiscing elit.')
   end
 
-  def test_add_issue_with_japanese_keywords
+  def test_add_work_package_with_japanese_keywords
     type = Type.create!(:name => '開発')
     Project.find(1).types << type
     issue = submit_email('japanese_keywords_iso_2022_jp.eml', :issue => {:project => 'ecookbook'}, :allow_override => 'type')
@@ -292,7 +292,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 'caaf384198bcbc9563ab5c058acd73cd', attachment.digest
   end
 
-  def test_add_issue_with_iso_8859_1_subject
+  def test_add_work_package_with_iso_8859_1_subject
     issue = submit_email(
               'subject_as_iso-8859-1.eml',
               :issue => {:project => 'ecookbook'}
@@ -334,7 +334,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_add_issue_should_send_email_notification
+  def test_add_work_package_should_send_email_notification
     Setting.notified_events = ['issue_added']
     ActionMailer::Base.deliveries.clear
     # This email contains: 'Project: onlinestore'
@@ -343,7 +343,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 1, ActionMailer::Base.deliveries.size
   end
 
-  def test_add_issue_note
+  def test_add_work_package_note
     journal = submit_email('ticket_reply.eml')
     assert journal.is_a?(Journal)
     assert_equal User.find_by_login('jsmith'), journal.user
@@ -366,7 +366,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 'Feature request', journal.journable.type.name
   end
 
-  def test_add_issue_note_with_attribute_changes
+  def test_add_work_package_note_with_attribute_changes
     WorkPackage.find(2).recreate_initial_journal!
     # This email contains: 'Status: Resolved'
     journal = submit_email('ticket_reply_with_status.eml')
@@ -386,7 +386,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert !journal.notes.match(/^Start Date:/i)
   end
 
-  def test_add_issue_note_should_send_email_notification
+  def test_add_work_package_note_should_send_email_notification
     WorkPackage.find(2).recreate_initial_journal!
     ActionMailer::Base.deliveries.clear
     journal = submit_email('ticket_reply.eml')
@@ -394,7 +394,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 3, ActionMailer::Base.deliveries.size
   end
 
-  def test_add_issue_note_should_not_set_defaults
+  def test_add_work_package_note_should_not_set_defaults
     journal = submit_email('ticket_reply.eml', :issue => {:type => 'Support request', :priority => 'High'})
     assert journal.is_a?(Journal)
     assert_match /This is reply/, journal.notes

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -54,7 +54,7 @@ class VersionTest < ActiveSupport::TestCase
         (v = Version.new.tap do |v|
           v.force_attributes = { :project => project, :name => 'Progress' }
         end).save!
-        add_issue(v, :estimated_hours => 10, :start_date => '2010-03-01')
+        add_work_package(v, :estimated_hours => 10, :start_date => '2010-03-01')
         FactoryGirl.create(:work_package, project: project, :subject => 'not assigned', :start_date => '2010-01-01')
 
         assert_equal '2010-03-01', v.start_date.to_s
@@ -68,7 +68,7 @@ class VersionTest < ActiveSupport::TestCase
           v.force_attributes = { :project => project, :name => 'Progress', :start_date => '2010-01-05' }
         end).save!
 
-        add_issue(v, :estimated_hours => 10, :start_date => '2010-03-01')
+        add_work_package(v, :estimated_hours => 10, :start_date => '2010-03-01')
 
         assert_equal '2010-01-05', v.start_date.to_s
       end
@@ -91,8 +91,8 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v)
-    add_issue(v, :done_ratio => 0)
+    add_work_package(v)
+    add_work_package(v, :done_ratio => 0)
     assert_progress_equal 0, v.completed_pourcent
     assert_progress_equal 0, v.closed_pourcent
   end
@@ -103,10 +103,10 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v, :status => status)
-    add_issue(v, :status => status, :done_ratio => 20)
-    add_issue(v, :status => status, :done_ratio => 70, :estimated_hours => 25)
-    add_issue(v, :status => status, :estimated_hours => 15)
+    add_work_package(v, :status => status)
+    add_work_package(v, :status => status, :done_ratio => 20)
+    add_work_package(v, :status => status, :done_ratio => 70, :estimated_hours => 25)
+    add_work_package(v, :status => status, :estimated_hours => 15)
     assert_progress_equal 100.0, v.completed_pourcent
     assert_progress_equal 100.0, v.closed_pourcent
   end
@@ -116,9 +116,9 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v)
-    add_issue(v, :done_ratio => 20)
-    add_issue(v, :done_ratio => 70)
+    add_work_package(v)
+    add_work_package(v, :done_ratio => 20)
+    add_work_package(v, :done_ratio => 70)
     assert_progress_equal (0.0 + 20.0 + 70.0)/3, v.completed_pourcent
     assert_progress_equal 0, v.closed_pourcent
   end
@@ -128,9 +128,9 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v)
-    add_issue(v, :done_ratio => 20)
-    add_issue(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
+    add_work_package(v)
+    add_work_package(v, :done_ratio => 20)
+    add_work_package(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
     assert_progress_equal (0.0 + 20.0 + 100.0)/3, v.completed_pourcent
     assert_progress_equal (100.0)/3, v.closed_pourcent
   end
@@ -140,10 +140,10 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v, :estimated_hours => 10)
-    add_issue(v, :estimated_hours => 20, :done_ratio => 30)
-    add_issue(v, :estimated_hours => 40, :done_ratio => 10)
-    add_issue(v, :estimated_hours => 25, :status => Status.find(:first, :conditions => {:is_closed => true}))
+    add_work_package(v, :estimated_hours => 10)
+    add_work_package(v, :estimated_hours => 20, :done_ratio => 30)
+    add_work_package(v, :estimated_hours => 40, :done_ratio => 10)
+    add_work_package(v, :estimated_hours => 25, :status => Status.find(:first, :conditions => {:is_closed => true}))
     assert_progress_equal (10.0*0 + 20.0*0.3 + 40*0.1 + 25.0*1)/95.0*100, v.completed_pourcent
     assert_progress_equal 25.0/95.0*100, v.closed_pourcent
   end
@@ -153,10 +153,10 @@ class VersionTest < ActiveSupport::TestCase
     (v = Version.new.tap do |v|
       v.force_attributes = { :project => project, :name => 'Progress' }
     end).save!
-    add_issue(v, :done_ratio => 20)
-    add_issue(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
-    add_issue(v, :estimated_hours => 10, :done_ratio => 30)
-    add_issue(v, :estimated_hours => 40, :done_ratio => 10)
+    add_work_package(v, :done_ratio => 20)
+    add_work_package(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
+    add_work_package(v, :estimated_hours => 10, :done_ratio => 30)
+    add_work_package(v, :estimated_hours => 40, :done_ratio => 10)
     assert_progress_equal (25.0*0.2 + 25.0*1 + 10.0*0.3 + 40.0*0.1)/100.0*100, v.completed_pourcent
     assert_progress_equal 25.0/100.0*100, v.closed_pourcent
   end
@@ -225,20 +225,20 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "return 0 with no estimated hours" do
-      add_issue(@version)
+      add_work_package(@version)
       assert_equal 0, @version.estimated_hours
     end
 
     should "return the sum of estimated hours" do
-      add_issue(@version, :estimated_hours => 2.5)
-      add_issue(@version, :estimated_hours => 5)
+      add_work_package(@version, :estimated_hours => 2.5)
+      add_work_package(@version, :estimated_hours => 5)
       assert_equal 7.5, @version.estimated_hours
     end
 
     should "return the sum of leaves estimated hours" do
-      parent = add_issue(@version)
-      add_issue(@version, :estimated_hours => 2.5, :parent_id => parent.id)
-      add_issue(@version, :estimated_hours => 5, :parent_id => parent.id)
+      parent = add_work_package(@version)
+      add_work_package(@version, :estimated_hours => 2.5, :parent_id => parent.id)
+      add_work_package(@version, :estimated_hours => 5, :parent_id => parent.id)
       assert_equal 7.5, @version.estimated_hours
     end
   end
@@ -280,7 +280,7 @@ class VersionTest < ActiveSupport::TestCase
 
   private
 
-  def add_issue(version, attributes={})
+  def add_work_package(version, attributes={})
     (v = WorkPackage.new.tap do |v|
       v.force_attributes = { :project => version.project,
                              :fixed_version => version,


### PR DESCRIPTION
- fix translation warning, by adding an general 'attachments' translation for our models
- do not use the deperecate methods `Query#values_for` and `Query#operator_for` anymore
- remove `puts` statements, which were forgotten in some specs
- sorted some translations (which did not change any test output :))
