### PR TITLE
require syck for ruby 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'daemons'
 
 gem 'rack-protection'
 
-gem 'syck', :platforms => [:ruby_20, :mingw_20], :require => false
+gem 'syck', :platforms => [:ruby_20, :mingw_20, :ruby_21, :mingw_21], :require => false
 
 group :production do
   # we use dalli as standard memcache client


### PR DESCRIPTION
we need to syck for ruby 2.1 as well, otherwise things fail...

currently this is the official way to declare multiple platform depedencies with bundler, see https://github.com/bundler/bundler/pull/2647
