### PR TITLE
Fix rake cucumber:plugins when being run with RAILS_ENV=test

### DIFF
--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -51,11 +51,14 @@ begin
       ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
     end
 
-    def get_plugin_features(prefix = '')
+    def get_plugin_features(prefix = nil)
       features = []
       Rails.application.config.plugins_to_test_paths.each do |dir|
         feature_dir = Shellwords.escape(File.join(dir, 'features'))
-        features += [prefix, feature_dir] if File.directory?(feature_dir)
+        if File.directory?(feature_dir)
+          features << prefix unless prefix.nil?
+          features << feature_dir
+        end
       end
       features
     end


### PR DESCRIPTION
The rake task previously gave empty arguments to cucumber, which
cucumber doesn't like.

The following is my theory on why this works when the rake task is
started in a non-test environment. In the test environment, cucumber
is set to not fork for startup performance. When forking, parameters
are given to cucumber in another way (as command line parameters) and
possibly processed differently. This results in the empty arguments
being skipped, while when not forking these empty arguments are
treated as feature folders that can't be found obviously.

With this fix the empty arguments are not given to cucumber.
