### PR TITLE
Renaming Issue tracking to Work package tracking

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -494,14 +494,14 @@ function setVisible(id, visible) {
 
 function observeProjectModules() {
   var f = function() {
-    /* Hides types and issues custom fields on the new project form when issue_tracking module is disabled */
-    var c = ($('project_enabled_module_names_issue_tracking').checked == true);
+    /* Hides types and issues custom fields on the new project form when work_package_tracking module is disabled */
+    var c = ($('project_enabled_module_names_work_package_tracking').checked == true);
     setVisible('project_types', c);
     setVisible('project_issue_custom_fields', c);
   };
 
   Event.observe(window, 'load', f);
-  Event.observe('project_enabled_module_names_issue_tracking', 'change', f);
+  Event.observe('project_enabled_module_names_work_package_tracking', 'change', f);
 }
 
 /*

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render :partial => "projects/form/modules", :locals => { :project => project } %>
 <% end %>
 
-<% if (project.new_record? || project.module_enabled?('issue_tracking')) %>
+<% if (project.new_record? || project.module_enabled?('work_package_tracking')) %>
   <% if renderTypes %>
     <fieldset class="box" id="project_types"><legend><%=l(:label_type_plural)%> <span style="font-size:0.9em">(<%= check_all_links 'project_types' %>)</span></legend>
       <%= render :partial => 'projects/form/types', :locals => { :f => f, :project => project } %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -199,7 +199,7 @@ default_projects_modules:
   default:
   - boards
   - calendar
-  - issue_tracking
+  - work_package_tracking
   - news
   - repository
   - time_tracking

--- a/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
+++ b/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
@@ -1,0 +1,12 @@
+class RenameModulenameIssueTracking < ActiveRecord::Migration
+  def up
+    update <<-SQL
+      UPDATE enabled_modules
+      SET name = 'work_package_tracking'
+      WHERE name = 'issue_tracking';
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
+++ b/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
@@ -8,5 +8,10 @@ class RenameModulenameIssueTracking < ActiveRecord::Migration
   end
 
   def down
+    update <<-SQL
+      UPDATE enabled_modules
+      SET name = 'issue_tracking'
+      WHERE name = 'work_package_tracking';
+    SQL
   end
 end

--- a/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
+++ b/db/migrate/20140121121616_rename_modulename_issue_tracking.rb
@@ -1,3 +1,32 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 class RenameModulenameIssueTracking < ActiveRecord::Migration
   def up
     update <<-SQL
@@ -5,6 +34,7 @@ class RenameModulenameIssueTracking < ActiveRecord::Migration
       SET name = 'work_package_tracking'
       WHERE name = 'issue_tracking';
     SQL
+    Setting['default_projects_modules']= Setting['default_projects_modules'].map {|m| m.gsub("issue_tracking","work_package_tracking")}
   end
 
   def down
@@ -13,5 +43,6 @@ class RenameModulenameIssueTracking < ActiveRecord::Migration
       SET name = 'issue_tracking'
       WHERE name = 'work_package_tracking';
     SQL
+    Setting['default_projects_modules']= Setting['default_projects_modules'].map {|m| m.gsub("work_package_tracking","issue_tracking")}
   end
 end

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -97,7 +97,7 @@ Redmine::AccessControl.map do |map|
                                   :members => [:paginate_users]
                                  }, :require => :member
 
-  map.project_module :issue_tracking do |map|
+  map.project_module :work_package_tracking do |map|
     # Issue categories
     map.permission :manage_categories, {:projects => :settings, :categories => [:new, :create, :edit, :update, :destroy]}, :require => :member
     # Issues

--- a/test/fixtures/enabled_modules.yml
+++ b/test/fixtures/enabled_modules.yml
@@ -28,7 +28,7 @@
 
 ---
 enabled_modules_001:
-  name: issue_tracking
+  name: work_package_tracking
   project_id: 1
   id: 1
 enabled_modules_002:
@@ -60,7 +60,7 @@ enabled_modules_010:
   project_id: 3
   id: 10
 enabled_modules_011:
-  name: issue_tracking
+  name: work_package_tracking
   project_id: 2
   id: 11
 enabled_modules_012:
@@ -68,11 +68,11 @@ enabled_modules_012:
   project_id: 3
   id: 12
 enabled_modules_013:
-  name: issue_tracking
+  name: work_package_tracking
   project_id: 3
   id: 13
 enabled_modules_014:
-  name: issue_tracking
+  name: work_package_tracking
   project_id: 5
   id: 14
 enabled_modules_015:

--- a/test/fixtures/files/140121133909_testfile.txt
+++ b/test/fixtures/files/140121133909_testfile.txt
@@ -1,0 +1,2 @@
+this is a text file for upload tests
+with multiple lines

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -167,7 +167,7 @@ class ProjectsControllerTest < ActionController::TestCase
             :type_ids => ['1', '3'],
             # an issue custom field that is not for all project
             :work_package_custom_field_ids => ['9'],
-            :enabled_module_names => ['issue_tracking', 'news', 'repository']
+            :enabled_module_names => ['work_package_tracking', 'news', 'repository']
           }
         assert_redirected_to '/projects/blog/settings'
 
@@ -180,7 +180,7 @@ class ProjectsControllerTest < ActionController::TestCase
         assert_nil project.parent
         assert_equal 'Beta', project.custom_value_for(3).value
         assert_equal [1, 3], project.types.map(&:id).sort
-        assert_equal ['issue_tracking', 'news', 'repository'], project.enabled_module_names.sort
+        assert_equal ['news', 'repository', 'work_package_tracking'], project.enabled_module_names.sort
         assert project.work_package_custom_fields.include?(WorkPackageCustomField.find(9))
       end
 
@@ -213,7 +213,7 @@ class ProjectsControllerTest < ActionController::TestCase
                                  :is_public => 1,
                                  :custom_field_values => { '3' => 'Beta' },
                                  :type_ids => ['1', '3'],
-                                 :enabled_module_names => ['issue_tracking', 'news', 'repository']
+                                 :enabled_module_names => ['work_package_tracking', 'news', 'repository']
                                 }
 
         assert_redirected_to '/projects/blog/settings'
@@ -223,7 +223,7 @@ class ProjectsControllerTest < ActionController::TestCase
         assert_equal 'weblog', project.description
         assert_equal true, project.is_public?
         assert_equal [1, 3], project.types.map(&:id).sort
-        assert_equal ['issue_tracking', 'news', 'repository'], project.enabled_module_names.sort
+        assert_equal ['news', 'repository', 'work_package_tracking'], project.enabled_module_names.sort
 
         # User should be added as a project member
         assert User.find(9).member_of?(project)
@@ -301,18 +301,18 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   def test_create_should_preserve_modules_on_validation_failure
-    with_settings :default_projects_modules => ['issue_tracking', 'repository'] do
+    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
       @request.session[:user_id] = 1
       assert_no_difference 'Project.count' do
         post :create, :project => {
           :name => "blog",
           :identifier => "",
-          :enabled_module_names => %w(issue_tracking news)
+          :enabled_module_names => %w(work_package_tracking news)
         }
       end
       assert_response :success
       project = assigns(:project)
-      assert_equal %w(issue_tracking news), project.enabled_module_names.sort
+      assert_equal %w(news work_package_tracking), project.enabled_module_names.sort
     end
   end
 
@@ -396,11 +396,11 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_modules
     @request.session[:user_id] = 2
-    Project.find(1).enabled_module_names = ['issue_tracking', 'news']
+    Project.find(1).enabled_module_names = ['work_package_tracking', 'news']
 
-    put :modules, :id => 1, :enabled_module_names => ['issue_tracking', 'repository']
+    put :modules, :id => 1, :enabled_module_names => ['work_package_tracking', 'repository']
     assert_redirected_to '/projects/ecookbook/settings/modules'
-    assert_equal ['issue_tracking', 'repository'], Project.find(1).enabled_module_names.sort
+    assert_equal ['repository', 'work_package_tracking'], Project.find(1).enabled_module_names.sort
   end
 
   def test_get_destroy_info

--- a/test/integration/api_test/projects_test.rb
+++ b/test/integration/api_test/projects_test.rb
@@ -112,7 +112,7 @@ class ApiTest::ProjectsTest < ActionDispatch::IntegrationTest
   context "POST /api/v1/projects" do
     context "with valid parameters" do
       setup do
-        Setting.default_projects_modules = ['issue_tracking', 'repository']
+        Setting.default_projects_modules = ['work_package_tracking', 'repository']
         @parameters = {:project => {:name => 'API test', :identifier => 'api-test'}}
       end
 
@@ -131,7 +131,7 @@ class ApiTest::ProjectsTest < ActionDispatch::IntegrationTest
           project = Project.first(:order => 'id DESC')
           assert_equal 'API test', project.name
           assert_equal 'api-test', project.identifier
-          assert_equal ['issue_tracking', 'repository'], project.enabled_module_names.sort
+          assert_equal ['repository', 'work_package_tracking'], project.enabled_module_names.sort
           assert_equal Type.all.size, project.types.size
 
           assert_response :created
@@ -140,14 +140,14 @@ class ApiTest::ProjectsTest < ActionDispatch::IntegrationTest
         end
 
         should "accept enabled_module_names attribute" do
-          @parameters[:project].merge!({:enabled_module_names => ['issue_tracking', 'news', 'time_tracking']})
+          @parameters[:project].merge!({:enabled_module_names => ['work_package_tracking', 'news', 'time_tracking']})
 
           assert_difference('Project.count') do
             post '/api/v1/projects.xml', @parameters, credentials('admin')
           end
 
           project = Project.first(:order => 'id DESC')
-          assert_equal ['issue_tracking', 'news', 'time_tracking'], project.enabled_module_names.sort
+          assert_equal ['news', 'time_tracking', 'work_package_tracking'], project.enabled_module_names.sort
         end
 
         should "accept type_ids attribute" do
@@ -205,14 +205,14 @@ class ApiTest::ProjectsTest < ActionDispatch::IntegrationTest
         end
 
         should "accept enabled_module_names attribute" do
-          @parameters[:project].merge!({:enabled_module_names => ['issue_tracking', 'news', 'time_tracking']})
+          @parameters[:project].merge!({:enabled_module_names => ['work_package_tracking', 'news', 'time_tracking']})
 
           assert_no_difference 'Project.count' do
             put '/api/v1/projects/2.xml', @parameters, credentials('admin')
           end
           assert_response :ok
           project = Project.find(2)
-          assert_equal ['issue_tracking', 'news', 'time_tracking'], project.enabled_module_names.sort
+          assert_equal ['news', 'time_tracking', 'work_package_tracking'], project.enabled_module_names.sort
         end
 
         should "accept type_ids attribute" do

--- a/test/unit/lib/redmine/access_control_test.rb
+++ b/test/unit/lib/redmine/access_control_test.rb
@@ -44,7 +44,7 @@ class Redmine::AccessControlTest < ActiveSupport::TestCase
     perm = @access_module.permission(:view_work_packages)
     assert perm.is_a?(Redmine::AccessControl::Permission)
     assert_equal :view_work_packages, perm.name
-    assert_equal :issue_tracking, perm.project_module
+    assert_equal :work_package_tracking, perm.project_module
     assert perm.actions.is_a?(Array)
     assert perm.actions.include?('issues/index')
   end

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -93,8 +93,8 @@ class ProjectTest < ActiveSupport::TestCase
       assert !Project.new(:identifier => 'test').blank?
     end
 
-    with_settings :default_projects_modules => ['issue_tracking', 'repository'] do
-      assert_equal ['issue_tracking', 'repository'], Project.new.enabled_module_names
+    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
+      assert_equal ['work_package_tracking', 'repository'], Project.new.enabled_module_names
     end
 
     assert_equal Type.all, Project.new.types
@@ -627,11 +627,11 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_enabled_module_names
-    with_settings :default_projects_modules => ['issue_tracking', 'repository'] do
+    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
       project = Project.new
 
-      project.enabled_module_names = %w(issue_tracking news)
-      assert_equal %w(issue_tracking news), project.enabled_module_names.sort
+      project.enabled_module_names = %w(work_package_tracking news)
+      assert_equal %w(news work_package_tracking), project.enabled_module_names.sort
     end
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -436,14 +436,14 @@ class UserTest < ActiveSupport::TestCase
 
       should "return false if related module is disabled" do
         project = Project.find(1)
-        project.enabled_module_names = ["issue_tracking"]
+        project.enabled_module_names = ["work_package_tracking"]
         assert @admin.allowed_to?(:add_work_packages, project)
         assert ! @admin.allowed_to?(:view_wiki_pages, project)
       end
 
       should "authorize nearly everything for admin users" do
         project = Project.find(1)
-        project.enabled_module_names = ["issue_tracking", "news", "wiki", "repository"]
+        project.enabled_module_names = ["work_package_tracking", "news", "wiki", "repository"]
         assert ! @admin.member_of?(project)
         %w(edit_work_packages delete_work_packages manage_news manage_repository manage_wiki).each do |p|
           assert @admin.allowed_to?(p.to_sym, project)
@@ -459,7 +459,7 @@ class UserTest < ActiveSupport::TestCase
 
       should "only managers are allowed to export tickets" do
         project = Project.find(1)
-        project.enabled_module_names = ["issue_tracking"]
+        project.enabled_module_names = ["work_package_tracking"]
         assert @jsmith.allowed_to?(:export_work_packages, project)    #Manager
         assert ! @dlopper.allowed_to?(:export_work_packages, project) #Developper
       end
@@ -472,7 +472,7 @@ class UserTest < ActiveSupport::TestCase
 
       should "return true only if user has permission on all these projects" do
         Project.all.each do |project|
-          project.enabled_module_names = ["issue_tracking"]
+          project.enabled_module_names = ["work_package_tracking"]
           project.save!
         end
 


### PR DESCRIPTION
With and without my changes, locally I get 8 errors in test/functional/attachments_controller_test.rb. So please be sure to check this pull request at travis! It does not seem to included automatically to the travis queue since i forked the repository this time. 

This is a fix for: https://www.openproject.org/work_packages/3967
