### PR TITLE
Fix asset precompilation with empty database

### DIFF
--- a/app/assets/javascripts/specific/main_menu.js.erb
+++ b/app/assets/javascripts/specific/main_menu.js.erb
@@ -4,7 +4,7 @@ jQuery(document).ready(function($) {
   // rejigger the main-menu sub-menu functionality.
   $("#main-menu .toggler").remove(); // remove the togglers so they're inserted properly later.
 
-  var toggler = $('<a class="toggler"><%= icon_wrapper("icon6 icon-toggler icon-arrow-right5-2", I18n.t("description_menu_item_toggle")) %></a>')
+  var toggler = $('<a class="toggler"><span class="icon6 icon-toggler icon-arrow-right5-2"/><span class="hidden-for-sighted">' + I18n.t("label_menu_item_toggle") + '</span></a>')
     .click(function(event) {
       var target = $(this);
 

--- a/app/assets/javascripts/specific/main_menu.js.erb
+++ b/app/assets/javascripts/specific/main_menu.js.erb
@@ -1,10 +1,8 @@
-<% environment.context_class.instance_eval { include ApplicationHelper } %>
-
 jQuery(document).ready(function($) {
   // rejigger the main-menu sub-menu functionality.
   $("#main-menu .toggler").remove(); // remove the togglers so they're inserted properly later.
 
-  var toggler = $('<a class="toggler"><span class="icon6 icon-toggler icon-arrow-right5-2"/><span class="hidden-for-sighted">' + I18n.t("label_menu_item_toggle") + '</span></a>')
+  var toggler = $('<a class="toggler"><span class="icon6 icon-toggler icon-arrow-right5-2"/><span class="hidden-for-sighted">' + I18n.t("js.label_menu_item_toggle") + '</span></a>')
     .click(function(event) {
       var target = $(this);
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -473,7 +473,6 @@ de:
   description_filter: "Filter"
   description_filter_toggle: "Filter aus/einblenden"
   description_category_reassign: "Neue Kategorie wählen"
-  description_menu_item_toggle: "Untermenüpunkte ein-/ausblenden"
   description_message_content: "Nachrichteninhalt"
   description_my_project: "Sie sind Mitglied"
   description_notes: "Kommentare"
@@ -586,6 +585,7 @@ de:
       noneSelection: "(keine)"
     label_collapse_all: "Alle zuklappen"
     label_expand_all: "Alle aufklappen"
+    label_menu_item_toggle: "Untermenüpunkte ein-/ausblenden"
 
   label_account: "Konto"
   label_activity: "Aktivität"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,7 +470,6 @@ en:
   description_filter: "Filter"
   description_filter_toggle: "Show/Hide filter"
   description_category_reassign: "Choose category"
-  description_menu_item_toggle: "Show/hide submenu items"
   description_message_content: "Message content"
   description_my_project: "You are member"
   description_notes: "Notes"
@@ -583,6 +582,7 @@ en:
       noneSelection: "(none)"
     label_collapse_all: "Collapse all"
     label_expand_all: "Expand all"
+    label_menu_item_toggle: "Show/hide submenu items"
 
   label_account: "Account"
   label_activity: "Activity"


### PR DESCRIPTION
Asset precompilation previously aborted with a "Table users does not
exist". My explanation for this is the "include ApplicationHelper" in
main_menu.js.rb includes an image_path method via ApplicationHelper in
the context_class, which previously had another image_path method (or
somehow catched the error on a non-existent method). The image_path
method from view_helpers.rb (included via ApplicationHelper) calls
current_theme, which in turn calls User.current. User.current the
tries to create an anonymous user, which obviously fails when running
asset:precompile on an empty databse without tables.

Not including the ApplicationHelper solves this problem.
