### PR TITLE
remove mocking framework 'mocha'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,6 @@ gem "i18n-js", :git => "https://github.com/fnando/i18n-js.git", :ref => '8801f8d
 group :test do
   gem 'shoulda'
   gem 'object-daddy', '~> 1.1.0'
-  gem 'mocha', '~> 0.13.1', :require => false
   gem "launchy", "~> 2.3.0"
   gem "factory_girl_rails", "~> 4.0"
   gem 'cucumber-rails', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,6 @@ DEPENDENCIES
   json_spec
   launchy (~> 2.3.0)
   letter_opener (~> 1.0.0)
-  mocha (~> 0.13.1)
   multi_json
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#4024` [Accessibility] Add proper page titles for sub pages
 * `#4090` 'Session Expires' setting breaks API
 * News subject contained in URL
+* Removes mocha mocking framework.
 
 ## 3.0.0pre44
 

--- a/lib/plugins/acts_as_journalized/test/reset_test.rb
+++ b/lib/plugins/acts_as_journalized/test/reset_test.rb
@@ -73,7 +73,7 @@ class ResetTest < Test::Unit::TestCase
       end
 
       should 'not destroy all journals after the target journal' do
-        VestalVersions::Version.any_instance.stubs(:destroy).raises(RuntimeError)
+        VestalVersions::Version.any_instance.stub(:destroy).and_raise(RuntimeError)
         @journals.reverse.each do |journal|
           assert_nothing_raised do
             @user.reset_to!(journal)
@@ -100,7 +100,7 @@ class ResetTest < Test::Unit::TestCase
       end
 
       should 'destroy all journals after the target journal' do
-        VestalVersions::Version.any_instance.stubs(:destroy).raises(RuntimeError)
+        VestalVersions::Version.any_instance.stub(:destroy).and_raise(RuntimeError)
         @journals.reverse.each do |journal|
           later_journals = @user.journals.after(journal)
           if later_journals.empty?

--- a/lib/plugins/acts_as_journalized/test/test_helper.rb
+++ b/lib/plugins/acts_as_journalized/test/test_helper.rb
@@ -34,7 +34,6 @@ require 'rubygems'
 require 'test/unit'
 require 'active_record'
 require 'shoulda'
-require 'mocha/setup'
 require 'vestal_versions'
 require 'schema'
 begin; require 'redgreen'; rescue LoadError; end

--- a/lib/plugins/dynamic_form/test/dynamic_form_i18n_test.rb
+++ b/lib/plugins/dynamic_form/test/dynamic_form_i18n_test.rb
@@ -8,35 +8,35 @@ class DynamicFormI18nTest < Test::Unit::TestCase
 
   def setup
     @object = stub :errors => stub(:count => 1, :full_messages => ['full_messages'])
-    @object.stubs :to_model => @object
-    @object.stubs :class => stub(:model_name => stub(:human => ""))
+    @object.stub :to_model => @object
+    @object.stub :class => stub(:model_name => stub(:human => ""))
 
     @object_name = 'book_seller'
     @object_name_without_underscore = 'book seller'
 
-    stubs(:content_tag).returns 'content_tag'
+    stub(:content_tag).and_return 'content_tag'
 
-    I18n.stubs(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').returns "1 error prohibited this  from being saved"
-    I18n.stubs(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).returns 'There were problems with the following fields:'
+    I18n.stub(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').and_return "1 error prohibited this  from being saved"
+    I18n.stub(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).and_return 'There were problems with the following fields:'
   end
 
   def test_error_messages_for_given_a_header_option_it_does_not_translate_header_message
-    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').never
+    I18n.should_receive(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').never
     error_messages_for(:object => @object, :header_message => 'header message', :locale => 'en')
   end
 
   def test_error_messages_for_given_no_header_option_it_translates_header_message
-    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').returns 'header message'
+    I18n.should_receive(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').and_return 'header message'
     error_messages_for(:object => @object, :locale => 'en')
   end
 
   def test_error_messages_for_given_a_message_option_it_does_not_translate_message
-    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).never
+    I18n.should_receive(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).never
     error_messages_for(:object => @object, :message => 'message', :locale => 'en')
   end
 
   def test_error_messages_for_given_no_message_option_it_translates_message
-    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).returns 'There were problems with the following fields:'
+    I18n.should_receive(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).and_return 'There were problems with the following fields:'
     error_messages_for(:object => @object, :locale => 'en')
   end
 end

--- a/lib/plugins/verification/test/test_helper.rb
+++ b/lib/plugins/verification/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'test/unit'
 require 'active_support'
 require 'action_controller'
-require 'mocha/setup'
 
 require File.dirname(__FILE__) + '/../lib/action_controller/verification'
 

--- a/lib/plugins/verification/test/verification_test.rb
+++ b/lib/plugins/verification/test/verification_test.rb
@@ -270,7 +270,7 @@ class VerificationTest < ActionController::TestCase
   
   def test_guarded_http_method_respects_overwritten_request_method
     # Overwrite http method on application level like Rails supports via sending a _method parameter
-    @request.stubs(:request_method).returns('POST')
+    @request.stub(:request_method).and_return('POST')
 
     put :must_be_post
     assert_equal "Was a post!", @response.body

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -165,7 +165,7 @@ describe ApplicationHelper do
     before do
       @project = project
 
-      User.stubs(:current).returns(project_member)
+      User.stub(:current).and_return(project_member)
 
       Setting.enabled_scm = Setting.enabled_scm << "Filesystem" unless Setting.enabled_scm.include? "Filesystem"
     end

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -58,7 +58,7 @@ class AccountControllerTest < ActionController::TestCase
   end
 
   def test_login_should_reset_session
-    @controller.expects(:reset_session).once
+    @controller.should_receive(:reset_session).once
 
     post :login, :username => 'jsmith', :password => 'jsmith'
     assert_response 302
@@ -181,7 +181,7 @@ class AccountControllerTest < ActionController::TestCase
   end
 
   def test_logout_should_reset_session
-    @controller.expects(:reset_session).once
+    @controller.should_receive(:reset_session).once
 
     @request.session[:user_id] = 2
     get :logout

--- a/test/functional/sys_controller_test.rb
+++ b/test/functional/sys_controller_test.rb
@@ -29,7 +29,6 @@
 
 require File.expand_path('../../test_helper', __FILE__)
 require 'sys_controller'
-require 'mocha/setup'
 
 # Re-raise errors caught by the controller.
 class SysController; def rescue_action(e) raise e end; end
@@ -69,13 +68,13 @@ class SysControllerTest < ActionController::TestCase
   end
 
   def test_fetch_changesets
-    Repository::Subversion.any_instance.expects(:fetch_changesets).returns(true)
+    Repository::Subversion.any_instance.should_receive(:fetch_changesets).and_return(true)
     get :fetch_changesets
     assert_response :success
   end
 
   def test_fetch_changesets_one_project
-    Repository::Subversion.any_instance.expects(:fetch_changesets).returns(true)
+    Repository::Subversion.any_instance.should_receive(:fetch_changesets).and_return(true)
     get :fetch_changesets, :id => 'ecookbook'
     assert_response :success
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,13 +38,13 @@ end
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'fileutils'
+require 'rspec/mocks'
 
 require File.expand_path(File.dirname(__FILE__) + '/helper_testcase')
 require Rails.root.join('test/mocks/open_id_authentication_mock.rb')
 
 require File.expand_path(File.dirname(__FILE__) + '/object_daddy_helpers')
 include ObjectDaddyHelpers
-
 
 class ActionDispatch::IntegrationTest
   include Shoulda::Matchers::ActionController
@@ -95,6 +95,20 @@ class ActiveSupport::TestCase
     end
     # By default bypass worker queue and execute asynchronous tasks at once
     Delayed::Worker.delay_jobs = false
+
+    # initializes the mocking features
+    RSpec::Mocks.setup(self)
+  end
+
+  def teardown
+    begin
+      super
+      # verifies method invocations
+      RSpec::Mocks.verify
+    ensure
+      # removes all mockings
+      RSpec::Mocks.teardown
+    end
   end
 
   def log_user(login, password)
@@ -115,10 +129,10 @@ class ActiveSupport::TestCase
   # Mock out a file
   def self.mock_file
     file = 'a_file.png'
-    file.stubs(:size).returns(32)
-    file.stubs(:original_filename).returns('a_file.png')
-    file.stubs(:content_type).returns('image/png')
-    file.stubs(:read).returns(false)
+    file.stub(:size).and_return(32)
+    file.stub(:original_filename).and_return('a_file.png')
+    file.stub(:content_type).and_return('image/png')
+    file.stub(:read).and_return(false)
     file
   end
 
@@ -250,8 +264,8 @@ class ActiveSupport::TestCase
       should "use the new value's name" do
         journal = FactoryGirl.build :work_package_journal
 
-        journal.stubs(:journable).returns(WorkPackage.last)
-        journal.stubs(:details).returns({prop_key => [@old_value.id, @new_value.id]})
+        journal.stub(:journable).and_return(WorkPackage.last)
+        journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
 
         assert_match @new_value.class.find(@new_value.id).name, journal.render_detail(prop_key, :no_html => true)
       end
@@ -259,8 +273,8 @@ class ActiveSupport::TestCase
       should "use the old value's name" do
         journal = FactoryGirl.build :work_package_journal
 
-        journal.stubs(:journable).returns(WorkPackage.last)
-        journal.stubs(:details).returns({prop_key => [@old_value.id, @new_value.id]})
+        journal.stub(:journable).and_return(WorkPackage.last)
+        journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
 
         assert_match @old_value.class.find(@old_value.id).name, journal.render_detail(prop_key, :no_html => true)
       end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -81,13 +81,13 @@ class CommentTest < ActiveSupport::TestCase
     news = FactoryGirl.create(:news, :project => project, :author => user)
 
     # with notifications for that event turned on
-    Notifier.stubs(:notify?).with(:news_comment_added).returns(true)
+    Notifier.stub(:notify?).with(:news_comment_added).and_return(true)
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
       Comment.create!(:commented => news, :author => user, :comments => 'more useful stuff')
     end
 
     # with notifications for that event turned off
-    Notifier.stubs(:notify?).with(:news_comment_added).returns(false)
+    Notifier.stub(:notify?).with(:news_comment_added).and_return(false)
     assert_no_difference 'ActionMailer::Base.deliveries.size' do
       Comment.create!(:commented => news, :author => user, :comments => 'more useful stuff')
     end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -57,7 +57,7 @@ class ApplicationHelperTest < ActionView::TestCase
         :filesize => 280,
         :description => 'This is a logo'
 
-    User.stubs(:current).returns(@project_member)
+    User.stub(:current).and_return(@project_member)
   end
 
   def request
@@ -231,7 +231,7 @@ RAW
   end
 
   def test_redmine_links_git_commit
-    User.stubs(:current).returns(@admin)
+    User.stub(:current).and_return(@admin)
     changeset_link = link_to('abcd',
                                {
                                  :controller => 'repositories',

--- a/test/unit/journal_observer_test.rb
+++ b/test/unit/journal_observer_test.rb
@@ -47,7 +47,7 @@ class JournalObserverTest < ActiveSupport::TestCase
     @user.members.first.roles << @workflow.role
     @user.reload
 
-    User.stubs(:current).returns(@user)
+    User.stub(:current).and_return(@user)
 
     ActionMailer::Base.deliveries.clear
   end

--- a/test/unit/lib/chili_project/database_test.rb
+++ b/test/unit/lib/chili_project/database_test.rb
@@ -30,7 +30,7 @@ require File.expand_path('../../../../test_helper', __FILE__)
 
 class ChiliProject::DatabaseTest < ActiveSupport::TestCase
   setup do
-    ChiliProject::Database.stubs(:adapter_name).returns "SQLite"
+    ChiliProject::Database.stub(:adapter_name).and_return "SQLite"
   end
 
   should "return the correct identifier" do
@@ -45,7 +45,7 @@ class ChiliProject::DatabaseTest < ActiveSupport::TestCase
 
   should "return a version string for SQLite3" do
     begin
-      ChiliProject::Database.stubs(:adapter_name).returns "SQLite"
+      ChiliProject::Database.stub(:adapter_name).and_return "SQLite"
 
       if Object.const_defined?('RUBY_ENGINE') && ::RUBY_ENGINE == 'jruby'
         # If we have the SQLite3 gem installed, save the old constant
@@ -66,7 +66,7 @@ class ChiliProject::DatabaseTest < ActiveSupport::TestCase
         elsif %w(SQLite3 Driver Native API).inject(Object){ |m, defined|
           m = (m && m.const_defined?(defined)) ? m.const_get(defined) : false
         }
-          SQLite3::Driver::Native::API.stubs('sqlite3_libversion').returns "1.2.3"
+          SQLite3::Driver::Native::API.stub('sqlite3_libversion').and_return "1.2.3"
         # Fallback if nothing else worked: Stub the old SQLite3 API
         else
           # if we don't have any sqlite3 module, stub the whole module
@@ -98,17 +98,17 @@ class ChiliProject::DatabaseTest < ActiveSupport::TestCase
   end
 
   should "return a version string for PostgreSQL" do
-    ChiliProject::Database.stubs(:adapter_name).returns "PostgreSQL"
+    ChiliProject::Database.stub(:adapter_name).and_return "PostgreSQL"
     raw_version = "PostgreSQL 8.3.11 on x86_64-pc-linux-gnu, compiled by GCC gcc-4.3.real (Debian 4.3.2-1.1) 4.3.2"
-    ActiveRecord::Base.connection.stubs(:select_value).returns raw_version
+    ActiveRecord::Base.connection.stub(:select_value).and_return raw_version
 
     assert_equal "8.3.11", ChiliProject::Database.version
     assert_equal raw_version, ChiliProject::Database.version(true)
   end
 
   should "return a version string for MySQL" do
-    ChiliProject::Database.stubs(:adapter_name).returns "MySQL"
-    ActiveRecord::Base.connection.stubs(:select_value).returns "5.1.2"
+    ChiliProject::Database.stub(:adapter_name).and_return "MySQL"
+    ActiveRecord::Base.connection.stub(:select_value).and_return "5.1.2"
 
     assert_equal "5.1.2", ChiliProject::Database.version
     assert_equal "5.1.2", ChiliProject::Database.version(true)

--- a/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
@@ -31,230 +31,228 @@
 # We need to consider Ruby 1.9 compatibility.
 
 require File.expand_path('../../../../../../test_helper', __FILE__)
-begin
-  class GitAdapterTest < ActiveSupport::TestCase
-    REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
 
-    FELIX_UTF8 = "Felix Schäfer"
-    FELIX_HEX  = "Felix Sch\xC3\xA4fer"
-    CHAR_1_HEX = "\xc3\x9c"
+class GitAdapterTest < ActiveSupport::TestCase
+  REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
 
-    ## Ruby uses ANSI api to fork a process on Windows.
-    ## Japanese Shift_JIS and Traditional Chinese Big5 have 0x5c(backslash) problem
-    ## and these are incompatible with ASCII.
-    # WINDOWS_PASS = Redmine::Platform.mswin?
-    WINDOWS_PASS = false
+  FELIX_UTF8 = "Felix Schäfer"
+  FELIX_HEX  = "Felix Sch\xC3\xA4fer"
+  CHAR_1_HEX = "\xc3\x9c"
 
-    if File.directory?(REPOSITORY_PATH)
-      def setup
-        @adapter = Redmine::Scm::Adapters::GitAdapter.new(
-                      REPOSITORY_PATH,
-                      nil,
-                      nil,
-                      nil,
-                      'ISO-8859-1'
-                      )
-        assert @adapter
-        @char_1        = CHAR_1_HEX.dup
-        if @char_1.respond_to?(:force_encoding)
-          @char_1.force_encoding('UTF-8')
-        end
+  ## Ruby uses ANSI api to fork a process on Windows.
+  ## Japanese Shift_JIS and Traditional Chinese Big5 have 0x5c(backslash) problem
+  ## and these are incompatible with ASCII.
+  # WINDOWS_PASS = Redmine::Platform.mswin?
+  WINDOWS_PASS = false
+
+  if File.directory?(REPOSITORY_PATH)
+    def setup
+      @adapter = Redmine::Scm::Adapters::GitAdapter.new(
+                    REPOSITORY_PATH,
+                    nil,
+                    nil,
+                    nil,
+                    'ISO-8859-1'
+                    )
+      assert @adapter
+      @char_1        = CHAR_1_HEX.dup
+      if @char_1.respond_to?(:force_encoding)
+        @char_1.force_encoding('UTF-8')
       end
+    end
 
-      def test_scm_version
-        to_test = { "git version 1.7.3.4\n"             => [1,7,3,4],
-                    "1.6.1\n1.7\n1.8"                   => [1,6,1],
-                    "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
-        to_test.each do |s, v|
-          test_scm_version_for(s, v)
-        end
+    def test_scm_version
+      to_test = { "git version 1.7.3.4\n"             => [1,7,3,4],
+                  "1.6.1\n1.7\n1.8"                   => [1,6,1],
+                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
+      to_test.each do |s, v|
+        test_scm_version_for(s, v)
       end
+    end
 
-      def test_branches
-        assert_equal  [
-              'latin-1-path-encoding',
-              'master',
-              'test-latin-1',
-              'test_branch',
-            ], @adapter.branches
+    def test_branches
+      assert_equal  [
+            'latin-1-path-encoding',
+            'master',
+            'test-latin-1',
+            'test_branch',
+          ], @adapter.branches
+    end
+
+    def test_tags
+      assert_equal  [
+            "tag00.lightweight",
+            "tag01.annotated",
+          ], @adapter.tags
+    end
+
+    def test_getting_all_revisions
+      assert_equal 21, @adapter.revisions('',nil,nil,:all => true).length
+    end
+
+    def test_getting_certain_revisions
+      assert_equal 1, @adapter.revisions('','899a15d^','899a15d').length
+    end
+
+    def test_revisions_reverse
+      revs1 = @adapter.revisions('',nil,nil,{:all => true, :reverse => true })
+      assert_equal 21, revs1.length
+      assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', revs1[0].identifier
+      assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs1[20].identifier
+
+      since2 = Time.gm(2010, 9, 30, 0, 0, 0)
+      revs2 = @adapter.revisions('',nil,nil,{:all => true, :since => since2, :reverse => true })
+      assert_equal 6, revs2.length
+      assert_equal '67e7792ce20ccae2e4bb73eed09bb397819c8834', revs2[0].identifier
+      assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs2[5].identifier
+    end
+
+    def test_getting_revisions_with_spaces_in_filename
+      assert_equal 1, @adapter.revisions("filemane with spaces.txt",
+                                         nil, nil, :all => true).length
+    end
+
+    def test_getting_revisions_with_leading_and_trailing_spaces_in_filename
+      assert_equal " filename with a leading space.txt ",
+         @adapter.revisions(" filename with a leading space.txt ",
+                             nil, nil, :all => true)[0].paths[0][:path]
+    end
+
+    def test_getting_entries_with_leading_and_trailing_spaces_in_filename
+      assert_equal " filename with a leading space.txt ",
+         @adapter.entries('',
+                 '83ca5fd546063a3c7dc2e568ba3355661a9e2b2c')[3].name
+    end
+
+    def test_annotate
+      annotate = @adapter.annotate('sources/watchers_controller.rb')
+      assert_kind_of Redmine::Scm::Adapters::Annotate, annotate
+      assert_equal 41, annotate.lines.size
+      assert_equal "# This program is free software; you can redistribute it and/or",
+                   annotate.lines[4].strip
+      assert_equal "7234cb2750b63f47bff735edc50a1c0a433c2518",
+                    annotate.revisions[4].identifier
+      assert_equal "jsmith", annotate.revisions[4].author
+    end
+
+    def test_annotate_moved_file
+      annotate = @adapter.annotate('renamed_test.txt')
+      assert_kind_of Redmine::Scm::Adapters::Annotate, annotate
+      assert_equal 2, annotate.lines.size
+    end
+
+    def test_last_rev
+      last_rev = @adapter.lastrev("README",
+                                  "4f26664364207fa8b1af9f8722647ab2d4ac5d43")
+      assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.scmid
+      assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.identifier
+      assert_equal "Adam Soltys <asoltys@gmail.com>", last_rev.author
+      assert_equal "2009-06-24 05:27:38".to_time, last_rev.time
+    end
+
+    def test_last_rev_with_spaces_in_filename
+      last_rev = @adapter.lastrev("filemane with spaces.txt",
+                                  "ed5bb786bbda2dee66a2d50faf51429dbc043a7b")
+      str_felix_utf8 = FELIX_UTF8.dup
+      str_felix_hex  = FELIX_HEX.dup
+      last_rev_author = last_rev.author
+      if last_rev_author.respond_to?(:force_encoding)
+        last_rev_author.force_encoding('UTF-8')
       end
+      assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.scmid
+      assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.identifier
+      assert_equal "#{str_felix_utf8} <felix@fachschaften.org>",
+                     last_rev.author
+      assert_equal "#{str_felix_hex} <felix@fachschaften.org>",
+                     last_rev.author
+      assert_equal "2010-09-18 19:59:46".to_time, last_rev.time
+    end
 
-      def test_tags
-        assert_equal  [
-              "tag00.lightweight",
-              "tag01.annotated",
-            ], @adapter.tags
-      end
-
-      def test_getting_all_revisions
-        assert_equal 21, @adapter.revisions('',nil,nil,:all => true).length
-      end
-
-      def test_getting_certain_revisions
-        assert_equal 1, @adapter.revisions('','899a15d^','899a15d').length
-      end
-
-      def test_revisions_reverse
-        revs1 = @adapter.revisions('',nil,nil,{:all => true, :reverse => true })
-        assert_equal 21, revs1.length
-        assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', revs1[0].identifier
-        assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs1[20].identifier
-
-        since2 = Time.gm(2010, 9, 30, 0, 0, 0)
-        revs2 = @adapter.revisions('',nil,nil,{:all => true, :since => since2, :reverse => true })
-        assert_equal 6, revs2.length
-        assert_equal '67e7792ce20ccae2e4bb73eed09bb397819c8834', revs2[0].identifier
-        assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs2[5].identifier
-      end
-
-      def test_getting_revisions_with_spaces_in_filename
-        assert_equal 1, @adapter.revisions("filemane with spaces.txt",
-                                           nil, nil, :all => true).length
-      end
-
-      def test_getting_revisions_with_leading_and_trailing_spaces_in_filename
-        assert_equal " filename with a leading space.txt ",
-           @adapter.revisions(" filename with a leading space.txt ",
-                               nil, nil, :all => true)[0].paths[0][:path]
-      end
-
-      def test_getting_entries_with_leading_and_trailing_spaces_in_filename
-        assert_equal " filename with a leading space.txt ",
-           @adapter.entries('',
-                   '83ca5fd546063a3c7dc2e568ba3355661a9e2b2c')[3].name
-      end
-
-      def test_annotate
-        annotate = @adapter.annotate('sources/watchers_controller.rb')
-        assert_kind_of Redmine::Scm::Adapters::Annotate, annotate
-        assert_equal 41, annotate.lines.size
-        assert_equal "# This program is free software; you can redistribute it and/or",
-                     annotate.lines[4].strip
-        assert_equal "7234cb2750b63f47bff735edc50a1c0a433c2518",
-                      annotate.revisions[4].identifier
-        assert_equal "jsmith", annotate.revisions[4].author
-      end
-
-      def test_annotate_moved_file
-        annotate = @adapter.annotate('renamed_test.txt')
-        assert_kind_of Redmine::Scm::Adapters::Annotate, annotate
-        assert_equal 2, annotate.lines.size
-      end
-
-      def test_last_rev
-        last_rev = @adapter.lastrev("README",
-                                    "4f26664364207fa8b1af9f8722647ab2d4ac5d43")
-        assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.scmid
-        assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.identifier
-        assert_equal "Adam Soltys <asoltys@gmail.com>", last_rev.author
-        assert_equal "2009-06-24 05:27:38".to_time, last_rev.time
-      end
-
-      def test_last_rev_with_spaces_in_filename
-        last_rev = @adapter.lastrev("filemane with spaces.txt",
-                                    "ed5bb786bbda2dee66a2d50faf51429dbc043a7b")
-        str_felix_utf8 = FELIX_UTF8.dup
-        str_felix_hex  = FELIX_HEX.dup
-        last_rev_author = last_rev.author
-        if last_rev_author.respond_to?(:force_encoding)
-          last_rev_author.force_encoding('UTF-8')
-        end
-        assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.scmid
-        assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.identifier
-        assert_equal "#{str_felix_utf8} <felix@fachschaften.org>",
-                       last_rev.author
-        assert_equal "#{str_felix_hex} <felix@fachschaften.org>",
-                       last_rev.author
-        assert_equal "2010-09-18 19:59:46".to_time, last_rev.time
-      end
-
-      # TODO: need to handle edge cases of non-binary content that isn't UTF-8
-      should_eventually "test_latin_1_path" do
-        if WINDOWS_PASS
-          #
-        else
-          p2 = "latin-1-dir/test-#{@char_1}-2.txt"
-          ['4fc55c43bf3d3dc2efb66145365ddc17639ce81e', '4fc55c43bf3'].each do |r1|
-            assert @adapter.diff(p2, r1)
-            assert @adapter.cat(p2, r1)
-            annotation = @adapter.annotate(p2, r1)
-            assert annotation.present?, "No annotation returned"
-            assert_equal 1, annotation.lines.length
-            ['64f1f3e89ad1cb57976ff0ad99a107012ba3481d', '64f1f3e89ad1cb5797'].each do |r2|
-              assert @adapter.diff(p2, r1, r2)
-            end
+    # TODO: need to handle edge cases of non-binary content that isn't UTF-8
+    should_eventually "test_latin_1_path" do
+      if WINDOWS_PASS
+        #
+      else
+        p2 = "latin-1-dir/test-#{@char_1}-2.txt"
+        ['4fc55c43bf3d3dc2efb66145365ddc17639ce81e', '4fc55c43bf3'].each do |r1|
+          assert @adapter.diff(p2, r1)
+          assert @adapter.cat(p2, r1)
+          annotation = @adapter.annotate(p2, r1)
+          assert annotation.present?, "No annotation returned"
+          assert_equal 1, annotation.lines.length
+          ['64f1f3e89ad1cb57976ff0ad99a107012ba3481d', '64f1f3e89ad1cb5797'].each do |r2|
+            assert @adapter.diff(p2, r1, r2)
           end
         end
       end
+    end
 
-      def test_entries_tag
-        entries1 = @adapter.entries(nil, 'tag01.annotated')
-        assert entries1
-        assert_equal 3, entries1.size
-        assert_equal 'sources', entries1[1].name
-        assert_equal 'sources', entries1[1].path
-        assert_equal 'dir', entries1[1].kind
-        readme = entries1[2]
-        assert_equal 'README', readme.name
-        assert_equal 'README', readme.path
-        assert_equal 'file', readme.kind
-        assert_equal 27, readme.size
-        assert_equal '899a15dba03a3b350b89c3f537e4bbe02a03cdc9', readme.lastrev.identifier
-        assert_equal Time.gm(2007, 12, 14, 9, 24, 1), readme.lastrev.time
-      end
+    def test_entries_tag
+      entries1 = @adapter.entries(nil, 'tag01.annotated')
+      assert entries1
+      assert_equal 3, entries1.size
+      assert_equal 'sources', entries1[1].name
+      assert_equal 'sources', entries1[1].path
+      assert_equal 'dir', entries1[1].kind
+      readme = entries1[2]
+      assert_equal 'README', readme.name
+      assert_equal 'README', readme.path
+      assert_equal 'file', readme.kind
+      assert_equal 27, readme.size
+      assert_equal '899a15dba03a3b350b89c3f537e4bbe02a03cdc9', readme.lastrev.identifier
+      assert_equal Time.gm(2007, 12, 14, 9, 24, 1), readme.lastrev.time
+    end
 
-      def test_entries_branch
-        entries1 = @adapter.entries(nil, 'test_branch')
-        assert entries1
-        assert_equal 4, entries1.size
-        assert_equal 'sources', entries1[1].name
-        assert_equal 'sources', entries1[1].path
-        assert_equal 'dir', entries1[1].kind
-        readme = entries1[2]
-        assert_equal 'README', readme.name
-        assert_equal 'README', readme.path
-        assert_equal 'file', readme.kind
-        assert_equal 159, readme.size
-        assert_equal '713f4944648826f558cf548222f813dabe7cbb04', readme.lastrev.identifier
-        assert_equal Time.gm(2009, 6, 19, 4, 37, 23), readme.lastrev.time
-      end
+    def test_entries_branch
+      entries1 = @adapter.entries(nil, 'test_branch')
+      assert entries1
+      assert_equal 4, entries1.size
+      assert_equal 'sources', entries1[1].name
+      assert_equal 'sources', entries1[1].path
+      assert_equal 'dir', entries1[1].kind
+      readme = entries1[2]
+      assert_equal 'README', readme.name
+      assert_equal 'README', readme.path
+      assert_equal 'file', readme.kind
+      assert_equal 159, readme.size
+      assert_equal '713f4944648826f558cf548222f813dabe7cbb04', readme.lastrev.identifier
+      assert_equal Time.gm(2009, 6, 19, 4, 37, 23), readme.lastrev.time
+    end
 
-      def test_entries_latin_1_files
-        entries1 = @adapter.entries('latin-1-dir', '64f1f3e8')
+    def test_entries_latin_1_files
+      entries1 = @adapter.entries('latin-1-dir', '64f1f3e8')
+      assert entries1
+      assert_equal 3, entries1.size
+      f1 = entries1[1]
+      assert_equal "test-#{@char_1}-2.txt", f1.name
+      assert_equal "latin-1-dir/test-#{@char_1}-2.txt", f1.path
+      assert_equal 'file', f1.kind
+    end
+
+    def test_entries_latin_1_dir
+      if WINDOWS_PASS
+        #
+      else
+        entries1 = @adapter.entries("latin-1-dir/test-#{@char_1}-subdir",
+                                    '1ca7f5ed')
         assert entries1
         assert_equal 3, entries1.size
         f1 = entries1[1]
         assert_equal "test-#{@char_1}-2.txt", f1.name
-        assert_equal "latin-1-dir/test-#{@char_1}-2.txt", f1.path
+        assert_equal "latin-1-dir/test-#{@char_1}-subdir/test-#{@char_1}-2.txt", f1.path
         assert_equal 'file', f1.kind
       end
-
-      def test_entries_latin_1_dir
-        if WINDOWS_PASS
-          #
-        else
-          entries1 = @adapter.entries("latin-1-dir/test-#{@char_1}-subdir",
-                                      '1ca7f5ed')
-          assert entries1
-          assert_equal 3, entries1.size
-          f1 = entries1[1]
-          assert_equal "test-#{@char_1}-2.txt", f1.name
-          assert_equal "latin-1-dir/test-#{@char_1}-subdir/test-#{@char_1}-2.txt", f1.path
-          assert_equal 'file', f1.kind
-        end
-      end
-
-      private
-
-      def test_scm_version_for(scm_command_version, version)
-        @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_command_version)
-        assert_equal version, @adapter.class.scm_command_version
-      end
-
-    else
-      puts "Git test repository NOT FOUND. Skipping unit tests !!!"
-      def test_fake; assert true end
     end
+
+    private
+
+    def test_scm_version_for(scm_command_version, version)
+      @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_command_version)
+      assert_equal version, @adapter.class.scm_command_version
+    end
+
+  else
+    puts "Git test repository NOT FOUND. Skipping unit tests !!!"
+    def test_fake; assert true end
   end
 end
-

--- a/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
@@ -32,8 +32,6 @@
 
 require File.expand_path('../../../../../../test_helper', __FILE__)
 begin
-  require 'mocha/setup'
-
   class GitAdapterTest < ActiveSupport::TestCase
     REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
 
@@ -249,7 +247,7 @@ begin
       private
 
       def test_scm_version_for(scm_command_version, version)
-        @adapter.class.expects(:scm_version_from_command_line).returns(scm_command_version)
+        @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_command_version)
         assert_equal version, @adapter.class.scm_command_version
       end
 
@@ -257,11 +255,6 @@ begin
       puts "Git test repository NOT FOUND. Skipping unit tests !!!"
       def test_fake; assert true end
     end
-  end
-
-rescue LoadError
-  class GitMochaFake < ActiveSupport::TestCase
-    def test_fake; assert(false, "Requires mocha to run those tests")  end
   end
 end
 

--- a/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
@@ -29,39 +29,37 @@
 
 require File.expand_path('../../../../../../test_helper', __FILE__)
 
-begin
-  class SubversionAdapterTest < ActiveSupport::TestCase
+class SubversionAdapterTest < ActiveSupport::TestCase
 
-    if repository_configured?('subversion')
-      def setup
-        @adapter = Redmine::Scm::Adapters::SubversionAdapter.new(self.class.subversion_repository_url)
-      end
-
-      def test_client_version
-        v = Redmine::Scm::Adapters::SubversionAdapter.client_version
-        assert v.is_a?(Array)
-      end
-
-      def test_scm_version
-        to_test = { "svn, version 1.6.13 (r1002816)\n"  => [1,6,13],
-                    "svn, versione 1.6.13 (r1002816)\n" => [1,6,13],
-                    "1.6.1\n1.7\n1.8"                   => [1,6,1],
-                    "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
-        to_test.each do |s, v|
-          test_scm_version_for(s, v)
-        end
-      end
-
-      private
-
-      def test_scm_version_for(scm_version, version)
-        @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_version)
-        assert_equal version, @adapter.class.svn_binary_version
-      end
-
-    else
-      puts "Subversion test repository NOT FOUND. Skipping unit tests !!!"
-      def test_fake; assert true end
+  if repository_configured?('subversion')
+    def setup
+      @adapter = Redmine::Scm::Adapters::SubversionAdapter.new(self.class.subversion_repository_url)
     end
+
+    def test_client_version
+      v = Redmine::Scm::Adapters::SubversionAdapter.client_version
+      assert v.is_a?(Array)
+    end
+
+    def test_scm_version
+      to_test = { "svn, version 1.6.13 (r1002816)\n"  => [1,6,13],
+                  "svn, versione 1.6.13 (r1002816)\n" => [1,6,13],
+                  "1.6.1\n1.7\n1.8"                   => [1,6,1],
+                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
+      to_test.each do |s, v|
+        test_scm_version_for(s, v)
+      end
+    end
+
+    private
+
+    def test_scm_version_for(scm_version, version)
+      @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_version)
+      assert_equal version, @adapter.class.svn_binary_version
+    end
+
+  else
+    puts "Subversion test repository NOT FOUND. Skipping unit tests !!!"
+    def test_fake; assert true end
   end
 end

--- a/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
@@ -30,8 +30,6 @@
 require File.expand_path('../../../../../../test_helper', __FILE__)
 
 begin
-  require 'mocha/setup'
-
   class SubversionAdapterTest < ActiveSupport::TestCase
 
     if repository_configured?('subversion')
@@ -57,7 +55,7 @@ begin
       private
 
       def test_scm_version_for(scm_version, version)
-        @adapter.class.expects(:scm_version_from_command_line).returns(scm_version)
+        @adapter.class.should_receive(:scm_version_from_command_line).and_return(scm_version)
         assert_equal version, @adapter.class.svn_binary_version
       end
 
@@ -65,10 +63,5 @@ begin
       puts "Subversion test repository NOT FOUND. Skipping unit tests !!!"
       def test_fake; assert true end
     end
-  end
-
-rescue LoadError
-  class SubversionMochaFake < ActiveSupport::TestCase
-    def test_fake; assert(false, "Requires mocha to run those tests")  end
   end
 end

--- a/test/unit/mail_handler_test.rb
+++ b/test/unit/mail_handler_test.rb
@@ -304,7 +304,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_should_ignore_emails_from_locked_users
     User.find(2).lock!
 
-    MailHandler.any_instance.expects(:dispatch).never
+    MailHandler.any_instance.should_receive(:dispatch).never
     assert_no_difference 'WorkPackage.count' do
       assert_equal false, submit_email('ticket_on_given_project.eml')
     end
@@ -318,7 +318,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_should_ignore_auto_replied_emails
-    MailHandler.any_instance.expects(:dispatch).never
+    MailHandler.any_instance.should_receive(:dispatch).never
     [
       "X-Auto-Response-Suppress: OOF",
       "Auto-Submitted: auto-replied",

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -213,7 +213,7 @@ class UserTest < ActiveSupport::TestCase
       context "with failed connection to the LDAP server" do
         should "return nil" do
           @auth_source = LdapAuthSource.find(1)
-          AuthSource.any_instance.stubs(:initialize_ldap_con).raises(Net::LDAP::LdapError, 'Cannot connect')
+          AuthSource.any_instance.stub(:initialize_ldap_con).and_raise(Net::LDAP::LdapError, 'Cannot connect')
 
           assert_equal nil, User.try_to_login('edavis', 'wrong')
         end
@@ -430,7 +430,7 @@ class UserTest < ActiveSupport::TestCase
     context "with a unique project" do
       should "return false if project is archived" do
         project = Project.find(1)
-        Project.any_instance.stubs(:status).returns(Project::STATUS_ARCHIVED)
+        Project.any_instance.stub(:status).and_return(Project::STATUS_ARCHIVED)
         assert ! @admin.allowed_to?(:view_work_packages, Project.find(1))
       end
 

--- a/test/unit/watcher_test.rb
+++ b/test/unit/watcher_test.rb
@@ -61,7 +61,7 @@ class WatcherTest < ActiveSupport::TestCase
   end
 
   def test_watcher_users_should_not_validate_user
-    @user.stubs(:valid?).returns(false)
+    @user.stub(:valid?).and_return(false)
     @issue.watcher_users << @user
     assert @issue.watched_by?(@user)
   end


### PR DESCRIPTION
This PR removes `mocha` as a dependency from OpenProject (Core).

Numerous times I got confused when using `stub`, `stubs`, `returns`, `and_return`, `expects`, `should_receive` etc. due to rspec and mocha providing mocking facilities. Today, I ran into some trouble where a mocha mock wasn't removed correctly. Since nowadays `rspec-mocks` provides almost the same mocking capabilities as mocha does, I decided to remove the last remaining bits of it and exclusively use rspec-mocks in OpenProject's core.

note to reviewer: second commit does indentation only.
