### PR TITLE
Fix CSV Export Encoding

### DIFF
--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -91,7 +91,12 @@ class TimelogController < ApplicationController
                                   :include => [:project, :activity, :user, {:work_package => [:type, :assigned_to, :priority]}],
                                   :conditions => cond.conditions,
                                   :order => sort_clause)
-        send_data(entries_to_csv(@entries), :type => 'text/csv; header=present', :filename => 'timelog.csv')
+        charset = "charset=#{l(:general_csv_encoding).downcase}"
+
+        send_data(
+          entries_to_csv(@entries),
+          :type => "text/csv; #{charset}; header=present",
+          :filename => 'timelog.csv')
       }
     end
   end

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -232,8 +232,9 @@ class WorkPackagesController < ApplicationController
       end
       format.csv do
         serialized_work_packages = WorkPackage::Exporter.csv(work_packages, @project)
+        charset = "charset=#{l(:general_csv_encoding).downcase}"
 
-        send_data(serialized_work_packages, :type => 'text/csv; charset=utf-8; header=present',
+        send_data(serialized_work_packages, :type => "text/csv; #{charset}; header=present",
                                             :filename => 'export.csv')
       end
       format.pdf do

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -233,7 +233,7 @@ class WorkPackagesController < ApplicationController
       format.csv do
         serialized_work_packages = WorkPackage::Exporter.csv(work_packages, @project)
 
-        send_data(serialized_work_packages, :type => 'text/csv; header=present',
+        send_data(serialized_work_packages, :type => 'text/csv; charset=utf-8; header=present',
                                             :filename => 'export.csv')
       end
       format.pdf do

--- a/app/helpers/timelog_helper.rb
+++ b/app/helpers/timelog_helper.rb
@@ -29,6 +29,7 @@
 
 module TimelogHelper
   include ApplicationHelper
+  include WorkPackage::CsvExporter
 
   def render_timelog_breadcrumb
     links = []
@@ -113,7 +114,7 @@ module TimelogHelper
       # Export custom fields
       headers += custom_fields.collect(&:name)
 
-      csv << headers.collect {|c| begin; c.to_s.encode(l(:general_csv_encoding), 'UTF-8'); rescue; c.to_s; end }
+      csv << encode_csv_columns(headers)
       # csv lines
       entries.each do |entry|
         fields = [format_date(entry.spent_on),
@@ -128,7 +129,7 @@ module TimelogHelper
                   ]
         fields += custom_fields.collect {|f| show_value(entry.custom_value_for(f)) }
 
-        csv << fields.collect {|c| begin; c.to_s.encode(l(:general_csv_encoding), 'UTF-8'); rescue; c.to_s; end }
+        csv << encode_csv_columns(fields)
       end
     end
     export

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -61,7 +61,7 @@ module WorkPackage::CsvExporter
       custom_fields.each {|f| headers << f.name}
       # Description in the last column
       headers << CustomField.human_attribute_name(:description)
-      csv << headers.collect {|c| begin; c.to_s.encode(l(:general_csv_encoding), 'UTF-8'); rescue; c.to_s; end }
+      csv << encode_csv_columns(headers)
       # csv lines
       work_packages.each do |work_package|
         fields = [work_package.id,
@@ -84,10 +84,28 @@ module WorkPackage::CsvExporter
                   ]
         custom_fields.each {|f| fields << show_value(work_package.custom_value_for(f)) }
         fields << work_package.description
-        csv << fields.collect {|c| begin; c.to_s.encode(l(:general_csv_encoding), 'UTF-8'); rescue; c.to_s; end }
+        csv << encode_csv_columns(fields)
       end
     end
 
     export
+  end
+
+  def encode_csv_columns(columns)
+    columns.map do |cell|
+      encode_csv_cell cell
+    end
+  end
+
+  def encode_csv_cell(cell)
+    content = cell.to_s
+    begin
+      content.to_s.encode l(:general_csv_encoding), content.encoding.name
+    rescue
+      Rails.logger.warn(
+        "Could not encode the following cell from #{c.encoding} to #{l(:general_csv_encoding)}:" \
+        "\n  '#{content}'")
+      content.to_s
+    end
   end
 end

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -91,16 +91,16 @@ module WorkPackage::CsvExporter
     export
   end
 
-  def encode_csv_columns(columns)
+  def encode_csv_columns(columns, encoding = l(:general_csv_encoding))
     columns.map do |cell|
-      encode_csv_cell cell
+      encode_csv_cell cell, encoding
     end
   end
 
-  def encode_csv_cell(cell)
+  def encode_csv_cell(cell, encoding = l(:general_csv_encoding))
     content = cell.to_s
     begin
-      content.to_s.encode l(:general_csv_encoding), content.encoding.name
+      content.to_s.encode encoding, content.encoding.name
     rescue
       Rails.logger.warn(
         "Could not encode the following cell from #{c.encoding} to #{l(:general_csv_encoding)}:" \

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -93,7 +93,7 @@ module WorkPackage::CsvExporter
 
   def encode_csv_columns(columns, encoding = l(:general_csv_encoding))
     columns.map do |cell|
-      Redmine::CodesetUtil.from_utf8(content, encoding)
+      Redmine::CodesetUtil.from_utf8(cell, encoding)
     end
   end
 end

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -93,7 +93,7 @@ module WorkPackage::CsvExporter
 
   def encode_csv_columns(columns, encoding = l(:general_csv_encoding))
     columns.map do |cell|
-      Redmine::CodesetUtil.from_utf8(cell, encoding)
+      Redmine::CodesetUtil.from_utf8(cell.to_s, encoding)
     end
   end
 end

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -93,19 +93,7 @@ module WorkPackage::CsvExporter
 
   def encode_csv_columns(columns, encoding = l(:general_csv_encoding))
     columns.map do |cell|
-      encode_csv_cell cell, encoding
-    end
-  end
-
-  def encode_csv_cell(cell, encoding = l(:general_csv_encoding))
-    content = cell.to_s
-    begin
-      content.to_s.encode encoding, content.encoding.name
-    rescue
-      Rails.logger.warn(
-        "Could not encode the following cell from #{c.encoding} to #{l(:general_csv_encoding)}:" \
-        "\n  '#{content}'")
-      content.to_s
+      Redmine::CodesetUtil.from_utf8(content, encoding)
     end
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -542,7 +542,7 @@ de:
     work_package_note: 'Arbeitspaket kommentiert'
 
   general_csv_decimal_separator: ","
-  general_csv_encoding: "ISO-8859-1"
+  general_csv_encoding: "UTF-8"
   general_csv_separator: ";"
   general_first_day_of_week: "1"
   general_lang_name: "Deutsch"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,7 +538,7 @@ en:
     work_package_note: 'Work Package note added'
 
   general_csv_decimal_separator: "."
-  general_csv_encoding: "ISO-8859-1"
+  general_csv_encoding: "UTF-8"
   general_csv_separator: ","
   general_first_day_of_week: "7"
   general_lang_name: "English"

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -188,7 +188,7 @@ describe WorkPackagesController do
                                                       .and_return(mock_csv)
 
             controller.should_receive(:send_data).with(mock_csv,
-                                                       :type => 'text/csv; header=present',
+                                                       :type => 'text/csv; charset=utf-8; header=present',
                                                        :filename => 'export.csv') do |*args|
               # We need to render something because otherwise
               # the controller will and he will not find a suitable template

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -272,7 +272,7 @@ describe WorkPackagesController do
     # and its description encoded in UTF-8 it will result in a CompatibilityError.
     # This would not happen if the description contained only letters covered by
     # ISO-8859-1. Since this can happen, though, it is more sensible to encode everything
-    # in UTF-8 which gets red of this problem altogether.
+    # in UTF-8 which gets rid of this problem altogether.
     let(:work_package) do
       FactoryGirl.create(
         :work_package,

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -263,6 +263,39 @@ describe WorkPackagesController do
     end
   end
 
+  describe 'index with actual data' do
+    require 'csv'
+    render_views
+
+    ##
+    # When Ruby tries to join the following work package's subject encoded in ISO-8859-1
+    # and its description encoded in UTF-8 it will result in a CompatibilityError.
+    # This would not happen if the description contained only letters covered by
+    # ISO-8859-1. Since this can happen, though, it is more sensible to encode everything
+    # in UTF-8 which gets red of this problem altogether.
+    let(:work_package) do
+      FactoryGirl.create(
+        :work_package,
+        :subject => "Ruby encodes ß as '\\xDF' in ISO-8859-1.",
+        :description => "\u2022 requires unicode.")
+    end
+    let(:current_user) { FactoryGirl.create(:admin) }
+
+    it "performs a successful export" do
+      wp = work_package
+
+      expect do
+        get :index, :format => 'csv'
+      end.to_not raise_error(Encoding::CompatibilityError)
+
+      data = CSV.parse(response.body)
+
+      expect(data.size).to eq(2)
+      expect(data.last).to include(wp.subject)
+      expect(data.last).to include(wp.description)
+    end
+  end
+
   describe 'index with a broken project reference' do
     before { get('index', :project_id => 'project_that_doesnt_exist') }
 


### PR DESCRIPTION
WP [#4169](https://www.openproject.org/work_packages/4169)

Changelog Entry:
- `#4169` Fix: CSV Export can't handle UTF-8 in conjunction with ASCII letters >= 160 (such as ä)
