### PR TITLE
Configuration: Fix setting rails_cache_store via environment variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ OpenProject::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # rails defaults to :file_store, use :dalli when :memcaches is configured in configuration.yml
-  if OpenProject::Configuration['rails_cache_store'] == :memcache
+  if OpenProject::Configuration['rails_cache_store'].to_s == 'memcache'
     config.cache_store = :dalli_store
   end
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -59,6 +59,7 @@ In case you want to use environment variables, but you have no easy way to set t
 * `autologin_cookie_path` (default: '/')
 * `autologin_cookie_secure` (default: false)
 * `database_cipher_key`     (default: nil)
+* `rails_cache_store` not set or memcache (default: not set, uses file_store)
 * `scm_git_command` (default: 'git')
 * `scm_subversion_command` (default: 'git')
 


### PR DESCRIPTION
Environment variables can't have Symbol values.

No ticket or changelog entry for this.
