### PR TITLE
correctly call user logout when self deleted

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -277,7 +277,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html do
         if @user == User.current
-          logged_user = nil
+          self.logged_user = nil
           redirect_to signin_path
         else
           redirect_to users_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -272,14 +272,14 @@ class UsersController < ApplicationController
       @user.destroy :
       @user.delay.destroy
 
-    flash[:notice] = l('account.deleted')
-
     respond_to do |format|
       format.html do
         if @user == User.current
           self.logged_user = nil
+          flash[:notice] = l('account.deleted')
           redirect_to signin_path
         else
+          flash[:notice] = l('account.deleted')
           redirect_to users_path
         end
       end


### PR DESCRIPTION
the user wasn't correctly logged out after deleting him/herself because the intended method call was actual an assignment to a local variable. this wasn't a big issue since the account got locked before deletion, but now it works as intended. also did some refactoring to make the case where the user deletes itself more clear.
