### PR TITLE
Fix: project scope lost upon click on search category

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -58,7 +58,7 @@ module SearchHelper
     options = [[l(:label_project_all), 'all']]
     options << [l(:label_my_projects), 'my_projects'] unless User.current.memberships.empty?
     options << [l(:label_and_its_subprojects, @project.name), 'subprojects'] unless @project.nil? || @project.descendants.active.empty?
-    options << [@project.name, ''] unless @project.nil?
+    options << [@project.name, 'current_project'] unless @project.nil?
     label_tag("scope", l(:description_project_scope), :class => "hidden-for-sighted") +
     select_tag('scope', options_for_select(options, params[:scope].to_s)) if options.size > 1
   end
@@ -70,7 +70,17 @@ module SearchHelper
       c = results_by_type[t]
       next if c == 0
       text = "#{type_label(t)} (#{c})"
-      links << link_to(h(text), :q => params[:q], :titles_only => params[:title_only], :all_words => params[:all_words], :scope => params[:scope], t => 1)
+      target = {
+        :controller => 'search',
+        :project_id => (@project.identifier if @project),
+        :action => 'index',
+        :q => params[:q],
+        :titles_only => params[:title_only],
+        :all_words => params[:all_words],
+        :scope => params[:scope],
+        t => 1
+      }
+      links << link_to(h(text), target)
     end
     ('<ul>' + links.map {|link| content_tag('li', link)}.join(' ') + '</ul>').html_safe unless links.empty?
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'search/index' do
+  let(:project) { FactoryGirl.create(:project) }
+  let(:scope) { "foobar" }
+
+  before do
+    helper.stub(:params).and_return({
+      :q => "foobar",
+      :all_words => "1",
+      :scope => scope
+    })
+    assign(:project, project)
+  end
+
+  it 'renders correct result-by-type links' do
+    results_by_type = {"work_packages"=>1, "wiki_pages"=>1}
+    response = helper.render_results_by_type(results_by_type)
+
+    expect(response).to have_selector("a", :count => results_by_type.size)
+    expect(response).to include("/projects/#{project.identifier}/search")
+    expect(response).to include("scope=#{scope}")
+  end
+end


### PR DESCRIPTION
WP [#3903](https://www.openproject.org/work_packages/3903)

change log:
- `#3903` Fix: [Search] Project scope lost when clicking on search category link
