### PR TITLE
fixes pagination for postgres

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -50,8 +50,9 @@ class SearchController < ApplicationController
         @project
       end
 
-    offset = nil
-    begin; offset = params[:offset].to_time if params[:offset]; rescue; end
+    offset = begin
+      Time.at(Rational(params[:offset])) if params[:offset]
+    rescue; end
 
     # quick jump to an work_package
     if @question.match(/\A#?(\d+)\z/) && WorkPackage.visible.find_by_id($1.to_i)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -87,11 +87,11 @@ module SearchHelper
 
   def link_to_previous_search_page(pagination_previous_date)
     link_to_content_update(l(:label_previous),
-                           params.merge(:previous => 1, :offset => pagination_previous_date.strftime("%Y%m%d%H%M%S")), :class => 'navigate-left')
+                           params.merge(:previous => 1, :offset => pagination_previous_date.to_r.to_s), :class => 'navigate-left')
   end
 
   def link_to_next_search_page(pagination_next_date)
     link_to_content_update(l(:label_next),
-                           params.merge(:previous => nil, :offset => pagination_next_date.strftime("%Y%m%d%H%M%S")), :class => 'navigate-right')
+                           params.merge(:previous => nil, :offset => pagination_next_date.to_r.to_s), :class => 'navigate-right')
   end
 end

--- a/features/search/pagination.feature
+++ b/features/search/pagination.feature
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Pagination
+  Background:
+    Given there are 15 work packages with "wurst" in their description
+    And I am admin
+
+  @javascript
+  Scenario: The search result pages do not change while going back and forth
+    When I search globally for "wurst"
+    Then I can see the 6th through 15th of those work packages
+  	And there are pagination links
+  	And I turn over to the next results page
+  	Then I can see the 1st through 5th of those work packages
+  	And there are pagination links
+  	And I turn over to the previous results page
+  	Then I can see the 6th through 15th of those work packages

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,13 +1,71 @@
-When /^I search globally for "([^"]*)"$/ do |query|
+Given(/^there are (\d+) work packages with "(.*?)" in their description$/) do |num, desc|
+  work_packages = FactoryGirl.create_list :work_package, num.to_i, description: desc
+  time = Time.now
+  # ensure temporal order:
+  work_packages.reverse.each_with_index do |wp, i|
+    wp.created_at = time - i.seconds
+    wp.save
+  end
+
+  @search_work_packages = work_packages
+end
+
+Then(/^I can see the (\d+(?:st|nd|rd|th)) through (\d+(?:st|nd|rd|th)) of those work packages$/) do |from, to|
+  from = from.to_i - 1
+  to = to.to_i - 1
+  count = (to - from).abs + 1
+
+  found_wps = page.all(:css, "dt.work_package-edit")
+  expect(found_wps.size).to eq(count)
+
+  expected_wps = @search_work_packages[from..to]
+  expect(expected_wps.size).to eq(count)
+
+  expected_wps.each do |wp|
+    path = Rails.application.routes.url_helpers.work_package_path(wp)
+    linked = found_wps.any? do |e|
+      e.find("a")["href"].include? path
+    end
+    expect(linked).to be(true)
+  end
+end
+
+When(/^I search globally for "([^"]*)"$/) do |query|
   steps %Q{
-    And I fill in "stuff" for "q"
+    And I fill in "#{query}" for "q"
     And I press the "return" key on element "#q"
+    And I wait for the AJAX requests to finish
   }
 end
 
-When /^I search for "([^"]*)" after having searched$/ do |query|
+When(/^I search for "([^"]*)" after having searched$/) do |query|
   steps %Q{
-    And I fill in "stuff" for "q" within "#content"
+    And I fill in "#{query}" for "q" within "#content"
     And I press "Submit" within "#content"
+    And I wait for the AJAX requests to finish
   }
+end
+
+When(/^there are pagination links$/) do
+  links = page.all(:css, ".search-pagination a")
+
+  if links.size == 2
+    @search_previous_url = links.first["href"]
+    @search_next_url = links.last["href"]
+  elsif links.size == 1
+    @search_previous_url = nil
+    @search_next_url = links.first["href"]
+  else
+    fail "There are no pagination links!"
+  end
+end
+
+When(/^I turn over to the previous results page$/) do
+  expect(@search_previous_url).not_to be(nil)
+  visit @search_previous_url
+end
+
+When(/^I turn over to the next results page$/) do
+  expect(@search_next_url).not_to be(nil)
+  visit @search_next_url
 end


### PR DESCRIPTION
It does this by using a offset parameter that doesn't lose precision.
This breaks compatibility with Ruby 1.8.7 by using a Rational.

WP [#2616](https://www.openproject.org/work_packages/2616)

Change Log:
- `#2616` Fix:  Search: Clicking on 'Back' results in wrong data
