### PR TITLE
FIX Wrong message "project identifier can't be edited"

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1376,7 +1376,7 @@ de:
   text_plugin_assets_writable: "Verzeichnis für Plugin-Assets beschreibbar"
   text_powered_by: "Powered by %{link}"
   text_project_destroy_confirmation: "Sind Sie sicher, dass sie das Projekt löschen wollen?"
-  text_project_identifier_info: "Kleinbuchstaben (a-z), Ziffern, Binde- und Unterstriche erlaubt, muss mit einem Kleinbuchstaben beginnen.<br />Einmal gespeichert, kann die Kennung nicht mehr geändert werden."
+  text_project_identifier_info: "Kleinbuchstaben (a-z), Ziffern, Binde- und Unterstriche erlaubt, muss mit einem Kleinbuchstaben beginnen."
   text_reassign: "Neu zuweisen an"
   text_reassign_to: "Ziel-Arbeitspaket:"
   text_regexp_info: "z. B. ^[A-Z0-9]+$"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1359,7 +1359,7 @@ en:
   text_plugin_assets_writable: "Plugin assets directory writable"
   text_powered_by: "Powered by %{link}"
   text_project_destroy_confirmation: "Are you sure you want to delete this project and related data?"
-  text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter.<br />Once saved, the identifier cannot be changed."
+  text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter."
   text_reassign: "Reassign to"
   text_reassign_to: "work package:"
   text_regexp_info: "eg. ^[A-Z0-9]+$"


### PR DESCRIPTION
Fixes https://www.openproject.org/work_packages/4755
- `#4755` Wrong message "project identifier can't be edited"
