### PR TITLE
[FIX] Doubled watcher list in wp new 4762

### DIFF
--- a/app/views/work_packages/_form.html.erb
+++ b/app/views/work_packages/_form.html.erb
@@ -66,9 +66,6 @@ See doc/COPYRIGHT.rdoc for more details.
     <% work_package.project.users.sort.each do |user| -%>
       <label class="floating"><%= check_box_tag 'work_package[watcher_user_ids][]', user.id, work_package.watched_by?(user) %> <%=h user %></label>
     <% end -%>
-    <% work_package.project.users.sort.each do |user| -%>
-      <label class="floating"><%= check_box_tag 'work_package[watcher_user_ids][]', user.id, work_package.watched_by?(user) %> <%=h user %></label>
-    <% end -%>
   </div>
 <% end %>
 


### PR DESCRIPTION
Implements [ticket 4762](https://www.openproject.org/work_packages/4762)
- `#4762` List of watchers displayed twice when creating a work package
