### PR TITLE
Fixed 500 passing the note parameter on work package create

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -58,7 +58,7 @@ module Api
 
       def create
         @planning_element = @project.work_packages.build
-        @planning_element.update_attributes(permitted_params.planning_element)
+        @planning_element.update_attributes(permitted_params.planning_element.except :note)
 
         # The planning_element inherits from workpackage, which requires an author.
         # Using the current_user also satisfies this demand for API-calls


### PR DESCRIPTION
Implements https://www.openproject.org/work_packages/4337

Suggested changelog entry:
- `#4337` Fix: HTTP 500 when creating WP with note via API
