### PR TITLE
show current search scope

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -60,7 +60,7 @@ module SearchHelper
     options << [l(:label_and_its_subprojects, @project.name), 'subprojects'] unless @project.nil? || @project.descendants.active.empty?
     options << [@project.name, 'current_project'] unless @project.nil?
     label_tag("scope", l(:description_project_scope), :class => "hidden-for-sighted") +
-    select_tag('scope', options_for_select(options, params[:scope].to_s)) if options.size > 1
+    select_tag('scope', options_for_select(options, current_scope)) if options.size > 1
   end
 
   def render_results_by_type(results_by_type)
@@ -77,12 +77,16 @@ module SearchHelper
         :q => params[:q],
         :titles_only => params[:title_only],
         :all_words => params[:all_words],
-        :scope => params[:scope],
+        :scope => current_scope,
         t => 1
       }
       links << link_to(h(text), target)
     end
     ('<ul>' + links.map {|link| content_tag('li', link)}.join(' ') + '</ul>').html_safe unless links.empty?
+  end
+
+  def current_scope
+    params[:scope] || ('current_project' unless @project.nil?)
   end
 
   def link_to_previous_search_page(pagination_previous_date)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#3312` Fix: [Administration - Custom Fields] "Visible" and "Editable" in user custom field cannot be unchecked
 * `#4858` XSS in wp auto-completion
 * Added pry-byebug for ruby 2.1
+* `#4793` Fix: [Search] Current project scope not shown
 
 ## 3.0.0pre48
 

--- a/spec/views/search/index.html.erb_spec.rb
+++ b/spec/views/search/index.html.erb_spec.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'search/index' do
+  let(:project)      { FactoryGirl.create :project }
+  let(:user)         { FactoryGirl.create :admin, :member_in_project => project }
+  let(:work_package) { FactoryGirl.create :work_package, :project => project }
+
+  before do
+    assign :project, project
+    assign :object_types, ["work_packages"]
+    assign :scope, ["work_packages", "changesets"]
+    assign :results, [work_package]
+    assign :results_by_type, {"work_packages" => 1}
+    assign :question, "foo"
+    assign :tokens, ["bar"]
+  end
+
+  it 'selects the current project' do
+    render
+
+    # the current project should be selected as the scope
+    expect(response).to have_selector("option[selected]", :text => project.name)
+
+    # The grouped result link should retain the scope
+    response.should have_xpath("//a[contains(@href,'current_project')]", :text => /work packages.*/i)
+  end
+end


### PR DESCRIPTION
WP [#4793](https://www.openproject.org/work_packages/4793)

change log:
- `#4793` Fix: [Search] Current project scope not shown
