### PR TITLE
[FIX] Long work package headings 4186

### DIFF
--- a/app/assets/stylesheets/content/_headings.css.sass
+++ b/app/assets/stylesheets/content/_headings.css.sass
@@ -26,32 +26,6 @@
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
 
-@import global/all
-@import fonts/lato
-@import fonts/openproject_icon_font
-@import external
-@import select2_customizing
-@import jstoolbar
-@import content/context_menu
-@import print
-@import scm
-@import top-shelf
-@import work_packages
-@import openproject_plugins
-@import layout/all
-@import content/forms
-@import content/flash_messages
-@import content/calendar
-@import content/wiki
-@import content/links
-@import content/action_menu_main
-@import content/my_page
-@import content/buttons
-@import content/boxes
-@import content/tabular
-@import content/work_package_report
-@import content/expandable_group_content
-@import content/control_colors
-@import content/tabular
-@import content/headings
-@import default/main
+#content
+  h2
+    padding-right: 340px


### PR DESCRIPTION
Implements [ticket 4186](https://www.openproject.org/work_packages/4186)
- `#4186` Long work package subject covers up edit buttons
