### PR TITLE
Fix/byebug for mri 21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,7 @@ group :development do
   gem 'pry-rails'
   gem 'pry-stack_explorer'
   gem 'pry-rescue'
-  gem 'pry-byebug', :platforms => :mri_20
+  gem 'pry-byebug', :platforms => [:mri_20,:mri_21]
   gem 'pry-debugger', :platforms => :mri_19
   gem 'pry-doc'
   gem 'rails-dev-tweaks', '~> 0.6.1'


### PR DESCRIPTION
For debugging in pry we use the `pry-byebug` gem. Unfortunately it was only enabled for `mri_20`.
I've added `mri_21` to the list.
