### PR TITLE
Added default sorted scope to Status, so whenever statuses are

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -36,9 +36,8 @@ class StatusesController < ApplicationController
 
   verify :method => :get, :only => :index, :render => {:nothing => true, :status => :method_not_allowed }
   def index
-    @statuses = Status.order('position')
-                                 .page(params[:page])
-                                 .per_page(per_page_param)
+    @statuses = Status.page(params[:page])
+                      .per_page(per_page_param)
 
     render :action => "index", :layout => false if request.xhr?
   end

--- a/app/controllers/work_packages/context_menus_controller.rb
+++ b/app/controllers/work_packages/context_menus_controller.rb
@@ -69,7 +69,7 @@ class WorkPackages::ContextMenusController < ApplicationController
     end
 
     @priorities = IssuePriority.all.reverse
-    @statuses = Status.find(:all, :order => 'position')
+    @statuses = Status.all
     @back = back_url
 
     render :layout => false

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -62,7 +62,7 @@ class WorkflowsController < ApplicationController
     if @type && @used_statuses_only && @type.statuses.any?
       @statuses = @type.statuses
     end
-    @statuses ||= Status.find(:all, :order => 'position')
+    @statuses ||= Status.all
 
     if @type && @role && @statuses.any?
       workflows = Workflow.all(:conditions => {:role_id => @role.id, :type_id => @type.id})

--- a/app/models/queries/work_packages/available_filter_options.rb
+++ b/app/models/queries/work_packages/available_filter_options.rb
@@ -43,7 +43,7 @@ module Queries::WorkPackages::AvailableFilterOptions
     types = project.nil? ? Type.find(:all, order: 'position') : project.rolled_up_types
 
     @available_work_package_filters = {
-      status_id:       { type: :list_status, order: 1, values: Status.find(:all, order: 'position').collect{|s| [s.name, s.id.to_s] } },
+      status_id:       { type: :list_status, order: 1, values: Status.all.collect{|s| [s.name, s.id.to_s] } },
       type_id:         { type: :list, order: 2, values: types.collect{|s| [s.name, s.id.to_s] } },
       priority_id:     { type: :list, order: 3, values: IssuePriority.all.collect{|s| [s.name, s.id.to_s] } },
       subject:         { type: :text, order: 8 },

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -31,6 +31,7 @@ class Status < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
   extend Pagination::Model
 
+  default_scope order('position ASC')
   before_destroy :check_integrity
   has_many :workflows, :foreign_key => "old_status_id"
   acts_as_list

--- a/app/services/reports/report.rb
+++ b/app/services/reports/report.rb
@@ -42,7 +42,7 @@ class Reports::Report
   end
 
   def statuses
-    @statuses ||= Status.order('position')
+    @statuses ||= Status.all
   end
 
   # ---- every report needs to implement these methods to supply all needed data for a report -----

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -58,7 +58,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <span>
   <label style="float:none; margin-left:0px; display: inline;">
     <%= l(:label_applied_status) %>:
-    <%= setting_select :commit_fix_status_id, [["", 0]] + Status.find(:all).collect{|status| [status.name, status.id.to_s]}, :label => false %>
+    <%= setting_select :commit_fix_status_id, [["", 0]] + Status.all.collect{|status| [status.name, status.id.to_s]}, :label => false %>
   </label>
   <label style="float:none; margin-left:0px; display: inline;">
     <%= WorkPackage.human_attribute_name(:done_ratio) %>:


### PR DESCRIPTION
retrieved without any ordering parameter, they should be sorted
automatically

Implements https://www.openproject.org/work_packages/3084 and https://www.openproject.org/work_packages/2674

Suggested Changelog entry for core:
- `#3084` Fix: [Administration - Work Packages] Workflow Status sorting not respected
