### PR TITLE
Fix/validate presence of name in query 3404

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -242,7 +242,7 @@ module Api
         if params[:f]
           #we need a project to make project-specific custom fields work
           project = timeline_to_project(params[:timeline])
-          query = Query.new(:project => project, :name => ' ')
+          query = Query.new(:project => project, :name => '_')
 
           query.add_filters(params[:f], params[:op], params[:v])
 

--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -242,7 +242,7 @@ module Api
         if params[:f]
           #we need a project to make project-specific custom fields work
           project = timeline_to_project(params[:timeline])
-          query = Query.new(:project => project)
+          query = Query.new(:project => project, :name => ' ')
 
           query.add_filters(params[:f], params[:op], params[:v])
 

--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -231,7 +231,7 @@ module Project::Copy
       # Copies queries from +project+
     def copy_queries(project)
       project.queries.each do |query|
-        new_query = ::Query.new name: ' '
+        new_query = ::Query.new name: '_'
         new_query.attributes = query.attributes.dup.except("id", "project_id", "sort_criteria")
         new_query.sort_criteria = query.sort_criteria if query.sort_criteria
         new_query.project = self

--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -231,7 +231,7 @@ module Project::Copy
       # Copies queries from +project+
     def copy_queries(project)
       project.queries.each do |query|
-        new_query = ::Query.new
+        new_query = ::Query.new name: ' '
         new_query.attributes = query.attributes.dup.except("id", "project_id", "sort_criteria")
         new_query.sort_criteria = query.sort_criteria if query.sort_criteria
         new_query.project = self

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -44,11 +44,11 @@ class Query < ActiveRecord::Base
 
   attr_protected :project_id #, :user_id
 
-  validates_presence_of :name, on: :save
+  validates :name, presence: true
   validates_length_of :name, :maximum => 255
 
   validate :validate_work_package_filters
-  validates_presence_of :filters
+  validates :filters, presence: true
 
   after_initialize :remember_project_scope
 

--- a/app/services/planning_comparison_service.rb
+++ b/app/services/planning_comparison_service.rb
@@ -63,7 +63,7 @@ SQL
                                       .joins(:project) # query doesn't provide these joins itself...
                                       .for_projects(projects)
 
-      query = Query.new
+      query = Query.new name: 'generated-query'
       query.add_filters(filter[:f], filter[:op], filter[:v])
 
       work_package_scope.with_query(query)

--- a/app/views/queries/_form.html.erb
+++ b/app/views/queries/_form.html.erb
@@ -27,6 +27,10 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%# expects the following locals:
+  - @query and query: a Query object
+%>
+
 <%= error_messages_for 'query' %>
 <%= hidden_field_tag 'confirm', 1 %>
 
@@ -34,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="tabular">
     <p>
-      <%= label :query, :name %>
+      <%= label :query, :name, required_field_name(Query.human_attribute_name(:name)) %>
       <%= text_field 'query', 'name', size: 80 %>
     </p>
     <% if query.any_summable_columns? %>

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -51,6 +51,12 @@ describe Query do
   end
 
   describe '#valid?' do
+    it "should not be valid without a name" do
+      query.name = ''
+      expect(query.valid?).to be_false
+      expect(query.errors[:name].first).to include(I18n.t('activerecord.errors.messages.blank'))
+    end
+
     context 'with a missing value' do
       before do
         query.add_filter('due_date', 't-', [''])
@@ -71,7 +77,7 @@ describe Query do
         expect(query.errors[:filters]).to include(I18n.t('activerecord.errors.messages.blank'))
       end
     end
-    
+
     context 'with a missing value for a custom field' do
       let(:custom_field) { FactoryGirl.create :text_issue_custom_field }
       let(:query) { FactoryGirl.build(:query)}
@@ -79,7 +85,7 @@ describe Query do
       before do
         query.filters = [Queries::WorkPackages::Filter.new("cf_" + custom_field.id.to_s, operator: "=", values: ['']) ]
       end
-      
+
       it 'should have the name of the custom field in the error message' do
         expect(query.valid?).to be_false
         expect(query.errors.messages[:base].to_s).to include(custom_field.name)

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -53,7 +53,7 @@ describe Query do
   describe '#valid?' do
     it "should not be valid without a name" do
       query.name = ''
-      expect(query.valid?).to be_false
+      expect(query.save).to be_false
       expect(query.errors[:name].first).to include(I18n.t('activerecord.errors.messages.blank'))
     end
 

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -252,12 +252,12 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_default_columns
-    q = Query.new
+    q = Query.new name: '_'
     assert !q.columns.empty?
   end
 
   def test_set_column_names
-    q = Query.new
+    q = Query.new name: '_'
     q.column_names = ['type', :subject, '', 'unknonw_column']
     assert_equal [:type, :subject], q.columns.collect {|c| c.name}
     c = q.columns.first
@@ -265,12 +265,12 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_groupable_columns_should_include_custom_fields
-    q = Query.new
+    q = Query.new name: '_'
     assert q.groupable_columns.detect {|c| c.is_a? QueryCustomFieldColumn}
   end
 
   def test_grouped_with_valid_column
-    q = Query.new(:group_by => 'status')
+    q = Query.new(:group_by => 'status', :name => '_')
     assert q.grouped?
     assert_not_nil q.group_by_column
     assert_equal :status, q.group_by_column.name
@@ -279,25 +279,25 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_grouped_with_invalid_column
-    q = Query.new(:group_by => 'foo')
+    q = Query.new(:group_by => 'foo', :name => '_')
     assert !q.grouped?
     assert_nil q.group_by_column
     assert_nil q.group_by_statement
   end
 
   def test_default_sort
-    q = Query.new
+    q = Query.new name: '_'
     assert_equal [], q.sort_criteria
   end
 
   def test_set_sort_criteria_with_hash
-    q = Query.new
+    q = Query.new name: '_'
     q.sort_criteria = {'0' => ['priority', 'desc'], '2' => ['type']}
     assert_equal [['priority', 'desc'], ['type', 'asc']], q.sort_criteria
   end
 
   def test_set_sort_criteria_with_array
-    q = Query.new
+    q = Query.new name: '_'
     q.sort_criteria = [['priority', 'desc'], 'type']
     assert_equal [['priority', 'desc'], ['type', 'asc']], q.sort_criteria
   end
@@ -311,7 +311,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_sort_by_string_custom_field_asc
-    q = Query.new
+    q = Query.new name: '_'
     c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
@@ -325,7 +325,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_sort_by_string_custom_field_desc
-    q = Query.new
+    q = Query.new name: '_'
     c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
@@ -339,7 +339,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_sort_by_float_custom_field_asc
-    q = Query.new
+    q = Query.new name: '_'
     c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
     assert c
     assert c.sortable
@@ -353,7 +353,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_invalid_query_should_raise_query_statement_invalid_error
-    q = Query.new
+    q = Query.new name: '_'
     assert_raise ActiveRecord::StatementInvalid do
       q.results(:conditions => "foo = 1").work_packages.all
     end
@@ -386,7 +386,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_label_for
-    q = Query.new
+    q = Query.new name: '_'
     assert_equal 'assigned_to', q.label_for('assigned_to_id')
   end
 
@@ -702,5 +702,4 @@ class QueryTest < ActiveSupport::TestCase
       end
     end
   end
-
 end


### PR DESCRIPTION
see: https://www.openproject.org/work_packages/3404

you may use this pretty awesome text for your changelog entry

<pre>* `#3404`[Work package tracking] Custom queries with empty names can be saved </pre>
