### PR TITLE
add :editable, :visible to permitted_params of custom_fields

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -282,6 +282,7 @@ class PermittedParams < Struct.new(:params, :user)
         :hexcode,
         :move_to ],
       :custom_field => [
+        :editable,
         :field_format,
         :is_filter,
         :is_for_all,
@@ -293,6 +294,7 @@ class PermittedParams < Struct.new(:params, :user)
         :possible_values,
         :regexp,
         :searchable,
+        :visible,
         :translations_attributes => [
           :_destroy,
           :default_value,

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -107,6 +107,14 @@ describe PermittedParams do
     end
   end
 
+  describe :custom_field do
+    it "should permit move_to" do
+      params = ActionController::Parameters.new(:custom_field => { "editable" => "0", "visible" => "0", 'filtered' => 42 } )
+
+      PermittedParams.new(params, user).custom_field.should == { "editable" => "0", "visible" => "0" }
+    end
+  end
+
   describe :planning_element_type do
     it "should permit move_to" do
       hash = { "name" => "blubs" }


### PR DESCRIPTION
see: https://www.openproject.org/work_packages/3312

suggested changelog entry:

<pre>* `#3312` [Administration - Custom Fields] "Visible" and "Editable" in user custom field cannot be unchecked</pre>
