### PR TITLE
Gemfile improvements: Optional therubyracer, guard in development group, no direct execjs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -177,10 +177,6 @@ group :development do
   gem 'rb-fsevent', :group => :test
   gem 'thin'
   gem 'faker'
-end
-
-group :tools do
-  # why tools? see: https://github.com/guard/guard-test
   gem 'guard-test'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,11 +71,6 @@ gem 'htmldiff'
 # used for statistics on svn repositories
 gem 'svg-graph'
 
-gem 'execjs'
-
-# You don't need therubyracer if you have nodejs installed on the machine precompiling assets.
-gem 'therubyracer', :group => :therubyracer
-
 gem "date_validator"
 
 # replacing rsb with rabl --
@@ -115,6 +110,9 @@ group :assets do
   gem 'select2-rails', '~> 3.3.2'
   gem 'jquery-atwho-rails'
 end
+
+# You don't need therubyracer if you have nodejs installed on the machine precompiling assets.
+gem 'therubyracer', :group => :therubyracer
 
 gem "prototype-rails"
 # remove once we no longer use the deprecated "link_to_remote", "remote_form_for" and alike methods

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,8 @@ gem 'svg-graph'
 
 gem 'execjs'
 
-gem 'therubyracer'
+# You don't need therubyracer if you have nodejs installed on the machine precompiling assets.
+gem 'therubyracer', :group => :therubyracer
 
 gem "date_validator"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,6 @@ DEPENDENCIES
   database_cleaner
   date_validator
   delayed_job_active_record (= 0.3.3)
-  execjs
   factory_girl_rails (~> 4.0)
   faker
   globalize


### PR DESCRIPTION
- Optional therubyracer allows asset precompilation without bundling a V8 runtime by using Node
- Guard in test group automatically excludes guard when the test group is not being used. The guard docs no longer mention that guard should be put into a tools group.
- No execjs dependency allows production use with precompiled assets without a JavaScript runtime on the production servers
