### PR TITLE
[WIP] allow storage path to be a lambda

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -167,7 +167,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def self.storage_path
-    @@storage_path.is_a?(Proc) ? @@storage_path.call : @@storage_path
+    @@storage_path.respond_to?(:call) ? @@storage_path.call : @@storage_path
   end
 
   # Bulk attaches a set of files to an object


### PR DESCRIPTION
NOTE: on hold, i'm not sure about this atm, discussion welcome

this PR allows setting the Attachment storage path to a lambda in order to evaluate to something dynamic per request, e.g. for added security. doesn't affect the current behaviour.

a contrieved example:

``` ruby
Attachment.storage_path = lambda { User.current.admin? ? 'secure' : 'not_secure' }

attachment.disk_filename # => 'somefile.txt'

User.current = some_admin
attachment.diskfile # => '/secure/somefile.txt'

User.current = some_user
attachment.diskfile # => '/not_secure/somefile.txt'
```
