### PR TITLE
Remove unused rmagick dependency and check in admin/info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,24 +180,6 @@ group :development do
   gem 'guard-test'
 end
 
-group :rmagick do
-  gem "rmagick", ">= 1.15.17"
-  # Older distributions might not have a sufficiently new ImageMagick version
-  # for the current rmagick release (current rmagick is rmagick 2, which
-  # requires ImageMagick 6.4.9 or later). If this is the case for you, comment
-  # the line above this comment block and uncomment the one underneath it to
-  # get an rmagick version known to work on older distributions.
-  #
-  # The following distributíons are known to *not* ship with a usable
-  # ImageMagick version. There might be additional ones.
-  #   * Ubuntu 9.10 and older
-  #   * Debian Lenny 5.0 and older
-  #   * CentOS 5 and older
-  #   * RedHat 5 and older
-  #
-  #gem "rmagick", "< 2.0.0"
-end
-
 # Use the commented pure ruby gems, if you have not the needed prerequisites on
 # board to compile the native ones.  Note, that their use is discouraged, since
 # their integration is propbably not that well tested and their are slower in

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,6 @@ GEM
       json (~> 1.4)
     ref (1.0.5)
     request_store (1.0.5)
-    rmagick (2.13.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -414,7 +413,6 @@ DEPENDENCIES
   rb-readline
   rdoc (>= 2.4.2)
   request_store
-  rmagick (>= 1.15.17)
   rspec (~> 2.0)
   rspec-example_disabler
   rspec-rails (~> 2.0)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -105,8 +105,7 @@ class AdminController < ApplicationController
     @db_adapter_name = ActiveRecord::Base.connection.adapter_name
     @checklist = [
       [:text_default_administrator_account_changed, User.default_admin_account_changed?],
-      [:text_file_repository_writable, File.writable?(Attachment.storage_path)],
-      [:text_rmagick_available, Object.const_defined?(:Magick)]
+      [:text_file_repository_writable, File.writable?(Attachment.storage_path)]
     ]
   end
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1386,7 +1386,6 @@ de:
   text_reassign_to: "Ziel-Arbeitspaket:"
   text_regexp_info: "z. B. ^[A-Z0-9]+$"
   text_repository_usernames_mapping: "Bitte legen Sie die Zuordnung der OpenProject-Benutzer zu den Benutzernamen der Commit-Log-Meldungen des Projektarchivs fest.\nBenutzer mit identischen OpenProject- und Projektarchiv-Benutzernamen oder -E-Mail-Adressen werden automatisch zugeordnet."
-  text_rmagick_available: "RMagick verfügbar (optional)"
   text_select_mail_notifications: "Bitte wählen Sie die Aktionen aus, für die eine Mailbenachrichtigung gesendet werden soll."
   text_select_project_modules: "Bitte wählen Sie die Module aus, die in diesem Projekt aktiviert sein sollen:"
   text_status_changed_by_changeset: "Status geändert durch Changeset %{value}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1371,7 +1371,6 @@ en:
   text_reassign_to: "work package:"
   text_regexp_info: "eg. ^[A-Z0-9]+$"
   text_repository_usernames_mapping: "Select or update the OpenProject user mapped to each username found in the repository log.\nUsers with the same OpenProject and repository username or email are automatically mapped."
-  text_rmagick_available: "RMagick available (optional)"
   text_select_mail_notifications: "Select actions for which email notifications should be sent."
   text_select_project_modules: "Select modules to enable for this project:"
   text_status_changed_by_changeset: "Applied in changeset %{value}."

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -41,11 +41,6 @@ require 'redmine/notifiable'
 require 'redmine/wiki_formatting'
 require 'redmine/scm/base'
 
-begin
-  require 'RMagick' unless Object.const_defined?(:Magick)
-rescue LoadError
-  # RMagick is not available
-end
 
 require 'csv'
 require 'globalize'


### PR DESCRIPTION
Only thing that still references Magick is RFPDF, which can embed images into PDFs. We don't do that and will hopefully never implement new things with RFPDF, so we don't need rmagick any more.

Changelog Entry:
`* Remove unused rmagick dependency`
