### PR TITLE
Meets #2393: No warning when leaving site without saving

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -505,6 +505,7 @@ var WarnLeavingUnsaved = Class.create({
 	},
 
 	unload: function(){
+      this.observedElements.each(function(item){ item.blur(); });
 		if(this.changedForms)
       return this.message;
 	},


### PR DESCRIPTION
Fix tasks:

```
* `#2393` Fix: No warning when leaving site without saving
```
