### PR TITLE
Fix/update jquery atwho rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
   gem 'jquery-ui-rails'
   gem 'select2-rails', '~> 3.3.2'
-  gem 'jquery-atwho-rails'
+  gem 'jquery-atwho-rails', '~> 0.4.7'
 end
 
 # You don't need therubyracer if you have nodejs installed on the machine precompiling assets.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     i18n (0.6.5)
     interception (0.3)
     journey (1.0.4)
-    jquery-atwho-rails (0.4.1)
+    jquery-atwho-rails (0.4.7)
     jquery-rails (2.0.3)
       railties (>= 3.1.0, < 5.0)
       thor (~> 0.14)
@@ -383,7 +383,7 @@ DEPENDENCIES
   guard-test
   htmldiff
   i18n-js!
-  jquery-atwho-rails
+  jquery-atwho-rails (~> 0.4.7)
   jquery-rails (~> 2.0.3)
   jquery-ui-rails
   jruby-openssl

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery.ui.all
 //= require jquery-ui-i18n
-//= require jquery.atwho
+//= require jquery.atwho/index
 //= require jquery_ujs
 //= require jquery_noconflict
 //= require jquery.colorcontrast


### PR DESCRIPTION
there is a new jquery-atwho-rails version out there which renames their js-include-files.

People seem to stumble over this change which is why I want to provide an update to the latest version.

see: https://www.openproject.org/work_packages/5079
and https://www.openproject.org/topics/693?board_id=9

Changelog Entry:
    \* `#5979` Update to current version of jquery.atwho
