### PR TITLE
Bugfix/3395 after error message form fields empty

### DIFF
--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <h2><%= link_to h(@board.name), :controller => '/boards', :action => 'show', :project_id => @project, :id => @board %> &#187; <%= l(:label_message_new) %></h2>
 
-<%= form_for Message.new,
+<%= form_for @message,
              :url => board_topics_path(@board),
              :html => { :multipart => true,
                         :id => 'message-form'} do |f| %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -28,7 +28,6 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <h2><%= link_to h(@board.name), :controller => '/boards', :action => 'show', :project_id => @project, :id => @board %> &#187; <%= l(:label_message_new) %></h2>
-
 <%= form_for @message,
              :url => board_topics_path(@board),
              :html => { :multipart => true,

--- a/features/messages/message.feature
+++ b/features/messages/message.feature
@@ -71,11 +71,10 @@ Feature: Issue textile quickinfo links
     When I go to the message page of message "message #1"
     Then I should see "Replies (2)"
 
-  Scenario: Check fields values after error message raise when title/description is empty
+  Scenario: Check field value after error message raise when title is empty
     When I go to the boards page of the project called "parent"
     And I follow "New message"
     And I fill in "New relase FAQ" for "message_subject"
     When I click on the first button matching "Create"
     Then there should be an error message
     Then the "message_subject" field should contain "New relase FAQ"
-

--- a/features/messages/message.feature
+++ b/features/messages/message.feature
@@ -70,3 +70,12 @@ Feature: Issue textile quickinfo links
       | reply #2 |
     When I go to the message page of message "message #1"
     Then I should see "Replies (2)"
+
+  Scenario: Check fields values after error message raise when title/description is empty
+    When I go to the boards page of the project called "parent"
+    And I follow "New message"
+    And I fill in "New relase FAQ" for "message_subject"
+    When I click on the first button matching "Create"
+    Then there should be an error message
+    Then the "message_subject" field should contain "New relase FAQ"
+

--- a/features/messages/message.feature
+++ b/features/messages/message.feature
@@ -78,3 +78,11 @@ Feature: Issue textile quickinfo links
     When I click on the first button matching "Create"
     Then there should be an error message
     Then the "message_subject" field should contain "New relase FAQ"
+
+  Scenario: Check field value after error message raise when description is empty
+    When I go to the boards page of the project called "parent"
+    And I follow "New message"
+    And I fill in "Here you find the most frequently asked questions" for "message_content"
+    When I click on the first button matching "Create"
+    Then there should be an error message
+    Then the "message_content" field should contain "Here you find the most frequently asked questions"


### PR DESCRIPTION
Fixed by replacing "form_for Message.new" with "form_for @message"

```
* `#3395` Fix: After error message values are gone during creation of message
```
