### PR TITLE
unifies creation/deletion/error notices in user's membership tab

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1248,15 +1248,16 @@ var activateError = function() {
 }
 
 var activateFlash = function() {
-  var flashMessage = jQuery('.flash');
+  var flashMessages = jQuery('.flash');
 
   // Ignore flash messages of class 'ignored-by-flash-activation' because those
   // messages are completely handled via JavaScript (see types_checkboxes.js for
   // details). We wouldn't have to ignore this message if the flash element
   // would be completely created via JavaScript and not available in the DOM by
   // default.
-  flashMessage.each(function (ix, e) {
-    if (!jQuery(e).hasClass('ignored-by-flash-activation')) {
+  flashMessages.each(function (ix, e) {
+    flashMessage = jQuery(e);
+    if (!flashMessage.hasClass('ignored-by-flash-activation')) {
       flashMessage.show();
     }
   });

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -80,11 +80,11 @@ JS
 
   def update
     member = update_member_from_params
-    member.save
+    if member.save
+      flash.now.notice = l(:notice_successful_update)
+    end
 
     respond_to do |format|
-      flash.now.notice = l(:notice_successful_update)
-
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project, :page => params[:page] }
       format.js do
         @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
@@ -107,10 +107,9 @@ JS
   def destroy
     if @member.deletable?
       @member.destroy
+      flash.now.notice = l(:notice_successful_delete)
     end
     respond_to do |format|
-      flash.now.notice = l(:notice_successful_delete)
-
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project }
       format.js do
         @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -54,26 +54,26 @@ JS
 
         format.html { redirect_to settings_project_path(@project, :tab => 'members') }
 
-        format.js {
+        format.js do
           @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
-          render(:update) {|page|
+          render(:update) do |page|
             page.replace_html "tab-content-members", :partial => 'projects/settings/members'
             page.insert_html :top, "tab-content-members", render_flash_messages
 
             page << TAB_SCRIPTS
-          }
-        }
+          end
+        end
       else
-        format.js {
+        format.js do
           @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
-          render(:update) {|page|
+          render(:update) do |page|
             if params[:member]
-              page.insert_html :top, "tab-content-members", :partial => "members/member_errors", :locals => {:member => members.first}
+              page.insert_html :top, "tab-content-members", :partial => "members/member_errors", :locals => { :member => members.first }
             else
-              page.insert_html :top, "tab-content-members", :partial => "members/common_error", :locals => {:message => l(:error_check_user_and_role)}
+              page.insert_html :top, "tab-content-members", :partial => "members/common_error", :locals => { :message => l(:error_check_user_and_role) }
             end
-            }
-        }
+          end
+        end
       end
     end
   end
@@ -86,10 +86,10 @@ JS
       flash.now.notice = l(:notice_successful_update)
 
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project, :page => params[:page] }
-      format.js {
+      format.js do
         @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
 
-        render(:update) { |page|
+        render(:update) do |page|
           if params[:membership]
             @user = member.user
             page.replace_html "tab-content-memberships", :partial => 'users/memberships'
@@ -99,8 +99,8 @@ JS
           page.insert_html :top, "tab-content-members", render_flash_messages
           page << TAB_SCRIPTS
           page.visual_effect(:highlight, "member-#{@member.id}") unless Member.find_by_id(@member.id).nil?
-        }
-      }
+        end
+      end
     end
   end
 
@@ -112,14 +112,14 @@ JS
       flash.now.notice = l(:notice_successful_delete)
 
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project }
-      format.js {
-          @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
-          render(:update) {|page|
+      format.js do
+        @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
+        render(:update) do |page|
           page.replace_html "tab-content-members", :partial => 'projects/settings/members'
           page.insert_html :top, "tab-content-members", render_flash_messages
           page << TAB_SCRIPTS
-        }
-      }
+        end
+      end
     end
   end
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -106,11 +106,14 @@ JS
       @member.destroy
     end
     respond_to do |format|
+      flash.now.notice = l(:notice_successful_delete)
+
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project }
       format.js {
           @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
           render(:update) {|page|
           page.replace_html "tab-content-members", :partial => 'projects/settings/members'
+          page.insert_html :top, "tab-content-members", render_flash_messages
           page << TAB_SCRIPTS
         }
       }

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -83,6 +83,8 @@ JS
     member.save
 
     respond_to do |format|
+      flash.now.notice = l(:notice_successful_update)
+
       format.html { redirect_to :controller => '/projects', :action => 'settings', :tab => 'members', :id => @project, :page => params[:page] }
       format.js {
         @pagination_url_options = {controller: 'projects', action: 'settings', id: @project}
@@ -94,6 +96,7 @@ JS
           else
             page.replace_html "tab-content-members", :partial => 'projects/settings/members'
           end
+          page.insert_html :top, "tab-content-members", render_flash_messages
           page << TAB_SCRIPTS
           page.visual_effect(:highlight, "member-#{@member.id}") unless Member.find_by_id(@member.id).nil?
         }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -247,13 +247,14 @@ class UsersController < ApplicationController
         format.js {
           render(:update) {|page|
             page.replace_html "tab-content-memberships", :partial => 'users/memberships'
+            page.insert_html :top, "tab-content-memberships", :partial => "members/common_notice", :locals => {:message => l(:notice_successful_update)}
             page.visual_effect(:highlight, "member-#{@membership.id}")
           }
         }
       else
         format.js {
           render(:update) {|page|
-            page.alert(l(:notice_failed_to_save_members, :errors => @membership.errors.full_messages.join(', ')))
+            page.insert_html :top, "tab-content-memberships", :partial => "members/member_errors", :locals => {:member => @membership}
           }
         }
       end
@@ -295,7 +296,12 @@ class UsersController < ApplicationController
     end
     respond_to do |format|
       format.html { redirect_to :controller => '/users', :action => 'edit', :id => @user, :tab => 'memberships' }
-      format.js { render(:update) {|page| page.replace_html "tab-content-memberships", :partial => 'users/memberships'} }
+      format.js {
+        render(:update) { |page|
+          page.replace_html "tab-content-memberships", :partial => 'users/memberships'
+          page.insert_html :top, "tab-content-memberships", :partial => "members/common_notice", :locals => {:message => l(:notice_successful_delete)}
+        }
+      }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -254,6 +254,7 @@ class UsersController < ApplicationController
       else
         format.js {
           render(:update) {|page|
+            page.replace_html "tab-content-memberships", :partial => 'users/memberships'
             page.insert_html :top, "tab-content-memberships", :partial => "members/member_errors", :locals => {:member => @membership}
           }
         }

--- a/app/views/members/_common_notice.html.erb
+++ b/app/views/members/_common_notice.html.erb
@@ -1,0 +1,38 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<div class="flash notice">
+  <ul>
+    <li>
+      <a  href="#">
+        <%= h message %>
+      </a>
+    </li>
+  <ul>
+</div>

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% roles = Role.find_all_givable %>
 <% projects = Project.active.find(:all, :order => 'lft') %>
+<%= javascript_include_tag "activate_error_messages" %>
 
 <div class="splitcontentleft">
 <% if @user.memberships.any? %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ OpenProject::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   config.assets.precompile += %w( default.css
                                   rtl.css context_menu_rtl.css
-                                  accessibility.js accessibility.css
+                                  accessibility.js accessibility.css activate_error_messages.js
                                   copy_issue_actions.js repository_navigation.js select_list_move.js
                                   jstoolbar/lang/*.js calendar/lang/*.js )
 


### PR DESCRIPTION
[`* `#3775` No success message when adding a user to a project`](https://www.openproject.org/work_packages/3775)
Additionally removes the unexpected alert message as well as adding a new successful deletion message.
