### PR TITLE
Fix/members double escaping

### DIFF
--- a/app/assets/javascripts/members_select_boxes.js
+++ b/app/assets/javascripts/members_select_boxes.js
@@ -51,7 +51,7 @@ jQuery(document).ready(function($) {
     };
 
     formatItemSelection = function (item) {
-      return OpenProject.Helpers.markupEscape(item.name);
+      return item.name;
     };
     
     $("#members_add_form select.select2-select").each(function (ix, elem){

--- a/app/assets/javascripts/members_select_boxes.js
+++ b/app/assets/javascripts/members_select_boxes.js
@@ -87,13 +87,7 @@ jQuery(document).ready(function($) {
                       };
                   },
                   results: function (data, page) {
-
-                      active_items = [];
-                      data.results.items.each(function (e) {
-                        e.name = $('<pre>').text(e.name).html();
-                        active_items.push(e);
-                      });
-                      return {'results': active_items, 'more': data.results.more};
+                      return {'results': data.results.items, 'more': data.results.more};
                   }
               },
               formatResult: formatItems,

--- a/features/members/membership.feature
+++ b/features/members/membership.feature
@@ -47,6 +47,11 @@ Feature: Membership
         | Firstname | Hannibal |
         | Lastname  | Smith    |
 
+      And there is 1 User with:
+        | Login     | crash                         |
+        | Firstname | <script>alert('h4x');<script> |
+        | Lastname  | <script>alert('h4x');<script> |
+
       And there is a group named "A-Team" with the following members:
         | peter    |
         | hannibal |
@@ -85,6 +90,20 @@ Feature: Membership
      When I go to the members tab of the settings page of the project "project1"
       And I enter the principal name "Smith, H"
       Then I should see "Hannibal Smith"
+
+  @javascript
+  Scenario: Escaping should work properly when entering a name
+     When I go to the members tab of the settings page of the project "project1"
+     And  I enter the principal name "script"
+     Then I should not see an alert dialog
+      And I should see "<script>alert('h4x');<script>"
+
+  @javascript
+  Scenario: Escaping should work properly when selecting a user
+     When I go to the members tab of the settings page of the project "project1"
+     When I select the principal "script"
+     Then I should not see an alert dialog
+      And I should see "<script>alert('h4x');<script>"
 
   @javascript
   Scenario: Adding and Removing a Group as Member, impaired

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -470,6 +470,19 @@ When /^I confirm popups$/ do
   page.driver.browser.switch_to.alert.accept
 end
 
+# Needs Selenium!
+Then(/^I should( not )?see a(?:n) alert dialog$/) do |negative|
+  negative = !!negative
+  if Capybara.current_driver.to_s.include?("selenium")
+    begin
+      page.driver.browser.switch_to.alert
+      expect(negative).to eq(false)
+    rescue Selenium::WebDriver::Error::NoAlertPresentError
+      expect(negative).to eq(true)
+    end
+  end
+end
+
 Then(/^I should see a confirm dialog$/) do
   page.should have_selector("#confirm_dialog")
 end


### PR DESCRIPTION
[`* `#1502` Multiple escaping on user select2 field in project members tab`](https://www.openproject.org/work_packages/1502)
