### PR TITLE
Added whitelisting of watchers and time entries for planning elements

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -97,7 +97,7 @@ module Api
         @planning_element = WorkPackage.find(params[:id])
         @planning_element.attributes = permitted_params.planning_element({:project => @project}).except :note
 
-        @planning_element.add_journal(User.current, permitted_params.planning_element[:note])
+        @planning_element.add_journal(User.current, permitted_params.planning_element({:project => @project})[:note])
 
         successfully_updated = @planning_element.save
 

--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -59,7 +59,7 @@ module Api
 
       def create
         @planning_element = @project.work_packages.build
-        @planning_element.update_attributes(permitted_params.planning_element.except :note)
+        @planning_element.update_attributes(permitted_params.planning_element({:project => @project}).except :note)
 
         @planning_element.attach_files(params[:attachments])
 
@@ -95,7 +95,7 @@ module Api
 
       def update
         @planning_element = WorkPackage.find(params[:id])
-        @planning_element.attributes = permitted_params.planning_element.except :note
+        @planning_element.attributes = permitted_params.planning_element({:project => @project}).except :note
 
         @planning_element.add_journal(User.current, permitted_params.planning_element[:note])
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -344,15 +344,17 @@ class PermittedParams < Struct.new(:params, :user)
         :subject,
         Proc.new do |args|
           # avoid costly allowed_to? if the param is not there at all
-          if args[:params]["work_package"].has_key?("watcher_user_ids") &&
-            args[:user].allowed_to?(:add_work_package_watchers, args[:project])
+          if args[:params]["work_package"] &&
+             args[:params]["work_package"].has_key?("watcher_user_ids") &&
+             args[:user].allowed_to?(:add_work_package_watchers, args[:project])
 
             { :watcher_user_ids => [] }
           end
         end,
         Proc.new do |args|
           # avoid costly allowed_to? if the param is not there at all
-          if args[:params]["work_package"].has_key?("time_entry") &&
+          if args[:params]["work_package"] &&
+             args[:params]["work_package"].has_key?("time_entry") &&
              args[:user].allowed_to?(:log_time, args[:project])
 
             { time_entry: [:hours, :activity_id, :comments] }
@@ -380,15 +382,17 @@ class PermittedParams < Struct.new(:params, :user)
         :subject,
         Proc.new do |args|
           # avoid costly allowed_to? if the param is not there at all
-          if args[:params]["planning_element"].has_key?("watcher_user_ids") &&
-            args[:user].allowed_to?(:add_work_package_watchers, args[:project])
+          if args[:params]["planning_element"] &&
+             args[:params]["planning_element"].has_key?("watcher_user_ids") &&
+             args[:user].allowed_to?(:add_work_package_watchers, args[:project])
 
             { :watcher_user_ids => [] }
           end
         end,
         Proc.new do |args|
           # avoid costly allowed_to? if the param is not there at all
-          if args[:params]["planning_element"].has_key?("time_entry") &&
+          if args[:params]["planning_element"] &&
+             args[:params]["planning_element"].has_key?("time_entry") &&
              args[:user].allowed_to?(:log_time, args[:project])
 
             { time_entry: [:hours, :activity_id, :comments] }

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -342,9 +342,6 @@ class PermittedParams < Struct.new(:params, :user)
         :status_id,
         :type_id,
         :subject,
-        # attributes unique to :new_work_package
-        :notes,
-        :lock_version,
         Proc.new do |args|
           # avoid costly allowed_to? if the param is not there at all
           if args[:params]["work_package"].has_key?("watcher_user_ids") &&
@@ -360,7 +357,10 @@ class PermittedParams < Struct.new(:params, :user)
 
             { time_entry: [:hours, :activity_id, :comments] }
           end
-        end ],
+        end,
+        # attributes unique to :new_work_package
+        :notes,
+        :lock_version ],
       :planning_element => [
         # attributes common with :new_work_package above
         :assigned_to_id,
@@ -378,6 +378,22 @@ class PermittedParams < Struct.new(:params, :user)
         :status_id,
         :type_id,
         :subject,
+        Proc.new do |args|
+          # avoid costly allowed_to? if the param is not there at all
+          if args[:params]["planning_element"].has_key?("watcher_user_ids") &&
+            args[:user].allowed_to?(:add_work_package_watchers, args[:project])
+
+            { :watcher_user_ids => [] }
+          end
+        end,
+        Proc.new do |args|
+          # avoid costly allowed_to? if the param is not there at all
+          if args[:params]["planning_element"].has_key?("time_entry") &&
+             args[:user].allowed_to?(:log_time, args[:project])
+
+            { time_entry: [:hours, :activity_id, :comments] }
+          end
+        end,
         # attributes unique to planning_element
         :note,
         :planning_element_status_comment,


### PR DESCRIPTION
This is necessary for fixing https://www.openproject.org/work_packages/5214

Suggested changelog entry:

<pre>` * Allow setting watchers and time entries for work packages via API`</pre>
