### PR TITLE
Removes symbols from the creation process of journals ...

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -103,11 +103,11 @@ class Journal < ActiveRecord::Base
   alias_method :changed_data, :details
 
   def new_value_for(prop)
-    details[prop.to_sym].last if details.keys.include? prop.to_sym
+    details[prop].last if details.keys.include? prop
   end
 
   def old_value_for(prop)
-    details[prop.to_sym].first if details.keys.include? prop.to_sym
+    details[prop].first if details.keys.include? prop
   end
 
   def data
@@ -166,10 +166,10 @@ class Journal < ActiveRecord::Base
 
   def get_association_changes(predecessor, journal_association, association, key, value)
     changes = {}
-    journal_assoc_name = "#{journal_association}_journals".to_sym
+    journal_assoc_name = "#{journal_association}_journals"
 
     if predecessor.nil?
-      send(journal_assoc_name).each_with_object(changes) {|a, h| h["#{association}_#{a.send(key)}".to_sym] = [nil, a.send(value)] }
+      send(journal_assoc_name).each_with_object(changes) {|a, h| h["#{association}_#{a.send(key)}"] = [nil, a.send(value)] }
     else
       current = send(journal_assoc_name).map(&:attributes)
       predecessor_attachable_journals = predecessor.send(journal_assoc_name).map(&:attributes)

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -139,7 +139,7 @@ class Journal < ActiveRecord::Base
     return {} if data.nil?
 
     if @changes.nil?
-      @changes = {}
+      @changes = HashWithIndifferentAccess.new
 
       if predecessor.nil?
         @changes = data.journaled_attributes.select{|_,v| !v.nil?}

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -60,7 +60,7 @@ class JournalManager
 
   def self.association_changed?(journable, journal_association, association, id, key, value)
     if journable.respond_to? association
-      journal_assoc_name = "#{journal_association}_journals".to_sym
+      journal_assoc_name = "#{journal_association}_journals"
       changes = {}
       current = journable.send(association).map {|a| { key.to_s => a.send(id), value.to_s => a.send(value)} }
       predecessor = journable.journals.last.send(journal_assoc_name).map(&:attributes)
@@ -97,17 +97,17 @@ class JournalManager
 
   def self.added_references(merged_references, key, value)
     merged_references.select {|_, v| v[0].nil? and not v[1].nil?}
-                     .each_with_object({}) { |k,h| h["#{key}_#{k[0]}".to_sym] = [nil, k[1][1][value]] }
+                     .each_with_object({}) { |k,h| h["#{key}_#{k[0]}"] = [nil, k[1][1][value]] }
   end
 
   def self.removed_references(merged_references, key, value)
     merged_references.select {|_, v| not v[0].nil? and v[1].nil?}
-                             .each_with_object({}) { |k,h| h["#{key}_#{k[0]}".to_sym] = [k[1][0][value], nil] }
+                             .each_with_object({}) { |k,h| h["#{key}_#{k[0]}"] = [k[1][0][value], nil] }
   end
 
   def self.changed_references(merged_references, key, value)
     merged_references.select {|_, v| not v[0].nil? and not v[1].nil? and v[0][value] != v[1][value]}
-                     .each_with_object({}) { |k,h| h["#{key}_#{k[0]}".to_sym] = [k[1][0][value], k[1][1][value]] }
+                     .each_with_object({}) { |k,h| h["#{key}_#{k[0]}"] = [k[1][0][value], k[1][1][value]] }
 
   end
 

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -61,7 +61,7 @@ describe MessagesController do
         end
 
         describe :journal do
-          let(:attachment_id) { "attachments_#{Message.last.attachments.first.id}".to_sym }
+          let(:attachment_id) { "attachments_#{Message.last.attachments.first.id}" }
 
           subject { Message.last.journals.last.changed_data }
 
@@ -89,7 +89,7 @@ describe MessagesController do
 
   describe :attachment do
     let!(:message) { FactoryGirl.create(:message) }
-    let(:attachment_id) { "attachments_#{message.attachments.first.id}".to_sym }
+    let(:attachment_id) { "attachments_#{message.attachments.first.id}" }
     let(:params) { { id: message.id,
                      attachments: { '1' => { file: filename,
                                              description: '' } } } }
@@ -164,7 +164,7 @@ describe MessagesController do
       end
 
       context :journal do
-        let(:attachment_id) { "attachments_#{attachment.id}".to_sym }
+        let(:attachment_id) { "attachments_#{attachment.id}" }
 
         describe :key do
           subject { message.journals.last.changed_data }

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -927,7 +927,7 @@ describe WorkPackagesController do
         before { post 'create', params }
 
         describe :journal do
-          let(:attachment_id) { "attachments_#{new_work_package.attachments.first.id}".to_sym }
+          let(:attachment_id) { "attachments_#{new_work_package.attachments.first.id}" }
 
           subject { new_work_package.journals.last.changed_data }
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -157,7 +157,7 @@ describe WorkPackage do
           [:subject, :description, :type_id, :status_id, :priority_id,
            :start_date, :due_date, :estimated_hours, :assigned_to_id,
            :responsible_id, :parent_id].each do |a|
-            subject.should have_key(a), "Missing change for #{a.to_s}"
+            subject.should have_key(a.to_s), "Missing change for #{a.to_s}"
           end
         end
       end
@@ -195,7 +195,7 @@ describe WorkPackage do
 
     context "attachments" do
       let(:attachment) { FactoryGirl.build :attachment }
-      let(:attachment_id) { "attachments_#{attachment.id}".to_sym }
+      let(:attachment_id) { "attachments_#{attachment.id}" }
 
       before do
         work_package.attachments << attachment
@@ -240,7 +240,7 @@ describe WorkPackage do
                                               customized: work_package,
                                               custom_field: custom_field }
 
-      let(:custom_field_id) { "custom_fields_#{custom_value.custom_field_id}".to_sym }
+      let(:custom_field_id) { "custom_fields_#{custom_value.custom_field_id}" }
 
       shared_context "work package with custom value" do
         before do

--- a/spec/models/work_package/work_package_planning_spec.rb
+++ b/spec/models/work_package/work_package_planning_spec.rb
@@ -281,7 +281,7 @@ describe WorkPackage do
       pe.update_attribute(:due_date, Date.new(2012, 2, 1))
 
       pe.journals.size.should == 2
-      changes = pe.journals.last.changed_data.to_hash
+      changes = pe.journals.last.changed_data
 
       changes.size.should == 1
 
@@ -319,7 +319,7 @@ describe WorkPackage do
         pe.reload
 
         pe.journals.size.should == 3
-        changes = pe.journals.last.changed_data.to_hash
+        changes = pe.journals.last.changed_data
 
         changes.size.should == 1
         changes.should include(:start_date)


### PR DESCRIPTION
... so creating lots and lots of objects won't exhaust memory.
[`* `#1865` Journal creates Symbols from attachment ids`](https://www.openproject.org/work_packages/1865)
