### PR TITLE
Meets Bug #4040: Referencing work packages with ### in news, forums and meetings does not work

### DIFF
--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -56,7 +56,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="message">
 <p><span class="author"><%= authoring @topic.created_on, @topic.author %></span></p>
 <div class="wiki">
-<%= textilizable(@topic.content, :attachments => @topic.attachments) %>
+<%= textilizable(@topic.content, :object => @topic, :attachments => @topic.attachments) %>
 </div>
 <%= link_to_attachments @topic, :author => false %>
 </div>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -38,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= "(#{l(:label_x_comments, :count => news.comments_count)})" if news.comments_count > 0 %></h3>
     <p class="author"><%= authoring news.created_on, news.author %></p>
     <div class="wiki">
-      <%= textilizable(news.summary.present? ? news.summary : truncate(news.description)) %>
+      <%= textilizable(news.summary.present? ? news.summary : truncate(news.description), :object => news) %>
     </div>
 <% end %>
 <% end %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -64,7 +64,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <p><% unless @news.summary.blank? %><em><%=h @news.summary %></em><br /><% end %>
 <span class="author"><%= authoring @news.created_on, @news.author %></span></p>
 <div class="wiki">
-<%= textilizable(@news.description) %>
+<%= textilizable(@news.description, :object => @news) %>
 </div>
 <br />
 
@@ -82,7 +82,7 @@ See doc/COPYRIGHT.rdoc for more details.
                               :alt     => l(:button_delete) %>
   </div>
   <h4 class="comment"><%= avatar(comment.author, :size => "24") %><%= authoring comment.created_on, comment.author %></h4>
-  <%= textilizable(comment.comments) %>
+  <%= textilizable(comment.comments, :object => comment) %>
 <% end %>
 </div>
 


### PR DESCRIPTION
```
* `#4040` Fix: Referencing work packages with ### in news, forums and meetings does not work
```
