### PR TITLE
Meets Bug #4701: Wiki change notification mail contains invalid diff link

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -180,7 +180,7 @@ class UserMailer < ActionMailer::Base
                              :action     => :diff,
                              :project_id => wiki_content.project,
                              :id         => wiki_content.page.title,
-                             :version    => wiki_content.version)
+                             :version    => wiki_content.version + 1)
 
     open_project_headers 'Project'      => @wiki_content.project.identifier,
                          'Wiki-Page-Id' => @wiki_content.page.id,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -180,6 +180,7 @@ class UserMailer < ActionMailer::Base
                              :action     => :diff,
                              :project_id => wiki_content.project,
                              :id         => wiki_content.page.title,
+                             # using wiki_content.version + 1 because at this point the journal is not saved yet
                              :version    => wiki_content.version + 1)
 
     open_project_headers 'Project'      => @wiki_content.project.identifier,

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -67,6 +67,19 @@ describe UserMailer do
     end
   end
 
+  describe :wiki_content_updated do
+    let(:wiki_content) { FactoryGirl.create(:wiki_content) }
+    let!(:mail) { UserMailer.wiki_content_updated(user, wiki_content) }
+
+    it "should link to the latest version diff page" do
+      expect(mail.body.encoded).to include "diff/2"
+    end
+
+    after do
+      User.current = nil
+    end
+  end
+
   describe :message_id do
     describe 'same user' do
       let(:journal_2) { FactoryGirl.build_stubbed(:work_package_journal) }


### PR DESCRIPTION
```
* `#4701` Fix: Wiki change notification mail contains invalid diff link
```
