### PR TITLE
present correct questions for deletion of documents

### DIFF
--- a/lib/tasks/shared/user_feedback.rb
+++ b/lib/tasks/shared/user_feedback.rb
@@ -27,34 +27,22 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require_relative 'shared/user_feedback'
-
-namespace :migrations do
-  namespace :attachments do
-    include ::Tasks::Shared::UserFeedback
-
-    desc "Removes all attachments from versions and projects"
-    task :delete_from_projects_and_versions => :environment do |task|
-      try_delete_attachments_from_projects_and_versions
-    end
-
-    def try_delete_attachments_from_projects_and_versions
-      begin
-        if !$stdout.isatty || user_agrees_to_delete_versions_and_projects_documents
-          puts "Delete all attachments attached to projects or versions..."
-
-          Attachment.where(:container_type => ['Version','Project']).destroy_all
+module Tasks
+  module Shared
+    module UserFeedback
+      def ask_for_confirmation(questions)
+        questions.all? do |question|
+          ask_confirmation_question(question)
         end
-      rescue
-        raise "Cannot delete attachments from projects and versions! There may be migrations missing...?"
       end
-    end
 
-    def user_agrees_to_delete_versions_and_projects_documents
-      questions = ["CAUTION: This rake task will delete ALL attachments attached to versions or projects!",
-                   "DISCLAIMER: This is the final warning: You're going to lose information!"]
+      def ask_confirmation_question(question)
+        puts "\n\n"
+        puts question
+        puts "\nDo you want to continue? [y/N]"
 
-      ask_for_confirmation(questions)
+        STDIN.gets.chomp == 'y'
+      end
     end
   end
 end


### PR DESCRIPTION
I refactored the questions asked to a user in order to confirm the rake tasks for document deletion out into a  shared module. I started that when one task started asking me the questions meant for another task. Apparently, methods defined inside a rake task are not protected from methods in another rake task, so that they can overwrite one another. This is fixed along the way.
