### PR TITLE
uses named routes for topics/boards

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,12 +158,10 @@ module ApplicationHelper
   def link_to_message(message, options={}, html_options = nil)
     link_to(
       h(truncate(message.subject, :length => 60)),
-      { :controller => '/messages', :action => 'show',
-        :board_id => message.board_id,
-        :id => message.root,
-        :r => (message.parent_id && message.id),
-        :anchor => (message.parent_id ? "message-#{message.id}" : nil)
-      }.merge(options),
+      topic_path(message.root,
+                 { :r => (message.parent_id && message.id),
+                   :anchor => (message.parent_id ? "message-#{message.id}" : nil)
+                 }.merge(options)),
       html_options
     )
   end

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -37,7 +37,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div id="add-message" style="display:none;">
 <% if authorize_for('messages', 'new') %>
-<h2><%= link_to h(@board.name), :controller => '/boards', :action => 'show', :project_id => @project, :id => @board %> &#187; <%= l(:label_message_new) %></h2>
+<h2><%= link_to h(@board.name), project_board_path(@project, @board) %> &#187; <%= l(:label_message_new) %></h2>
 <%= form_for Message.new,
              :url => board_topics_path(@board),
              :html => { :multipart => true,
@@ -74,7 +74,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <td class="subject">
         <%= icon_wrapper('icon-context icon-locked',l(:label_board_locked)) if topic.locked? %>
         <%= image_tag 'bullet_go.png', :alt => l(:label_board_sticky) if topic.sticky? %>
-        <%= link_to h(topic.subject), { :controller => '/messages', :action => 'show', :board_id => @board, :id => topic } %>
+        <%= link_to h(topic.subject), topic_path(topic) %>
       </td>
       <td class="author" align="center"><%= link_to_user(topic.author) %></td>
       <td class="created_on" align="center"><%= format_time(topic.created_on) %></td>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -28,8 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% breadcrumb_paths(
-  link_to(l(:label_board_plural), {:controller => '/boards', :action => 'index', :project_id => @project}),
-  link_to(h(@board.name), {:controller => '/boards', :action => 'show', :project_id => @project, :id => @board}))
+  link_to(l(:label_board_plural), project_boards_path(@project)),
+  link_to(h(@board.name), project_board_path(@project, @board)))
 %>
 
 <% content_for :action_menu_specific do %>
@@ -68,7 +68,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="message reply" id="<%= "message-#{message.id}" %>">
     <h4>
       <%= avatar(message.author, :size => "24") %>
-      <%= link_to h(message.subject), { :controller => '/messages', :action => 'show', :board_id => @board, :id => @topic, :r => message, :anchor => "message-#{message.id}" } %>
+      <%= link_to h(message.subject), topic_path(@topic,
+                                                 :r => message,
+                                                 :anchor => "message-#{message.id}") %>
       -
       <%= authoring message.created_on, message.author %>
     </h4>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -279,19 +279,18 @@ describe ApplicationHelper do
 
       before do
         message1.reload
-        @message_url = {:controller => 'messages', :action => 'show', :board_id => board.id, :id => message1.id}
       end
 
       context "Plain message" do
         subject { textilizable("message##{message1.id}") }
 
-        it { should eq("<p>#{link_to(message1.subject, @message_url, :class => 'message')}</p>") }
+        it { should eq("<p>#{link_to(message1.subject, topic_path(message1), :class => 'message')}</p>") }
       end
 
       context "Message with parent" do
         subject { textilizable("message##{message2.id}") }
 
-        it { should eq("<p>#{link_to(message2.subject, @message_url.merge(:anchor => "message-#{message2.id}", :r => message2.id), :class => 'message')}</p>") }
+        it { should eq("<p>#{link_to(message2.subject, topic_path(message1, :anchor => "message-#{message2.id}", :r => message2.id), :class => 'message')}</p>") }
       end
     end
 


### PR DESCRIPTION
This fixes the ugly routes displayed in the forum (e.g. https://www.openproject.org/topics/896?board_id=6) and shortens the code on top.

Unfortunately, the link_to_if_authorized helper does rely on the hash form for urls. Not all urls could be changed because of that.
