### PR TITLE
Add OpenProject::Notifications as publish/subscribe mechanism

### DIFF
--- a/lib/open_project/notifications.rb
+++ b/lib/open_project/notifications.rb
@@ -1,0 +1,51 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  class Notifications
+    # Subscribe to a specific event with name
+    # Contrary to ActiveSupport::Notifications, we don't support regexps here, but only
+    # single events specified as string.
+    def self.subscribe(name, &block)
+      ActiveSupport::Notifications.subscribe(name.to_s) do |name, start, finish, id, payload|
+        block.call(payload)
+      end
+      # Don't return a subscription object as it's an implementation detail.
+      return nil
+    end
+
+    # Send a notification
+    # payload should be a Hash and might be marshalled and unmarshalled before being
+    # delivered (although it is not at the moment), so don't count on object equality
+    # for the payload.
+    def self.send(name, payload)
+      ActiveSupport::Notifications.instrument(name, payload)
+    end
+
+  end
+end

--- a/spec/lib/open_project/notifications_spec.rb
+++ b/spec/lib/open_project/notifications_spec.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenProject::Notifications do
+  let(:probe) { lambda{ |*args| } }
+  let(:payload) { { 'test' => 'payload' } }
+
+  describe '.send' do
+    before do
+      # We can't clean this up, so we need to use a unique name
+      OpenProject::Notifications.subscribe("notifications_spec_send", &probe)
+
+      probe.should_receive(:call) do |payload|
+        # Don't check for object identity for the payload as it might be
+        # marshalled and unmarshalled before being delivered in the future.
+        expect(payload).to eql(payload)
+      end
+    end
+
+    it 'should deliver a notification' do
+      OpenProject::Notifications.send("notifications_spec_send", payload)
+    end
+  end
+
+end


### PR DESCRIPTION
https://openproject.org/work_packages/5311

This allows code to register for certain events, we might later use
this later e.g. for sending mails on specific events like WorkPackage
updates.

Changelog:

```
* `#5311` Encapsulate ActiveSupport::Notifications
```
