### PR TITLE
Meets Bug #3148: Comparison of history versions in wiki pages ignores newlines

### DIFF
--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -53,4 +53,8 @@ module WikiHelper
       breadcrumb_paths(*(related_pages.collect{|parent| link_to h(parent.breadcrumb_title), {:id => parent.title, :project_id => parent.project, :action => "show"}} + [h(page.breadcrumb_title)]))
     end
   end
+
+  def nl2br(content)
+    content.gsub(/(?:\n\r?|\r\n?)/, '<br />').html_safe
+  end
 end

--- a/app/views/wiki/diff.html.erb
+++ b/app/views/wiki/diff.html.erb
@@ -44,5 +44,5 @@ See doc/COPYRIGHT.rdoc for more details.
 </p>
 
 <div class="text-diff">
-  <%= @html_diff.html_safe %>
+  <%= nl2br @html_diff %>
 </div>


### PR DESCRIPTION
```
* `#3148` Fix: Comparison of history versions in wiki pages ignores newlines
```
