### PR TITLE
Meets #3348: Menu item "more functions" is cut off where content ends

### DIFF
--- a/app/assets/stylesheets/content/_wiki.css.sass
+++ b/app/assets/stylesheets/content/_wiki.css.sass
@@ -161,3 +161,6 @@ h1:hover, h2:hover, h3:hover
       background: url(image-path('wiki_styles/note_small.png')) 5px 4px no-repeat #F5FFFA
       border: 1px solid #C7CFCA
 
+.controller-wiki
+  #content
+    overflow: visible


### PR DESCRIPTION
```
*  `#3348` Fix: Menu item "more functions" is cut off where content ends
```
