### PR TITLE
Meets Bug #3063: Quotes in versions are not properly HTML-escaped

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -30,7 +30,7 @@
 module ProjectsHelper
   def link_to_version(version, html_options = {}, options={})
     return '' unless version && version.is_a?(Version)
-    link_to_if version.visible?, options[:before_text].to_s + format_version_name(version), { :controller => '/versions', :action => 'show', :id => version }, html_options
+    link_to_if version.visible?, options[:before_text].to_s.html_safe + format_version_name(version), { :controller => '/versions', :action => 'show', :id => version }, html_options
   end
 
   def project_settings_tabs


### PR DESCRIPTION
```
* `#3063` Fix: Quotes in versions are not properly HTML-escaped
```
