### PR TITLE
remove border around gravatars

### DIFF
--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -716,7 +716,7 @@ ins.diffmod, ins.diffins { background: #cfc; }
 
 /***** My page layout *****/
 img.gravatar {
-  border: solid 1px #d5d5d5;
+  border: none;
   background: #fff;
 }
 
@@ -988,7 +988,7 @@ div.issue hr {
   font-weight: bold;
 }
 .gravatar {
-  border: 1px solid #aaa;
+  border: none;
 }
 .issue p {
   margin-bottom: 5px;

--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -716,7 +716,6 @@ ins.diffmod, ins.diffins { background: #cfc; }
 
 /***** My page layout *****/
 img.gravatar {
-  border: none;
   background: #fff;
 }
 
@@ -986,9 +985,6 @@ div.issue hr {
 }
 #content div.issue table th {
   font-weight: bold;
-}
-.gravatar {
-  border: none;
 }
 .issue p {
   margin-bottom: 5px;


### PR DESCRIPTION
There is this nearly invisible border around gravatar images. wouldn't it be better to remove it?

Have a look at github's gravatar:
![selection_124](https://f.cloud.github.com/assets/206108/2526918/fcf2a23e-b4fe-11e3-8b11-27b7a9b38aec.png)

Without the border the gravatar looks much nicer:
![selection_123](https://f.cloud.github.com/assets/206108/2526921/074bdcbe-b4ff-11e3-9efb-6fa762a77531.png)
