### PR TITLE
Meets Bug #3019: Quote icon in wrong position

### DIFF
--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -1080,14 +1080,14 @@ table.files {
   display: block;
 }
 #content blockquote, .wiki ol, .wiki ul {
-  padding-left: 9px;
+  padding-left: 22px;
 }
 .wiki p {
   margin-bottom: 5px;
 }
 blockquote {
   font-style: italic;
-  background: url(<%= asset_path 'blockquote-bg.png' %>) no-repeat 25px 3px;
+  background: url(<%= asset_path 'blockquote-bg.png' %>) no-repeat 5px 3px;
 }
 .wiki ul li {
   list-style: disc inside none;


### PR DESCRIPTION
```
* `#3019` Fix: Quote icon in wrong position
```
