### PR TITLE
[security] fixed back url verification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -427,7 +427,7 @@ class ApplicationController < ActionController::Base
       begin
         uri = URI.parse(back_url)
         # do not redirect user to another host or to the login or register page
-        if ((uri.relative? && back_url.match(%r{\A/\w})) || (uri.host == request.host)) && !uri.path.match(%r{/(login|account/register)})
+        if ((uri.relative? && !back_url.match(%r{\A\/\/})) || (uri.host == request.host)) && !uri.path.match(%r{/(login|account/register)})
           redirect_to(back_url)
           return
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -427,7 +427,7 @@ class ApplicationController < ActionController::Base
       begin
         uri = URI.parse(back_url)
         # do not redirect user to another host or to the login or register page
-        if (uri.relative? || (uri.host == request.host)) && !uri.path.match(%r{/(login|account/register)})
+        if ((uri.relative? && back_url.match(%r{\A/\w})) || (uri.host == request.host)) && !uri.path.match(%r{/(login|account/register)})
           redirect_to(back_url)
           return
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -426,12 +426,15 @@ class ApplicationController < ActionController::Base
     if !back_url.blank?
       begin
         uri = URI.parse(back_url)
-        # do not redirect user to another host or to the login or register page
-        # do not allow protocol relative URIs
-        if ((uri.relative? && back_url.match(%r{\A/\w})) \
-             || (uri.host == request.host) \
-             || (uri.to_s == home_path) \
-           && !uri.path.match(%r{/(login|account/register)}))
+
+        # do not redirect user to another host (even protocol relative urls have the host set)
+        # whenever a host is set it must match the request's host
+        uri_local_to_host = uri.host.nil? || uri.host == request.host
+
+        # do not redirect user to the login or register page
+        uri_path_allowed  = !uri.path.match(%r{/(login|account/register)})
+
+        if uri_local_to_host && uri_path_allowed
           redirect_to(back_url)
           return
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -427,7 +427,11 @@ class ApplicationController < ActionController::Base
       begin
         uri = URI.parse(back_url)
         # do not redirect user to another host or to the login or register page
-        if ((uri.relative? && !back_url.match(%r{\A\/\/})) || (uri.host == request.host)) && !uri.path.match(%r{/(login|account/register)})
+        # do not allow protocol relative URIs
+        if ((uri.relative? && back_url.match(%r{\A/\w})) \
+             || (uri.host == request.host) \
+             || (uri.to_s == home_path) \
+           && !uri.path.match(%r{/(login|account/register)}))
           redirect_to(back_url)
           return
         end

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -68,6 +68,17 @@ class AccountControllerTest < ActionController::TestCase
     assert_redirected_to home_url
   end
 
+  def test_login_should_not_redirect_to_another_host
+    back_urls = [
+      'http://test.foo/fake',
+      '//test.foo/fake'
+    ]
+    back_urls.each do |back_url|
+      post :login, :username => 'jsmith', :password => 'jsmith', :back_url => back_url
+      assert_redirected_to '/my/page'
+    end
+  end
+
   if Object.const_defined?(:OpenID)
 
   def test_login_with_openid_for_existing_user

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -69,14 +69,13 @@ class AccountControllerTest < ActionController::TestCase
   end
 
   def test_login_should_not_redirect_to_another_host
-    back_urls = [
-      'http://test.foo/fake',
-      '//test.foo/fake'
-    ]
-    back_urls.each do |back_url|
-      post :login, :username => 'jsmith', :password => 'jsmith', :back_url => back_url
-      assert_redirected_to '/my/page'
-    end
+    post :login, :username => 'jsmith', :password => 'jsmith', :back_url => 'http://test.foo/fake'
+    assert_redirected_to '/my/page'
+  end
+
+  def test_login_should_not_redirect_to_another_host_using_protocol_relative_url
+    post :login, :username => 'jsmith', :password => 'jsmith', :back_url => '//test.foo/fake'
+    assert_redirected_to '/my/page'
   end
 
   if Object.const_defined?(:OpenID)

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -69,13 +69,17 @@ class AccountControllerTest < ActionController::TestCase
   end
 
   def test_login_should_not_redirect_to_another_host
-    post :login, :username => 'jsmith', :password => 'jsmith', :back_url => 'http://test.foo/fake'
-    assert_redirected_to '/my/page'
-  end
+    back_urls = [
+      'http://test.foo/fake',
+      '//test.foo/fake'
+    ]
+    back_urls.each do |back_url|
+      post :login, :username => 'jsmith', :password => 'jsmith', :back_url => back_url
+      assert_redirected_to '/my/page'
 
-  def test_login_should_not_redirect_to_another_host_using_protocol_relative_url
-    post :login, :username => 'jsmith', :password => 'jsmith', :back_url => '//test.foo/fake'
-    assert_redirected_to '/my/page'
+      # User.current = nil has no effect
+      @request.session.delete(:user_id)
+    end
   end
 
   def test_login_should_redirect_to_home_url

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -78,6 +78,11 @@ class AccountControllerTest < ActionController::TestCase
     assert_redirected_to '/my/page'
   end
 
+  def test_login_should_redirect_to_home_url
+    post :login, :username => 'jsmith', :password => 'jsmith', :back_url => '/'
+    assert_redirected_to home_url
+  end
+
   if Object.const_defined?(:OpenID)
 
   def test_login_with_openid_for_existing_user


### PR DESCRIPTION
This are the same changes @marutosi did in his PR against the `migrate/1.5_to_2.4` branch except it is posted against the `dev` branch.

Backporting to `stable` should be done once the tests ass.

see:
- http://www.redmine.org/news/90
- http://www.redmine.org/projects/redmine/wiki/Security_Advisories/13
