### PR TITLE
Peg simplecov version to 0.8.0.pre

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ group :test do
   gem 'rb-readline' # ruby on CI needs this
   # why in Gemfile? see: https://github.com/guard/guard-test
   gem 'ruby-prof'
-  gem 'simplecov', ">= 0.8.pre"
+  gem 'simplecov', '0.8.0.pre'
   gem "shoulda-matchers"
   gem "json_spec"
   gem "activerecord-tableless", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
     mime-types (1.25.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.8.2)
+    multi_json (1.9.2)
     multi_test (0.0.2)
     mysql2 (0.3.11)
     net-ldap (0.2.2)
@@ -425,7 +425,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda
   shoulda-matchers
-  simplecov (>= 0.8.pre)
+  simplecov (= 0.8.0.pre)
   sqlite3
   strong_parameters
   svg-graph


### PR DESCRIPTION
simplecov >= 0.8.1 causes an issue preventing execution of the Test::Unit suite.
