### PR TITLE
some plugin fixes

### DIFF
--- a/app/assets/javascripts/openproject_plugins.js.erb
+++ b/app/assets/javascripts/openproject_plugins.js.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%=
+<%
   Redmine::Plugin.all.collect do |plugin|
     plugin.registered_global_assets[:js].each do |path|
       require_asset path

--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -1851,3 +1851,7 @@ h4.comment img {
   background: #FFFFBB;
   color: #4B4B4B;
 }
+
+.atwho-view .cur strong {
+    color: black;
+}


### PR DESCRIPTION
This PR fixes two small things:
1. global assets require for plugins
2. at.who autocompletion styling
### 1. global assets require for plugins

Plugins can include assets to all OpenProject pages. This is handled in `app/assets/javascripts/openproject_plugins.js.erb` using `<%= ... %>`. Unfortunately, this only prints the assets array. `<% .. %>` however does not print the array, but actually requires the plugin assets.
### 2. at.who autocompletion styling

at.who (the issue auto-completion in textareas) highlight the currently matched text in white on a bright yellow background. This is hardly readable, so we print that text in black.

see: 
![selection_127](https://cloud.githubusercontent.com/assets/206108/2610150/eff5601a-bb81-11e3-86e9-fbeaa2c9fd2e.png)

versus
![selection_126](https://cloud.githubusercontent.com/assets/206108/2610151/f5ddb432-bb81-11e3-986a-994a451a9ce4.png)

`
