### PR TITLE
Use ForbiddenAttributesProtection for User

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -94,7 +94,7 @@ class AccountController < ApplicationController
       @user = User.new(:language => Setting.default_language)
     else
       @user = User.new
-      @user.safe_attributes = params[:user]
+      @user.attributes = permitted_params.user
       @user.admin = false
       @user.register
       if session[:auth_source_registration]

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -80,7 +80,7 @@ module Api
 
       def create
         @user = User.new(:language => Setting.default_language, :mail_notification => Setting.default_notification_option)
-        @user.safe_attributes = params[:user]
+        @user.attributes = permitted_params.user_create_as_admin
         @user.admin = params[:user][:admin] || false
         @user.login = params[:user][:login]
         @user.password, @user.password_confirmation = params[:user][:password], params[:user][:password_confirmation] if @user.change_password_allowed?
@@ -112,7 +112,7 @@ module Api
       def update
         @user.admin = params[:user][:admin] if params[:user][:admin]
         @user.login = params[:user][:login] if params[:user][:login]
-        @user.safe_attributes = params[:user].except(:login) # :login is protected
+        @user.attributes = permitted_params.user_update_as_admin
         if params[:user][:password].present? && @user.change_password_allowed?
           @user.password, @user.password_confirmation = params[:user][:password], params[:user][:password_confirmation]
         end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -69,7 +69,7 @@ class MyController < ApplicationController
     @user = User.current
     @pref = @user.pref
     if request.put?
-      @user.safe_attributes = params[:user]
+      @user.attributes = permitted_params.user
       @user.pref.attributes = params[:pref]
       @user.pref[:no_self_notified] = (params[:no_self_notified] == '1')
       if @user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,7 +115,7 @@ class UsersController < ApplicationController
   verify :method => :post, :only => :create, :render => {:nothing => true, :status => :method_not_allowed }
   def create
     @user = User.new(:language => Setting.default_language, :mail_notification => Setting.default_notification_option)
-    @user.safe_attributes = params[:user]
+    @user.attributes = permitted_params.user_create_as_admin
     @user.admin = params[:user][:admin] || false
     @user.login = params[:user][:login]
     if @user.change_password_allowed?

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -481,4 +481,25 @@ class PermittedParams < Struct.new(:params, :current_user)
       :move_to => [ :move_to ]
     }
   end
+
+  private
+  ## Add attributes as permitted attributes (only to be used by the plugins plugin)
+  #
+  # attributes should be given as a Hash in the form
+  # {:key => [:param1, :param2]}
+  def self.add_permitted_attributes(attributes)
+    # Make sure the permitted attributes are cached in @whitelisted_params
+    permitted_attributes
+
+    # Check no unsupported parameters are attempted to be whitelisted (they're ignored)
+    unknown_keys = (attributes.keys - @whitelisted_params.keys)
+    if unknown_keys.size > 0
+      Rails.logger.warn(
+        "Attempt to whitelist attributes for unknown keys: #{unknown_keys}, ignoring them.")
+    end
+
+    attributes.each_pair do |key, attrs|
+      @whitelisted_params[key] += attrs unless unknown_keys.include?(key)
+    end
+  end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -27,7 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class PermittedParams < Struct.new(:params, :user)
+class PermittedParams < Struct.new(:params, :current_user)
 
   # This class intends to provide a method for all params hashes coming from the
   # client and that are used for mass assignment.
@@ -184,18 +184,37 @@ class PermittedParams < Struct.new(:params, :user)
 
   alias :update_work_package :new_work_package
 
+  def user
+    permitted_params = params.require(:user).permit(*self.class.permitted_attributes[:user])
+    permitted_params.merge!(custom_field_values(:user))
+  end
+
   def user_update_as_admin
-    if user.admin?
-      permitted_params = params.require(:user).permit(:firstname,
-                                                      :lastname,
-                                                      :mail,
-                                                      :mail_notification,
-                                                      :language,
-                                                      :custom_fields,
-                                                      :identity_url,
-                                                      :auth_source_id,
-                                                      :force_password_change,
-                                                      :group_ids => [])
+    if current_user.admin?
+      allowed_params = self.class.permitted_attributes[:user] + \
+                       [ :auth_source_id,
+                         :force_password_change,
+                         # Found these in safe_attributes and added them here as I
+                         # didn't know the consequences of removing these.
+                         # They were not allowed on update.
+                         :group_ids => []]
+
+      permitted_params = params.require(:user).permit(*allowed_params)
+      permitted_params.merge!(custom_field_values(:user))
+
+      permitted_params
+    else
+      params.require(:user).permit()
+    end
+  end
+
+  def user_create_as_admin
+    if current_user.admin?
+      allowed_params = self.class.permitted_attributes[:user] + \
+                       [ :auth_source_id,
+                         :force_password_change]
+
+      permitted_params = params.require(:user).permit(*allowed_params)
       permitted_params.merge!(custom_field_values(:user))
 
       permitted_params
@@ -255,7 +274,7 @@ class PermittedParams < Struct.new(:params, :user)
   end
 
   def permitted_attributes(key, additions = {})
-    merged_args = { :params => params, :user => user }.merge(additions)
+    merged_args = { :params => params, :current_user => current_user }.merge(additions)
 
     self.class.permitted_attributes[key].map do |permission|
       if permission.respond_to?(:call)
@@ -346,7 +365,7 @@ class PermittedParams < Struct.new(:params, :user)
           # avoid costly allowed_to? if the param is not there at all
           if args[:params]["work_package"] &&
              args[:params]["work_package"].has_key?("watcher_user_ids") &&
-             args[:user].allowed_to?(:add_work_package_watchers, args[:project])
+             args[:current_user].allowed_to?(:add_work_package_watchers, args[:project])
 
             { :watcher_user_ids => [] }
           end
@@ -355,7 +374,7 @@ class PermittedParams < Struct.new(:params, :user)
           # avoid costly allowed_to? if the param is not there at all
           if args[:params]["work_package"] &&
              args[:params]["work_package"].has_key?("time_entry") &&
-             args[:user].allowed_to?(:log_time, args[:project])
+             args[:current_user].allowed_to?(:log_time, args[:project])
 
             { time_entry: [:hours, :activity_id, :comments] }
           end
@@ -384,7 +403,7 @@ class PermittedParams < Struct.new(:params, :user)
           # avoid costly allowed_to? if the param is not there at all
           if args[:params]["planning_element"] &&
              args[:params]["planning_element"].has_key?("watcher_user_ids") &&
-             args[:user].allowed_to?(:add_work_package_watchers, args[:project])
+             args[:current_user].allowed_to?(:add_work_package_watchers, args[:project])
 
             { :watcher_user_ids => [] }
           end
@@ -393,7 +412,7 @@ class PermittedParams < Struct.new(:params, :user)
           # avoid costly allowed_to? if the param is not there at all
           if args[:params]["planning_element"] &&
              args[:params]["planning_element"].has_key?("time_entry") &&
-             args[:user].allowed_to?(:log_time, args[:project])
+             args[:current_user].allowed_to?(:log_time, args[:project])
 
             { time_entry: [:hours, :activity_id, :comments] }
           end
@@ -443,6 +462,14 @@ class PermittedParams < Struct.new(:params, :user)
         :color_id,
         :project_ids => [],
         :custom_field_ids => [] ],
+      :user => [
+        :firstname,
+        :lastname,
+        :mail,
+        :mail_notification,
+        :language,
+        :custom_fields,
+        :identity_url ],
       :wiki_page => [
         :title,
         :parent_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,8 +134,6 @@ class User < Principal
 
   attr_accessor :password, :password_confirmation
   attr_accessor :last_before_login_on
-  # Prevents unauthorized assignments
-  attr_protected :login, :admin, :password, :password_confirmation
 
   validates_presence_of :login,
                         :firstname,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@
 require "digest/sha1"
 
 class User < Principal
-  include Redmine::SafeAttributes
+  include ActiveModel::ForbiddenAttributesProtection
 
   # Account statuses
   # Code accessing the keys assumes they are ordered, which they are since Ruby 1.9
@@ -654,18 +654,6 @@ class User < Principal
       end
     end
   end
-
-  # These are also implemented as strong_parameters, so also see
-  # app/models/permitted_params.rb
-  # Delete these if everything in the UsersController uses strong_parameters.
-  safe_attributes 'firstname', 'lastname', 'mail', 'mail_notification', 'language',
-                  'custom_field_values', 'custom_fields', 'identity_url'
-
-  safe_attributes 'auth_source_id', 'force_password_change',
-    :if => lambda {|user, current_user| current_user.admin?}
-
-  safe_attributes 'group_ids',
-    :if => lambda {|user, current_user| current_user.admin? && !user.new_record?}
 
   # Utility method to help check if a user should be notified about an
   # event.

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -191,7 +191,10 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_create_with_failure
     assert_no_difference 'User.count' do
-      post :create, :user => {}
+      # Provide at least one user  field, otherwise strong_parameters regards the user parameter
+      # as non-existent and raises ActionController::ParameterMissing, which in turn
+      # results in a 400.
+      post :create, :user => { :login => 'jdoe' }
     end
 
     assert_response :success


### PR DESCRIPTION
This removes safe_attributes and attr_protected on User and adds ForbiddenAttributesProtection as single mass assignment protection.

Renaming user to current_user is necessary as we're adding a user method.

This should bring us a little step closer to Rails 4.

Implemented as part of https://www.openproject.org/work_packages/5553
