### PR TITLE
Fix/ruby 2 0

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -978,7 +978,7 @@ class WorkPackage < ActiveRecord::Base
 
   # Update issues so their versions are not pointing to a
   # fixed_version that is not shared with the issue's project
-  private_class_method def self.update_versions(conditions=nil)
+  def self.update_versions(conditions=nil)
     # Only need to update issues with a fixed_version from
     # a different project and that is not systemwide shared
     WorkPackage.all(:conditions => merge_conditions("#{WorkPackage.table_name}.fixed_version_id IS NOT NULL" +
@@ -994,6 +994,7 @@ class WorkPackage < ActiveRecord::Base
       end
     end
   end
+  private_class_method :update_versions
 
   # Default assignment based on category
   def default_assign
@@ -1028,7 +1029,7 @@ class WorkPackage < ActiveRecord::Base
   # * project - Project to search in.
   # * field - String. Issue field to key off of in the grouping.
   # * joins - String. The table name to join against.
-  private_class_method def self.count_and_group_by(options)
+  def self.count_and_group_by(options)
     project = options.delete(:project)
     select_field = options.delete(:field)
     joins = options.delete(:joins)
@@ -1047,6 +1048,8 @@ class WorkPackage < ActiveRecord::Base
                                                 and i.project_id=#{project.id}
                                               group by s.id, s.is_closed, j.id")
   end
+  private_class_method :count_and_group_by
+
   # <<< issues.rb <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   def set_attachments_error_details

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -978,7 +978,7 @@ class WorkPackage < ActiveRecord::Base
 
   # Update issues so their versions are not pointing to a
   # fixed_version that is not shared with the issue's project
-  def self.update_versions(conditions=nil)
+  private_class_method def self.update_versions(conditions=nil)
     # Only need to update issues with a fixed_version from
     # a different project and that is not systemwide shared
     WorkPackage.all(:conditions => merge_conditions("#{WorkPackage.table_name}.fixed_version_id IS NOT NULL" +


### PR DESCRIPTION
Use ruby 2.0 syntax again and use `private_class_method` for class methods which were intended to be private.
