### PR TITLE
Column sums can now be called without a project id.

### DIFF
--- a/app/assets/javascripts/angular/directives/work_packages/work-package-total-sums-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-total-sums-directive.js
@@ -37,7 +37,7 @@ angular.module('openproject.workPackages.directives')
       return {
         pre: function(scope, iElement, iAttrs, controller) {
           function fetchSums() {
-            scope.withLoading(WorkPackageService.getWorkPackagesSums, [scope.projectIdentifier, scope.columns])
+            scope.withLoading(WorkPackageService.getWorkPackagesSums, [scope.projectIdentifier, scope.query, scope.columns])
               .then(function(data){
                 angular.forEach(scope.columns, function(column, i){
                   column.total_sum = data.column_sums[i];

--- a/app/assets/javascripts/angular/helpers/components/path-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/path-helper.js
@@ -125,9 +125,12 @@ angular.module('openproject.helpers')
     apiProjectUsersPath: function(projectIdentifier) {
       return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.usersPath();
     },
-    apiWorkPackagesSumsPath: function(projectIdentifier) {
+    apiProjectWorkPackagesSumsPath: function(projectIdentifier) {
       return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.workPackagesPath() + '/column_sums';
     },
+    apiWorkPackagesSumsPath: function() {
+      return PathHelper.apiWorkPackagesPath() + '/column_sums';
+    }
   };
 
   return PathHelper;

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -66,7 +66,7 @@ angular.module('openproject.services')
     },
 
     // Note: Should this be on a project-service?
-    getWorkPackagesSums: function(projectIdentifier, columns){
+    getWorkPackagesSums: function(projectIdentifier, query, columns){
       var columnNames = columns.map(function(column){
         return column.name;
       });
@@ -77,9 +77,9 @@ angular.module('openproject.services')
         var url = PathHelper.apiWorkPackagesSumsPath();
       }
 
-      var params = {
+      var params = angular.extend(query.toParams(), {
         'column_names[]': columnNames
-      };
+      });
 
       return WorkPackageService.doQuery(url, params);
     },

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -71,7 +71,11 @@ angular.module('openproject.services')
         return column.name;
       });
 
-      var url = PathHelper.apiWorkPackagesSumsPath(projectIdentifier);
+      if (projectIdentifier){
+        var url = PathHelper.apiProjectWorkPackagesSumsPath(projectIdentifier);
+      } else {
+        var url = PathHelper.apiWorkPackagesSumsPath();
+      }
 
       var params = {
         'column_names[]': columnNames

--- a/app/controllers/api/v3/work_packages_controller.rb
+++ b/app/controllers/api/v3/work_packages_controller.rb
@@ -46,7 +46,7 @@ module Api
       # before_filter :authorize # TODO specify authorization
       before_filter :authorize_request, only: [:column_data]
 
-      before_filter :find_optional_project, only: [:index]
+      before_filter :find_optional_project, only: [:index, :column_sums]
 
       before_filter :load_query, only: [:index]
       before_filter :assign_work_packages, only: [:index]
@@ -80,8 +80,11 @@ module Api
         raise 'API Error' unless params[:column_names]
 
         column_names = params[:column_names]
-        project = Project.find_visible(current_user, params[:project_id])
-        work_packages = project.work_packages
+        work_packages = if @project
+                          @project.work_packages
+                        else
+                          WorkPackage.visible
+                        end
 
         @column_sums = columns_total_sums(column_names, work_packages)
       end

--- a/app/controllers/api/v3/work_packages_controller.rb
+++ b/app/controllers/api/v3/work_packages_controller.rb
@@ -45,10 +45,8 @@ module Api
 
       # before_filter :authorize # TODO specify authorization
       before_filter :authorize_request, only: [:column_data]
-
       before_filter :find_optional_project, only: [:index, :column_sums]
-
-      before_filter :load_query, only: [:index]
+      before_filter :load_query, only: [:index, :column_sums]
       before_filter :assign_work_packages, only: [:index]
 
       def index
@@ -80,13 +78,7 @@ module Api
         raise 'API Error' unless params[:column_names]
 
         column_names = params[:column_names]
-        work_packages = if @project
-                          @project.work_packages
-                        else
-                          WorkPackage.visible
-                        end
-
-        @column_sums = columns_total_sums(column_names, work_packages)
+        @column_sums = columns_total_sums(column_names, all_query_work_packages)
       end
 
       private
@@ -126,6 +118,10 @@ module Api
         # authorize_global unless performed?
       end
 
+      def find_optional_project
+        @project = Project.find(params[:project_id]) if params[:project_id]
+      end
+
       def assign_work_packages
         @work_packages = current_work_packages(@project) unless performed?
       end
@@ -145,6 +141,12 @@ module Api
         set_work_packages_meta_data(@query, results, work_packages)
 
         work_packages
+      end
+
+      def all_query_work_packages
+        # Note: Do not apply pagination. Used to obtain total query meta data.
+        results = @query.results include: [:assigned_to, :type, :priority, :category, :fixed_version]
+        work_packages = results.work_packages.all
       end
 
       def set_work_packages_meta_data(query, results, work_packages)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ OpenProject::Application.routes.draw do
     namespace :v3 do
       resources :work_packages, only: [:index] do
         get :column_data, on: :collection
+        get :column_sums, on: :collection
       end
       resources :queries, only: [:show] do
         get :available_columns, on: :collection

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -94,6 +94,9 @@ Redmine::AccessControl.map do |map|
   map.permission :load_column_data, {
                  :work_packages => [ :column_data ]
                  }
+  map.permission :load_column_sums, {
+                 :work_packages => [ :column_sums ]
+                 }
 
   map.project_module :work_package_tracking do |map|
     # Issue categories


### PR DESCRIPTION
This might fix "Bug #5770: Sum of story points not displayed in work package table" although it might be due to something else plugin related.

Before we merge this there is something that I want to confirm - that the sums should be summing all work packages and not just the total which are returned by the query. I remember asking this a while back and Jens said that it should indeed be all the work packages, but when viewing the work packages table without a project that seems pretty crazy because it's going to be summing all the work packages which are visible to that user which could be a lot and could become a resource hog.
