### PR TITLE
Switch rspec-example_disabler to a git dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ group :test do
   gem 'rspec', '~> 2.14'
   # also add to development group, so "spec" rake task gets loaded
   gem "rspec-rails", "~> 2.14", :group => :development
-  gem 'rspec-example_disabler'
+  gem 'rspec-example_disabler', github: 'finnlabs/rspec-example_disabler', branch: 'master'
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/finnlabs/rspec-example_disabler.git
+  revision: deb9c38e3f4e3688724583ac1ff58e1ae8aba409
+  branch: master
+  specs:
+    rspec-example_disabler (0.0.1)
+
+GIT
   remote: https://github.com/finnlabs/rack-protection.git
   revision: 5a7d1bd2f05ca75faf7909c8cc978732a0080898
   ref: 5a7d1bd
@@ -270,7 +277,6 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     rspec-core (2.14.8)
-    rspec-example_disabler (0.0.1)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
@@ -415,7 +421,7 @@ DEPENDENCIES
   rdoc (>= 2.4.2)
   request_store
   rspec (~> 2.14)
-  rspec-example_disabler
+  rspec-example_disabler!
   rspec-rails (~> 2.14)
   ruby-openid (~> 2.2.3)
   ruby-prof


### PR DESCRIPTION
Using master until further work on a new rspec-example_disabler
release.

Master contains a fix for an issue in an OpenProject environment
configured with certain private plugins that disable Controller specs
with `RSpec::ExampleDisabler`: rather than being disabled, examples
were instead resulting in a `NoMethodError`.

See: https://github.com/finnlabs/rspec-example_disabler/commit/45cf9ce55ae6a27e74b202c806d30b4865aee03b
