### PR TITLE
speedup migrations by adding indices sooner

### DIFF
--- a/db/migrate/20130920081135_legacy_attachment_journal_data.rb
+++ b/db/migrate/20130920081135_legacy_attachment_journal_data.rb
@@ -32,11 +32,15 @@ require_relative 'migration_utils/legacy_journal_migrator'
 class LegacyAttachmentJournalData < ActiveRecord::Migration
 
   def up
+    add_index "attachment_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals
+
+    remove_index "attachment_journals", ["journal_id"]
   end
 
   private

--- a/db/migrate/20130920085055_legacy_changeset_journal_data.rb
+++ b/db/migrate/20130920085055_legacy_changeset_journal_data.rb
@@ -31,11 +31,15 @@ require_relative 'migration_utils/legacy_journal_migrator'
 
 class LegacyChangesetJournalData < ActiveRecord::Migration
   def up
+    add_index "changeset_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals
+
+    remove_index "changeset_journals", ["journal_id"]
   end
 
   private

--- a/db/migrate/20130920090201_legacy_news_journal_data.rb
+++ b/db/migrate/20130920090201_legacy_news_journal_data.rb
@@ -31,11 +31,15 @@ require_relative 'migration_utils/legacy_journal_migrator'
 
 class LegacyNewsJournalData < ActiveRecord::Migration
   def up
+    add_index "news_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals
+
+    remove_index "news_journals", ["journal_id"]
   end
 
   private

--- a/db/migrate/20130920090641_legacy_message_journal_data.rb
+++ b/db/migrate/20130920090641_legacy_message_journal_data.rb
@@ -32,11 +32,15 @@ require_relative 'migration_utils/journal_migrator_concerns'
 
 class LegacyMessageJournalData < ActiveRecord::Migration
   def up
+    add_index "message_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals 'attachable_journals'
+
+    remove_index "message_journals", ["journal_id"]
   end
 
   private

--- a/db/migrate/20130920092800_legacy_time_entry_journal_data.rb
+++ b/db/migrate/20130920092800_legacy_time_entry_journal_data.rb
@@ -32,11 +32,15 @@ require_relative 'migration_utils/journal_migrator_concerns'
 
 class LegacyTimeEntryJournalData < ActiveRecord::Migration
   def up
+    add_index "time_entry_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals 'customizable_journals'
+
+    remove_index "time_entry_journals", ["journal_id"]
   end
 
   private

--- a/db/migrate/20130920093823_legacy_wiki_content_journal_data.rb
+++ b/db/migrate/20130920093823_legacy_wiki_content_journal_data.rb
@@ -34,11 +34,15 @@ class LegacyWikiContentJournalData < ActiveRecord::Migration
   end
 
   def up
+    add_index "wiki_content_journals", ["journal_id"]
+
     migrator.run
   end
 
   def down
     migrator.remove_journals_derived_from_legacy_journals
+
+    remove_index "wiki_content_journals", ["journal_id"]
   end
 
   def migrator

--- a/db/migrate/20130920094524_legacy_issue_journal_data.rb
+++ b/db/migrate/20130920094524_legacy_issue_journal_data.rb
@@ -35,6 +35,8 @@ class LegacyIssueJournalData < ActiveRecord::Migration
   include Migration::Utils
 
   def up
+    add_index "work_package_journals", ["journal_id"]
+
     migrator.run
 
     reset_public_key_sequence_in_postgres 'journals'
@@ -43,6 +45,8 @@ class LegacyIssueJournalData < ActiveRecord::Migration
   def down
     migrator.remove_journals_derived_from_legacy_journals 'customizable_journals',
                                                           'attachable_journals'
+
+    remove_index "work_package_journals", ["journal_id"]
   end
 
   def migrator

--- a/db/migrate/20131108124300_add_index_to_all_the_journals.rb
+++ b/db/migrate/20131108124300_add_index_to_all_the_journals.rb
@@ -29,12 +29,26 @@
 
 class AddIndexToAllTheJournals < ActiveRecord::Migration
   def change
-    add_index "attachment_journals", ["journal_id"]
-    add_index "changeset_journals", ["journal_id"]
-    add_index "message_journals", ["journal_id"]
-    add_index "news_journals", ["journal_id"]
-    add_index "time_entry_journals", ["journal_id"]
-    add_index "wiki_content_journals", ["journal_id"]
-    add_index "work_package_journals", ["journal_id"]
+    # This now is only a no op.
+    #
+    # The creation of indexes has been moved in order to speed up migration.
+    #
+    # It remains here as some installations might already have
+    # executed the migration.
+    #
+    # Moved to 20130920081135_legacy_attachment_journal_data.rb
+    # add_index "attachment_journals", ["journal_id"]
+    # Moved to 20130920085055_legacy_changeset_journal_data.rb
+    # add_index "changeset_journals", ["journal_id"]
+    # Moved to 20130920090641_legacy_message_journal_data.rb
+    # add_index "message_journals", ["journal_id"]
+    # Moved to 20130920090201_legacy_news_journal_data.rb
+    # add_index "news_journals", ["journal_id"]
+    # Moved to 20130920092800_legacy_time_entry_journal_data.rb
+    # add_index "time_entry_journals", ["journal_id"]
+    # Moved to 20130920093823_legacy_wiki_content_journal_data.rb
+    # add_index "wiki_content_journals", ["journal_id"]
+    # Moved to 20130920094524_legacy_issue_journal_data.rb
+    # add_index "work_package_journals", ["journal_id"]
   end
 end


### PR DESCRIPTION
On a mid sized installations (~ 45000 tickets), the migrations tended to take hours. Adding the indices sooner should speed up migration considerably.

Noticed this when scanning through the log while migrating the installation. A "Select \* from work_package_journals where journaled_id = X" took about 200ms each. I added an index while the migration was running and the time required for each select went down to 2ms. 

The sum of this change does not change the database schema at all. I left the add_index_to_all_the_journals migration in place to not disturb systems that are already migrated. However, the mentioned migration is now a no op.
