### PR TITLE
Add rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+LineLength:
+  Max: 99
+HashSyntax:
+  Enabled: false


### PR DESCRIPTION
This allows us to define how our coding style should look like in a way that can be automatically checked.

This is only a beginning and sets the maximum line length to 99.

Please use https://www.openproject.org/wp/6142 for discussion.
