### PR TITLE
Inluding query available columns in the meta data.

### DIFF
--- a/app/assets/javascripts/angular/controllers/work-packages-controller.js
+++ b/app/assets/javascripts/angular/controllers/work-packages-controller.js
@@ -72,6 +72,7 @@ angular.module('openproject.workPackages.controllers')
     var meta = json.meta;
 
     if (!$scope.columns) $scope.columns = meta.columns;
+    if (!$scope.groupableColumns) $scope.groupableColumns = meta.groupable_columns;
     $scope.query = QueryService.getQuery() || QueryService.initQuery($scope.query_id, meta.query, $scope.columns, afterQuerySetupCallback);
 
     PaginationService.setPerPageOptions(meta.per_page_options);

--- a/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
@@ -35,7 +35,7 @@ angular.module('openproject.workPackages.directives')
     link: function(scope, element, attributes) {
       scope.$watch('query.groupBy', function(groupBy) {
         if (scope.columns) {
-          var groupByColumnIndex = scope.columns.map(function(column){
+          var groupByColumnIndex = scope.groupableColumns.map(function(column){
             return column.name;
           }).indexOf(groupBy);
 

--- a/app/controllers/api/v3/work_packages_controller.rb
+++ b/app/controllers/api/v3/work_packages_controller.rb
@@ -150,6 +150,7 @@ module Api
         @work_packages_meta_data = {
           query:                        query.as_json(except: :filters, include: :filters),
           columns:                      get_columns_for_json(query.columns),
+          groupable_columns:            get_columns_for_json(query.groupable_columns),
           work_package_count_by_group:  results.work_package_count_by_group,
           sums:                         query.columns.map { |column| results.total_sum_of(column) },
           group_sums:                   query.group_by_column && query.columns.map { |column| results.grouped_sums(column) },

--- a/public/templates/work_packages/work_packages_options.html
+++ b/public/templates/work_packages/work_packages_options.html
@@ -34,7 +34,7 @@
                 name="group_by"
                 ng-model="query.groupBy">
           <option value=""></option>
-          <option ng-repeat="column in columns"
+          <option ng-repeat="column in groupableColumns"
                   ng-selected="column.name === query.groupBy"
                   value="{{ column.name }}">{{ column.title }}</option>
         </select>


### PR DESCRIPTION
Groupable columns in the work packages options now match the ones shown on the save/edit query view. The bug was happening because a columns were being selected in the edit view which didn't exist in the options template.
