### PR TITLE
Dev angular maintain query state

### DIFF
--- a/app/assets/javascripts/angular/controllers/work-packages-controller.js
+++ b/app/assets/javascripts/angular/controllers/work-packages-controller.js
@@ -28,8 +28,8 @@
 
 angular.module('openproject.workPackages.controllers')
 
-.controller('WorkPackagesController', ['$scope', '$window', 'WorkPackagesTableHelper', 'WorkPackageService', 'QueryService', 'PaginationService', 'WorkPackageLoadingHelper', 'INITIALLY_SELECTED_COLUMNS', 'OPERATORS_AND_LABELS_BY_FILTER_TYPE',
-            function($scope, $window, WorkPackagesTableHelper, WorkPackageService, QueryService, PaginationService, WorkPackageLoadingHelper, INITIALLY_SELECTED_COLUMNS, OPERATORS_AND_LABELS_BY_FILTER_TYPE) {
+.controller('WorkPackagesController', ['$scope', '$window', '$location', 'WorkPackagesTableHelper', 'WorkPackageService', 'QueryService', 'PaginationService', 'WorkPackageLoadingHelper', 'INITIALLY_SELECTED_COLUMNS', 'OPERATORS_AND_LABELS_BY_FILTER_TYPE',
+            function($scope, $window, $location, WorkPackagesTableHelper, WorkPackageService, QueryService, PaginationService, WorkPackageLoadingHelper, INITIALLY_SELECTED_COLUMNS, OPERATORS_AND_LABELS_BY_FILTER_TYPE) {
 
 
   function setUrlParams(location) {
@@ -45,7 +45,16 @@ angular.module('openproject.workPackages.controllers')
     $scope.loading = false;
     $scope.disableFilters = false;
 
-    $scope.withLoading(WorkPackageService.getWorkPackagesByQueryId, [$scope.projectIdentifier, $scope.query_id])
+    // This is where we should get work packages based on url query params if we have them
+    if($location.search()['f[]']){
+      var getMethod = WorkPackageService.getWorkPackagesFromUrlQueryParams;
+      var params = [$scope.projectIdentifier, $location];
+    } else {
+      var getMethod = WorkPackageService.getWorkPackagesByQueryId;
+      var params = [$scope.projectIdentifier, $scope.query_id];
+    }
+
+    $scope.withLoading(getMethod, params)
       .then($scope.setupWorkPackagesTable)
       .then(initAvailableColumns);
   }
@@ -61,6 +70,20 @@ angular.module('openproject.workPackages.controllers')
   function afterQuerySetupCallback(query) {
     $scope.showFilters = query.filters.length > 0;
   }
+
+  $scope.updateBackUrl = function(){
+    // Easier than trying to extract it from $location
+    var relativeUrl = "/work_packages";
+    if ($scope.projectIdentifier){
+      relativeUrl = "/projects/" + $scope.projectIdentifier + relativeUrl;
+    }
+
+    if($scope.query){
+      relativeUrl = relativeUrl + "#?" + $scope.query.serialiseForAngular();
+    }
+
+    $scope.backUrl = relativeUrl;
+  };
 
   $scope.submitQueryForm = function(){
     jQuery("#selected_columns option").attr('selected',true);
@@ -86,6 +109,7 @@ angular.module('openproject.workPackages.controllers')
       column.total_sum = meta.sums[i];
       if (meta.group_sums) column.group_sums = meta.group_sums[i];
     });
+    $scope.updateBackUrl();
   };
 
   $scope.updateResults = function() {

--- a/app/assets/javascripts/angular/controllers/work-packages-controller.js
+++ b/app/assets/javascripts/angular/controllers/work-packages-controller.js
@@ -45,7 +45,6 @@ angular.module('openproject.workPackages.controllers')
     $scope.loading = false;
     $scope.disableFilters = false;
 
-    // This is where we should get work packages based on url query params if we have them
     if($location.search()['f[]']){
       var getMethod = WorkPackageService.getWorkPackagesFromUrlQueryParams;
       var params = [$scope.projectIdentifier, $location];

--- a/app/assets/javascripts/angular/directives/components/back-url.js
+++ b/app/assets/javascripts/angular/directives/components/back-url.js
@@ -26,47 +26,11 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-angular.module('openproject.workPackages.directives')
+angular.module('openproject.uiComponents')
 
-.directive('workPackagesTable', ['I18n', function(I18n){
+.directive('backUrl', [function() {
   return {
     restrict: 'E',
-    replace: true,
-    templateUrl: '/templates/work_packages/work_packages_table.html',
-    scope: {
-      projectIdentifier: '=',
-      columns: '=',
-      rows: '=',
-      query: '=',
-      countByGroup: '=',
-      groupBy: '=',
-      groupByColumn: '=',
-      displaySums: '=',
-      totalSums: '=',
-      groupSums: '=',
-      updateResults: '&',
-      withLoading: '=',
-      updateBackUrl: '='
-    },
-    link: function(scope, element, attributes) {
-      scope.I18n = I18n;
-
-      // groupings
-      scope.grouped = scope.groupByColumn !== undefined;
-      scope.groupExpanded = {};
-
-      scope.setCheckedStateForAllRows = function(state) {
-        angular.forEach(scope.rows, function(row) {
-          row.checked = state;
-        });
-      };
-
-      scope.$watch('query.sortation.sortElements', function(oldValue, newValue) {
-        if (newValue !== oldValue) {
-          scope.updateResults();
-          scope.updateBackUrl();
-        }
-      });
-    }
+    templateUrl: '/templates/components/back_url.html',
   };
 }]);

--- a/app/assets/javascripts/angular/directives/work_packages/query-filter-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/query-filter-directive.js
@@ -61,6 +61,7 @@ angular.module('openproject.workPackages.directives')
             PaginationService.resetPage();
 
             applyFilters();
+            scope.updateBackUrl();
           }
         }
       }, true);

--- a/app/assets/javascripts/angular/directives/work_packages/query-form-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/query-form-directive.js
@@ -42,6 +42,7 @@ angular.module('openproject.workPackages.directives')
             if (newValue !== oldValue && newValue !== undefined) {
               // TODO find out why newValue get set to undefined on initial page load
               scope.updateResults();
+              scope.updateBackUrl();
             }
           });
         }

--- a/app/assets/javascripts/angular/directives/work_packages/work-package-group-sums-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-group-sums-directive.js
@@ -48,6 +48,7 @@ angular.module('openproject.workPackages.directives')
           scope.$watch('groupSums.length', function() {
             // map columns to sums if the column data is a number
             setSums();
+            scope.updateBackUrl();
           });
 
         }

--- a/app/assets/javascripts/angular/directives/work_packages/work-package-total-sums-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-total-sums-directive.js
@@ -47,7 +47,10 @@ angular.module('openproject.workPackages.directives')
 
           scope.$watch('columns.length', function(length, formerLength) {
             // map columns to sums if the column data is a number
-            if(length >= formerLength) fetchSums();
+            if(length >= formerLength){
+              fetchSums();
+              scope.updateBackUrl();
+            }
           });
         }
       };

--- a/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
@@ -40,6 +40,7 @@ angular.module('openproject.workPackages.directives')
           }).indexOf(groupBy);
 
           scope.groupByColumn = scope.columns[groupByColumnIndex];
+          scope.updateBackUrl();
         }
       });
     }

--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -62,6 +62,21 @@ angular.module('openproject.models')
       );
     },
 
+    serialiseForAngular: function(){
+      var params = this.toParams();
+      var serialised = '';
+      angular.forEach(params, function(value, key){
+        if(typeof value == "string"){
+          serialised = serialised + "&" + key + "=" + value;
+        } else if(Array.isArray(value)){
+          angular.forEach(value, function(v){
+            serialised = serialised + "&" + key + "=" + v;
+          });
+        }
+      });
+      return serialised.slice(1, serialised.length);
+    },
+
     /**
      * @name setAvailableWorkPackageFilters
      * @function

--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -67,10 +67,10 @@ angular.module('openproject.models')
       var serialised = '';
       angular.forEach(params, function(value, key){
         if(typeof value == "string"){
-          serialised = serialised + "&" + key + "=" + value;
+          serialised = serialised + "&" + key + "=" + encodeURIComponent(value);
         } else if(Array.isArray(value)){
           angular.forEach(value, function(v){
-            serialised = serialised + "&" + key + "=" + v;
+            serialised = serialised + "&" + key + "=" + encodeURIComponent(v);
           });
         }
       });

--- a/app/assets/javascripts/angular/openproject-app.js
+++ b/app/assets/javascripts/angular/openproject-app.js
@@ -52,7 +52,8 @@ var openprojectApp = angular.module('openproject', ['ui.select2', 'ui.date', 'op
 
 openprojectApp
   .config(['$locationProvider', '$httpProvider', function($locationProvider, $httpProvider) {
-    $locationProvider.html5Mode(true);
+    // Note: Not using this because we want to use $location to get the url params and html5Mode prevents all the links from working normally.
+    // $locationProvider.html5Mode(true);
     $httpProvider.defaults.headers.common['X-CSRF-TOKEN'] = jQuery('meta[name=csrf-token]').attr('content'); // TODO find a more elegant way to keep the session alive
   }])
   .run(['$http', function($http){

--- a/app/assets/javascripts/angular/services/query-service.js
+++ b/app/assets/javascripts/angular/services/query-service.js
@@ -28,8 +28,8 @@
 
 angular.module('openproject.services')
 
-.service('QueryService', ['Query', 'Sortation', '$http', 'PathHelper', '$q', 'AVAILABLE_WORK_PACKAGE_FILTERS', 'StatusService', 'TypeService', 'PriorityService', 'UserService', 'VersionService', 'RoleService', 'GroupService', 'ProjectService',
-  function(Query, Sortation, $http, PathHelper, $q, AVAILABLE_WORK_PACKAGE_FILTERS, StatusService, TypeService, PriorityService, UserService, VersionService, RoleService, GroupService, ProjectService) {
+.service('QueryService', ['Query', 'Sortation', '$http', '$location', 'PathHelper', '$q', 'AVAILABLE_WORK_PACKAGE_FILTERS', 'StatusService', 'TypeService', 'PriorityService', 'UserService', 'VersionService', 'RoleService', 'GroupService', 'ProjectService',
+  function(Query, Sortation, $http, $location, PathHelper, $q, AVAILABLE_WORK_PACKAGE_FILTERS, StatusService, TypeService, PriorityService, UserService, VersionService, RoleService, GroupService, ProjectService) {
 
   var query;
 
@@ -59,6 +59,7 @@ angular.module('openproject.services')
 
       return query;
     },
+
     getQuery: function() {
       return query;
     },

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -41,6 +41,16 @@ angular.module('openproject.services')
       return WorkPackageService.doQuery(url, params);
     },
 
+    getWorkPackagesFromUrlQueryParams: function(projectIdentifier, location) {
+      var url = projectIdentifier ? PathHelper.apiProjectWorkPackagesPath(projectIdentifier) : PathHelper.apiWorkPackagesPath();
+
+      // Build up query from params...
+      var params = {};
+      angular.extend(params, location.search());
+
+      return WorkPackageService.doQuery(url, params);
+    },
+
     getWorkPackages: function(projectIdentifier, query, paginationOptions) {
       var url = projectIdentifier ? PathHelper.apiProjectWorkPackagesPath(projectIdentifier) : PathHelper.apiWorkPackagesPath();
       var params = angular.extend(query.toParams(), {

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -43,8 +43,6 @@ angular.module('openproject.services')
 
     getWorkPackagesFromUrlQueryParams: function(projectIdentifier, location) {
       var url = projectIdentifier ? PathHelper.apiProjectWorkPackagesPath(projectIdentifier) : PathHelper.apiWorkPackagesPath();
-
-      // Build up query from params...
       var params = {};
       angular.extend(params, location.search());
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -421,8 +421,13 @@ class ApplicationController < ActionController::Base
     params[:back_url] || request.env['HTTP_REFERER']
   end
 
-  def redirect_back_or_default(default)
-    back_url = URI.escape(CGI.unescape(params[:back_url].to_s))
+  def redirect_back_or_default(default, escape = true)
+    back_url = if escape
+                 URI.escape(CGI.unescape(params[:back_url].to_s))
+               else
+                 params[:back_url]
+               end
+    binding.pry
     # if we have a back_url it must not contain two consecutive dots
     if back_url.present? && !back_url.match(%r{\.\.})
       begin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -427,7 +427,7 @@ class ApplicationController < ActionController::Base
                else
                  params[:back_url]
                end
-    binding.pry
+
     # if we have a back_url it must not contain two consecutive dots
     if back_url.present? && !back_url.match(%r{\.\.})
       begin

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -68,7 +68,7 @@ class WorkPackages::BulkController < ApplicationController
       end
     end
     set_flash_from_bulk_save(@work_packages, unsaved_work_package_ids)
-    redirect_back_or_default({controller: '/work_packages', action: :index, project_id: @project})
+    redirect_back_or_default({controller: '/work_packages', action: :index, project_id: @project}, false)
   end
 
   def destroy

--- a/app/views/work_packages/_list.html.erb
+++ b/app/views/work_packages/_list.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= form_tag({}) do -%>
-  <back-url back-url="backUrl"></back-url>
+  <back-url></back-url>
   <div class="autoscroll">
 
     <work-packages-table ng-if="rows && columns"
@@ -44,7 +44,8 @@ See doc/COPYRIGHT.rdoc for more details.
                          group-sums="groupSums"
                          class="list issues"
                          update-results="updateResults()"
-                         with-loading="withLoading">
+                         with-loading="withLoading"
+                         update-back-url="updateBackUrl">
     </work-packages-table>
 
     <table-pagination total-entries="totalEntries"

--- a/app/views/work_packages/_list.html.erb
+++ b/app/views/work_packages/_list.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= form_tag({}) do -%>
-  <%= hidden_field_tag 'back_url', url_for(params) %>
+  <back-url back-url="backUrl"></back-url>
   <div class="autoscroll">
 
     <work-packages-table ng-if="rows && columns"

--- a/public/templates/components/back_url.html
+++ b/public/templates/components/back_url.html
@@ -1,0 +1,1 @@
+<input type="text" name="back_url" id="back_url" value="{{backUrl}}"></input>

--- a/public/templates/components/back_url.html
+++ b/public/templates/components/back_url.html
@@ -1,1 +1,1 @@
-<input type="text" name="back_url" id="back_url" value="{{backUrl}}"></input>
+<input type="hidden" name="back_url" id="back_url" value="{{backUrl}}"></input>


### PR DESCRIPTION
the updateBackUrl is being called from quite a few different watchers, which seems like repetition but there is not place where the whole query is being watched so i think it's the best way to do it. might be possible to have a "withUpdateBackUrl" method in the same style as withLoading but this would probably be overkill.
