### PR TITLE
Checking for filters with nil values.

### DIFF
--- a/app/models/queries/filter.rb
+++ b/app/models/queries/filter.rb
@@ -130,7 +130,7 @@ class Queries::Filter
   private
 
   def validate_presence_of_values
-    errors.add(:values, I18n.t('activerecord.errors.messages.blank')) if values.reject(&:blank?).empty?
+    errors.add(:values, I18n.t('activerecord.errors.messages.blank')) if values.nil? || values.reject(&:blank?).empty?
   end
 
   def validate_filter_values


### PR DESCRIPTION
Hard to see where/when this started happening... maybe a side effect of using select2 for the work package filters on the new timelines view. Result is that the created query used in timelines has a few filters on it which have operator '=' but no values. Have just put in a check so that it doesn't try to iterate over nil when validating the filters.

This doesn't seem worth writing a test for. 
