### PR TITLE
disable async jobs in test env by default

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -271,11 +271,7 @@ class UsersController < ApplicationController
     @user.status = User::STATUSES[:locked]
     @user.save
 
-    # TODO: use Delayed::Worker.delay_jobs = false in test environment as soon as
-    # delayed job allows for it
-    Rails.env.test? ?
-      @user.destroy :
-      @user.delay.destroy
+    @user.delay.destroy
 
     # log the user out if it's a self-delete
     # must be called before setting the flash message

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -27,6 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+# log delayed job's output to whatever rails logs to
 Delayed::Worker.logger = Rails.logger
 
 # By default bypass worker queue and execute asynchronous tasks at once

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -28,3 +28,6 @@
 #++
 
 Delayed::Worker.logger = Rails.logger
+
+# By default bypass worker queue and execute asynchronous tasks at once
+Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/spec/models/work_package/work_package_action_mailer_spec.rb
+++ b/spec/models/work_package/work_package_action_mailer_spec.rb
@@ -29,10 +29,6 @@
 require 'spec_helper'
 
 describe WorkPackage do
-  before :each do
-    Delayed::Worker.delay_jobs = false
-  end
-
   describe ActionMailer::Base do
     let(:user_1) { FactoryGirl.create(:user,
                                       mail: "dlopper@somenet.foo") }

--- a/spec/models/work_package/work_package_acts_as_watchable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_watchable_spec.rb
@@ -134,10 +134,6 @@ describe WorkPackage do
   context 'notifications' do
     let(:number_of_recipients) { (work_package.recipients | work_package.watcher_recipients).length }
 
-    before :each do
-      Delayed::Worker.delay_jobs = false
-    end
-
     it 'sends one delayed mail notification for each watcher recipient' do
       UserMailer.stub_chain :work_package_updated, :deliver
       expect(UserMailer).to receive(:work_package_updated).exactly(number_of_recipients).times

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -93,8 +93,6 @@ class ActiveSupport::TestCase
         ActiveRecord::Base.connection.reset_pk_sequence!(model.table_name)
       end
     end
-    # By default bypass worker queue and execute asynchronous tasks at once
-    Delayed::Worker.delay_jobs = false
 
     # initializes the mocking features
     RSpec::Mocks.setup(self)


### PR DESCRIPTION
disables delaying of jobs in test environment by default
