### PR TITLE
Bug 6360 group by unselected column fix

### DIFF
--- a/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
@@ -37,7 +37,7 @@ angular.module('openproject.workPackages.directives')
       workPackage: '=',
       column: '=',
       displayType: '@',
-      displayEmpty: '='
+      displayEmpty: '@'
     },
     templateUrl: '/templates/work_packages/work_package_column.html',
     link: function(scope, element, attributes) {

--- a/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
@@ -46,29 +46,56 @@ angular.module('openproject.workPackages.directives')
       // Set text to be displayed
       scope.$watch('workPackage', setColumnData, true);
 
+
       function setColumnData() {
+        setDisplayText(getFormattedColumnValue());
+
+        if (scope.column.meta_data.link.display) {
+          displayDataAsLink();
+        } else {
+          setCustomDisplayType();
+        }
+      }
+
+      function getFormattedColumnValue() {
         // retrieve column value from work package
         if (scope.column.custom_field) {
           var custom_field = scope.column.custom_field;
-          var formattedValue = WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field);
+          return WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field);
         } else {
-          // custom display types
-          if (scope.column.name === 'done_ratio') scope.displayType = 'progress_bar';
-          var formattedValue = WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column);
+          return WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column);
         }
+      }
 
-        if (typeof formattedValue == 'number' || formattedValue){
-          scope.displayText = formattedValue;
+      /**
+       * @name setDisplayText
+       * @function
+       *
+       * @description
+       * Sets scope.displayText to the passed value or applies a default
+       *
+       * @param {String|Number} value The value for scope.displayText
+       *
+       * @returns null
+       */
+      function setDisplayText(value) {
+        if (typeof value == 'number' || value){
+          scope.displayText = value;
         } else {
           scope.displayText = scope.displayEmpty || '';
         }
+      }
 
+      function setCustomDisplayType() {
+        if (scope.column.name === 'done_ratio') scope.displayType = 'progress_bar';
+        // ...
+      }
+
+      function displayDataAsLink() {
         // Example of how we can look to the provided meta data to format the column
         // This relies on the meta being sent from the server
-        if (scope.column.meta_data.link.display) {
-          scope.displayType = 'link';
-          scope.url = getLinkFor(scope.column.meta_data.link);
-        }
+        scope.displayType = 'link';
+        scope.url = getLinkFor(scope.column.meta_data.link);
       }
 
       function getLinkFor(link_meta){

--- a/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
@@ -50,13 +50,17 @@ angular.module('openproject.workPackages.directives')
         // retrieve column value from work package
         if (scope.column.custom_field) {
           var custom_field = scope.column.custom_field;
-
-          scope.displayText = WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field) || scope.displayEmpty || '';
+          var formattedValue = WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field);
         } else {
           // custom display types
           if (scope.column.name === 'done_ratio') scope.displayType = 'progress_bar';
+          var formattedValue = WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column);
+        }
 
-          scope.displayText = WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column) || scope.displayEmpty || '';
+        if (typeof formattedValue == 'number' || formattedValue){
+          scope.displayText = formattedValue;
+        } else {
+          scope.displayText = scope.displayEmpty || '';
         }
 
         // Example of how we can look to the provided meta data to format the column

--- a/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-package-column-directive.js
@@ -36,7 +36,8 @@ angular.module('openproject.workPackages.directives')
     scope: {
       workPackage: '=',
       column: '=',
-      displayType: '@'
+      displayType: '@',
+      displayEmpty: '='
     },
     templateUrl: '/templates/work_packages/work_package_column.html',
     link: function(scope, element, attributes) {
@@ -50,12 +51,12 @@ angular.module('openproject.workPackages.directives')
         if (scope.column.custom_field) {
           var custom_field = scope.column.custom_field;
 
-          scope.displayText = WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field) || '';
+          scope.displayText = WorkPackagesHelper.getFormattedCustomValue(scope.workPackage, custom_field) || scope.displayEmpty || '';
         } else {
           // custom display types
           if (scope.column.name === 'done_ratio') scope.displayType = 'progress_bar';
 
-          scope.displayText = WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column) || '';
+          scope.displayText = WorkPackagesHelper.getFormattedColumnData(scope.workPackage, scope.column) || scope.displayEmpty || '';
         }
 
         // Example of how we can look to the provided meta data to format the column

--- a/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-packages-options-directive.js
@@ -39,7 +39,7 @@ angular.module('openproject.workPackages.directives')
             return column.name;
           }).indexOf(groupBy);
 
-          scope.groupByColumn = scope.columns[groupByColumnIndex];
+          scope.groupByColumn = scope.groupableColumns[groupByColumnIndex];
           scope.updateBackUrl();
         }
       });

--- a/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
@@ -41,6 +41,8 @@ angular.module('openproject.workPackages.helpers')
         case 'object':
           if (content === null) return '';
           return content.name || content.subject;
+        case 'number':
+          return content;
         default:
           return content || '';
       }

--- a/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
@@ -40,7 +40,7 @@ angular.module('openproject.workPackages.helpers')
       switch(typeof(content)) {
         case 'object':
           if (content === null) return '';
-          return content.name || content.subject;
+          return content.name || content.subject || '';
         case 'number':
           return content;
         default:
@@ -63,12 +63,12 @@ angular.module('openproject.workPackages.helpers')
     getRawCustomValue: function(object, customFieldId) {
       if (!object.custom_values) return null;
 
-      var customValue = object.custom_values.filter(function(customValue){
+      var values = object.custom_values.filter(function(customValue){
         return customValue && customValue.custom_field_id === customFieldId;
-      }).first();
+      });
 
-      if (customValue) {
-        return customValue.value;
+      if (values && values.length > 0) {
+        return values[0].value;
       } else {
         return '';
       }

--- a/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
@@ -31,7 +31,11 @@ angular.module('openproject.workPackages.helpers')
 .factory('WorkPackagesHelper', ['dateFilter', 'CustomFieldHelper', function(dateFilter, CustomFieldHelper) {
   var WorkPackagesHelper = {
     getRowObjectContent: function(object, option) {
-      var content = object[option];
+      if(CustomFieldHelper.isCustomFieldKey(option)){
+        var content = WorkPackagesHelper.getRawCustomValue(object, CustomFieldHelper.getCustomFieldId(option));
+      } else {
+        var content = object[option];
+      }
 
       switch(typeof(content)) {
         case 'object':
@@ -51,6 +55,20 @@ angular.module('openproject.workPackages.helpers')
         }
       } else {
         workPackage[attributeName] = data;
+      }
+    },
+
+    getRawCustomValue: function(object, customFieldId) {
+      if (!object.custom_values) return null;
+
+      var customValue = object.custom_values.filter(function(customValue){
+        return customValue && customValue.custom_field_id === customFieldId;
+      }).first();
+
+      if (customValue) {
+        return customValue.value;
+      } else {
+        return '';
       }
     },
 

--- a/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/work-packages-helper.js
@@ -67,7 +67,7 @@ angular.module('openproject.workPackages.helpers')
         return customValue && customValue.custom_field_id === customFieldId;
       });
 
-      if (values && values.length > 0) {
+      if (values && values.length) {
         return values[0].value;
       } else {
         return '';
@@ -77,12 +77,12 @@ angular.module('openproject.workPackages.helpers')
     getFormattedCustomValue: function(object, customField) {
       if (!object.custom_values) return null;
 
-      var customValue = object.custom_values.filter(function(customValue){
+      var values = object.custom_values.filter(function(customValue){
         return customValue && customValue.custom_field_id === customField.id;
-      }).first();
+      });
 
-      if(customValue) {
-        return CustomFieldHelper.formatCustomFieldValue(customValue.value, customField.field_format);
+      if(values && values.length) {
+        return CustomFieldHelper.formatCustomFieldValue(values[0].value, customField.field_format);
       }
     },
 

--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -51,9 +51,7 @@ angular.module('openproject.models')
       return angular.extend.apply(this, [
         {
           'f[]': this.getFilterNames(this.getActiveConfiguredFilters()),
-          'c[]': this.columns.map(function(column) {
-            return column.name;
-           }),
+          'c[]': this.getParamColumns(),
           'group_by': this.groupBy,
           'sort': this.sortation.encode()
         }].concat(this.getActiveConfiguredFilters().map(function(filter) {
@@ -139,6 +137,17 @@ angular.module('openproject.models')
       return (filters || this.filters).map(function(filter){
         return filter.name;
       });
+    },
+
+    getParamColumns: function(){
+      var selectedColumns = this.columns.map(function(column) {
+        return column.name;
+      });
+      // To be able to group the work packages we need to add in the group by column if it is not already in the selected columns
+      if(selectedColumns.indexOf(this.groupBy) == -1){
+        selectedColumns.push(this.groupBy);
+      }
+      return selectedColumns;
     },
 
     getFilterByName: function(filterName) {

--- a/app/views/api/v3/work_packages/index.api.rabl
+++ b/app/views/api/v3/work_packages/index.api.rabl
@@ -35,7 +35,7 @@ child @work_packages => :work_packages do
       when Category
         wp.send(column_name).as_json(only: [:id, :name])
       when Project
-        wp.send(column_name).as_json(only: [:id, :name])
+        wp.send(column_name).as_json(only: [:id, :name, :identifier])
       when IssuePriority
         wp.send(column_name).as_json(only: [:id, :name])
       when Status

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -74,6 +74,8 @@ module.exports = function(config) {
       'app/assets/javascripts/angular/services/query-service.js',
       'app/assets/javascripts/angular/services/pagination-service.js',
 
+      "app/assets/javascripts/angular/directives/work_packages/*.js",
+
       "app/assets/javascripts/angular/controllers/timelines-controller.js",
       "app/assets/javascripts/angular/controllers/work-packages-controller.js",
 

--- a/karma/tests/directives/work_packages/work-package-column-directive-test.js
+++ b/karma/tests/directives/work_packages/work-package-column-directive-test.js
@@ -1,0 +1,187 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('workPackageColumn Directive', function() {
+    var compile, element, rootScope, scope;
+
+    beforeEach(angular.mock.module('openproject.workPackages.directives'));
+    beforeEach(module('templates'));
+
+    beforeEach(inject(function($rootScope, $compile) {
+      var html;
+      html = '<span work-package-column work-package="workPackage" column="column" display-type="displayType" display-empty="-"></span>';
+
+      element = angular.element(html);
+      rootScope = $rootScope;
+      scope = $rootScope.$new();
+
+      compile = function() {
+        $compile(element)(scope);
+        scope.$digest();
+      };
+    }));
+
+    describe('element', function() {
+      beforeEach(function() {
+        scope.workPackage = {
+          subject: "Subject1",
+          type: { id: 1, name: 'Bug'},
+          sheep: 10,
+          custom_values: [ { custom_field_id: 1, field_format: 'string', value: 'asdf1234'} ]
+        };
+      });
+
+      describe('rendering an object field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: false,
+            groupable: 'type',
+            meta_data: { data_type: 'object', link: { display: false} },
+            name: 'type',
+            sortable: 'types:position',
+            title: 'Type'
+          };
+          scope.displayType = 'text';
+
+          compile();
+        });
+
+        it('should render a span', function() {
+          expect(element.prop('tagName')).to.equal('SPAN');
+        });
+
+        it('should contain the object title', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('Bug');
+        });
+      });
+
+      describe('rendering a text field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: false,
+            groupable: false,
+            meta_data: { data_type: 'string', link: { display: false} },
+            name: 'subject',
+            sortable: 'work_packages.subject',
+            title: 'Subject'
+          };
+          scope.displayType = 'text';
+
+          compile();
+        });
+
+        it('should contain the text', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('Subject1');
+        });
+      });
+
+      describe('rendering a number field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: false,
+            groupable: false,
+            meta_data: { data_type: 'integer', link: { display: false} },
+            name: 'sheep',
+            sortable: 'work_packages.sheep',
+            title: 'Sheep'
+          };
+          scope.displayType = 'number';
+
+          compile();
+        });
+
+        it('should contain the text', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('10');
+        });
+      });
+
+      describe('rendering a custom string field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: { field_format: 'string', id: 1 },
+            groupable: false,
+            meta_data: { data_type: 'string', link: { display: false} },
+            name: 'a_custom_field',
+            title: 'A Custom Field'
+          };
+          scope.displayType = 'text';
+
+          compile();
+        });
+
+        it('should contain the text', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('asdf1234');
+        });
+      });
+
+      describe('rendering missing field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: false,
+            groupable: false,
+            meta_data: { data_type: 'string', link: { display: false} },
+            name: 'non_existant',
+            title: 'Non-existant'
+          };
+          scope.displayType = 'text';
+
+          compile();
+        });
+
+        it('should contain the display empty text', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('-');
+        });
+      });
+
+      describe('rendering missing custom field', function(){
+        beforeEach(function(){
+          scope.column = {
+            custom_field: { field_format: 'string', id: 2 },
+            groupable: false,
+            meta_data: { data_type: 'string', link: { display: false} },
+            name: 'non_existant',
+            title: 'Non-existant'
+          };
+          scope.displayType = 'text';
+
+          compile();
+        });
+
+        it('should contain the display empty text', function() {
+          var content = element.find('span').first();
+          expect(content.text()).to.equal('-');
+        });
+      });
+
+    });
+});

--- a/karma/tests/helpers/components/work-packages-helper-test.js
+++ b/karma/tests/helpers/components/work-packages-helper-test.js
@@ -1,0 +1,108 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+describe('Work packages helper', function() {
+  var WorkPackagesHelper;
+
+  beforeEach(module('openproject.helpers'));
+  beforeEach(inject(function(_WorkPackagesHelper_) {
+    WorkPackagesHelper = _WorkPackagesHelper_;
+  }));
+
+  describe('getRowObjectContent', function() {
+    var getRowObjectContent;
+
+    beforeEach(function() {
+      getRowObjectContent = WorkPackagesHelper.getRowObjectContent;
+    });
+
+    describe('with an object', function() {
+      it('should return object name', function() {
+        var object = {
+          assignee: { name: 'user1', subject: 'not this' }
+        };
+
+        expect(getRowObjectContent(object, 'assignee')).to.equal('user1');
+      });
+
+      it('should return object subject', function() {
+        var object = {
+          assignee: { subject: 'subject1' }
+        };
+
+        expect(getRowObjectContent(object, 'assignee')).to.equal('subject1');
+      });
+
+      it('should handle null and emtpy objects', function() {
+        expect(getRowObjectContent({ assignee: {}}, 'assignee')).to.equal('');
+        expect(getRowObjectContent({}, 'assignee')).to.equal('');
+      });
+    });
+
+    describe('with a number', function() {
+      it('should return the number', function() {
+        expect(getRowObjectContent({ number_field: 10 }, 'number_field')).to.equal(10);
+      });
+
+      it('should handle missing data', function() {
+        expect(getRowObjectContent({}, 'number_field')).to.equal('');
+      });
+    });
+
+    describe('with a custom field', function() {
+      it('should return type string custom field', function() {
+        var object = {
+          custom_values: [ { custom_field_id: 1, value: 'custom field string'} ]
+        }
+
+        expect(getRowObjectContent(object, 'cf_1')).to.equal('custom field string');
+      });
+
+      it('should return type object custom field', function() {
+        var object = {
+          custom_values: [ { custom_field_id: 1, value: { name: 'name1' }} ]
+        }
+
+        expect(getRowObjectContent(object, 'cf_1')).to.equal('name1');
+      });
+
+      it('should handle missing data', function() {
+        var object = {
+          custom_values: [ { custom_field_id: 1, value: 'whatever'} ]
+        }
+
+        expect(getRowObjectContent(object, 'cf_2')).to.equal('');
+        expect(getRowObjectContent({}, 'cf_1')).to.equal('');
+      });
+
+    });
+
+  });
+});

--- a/public/templates/work_packages/work_package_column.html
+++ b/public/templates/work_packages/work_package_column.html
@@ -6,7 +6,5 @@
 
   <a ng-switch-when="link" href="{{ url }}">{{ displayText }}</a>
 
-  <span ng-switch-default>
-    {{ displayText }}
-  </span>
+  <span ng-switch-default>{{ displayText }}</span>
 </span>

--- a/public/templates/work_packages/work_packages_table.html
+++ b/public/templates/work_packages/work_packages_table.html
@@ -61,7 +61,7 @@
         </span>
 
         <span>
-          <span work-package-column work-package="row.object" column="groupByColumn" display-empty="'-'">
+          <span work-package-column work-package="row.object" column="groupByColumn" display-empty="-">
           </span>
 
           <span class="count">

--- a/public/templates/work_packages/work_packages_table.html
+++ b/public/templates/work_packages/work_packages_table.html
@@ -61,7 +61,7 @@
         </span>
 
         <span>
-          <span work-package-column work-package="row.object" column="groupByColumn">
+          <span work-package-column work-package="row.object" column="groupByColumn" display-empty="'-'">
           </span>
 
           <span class="count">

--- a/spec/views/api/v3/work_packages/index_api_json_spec.rb
+++ b/spec/views/api/v3/work_packages/index_api_json_spec.rb
@@ -80,4 +80,13 @@ describe 'api/v3/work_packages/index.api.rabl' do
     it { should have_json_path('work_packages/1/description')     }
     it { should have_json_path('work_packages/1/due_date')        }
   end
+
+  describe 'with project column' do
+    let(:work_packages) { [FactoryGirl.build(:work_package)] }
+    let(:column_names) { %w(subject project) }
+    let(:custom_field_column_names) { [] }
+
+    it { should have_json_path('work_packages/0/project') }
+    it { should have_json_path('work_packages/0/project/identifier') }
+  end
 end


### PR DESCRIPTION
This fixes a few issues:

Sums for number values weren't being shown in the groups headers.

Grouping was broken since we changed the available group by columns. The way we have structured it means that we can only group by columns if the column data has already been loaded. To fix this I augmented the c[] param to work packages index to include the group by column if it's not in there already so that all the necessary data is returned.
