### PR TITLE
Display correct progress bar level when the done ratio is added (fixes #...

### DIFF
--- a/app/assets/javascripts/angular/directives/components/progress-bar-directive.js
+++ b/app/assets/javascripts/angular/directives/components/progress-bar-directive.js
@@ -41,12 +41,14 @@ angular.module('openproject.uiComponents')
     templateUrl: '/templates/components/progress_bar.html',
     link: function(scope) {
       // apply defaults
-      scope.progress = scope.progress || 0;
       scope.width = scope.width || '100px';
       scope.legend = scope.legend || '';
 
       scope.scaleLength = 100;
-      scope.progress = Math.round(scope.progress);
+
+      scope.$watch('progress', function(progress) {
+        scope.progressInPercent = Math.round(Number(progress));
+      });
     }
   };
 }]);

--- a/karma/tests/directives/components/progress-bar-directive-test.js
+++ b/karma/tests/directives/components/progress-bar-directive-test.js
@@ -66,5 +66,17 @@ describe('progressBar Directive', function() {
         expect(cell.length).to.equal(2); // ng-if adds 2 to DOM
         expect(cell.css('width')).to.equal('50%');
       });
+
+      describe('when the progress is updated within the scope', function() {
+        beforeEach(function() {
+          scope.progress = '20';
+          scope.$apply();
+        });
+
+        it('should update the progress bar', function() {
+          var cell = element.find('table td');
+          expect(cell.css('width')).to.equal('20%');
+        });
+      });
     });
 });

--- a/public/templates/components/progress_bar.html
+++ b/public/templates/components/progress_bar.html
@@ -2,8 +2,8 @@
   <table class="progress" ng-style="{width: width}">
     <tbody>
       <tr>
-        <td class="closed" ng-if="progress > 0" ng-style="{width: progress + '%'}"></td>
-        <td class="todo" ng-style="{width: (scaleLength - progress) + '%'}"></td>
+        <td class="closed" ng-if="progressInPercent > 0" ng-style="{width: progressInPercent + '%'}"></td>
+        <td class="todo" ng-style="{width: (scaleLength - progressInPercent) + '%'}"></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
...7063)

Setting progress to zero caused the displayText not to be correctly set with the work package column value.

https://www.openproject.org/work_packages/7063
