### PR TITLE
Show error on attempt to register with disabled self registration

### DIFF
--- a/app/controllers/concerns/omniauth_login.rb
+++ b/app/controllers/concerns/omniauth_login.rb
@@ -29,7 +29,7 @@ module OmniauthLogin
   # in our database) will be created using this method.
   def create_user_from_omniauth(user, auth_hash)
     # Self-registration off
-    return redirect_to(signin_url) unless Setting.self_registration?
+    return self_registration_disabled unless Setting.self_registration?
 
     # Create on the fly
     fill_user_fields_from_omniauth(user, auth_hash)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -42,6 +42,9 @@ de:
       login_consequences:
         other: "Der Account wird aus dem System entfernt. Der Nutzer wird daher nicht mehr in der Lage sein, sich mit seinem derzeitigen Nutzernamen und Passwort anzumelden. Sofern der Nutzer es wünscht, kann er sich über die von der Anwendung zur Verfügung gestellten Mechanismen einen neuen Account zulegen."
         self: "Ihr Account wird aus dem System entfernt. Sie werden daher nicht mehr in der Lage sein, sich mit Ihrem derzeitigen Nutzernamen und Passwort anzumelden. Sofern Sie es wünschen, können Sie sich über die von der Anwendung zur Verfügung gestellten Mechanismen einen neuen Account zulegen."
+    error_self_registration_disabled: >
+      Auf diesem System ist die Nutzerregistierung deaktiviert. Bitte fragen Sie einen
+      Administrator nach einem Nutzerkonto.
 
   actionview_instancetag_blank_option: "Bitte auswählen"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en:
       login_consequences:
         other: "The account will be deleted from the system. Therefore, the user will no longer be able to log in with his current credentials. He/she can choose to become a user of this application again by the means this application grants."
         self: "Your account will be deleted from the system. Therefore, you will no longer be able to log in with your current credentials. If you choose to become a user of this application again, you can do so by using the means this application grants."
+    error_self_registration_disabled: >
+      User registration is disabled on this system. Please ask an administrator to create an
+      account for you.
 
   actionview_instancetag_blank_option: "Please select"
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -193,8 +193,12 @@ describe AccountController do
         get :register
       end
 
-      it 'redirects to home' do
-        should redirect_to('/') { home_url }
+      it 'redirects to signin_path' do
+        expect(response).to redirect_to signin_path
+      end
+
+      it 'shows the right flash message' do
+        expect(flash[:error]).to eq(I18n.t('account.error_self_registration_disabled'))
       end
     end
   end
@@ -309,8 +313,12 @@ describe AccountController do
         }
       end
 
-      it 'redirects to home' do
-        should redirect_to('/') { home_url }
+      it 'redirects to signin_path' do
+        expect(response).to redirect_to signin_path
+      end
+
+      it 'shows the right flash message' do
+        expect(flash[:error]).to eq(I18n.t('account.error_self_registration_disabled'))
       end
     end
 

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -167,6 +167,10 @@ describe AccountController do
         it 'redirects to signin_path' do
           expect(response).to redirect_to signin_path
         end
+
+        it 'shows the right flash message' do
+          expect(flash[:error]).to eq(I18n.t('account.error_self_registration_disabled'))
+        end
       end
     end
 


### PR DESCRIPTION
[`* `#7051` Wrong success message when user is not allowed to register himself`](https://www.openproject.org/work_packages/7051)

This happens for normal registration as well as registration via omniauth.

This also changes the redirect to not go to / and go to signin_url instead.
