### PR TITLE
Gemfile: Clean up some development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,6 @@ group :development do
   gem 'pry-stack_explorer'
   gem 'pry-rescue'
   gem 'pry-byebug', :platforms => [:mri_20,:mri_21]
-  gem 'pry-debugger', :platforms => :mri_19
   gem 'pry-doc'
   gem 'rails-dev-tweaks', '~> 0.6.1'
   gem 'thin'

--- a/Gemfile
+++ b/Gemfile
@@ -167,12 +167,8 @@ group :development do
   gem 'pry-debugger', :platforms => :mri_19
   gem 'pry-doc'
   gem 'rails-dev-tweaks', '~> 0.6.1'
-  gem 'guard-rspec'
-  gem 'guard-cucumber'
-  gem 'rb-fsevent', :group => :test
   gem 'thin'
   gem 'faker'
-  gem 'guard-test'
 end
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,6 @@ GEM
       xpath (~> 2.0)
     capybara-screenshot (0.3.6)
       capybara (>= 1.0, < 3)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
     codeclimate-test-reporter (0.1.1)
@@ -140,28 +138,12 @@ GEM
     faker (1.2.0)
       i18n (~> 0.5)
     ffi (1.9.3)
-    formatador (0.2.4)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalize (3.0.0)
       activemodel (>= 3.0.0)
       activerecord (>= 3.0.0)
       paper_trail (~> 2)
-    guard (2.2.2)
-      formatador (>= 0.2.4)
-      listen (~> 2.1)
-      lumberjack (~> 1.0)
-      pry (>= 0.9.12)
-      thor (>= 0.18.1)
-    guard-cucumber (1.4.0)
-      cucumber (>= 1.2.0)
-      guard (>= 1.1.0)
-    guard-rspec (3.1.0)
-      guard (>= 1.8)
-      rspec (~> 2.13)
-    guard-test (1.0.0)
-      guard (>= 1.8)
-      test-unit (~> 2.2)
     hashie (2.0.5)
     hike (1.2.3)
     htmldiff (0.0.1)
@@ -184,11 +166,6 @@ GEM
     letter_opener (1.0.0)
       launchy (>= 2.0.4)
     libv8 (3.11.8.17)
-    listen (2.1.2)
-      celluloid (>= 0.15.2)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    lumberjack (1.0.4)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -268,9 +245,6 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rake (10.1.0)
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
-      ffi (>= 0.5.0)
     rb-readline (0.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -336,7 +310,6 @@ GEM
     structured_warnings (0.1.4)
     svg-graph (1.0.5)
     syck (1.0.1)
-    test-unit (2.5.5)
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
@@ -347,7 +320,6 @@ GEM
     thor (0.18.1)
     tilt (1.4.1)
     timecop (0.6.1)
-    timers (1.1.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -387,9 +359,6 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   faker
   globalize
-  guard-cucumber
-  guard-rspec
-  guard-test
   htmldiff
   i18n-js!
   jquery-atwho-rails (~> 0.4.7)
@@ -420,7 +389,6 @@ DEPENDENCIES
   rails (~> 3.2.17)
   rails-dev-tweaks (~> 0.6.1)
   rails_autolink
-  rb-fsevent
   rb-readline
   rdoc (>= 2.4.2)
   request_store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,12 +114,7 @@ GEM
     date_validator (0.7.0)
       activemodel (>= 3)
     debug_inspector (0.0.2)
-    debugger (1.6.0)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.1)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.2)
     delayed_job (3.0.5)
       activesupport (~> 3.0)
     delayed_job_active_record (0.3.3)
@@ -198,9 +193,6 @@ GEM
     pry-byebug (1.3.2)
       byebug (~> 2.7)
       pry (~> 0.9.12)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
     pry-doc (0.4.6)
       pry (>= 0.9)
       yard (>= 0.8)
@@ -378,7 +370,6 @@ DEPENDENCIES
   prototype-rails
   prototype_legacy_helper (= 0.0.0)!
   pry-byebug
-  pry-debugger
   pry-doc
   pry-rails
   pry-rescue


### PR DESCRIPTION
We don't use guard and don't support 1.9 any more.
