### PR TITLE
Remove Rails2 Ruby1.9 utf8nize!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,24 +62,6 @@ class ApplicationController < ActionController::Base
     cookies.delete(:autologin)
   end
 
-  # FIXME: Remove this when all of Rack and Rails have learned how to
-  # properly use encodings
-  before_filter :params_filter
-  def params_filter
-    self.utf8nize!(params) if RUBY_VERSION >= '1.9'
-  end
-  def utf8nize!(obj)
-    if obj.is_a? String
-      obj.respond_to?(:force_encoding) ? obj.force_encoding("UTF-8") : obj
-    elsif obj.is_a? Hash
-      obj.each {|k, v| obj[k] = self.utf8nize!(v)}
-    elsif obj.is_a? Array
-      obj.each {|v| self.utf8nize!(v)}
-    else
-      obj
-    end
-  end
-
   before_filter :user_setup,
                 :check_if_login_required,
                 :log_requesting_user,


### PR DESCRIPTION
This is #1109, which was falsely created against stable instead of dev.
