### PR TITLE
remove duplicated method from moves_controller

### DIFF
--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -99,17 +99,6 @@ class WorkPackages::MovesController < ApplicationController
 
   private
 
-  # Filter for bulk work package operations
-  def find_work_packages
-    @work_packages = WorkPackage.includes(:project)
-                                .find_all_by_id(params[:work_package_id] || params[:ids])
-    raise ActiveRecord::RecordNotFound if @work_packages.empty?
-    @projects = @work_packages.collect(&:project).compact.uniq
-    @project = @projects.first if @projects.size == 1
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
-
   def prepare_for_work_package_move
     @work_packages.sort!
     @copy = params.has_key? :copy
@@ -123,3 +112,4 @@ class WorkPackages::MovesController < ApplicationController
   end
 
 end
+


### PR DESCRIPTION
The find_work_package method was present in
work_packages/moves_controller.rb as well as in
application_controller.rb.

As the MovesController inherits from Application controller and the
methods in both controllers are identical, it can be removed from the
MovesController.

see: https://codeclimate.com/repos/528f351813d637200e02ef84/WorkPackages::MovesController
