### PR TITLE
Account/register: Show login field when registering via Omniauth

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -192,7 +192,8 @@ class PermittedParams < Struct.new(:params, :current_user)
   end
 
   def user_register_via_omniauth
-    permitted_params = params.require(:user).permit(:firstname, :lastname, :mail, :language)
+    permitted_params = params.require(:user) \
+                             .permit(:login, :firstname, :lastname, :mail, :language)
     permitted_params.merge!(custom_field_values(:user))
 
     permitted_params

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -38,8 +38,10 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= error_messages_for :user %>
 
   <div class="box">
-    <% if @user.change_password_allowed? %>
+    <% if @user.auth_source_id.nil? %>
       <p><%= f.text_field :login, :size => 25, :required => true %></p>
+    <% end %>
+    <% if @user.change_password_allowed? %>
       <p>
         <%= f.password_field :password,
                              :required => true,

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -100,12 +100,13 @@ describe AccountController do
             omniauth: true,
             timestamp: Time.new)
           session[:auth_source_registration] = auth_source_registration
-          post :register, :user => { :firstname => 'Foo',
+          post :register, :user => { :login => 'login@bar.com',
+                                     :firstname => 'Foo',
                                      :lastname => 'Smith',
                                      :mail => 'foo@bar.com' }
           expect(response).to redirect_to my_first_login_path
 
-          user = User.find_by_login('foo@bar.com')
+          user = User.find_by_login('login@bar.com')
           expect(user).to be_an_instance_of(User)
           expect(user.auth_source_id).to be_nil
           expect(user.current_password).to be_nil

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -662,6 +662,28 @@ describe PermittedParams do
     end
   end
 
+  describe '#user_register_via_omniauth' do
+    user_permissions = %w(login firstname lastname mail language)
+
+    user_permissions.each do |field|
+      it "should permit #{field}" do
+        hash = { field => 'test' }
+        params = ActionController::Parameters.new(:user => hash)
+
+        expect(PermittedParams.new(params, admin).user_register_via_omniauth).to eq(
+          field => 'test')
+      end
+    end
+
+    it 'should not allow identity_url' do
+      hash = { 'identity_url'  => 'test_identity_url' }
+
+      params = ActionController::Parameters.new(:user => hash)
+
+      expect(PermittedParams.new(params, admin).user_register_via_omniauth).to eq({})
+    end
+  end
+
   shared_context 'prepare params comparison' do
     let(:params_key) { (defined? hash_key) ? hash_key : attribute }
     let(:params) { ActionController::Parameters.new(params_key => hash) }

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'account/register' do
+  before do
+    assign(:user, user)
+    render
+  end
+
+  context 'with auth source' do
+    let(:auth_source) { FactoryGirl.create :auth_source }
+    let(:user)        { FactoryGirl.build :user, auth_source: auth_source }
+
+    it 'should not show a login field' do
+      expect(response.body).to_not include('user[login]')
+    end
+  end
+
+  context 'without auth source' do
+    let(:user) { FactoryGirl.build :user, auth_source: nil }
+
+    it 'should show a login field' do
+      expect(response.body).to include('user[login]')
+    end
+  end
+
+end


### PR DESCRIPTION
https://www.openproject.org/work_packages/7050

There's no reason to prevent a user from changing their login, it
might actually be required if the login has already been taken.
