### PR TITLE
infer content type from contents of file instead of its file extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,9 @@ gem 'jquery-rails', '~> 2.0.3'
 # using the commit before this comment
 gem "i18n-js", :git => "https://github.com/fnando/i18n-js.git", :ref => '8801f8d17ef96c48a7a0269e251fcf1648c8f441'
 
+# small wrapper around the command line
+gem 'cocaine'
+
 
 # Security fixes
 # Gems we don't depend directly on, but specify here to make sure we don't use a vulnerable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
       timers (~> 1.1.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.4)
+      climate_control (>= 0.0.3, < 1.0)
     codeclimate-test-reporter (0.1.1)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.0.9)
@@ -364,6 +368,7 @@ DEPENDENCIES
   awesome_nested_set
   capybara
   capybara-screenshot
+  cocaine
   codeclimate-test-reporter
   coderay (~> 1.0.5)
   coffee-rails (~> 3.2.1)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -49,10 +49,12 @@ class AttachmentsController < ApplicationController
       @attachment.increment_download
     end
 
-    # images are sent inline
+    # browsers should not try to guess the content-type
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+
     send_file @attachment.diskfile, :filename => filename_for_content_disposition(@attachment.filename),
-                                    :type => detect_content_type(@attachment),
-                                    :disposition => (@attachment.image? ? 'inline' : 'attachment')
+                                    :type => @attachment.content_type,
+                                    :disposition => @attachment.content_disposition
 
   end
 
@@ -88,14 +90,6 @@ private
 
   def delete_authorize
     @attachment.deletable? ? true : deny_access
-  end
-
-  def detect_content_type(attachment)
-    content_type = attachment.content_type
-    if content_type.blank?
-      content_type = Redmine::MimeType.of(attachment.filename)
-    end
-    content_type.to_s
   end
 
   def destroy_response_url(container)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -30,17 +30,21 @@
 require "digest/md5"
 
 class Attachment < ActiveRecord::Base
+  ALLOWED_IMAGE_TYPES = %w[ image/gif image/jpeg image/png image/tiff image/bmp ]
+
   belongs_to :container, :polymorphic => true
 
   belongs_to :author, :class_name => "User", :foreign_key => "author_id"
 
   attr_protected :author_id
 
-  validates_presence_of :container, :filename, :author
+  validates_presence_of :container, :filename, :author, :content_type
   validates_length_of :filename, :maximum => 255
   validates_length_of :disk_filename, :maximum => 255
 
   validate :filesize_below_allowed_maximum
+
+  after_initialize :set_default_content_type
 
   before_save :copy_file_to_destination
   after_destroy :delete_file_on_disk
@@ -70,12 +74,6 @@ class Attachment < ActiveRecord::Base
         if @temp_file.respond_to?(:original_filename)
           self.filename = @temp_file.original_filename
           self.filename.force_encoding("UTF-8") if filename.respond_to?(:force_encoding)
-        end
-        if @temp_file.respond_to?(:content_type)
-          self.content_type = @temp_file.content_type.to_s.chomp
-        end
-        if content_type.blank? && filename.present?
-          self.content_type = Redmine::MimeType.of(filename)
         end
         self.filesize = @temp_file.size
       end
@@ -115,10 +113,7 @@ class Attachment < ActiveRecord::Base
         end
       end
       self.digest = md5.hexdigest
-    end
-    # Don't save the content type if it's longer than the authorized length
-    if self.content_type && self.content_type.length > 255
-      self.content_type = nil
+      self.content_type = self.class.content_type_for(diskfile)
     end
   end
 
@@ -141,6 +136,10 @@ class Attachment < ActiveRecord::Base
     container.respond_to?(:project)? container.project : nil
   end
 
+  def content_disposition
+    inlineable? ? 'inline' : 'attachment'
+  end
+
   def visible?(user=User.current)
     container.attachments_visible?(user)
   end
@@ -149,21 +148,37 @@ class Attachment < ActiveRecord::Base
     container.attachments_deletable?(user)
   end
 
-  def image?
-    self.filename =~ /\.(jpe?g|gif|png)\z/i
+  # images are sent inline
+  def inlineable?
+    is_image?
+  end
+
+  def is_image?
+    ALLOWED_IMAGE_TYPES.include?(content_type)
+  end
+
+  # backwards compatibility for plugins
+  alias :image? :is_image?
+
+  def is_pdf?
+    content_type == 'application/pdf'
   end
 
   def is_text?
-    Redmine::MimeType.is_type?('text', filename)
+    content_type =~ /\Atext\/.+/
   end
 
   def is_diff?
-    self.filename =~ /\.(patch|diff)\z/i
+    is_text? && self.filename =~ /\.(patch|diff)\z/i
   end
 
   # Returns true if the file is readable
   def readable?
     File.readable?(diskfile)
+  end
+
+  def set_default_content_type
+    self.content_type = OpenProject::ContentTypeDetector::SENSIBLE_DEFAULT if content_type.blank?
   end
 
   # Bulk attaches a set of files to an object
@@ -191,6 +206,10 @@ class Attachment < ActiveRecord::Base
       end
     end
     {:files => attached, :unsaved => obj.unsaved_attachments}
+  end
+
+  def self.content_type_for(file_path)
+    Redmine::MimeType.narrow_type(file_path, OpenProject::ContentTypeDetector.new(file_path).detect)
   end
 
 private

--- a/db/migrate/20140430125956_reset_content_types.rb
+++ b/db/migrate/20140430125956_reset_content_types.rb
@@ -1,0 +1,11 @@
+class ResetContentTypes < ActiveRecord::Migration
+  def up
+    Attachment.all.each do |attachment|
+      attachment.update_column(:content_type, Attachment.content_type_for(attachment.diskfile))
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/lib/open_project/content_type_detector.rb
+++ b/lib/open_project/content_type_detector.rb
@@ -1,0 +1,130 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This file is mostly based on source code of thoughbot's paperclip gem
+#
+#   https://github.com/thoughtbot/paperclip
+#
+# which is released under:
+#
+# The MIT License
+#
+# Copyright (c) 2008-2014 Jon Yurek and thoughtbot, inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Modifications:
+# - sensible default changed to "application/binary"
+# - removed references to paperclip
+
+#
+# The content-type detection strategy is as follows:
+#
+# 1. Blank/Empty files: If there's no filename or the file is empty,
+#    provide a sensible default (application/binary or inode/x-empty)
+#
+# 2. Calculated match: Return the first result that is found by both the
+#    `file` command and MIME::Types.
+#
+# 3. Standard types: Return the first standard (without an x- prefix) entry
+#    in MIME::Types
+#
+# 4. Experimental types: If there were no standard types in MIME::Types
+#    list, try to return the first experimental one
+#
+# 5. Raw `file` command: Just use the output of the `file` command raw, or
+#    a sensible default. This is cached from Step 2.
+#
+module OpenProject
+  class ContentTypeDetector
+
+    # application/binary is more secure than application/octet-stream
+    # see: http://security.stackexchange.com/q/12896
+    SENSIBLE_DEFAULT = "application/binary"
+    EMPTY_TYPE = "inode/x-empty"
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    # Returns a String describing the file's content type
+    def detect
+      type = if blank_name?
+        SENSIBLE_DEFAULT
+      elsif empty_file?
+        EMPTY_TYPE
+      elsif calculated_type_matches.any?
+        calculated_type_matches.first
+      else
+        type_from_file_command || SENSIBLE_DEFAULT
+      end.to_s
+    end
+
+    private
+
+    def empty_file?
+      File.exists?(@filename) && File.size(@filename) == 0
+    end
+
+    alias :empty? :empty_file?
+
+    def blank_name?
+      @filename.nil? || @filename.empty?
+    end
+
+    def possible_types
+      MIME::Types.type_for(@filename).collect(&:content_type)
+    end
+
+    def calculated_type_matches
+      possible_types.select{|content_type| content_type == type_from_file_command }
+    end
+
+    def type_from_file_command
+      @type_from_file_command ||= FileCommandContentTypeDetector.new(@filename).detect
+    end
+
+  end
+end

--- a/lib/open_project/file_command_content_type_detector.rb
+++ b/lib/open_project/file_command_content_type_detector.rb
@@ -1,0 +1,93 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This file is mostly based on source code of thoughbot's paperclip gem
+#
+#   https://github.com/thoughtbot/paperclip
+#
+# which is released under:
+#
+# The MIT License
+#
+# Copyright (c) 2008-2014 Jon Yurek and thoughtbot, inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Modifications:
+# - sensible default changed to "application/binary"
+# - removed references to paperclip
+
+module OpenProject
+  class FileCommandContentTypeDetector
+
+    SENSIBLE_DEFAULT = "application/binary"
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def detect
+      type_from_file_command
+    end
+
+    private
+
+    def type_from_file_command
+      type = begin
+        # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
+        Cocaine::CommandLine.new("file", "-b --mime :file").run(file: @filename)
+      rescue Cocaine::CommandLineError
+        SENSIBLE_DEFAULT
+      end
+
+      if type.nil? || type.match(/\(.*?\)/)
+        type = SENSIBLE_DEFAULT
+      end
+      type.split(/[:;\s]+/)[0]
+    end
+
+  end
+end
+

--- a/lib/redmine/mime_type.rb
+++ b/lib/redmine/mime_type.rb
@@ -112,5 +112,10 @@ module Redmine
       main_mimetype = main_mimetype_of(name)
       type.to_s == main_mimetype
     end
+
+    def self.narrow_type(name, content_type)
+      (content_type.split('/').first == main_mimetype_of(name)) ? of(name) : content_type
+    end
+
   end
 end

--- a/spec/lib/open_project/content_type_detector_spec.rb
+++ b/spec/lib/open_project/content_type_detector_spec.rb
@@ -1,0 +1,98 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This file is mostly based on source code of thoughbot's paperclip gem
+#
+#   https://github.com/thoughtbot/paperclip
+#
+# which is released under:
+#
+# The MIT License
+#
+# Copyright (c) 2008-2014 Jon Yurek and thoughtbot, inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'spec_helper'
+
+describe OpenProject::ContentTypeDetector do
+  it 'gives a sensible default when the name is empty' do
+    assert_equal "application/binary", OpenProject::ContentTypeDetector.new("").detect
+  end
+
+  it 'returns the empty content type when the file is empty' do
+    tempfile = Tempfile.new("empty")
+    assert_equal "inode/x-empty", OpenProject::ContentTypeDetector.new(tempfile.path).detect
+    tempfile.close
+  end
+
+  it 'returns content type of file if it is an acceptable type' do
+    MIME::Types.stub(:type_for).and_return([MIME::Type.new('application/mp4'), MIME::Type.new('video/mp4'), MIME::Type.new('audio/mp4')])
+    Cocaine::CommandLine.any_instance.stub(:run).and_return("video/mp4")
+    @filename = "my_file.mp4"
+    assert_equal "video/mp4", OpenProject::ContentTypeDetector.new(@filename).detect
+  end
+
+  it 'finds the right type in the list via the file command' do
+    @filename = "#{Dir.tmpdir}/something.hahalolnotreal"
+    File.open(@filename, "w+") do |file|
+      file.puts "This is a text file."
+      file.rewind
+      assert_equal "text/plain", OpenProject::ContentTypeDetector.new(file.path).detect
+    end
+    FileUtils.rm @filename
+  end
+
+  it 'returns a sensible default if something is wrong, like the file is gone' do
+    @filename = "/path/to/nothing"
+    assert_equal "application/binary", OpenProject::ContentTypeDetector.new(@filename).detect
+  end
+
+  it 'returns a sensible default when the file command is missing' do
+    Cocaine::CommandLine.any_instance.stub(:run).and_raise(Cocaine::CommandLineError.new)
+    @filename = "/path/to/something"
+    assert_equal "application/binary", OpenProject::ContentTypeDetector.new(@filename).detect
+  end
+end

--- a/spec/lib/open_project/file_command_content_type_detector_spec.rb
+++ b/spec/lib/open_project/file_command_content_type_detector_spec.rb
@@ -1,0 +1,83 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This file is mostly based on source code of thoughbot's paperclip gem
+#
+#   https://github.com/thoughtbot/paperclip
+#
+# which is released under:
+#
+# The MIT License
+#
+# Copyright (c) 2008-2014 Jon Yurek and thoughtbot, inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'spec_helper'
+
+describe OpenProject::FileCommandContentTypeDetector do
+  it 'returns a content type based on the content of the file' do
+    tempfile = Tempfile.new("something")
+    tempfile.write("This is a file.")
+    tempfile.rewind
+
+    assert_equal "text/plain", OpenProject::FileCommandContentTypeDetector.new(tempfile.path).detect
+
+    tempfile.close
+  end
+
+  it 'returns a sensible default when the file command is missing' do
+    Cocaine::CommandLine.any_instance.stub(:run).and_raise(Cocaine::CommandLineError.new)
+    @filename = "/path/to/something"
+    assert_equal "application/binary",
+      OpenProject::FileCommandContentTypeDetector.new(@filename).detect
+  end
+
+  it 'returns a sensible default on the odd chance that run returns nil' do
+    Cocaine::CommandLine.any_instance.stub(:run).and_return(nil)
+    assert_equal "application/binary",
+      OpenProject::FileCommandContentTypeDetector.new("windows").detect
+  end
+end

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -64,7 +64,7 @@ attachments_004:
   filename: source.rb
   author_id: 2
   description: This is a Ruby source file
-  content_type: application/x-ruby
+  content_type: text/x-ruby
 attachments_005:
   created_on: 2006-07-19 21:07:27 +02:00
   container_type: WorkPackage
@@ -88,7 +88,7 @@ attachments_006:
   filesize: 157
   filename: archive.zip
   author_id: 2
-  content_type: application/octet-stream
+  content_type: application/zip
 attachments_007:
   created_on: 2006-07-19 21:07:27 +02:00
   container_type: WorkPackage
@@ -100,7 +100,7 @@ attachments_007:
   filesize: 157
   filename: archive.zip
   author_id: 1
-  content_type: application/octet-stream
+  content_type: application/zip
 attachments_010:
   created_on: 2006-07-19 21:07:27 +02:00
   container_type: WorkPackage

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -87,19 +87,19 @@ class AttachmentsControllerTest < ActionController::TestCase
 
     get :show, :id => 4
     assert_response :success
-    assert_equal 'application/x-ruby', @response.content_type
+    assert_equal 'text/x-ruby', @response.content_type
   end
 
   def test_show_other
     get :show, :id => 6
     assert_response :success
-    assert_equal 'application/octet-stream', @response.content_type
+    assert_equal 'application/zip', @response.content_type
   end
 
   def test_download_text_file
     get :download, :id => 4
     assert_response :success
-    assert_equal 'application/x-ruby', @response.content_type
+    assert_equal 'text/x-ruby', @response.content_type
   end
 
   def test_download_should_assign_content_type_if_blank
@@ -107,7 +107,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
     get :download, :id => 4
     assert_response :success
-    assert_equal 'text/x-ruby', @response.content_type
+    assert_equal 'application/binary', @response.content_type
   end
 
   def test_download_missing_file

--- a/test/unit/lib/redmine/mime_type_test.rb
+++ b/test/unit/lib/redmine/mime_type_test.rb
@@ -69,4 +69,12 @@ class Redmine::MimeTypeTest < ActiveSupport::TestCase
       assert_equal expected, Redmine::MimeType.is_type?(*args)
     end
   end
+
+  def test_narrow_type_for_equal_main_type
+    assert_equal 'text/x-ruby', Redmine::MimeType.narrow_type('rubyfile.rb', 'text/plain')
+  end
+
+  def test_use_original_type_if_main_type_differs
+    assert_equal 'application/zip', Redmine::MimeType.narrow_type('rubyfile.rb', 'application/zip')
+  end
 end


### PR DESCRIPTION
Overview:
- always set content-type of file uploads on the server, sensible default if no type can be retrieved
- sensible default is `application/binary` as it's more secure than `octet-stream` (see: http://security.stackexchange.com/q/12896)
- set `nosniff` header when displaying attachments to instruct browsers not to guess content type

Details:
- ruby's Mime::Types gets content types by file extensions, that's not enough 
- uses file command to cross-check proposed content types by Mime::Types
- Redmine uses special mime-types, use them when above checks succeed
- some controller cleanup as we can assume that content_type is set (after_initialize defaults to sensible default for attachments already in the database that don't have a content type)

[`* `#1725` Content-sniffing-based XSS for attachments`](https://www.openproject.org/work_packages/1725)
