### PR TITLE
Fix i18n and nokogiri vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,18 @@ gem 'jquery-rails', '~> 2.0.3'
 # using the commit before this comment
 gem "i18n-js", :git => "https://github.com/fnando/i18n-js.git", :ref => '8801f8d17ef96c48a7a0269e251fcf1648c8f441'
 
+
+# Security fixes
+# Gems we don't depend directly on, but specify here to make sure we don't use a vulnerable
+# version. Please add a link to a security advisory when adding a Gem here.
+
+gem 'i18n', '>=0.6.8'
+# see https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998
+
+gem 'nokogiri', '>=1.5.11'
+# see https://groups.google.com/forum/#!topic/ruby-security-ann/DeJpjTAg1FA
+
+
 group :test do
   gem 'shoulda'
   gem 'object-daddy', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     multi_test (0.0.2)
     mysql2 (0.3.11)
     net-ldap (0.2.2)
-    nokogiri (1.5.9)
+    nokogiri (1.5.11)
     object-daddy (1.1.1)
     oj (2.1.6)
     paper_trail (2.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       test-unit (~> 2.2)
     hike (1.2.3)
     htmldiff (0.0.1)
-    i18n (0.6.5)
+    i18n (0.6.8)
     interception (0.3)
     journey (1.0.4)
     jquery-atwho-rails (0.4.1)
@@ -383,6 +383,7 @@ DEPENDENCIES
   guard-rspec
   guard-test
   htmldiff
+  i18n (>= 0.6.8)
   i18n-js!
   jquery-atwho-rails
   jquery-rails (~> 2.0.3)
@@ -394,6 +395,7 @@ DEPENDENCIES
   multi_json
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.2.2)
+  nokogiri (>= 1.5.11)
   object-daddy (~> 1.1.0)
   oj
   pg (~> 0.17.1)


### PR DESCRIPTION
https://www.openproject.org/work_packages/7160

This is #1150 against release/3.0 (I created #1150 incorrectly against dev).

i18n: [0.6.8 is lowest 0.6.x version available](https://rubygems.org/gems/i18n), [Changelog](https://github.com/svenfuchs/i18n/commits/61f975bd862e2ce3a9f77fb5afdf11831fbcbb22)

nokogiri: [only had bugfixes](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc#1511--2013-12-14)
