### PR TITLE
Fix flash message shown when an account is inactive

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -192,8 +192,7 @@ class AccountController < ApplicationController
       if user and user.check_password?(password)
         # correct password
         if not user.active?
-          return inactive_account if user.registered?
-          invalid_credentials
+          account_inactive(user, flash_now: true)
         elsif user.force_password_change
           return if redirect_if_password_change_not_allowed(user)
           render_password_change(I18n.t(:notice_account_new_password_forced))
@@ -244,7 +243,8 @@ class AccountController < ApplicationController
     if user.active?
       successful_authentication(user)
     else
-      account_pending
+      account_inactive(user, flash_now: false)
+      redirect_to signin_path
     end
   end
 
@@ -272,20 +272,6 @@ class AccountController < ApplicationController
     @user = user
     session[:auth_source_registration] = auth_source_options unless auth_source_options.empty?
     render :action => 'register'
-  end
-
-  def invalid_credentials
-    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip} at #{Time.now.utc}"
-    if Setting.brute_force_block_after_failed_logins.to_i == 0
-      flash.now[:error] = I18n.t(:notice_account_invalid_credentials)
-    else
-      flash.now[:error] = I18n.t(:notice_account_invalid_credentials_or_blocked)
-    end
-  end
-
-  def inactive_account
-    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip} at #{Time.now.utc} (INACTIVE)"
-    flash.now[:error] = l(:notice_account_inactive)
   end
 
   def redirect_if_password_change_not_allowed(user)
@@ -367,6 +353,44 @@ class AccountController < ApplicationController
   def self_registration_disabled
     flash[:error] = I18n.t('account.error_self_registration_disabled')
     redirect_to signin_url
+  end
+
+  # Call if an account is inactive - either registered or locked
+  def account_inactive(user, flash_now: true)
+    if user.registered?
+      account_not_activated(flash_now: flash_now)
+    else
+      invalid_credentials(flash_now: flash_now)
+    end
+  end
+
+  # Log an attempt to log in to an account in "registered" state and show a flash message.
+  def account_not_activated(flash_now: true)
+    flash_hash = flash_now ? flash.now : flash
+
+    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
+                " at #{Time.now.utc} (NOT ACTIVATED)"
+
+    if Setting.self_registration == '1'
+      flash_hash[:error] = I18n.t('account.error_inactive_activation_by_mail')
+    else
+      flash_hash[:error] = I18n.t('account.error_inactive_manual_activation')
+    end
+  end
+
+  # Log an attempt to log in to a locked account or with invalid credentials
+  #  and show a flash message.
+  def invalid_credentials(flash_now: true)
+    flash_hash = flash_now ? flash.now : flash
+
+    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
+                " at #{Time.now.utc}"
+
+    if Setting.brute_force_block_after_failed_logins.to_i == 0
+      flash_hash[:error] = I18n.t(:notice_account_invalid_credentials)
+    else
+      flash_hash[:error] = I18n.t(:notice_account_invalid_credentials_or_blocked)
+    end
   end
 
   def account_pending

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -42,6 +42,12 @@ de:
       login_consequences:
         other: "Der Account wird aus dem System entfernt. Der Nutzer wird daher nicht mehr in der Lage sein, sich mit seinem derzeitigen Nutzernamen und Passwort anzumelden. Sofern der Nutzer es wünscht, kann er sich über die von der Anwendung zur Verfügung gestellten Mechanismen einen neuen Account zulegen."
         self: "Ihr Account wird aus dem System entfernt. Sie werden daher nicht mehr in der Lage sein, sich mit Ihrem derzeitigen Nutzernamen und Passwort anzumelden. Sofern Sie es wünschen, können Sie sich über die von der Anwendung zur Verfügung gestellten Mechanismen einen neuen Account zulegen."
+    error_inactive_activation_by_mail: >
+      Ihr Konto wurde noch nicht aktiviert. Zur Aktivierung folgen Sie bitte dem Link,
+      der Ihnen bei der Registrierung per E-Mail zugeschickt wurde.
+    error_inactive_manual_activation: >
+      Ihr Konto wurde noch nicht aktiviert. Bitte warten Sie auf die Aktivierung
+      Ihres Kontos durch einen Administrator.
     error_self_registration_disabled: >
       Auf diesem System ist die Nutzerregistierung deaktiviert. Bitte fragen Sie einen
       Administrator nach einem Nutzerkonto.
@@ -1029,7 +1035,6 @@ de:
   noscript_learn_more: "Weitere Informationen"
 
   notice_account_activated: "Ihr Konto ist aktiviert. Sie können sich jetzt anmelden."
-  notice_account_inactive: "Ihr Konto ist nicht aktiviert. Zur Aktivierung folgen Sie bitte dem Link, der Ihnen bei der Registrierung per E-Mail zugeschickt wurde."
   notice_account_invalid_credentials: "Benutzer oder Kennwort ist ungültig."
   notice_account_invalid_credentials_or_blocked: "Benutzer oder Kennwort ist ungültig oder der Account wurde wegen mehrfacher Falscheingabe temporär gesperrt, in diesem Fall wird er in Kürze automatisch wieder freigeschaltet."
   notice_account_lost_email_sent: "Eine E-Mail mit Anweisungen, wie ein neues Kennwort gewählt wird, wurde Ihnen zugeschickt."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,12 @@ en:
       login_consequences:
         other: "The account will be deleted from the system. Therefore, the user will no longer be able to log in with his current credentials. He/she can choose to become a user of this application again by the means this application grants."
         self: "Your account will be deleted from the system. Therefore, you will no longer be able to log in with your current credentials. If you choose to become a user of this application again, you can do so by using the means this application grants."
+    error_inactive_activation_by_mail: >
+      Your account has not yet been activated.
+      To activate your account, click on the link that was emailed to you.
+    error_inactive_manual_activation: >
+      Your account has not yet been activated.
+      Please wait for an administrator to activate your account.
     error_self_registration_disabled: >
       User registration is disabled on this system. Please ask an administrator to create an
       account for you.
@@ -1026,7 +1032,6 @@ en:
   noscript_learn_more: "Learn more"
 
   notice_account_activated: "Your account has been activated. You can now log in."
-  notice_account_inactive: "Your account has not yet been activated. To activate your account, click on the link that was emailed to you."
   notice_account_invalid_credentials: "Invalid user or password"
   notice_account_invalid_credentials_or_blocked: "Invalid user or password or the account is blocked due to multiple failed login attempts. If so, it will be unblocked automatically in a short time."
   notice_account_lost_email_sent: "An email with instructions to choose a new password has been sent to you."

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -184,12 +184,64 @@ describe AccountController do
           }
         )
       end
-      it 'should sign in the user after successful external authentication' do
-        request.env['omniauth.auth'] = omniauth_hash
-        FactoryGirl.create(:user, force_password_change: false, identity_url: 'google:123545')
-        post :omniauth_login
-        expect(response).to redirect_to controller: 'my', action: 'page'
+
+      let(:user) do
+        FactoryGirl.build(:user, force_password_change: false,
+                                 identity_url: 'google:123545')
       end
+
+      before do
+        request.env['omniauth.auth'] = omniauth_hash
+      end
+
+      context 'with an active account' do
+        it 'should sign in the user after successful external authentication' do
+          user.save!
+          post :omniauth_login
+
+          expect(response).to redirect_to my_page_path
+        end
+      end
+
+      context 'with a registered and not activated accout' do
+        before do
+          user.register
+          user.save!
+
+          with_settings(self_registration: '1') do
+            post :omniauth_login
+          end
+        end
+
+        it 'should show an error about a not activated account' do
+          expect(flash[:error]).to eql(I18n.t('account.error_inactive_manual_activation'))
+        end
+
+        it 'should redirect to signin_path' do
+          expect(response).to redirect_to signin_path
+        end
+      end
+
+      context 'with a locked account' do
+        before do
+          user.lock
+          user.save!
+
+          # Make sure we don't get a specific message when brute-force protection is enabled
+          with_settings(brute_force_block_after_failed_logins: '0') do
+            post :omniauth_login
+          end
+        end
+
+        it 'should show an error indicating a failed login' do
+          expect(flash[:error]).to eql(I18n.t(:notice_account_invalid_credentials))
+        end
+
+        it 'should redirect to signin_path' do
+          expect(response).to redirect_to signin_path
+        end
+      end
+
     end
 
     describe 'with an invalid auth_hash' do


### PR DESCRIPTION
https://www.openproject.org/work_packages/7149

Show different messages depending on whether the user is locked or
registered. In the latter case, also show different messages depending
on the self_registration setting (manual activation vs. mail).
