### PR TITLE
fix non-ascii attachment file name get corrupted in IE11 (#16711)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -555,7 +555,7 @@ class ApplicationController < ActionController::Base
 
   # Returns a string that can be used as filename value in Content-Disposition header
   def filename_for_content_disposition(name)
-    request.env['HTTP_USER_AGENT'] =~ %r{MSIE} ? ERB::Util.url_encode(name) : name
+    request.env['HTTP_USER_AGENT'] =~ %r{(MSIE|Trident)} ? ERB::Util.url_encode(name) : name
   end
 
   def api_request?


### PR DESCRIPTION
Contributed by Go MAEDA.

git-svn-id: http://svn.redmine.org/redmine/trunk@13101 e93f8b46-1217-0410-a6f0-8f06a7374b81
