### PR TITLE
[old branch] fixes issues history overlapping issues changeset

### DIFF
--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -89,13 +89,6 @@
 </div>
 <div style="clear: both;"></div>
 
-<% if @changesets.present? %>
-<div id="issue-changesets">
-<h3><%=l(:label_associated_revisions)%></h3>
-<%= render :partial => 'changesets', :locals => { :changesets => @changesets} %>
-</div>
-<% end %>
-
 <% if @journals.present? %>
 <div id="history">
 <h3><%=l(:label_history)%></h3>
@@ -103,6 +96,12 @@
 </div>
 <% end %>
 
+<% if @changesets.present? %>
+<div id="issue-changesets">
+<h3><%=l(:label_associated_revisions)%></h3>
+<%= render :partial => 'changesets', :locals => { :changesets => @changesets} %>
+</div>
+<% end %>
 
 <div style="clear: both;"></div>
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -346,14 +346,9 @@ fieldset#filters td.add-filter { text-align: right; vertical-align: top; }
 .buttons { margin-bottom: 1.4em; margin-top: 1em; }
 
 div#issue-changesets {
-  float:right;
-  width:45%;
-  margin: 1em 0 1em 1em;
+  width: 290px;
   background: #fff;
   padding-left: 1em;
-}
-div#issue-changesets h3 {
-  margin-top: 0;
 }
 div#issue-changesets div.changeset { padding: 4px;}
 div#issue-changesets div.changeset { border-bottom: 1px solid #ddd; }
@@ -1865,9 +1860,10 @@ table.files {
 #content table.files td a {
 	position:relative;
 }
-#history {
+#history, #issue-changesets {
   margin-top: 1em;
   margin-bottom:0px;
+  float: left;
 }
 #history h3 {
 	margin-bottom:20px;
@@ -3189,9 +3185,11 @@ a.sort.desc {
 #content #history {
   background:url("../images/dotted-separator.gif"?1349103766) repeat-x scroll 0 bottom   transparent;
   padding-bottom: 11px;
+  padding-right: 40px;
+  width: 700px;
 }
 
-#history .journal, #content .wiki-content p, #content .wiki-content li {
+#content .wiki-content p, #content .wiki-content li {
   width: 700px;
 }
 


### PR DESCRIPTION
Formerly the history of an issue would overlap the issue's changeset which would result in the user not beeing able to click on the links in the changeset. The solution is not perfect. It would look much nicer if the changesets would float right. But this is not possible with the content itself having no fixed with.

---

:information_source:  This is a maintenance PullRequest<sup>1</sup>

**The following actions may be done:**
- [ ] find the branch maintainer (or someone who cares enough)
- [ ] find/create a work package on openproject.org for this PR
- [ ] decide if the commits in this branch are still meant to be integrated
- [ ] delete the branch if the proposed change shall not be integrated
- [ ] rebase the branch on a current `dev`; test it

<sup>1</sup>: This PR was created to reduce the huge number of stale branches (branches which are older than 6 month and don't have a pull request). The goal is to give those branches a platform for review and discussion and -- on the long term -- either integrate or delete them.
