### PR TITLE
[prototype->jQuery] Remove usage of link_to_remote_if_authorized

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,12 +74,6 @@ module ApplicationHelper
     content_tag(:li, link) if link
   end
 
-  # Display a link to remote if user is authorized
-  def link_to_remote_if_authorized(name, options = {}, html_options = nil)
-    url = options[:url] || {}
-    link_to_remote(name, options, html_options) if authorize_for(url[:controller] || params[:controller], url[:action])
-  end
-
   # Displays a link to user's account page if active or registered
   def link_to_user(user, options={})
     if user.is_a?(User)

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -34,10 +34,11 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :action_menu_specific do %>
   <%= watcher_link(@topic, User.current) %>
-  <%= link_to_remote_if_authorized(l(:button_quote),
-                                   { :url => {:action => 'quote', :id => @topic} ,
-                                     :method => :get },
-                                   { :class => 'icon icon-quote'} ) unless @topic.locked? %>
+  <%= link_to(l(:button_quote),
+              { action: 'quote', id: @topic },
+              remote: true,
+              method: 'get',
+              class: 'icon icon-quote') if !@topic.locked? && authorize_for('messages', 'reply') %>
   <%= link_to(l(:button_edit),
               edit_topic_path(@topic),
               :class => 'icon icon-edit',
@@ -75,12 +76,13 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= authoring message.created_on, message.author %>
     </h4>
     <div class="message-reply-menu">
-      <%= link_to_remote_if_authorized(icon_wrapper('icon-context icon-quote', l(:button_quote)),
-                                       { :url => {:action => 'quote', :id => message},
-                                         :method => :get },
-                                       :title => l(:button_quote),
-                                       :class => 'no-decoration-on-hover',
-                                       :alt => l(:button_quote)) unless @topic.locked? %>
+      <%= link_to(icon_wrapper('icon-context icon-quote', l(:button_quote)),
+                  { action: 'quote', id: message },
+                  remote: true,
+                  method: 'get',
+                  title: l(:button_quote),
+                  class: 'no-decoration-on-hover',
+                  alt: l(:button_quote)) if !@topic.locked? && authorize_for('messages', 'reply') %>
       <%= link_to(icon_wrapper('icon-context icon-edit', l(:button_edit)),
                   { :action => 'edit', :id => message },
                   :title => l(:button_edit),


### PR DESCRIPTION
This refactoring helps to remove remaining prototype code.

see:https://www.openproject.org/work_packages/7066
