### PR TITLE
[prototype->jQuery] Remove usage of prototype in toggle_link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,11 +189,11 @@ module ApplicationHelper
     link.html_safe
   end
 
-  def toggle_link(name, id, options={}, html_options={})
-    onclick = "Element.toggle('#{id}'); "
-    onclick << (options[:focus] ? "Form.Element.focus('#{options[:focus]}'); " : "this.blur(); ")
-    onclick << "return false;"
-    link_to(name, "#", {:onclick => onclick}.merge(html_options))
+  def toggle_link(name, id, options = {}, html_options = {})
+    onclick = "jQuery('##{id}').toggle(); "
+    onclick << (options[:focus] ? "jQuery('##{options[:focus]}').focus(); " : 'this.blur(); ')
+    onclick << 'return false;'
+    link_to(name, '#', { onclick: onclick }.merge(html_options))
   end
 
   def delete_link(url, options={})


### PR DESCRIPTION
This is a refactoring to gradually remove the usage of prototype from our codebase.

see:https://www.openproject.org/work_packages/7066
