### PR TITLE
[prototype->jQuery] Remove usage of prototype tab js logic

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -41,6 +41,7 @@
 //= require settings
 //= require modal
 //= require keyboard_shortcuts
+//= require tab_handling
 //= require top-shelf
 //= require unsupported-browsers
 //= require autocomplete_textareas
@@ -221,70 +222,6 @@ function addFileField() {
   clone.writeAttribute('id', '');
   clone.innerHTML = clone.innerHTML.replace(/\[1\]/g, '['+ fileFieldCount + ']');
   $('attachments_fields').appendChild(clone);
-}
-
-function showTab(name) {
-    var f = $$('div#content .tab-content');
-	for(var i=0; i<f.length; i++){
-		Element.hide(f[i]);
-	}
-    var f = $$('div.tabs a');
-	for(var i=0; i<f.length; i++){
-		Element.removeClassName(f[i], "selected");
-	}
-	Element.show('tab-content-' + name);
-	Element.addClassName('tab-' + name, "selected");
-        Element.insert('tab-' + name, {top: $$('div.tabs .hidden-for-sighted')[0]})
-	return false;
-}
-
-function moveTabRight(el) {
-	var lis = Element.up(el, 'div.tabs').down('ul').childElements();
-	var tabsWidth = 0;
-	var i;
-	for (i=0; i<lis.length; i++) {
-		if (lis[i].visible()) {
-			tabsWidth += lis[i].getWidth() + 6;
-		}
-	}
-	if (tabsWidth < Element.up(el, 'div.tabs').getWidth() - 60) {
-		return;
-	}
-	i=0;
-	while (i<lis.length && !lis[i].visible()) {
-		i++;
-	}
-	lis[i].hide();
-}
-
-function moveTabLeft(el) {
-	var lis = Element.up(el, 'div.tabs').down('ul').childElements();
-	var i = 0;
-	while (i<lis.length && !lis[i].visible()) {
-		i++;
-	}
-	if (i>0) {
-		lis[i-1].show();
-	}
-}
-
-function displayTabsButtons() {
-	var lis;
-	var tabsWidth = 0;
-	var i;
-	$$('div.tabs').each(function(el) {
-		lis = el.down('ul').childElements();
-		for (i=0; i<lis.length; i++) {
-			if (lis[i].visible()) {
-				tabsWidth += lis[i].getWidth() + 6;
-			}
-		}
-		if ((tabsWidth < el.getWidth() - 20) && (lis[0].visible())) {
-			el.down('div.tabs-buttons').hide();
-		} else {
-			el.down('div.tabs-buttons').show();
-		}
-	});
 }
 
 function setPredecessorFieldsVisibility() {

--- a/app/assets/javascripts/tab_handling.js
+++ b/app/assets/javascripts/tab_handling.js
@@ -1,0 +1,103 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*
+  This module is responsible to manage tabed views in OpenProject,
+  which you can observe, for example, in the settings page.
+  Used by view/common/_tabs.html.erb in inline javascript.
+*/
+
+// Called when a tab was selected.
+// Responsible to hide the old selected tab and show the content
+// of the currently selected tab.
+function showTab(name, url) {
+  jQuery('div#content .tab-content').hide();
+  jQuery('div.tabs a').removeClass('selected');
+  jQuery('#tab-content-' + name).show();
+  jQuery('#tab-' + name).addClass('selected');
+  //replaces current URL with the "href" attribute of the current link
+  //(only triggered if supported by browser)
+  if ("replaceState" in window.history) {
+    window.history.replaceState(null, document.title, url);
+  }
+  return false;
+}
+
+/*
+  There are hidden buttons in the common/_tabs.html.erb view,
+  which shall allow the user to scrolls through the tab captions.
+  Those buttons are only visible if there is not enough room to
+  display all tab captions at once.
+*/
+
+// Check if there is enough room to display all tab captions
+// and show/hide the tabButtons accordingly.
+function displayTabsButtons() {
+  var lis;
+  var tabsWidth = 0;
+  var el;
+  jQuery('div.tabs').each(function() {
+    el = jQuery(this);
+    lis = el.find('ul').children();
+    lis.each(function(){
+      if (jQuery(this).is(':visible')) {
+        tabsWidth += jQuery(this).width() + 6;
+      }
+    });
+    if ((tabsWidth < el.width() - 60) && (lis.first().is(':visible'))) {
+      el.find('div.tabs-buttons').hide();
+    } else {
+      el.find('div.tabs-buttons').show();
+    }
+  });
+}
+
+// scroll the tab caption list right
+function moveTabRight(el) {
+  var lis = jQuery(el).parents('div.tabs').first().find('ul').children();
+  var tabsWidth = 0;
+  var i = 0;
+  lis.each(function() {
+    if (jQuery(this).is(':visible')) {
+      tabsWidth += jQuery(this).width() + 6;
+    }
+  });
+  if (tabsWidth < jQuery(el).parents('div.tabs').first().width() - 60) { return; }
+  while (i<lis.length && !lis.eq(i).is(':visible')) { i++; }
+  lis.eq(i).hide();
+}
+
+// scroll the tab caption list left
+function moveTabLeft(el) {
+  var lis = jQuery(el).parents('div.tabs').first().find('ul').children();
+  var i = 0;
+  while (i < lis.length && !lis.eq(i).is(':visible')) { i++; }
+  if (i > 0) {
+    lis.eq(i-1).show();
+  }
+}

--- a/app/views/common/_tabs.html.erb
+++ b/app/views/common/_tabs.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="tabs">
   <ul>
-  <% tabs.each do |tab| -%>
+  <% tabs.each do |tab| %>
     <li><%=
     position_span = you_are_here_info(tab[:name] == selected_tab)
     caption = case tab[:label]
@@ -40,26 +40,27 @@ See doc/COPYRIGHT.rdoc for more details.
     else
       l(tab[:label])
     end
-    link_to(position_span + caption, { :tab => tab[:name] },
-                                       :id => "tab-#{tab[:name]}",
-                                       :class => (tab[:name] != selected_tab ? nil : 'selected'),
-                                       :onclick => "showTab('#{tab[:name]}'); this.blur(); return false;") %></li>
-  <% end -%>
+    link_to(position_span + caption, { tab: tab[:name] },
+                                       id: "tab-#{tab[:name]}",
+                                       class: (tab[:name] != selected_tab ? nil : 'selected'),
+                                       onclick: "showTab('#{tab[:name]}'); this.blur(); return false;") %></li>
+  <% end %>
   </ul>
   <div class="tabs-buttons" style="display:none;">
-  	<button class="tab-left" onclick="moveTabLeft(this);"></button>
-  	<button class="tab-right" onclick="moveTabRight(this);"></button>
+    <button class="tab-left" onclick="moveTabLeft(this);"></button>
+    <button class="tab-right" onclick="moveTabRight(this);"></button>
   </div>
 </div>
 
 <script>
-	Event.observe(window, 'load', function() { displayTabsButtons(); });
-	Event.observe(window, 'resize', function() { displayTabsButtons(); });
+       Event.observe(window, 'load', function() { displayTabsButtons(); });
+       Event.observe(window, 'resize', function() { displayTabsButtons(); });
 </script>
 
-<% tabs.each do |tab| -%>
-  <%= content_tag('div', render(:partial => tab[:partial], :locals => {:tab => tab} ),
-                       :id => "tab-content-#{tab[:name]}",
-                       :style => (tab[:name] != selected_tab ? 'display:none' : nil),
-                       :class => 'tab-content') %>
-<% end -%>
+<% tabs.each do |tab| %>
+  <%= content_tag('div',
+                  render(partial: tab[:partial], locals: {tab: tab} ),
+                  id: "tab-content-#{tab[:name]}",
+                  style: (tab[:name] != selected_tab ? 'display:none' : nil),
+                  class: 'tab-content') %>
+<% end %>

--- a/app/views/common/_tabs.html.erb
+++ b/app/views/common/_tabs.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
     link_to(position_span + caption, { tab: tab[:name] },
                                        id: "tab-#{tab[:name]}",
                                        class: (tab[:name] != selected_tab ? nil : 'selected'),
-                                       onclick: "showTab('#{tab[:name]}'); this.blur(); return false;") %></li>
+                                       onclick: "showTab('#{tab[:name]}', this.href); this.blur(); return false;") %></li>
   <% end %>
   </ul>
   <div class="tabs-buttons" style="display:none;">

--- a/app/views/common/_tabs.html.erb
+++ b/app/views/common/_tabs.html.erb
@@ -53,8 +53,8 @@ See doc/COPYRIGHT.rdoc for more details.
 </div>
 
 <script>
-       Event.observe(window, 'load', function() { displayTabsButtons(); });
-       Event.observe(window, 'resize', function() { displayTabsButtons(); });
+  jQuery(function() { displayTabsButtons(); });
+  jQuery(window).resize(function() { displayTabsButtons(); });
 </script>
 
 <% tabs.each do |tab| %>

--- a/features/groups/group_memberships.feature
+++ b/features/groups/group_memberships.feature
@@ -59,7 +59,7 @@ Feature: Group Memberships
       And I click on "tab-members"
       And I add the principal "A-Team" as a member with the roles:
         | Manager |
-     Then I should be on the settings page of the project called "Project1"
+     Then I should be on the "members" tab of the settings page of the project called "Project1"
       And I should see "A-Team" within ".members"
       And I should see "Hannibal Smith" within ".members"
       And I should see "Peter Pan" within ".members"
@@ -93,7 +93,7 @@ Feature: Group Memberships
       And I add the principal "A-Team" as a member with the roles:
         | Manager |
 
-     Then I should be on the settings page of the project called "Project1"
+     Then I should be on the "members" tab of the settings page of the project called "Project1"
       And I wait for the AJAX requests to finish
 
      When I delete the "A-Team" membership


### PR DESCRIPTION
This refactoring helps to remove remaining prototype code and aims to make our code better maintainable by the way.

Also adds a feature already existing in redmine: the current tab state will be saved in the browser history (and current url) if the browser supports that

see:https://www.openproject.org/work_packages/7066
