### PR TITLE
[prototype->jQuery] Removed prototype usage of observeProjectModules()

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -485,21 +485,19 @@ function observeRelatedIssueField(url) {
                            });
 }
 
-function setVisible(id, visible) {
-  var el = $(id);
-  if (el) {if (visible) {el.show();} else {el.hide();}}
-}
-
+// Hides types and issues custom fields on the new project form when
+// work_package_tracking module is disabled.
 function observeProjectModules() {
   var f = function() {
-    /* Hides types and issues custom fields on the new project form when work_package_tracking module is disabled */
-    var c = ($('project_enabled_module_names_work_package_tracking').checked == true);
-    setVisible('project_types', c);
-    setVisible('project_issue_custom_fields', c);
+    if (jQuery('#project_enabled_module_names_work_package_tracking').attr('checked')) {
+      jQuery('#project_types, #project_issue_custom_fields').show();
+    } else {
+      jQuery('#project_types, #project_issue_custom_fields').hide();
+    }
   };
 
-  Event.observe(window, 'load', f);
-  Event.observe('project_enabled_module_names_work_package_tracking', 'change', f);
+  jQuery(window).load(f);
+  jQuery('#project_enabled_module_names_work_package_tracking').change(f);
 }
 
 /*

--- a/app/views/projects/form/_modules.html.erb
+++ b/app/views/projects/form/_modules.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
   <% Redmine::AccessControl.available_project_modules.each do |m| %>
     <label class="floating">
-      <%= check_box_tag 'project[enabled_module_names][]', 
+      <%= check_box_tag 'project[enabled_module_names][]',
                         m,
                         project.module_enabled?(m),
                         :id => "project_enabled_module_names_#{m}" %>
@@ -42,5 +42,5 @@ See doc/COPYRIGHT.rdoc for more details.
     </label>
   <% end %>
   <%= hidden_field_tag 'project[enabled_module_names][]', '' %>
-  <%= javascript_tag 'observeProjectModules()' %>
+  <%= javascript_tag 'observeProjectModules();' %>
 </fieldset>


### PR DESCRIPTION
This refactoring helps to remove remaining prototype code.

This can be tested in the create project form (administration -> project -> new project) when toggling the module "work package tracking". The" Types" fieldset should toggle its visibility.

![selection_032](https://cloud.githubusercontent.com/assets/206108/2829532/1deb2e42-cfa4-11e3-9a14-f3d1af7423ba.png)

see:https://www.openproject.org/work_packages/7066
