### PR TITLE
add Ruby 2.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@
 
 language: ruby
 rvm:
+  - 2.0
   - 2.1
 branches:
   only:


### PR DESCRIPTION
Rails 3 on Ruby 2.1.1 is broken.
http://www.redmine.org/issues/16194
