### PR TITLE
Fix/timeline wp shadow with end date 7281

### DIFF
--- a/app/assets/javascripts/angular/models/timelines/planning_element.js
+++ b/app/assets/javascripts/angular/models/timelines/planning_element.js
@@ -206,7 +206,7 @@ angular.module('openproject.timelines.models')
     },
     hasAlternateDates: function() {
       return (this.does_historical_differ("start_date") ||
-              this.does_historical_differ("end_date") ||
+              this.does_historical_differ("due_date") ||
               this.is_deleted);
     },
     isDeleted: function() {

--- a/karma/tests/planning_element_test.js
+++ b/karma/tests/planning_element_test.js
@@ -42,6 +42,16 @@ describe('Planning Element', function(){
       "start_date": "2012-11-11",
       "due_date": "2012-11-12"
     });
+
+    this.peWithDueDate = Factory.build("PlanningElement", {
+      timeline: Factory.build("Timeline"),
+      "due_date": "2012-11-12"
+    });
+
+    this.peWithStartDate = Factory.build("PlanningElement", {
+      timeline: Factory.build("Timeline"),
+      "start_date": "2012-11-11",
+    });
   });
 
   beforeEach(module('openproject.timelines.models', 'openproject.uiComponents'));
@@ -226,6 +236,18 @@ describe('Planning Element', function(){
       expect(peWithHistorical.alternate_end().getDate()).to.equal(12);
       expect(peWithHistorical.alternate_end().getMonth()).to.equal(10);
       expect(peWithHistorical.alternate_end().getFullYear()).to.equal(2012);
+    });
+
+    it('historical should have alternate dates with only one date different', function () {
+      peWithHistorical = Factory.build("PlanningElement", {
+        historical_element: this.peWithDueDate
+      });
+      expect(peWithHistorical.hasAlternateDates()).to.be.true;
+
+      peWithHistorical = Factory.build("PlanningElement", {
+        historical_element: this.peWithStartDate
+      });
+      expect(peWithHistorical.hasAlternateDates()).to.be.true;
     });
   });
 


### PR DESCRIPTION
timelines was looking for end_date but it's called due_date now... apparently.
