### PR TITLE
Add quiet_assets to mute assets pipeline logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,6 +183,7 @@ group :development do
   gem 'rails-dev-tweaks', '~> 0.6.1'
   gem 'thin'
   gem 'faker'
+  gem 'quiet_assets'
 end
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
     pry-stack_explorer (0.4.9.1)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rabl (0.9.3)
       activesupport (>= 2.3.14)
     rack (1.4.5)
@@ -372,6 +374,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
+  quiet_assets
   rabl (= 0.9.3)
   rack-protection!
   rack_session_access

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,6 +64,9 @@ OpenProject::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  # Mute asset pipeline logging (using Quiet Assets)
+  config.quiet_assets = true
+
   # Send mails to browser window
   config.action_mailer.delivery_method = :letter_opener
 end


### PR DESCRIPTION
Enabled in development environment only.
