### PR TITLE
[FIX] RSpec warnings for accessibility specs

### DIFF
--- a/spec/features/accessibility/support/toggable_fieldsets_spec.rb
+++ b/spec/features/accessibility/support/toggable_fieldsets_spec.rb
@@ -29,19 +29,19 @@
 require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 
-describe 'Toggable fieldset' do
-  shared_context 'find legend with text' do
-    let(:legend_text) { find('legend a span', text: fieldset_name) }
-    let(:fieldset) { legend_text.find(:xpath, '../../..') }
-  end
+shared_context 'find legend with text' do
+  let(:legend_text) { find('legend a span', text: fieldset_name) }
+  let(:fieldset) { legend_text.find(:xpath, '../../..') }
+end
 
-  shared_context 'find toggle label' do
-    let(:link) { legend_text.find(:xpath, '..') }
-    let(:toggle_state_label) { link.find("span.hidden-for-sighted", visible: false) }
+shared_context 'find toggle label' do
+  let(:link) { legend_text.find(:xpath, '..') }
+  let(:toggle_state_label) { link.find("span.hidden-for-sighted", visible: false) }
 
-    it { expect(toggle_state_label).not_to be_nil }
-   end
+  it { expect(toggle_state_label).not_to be_nil }
+end
 
+shared_context 'Toggable fieldset examples' do
   shared_examples_for 'toggable fieldset initially collapsed' do
     it_behaves_like 'collapsed fieldset'
 

--- a/spec/features/accessibility/work_packages/index_toggable_fieldsets_spec.rb
+++ b/spec/features/accessibility/work_packages/index_toggable_fieldsets_spec.rb
@@ -27,7 +27,6 @@
 #++
 
 require 'spec_helper'
-require 'features/accessibility/support/toggable_fieldsets_spec'
 require 'features/work_packages/work_packages_page'
 
 describe 'Work package index' do

--- a/spec/features/accessibility/work_packages/index_toggable_fieldsets_spec.rb
+++ b/spec/features/accessibility/work_packages/index_toggable_fieldsets_spec.rb
@@ -32,6 +32,8 @@ require 'features/work_packages/work_packages_page'
 
 describe 'Work package index' do
   describe 'Toggable fieldset', js: true do
+    include_context 'Toggable fieldset examples'
+
     let(:current_user) { FactoryGirl.create (:admin) }
     let(:work_packages_page) { WorkPackagesPage.new }
 


### PR DESCRIPTION
Fixes two kinds of warnings for the accessibility specs:

```
Accessing shared_examples defined across contexts is deprecated.
Please declare shared_examples within a shared context, or at the top level.
```

and

```
WARNING: Shared example group 'X' has been previously defined
```
