### PR TITLE
store sessions in the cache by default all the time

### DIFF
--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -146,7 +146,7 @@ default:
 
   # defines where session data is stored
   # possible values are :cookie_store, :cache_store, :active_record_store
-  session_store: :cookie_store
+  session_store: :cache_store
 
   # Configuration of SCM executable command.
   # Absolute path (e.g. /usr/local/bin/hg) or command name (e.g. hg.exe, bzr.exe)
@@ -183,7 +183,3 @@ development:
 # Configuration for the test environment
 test:
   email_delivery_method: :test
-
-# specific configuration options for production environment
-production:
-  session_store: :cache_store

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -59,9 +59,9 @@ In case you want to use environment variables, but you have no easy way to set t
 * `autologin_cookie_path` (default: '/')
 * `autologin_cookie_secure` (default: false)
 * `database_cipher_key`     (default: nil)
-* `rails_cache_store` not set or memcache (default: not set, uses file_store)
 * `scm_git_command` (default: 'git')
 * `scm_subversion_command` (default: 'git')
+* `session_store`: `active_record_store`, `cache_store`, or `cookie_store` (default: cache_store)
 
 Email configuration
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -47,7 +47,7 @@ module OpenProject
       # use dalli defaults for memcache
       'cache_memcache_server'   => nil,
       # where to store session data
-      'session_store'           => :cookie_store,
+      'session_store'           => :cache_store,
       # url-path prefix
       'rails_relative_url_root' => "",
 


### PR DESCRIPTION
let's store session data in whatever is used for the server-side cache as it's more secure than cookie based store.
