### PR TITLE
Fix for strange characters in select dropdowns (Chrome on Windows)

### DIFF
--- a/app/assets/stylesheets/global/_mixins.sass
+++ b/app/assets/stylesheets/global/_mixins.sass
@@ -205,3 +205,8 @@ $button_gray_font_color: #222222
       font-weight: $weight
       font-style:  $style
       src: font-url('#{$file-path}.svg##{$svg-font-id}') format('svg')
+    // Select dropdowns show strange characters on Chrome on Windows with the fix above
+    // Temporarily use another font for them.
+    // See https://www.openproject.org/work_packages/7479
+    select
+      font-family: sans-serif !important


### PR DESCRIPTION
This should be fixed properly later.

https://www.openproject.org/work_packages/7479
