### PR TITLE
we don't need no discs for li's in wiki tocs

### DIFF
--- a/app/assets/stylesheets/content/_wiki.css.sass
+++ b/app/assets/stylesheets/content/_wiki.css.sass
@@ -74,11 +74,12 @@ div.wiki
       background-repeat: no-repeat
       background-position: 0% 60%
       padding-left: 16px
+    li
+      list-style-type: none
   ul
     margin: 0
     padding: 0
   li
-    list-style-type: none
     margin: 0
   li li
     margin-left: 1.5em


### PR DESCRIPTION
Table of contents in wiki files (included via the `{{toc}}` macro) had an unusual styling.

| before | after |
| --- | --- |
| ![selection_139](https://cloud.githubusercontent.com/assets/206108/2929269/82bdd7bc-d787-11e3-8d35-c18297c61a72.png) | ![selection_140](https://cloud.githubusercontent.com/assets/206108/2929272/864519fe-d787-11e3-96d5-c0a6aaa91d8f.png) |

[`* `#7384` Headlines in wiki table of content are broken`](https://www.openproject.org/work_packages/7384)
