### PR TITLE
[Release][Fix] 4031 expand folder icon missing in front of repositoy folders

### DIFF
--- a/app/assets/stylesheets/scm.css.sass
+++ b/app/assets/stylesheets/scm.css.sass
@@ -401,3 +401,20 @@ div
     background: #505
     .head
       color: #f4f
+
+tr.dir
+  span
+    &.dir-expander
+      @include icon-common
+      margin-right: -15px
+      &:before
+        content: "\e089"
+  &.loading
+    span.dir-expander:before
+      content: "\e07a"
+  &.collapsed
+    span.dir-expander:before
+      content: "\e089"
+  &.open
+    span.dir-expander:before
+      content: "\e082"

--- a/app/views/repositories/_dir_list_content.html.erb
+++ b/app/views/repositories/_dir_list_content.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <tr id="<%= tr_id %>" class="<%= h params[:parent_id] %> entry <%= h(entry.kind) %>">
 <td style="padding-left: <%=18 * depth%>px;" class="filename">
 <% if entry.is_dir? %>
-<span class="expander" onclick="<%=  remote_function :url => {:action => 'show', :project_id => @project, :path => to_path_param(ent_path), :rev => @rev, :depth => (depth + 1), :parent_id => tr_id},
+<span class="icon dir-expander" onclick="<%=  remote_function :url => {:action => 'show', :project_id => @project, :path => to_path_param(ent_path), :rev => @rev, :depth => (depth + 1), :parent_id => tr_id},
                   :method => :get,
                   :update => { :success => tr_id },
                   :position => :after,


### PR DESCRIPTION
[`* `#4031` Expand folder icon missing in front of repository folders`](https://www.openproject.org/work_packages/4031)
