### PR TITLE
Meets  #7511: Label "Email updates" cut off in bulk-edit view

### DIFF
--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -125,7 +125,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= text_area_tag 'notes', @notes, :cols => 60, :rows => 10, :class => 'wiki-edit',
                   :'data-wp_autocomplete_url' => work_packages_auto_complete_path(:project_id => @project, :format => :json) %>
 <%= wikitoolbar_for 'notes' %>
-<%= send_notification_option %>
+<p><%= send_notification_option %></p>
 </fieldset>
 </div>
 


### PR DESCRIPTION
[`* `#7511` Fixes: Label "Email updates" cut off in bulk-edit view`](https://www.openproject.org/work_packages/7511)
