### PR TITLE
Meets #7492: Timeline outside of scroll area is broken in IE 11

### DIFF
--- a/app/assets/stylesheets/timelines.css.erb
+++ b/app/assets/stylesheets/timelines.css.erb
@@ -47,6 +47,7 @@ li.select2-result.select2-visible-selected-parent {
 
 .timeline svg {
   display: block;
+  overflow: hidden;
 }
 
 .tl-under-construction {


### PR DESCRIPTION
[`* `#7492` Timeline outside of scroll area is broken in IE 11`](https://www.openproject.org/work_packages/7492)
