### PR TITLE
Feature/jk shortcuts for wp table

### DIFF
--- a/app/assets/javascripts/keyboard_shortcuts.js
+++ b/app/assets/javascripts/keyboard_shortcuts.js
@@ -202,13 +202,12 @@
 })(jQuery);
 
 jQuery(function(){
-  // simulated hover effect on table lists when using the keyboard
-  var tables = jQuery('table.list');
-  if (tables.size() === 0) { return; }
-  tables.on('blur', 'tr *', function(){
-    jQuery(this).parents('table.list tr').removeClass('keyboard_hover');
+  // simulated hover effect on tables when using the keyboard
+  var content = jQuery('#content');
+  content.on('blur', 'table tr *', function(){
+    jQuery(this).parents('table tr').first().removeClass('keyboard_hover');
   });
-  tables.on('focus', 'tr *', function(){
-    jQuery(this).parents('table.list tr').addClass('keyboard_hover');
+  content.on('focus', 'table tr *', function(){
+    jQuery(this).parents('table tr').first().addClass('keyboard_hover');
   });
 });

--- a/app/assets/javascripts/keyboard_shortcuts.js
+++ b/app/assets/javascripts/keyboard_shortcuts.js
@@ -204,10 +204,11 @@
 jQuery(function(){
   // simulated hover effect on tables when using the keyboard
   var content = jQuery('#content');
-  content.on('blur', 'table tr *', function(){
+  content.on('hover', 'table tr *', function(){
     jQuery(this).parents('table tr').first().removeClass('keyboard_hover');
   });
   content.on('focus', 'table tr *', function(){
+    jQuery('.keyboard_hover').removeClass('keyboard_hover');
     jQuery(this).parents('table tr').first().addClass('keyboard_hover');
   });
 });

--- a/app/assets/javascripts/keyboard_shortcuts.js
+++ b/app/assets/javascripts/keyboard_shortcuts.js
@@ -125,23 +125,49 @@
     $('#search_wrap .search_field').focus();
   };
 
+  /*
+    Helper function for the j/k-shortcuts. Returns a list of j/k-enumerable
+    items on the current page.
+  */
   var find_list_in_page = function(){
-    var dom_lists, focus_elements;
-    focus_elements = [];
-    dom_lists = $('table.list');
-    dom_lists.find('tbody tr').each(function(index, tr){
+    var focus_elements = []; // list of [list_entry, first_link] elements
+
+    // old-style table lists
+    $('table.list tbody tr').each(function(index, tr){
       var first_link = $(tr).find('a:visible')[0];
-      if ( first_link !== undefined ) { focus_elements.push(first_link); }
+      if ( first_link !== undefined ) {
+        focus_elements.push( [tr, first_link] );
+      }
     });
+
+    // new angular work package list
+    $('.workpackages-table .issue').each(function(index, issue){
+      var first_link = $(issue).find('a:visible')[0];
+      if ( first_link !== undefined ) {
+        focus_elements.push( [issue, first_link] );
+      }
+    });
+
     return focus_elements;
   };
 
   var focus_item_offset = function(offset){
-    var list, index;
+    var list, items, i;
     list = find_list_in_page();
+    item = $(document.activeElement).parents('tr')[0];
     if (list === null) { return; }
-    index = list.indexOf($(document.activeElement).parents('table.list tr').find('a:visible')[0]);
-    $(list[(index+offset+list.length) % list.length]).focus();
+    if (item === undefined) {
+      $(list[0][1]).focus();
+      return;
+    }
+
+    // scan through list to find the index of the current item
+    for (i = 0; i < list.length; ++i) {
+      if ( list[i][0] === item ) {
+        break;
+      }
+    }
+    $(list[(i+offset+list.length) % list.length][1]).focus();
   };
 
   var focus_next_item = function(){

--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -59,7 +59,7 @@ table.workpackages-table
       background: #f8f8f8
   tr
     border-bottom: 1px solid #dddddd
-    &:hover
+    &:hover, &.keyboard_hover
       background: #e4f7fb
   tr td
     text-align: left


### PR DESCRIPTION
We have the <key><code>j</code></key> and  <key><code>k</code></key> shortcuts (which go through a list). They are great but didn't work for the new work package index list.

This is a thing of the past now! In the following gif, I'm going through the WP list with the <key><code>j</code></key>/<key><code>k</code></key> shortcuts and view the details of a WP through pressing <key><code>enter</code></key>.

![out](https://cloud.githubusercontent.com/assets/206108/3088548/e2d0e57a-e571-11e3-80fa-d91baa6f7e32.gif)
