### PR TITLE
Add accessibility test for calendar filter

### DIFF
--- a/spec/features/accessibility/work_packages/calendar_toggable_fieldsets_spec.rb
+++ b/spec/features/accessibility/work_packages/calendar_toggable_fieldsets_spec.rb
@@ -26,53 +26,28 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackagesPage
-  include Rails.application.routes.url_helpers
-  include Capybara::DSL
+require 'spec_helper'
+require 'features/support/toggable_fieldsets'
+require 'features/work_packages/work_packages_page'
 
-  def initialize(project=nil)
-    @project = project
-  end
+describe 'Work package calendar index' do
+  describe 'Toggable fieldset', js: true do
+    include_context 'Toggable fieldset examples'
 
-  def visit_index
-    visit index_path
-  end
+    let(:project) { FactoryGirl.create(:project) }
+    let(:current_user) { FactoryGirl.create (:admin) }
+    let(:work_packages_page) { WorkPackagesPage.new(project) }
 
-  def visit_show(id)
-    visit work_package_path(id)
-  end
+    before do
+      allow(User).to receive(:current).and_return current_user
 
-  def visit_edit(id)
-    visit edit_work_package_path(id)
-  end
+      work_packages_page.visit_calendar
+    end
 
-  def visit_calendar
-    visit index_path + "/calendar"
-  end
-
-  def click_work_packages_menu_item
-    find('#main-menu .work-packages').click
-  end
-
-  def click_toolbar_button(button)
-    find('.toolbar-container').click_button button
-  end
-
-  def select_query(query)
-    visit query_path(query);
-  end
-
-  def selected_filter(filter_name)
-    find(".filter-fields #h_#{filter_name}", visible: false)
-  end
-
-  private
-
-  def index_path
-    @project ? project_work_packages_path(@project) : work_packages_path
-  end
-
-  def query_path(query)
-    "#{index_path}?query_id=#{query.id}"
+    describe 'Filter fieldset', js: true do
+      it_behaves_like 'toggable fieldset initially expanded' do
+        let(:fieldset_name) { 'Filters' }
+      end
+    end
   end
 end

--- a/spec/features/support/toggable_fieldsets.rb
+++ b/spec/features/support/toggable_fieldsets.rb
@@ -31,7 +31,7 @@ require 'features/work_packages/work_packages_page'
 
 shared_context 'Toggable fieldset examples' do
   def toggable_title
-    find('legend a span', text: fieldset_name)
+    find('legend a', text: fieldset_name)
   end
 
   def toggable_content
@@ -90,7 +90,7 @@ shared_context 'Toggable fieldset examples' do
   shared_examples_for 'collapsed fieldset' do
     include_context 'collapsed CSS'
 
-    it { expect(toggable_title.find(:xpath, '../../..')[:class]).to include(collapsed_class_name) }
+    it { expect(toggable_title.find(:xpath, '../..')[:class]).to include(collapsed_class_name) }
   end
 
   shared_examples_for 'expanded fieldset' do


### PR DESCRIPTION
This PR adds an accessibility test for the calendar filter selection area. This test is a fallback because the original test work package filters and filter options will be removed in b59d2c99a0270f1aed398a735ef8b67c9c9739b5.
