### PR TITLE
Meets #7782: [MyProject] Long target version names destroy layout

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -60,6 +60,7 @@ $toggler-width: 40px
   float: left
   left: 0
   background-color: $main_menu_bg_color
+  word-break: break-all
   @include default-transition
 
   ul


### PR DESCRIPTION
- `#7782` Fixes:  Long target version names destroy layout
