### PR TITLE
[Release][Fix] 7623 fix fieldset legend style

### DIFF
--- a/app/assets/stylesheets/content/_forms.css.sass
+++ b/app/assets/stylesheets/content/_forms.css.sass
@@ -201,10 +201,10 @@ fieldset
       right: 5px
       top: 4px
   &.collapsible
-    legend:after
+    > legend:after
       content: "\e0d4"
     &.collapsed
-      legend:after
+      > legend:after
         content: "\e0d2"
   &.with-legend-control
     legend


### PR DESCRIPTION
[`* `#7623` Replace remaining icons by icon font`](https://www.openproject.org/work_packages/7623)

This PR fixes a styling issue that emerged when [fixing the icons in reporting engine](https://github.com/finnlabs/reporting_engine/pull/30)
