### PR TITLE
Meets #7684: No warning message when closing work package modal form which contains text via Escape key or click at location outside of modal

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -482,49 +482,44 @@ function observeProjectModules() {
   Event.observe('project_enabled_module_names_work_package_tracking', 'change', f);
 }
 
-/*
- * Class used to warn user when leaving a page with unsaved textarea
- * Author: mathias.fischer@berlinonline.de
-*/
+var WarnLeavingUnsaved = function(message) {
+  this.message = message;
+  var changedForms = false;
+  var isEmbed = window != window.parent;
+  var obj = this;
 
-var WarnLeavingUnsaved = Class.create({
-	observedForms: false,
-	observedElements: false,
-	changedForms: false,
-	message: null,
+  this.unload = function() {
+    if(changedForms && !isEmbed) {
+      return message;
+    }
+  };
 
-	initialize: function(message){
-		this.observedForms = $$('form');
-		this.observedElements =  $$('textarea');
-		this.message = message;
+  this.getChanged = function() {
+    return changedForms;
+  };
 
-		this.observedElements.each(this.observeChange.bind(this));
-		this.observedForms.each(this.submitAction.bind(this));
+  this.setChanged = function() {
+    changedForms = true;
+  };
 
-		window.onbeforeunload = this.unload.bind(this);
-	},
+  this.setUnchanged = function() {
+    changedForms = false;
+  };
 
-	unload: function(){
-		if(this.changedForms)
-      return this.message;
-	},
+  this.init = function() {
+    jQuery(document).on('change', 'textarea', function() {
+      obj.setChanged();
+    });
 
-	setChanged: function(){
-    this.changedForms = true;
-	},
+    jQuery(document).on('submit', 'form', function() {
+      obj.setUnchanged();
+    });
 
-	setUnchanged: function(){
-    this.changedForms = false;
-	},
+    jQuery(window).bind('beforeunload', this.unload);
+  };
 
-	observeChange: function(element){
-    element.observe('change',this.setChanged.bindAsEventListener(this));
-	},
-
-	submitAction: function(element){
-    element.observe('submit',this.setUnchanged.bindAsEventListener(this));
-	}
-});
+  this.init();
+};
 
 /*
  * 1 - registers a callback which copies the csrf token into the

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -61,11 +61,6 @@ var ModalHelper = (function() {
 
         // close when body is clicked
         body.on("click", ".ui-widget-overlay", jQuery.proxy(modalHelper.close, modalHelper));
-        body.on("keyup", function (e) {
-          if (e.which == 27) {
-            modalHelper.close();
-          }
-        });
 
         ModalHelper._done = true;
       } else {
@@ -142,7 +137,7 @@ var ModalHelper = (function() {
         body.find("#footnotes_debug").hide();
         body.css("min-width", "0px");
 
-        body.find(":input").change(function () {
+        jQuery(body).on('keyup', 'input, textarea', function() {
           modalDiv.data('changed', true);
         });
 
@@ -202,6 +197,8 @@ var ModalHelper = (function() {
   };
 
   ModalHelper.prototype.close = function() {
+    jQuery('input:focus, textarea:focus').trigger('blur'); // unfocus inputs and textareas to get the 'onChange' event triggered
+
     var modalDiv = this.modalDiv;
     if (!this.loadingModal) {
       if (modalDiv && (modalDiv.data('changed') !== true || confirm(I18n.t('js.timelines.really_close_dialog')))) {

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -37,6 +37,10 @@ When /^I click(?:| on) "([^"]*)"$/ do |name|
   click_link_or_button(name)
 end
 
+When /^I click(?:| on) the div "([^"]*)"$/ do |name|
+  find("##{name}").click
+end
+
 When /^(?:|I )jump to [Pp]roject "([^\"]*)"$/ do |project|
   click_link('Projects')
   # supports both variants of finding: by class and by id

--- a/features/step_definitions/timelines_then_steps.rb
+++ b/features/step_definitions/timelines_then_steps.rb
@@ -74,6 +74,10 @@ Then(/^I should see a modal window$/) do
   steps 'Then I should see a modal window with selector "#modalDiv"'
 end
 
+Then(/^I should not see a modal window$/) do
+  page.should_not have_selector("#modalDiv")
+end
+
 Then(/^(.*) in the modal$/) do |step|
   step(step + ' in the iframe "modalIframe"')
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -435,6 +435,11 @@ When /^(?:|I )click on the first button matching "([^"]*)"$/ do |button|
   first(:button, button).click
 end
 
+
+When /^(?:|I )click on the first anchor matching "([^"]*)"$/ do |anchor|
+  find(:xpath, "(//a[text()='#{anchor}'])[1]").click
+end
+
 def find_lowest_containing_element text, selector
   elements = []
 
@@ -472,4 +477,13 @@ end
 
 Then(/^I should see a confirm dialog$/) do
   page.should have_selector("#confirm_dialog")
+end
+
+Then /^I confirm the JS confirm dialog$/ do
+  page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertOpenError
+end
+
+Then /^I should see a JS confirm dialog$/ do
+  page.driver.browser.switch_to.alert.text.should_not be_nil
+  page.driver.browser.switch_to.alert.accept
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -105,6 +105,11 @@ end
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
+# Remove any modal dialog remaining from the scenarios which finish in an unclean state
+Before do |scenario|
+  page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertOpenError
+end
+
 # Capybara.register_driver :selenium do |app|
 #     Capybara::Selenium::Driver.new(app, :browser => :chrome)
 # end

--- a/features/timelines/timeline_modal_views.feature
+++ b/features/timelines/timeline_modal_views.feature
@@ -88,3 +88,20 @@ Feature: Timeline View Tests
      When I ctrl-click on "#2" in the modal
      Then I should see "February" in the new window
      Then I should see "Avocado Rincon" in the new window
+
+  @javascript
+  Scenario: closing the modal window with changes should display a warning message
+    When the role "manager" may have the following rights:
+      | view_timelines     |
+      | edit_timelines     |
+      | view_work_packages |
+      | edit_work_packages |
+    And there is a timeline "Testline" for project "ecookbook"
+    And I go to the page of the timeline "Testline" of the project called "ecookbook"
+    And I wait for timeline to load table
+    And I click on the Planning Element with name "January"
+    And I click on the first anchor matching "Update" in the modal
+    And I fill in "work_package_notes" with "A new comment" in the modal
+    And I click on the div "ui-dialog-closer"
+    Then I confirm the JS confirm dialog
+    And I should not see a modal window


### PR DESCRIPTION
[`* `#7684` No warning message when closing work package modal form which contains text via Escape key or click at location outside of modal`](https://www.openproject.org/work_packages/7684)
