### PR TITLE
map subdirectory unless Passenger is used

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -30,6 +30,19 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-use Rack::Protection::JsonCsrf
-use Rack::Protection::FrameOptions
-run OpenProject::Application
+
+##
+# Returns true if the application should be run under a subdirectory.
+def map_subdir?
+  # Don't map subdir when using Passenger as passenger takes care of that.
+  !defined?(::PhusionPassenger)
+end
+
+subdir = map_subdir? && OpenProject::Configuration.rails_relative_url_root.presence
+
+map (subdir || '/') do
+  use Rack::Protection::JsonCsrf
+  use Rack::Protection::FrameOptions
+
+  run OpenProject::Application
+end


### PR DESCRIPTION
Makes the subdirectory (rails_relative_url_root) work without having to change `config.ru`.

[Work Package #8421](https://www.openproject.org/work_packages/8421)
