### PR TITLE
Wiki: Increase font size and free space to make it more readable

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -80,12 +80,22 @@ div.wiki
       padding-left: 16px
     li
       list-style-type: none
-  ul
-    padding: 0
+
+  ol, ul
+    padding: 0 0 0 2em
+    margin: 0.3em 0
+
   li
+    list-style-position: outside
     margin: 0
-  li li
-    margin-left: 1.5em
+
+  ol li
+    list-style-type: decimal
+
+  ul li
+    list-style-type: disc
+
+
   fieldset legend
     font-weight: bold
     font-size: 10px

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -116,6 +116,8 @@ h1:hover, h2:hover, h3:hover
     color: #ddd
 
 .wiki
+  p
+    margin-bottom: 1em
   p, span
     &.see-also, &.caution, &.important, &.info, &.tip, &.note
       display: block

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -30,8 +30,9 @@
 div.wiki
   font-size: 14px
   line-height: 1.7em
-  h1
-    margin-top: 1em
+  h1, h2
+    margin: 1em 0 1em 0
+
   table
     border: 1px solid #505050
     border-collapse: collapse

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -29,7 +29,7 @@
 
 div.wiki
   font-size: 14px
-  line-height: 1.7em
+  line-height: 1.6em
   h1, h2
     margin: 1em 0 1em 0
 

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -28,6 +28,10 @@
 @import global/all
 
 div.wiki
+  font-size: 14px
+  line-height: 1.7em
+  h1
+    margin-top: 1em
   table
     border: 1px solid #505050
     border-collapse: collapse
@@ -57,7 +61,6 @@ div.wiki
     margin-right: 12px
     margin-left: 0
     display: table
-    font-size: 0.8em
     &.right
       float: right
       margin-left: 12px
@@ -77,7 +80,6 @@ div.wiki
     li
       list-style-type: none
   ul
-    margin: 0
     padding: 0
   li
     margin: 0
@@ -161,6 +163,9 @@ h1:hover, h2:hover, h3:hover
     &.smallnote
       background: url(image-path('wiki_styles/note_small.png')) 5px 4px no-repeat #F5FFFA
       border: 1px solid #C7CFCA
+
+.wiki-content
+  width: 700px
 
 .controller-wiki
   #content

--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -1035,9 +1035,6 @@ blockquote {
   font-style: italic;
   background: url(<%= asset_path 'blockquote-bg.png' %>) no-repeat 5px 3px;
 }
-.wiki ul li {
-  list-style: disc inside none;
-}
 .file-thumbs {
   margin: 20px 0 0;
   overflow: hidden;
@@ -1432,11 +1429,6 @@ tr.time-entry {
 
 .journal .contextual a[title=Edit] img {
   display: none;
-}
-
-/* comments */
-.wiki ol li {
-  list-style: decimal inside;
 }
 
 /* scm */

--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -1028,9 +1028,6 @@ table.files {
 #content blockquote, .wiki ol, .wiki ul {
   padding-left: 22px;
 }
-.wiki p {
-  margin-bottom: 5px;
-}
 blockquote {
   font-style: italic;
   background: url(<%= asset_path 'blockquote-bg.png' %>) no-repeat 5px 3px;

--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -1703,7 +1703,7 @@ content {
   padding-bottom: 11px;
 }
 
-#history .journal, #content .wiki-content p, #content .wiki-content li {
+#history .journal {
   width: 700px;
 }
 


### PR DESCRIPTION
This bugged me for a while. It's not perfect now, but I like it much better. Feedback welcome :)

![op-wiki-space](https://cloud.githubusercontent.com/assets/188986/3147952/07ca4194-ea5b-11e3-867e-8a59fe37d763.gif)

The one with the larger font and more free space is the new version.

See: https://www.openproject.org/work_packages/8605
