### PR TITLE
Meets #7682: Status of work package not displayed when linking work package via ## or ###

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -64,6 +64,7 @@ module WorkPackagesHelper
   #   link_to_work_package(package, :project => true)           # => Foo - Defect #6
   #   link_to_work_package(package, :id_only => true)           # => #6
   #   link_to_work_package(package, :subject_only => true)      # => This is the subject (as link)
+  #   link_to_work_package(package, :status => true)            # => #6 New (if #id => true)
   def link_to_work_package(package, options = {})
 
     if options[:subject_only]
@@ -100,6 +101,8 @@ module WorkPackagesHelper
     parts[:link] << h(package.kind.to_s) if options[:type]
 
     parts[:link] << "##{h(package.id)}" if options[:id]
+
+    parts[:link] << "#{h(package.status)}" if options[:id] && options[:status] && package.status
 
     # Hidden link part
 
@@ -179,7 +182,7 @@ module WorkPackagesHelper
       end
     end
 
-    link = link_to_work_package(work_package)
+    link = link_to_work_package(work_package, :status => true)
     link += " #{work_package.start_date.nil? ? "[?]" : work_package.start_date.to_s}"
     link += changed_dates["start_date"]
     link += " – #{work_package.due_date.nil? ? "[?]" : work_package.due_date.to_s}"

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -183,6 +183,15 @@ describe WorkPackagesHelper do
         helper.link_to_work_package(stub_work_package, :subject_only => true).should have_selector("a[href='#{work_package_path(stub_work_package)}']", :text => link_text)
       end
     end
+
+    describe "with the status displayed" do
+      it 'should return a link with the status name contained in the text' do
+        stub_work_package.type = stub_type
+
+        link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id} #{stub_work_package.status}$")
+        expect(helper.link_to_work_package(stub_work_package, :status => true)).to have_selector("a[href='#{work_package_path(stub_work_package)}']", :text => link_text)
+      end
+    end
   end
 
   describe :work_package_index_link do


### PR DESCRIPTION
[`* `#7682` Status of work package not displayed when linking work package via ## or ###`](https://www.openproject.org/work_packages/7682)
