### PR TITLE
[Fix] 4123 fix project event name translation

### DIFF
--- a/lib/plugins/acts_as_event/lib/acts_as_event.rb
+++ b/lib/plugins/acts_as_event/lib/acts_as_event.rb
@@ -41,7 +41,7 @@ module Redmine
                               :description => :description,
                               :author => :author,
                               :url => {:controller => '/welcome'},
-                              :name => ::I18n.t(self.name.underscore, scope: 'events'),
+                              :name => Proc.new { ::I18n.t(self.name.underscore, scope: 'events') },
                               :type => self.name.underscore.dasherize }
 
           cattr_accessor :event_options


### PR DESCRIPTION
[`* `#4123` Fix project event name translation`](https://www.openproject.org/work_packages/4123)
