### PR TITLE
[Fix] 7700 no flash message on status page

### DIFF
--- a/app/views/common/_error_base.html.erb
+++ b/app/views/common/_error_base.html.erb
@@ -27,18 +27,11 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% error_message = l("activerecord.errors.template.header.#{(error_messages.count == 1) ? 'one' : 'other'}",
-                     count: error_messages.count,
-                     model: object_name)
-%>
-
-<% content_for :error_details do %>
-  <p><%= l("errors.header_invalid_fields") %></p>
-  <ul>
-    <% error_messages.each do |message| %>
-      <li><%= message %></li>
-    <% end %>
-  </ul>
-<% end %>
-
-<%= render partial: "common/error_base", locals: { error_message: error_message } %>
+<div class="errorExplanation" id="errorExplanation" role="alert">
+  <% if content_for?(:error_details) %>
+    <h2><%= error_message %></h2>
+    <%= content_for :error_details %>
+  <% else %>
+    <%= error_message %>
+  <% end %>
+</div>

--- a/app/views/common/error.html.erb
+++ b/app/views/common/error.html.erb
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <h2><%=h @status %></h2>
 <%= render partial: "common/error_base", locals: { error_message: (h @message) } %>
+<%= call_hook(:view_common_error_details, { params: params, project: ((defined? @project) ? @project : nil) }) %>
 <p><a href="javascript:history.back()">Back</a></p>
 
 <% html_title h(@status) %>

--- a/app/views/common/error.html.erb
+++ b/app/views/common/error.html.erb
@@ -28,8 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <h2><%=h @status %></h2>
-
-<p id="errorExplanation"><%=h @message %></p>
+<%= render partial: "common/error_base", locals: { error_message: (h @message) } %>
 <p><a href="javascript:history.back()">Back</a></p>
 
 <% html_title h(@status) %>

--- a/test/functional/repositories_git_controller_test.rb
+++ b/test/functional/repositories_git_controller_test.rb
@@ -230,8 +230,8 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_annotate_binary_file
       get :annotate, :project_id => 3, :path => 'images/edit.png'
       assert_response 500
-      assert_tag :tag => 'p', :attributes => { :id => /errorExplanation/ },
-                              :content => /cannot be annotated/
+      assert_tag :tag => 'div', :attributes => { :id => /errorExplanation/ },
+                                :content => /cannot be annotated/
     end
 
     def test_revision

--- a/test/functional/repositories_subversion_controller_test.rb
+++ b/test/functional/repositories_subversion_controller_test.rb
@@ -175,7 +175,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       @repository.fetch_changesets
       @repository.reload
       get :entry, :project_id => PRJ_ID, :path => 'subversion_test/zzz.c'
-      assert_tag :tag => 'p', :attributes => { :id => /errorExplanation/ },
+      assert_tag :tag => 'div', :attributes => { :id => /errorExplanation/ },
                                 :content => /The entry or revision was not found in the repository/
     end
 


### PR DESCRIPTION
[`* `#7700` No flash message on status page`](https://www.openproject.org/work_packages/7700)
