### PR TITLE
Meets #2544: Identifier not adapted with name after error message

### DIFF
--- a/app/views/projects/form/attributes/_identifier.html.erb
+++ b/app/views/projects/form/attributes/_identifier.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <script type="text/javascript" charset="utf-8">
       projectIdentifierMaxLength = <%= Project::IDENTIFIER_MAX_LENGTH %>;
       projectIdentifierDefault = '<%= project.identifier %>';
-      projectIdentifierLocked = <%= !project.identifier.blank? %>;
+      projectIdentifierLocked = <%= !project.identifier.blank? && params[:action] != "create" %>;
       observeProjectIdentifier();
       observeProjectName();
     </script>

--- a/features/projects/create.feature
+++ b/features/projects/create.feature
@@ -45,3 +45,14 @@ Feature: Creating Projects
     When I go to the overview page of the project "Parent"
      And I follow "New subproject"
     Then I should not see "Responsible"
+
+  @javascript
+  Scenario: Creating a Project with an already existing identifier
+    When I go to the projects admin page
+     And I follow "New project"
+     And I fill in "project_name" with "Parent"
+     And I press "Save"
+    Then I should be on the projects page
+     And I should see "Identifier has already been taken"
+     And I fill in "project_name" with "Parent 2"
+     And the "Identifier" field should contain "parent-2" within "#content"


### PR DESCRIPTION
[`* `#2544` Identifier not adapted with name after error message`](https://www.openproject.org/work_packages/2544)
