### PR TITLE
alters database cleaning for rspec to avoid race conditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,11 @@ group :test do
   gem "factory_girl_rails", "~> 4.0"
   gem 'cucumber-rails', :require => false
   gem 'rack_session_access'
-  gem 'database_cleaner'
+  # restrict because in version 1.3 a lot of tests using acts as journalized
+  # fail stating: "Column 'user_id' cannot be null". I don't understand the
+  # connection with database cleaner here but setting it to 1.2 fixes the
+  # issue.
+  gem 'database_cleaner', '~> 1.2.0'
   gem "cucumber-rails-training-wheels" # http://aslakhellesoy.com/post/11055981222/the-training-wheels-came-off
   gem 'rspec', '~> 2.14'
   # also add to development group, so "spec" rake task gets loaded

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       cucumber-rails (>= 1.1.1)
     daemons (1.1.9)
     dalli (2.6.4)
-    database_cleaner (1.0.1)
+    database_cleaner (1.2.0)
     date_validator (0.7.0)
       activemodel (>= 3)
     debug_inspector (0.0.2)
@@ -394,7 +394,7 @@ DEPENDENCIES
   cucumber-rails-training-wheels
   daemons
   dalli
-  database_cleaner
+  database_cleaner (~> 1.2.0)
   date_validator
   delayed_job_active_record (= 0.3.3)
   factory_girl_rails (~> 4.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,9 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   #
-  # Taken from http://stackoverflow.com/a/13234966 - Thanks a lot!
+  # Taken from http://stackoverflow.com/questions/21922046/deadlock-detected-with-capybara-webkit
+  # which replaces the one we had before taken from http://stackoverflow.com/a/13234966
+  # Thanks a lot!
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
@@ -73,18 +75,21 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    if example.metadata[:js]
-      DatabaseCleaner.strategy = :truncation
-    else
-      DatabaseCleaner.strategy = :transaction
-    end
+    DatabaseCleaner.strategy = if example.metadata[:js]
+                                 # JS => doesn't share connections => can't use transactions
+                                 # truncations seem to fail more often + they are slower
+                                 :deletion
+                               else
+                                 # No JS/Devise => run with Rack::Test => transactions are ok
+                                 :transaction
+                               end
+
     DatabaseCleaner.start
   end
 
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of


### PR DESCRIPTION
Tries to implement a different way for cleaning the DB when running rspec tests.

This is taken 100% from [stackoverflow](http://stackoverflow.com/questions/21922046/deadlock-detected-with-capybara-webkit).

Without the changes, the capybara powered specs fail often on my machine due to race conditions where the thread running the tests was trying to access data the thread running the backend had not yet created. After the fix, that never happened to me. Additionally,  the specs run faster on my machine (subjective).

Please try whether this also works on your machine(s).
