### PR TITLE
Fix broken Work Packages Table when ?layout=false

### DIFF
--- a/app/assets/javascripts/angular/directives/work_packages/work-packages-table-directive.js
+++ b/app/assets/javascripts/angular/directives/work_packages/work-packages-table-directive.js
@@ -57,7 +57,7 @@ angular.module('openproject.workPackages.directives')
       scope.I18n = I18n;
       scope.workPackagesTableData = WorkPackagesTableService.getWorkPackagesTableData();
 
-      var topMenuHeight = document.getElementById('top-menu').getHeight() || 0;
+      var topMenuHeight = angular.element('#top-menu').prop('offsetHeight') || 0;
       scope.adaptVerticalPosition = function(event) {
         event.pageY -= topMenuHeight;
       };


### PR DESCRIPTION
Certain features, such as display of grouping headlines, appear to be
broken with layout hidden.

This bug helped banish another Prototype usage (`Element#getHeight()`)
from the code base. Using chainable `angular.element` (jQLite/jQuery)
we can handle a missing top-menu gracefully.

https://www.openproject.org/work_packages/9172
