### PR TITLE
Feature/reduce planning elements api memory

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -201,14 +201,33 @@ module Api
 
       end
 
-      def convert_object_to_struct(model)
-        OpenStruct.new(model.attributes)
+      Struct.new("WorkPackage", *[WorkPackage.column_names.map(&:to_sym), :custom_values, :child_ids].flatten)
+      Struct.new("CustomValue", *CustomValue.column_names.map(&:to_sym))
+
+      def convert_wp_to_struct(work_package)
+        struct = Struct::WorkPackage.new
+
+        fill_struct_with_attributes(struct, work_package)
+      end
+
+      def convert_custom_value_to_struct(custom_value)
+        struct = Struct::CustomValue.new
+
+        fill_struct_with_attributes(struct, custom_value)
+      end
+
+      def fill_struct_with_attributes(struct, model)
+        model.attributes.each do |attribute, value|
+          struct.send(:"#{attribute}=", value)
+        end
+
+        struct
       end
 
       def convert_wp_object_to_struct(model)
-        result = convert_object_to_struct(model)
+        result = convert_wp_to_struct(model)
         result.custom_values = model.custom_values.select{|cv| cv.value != ""}.map do |model|
-            convert_object_to_struct(model)
+          convert_custom_value_to_struct(model)
         end
         result
       end


### PR DESCRIPTION
This aims to ease the memory and performance issues noted on OP:
https://www.openproject.org/work_packages/9574

The main approach is to avoid using OpenStructs as they are reported to be slow and memory intensive:
- http://ruby-lang-love.blogspot.de/2011/05/short-story-about-openstruct-and.html
- http://stackoverflow.com/questions/1177594/ruby-struct-vs-openstruct

Unfortunately I haven't found more elaborate information.

On my system, having about 900 work packages in the tested project, the response time was reduced by about 50% (1000ms -> 500 ms) with the fix for json answers. XML responses have a similar drop in response time while still taking twice as much time as json responses. Continuously producing requests, the memory was also reduced by 50% (800MB -> 400MB).
