### PR TITLE
Emiting flash message event on rootscope instead of context menu scope.

### DIFF
--- a/app/assets/javascripts/angular/work_packages/work-package-context-menu.js
+++ b/app/assets/javascripts/angular/work_packages/work-package-context-menu.js
@@ -41,13 +41,14 @@ angular.module('openproject.workPackages')
 
 .controller('WorkPackageContextMenuController', [
   '$scope',
+  '$rootScope',
   'WorkPackagesTableHelper',
   'WorkPackageContextMenuHelper',
   'WorkPackageService',
   'WorkPackagesTableService',
   'I18n',
   '$window',
-  function($scope, WorkPackagesTableHelper, WorkPackageContextMenuHelper, WorkPackageService, WorkPackagesTableService, I18n, $window) {
+  function($scope, $rootScope, WorkPackagesTableHelper, WorkPackageContextMenuHelper, WorkPackageService, WorkPackagesTableService, I18n, $window) {
 
   $scope.I18n = I18n;
 
@@ -75,7 +76,7 @@ angular.module('openproject.workPackages')
     WorkPackageService.performBulkDelete(getSelectedWorkPackages())
       .success(function(data, status) {
         // TODO wire up to API and processs API response
-        $scope.$emit('flashMessage', {
+        $rootScope.$emit('flashMessage', {
           isError: false,
           text: I18n.t('js.work_packages.message_successful_bulk_delete')
         });
@@ -84,7 +85,7 @@ angular.module('openproject.workPackages')
       })
       .error(function(data, status) {
         // TODO wire up to API and processs API response
-        $scope.$emit('flashMessage', {
+        $rootScope.$emit('flashMessage', {
           isError: true,
           text: I18n.t('js.work_packages.message_error_during_bulk_delete')
         });


### PR DESCRIPTION
https://www.openproject.org/work_packages/9384

Perhaps someone wiser than me can tell me why the context menu controller scope has no parent scope. My fix is just to emit the event on rootscope but i get the feeling that if i understood ng-context-menu better there would be a way of correctly assigning the parent scope so the event would be picked up by rootscope as per usual.
