### PR TITLE
Consistent bg colour for group sum rows. Labels for 'None' groups.

### DIFF
--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -58,7 +58,7 @@ tr.project.idnt-8 td.name {padding-left: 11em;}
 tr.project.idnt-9 td.name {padding-left: 12.5em;}
 
 tr.issue { text-align: center; white-space: nowrap; }
-tr.issue.sum { font-weight: bold; }
+tr.issue.sum { font-weight: bold; background-color: #f6f7f8 }
 tr.issue td.subject, tr.issue td.category, td.assigned_to { white-space: normal; }
 tr.issue td.subject { text-align: left; }
 tr.issue td.done_ratio table.progress { margin-left: auto; margin-right: auto;}

--- a/public/templates/work_packages/work_packages_table.html
+++ b/public/templates/work_packages/work_packages_table.html
@@ -141,7 +141,7 @@
                ($last || row.groupName !== rows[$index+1].groupName)"
         ng-show="!groupByColumn || groupExpanded[row.groupName]"
         ng-class="[
-          $even && 'odd' || 'even',
+          'group-sum',
           'sum',
           'grouped',
           'issue',
@@ -149,7 +149,10 @@
         ]">
         <td colspan="{{3  - (!!hideWorkPackageDetails * 1)}}">
           {{ I18n.t('js.label_sum_for') }}
-          <span work-package-column work-package="row.object" column="groupByColumn"/>
+          <span work-package-column
+                work-package="row.object"
+                column="groupByColumn"
+                display-empty="-"/>
         </td>
         <td ng-repeat="column in columns">
           {{ column.group_sums[row.groupName] }}


### PR DESCRIPTION
https://www.openproject.org/work_packages/9835

Group sum rows were using the odd/even highlighting which was unwanted. Just highlighting them all now (assuming that's what we want).
'Sum for...' labels for 'none' groups didn't have a label here. I set the default to be '-' so that it matches the group header.
