### PR TITLE
Fix padding for arrow in selectable query title

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.css.sass
+++ b/app/assets/stylesheets/layout/_toolbar.css.sass
@@ -21,7 +21,7 @@
   li
     float: left
     &.toolbar-item
-      margin: 5px //$drop-nav-spacing // spacing between nav items
+      margin: 0 5px //$drop-nav-spacing // spacing between nav items
 
   button
     margin-right: 0
@@ -41,6 +41,7 @@
 
   h2
     border: 0
+    padding: 12px 0 0 0
 
   span
     color: $content_link_color
@@ -118,5 +119,6 @@
   i
     float: right
     color: #333333
+    padding-left: 5px
   &:hover
     text-decoration: none


### PR DESCRIPTION
- fixed padding for arrow in selectable query title
- added some space to H2 title, so that title and toolbar are on one
  line

https://www.openproject.org/work_packages/9895
