### PR TITLE
limits padding to work_packages show/update

### DIFF
--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -26,9 +26,11 @@
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
 
-#content
-  h2
-    padding-right: 340px
+body.controller-work_packages.action-show,
+body.controller-work_packages.action-update
+  #content
+    h2
+      padding-right: 340px
 
 
 h1


### PR DESCRIPTION
It was introduced to prevent long work package names from overlapping the menu. The problem seems to only exist there

https://www.openproject.org/work_packages/8457
