### PR TITLE
[Feature] 11253 copy project error messages always in english

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,6 +32,8 @@ class UserMailer < ActionMailer::Base
          :work_packages, # for css classes
          :custom_fields # for show_value
 
+  include OpenProject::LocaleHelper
+
   # wrap in a lambda to allow changing at run-time
   default :from => Proc.new { Setting.mail_from }
 
@@ -390,11 +392,6 @@ private
 
   def references(object, user)
     headers['References'] = "<#{self.class.generate_message_id(object, user)}>"
-  end
-
-  def with_locale_for(user, &block)
-    locale = user.language.presence || Setting.default_language.presence || I18n.default_locale
-    I18n.with_locale(locale, &block)
   end
 
   # Prepends given fields with 'X-OpenProject-' to save some duplication

--- a/app/models/copy_project_job.rb
+++ b/app/models/copy_project_job.rb
@@ -33,13 +33,16 @@ class CopyProjectJob < Struct.new(:user,
                                   :enabled_modules,
                                   :associations_to_copy,
                                   :send_mails)
+  include OpenProject::LocaleHelper
 
   def perform
-    target_project, errors = create_project_copy(source_project,
-                                                 target_project_params,
-                                                 enabled_modules,
-                                                 associations_to_copy,
-                                                 send_mails)
+    target_project, errors = with_locale_for(user) do
+      create_project_copy(source_project,
+                          target_project_params,
+                          enabled_modules,
+                          associations_to_copy,
+                          send_mails)
+    end
 
     if target_project
       UserMailer.delay.copy_project_succeeded(user, source_project, target_project, errors)

--- a/lib/open_project/locale_helper.rb
+++ b/lib/open_project/locale_helper.rb
@@ -1,0 +1,37 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module LocaleHelper
+    def with_locale_for(user, &block)
+      locale = user.language.presence || Setting.default_language.presence || I18n.default_locale
+      I18n.with_locale(locale, &block)
+    end
+  end
+end

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -130,7 +130,6 @@ describe CopyProjectsController do
 
         copy_project(project)
       end
-
     end
   end
 end

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -46,7 +46,7 @@ describe CopyProjectJob do
       allow(UserMailer).to receive(:copy_project_failed).and_return(double("mailer", deliver: true))
     end
 
-    it 'calls #with_locale_for' do
+    it 'sets locale correctly' do
       expect(copy_job).to receive(:create_project_copy) do |*args|
         expect(I18n.locale).to eq(:de)
         [nil, nil]

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -43,7 +43,11 @@ describe CopyProjectJob do
 
   describe 'copy localizes error message' do
     before do
-      allow(UserMailer).to receive(:copy_project_failed).and_return(double("mailer", deliver: true))
+      # 'Delayed Job' uses a work around to get Rails 3 mailers working with it
+      # (see https://github.com/collectiveidea/delayed_job#rails-3-mailers).
+      # Thus, we need to return a message object here, otherwise 'Delayed Job'
+      # will complain about an object without a method #deliver.
+      allow(UserMailer).to receive(:copy_project_failed).and_return(double("Mail::Message", deliver: true))
     end
 
     it 'sets locale correctly' do

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -1,0 +1,58 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CopyProjectJob do
+
+  let(:user) { FactoryGirl.create(:admin, language: :de) }
+  let(:source_project) { FactoryGirl.create(:project) }
+  let(:target_project) { FactoryGirl.create(:project) }
+
+  let(:copy_job) { CopyProjectJob.new user,
+                                      source_project,
+                                      target_project,
+                                      [], # enabled modules
+                                      [], # associations
+                                      false } # send mails
+
+  describe 'copy localizes error message' do
+    before do
+      allow(UserMailer).to receive(:copy_project_failed).and_return(double("mailer", deliver: true))
+    end
+
+    it 'calls #with_locale_for' do
+      expect(copy_job).to receive(:create_project_copy) do |*args|
+        expect(I18n.locale).to eq(:de)
+        [nil, nil]
+      end
+
+      copy_job.perform
+    end
+  end
+end


### PR DESCRIPTION
[`* `#11253` Copy project always returns non-localized error messages`](https://www.openproject.org/work_packages/11253)
