### PR TITLE
Paths for api corrected for saving queries without project

### DIFF
--- a/app/assets/javascripts/angular/helpers/components/path-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/path-helper.js
@@ -118,10 +118,10 @@ angular.module('openproject.helpers')
     apiV2ProjectPath: function(projectIdentifier) {
       return PathHelper.apiPrefixV2 + PathHelper.projectPath(projectIdentifier);
     },
-    apiV3ProjectsPath: function(){
+    apiProjectsPath: function(){
       return PathHelper.apiPrefixExperimental + PathHelper.projectsPath();
     },
-    apiV3ProjectPath: function(projectIdentifier) {
+    apiProjectPath: function(projectIdentifier) {
       return PathHelper.apiPrefixExperimental + PathHelper.projectPath(projectIdentifier);
     },
     apiV3QueryPath: function(queryId) {
@@ -131,34 +131,40 @@ angular.module('openproject.helpers')
       return PathHelper.apiPrefixExperimental + '/work_packages';
     },
     apiProjectWorkPackagesPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.workPackagesPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.workPackagesPath();
     },
     apiProjectSubProjectsPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.subProjectsPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.subProjectsPath();
     },
     apiProjectQueriesPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/queries';
+      return PathHelper.apiProjectPath(projectIdentifier) + '/queries';
     },
     apiProjectQueryPath: function(projectIdentifier, queryIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.queryPath(queryIdentifier);
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.queryPath(queryIdentifier);
+    },
+    apiQueriesPath: function() {
+      return PathHelper.apiPrefixExperimental + '/queries';
+    },
+    apiQueryPath: function(query_id) {
+      return PathHelper.apiQueriesPath() + '/' + query_id;
     },
     apiGroupedQueriesPath: function() {
-      return PathHelper.apiPrefixExperimental + '/queries/grouped';
+      return PathHelper.apiQueriesPath() + '/grouped';
     },
     apiAvailableColumnsPath: function() {
-      return PathHelper.apiPrefixExperimental + '/queries/available_columns';
+      return PathHelper.apiQueriesPath() + '/available_columns';
     },
     apiCustomFieldsPath: function() {
-      return PathHelper.apiPrefixExperimental + '/queries/custom_field_filters';
+      return PathHelper.apiQueriesPath() + '/custom_field_filters';
     },
     apiProjectCustomFieldsPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/queries/custom_field_filters';
+      return PathHelper.apiProjectPath(projectIdentifier) + '/queries/custom_field_filters';
     },
     apiProjectAvailableColumnsPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/queries/available_columns';
+      return PathHelper.apiProjectPath(projectIdentifier) + '/queries/available_columns';
     },
     apiProjectGroupedQueriesPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/queries/grouped';
+      return PathHelper.apiProjectPath(projectIdentifier) + '/queries/grouped';
     },
     apiQueryStarPath: function(queryId) {
       return PathHelper.apiV3QueryPath(queryId) + '/star';
@@ -194,13 +200,13 @@ angular.module('openproject.helpers')
       return PathHelper.apiPrefixExperimental + PathHelper.usersPath();
     },
     apiProjectVersionsPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.versionsPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.versionsPath();
     },
     apiProjectUsersPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.usersPath();
-    },
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.usersPath();
+    },  
     apiProjectWorkPackagesSumsPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectPath(projectIdentifier) + PathHelper.workPackagesPath() + '/column_sums';
+      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.workPackagesPath() + '/column_sums';
     },
     apiWorkPackagesSumsPath: function() {
       return PathHelper.apiWorkPackagesPath() + '/column_sums';

--- a/app/assets/javascripts/angular/services/project-service.js
+++ b/app/assets/javascripts/angular/services/project-service.js
@@ -4,7 +4,7 @@ angular.module('openproject.services')
 
   var ProjectService = {
     getProject: function(projectIdentifier) {
-      var url = PathHelper.apiV3ProjectPath(projectIdentifier);
+      var url = PathHelper.apiProjectPath(projectIdentifier);
 
       return $http.get(url).then(function(response) {
         return response.data.project;
@@ -12,7 +12,7 @@ angular.module('openproject.services')
     },
 
     getProjects: function() {
-      var url = PathHelper.apiV3ProjectsPath();
+      var url = PathHelper.apiProjectsPath();
 
       return ProjectService.doQuery(url)
         .then(function(projects){

--- a/app/assets/javascripts/angular/services/query-service.js
+++ b/app/assets/javascripts/angular/services/query-service.js
@@ -298,7 +298,8 @@ angular.module('openproject.services')
     // synchronization
 
     saveQuery: function() {
-      var url = PathHelper.apiProjectQueryPath(query.project_id, query.id);
+      var url = query.project_id ? PathHelper.apiProjectQueryPath(query.project_id, query.id) : PathHelper.apiQueryPath(query.id);
+
       return QueryService.doQuery(url, query.toUpdateParams(), 'PUT', function(response){
         QueryService.fetchAvailableGroupedQueries(query.project_id);
 
@@ -308,7 +309,8 @@ angular.module('openproject.services')
 
     saveQueryAs: function(name) {
       query.setName(name);
-      var url = PathHelper.apiProjectQueriesPath(query.project_id);
+      var url = query.project_id ? PathHelper.apiProjectQueriesPath(query.project_id) : PathHelper.apiQueriesPath();
+
       return QueryService.doQuery(url, query.toParams(), 'POST', function(response){
         query.save(response.data.query);
         QueryService.fetchAvailableGroupedQueries(query.project_id);

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -183,8 +183,8 @@ module Api
 
       def work_packages_links
         links = {}
-        links[:create] = api_experimental_query_path(@project) if User.current.allowed_to?(:add_work_packages, @project)
-        links[:export] = api_experimental_query_path(@project) if User.current.allowed_to?(:export_work_packages, @project)
+        links[:create] = api_experimental_work_packages_path(@project) if User.current.allowed_to?(:add_work_packages, @project)
+        links[:export] = api_experimental_work_packages_path(@project) if User.current.allowed_to?(:export_work_packages, @project, :global => @project.nil?)
         links
       end
 

--- a/public/templates/work_packages.list.html
+++ b/public/templates/work_packages.list.html
@@ -9,7 +9,7 @@
         <button class="button_highlight"
                 with-dropdown
                 dropdown-id="tasksDropdown"
-                ng-disabled="AuthorisationService.cannot('work_package', 'create')">
+                ng-disabled="cannot('work_package', 'create')">
           <i class="icon-add icon4"></i>
           {{ I18n.t('js.toolbar.unselected_title') }}
           <i class="icon-pulldown-arrow1 icon-dropdown"></i>


### PR DESCRIPTION
[`* `#11101` Not possible to save queries or to change their visibility in project-independent work package list`](https://www.openproject.org/work_packages/11101)

Was attempting to save to the project query path when there was no project. Also have cleaned up the path helper names a little bit.
