### PR TITLE
Made Christoph's heading styles apply just to work packages views.

### DIFF
--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -32,12 +32,14 @@ body.controller-work_packages.action-update
     h2
       padding-right: 340px
 
-
-h1
-  @include default-headline-h1
-h2
-  @include default-headline-h2
-h3
-  @include default-headline-h3
-h4
-  @include default-headline-h4
+body.controller-work_packages.action-index,
+body.controller-work_packages.action-show,
+body.controller-work_packages.action-update
+  h1
+    @include default-headline-h1
+  h2
+    @include default-headline-h2
+  h3
+    @include default-headline-h3
+  h4
+    @include default-headline-h4

--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -32,14 +32,11 @@ body.controller-work_packages.action-update
     h2
       padding-right: 340px
 
-body.controller-work_packages.action-index,
-body.controller-work_packages.action-show,
-body.controller-work_packages.action-update
-  h1
-    @include default-headline-h1
-  h2
-    @include default-headline-h2
-  h3
-    @include default-headline-h3
-  h4
-    @include default-headline-h4
+h1
+  @include default-headline-h1
+h2
+  @include default-headline-h2
+h3
+  @include default-headline-h3
+h4
+  @include default-headline-h4

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -30,8 +30,19 @@
 div.wiki
   font-size: $wiki_default_font_size
   line-height: 1.6em
-  h1, h2
+  h1
+    font-size: 18px
+  h2
+    font-size: 16px
+  h3
+    font-size: 13px
+    border-bottom: 1px dotted #bbbbbb
+  h1, h2, h3
     margin: 1em 0 1em 0
+    font-weight: bold
+    color: #555555
+    text-transform: none
+    border-bottom: 1px solid #bbbbbb
 
   table
     border: 1px solid #505050


### PR DESCRIPTION
[`* `#10773` Headlines in Wiki pages inconsistent`](https://www.openproject.org/work_packages/10773)

Hopefully this will make other views appear as they did previously. I only checked the wiki page which to me looks like it does in the screenshot of the old version.
