### PR TITLE
Fix/auth saving newly saved queries 11942

### DIFF
--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -70,6 +70,7 @@ angular.module('openproject.models')
       return angular.extend.apply(this, [
         {
           'id': this.id,
+          'query_id': this.id,
           'f[]': this.getFilterNames(this.getActiveConfiguredFilters()),
           'c[]': this.getParamColumns(),
           'group_by': this.groupBy,

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -56,7 +56,7 @@ angular.module('openproject.services')
 
     getWorkPackages: function(projectIdentifier, query, paginationOptions) {
       var url = projectIdentifier ? PathHelper.apiProjectWorkPackagesPath(projectIdentifier) : PathHelper.apiWorkPackagesPath();
-      var params = angular.extend(query.toParams(), {
+      var params = angular.extend(query.toUpdateParams(), {
         page: paginationOptions.page,
         per_page: paginationOptions.perPage
       });

--- a/app/controllers/api/experimental/concerns/query_loading.rb
+++ b/app/controllers/api/experimental/concerns/query_loading.rb
@@ -1,0 +1,63 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This is an alternative to retrieve_query in the old queryies helper.
+# Differences being that it's not looking to the session and also existing
+# queries will be augmented with the params data passed with them.
+module Api::Experimental::Concerns::QueryLoading
+  def init_query
+    if !params[:query_id].blank?
+      cond = "project_id IS NULL"
+      cond << " OR project_id = #{@project.id}" if @project
+      @query = Query.find(params[:query_id], :conditions => cond)
+      @query.project = @project
+    else
+      @query = Query.new({name: "_", :project => @project})
+    end
+    prepare_query
+    @query
+  end
+
+  def prepare_query
+    @query.is_public = false unless User.current.allowed_to?(:manage_public_queries, @project) || User.current.admin?
+    view_context.add_filter_from_params if params[:fields] || params[:f]
+    @query.group_by = params[:group_by] if params[:group_by].present?
+    @query.sort_criteria = prepare_sort_criteria if params[:sort]
+    @query.display_sums = params[:display_sums] if params[:display_sums].present?
+    @query.column_names = params[:c] if params[:c]
+    @query.column_names = nil if params[:default_columns]
+    @query.name = params[:name] if params[:name]
+    @query.is_public = params[:is_public] if params[:is_public]
+  end
+
+  def prepare_sort_criteria
+    # Note: There was a convention to have sortation strings in the form "type:desc,status:asc".
+    # For the sake of not breaking from convention we encoding/decoding the sortation.
+    params[:sort].split(',').collect{|p| [p.split(':')[0], p.split(':')[1] || 'asc']}
+  end
+end

--- a/app/controllers/api/experimental/concerns/query_loading.rb
+++ b/app/controllers/api/experimental/concerns/query_loading.rb
@@ -32,10 +32,8 @@
 module Api::Experimental::Concerns::QueryLoading
   def init_query
     if !params[:query_id].blank?
-      cond = "project_id IS NULL"
-      cond << " OR project_id = #{@project.id}" if @project
-      @query = Query.find(params[:query_id], :conditions => cond)
-      @query.project = @project
+      @query = Query.find(params[:query_id])
+      @query.project = @project if @query.project.nil?
     else
       @query = Query.new({name: "_", :project => @project})
     end

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -37,6 +37,7 @@ module Api
       include ApiController
       include Concerns::GrapeRouting
       include Concerns::ColumnData
+      include Concerns::QueryLoading
 
       include PaginationHelper
       include QueriesHelper
@@ -121,7 +122,7 @@ module Api
       end
 
       def load_query
-        @query ||= retrieve_query
+        @query ||= init_query
       rescue ActiveRecord::RecordNotFound
         render_404
       end

--- a/spec/controllers/api/experimental/work_packages_controller_spec.rb
+++ b/spec/controllers/api/experimental/work_packages_controller_spec.rb
@@ -62,6 +62,8 @@ describe Api::Experimental::WorkPackagesController do
                                             type: type,
                                             status: status_1,
                                             project: project_2) }
+  let(:query_1) { FactoryGirl.create(:query,
+                                     project: project_1) }
 
 
   let(:current_user) { FactoryGirl.create(:admin) }
@@ -103,11 +105,11 @@ describe Api::Experimental::WorkPackagesController do
         controller.stub(:set_work_packages_meta_data)
       end
 
-      context 'with 2 work packages' do
-        let(:work_packages) { [ work_package_1, work_package_2 ] }
+      context 'with project_1 work packages' do
+        let(:work_packages) { [ work_package_1, work_package_2, work_package_3 ] }
 
         it 'assigns work packages array + actions' do
-          get 'index', format: 'xml', query_id: 1
+          get 'index', format: 'xml', query_id: query_1.id, project_id: project_1.id
 
           expect(assigns(:work_packages).size).to eq(2)
 
@@ -119,11 +121,11 @@ describe Api::Experimental::WorkPackagesController do
         end
       end
 
-      context 'with 3 work packages' do
+      context 'with default query' do
         let(:work_packages) { [ work_package_1, work_package_2, work_package_3 ] }
 
         it 'assigns work packages array + actions' do
-          get 'index', format: 'xml', query_id: 1
+          get 'index', format: 'xml'
 
           expect(assigns(:work_packages).size).to eq(3)
           expect(assigns(:project)).to be_nil


### PR DESCRIPTION
[`* `#11942` When saving work packages and making changes that update WP list changes cannot be saved`](https://www.openproject.org/work_packages/11942)

I finally got too irritated with the old retrieve_query method and have re-implemented it in a simpler way in app/controllers/api/experimental/concerns/query_loading.rb. The experimental api controllers now use this but everything else still uses the old one so hopefully i didn't break anything.

The problem was that when using retrieve_query you couldn't pass a query_id to it because it would just load the query and ignore any other params. The result was that when you save a query and then make a change to it (add a filter, whatever) the workaround was to pass the modified query as params but without its id so that the backend would pay attention to it and not just load the saved query. This approach no longer works when returning the authorised query actions because it means that modified queries appear to be new (as they have no id) which means the user isn't allowed to update them. Hence the greyed out 'Save' action.

The fix was to re-write retreive_query. Now it doesn't look to the session at all, will load the query if you give it a query_id param and then will also update any of the attributes if you pass them as params.

Note: I actually did start writing some specs for this but once i saw how much of a bummer it's going to be to get all the the correct data in there to produce meaningful meta data it just didn't seem like a good way to spend my time considering if all goes to plan we're not even going to be using this code in a month. Feel free to object, perhaps i'm being lazy.
