### PR TITLE
Quick fix to prevent long names wrecking the timelines view.

### DIFF
--- a/public/templates/timelines/timeline_table.html
+++ b/public/templates/timelines/timeline_table.html
@@ -50,7 +50,7 @@
           </span>
 
           <span>
-            <a href="{{row.url}}" modal title="{{row.text}}" target="row.url" ng-class="{'tl-discreet-link': true, 'tl-project': rowObjectType === 'Project'}">{{row.text}}</a>
+            <a href="{{row.url}}" modal title="{{row.text}}" target="row.url" ng-class="{'tl-discreet-link': true, 'tl-project': rowObjectType === 'Project'}">{{ row.text | characters:40 }}</a>
           </span>
 
           <div ng-show="row.lastVisible" class="tl-invisible" style="height: 15px; width: 15px;"></div>


### PR DESCRIPTION
https://www.openproject.org/work_packages/7178

This isn't as good as it was pre-angular; used to be that there was a max width for the section with project and work package names and then they would get truncated nicely so that this width would never be exceeded. I tried making one like this as an angular directive but it had lots of jquery calls inside watchers which made it slow and unusable.

Robin said a quick fix for this would be fine so here it is;) Works in most cases but if you have many nested long names then it will push the width of the first column out indefinitely.
