### PR TITLE
Fix noisy Reform model accessor deprecation warnings

### DIFF
--- a/lib/api/v3/queries/query_model.rb
+++ b/lib/api/v3/queries/query_model.rb
@@ -48,6 +48,10 @@ module API
         property :sort_criteria, on: :query, type: String
         property :group_by, on: :query, type: String
         property :display_sums, on: :query, type: String
+
+        def query
+          model[:query]
+        end
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_model.rb
+++ b/lib/api/v3/work_packages/work_package_model.rb
@@ -51,6 +51,10 @@ module API
         property :assigned_to_id, on: :work_package, type: Integer
         property :fixed_version_id, on: :work_package, type: Integer
 
+        def work_package
+          model[:work_package]
+        end
+
         def type
           work_package.type.try(:name)
         end


### PR DESCRIPTION
```
[Reform] Deprecation WARNING: When using Composition, you may not call Form#query anymore to access the contained model. Please use Form#model[:query] and have a lovely day!
```

See https://github.com/apotonick/reform/blob/master/CHANGES.md#101
