### PR TITLE
Revert "Enable Bundler caching on Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ language: ruby
 rvm:
   - 2.1
 sudo: false
-cache: bundler
 branches:
   only:
     - dev


### PR DESCRIPTION
This reverts commit 4364e6a59afa0d1341fff5ff0383068680439b5c.

http://docs.travis-ci.com/user/caching/

> The features described here are currently only available
> for **private repositories** on travis-ci.com.
