### PR TITLE
API authentication now respects application wide login_required setting

### DIFF
--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -45,7 +45,7 @@ module API
       end
 
       def authenticate
-        raise API::Errors::Unauthenticated.new if current_user.nil? || current_user.anonymous?
+        raise API::Errors::Unauthenticated.new if current_user.nil? || current_user.anonymous? if Setting.login_required?
       end
 
       def authorize(api, endpoint, context: nil, global: false, user: current_user, allow: true)

--- a/spec/api/work_package_resource_spec.rb
+++ b/spec/api/work_package_resource_spec.rb
@@ -108,12 +108,12 @@ describe 'API v3 Work package resource' do
       end
 
       it 'should respond with 401' do
-        last_response.status.should eq(401)
+        last_response.status.should eq(403)
       end
 
       it 'should respond with explanatory error message' do
         parsed_errors = JSON.parse(last_response.body)['errors']
-        parsed_errors.should eq([{ 'key' => 'not_authenticated', 'messages' => ['You need to be authenticated to access this resource']}])
+        parsed_errors.should eq([{ 'key' => 'not_authorized', 'messages' => ['You are not authorize to access this resource']}])
       end
     end
 


### PR DESCRIPTION
The permission for accessing user resource is pretty simple for now: Depending on the application setting (login_required) we either allow access to everyone, or only to logged in users. 
This PR also takes care of bug, when it was not possible to access public project's work packages for anonymous user (https://www.openproject.org/work_packages/13689)
