### PR TITLE
Added created on date to wp details header.

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -96,6 +96,7 @@ de:
     label_none: "kein"
     label_not_contains: "enthält nicht"
     label_not_equals: "ist nicht"
+    label_on: "am"
     label_open_menu: "Menü öffnen"
     label_open_work_packages: "offen"
     label_previous: "Zurück"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -96,6 +96,7 @@ en:
     label_none: "none"
     label_not_contains: "doesn't contain"
     label_not_equals: "is not"
+    label_on: "on"
     label_open_menu: "Open menu"
     label_open_work_packages: "open"
     label_previous: "Previous"

--- a/public/templates/work_packages.list.details.html
+++ b/public/templates/work_packages.list.details.html
@@ -33,7 +33,7 @@
     <i class="star icon-star1"/>
     <a href>#{{ workPackage.props.id }}</a>
     <span ng-bind="I18n.t('js.label_added_by')"/>
-    <a ng-href="{{ userPath(workPackage.embedded.author.props.id) }}" ng-bind="workPackage.embedded.author.props.firstName + ' ' + workPackage.embedded.author.props.lastName"/>.
+    <a ng-href="{{ userPath(workPackage.embedded.author.props.id) }}" ng-bind="workPackage.embedded.author.props.firstName + ' ' + workPackage.embedded.author.props.lastName"/> <span ng-bind="I18n.t('js.label_on')"/> <span ng-bind="workPackage.props.createdAt|date:'longDate'"/>.
     <span ng-bind="I18n.t('js.label_last_updated_on')"/>
     <span ng-bind="workPackage.props.updatedAt|date:'longDate'"/>.
   </span>


### PR DESCRIPTION
https://www.openproject.org/work_packages/13600

As discussed we're not going for the "1 month ago" style dates from the old version right now.
