### PR TITLE
Replace default route part 1

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,6 +336,8 @@ OpenProject::Application.routes.draw do
     end
   end
 
+  get "/admin" => 'admin#index'
+
   #TODO: evaluate whether this can be turned into a namespace
   scope "admin" do
     match "/projects" => 'admin#projects', :via => :get

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ OpenProject::Application.routes.draw do
     get '/account/force_password_change', :action => 'force_password_change'
     post '/account/change_password', :action => 'change_password'
     match '/account/lost_password', action: 'lost_password', via: [:get, :post]
+    match '/account/register', action: 'register', via: [:get, :post]
 
     # omniauth routes
     match '/auth/:provider/callback', :action => 'omniauth_login',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,9 @@ OpenProject::Application.routes.draw do
     # this could probably be rewritten with a resource :as => 'roadmap'
     match '/roadmap' => 'versions#index', :via => :get
 
+    # :id is the project id, complete route is /projects/types/:id
+    post '/types/:id' => 'projects#types', on: :collection
+
     resources :news, :only => [:index, :new, :create]
 
     namespace :time_entries do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -483,6 +483,9 @@ OpenProject::Application.routes.draw do
   end
 
   scope :controller => 'my' do
+    post '/my/add_block', action: 'add_block'
+    post '/my/remove_block', action: 'remove_block'
+    get '/my/page_layout', action: 'page_layout'
     get '/my/password', :action => 'password'
     post '/my/change_password', :action => 'change_password'
     match '/my/first_login', :action => 'first_login', :via => [:get, :put]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -531,6 +531,12 @@ OpenProject::Application.routes.draw do
 
   resources :reported_project_statuses, :controller => 'reported_project_statuses'
 
+  # This route should probably be removed, but it's used at least by one cuke and we don't
+  # want to break it.
+  # This route intentionally occurs after the admin/roles/new route, so that one takes
+  # precedence when creating routes (possibly via helpers).
+  get 'roles/new' => 'roles#new', as: 'deprecated_roles_new'
+
   # Install the default route as the lowest priority.
   match '/:controller(/:action(/:id))'
   match '/robots' => 'welcome#robots', :defaults => { :format => :txt }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -413,6 +413,8 @@ OpenProject::Application.routes.draw do
     post :preview, on: :collection
     post :preview, on: :member
 
+    get 'quoted/:id', action: 'quoted', on: :collection
+
     get '/edit' => 'work_packages#edit', on: :member # made explicit to avoid conflict with catch-all route
     # states managed by client-side routing on work_package#index
     get '/*state' => 'work_packages#index', on: :member, id: /\d+/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -385,6 +385,13 @@ OpenProject::Application.routes.draw do
     match 'plugin/:id', action: 'plugin', via: [:get, :post]
   end
 
+  # We should fix this crappy routing (split up and rename controller methods)
+  get '/workflows' => 'workflows#index'
+  scope 'workflows', controller: 'workflows' do
+    match 'edit', action: 'edit', via: [:get, :post]
+    match 'copy', action: 'copy', via: [:get, :post]
+  end
+
   namespace :work_packages do
     match 'auto_complete' => 'auto_completes#index', :via => [:get, :post]
     resources :calendar, :controller => 'calendars', :only => [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,10 @@ OpenProject::Application.routes.draw do
   match '/roles/workflow/:id/:role_id/:type_id' => 'roles#workflow'
   match '/help/:ctrl/:page' => 'help#index'
 
-  resources :types
+  resources :types do
+    post 'move/:id', action: 'move', on: :collection
+  end
+
   resources :statuses, :except => :show do
     collection do
       post 'update_work_package_done_ratio'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ OpenProject::Application.routes.draw do
   scope :controller => 'account' do
     get '/account/force_password_change', :action => 'force_password_change'
     post '/account/change_password', :action => 'change_password'
-    get '/account/lost_password', :action => 'lost_password'
+    match '/account/lost_password', action: 'lost_password', via: [:get, :post]
 
     # omniauth routes
     match '/auth/:provider/callback', :action => 'omniauth_login',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,13 @@ OpenProject::Application.routes.draw do
     end
   end
 
+  # We should fix this crappy routing (split up and rename controller methods)
+  get '/settings' => 'settings#index'
+  scope 'settings', controller: 'settings' do
+    match 'edit', action: 'edit', via: [:get, :post]
+    match 'plugin/:id', action: 'plugin', via: [:get, :post]
+  end
+
   namespace :work_packages do
     match 'auto_complete' => 'auto_completes#index', :via => [:get, :post]
     resources :calendar, :controller => 'calendars', :only => [:index]

--- a/spec/routing/account_spec.rb
+++ b/spec/routing/account_spec.rb
@@ -36,4 +36,12 @@ describe 'account routes' do
   it '/account/lost_password POST routes to account#lost_password' do
     expect(post('/account/lost_password')).to route_to('account#lost_password')
   end
+
+  it '/accounts/register GET routes to account#register' do
+    expect(get('/account/register')).to route_to('account#register')
+  end
+
+  it '/accounts/register POST routes to account#register' do
+    expect(post('/account/register')).to route_to('account#register')
+  end
 end

--- a/spec/routing/account_spec.rb
+++ b/spec/routing/account_spec.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'account routes' do
+  it '/account/lost_password GET routes to account#lost_password' do
+    expect(get('/account/lost_password')).to route_to('account#lost_password')
+  end
+
+  it '/account/lost_password POST routes to account#lost_password' do
+    expect(post('/account/lost_password')).to route_to('account#lost_password')
+  end
+end

--- a/spec/routing/admin_spec.rb
+++ b/spec/routing/admin_spec.rb
@@ -1,0 +1,35 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'admin routes' do
+  it '/admin routes to admin#index' do
+    expect(get('/admin')).to route_to('admin#index')
+  end
+end

--- a/spec/routing/my_spec.rb
+++ b/spec/routing/my_spec.rb
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'my routes' do
+  it '/my/add_block POST routes to my#add_block' do
+    expect(post('/my/add_block')).to route_to('my#add_block')
+  end
+
+  it '/my/page_layout GET routes to my#page_layout' do
+    expect(get('/my/page_layout')).to route_to('my#page_layout')
+  end
+
+  it '/my/remove_block POST routes to my#remove_block' do
+    expect(post('/my/remove_block')).to route_to('my#remove_block')
+  end
+end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -76,4 +76,12 @@ describe ProjectsController do
     it { expect(get("projects/123/copy_project_from_settings")).to route_to(:controller => 'copy_projects', :action =>"copy_project", :id =>"123", :coming_from => "settings")}
     it { expect(post("projects/123/copy")).to                      route_to(:controller => 'copy_projects', :action =>"copy",         :id =>"123")}
   end
+
+  describe 'types' do
+    it do
+      expect(post('/projects/types/123')).to route_to(controller: 'projects',
+                                                      action: 'types',
+                                                      id: '123')
+    end
+  end
 end

--- a/spec/routing/roles_spec.rb
+++ b/spec/routing/roles_spec.rb
@@ -1,0 +1,38 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'roles routes' do
+
+  describe 'new' do
+    it do
+      expect(get('/roles/new')).to route_to('roles#new')
+    end
+  end
+end

--- a/spec/routing/settings_spec.rb
+++ b/spec/routing/settings_spec.rb
@@ -1,0 +1,46 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'settings routes' do
+  it { expect(get('/settings')).to route_to('settings#index') }
+  it { expect(get('/settings/edit')).to route_to('settings#edit') }
+  it { expect(post('/settings/edit')).to route_to('settings#edit') }
+
+  it do
+    expect(get('/settings/plugin/abc')).to route_to(controller: 'settings',
+                                                    action: 'plugin',
+                                                    id: 'abc')
+  end
+  it do
+    expect(post('/settings/plugin/abc')).to route_to(controller: 'settings',
+                                                     action: 'plugin',
+                                                     id: 'abc')
+  end
+end

--- a/spec/routing/status_routing_spec.rb
+++ b/spec/routing/status_routing_spec.rb
@@ -52,6 +52,10 @@ describe StatusesController do
   end
 
   describe "update_work_package_done_ratio" do
-    it { expect(get("/statuses/update_work_package_done_ratio")).to route_to(:controller => 'statuses', :action =>"update_work_package_done_ratio")}
+    it do
+      expect(post('/statuses/update_work_package_done_ratio')).to route_to(
+        controller: 'statuses',
+        action: 'update_work_package_done_ratio')
+    end
   end
 end

--- a/spec/routing/types_spec.rb
+++ b/spec/routing/types_spec.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'types routes' do
+  it do
+    expect(post('/types/move/123')).to route_to(controller: 'types',
+                                                action: 'move',
+                                                id: '123')
+  end
+end

--- a/spec/routing/work_packages_spec.rb
+++ b/spec/routing/work_packages_spec.rb
@@ -125,6 +125,12 @@ describe WorkPackagesController do
                                                             :action => 'create' )
   end
 
+  it do
+    expect(get('/work_packages/quoted/1')).to route_to(controller: 'work_packages',
+                                                       action: 'quoted',
+                                                       id: '1')
+  end
+
   it "should connect PUT /work_packages/1 to work_packages#update" do
     expect(put("/work_packages/1")).to route_to( :controller => 'work_packages',
                                              :action => 'update',

--- a/spec/routing/workflows_spec.rb
+++ b/spec/routing/workflows_spec.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'workflows routes' do
+  it { expect(get('/workflows')).to route_to('workflows#index') }
+
+  it { expect(get('/workflows/edit')).to route_to('workflows#edit') }
+  it { expect(post('/workflows/edit')).to route_to('workflows#edit') }
+
+  it { expect(get('/workflows/copy')).to route_to('workflows#copy') }
+  it { expect(post('/workflows/copy')).to route_to('workflows#copy') }
+end


### PR DESCRIPTION
This adds route for most of the missing routes I found via running core cukes and specs.

I tried to change as little as possible in order to break as little as possible. I.e. I didn't split up or rename controller actions even if that was desirable.

See the ticket or the commits for a list:
https://www.openproject.org/work_packages/4996

**Note:** Before merging this, we should make sure this works with all plugins.
