### PR TITLE
Fix/wp textile rendering

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -196,38 +196,13 @@ module WorkPackagesHelper
   end
 
   def work_package_quick_info_with_description(work_package, lines = 3)
-    description_lines = work_package.description.to_s.lines.to_a[0,lines]
-
-    if description_lines[lines-1] && work_package.description.to_s.lines.to_a.size > lines
-      description_lines[lines-1].strip!
-
-      while !description_lines[lines-1].end_with?("...") do
-        description_lines[lines-1] = description_lines[lines-1] + "."
-      end
-    end
-
-    description = if work_package.description.blank?
-                    empty_element_tag
-                  else
-                    format_text(description_lines.join(""))
-                  end
+    description = truncated_work_package_description(work_package, lines)
 
     link = work_package_quick_info(work_package)
 
-    link += content_tag(:div, :class => 'indent quick_info attributes') do
+    attributes = info_user_attributes(work_package)
 
-      responsible = if work_package.responsible_id.present?
-                      "<span class='label'>#{WorkPackage.human_attribute_name(:responsible)}:</span> " +
-                      "#{work_package.responsible.name}"
-                    end
-
-      assignee = if work_package.assigned_to_id.present?
-                   "<span class='label'>#{WorkPackage.human_attribute_name(:assigned_to)}:</span> " +
-                   "#{work_package.assigned_to.name}"
-                 end
-
-      [responsible, assignee].compact.join("<br>").html_safe
-    end
+    link += content_tag(:div, attributes, :class => 'indent quick_info attributes')
 
     link += content_tag(:div, description, :class => 'indent quick_info description')
 
@@ -649,5 +624,37 @@ module WorkPackagesHelper
        work_package_show_spent_time_attribute(work_package),
        work_package_show_fixed_version_attribute(work_package)
      ]
+  end
+
+  def truncated_work_package_description(work_package, lines = 3)
+    description_lines = work_package.description.to_s.lines.to_a[0,lines]
+
+    if description_lines[lines-1] && work_package.description.to_s.lines.to_a.size > lines
+      description_lines[lines-1].strip!
+
+      while !description_lines[lines-1].end_with?("...") do
+        description_lines[lines-1] = description_lines[lines-1] + "."
+      end
+    end
+
+    if work_package.description.blank?
+      empty_element_tag
+    else
+      format_text(description_lines.join(''))
+    end
+  end
+
+  def info_user_attributes(work_package)
+    responsible = if work_package.responsible_id.present?
+                    "<span class='label'>#{WorkPackage.human_attribute_name(:responsible)}:</span> " +
+                    "#{h(work_package.responsible.name)}"
+                  end
+
+    assignee = if work_package.assigned_to_id.present?
+                 "<span class='label'>#{WorkPackage.human_attribute_name(:assigned_to)}:</span> " +
+                 "#{h(work_package.assigned_to.name)}"
+               end
+
+    [responsible, assignee].compact.join("<br>").html_safe
   end
 end

--- a/lib/api/v3/activities/activity_model.rb
+++ b/lib/api/v3/activities/activity_model.rb
@@ -47,7 +47,7 @@ module API
         property :user_id, type: Integer
 
         def notes
-          format_text(model, :notes)
+          format_text(model.notes, :object => model.journable)
         end
 
         def raw_notes

--- a/lib/api/v3/activities/activity_model.rb
+++ b/lib/api/v3/activities/activity_model.rb
@@ -47,7 +47,7 @@ module API
         property :user_id, type: Integer
 
         def notes
-          format_text(raw_notes)
+          format_text(model, :notes)
         end
 
         def raw_notes

--- a/lib/api/v3/work_packages/work_package_model.rb
+++ b/lib/api/v3/work_packages/work_package_model.rb
@@ -63,7 +63,7 @@ module API
         end
 
         def description
-          format_text(work_package.description)
+          format_text(work_package, :description)
         end
 
         def raw_description

--- a/public/templates/work_packages/tabs/_user_activity.html
+++ b/public/templates/work_packages/tabs/_user_activity.html
@@ -4,7 +4,7 @@
   <img class="avatar" ng-src="{{ userAvatar }}" />
   <span class="user"><a ng-href="{{ userPath(userId) }}" name="{{ currentAnchor }}" ng-bind="userName"></a></span>
   <span class="date">commented on <span ng-bind="activity.props.createdAt | date:'short'"/></span>
-  <span class="comment">
+  <span class="comment wiki">
     <span class="message"
       ng-show="activity.props._type == 'Activity::Comment'"
       ng-bind-html="activity.props.comment"/>

--- a/public/templates/work_packages/tabs/overview.html
+++ b/public/templates/work_packages/tabs/overview.html
@@ -2,7 +2,7 @@
 
   <h3>Description</h3>
 
-  <div class="detail-panel-description-content">
+  <div class="detail-panel-description-content wiki">
     <span ng-bind-html="workPackage.props.description"/>
   </div>
 </div>


### PR DESCRIPTION
Addresses the following issues in the work package details pane when rendering textile:
- styling -> now using wiki css classes
- attachments -> correctly included because an attached to object is provided
- ###NUMBER rendering -> providing an object satisfies safety condition

This should fix most of what Robin is mentioning in https://www.openproject.org/work_packages/13560
