### PR TITLE
removes invalid , from generated html

### DIFF
--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -383,7 +383,7 @@ module OpenProject
           div_class = 'toc'
           div_class << ' right' if $1 == '>'
           div_class << ' left' if $1 == '<'
-          out = "<fieldset class='header_collapsible collapsible'><legend title='" + l(:description_toc_toggle)+ "', onclick='toggleFieldset(this);'><a href='javascript:'>#{l(:label_table_of_contents)}</a></legend><div>"
+          out = "<fieldset class='header_collapsible collapsible'><legend title='" + l(:description_toc_toggle)+ "' onclick='toggleFieldset(this);'><a href='javascript:'>#{l(:label_table_of_contents)}</a></legend><div>"
           out << "<ul class=\"#{div_class}\"><li>"
           root = headings.map(&:first).min
           current = root


### PR DESCRIPTION
removes ',' from html generated by the toc macro and by that enables using the macro within the work package description (for whatever reasons)

The angular sanitisation still removes more from the generated markup so that the toc looks different from what is expected. But given that using the macro in this context is highly unlikely I believe that is OK.

https://www.openproject.org/work_packages/13560
