### PR TITLE
places footer relatively and remove bottom padding

### DIFF
--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -52,6 +52,7 @@ body
 
   background-size: $main_menu_width 100%
   min-height: 100%
+  height: auto
   position: relative
   &.nosidebar, &.nomenus
     background: none
@@ -76,8 +77,8 @@ h4, .wiki h3
 #main
   position: relative
   z-index: 20
-  padding-bottom: 155px
   overflow: auto
+  padding-bottom: $footer_height
 
 #content
   @include default-transition

--- a/app/assets/stylesheets/layout/_footer.sass
+++ b/app/assets/stylesheets/layout/_footer.sass
@@ -31,13 +31,12 @@
   z-index: 20
   text-align: right
   width: 100%
-  position: absolute
+  position: relative
   height: $footer_height
+  margin-top: -$footer_height
   padding: 0
-  right: 0
   clear: both
   background-color: $footer_bg_color
-  bottom: 0
   @include default-font-normal($footer_font_color)
 
   .footer-content

--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -129,6 +129,10 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
   </div>
 
+
+  <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
+
+</div>
   <% if (show_decoration) %>
     <div id="footer">
       <div class="footer-content">
@@ -136,10 +140,6 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
   <% end %>
-
-  <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
-
-</div>
 <%= call_hook :view_layouts_base_body_bottom %>
 </body>
 </html>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -133,6 +133,10 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
   </div>
 
+
+  <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
+
+</div>
   <% if (show_decoration) %>
     <div id="footer">
       <div class="footer-content">
@@ -140,10 +144,6 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
   <% end %>
-
-  <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
-
-</div>
 <%= call_hook :view_layouts_base_body_bottom %>
 </body>
 </html>


### PR DESCRIPTION
alternative footer implementation that should prevent the footer from hiding the menu. It is based on [this tutorial](http://www.lwis.net/journal/2008/02/08/pure-css-sticky-footer/)

Additionally, it removes the 155px padding at the bottom which produces a lot of empty space. So e.g. https://github.com/opf/openproject/pull/1601 would no longer be necessary. However, some pages currently rely on this padding (e.g. work package, backlogs) and thus merging this without taking a look at fixing this might be hasty.
