### PR TITLE
Feature/resilient raphaël

### DIFF
--- a/app/assets/javascripts/angular/models/timelines/custom-field.js
+++ b/app/assets/javascripts/angular/models/timelines/custom-field.js
@@ -51,7 +51,7 @@
 
 // environment and other global vars
 /*jshint browser:true, devel:true*/
-/*global jQuery:false, Raphael:false, Timeline:true*/
+/*global angular:false, Timeline:true*/
 
 angular.module('openproject.timelines.models')
 

--- a/karma/tests/timeline_stubs.js
+++ b/karma/tests/timeline_stubs.js
@@ -35,8 +35,6 @@ var modalHelperInstance = {
 
 jQuery.fn.slider = {};
 
-var Raphael = {};
-
 var possibleData = {
   projects: [{
       "id":1,

--- a/lib/tasks/copyright.rake
+++ b/lib/tasks/copyright.rake
@@ -200,8 +200,6 @@ namespace :copyright do
                 "app/assets/javascripts/Bitstream_Vera_Sans_400.font.js",
                 "app/assets/javascripts/date-de-DE.js",
                 "app/assets/javascripts/date-en-US.js",
-                "app/assets/javascripts/raphael.js",
-                "app/assets/javascripts/raphael-min.js",
                 "app/assets/javascripts/jstoolbar/"]
 
     rewrite_copyright("js", excluded, :js, args[:arg1])


### PR DESCRIPTION
While revisiting my raphaël removal branch (https://github.com/opf/openproject/commit/86aac5c1b91a4f725d7f88ca9e961974c4dff572), I found it already merged. There are, however, some Raphaël references remaining in the codebase. This patch removes them.
