### PR TITLE
Fixes a padding problem in non-date cells for timelines.

### DIFF
--- a/app/assets/stylesheets/timelines.css.erb
+++ b/app/assets/stylesheets/timelines.css.erb
@@ -380,6 +380,8 @@ a.tl-discreet-link:hover, input.icon:hover {
 .tl-column {
   left: 100px;
   display: inline-block;
+  line-height: 18px;
+  padding-bottom: 8px;
 }
 
 #content .tl-word-ellipsis {


### PR DESCRIPTION
Turns this:
![before](https://cloud.githubusercontent.com/assets/99448/3572599/938506ae-0b69-11e4-87b2-e2184413832b.png)
into this:
![after](https://cloud.githubusercontent.com/assets/99448/3572602/9b95b1b8-0b69-11e4-928a-2c2b28605b0e.png)
