### PR TITLE
updates reform gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,7 +200,7 @@ end
 gem 'grape', '~> 0.7.0'
 gem 'representable', git: 'https://github.com/finnlabs/representable'
 gem 'roar',   '~> 0.12.6'
-gem 'reform', require: false
+gem 'reform', '~> 1.0.4', require: false
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on
 # board to compile the native ones.  Note, that their use is discouraged, since

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       json (~> 1.4)
     redcarpet (3.0.0)
     ref (1.0.5)
-    reform (1.0.1)
+    reform (1.0.4)
       activemodel
       disposable (~> 0.0.4)
       representable (~> 1.8.1)
@@ -497,7 +497,7 @@ DEPENDENCIES
   rails_autolink
   rb-readline (~> 0.5.1)
   rdoc (>= 2.4.2)
-  reform
+  reform (~> 1.0.4)
   representable!
   request_store
   roar (~> 0.12.6)


### PR DESCRIPTION
Updates reform to profit from now [fully qualified modules](https://github.com/apotonick/reform/commit/bf236ffc9fd5725126489e5aa5709e0f7f6d0985).

This fixes incompatibilities with reporting_engine's Widget::Controls::Save class.

Thanks goes to @myabc for this.

Fixes: https://www.openproject.org/work_packages/13838
