### PR TITLE
Feature/svn repo integration

### DIFF
--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -29,6 +29,7 @@
 
 class SysController < ActionController::Base
   before_filter :check_enabled
+  before_filter :require_basic_auth, :only => [ :repo_auth ]
 
   def projects
     p = Project.active.has_module(:repository).find(:all, :include => :repository, :order => 'identifier')
@@ -70,6 +71,19 @@ class SysController < ActionController::Base
     render :nothing => true, :status => 404
   end
 
+  def repo_auth
+    @project = Project.find_by_identifier(params[:repository])
+
+    if ( %w(GET PROPFIND REPORT OPTIONS).include?(params[:method]) &&
+        @authenticated_user.allowed_to?(:browse_repository, @project) ) ||
+        @authenticated_user.allowed_to?(:commit_access, @project)
+      render :text => "Access granted"
+      return
+    end
+
+    render :text => "Not allowed", :status => 403 # default to deny
+  end
+
   protected
 
   def check_enabled
@@ -78,5 +92,38 @@ class SysController < ActionController::Base
       render :text => 'Access denied. Repository management WS is disabled or key is invalid.', :status => 403
       return false
     end
+  end
+
+  private
+
+  def require_basic_auth
+    authenticate_with_http_basic do |username, password|
+      @authenticated_user = cached_user_login(username, password)
+      return true if @authenticated_user
+    end
+
+    response.headers["WWW-Authenticate"] = 'Basic realm="Repository Authentication"'
+    render :text => "Authorization required", :status => 401
+    false
+  end
+
+  def user_login(username, password)
+    User.try_to_login(username, password)
+  end
+
+  def cached_user_login(username, password)
+    unless Setting.repository_authentication_caching_enabled?
+      return user_login(username, password)
+    end
+    user = nil
+    user_id = Rails.cache.fetch(OpenProject::RepositoryAuthentication::CACHE_PREFIX + Digest::SHA1.hexdigest("#{username}#{password}"),
+                                :expires_in => OpenProject::RepositoryAuthentication::CACHE_EXPIRES_AFTER) do
+      user = user_login(username, password)
+      user ? user.id.to_s : '-1'
+    end
+
+    return nil if user_id.blank? or user_id == '-1'
+
+    user || User.find_by_id(user_id.to_i)
   end
 end

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -48,6 +48,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <em><%= l(:text_comma_separated) %></em></p>
 
 <p><%= setting_text_field :repository_log_display_limit, :size => 6 %></p>
+
+<p><%= setting_check_box :repository_authentication_caching_enabled %></p>
 </div>
 
 <fieldset class="box tabular settings"><legend><%= l(:text_work_packages_ref_in_commit_messages) %></legend>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1267,6 +1267,7 @@ de:
   setting_plain_text_mail: "Nur reinen Text (kein HTML) senden"
   setting_protocol: "Protokoll"
   setting_repositories_encodings: "Kodierungen der Projektarchive"
+  setting_repository_authentication_caching_enabled: "Aktiviere Cache für Authentifizierungsversuche von Versionskontrollsoftware"
   setting_repository_log_display_limit: "Maximale Anzahl anzuzeigender Revisionen in der Historie einer Datei"
   setting_rest_api_enabled: "REST-Schnittstelle aktivieren"
   setting_self_registration: "Anmeldung ermöglicht"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1255,6 +1255,7 @@ en:
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_repositories_encodings: "Repositories encodings"
+  setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_rest_api_enabled: "Enable REST web service"
   setting_self_registration: "Self-registration"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -134,7 +134,7 @@ sys_api_enabled:
 sys_api_key:
   default: ''
 repository_authentication_caching_enabled:
-  default: true
+  default: 1
 commit_ref_keywords:
   default: 'refs,references,IssueID'
 commit_fix_keywords:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,6 +133,8 @@ sys_api_enabled:
   default: 0
 sys_api_key:
   default: ''
+repository_authentication_caching_enabled:
+  default: true
 commit_ref_keywords:
   default: 'refs,references,IssueID'
 commit_fix_keywords:

--- a/extra/svn/OpenProjectAuthentication.pm
+++ b/extra/svn/OpenProjectAuthentication.pm
@@ -15,11 +15,11 @@ done against an OpenProject web service.
 
 For this to automagically work, you need to have a recent reposman.rb.
 
-Sorry ruby users but you need some perl modules, at least mod_perl2.
+Sorry ruby users but you need some perl modules, at least mod_perl2 and apache2-svn.
 
 On debian/ubuntu you must do :
 
-  aptitude install libapache2-mod-perl2
+  aptitude install libapache2-mod-perl2 libapache2-svn
 
 =head1 CONFIGURATION
 
@@ -37,9 +37,9 @@ On debian/ubuntu you must do :
      PerlAccessHandler Apache::Authn::OpenProject::access_handler
      PerlAuthenHandler Apache::Authn::OpenProject::authen_handler
 
-    OpenProjectUrl "http://example.com/openproject/"
-    OpenProjectApiKey "<API key>"
-  </Location>
+     OpenProjectUrl "http://example.com/openproject/"
+     OpenProjectApiKey "<API key>"
+   </Location>
 
 To be able to browse repository inside openproject, you must add something
 like that :
@@ -64,7 +64,7 @@ and you will have to use this reposman.rb command line to create repository :
 use strict;
 use warnings FATAL => 'all', NONFATAL => 'redefine';
 
-use Digest::SHA1;
+use Digest::SHA;
 
 use Apache2::Module;
 use Apache2::Access;

--- a/extra/svn/OpenProjectAuthentication.pm
+++ b/extra/svn/OpenProjectAuthentication.pm
@@ -1,0 +1,188 @@
+package Apache::Authn::Redmine;
+
+=head1 Apache::Authn::Redmine
+
+Redmine - a mod_perl module to authenticate webdav subversion users
+against an OpenProject web service
+
+=head1 SYNOPSIS
+
+This module allow anonymous users to browse public project and
+registred users to browse and commit their project. Authentication is
+done against an OpenProject web service.
+
+=head1 INSTALLATION
+
+For this to automagically work, you need to have a recent reposman.rb
+(after r860) and if you already use reposman, read the last section to
+migrate.
+
+Sorry ruby users but you need some perl modules, at least mod_perl2.
+
+On debian/ubuntu you must do :
+
+  aptitude install libapache2-mod-perl2
+
+=head1 CONFIGURATION
+
+   ## This module has to be in your perl path
+   ## eg:  /usr/lib/perl5/Apache/Authn/OpenProjectAuthentication.pm
+   PerlLoadModule Apache::Authn::OpenProjectAuthentication
+   <Location /svn>
+     DAV svn
+     SVNParentPath "/var/svn"
+
+     AuthType Basic
+     AuthName OpenProject
+     Require valid-user
+
+     PerlAccessHandler Apache::Authn::Redmine::access_handler
+     PerlAuthenHandler Apache::Authn::Redmine::authen_handler
+
+    RedmineUrl "http://example.com/openproject/"
+    RedmineApiKey "<API key>"
+  </Location>
+
+To be able to browse repository inside redmine, you must add something
+like that :
+
+   <Location /svn-private>
+     DAV svn
+     SVNParentPath "/var/svn"
+     Order deny,allow
+     Deny from all
+     # only allow reading orders
+     <Limit GET PROPFIND OPTIONS REPORT>
+       Allow from redmine.server.ip
+     </Limit>
+   </Location>
+
+and you will have to use this reposman.rb command line to create repository :
+
+  reposman.rb --redmine my.redmine.server --svn-dir /var/svn --owner www-data -u http://svn.server/svn-private/
+
+=head1 MIGRATION FROM OLDER RELEASES
+
+If you use an older reposman.rb (r860 or before), you need to change
+rights on repositories to allow the apache user to read and write
+S<them :>
+
+  sudo chown -R www-data /var/svn/*
+  sudo chmod -R u+w /var/svn/*
+
+And you need to upgrade at least reposman.rb (after r860).
+
+=cut
+
+use strict;
+use warnings FATAL => 'all', NONFATAL => 'redefine';
+
+use Digest::SHA1;
+
+use Apache2::Module;
+use Apache2::Access;
+use Apache2::ServerRec qw();
+use Apache2::RequestRec qw();
+use Apache2::RequestUtil qw();
+use Apache2::Const qw(:common :override :cmd_how);
+use APR::Pool ();
+use APR::Table ();
+
+use HTTP::Request::Common qw(POST);
+use LWP::UserAgent;
+
+# use Apache2::Directive qw();
+
+my @directives = (
+  {
+    name => 'RedmineUrl',
+    req_override => OR_AUTHCFG,
+    args_how => TAKE1,
+    errmsg => 'URL of your (local) OpenProject. (e.g. http://localhost/ or http://www.example.com/openproject/)',
+  },
+  {
+    name => 'RedmineApiKey',
+    req_override => OR_AUTHCFG,
+    args_how => TAKE1,
+  },
+);
+
+sub RedmineUrl { set_val('RedmineUrl', @_); }
+sub RedmineApiKey { set_val('RedmineApiKey', @_); }
+
+sub trim {
+  my $string = shift;
+  $string =~ s/\s{2,}/ /g;
+  return $string;
+}
+
+sub set_val {
+  my ($key, $self, $parms, $arg) = @_;
+  $self->{$key} = $arg;
+}
+
+Apache2::Module::add(__PACKAGE__, \@directives);
+
+sub access_handler {
+  my $r = shift;
+
+  unless ($r->some_auth_required) {
+   $r->log_reason("No authentication has been configured");
+   return FORBIDDEN;
+  }
+
+  return OK
+}
+
+sub authen_handler {
+  my $r = shift;
+
+  my ($status, $password) = $r->get_basic_auth_pw();
+  my $login = $r->user;
+
+  return $status unless $status == OK;
+
+  my $identifier = get_project_identifier($r);
+  my $method = $r->method;
+
+  if( is_access_allowed( $login, $password, $identifier, $method, $r ) ) {
+    return OK;
+  } else {
+    $r->note_auth_failure();
+    return AUTH_REQUIRED;
+  }
+}
+
+# we send a request to the redmine sys api
+# and use the user's given login and password for basic auth
+# for accessing the redmine sys api an api key is needed
+sub is_access_allowed {
+  my $login = shift;
+  my $password = shift;
+  my $identifier = shift;
+  my $method = shift;
+  my $r = shift;
+
+  my $cfg = Apache2::Module::get_config( __PACKAGE__, $r->server, $r->per_dir_config );
+
+  my $key = $cfg->{RedmineApiKey};
+  my $redmine_url = $cfg->{RedmineUrl} . '/sys/repo_auth';
+
+  my $redmine_req = POST $redmine_url , [ repository => $identifier, key => $key, method => $method ];
+  $redmine_req->authorization_basic( $login, $password );
+
+  my $ua = LWP::UserAgent->new;
+  my $response = $ua->request($redmine_req);
+
+  return $response->is_success();
+}
+
+sub get_project_identifier {
+    my $r = shift;
+
+    my $location = $r->location;
+    my ($identifier) = $r->uri =~ m{$location/*([^/]+)};
+    $identifier;
+}
+
+1;

--- a/extra/svn/reposman.rb
+++ b/extra/svn/reposman.rb
@@ -93,6 +93,7 @@ OptionParser.new do |opts|
                                            " -r openproject.example.net",
                                            " -r http://openproject.example.net",
                                            " -r https://openproject.example.net") {|v| $openproject_host = v}
+  opts.on('',  "--redmine-host HOST",      "DEPRECATED: please use --openproject-host instead") {|v| $openproject_host = v}
   opts.on("-k", "--key KEY",               "use KEY as the OpenProject API key") {|v| $api_key = v}
   opts.separator("")
   opts.separator("Options:")

--- a/extra/svn/reposman.rb
+++ b/extra/svn/reposman.rb
@@ -2,7 +2,7 @@
 #-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2013 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -40,7 +40,7 @@ SUPPORTED_SCM = %w( Subversion Git Filesystem )
 
 $verbose      = 0
 $quiet        = false
-$redmine_host = ''
+$openproject_host = ''
 $repos_base   = ''
 $svn_owner    = 'root'
 $svn_group    = 'root'
@@ -88,56 +88,56 @@ OptionParser.new do |opts|
   opts.separator("Manages your repositories with OpenProject.")
   opts.separator("")
   opts.separator("Required arguments:")
-  opts.on("-s", "--svn-dir DIR",        "use DIR as base directory for svn repositories") {|v| $repos_base = v}
-  opts.on("-r", "--redmine-host HOST",  "assume Redmine is hosted on HOST. Examples:",
-                                        " -r redmine.example.net",
-                                        " -r http://redmine.example.net",
-                                        " -r https://redmine.example.net") {|v| $redmine_host = v}
-  opts.on("-k", "--key KEY",            "use KEY as the Redmine API key") {|v| $api_key = v}
+  opts.on("-s", "--svn-dir DIR",           "use DIR as base directory for svn repositories") {|v| $repos_base = v}
+  opts.on("-r", "--openproject-host HOST", "assume OpenProject is hosted on HOST. Examples:",
+                                           " -r openproject.example.net",
+                                           " -r http://openproject.example.net",
+                                           " -r https://openproject.example.net") {|v| $openproject_host = v}
+  opts.on("-k", "--key KEY",               "use KEY as the OpenProject API key") {|v| $api_key = v}
   opts.separator("")
   opts.separator("Options:")
-  opts.on("-o", "--owner OWNER",        "owner of the repository. using the rails login",
-                                        "allows users to browse the repository within",
-                                        "Redmine even for private projects. If you want to",
-                                        "share repositories through Redmine.pm, you need",
-                                        "to use the apache owner.") {|v| $svn_owner = v; $use_groupid = false}
-  opts.on("-g", "--group GROUP",        "group of the repository (default: root)") {|v| $svn_group = v; $use_groupid = false}
-  opts.on(      "--public-mode MODE",   "file mode for new public repositories (default: 0775)") {|v| $public_mode = v}
-  opts.on(      "--private-mode MODE",  "file mode for new private repositories (default: 0770)") {|v| $private_mode = v}
-  opts.on(      "--scm SCM",            "the kind of SCM repository you want to create",
-                                        "(and register) in Redmine (default: Subversion).",
-                                        "reposman is able to create Git and Subversion",
-                                        "repositories.",
-                                        "For all other kind, you must specify a --command",
-                                        "option") {|v| v.capitalize; log("Invalid SCM: #{v}", :exit => true) unless SUPPORTED_SCM.include?(v)}
-  opts.on("-u", "--url URL",            "the base url Redmine will use to access your",
-                                        "repositories. This option is used to automatically",
-                                        "register the repositories in Redmine. The project ",
-                                        "identifier will be appended to this url.",
-                                        "Examples:",
-                                        " -u https://example.net/svn",
-                                        " -u file:///var/svn/",
-                                        "if this option isn't set, reposman won't register",
-                                        "the repositories in Redmine") {|v| $svn_url = v}
-  opts.on("-c", "--command COMMAND",    "use this command instead of 'svnadmin create' to",
-                                        "create a repository. This option can be used to",
-                                        "create repositories other than subversion and git",
-                                        "kind.",
-                                        "This command override the default creation for git",
-                                        "and subversion.") {|v| $command = v}
-  opts.on("-f", "--force",              "force repository creation even if the project",
-                                        "repository is already declared in Redmine") {$force = true}
-  opts.on("-t", "--test",               "only show what should be done") {$test = true}
-  opts.on("-h", "--help",               "show help and exit") {puts opts; exit 1}
-  opts.on("-v", "--verbose",            "verbose") {$verbose += 1}
-  opts.on("-V", "--version",            "print version and exit") {puts Version; exit}
-  opts.on("-q", "--quiet",              "no log") {$quiet = true}
+  opts.on("-o", "--owner OWNER",           "owner of the repository. using the rails login",
+                                           "allows users to browse the repository within",
+                                           "OpenProject even for private projects. If you want to",
+                                           "share repositories through OpenProject.pm, you need",
+                                           "to use the apache owner.") {|v| $svn_owner = v; $use_groupid = false}
+  opts.on("-g", "--group GROUP",           "group of the repository (default: root)") {|v| $svn_group = v; $use_groupid = false}
+  opts.on(      "--public-mode MODE",      "file mode for new public repositories (default: 0775)") {|v| $public_mode = v}
+  opts.on(      "--private-mode MODE",     "file mode for new private repositories (default: 0770)") {|v| $private_mode = v}
+  opts.on(      "--scm SCM",               "the kind of SCM repository you want to create",
+                                           "(and register) in OpenProject (default: Subversion).",
+                                           "reposman is able to create Git and Subversion",
+                                           "repositories.",
+                                           "For all other kind, you must specify a --command",
+                                           "option") {|v| v.capitalize; log("Invalid SCM: #{v}", :exit => true) unless SUPPORTED_SCM.include?(v)}
+  opts.on("-u", "--url URL",               "the base url OpenProject will use to access your",
+                                           "repositories. This option is used to automatically",
+                                           "register the repositories in OpenProject. The project ",
+                                           "identifier will be appended to this url.",
+                                           "Examples:",
+                                           " -u https://example.net/svn",
+                                           " -u file:///var/svn/",
+                                           "if this option isn't set, reposman won't register",
+                                           "the repositories in OpenProject") {|v| $svn_url = v}
+  opts.on("-c", "--command COMMAND",       "use this command instead of 'svnadmin create' to",
+                                           "create a repository. This option can be used to",
+                                           "create repositories other than subversion and git",
+                                           "kind.",
+                                           "This command override the default creation for git",
+                                           "and subversion.") {|v| $command = v}
+  opts.on("-f", "--force",                 "force repository creation even if the project",
+                                           "repository is already declared in OpenProject") {$force = true}
+  opts.on("-t", "--test",                  "only show what should be done") {$test = true}
+  opts.on("-h", "--help",                  "show help and exit") {puts opts; exit 1}
+  opts.on("-v", "--verbose",               "verbose") {$verbose += 1}
+  opts.on("-V", "--version",               "print version and exit") {puts Version; exit}
+  opts.on("-q", "--quiet",                 "no log") {$quiet = true}
   opts.separator("")
   opts.separator("Examples:")
-  opts.separator("  reposman.rb --svn-dir=/var/svn --redmine-host=redmine.example.net --scm Subversion")
-  opts.separator("  reposman.rb -s /var/git -r redmine.example.net -u http://svn.example.net --scm Git")
+  opts.separator("  reposman.rb --svn-dir=/var/svn --openproject-host=openproject.example.net --scm Subversion")
+  opts.separator("  reposman.rb -s /var/git -r openproject.example.net -u http://svn.example.net --scm Git")
   opts.separator("")
-  opts.separator("You can find more information on the redmine's wiki:\nhttp://www.redmine.org/projects/redmine/wiki/HowTos")
+  opts.separator("You might find more information on the openproject's wiki:\nhttps://www.openproject.org/projects/openproject/wiki/Support")
 end.parse!
 
 if $test
@@ -155,7 +155,7 @@ end
 
 $svn_url += "/" if $svn_url and not $svn_url.match(/\/$/)
 
-if ($redmine_host.empty? or $repos_base.empty?)
+if ($openproject_host.empty? or $repos_base.empty?)
   puts "Required argument missing. Type 'reposman.rb --help' for usage."
   exit 1
 end
@@ -164,12 +164,12 @@ unless File.directory?($repos_base)
   log("directory '#{$repos_base}' doesn't exists", :exit => true)
 end
 
-log("querying Redmine for projects...", :level => 1);
+log("querying OpenProject for projects...", :level => 1);
 
-$redmine_host.gsub!(/^/, "http://") unless $redmine_host.match("^https?://")
-$redmine_host.gsub!(/\/$/, '')
+$openproject_host.gsub!(/^/, "http://") unless $openproject_host.match("^https?://")
+$openproject_host.gsub!(/\/$/, '')
 
-api_uri = URI.parse("#{$redmine_host}/sys")
+api_uri = URI.parse("#{$openproject_host}/sys")
 http = Net::HTTP.new(api_uri.host, api_uri.port)
 http.use_ssl = (api_uri.scheme == 'https')
 http_headers = {'User-Agent' => "OpenProject-Repository-Manager/#{Version}"}
@@ -179,7 +179,7 @@ begin
   response = http.get("#{api_uri.path}/projects.json?key=#{$api_key}", http_headers)
   projects = JSON.parse(response.body)
 rescue => e
-  log("Unable to connect to #{$redmine_host}: #{e}", :exit => true)
+  log("Unable to connect to #{$openproject_host}: #{e}", :exit => true)
 end
 
 if projects.nil?
@@ -253,10 +253,10 @@ projects.each do |project|
     log("\tmode change on #{repos_path}");
 
   else
-    # if repository is already declared in redmine, we don't create
+    # if repository is already declared in openproject, we don't create
     # unless user use -f with reposman
     if $force == false and project.has_key?('repository')
-      log("\trepository for project #{project['identifier']} already exists in Redmine", :level => 1)
+      log("\trepository for project #{project['identifier']} already exists in OpenProject", :level => 1)
       next
     end
 
@@ -264,7 +264,7 @@ projects.each do |project|
 
     if $test
       log("\tcreate repository #{repos_path}")
-      log("\trepository #{repos_path} registered in Redmine with url #{$svn_url}#{project['identifier']}") if $svn_url;
+      log("\trepository #{repos_path} registered in OpenProject with url #{$svn_url}#{project['identifier']}") if $svn_url;
       next
     end
 
@@ -287,9 +287,9 @@ projects.each do |project|
                   "vendor=#{$scm}&repository[url]=#{$svn_url}#{project['identifier']}&key=#{$api_key}",
                   "",  # empty data
                   http_headers)
-        log("\trepository #{repos_path} registered in Redmine with url #{$svn_url}#{project['identifier']}");
+        log("\trepository #{repos_path} registered in OpenProject with url #{$svn_url}#{project['identifier']}");
       rescue => e
-        log("\trepository #{repos_path} not registered in Redmine: #{e.message}");
+        log("\trepository #{repos_path} not registered in OpenProject: #{e.message}");
       end
     end
 

--- a/lib/open_project/repository_authentication.rb
+++ b/lib/open_project/repository_authentication.rb
@@ -1,0 +1,35 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module RepositoryAuthentication
+    CACHE_PREFIX = "openproject/repository_authentication/login_"
+    CACHE_EXPIRES_AFTER = 10.minutes
+  end
+end

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -1,0 +1,228 @@
+require 'spec_helper'
+
+module OpenProjectRepositoryAuthenticationSpecs
+  describe SysController do
+    let(:commit_role) { FactoryGirl.create(:role, :permissions => [:commit_access,
+                                                                  :browse_repository]) }
+    let(:browse_role) { FactoryGirl.create(:role, :permissions => [:browse_repository]) }
+    let(:guest_role) { FactoryGirl.create(:role, :permissions => []) }
+    let(:valid_user_password) { "Top Secret Password" }
+    let(:valid_user) { FactoryGirl.create(:user, :login => "johndoe",
+                                                 :password => valid_user_password,
+                                                 :password_confirmation => valid_user_password)}
+
+    before(:each) do
+      FactoryGirl.create(:non_member, :permissions => [:browse_repository])
+      DeletedUser.first # creating it first in order to avoid problems with should_receive
+
+      random_project = FactoryGirl.create(:project, :is_public => false)
+      @member = FactoryGirl.create(:member, :user => valid_user,
+                                            :roles => [browse_role],
+                                            :project => random_project)
+      Setting.stub(:sys_api_key).and_return("12345678")
+      Setting.stub(:sys_api_enabled?).and_return(true)
+    end
+
+    describe :repo_auth, "for valid login, but no access to repo_auth" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+        post "repo_auth", { :key => @key, :repository => "without-access", :method => "GET" }
+      end
+
+      it "should respond 403 not allowed" do
+        response.code.should == "403"
+        response.body.should == "Not allowed"
+      end
+    end
+
+    describe :repo_auth, "for valid login and user has browse repository permission (role reporter) for project" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        @project = FactoryGirl.create(:project, :is_public => false)
+        @member = FactoryGirl.create(:member, :user => valid_user,
+                                              :roles => [browse_role],
+                                              :project => @project)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+      end
+
+      it "should respond 200 okay dokay for GET" do
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "GET" }
+        response.code.should == "200"
+      end
+
+      it "should respond 403 not allowed for POST" do
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "POST" }
+        response.code.should == "403"
+      end
+    end
+
+    describe :repo_auth, "for valid login and user has commit access permission (role developer) for project" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        @project = FactoryGirl.create(:project, :is_public => false)
+        @member = FactoryGirl.create(:member, :user => valid_user,
+                                              :roles => [commit_role],
+                                              :project => @project )
+        valid_user.save
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+      end
+
+      it "should respond 200 okay dokay for GET" do
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "GET" }
+        response.code.should == "200"
+      end
+
+      it "should respond 200 okay dokay for POST" do
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "POST" }
+        response.code.should == "200"
+      end
+    end
+
+    describe :repo_auth, "for invalid login and user has role manager for project" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        @project = FactoryGirl.create(:project, :is_public => false )
+        @member = FactoryGirl.create(:member, :user => valid_user,
+                                              :roles => [commit_role],
+                                              :project => @project)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password + "made invalid")
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "GET" }
+      end
+
+      it "should respond 401 auth required" do
+        response.code.should == "401"
+      end
+    end
+
+    describe :repo_auth, "for valid login and user is not member for project" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        @project = FactoryGirl.create(:project, :is_public => false)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "GET" }
+      end
+
+      it "should respond 403 not allowed" do
+        response.code.should == "403"
+      end
+    end
+
+    describe :repo_auth, "for valid login and project is public" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        @project = FactoryGirl.create(:project, :is_public => true)
+
+        random_project = FactoryGirl.create(:project, :is_public => false)
+        @member = FactoryGirl.create(:member, :user => valid_user,
+                                              :roles => [browse_role],
+                                              :project => random_project)
+
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+        post "repo_auth", { :key => @key, :repository => @project.identifier, :method => "GET" }
+      end
+
+      it "should respond 200 OK" do
+        response.code.should == "200"
+      end
+    end
+
+    describe :repo_auth, "for invalid credentials" do
+      before(:each) do
+        @key = Setting.sys_api_key
+        post "repo_auth", { :key => @key, :repository => "any-repo", :method => "GET" }
+      end
+
+      it "should respond 401 auth required" do
+        response.code.should == "401"
+        response.body.should == "Authorization required"
+      end
+    end
+
+    describe :repo_auth, "for invalid api key" do
+      before(:each) do
+        @key = "invalid"
+      end
+
+      it "should respond 403 for valid username/password" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+        post "repo_auth", { :key => @key, :repository => "any-repo", :method => "GET" }
+        response.code.should == "403"
+        response.body.should == "Access denied. Repository management WS is disabled or key is invalid."
+      end
+
+      it "should respond 403 for invalid username/password" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("invalid", "invalid")
+        post "repo_auth", { :key => @key, :repository => "any-repo", :method => "GET" }
+        response.code.should == "403"
+        response.body.should == "Access denied. Repository management WS is disabled or key is invalid."
+      end
+    end
+
+    before(:each) do
+      Rails.cache.clear
+      Rails.cache.stub(:kind_of?).with(anything).and_return(false)
+    end
+
+    describe :cached_user_login do
+      let(:cache_key) { OpenProject::RepositoryAuthentication::CACHE_PREFIX +
+                        Digest::SHA1.hexdigest("#{valid_user.login}#{valid_user_password}") }
+      let(:cache_expiry) { OpenProject::RepositoryAuthentication::CACHE_EXPIRES_AFTER }
+
+      it "should call user_login only once when called twice" do
+        controller.should_receive(:user_login).once.and_return(valid_user)
+        2.times { controller.send(:cached_user_login, valid_user.login, valid_user_password) }
+      end
+
+      it "should return the same as user_login for valid creds" do
+        controller.send(:cached_user_login, valid_user.login, valid_user_password).should ==
+        controller.send(:user_login, valid_user.login, valid_user_password)
+      end
+
+      it "should return the same as user_login for invalid creds" do
+        controller.send(:cached_user_login, "invalid", "invalid").should ==
+          controller.send(:user_login, "invalid", "invalid")
+      end
+
+      it "should use cache" do
+        # allow the cache to return something reasonable for
+        # other requests, while ensuring that it is not queried
+        # with the cache key in question
+
+        # unfortunately, and_call_original currently fails
+        Rails.cache.stub(:fetch) do |*args|
+          args.first.should_not == cache_key
+
+          name = args.first.split("/").last
+          Marshal.dump(Setting.send(:find_or_default, name).value)
+        end
+        #Rails.cache.should_receive(:fetch).with(anything).and_call_original
+        Rails.cache.should_receive(:fetch).with(cache_key, :expires_in => cache_expiry) \
+                                          .and_return(Marshal.dump(valid_user.id.to_s))
+        controller.send(:cached_user_login, valid_user.login, valid_user_password)
+      end
+
+      describe "with caching disabled" do
+        before do
+          Setting.stub(:repository_authentication_caching_enabled?).and_return false
+        end
+
+        it 'should not use a cache' do
+          # allow the cache to return something reasonable for
+          # other requests, while ensuring that it is not queried
+          # with the cache key in question
+          #
+          # unfortunately, and_call_original currently fails
+          Rails.cache.stub(:fetch) do |*args|
+            args.first.should_not == cache_key
+
+            name = args.first.split("/").last
+            Marshal.dump(Setting.send(:find_or_default, name).value)
+          end
+
+          controller.send(:cached_user_login, valid_user.login, valid_user_password)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -21,6 +21,7 @@ module OpenProjectRepositoryAuthenticationSpecs
                                             :project => random_project)
       Setting.stub(:sys_api_key).and_return("12345678")
       Setting.stub(:sys_api_enabled?).and_return(true)
+      Setting.stub(:repository_authentication_caching_enabled?).and_return(true)
     end
 
     describe :repo_auth, "for valid login, but no access to repo_auth" do
@@ -204,7 +205,7 @@ module OpenProjectRepositoryAuthenticationSpecs
 
       describe "with caching disabled" do
         before do
-          Setting.stub(:repository_authentication_caching_enabled?).and_return false
+          Setting.stub(:repository_authentication_caching_enabled?).and_return(false)
         end
 
         it 'should not use a cache' do


### PR DESCRIPTION
This PR aims to make the (currently private) plugin [repository_authentication](https://github.com/finnlabs/openproject-repository_authentication) obsolete by implementing its functionality in the OpenProject core.

This enables everyone to have subversions repositories again (and might be extended for git support).
Also, this is a step to have an easier installation using packager.io (as cyril at packager.io is currently working on configuration scripts for svn integration - and he needs the parts provided in this PR).

One of the main features is that repository authentication logic is moved from the perl module into OpenProject. Redmine (and the old plugin) did it in a perl module which is faster but not DRY.
Being DRY in our complicated authentication logic seems to be more important.

See: https://www.openproject.org/work_packages/13898
