### PR TITLE
fixes path on work package bulk edit

### DIFF
--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <h2><%= l(:label_bulk_edit_selected_work_packages) %></h2>
 
-<ul><%= @work_packages.collect {|i| content_tag('li', link_to(h("#{i.type} ##{i.id}"), { :action => 'show', :id => i }) + h(": #{i.subject}")) }.join("\n").html_safe %></ul>
+<ul><%= @work_packages.collect {|i| content_tag('li', link_to(h("#{i.type} ##{i.id}"), work_package_path(i)) + h(": #{i.subject}")) }.join("\n").html_safe %></ul>
 
 <%= form_tag(url_for(controller: '/work_packages/bulk', action: :update, ids: @work_packages),
              method: :put) do %>


### PR DESCRIPTION
Otherwise the paths points to /work_packages/bulk/show/:id 

https://www.openproject.org/work_packages/14310
