### PR TITLE
remove dev-angular branch from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ branches:
     - dev
     - stable
     - release/3.0
-    - dev-angular
 env:
   # Frontend
   - "TEST_SUITE=karma"


### PR DESCRIPTION
Git-flow recommends to use "--no-ff".
http://nvie.com/posts/a-successful-git-branching-model/

But dev-angular reffers to same revision with dev.

<pre>
$ git branch -v -r --abbrev=9 | grep gh-finn/dev
  gh-finn/dev           cc5bedac9 Merge pull request #1386 from opf/bugfix/icon-font-toggler
  gh-finn/dev-angular   cc5bedac9 Merge pull request #1386 from opf/bugfix/icon-font-toggler
</pre>
