### PR TITLE
Meets #14433: Long version names with long wiki name destroys layout

### DIFF
--- a/app/assets/stylesheets/default/main.css.erb
+++ b/app/assets/stylesheets/default/main.css.erb
@@ -304,6 +304,29 @@ div#version-summary { float: right; width: 380px; margin-left: 16px; margin-bott
 div#version-summary fieldset { margin-bottom: 1em; }
 div#version-summary .total-hours { text-align: right; }
 
+.top-page{
+  width: 100%;
+  border-bottom: 1px solid #bbbbbb;
+  margin: 0 0 10px;
+}
+
+.top-page h2{
+  padding-right: 0px!important;
+  border: none;
+  margin: 0;
+  text-align:left;
+  display: block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.top-page ul{
+  margin: 0;
+  text-align:right;
+  white-space: nowrap;
+}
+
 table#time-report td.hours, table#time-report th.period, table#time-report th.total { text-align: right; padding-right: 0.5em; }
 table#time-report tbody tr { font-style: italic; color: #333; }
 table#time-report tbody tr.last-level { font-style: normal; color: #555; }

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -29,13 +29,19 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :action_menu_specific do %>
   <%= link_to_if_authorized l(:button_edit), {:controller => '/versions', :action => 'edit', :id => @version}, :class => 'icon icon-edit' %>
-  <%= link_to_if_authorized(l(:button_edit_associated_wikipage, :page_title => @version.wiki_page_title), {:controller => '/wiki', :action => 'edit', :project_id => @version.project, :id => Wiki.titleize(@version.wiki_page_title)}, :class => 'icon icon-edit') unless @version.wiki_page_title.blank? || @version.project.wiki.nil? %>
+  <%= link_to_if_authorized(l(:button_edit_associated_wikipage, :page_title => truncate(@version.wiki_page_title, :length => 50, :separator => ' ')),
+                            {:controller => '/wiki', :action => 'edit',
+                             :project_id => @version.project,
+                             :id => Wiki.titleize(@version.wiki_page_title)},
+                            :title => Wiki.titleize(@version.wiki_page_title),
+                            :class => 'icon icon-edit tooltip') unless @version.wiki_page_title.blank? || @version.project.wiki.nil? %>
   <%= call_hook(:view_versions_show_contextual, { :version => @version, :project => @project }) %>
 <% end %>
 
-<h2><%= h(@version.name) %></h2>
-
-<%= render :partial => 'layouts/action_menu_specific' %>
+<div class="top-page">
+  <%= render :partial => 'layouts/action_menu_specific' %>
+  <h2 title="<%= h(@version.name)%>"><%= h(@version.name) %></h2>
+</div>
 
 <div id="version-summary">
   <% if @version.estimated_hours > 0 || User.current.allowed_to?(:view_time_entries, @project) %>


### PR DESCRIPTION
[`* `#14433` Long version names with long wiki name destroys layout`](https://www.openproject.org/work_packages/14433)
