### PR TITLE
Meets #14375: Footer is not fixed at the bottom after opening a taskboard

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -128,6 +128,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= call_hook :view_layouts_base_content %>
       <div style="clear:both;">&nbsp;</div>
     </div>
+    <div style="clear:both;">&nbsp;</div>
   </div>
 
   <% if (show_decoration) %>


### PR DESCRIPTION
[`* `#14375` Footer is not fixed at the bottom after opening a taskboard`](https://www.openproject.org/work_packages/14375)
