### PR TITLE
Use sane default sendmail options

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -64,8 +64,8 @@ module OpenProject
       'smtp_password' => nil,
       'smtp_enable_starttls_auto' => nil,
       'smtp_openssl_verify_mode' => nil,  # 'none', 'peer', 'client_once' or 'fail_if_no_peer_cert'
-      'sendmail_location' => nil,
-      'sendmail_arguments' => nil,
+      'sendmail_location' => '/usr/sbin/sendmail',
+      'sendmail_arguments' => '-i',
 
       'disable_password_login' => false,
       'omniauth_direct_login_provider' => nil


### PR DESCRIPTION
[mikel/mail uses some standard sendmail options](https://github.com/mikel/mail/blob/1caf1b83c112ac7df2c7d95c3aa4d5604857235c/lib/mail/network/delivery_methods/sendmail.rb#L43), which we should also use.
They can always be overridden in configuration.yml or appropriate environment variables if needed.

This would fix weird behaviour when trying to use sendmail for mail delivery. Currently we have to specify the sendmail path and argument, even if they have the default values, because they are overriden to `nil` in configuration.rb.

remotely related to: https://www.openproject.org/work_packages/7377
