### PR TITLE
Revert "Use sane default sendmail options"

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -64,8 +64,8 @@ module OpenProject
       'smtp_password' => nil,
       'smtp_enable_starttls_auto' => nil,
       'smtp_openssl_verify_mode' => nil,  # 'none', 'peer', 'client_once' or 'fail_if_no_peer_cert'
-      'sendmail_location' => '/usr/sbin/sendmail',
-      'sendmail_arguments' => '-i',
+      'sendmail_location' => nil,
+      'sendmail_arguments' => nil,
 
       'disable_password_login' => false,
       'omniauth_direct_login_provider' => nil


### PR DESCRIPTION
Reverts opf/openproject#1677

After long discussions it seems unviable to change non-working default options to probably working ones....
