### PR TITLE
Getting ready for Teatro

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,10 @@
+stage:
+  before:
+    - bower install --allow-root
+    - cp config/configuration.yml.example config/configuration.yml
+    - cp config/database.teatro.yml config/database.yml
+    - export SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  database:
+    - bundle exec rake db:create db:migrate
+    - bundle exec rake db:seed RAILS_ENV=development

--- a/config/database.teatro.yml
+++ b/config/database.teatro.yml
@@ -1,0 +1,13 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  database: teatro
+  pool: 5
+  min_messages: warning
+  username: postgres
+
+development:
+  <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
Hey!

I am developer at Teatro.io and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Teatro.io is free for open source projects — some large projects like GitLab (https://github.com/gitlabhq/gitlabhq/pull/7140 ), ErrBit (works out-of-the-box, @ndbroadbent approved Teatro), Rails Admin (https://github.com/sferik/rails_admin/pull/2029) and others are already using Teatro as free stage servers.

Here's URL of Teatro stage server for my fork of OpenProject: http://teatro.semenyukdmitriy-openproject-c0cbbd9c72a820fede1e.ttrcloud.com/. Awesome, isn't it?

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with like to unique stage server that was made for this specific branch (see https://github.com/semenyukdmitriy/openproject/pull/1 for example).

To use Teatro you need:
— sign in using Github account on http://Teatro.io
— add your project

**Benefits**:
— demo for new users (always up to date!)
— the way to test changes: each Pull Request gets separate stage server
— FREE for open source!

Have any questions? — Post a comment.
