### PR TITLE
Attempt to fix teatro setup

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -3,7 +3,7 @@ stage:
     - bower install --allow-root
     - cp config/configuration.yml.example config/configuration.yml
     - cp config/database.teatro.yml config/database.yml
-    - export SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - bundle exec rake generate_secret_token 
 
   database:
     - bundle exec rake db:create db:migrate


### PR DESCRIPTION
It seems that the secret token env var was not persistent.
Now we generate the secret token as a file and things should be
persistent.

See @meeee's comment in #1681 (comment)
