### PR TITLE
Meets #14416: German translation of "Subproject" is wrong / misleading

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -179,7 +179,7 @@ de:
         progress: "% erledigt"
         responsible: "Verantwortlicher"
         spent_time: "Aufgewendete Zeit"
-        subproject: "Unterprojekt von"
+        subproject: "Unterprojekt"
         time_entries: "Logzeit"
         type: "Typ"
         watcher: "Beobachter"

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -152,7 +152,7 @@ de:
       project: "Projekt"
       responsible: "Verantwortlicher"
       spent_time: "Aufgewendete Zeit"
-      subproject: "Unterprojekt von"
+      subproject: "Unterprojekt"
       start_date: "Beginn"
       status: "Status"
       subject: "Thema"


### PR DESCRIPTION
[`* `#14416` German translation of "Subproject" is wrong / misleading`](https://www.openproject.org/work_packages/14416)
