### PR TITLE
Meets #14374: Several objects not copied when copying project

### DIFF
--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -245,6 +245,15 @@ module Project::Copy
       project.boards.each do |board|
         new_board = Board.new
         new_board.attributes = board.attributes.dup.except("id", "project_id", "topics_count", "messages_count", "last_message_id")
+        topics = board.topics.where("parent_id is NULL")
+        topics.each do |topic|
+          new_topic = Message.new
+          new_topic.attributes = topic.attributes.dup.except("id", "board_id", "author_id", "replies_count", "last_reply_id", "created_on", "updated_on")
+          new_topic.board = new_board
+          new_topic.author_id = topic.author_id
+          new_board.topics << new_topic
+        end
+
         new_board.project = self
         self.boards << new_board
       end

--- a/spec/models/project/copy_spec.rb
+++ b/spec/models/project/copy_spec.rb
@@ -338,16 +338,33 @@ describe Project::Copy do
     end
 
     describe :copy_boards do
-      before do
-        FactoryGirl.create(:board, project: project)
+      let(:board) { FactoryGirl.create(:board, project: project) }
 
-        copy.send(:copy_boards, project)
-        copy.save
+      context "boards are copied" do
+        before do
+          copy.send(:copy_boards, project)
+          copy.save
+        end
+
+        subject { copy.boards.count }
+
+        it { should == project.boards.count }
       end
 
-      subject { copy.boards.count }
+      context "board topics are copied" do
+        before do
+          topic = FactoryGirl.create(:message, board: board)
+          message = FactoryGirl.create(:message, board: board, parent_id: topic.id)
 
-      it { should == project.boards.count }
+          copy.send(:copy_boards, project)
+          copy.save
+        end
+
+        it "should copy topics without replies" do
+          expect(copy.boards.first.topics.count).to eq(project.boards.first.topics.count)
+          expect(copy.boards.first.messages.count).to_not eq(project.boards.first.messages.count)
+        end
+      end
     end
 
     describe :copy_versions do


### PR DESCRIPTION
[`* `#14374` Several objects not copied when copying project`](https://www.openproject.org/work_packages/14374)
