### PR TITLE
[Feature] 14750 wrong time in wp table and details pane

### DIFF
--- a/app/views/api/experimental/work_packages/index.api.rabl
+++ b/app/views/api/experimental/work_packages/index.api.rabl
@@ -66,7 +66,7 @@ child @work_packages => :work_packages do
   end
 
   node :created_at do |wp|
-    wp.updated_at.utc.iso8601
+    wp.created_at.utc.iso8601
   end
 
   node :_actions do |wp|

--- a/public/templates/work_packages.list.details.html
+++ b/public/templates/work_packages.list.details.html
@@ -35,9 +35,9 @@
       ng-if="toggleWatchLink" />
     <a href="#">#{{ workPackage.props.id }}</a>
     <span ng-bind="I18n.t('js.label_added_by')"/>
-      <a ng-href="{{ userPath(author.props.id) }}" ng-bind="author.props.name"/> <span ng-bind="I18n.t('js.label_on')"/> <date dateValue="workPackage.props.createdAt"></date>.
+      <a ng-href="{{ userPath(author.props.id) }}" ng-bind="author.props.name"/> <span ng-bind="I18n.t('js.label_on')"/> <date date-value="workPackage.props.createdAt"></date>.
     <span ng-bind="I18n.t('js.label_last_updated_on')"/>
-      <date dateValue="workPackage.props.updatedAt"></date>.
+      <date date-value="workPackage.props.updatedAt"></date>.
   </span>
 
   <div class="work-package-details-tab" ui-view></div>

--- a/spec/views/api/experimental/work_packages/index_api_json_spec.rb
+++ b/spec/views/api/experimental/work_packages/index_api_json_spec.rb
@@ -76,6 +76,18 @@ describe 'api/experimental/work_packages/index.api.rabl' do
     it { should have_json_size(0).at_path('work_packages') }
   end
 
+  describe 'created/updated at' do
+    let(:wp) { FactoryGirl.build(:work_package,
+                                 created_at: DateTime.now,
+                                 updated_at: (DateTime.now + 1.day)) }
+    let(:work_packages) { [ wp ] }
+    let(:column_names) { [] }
+    let(:custom_field_column_names) { [] }
+
+    it { expect(parse_json(subject)['work_packages'][0]['updated_at']).to eq(wp.updated_at.utc.iso8601) }
+    it { expect(parse_json(subject)['work_packages'][0]['created_at']).to eq(wp.created_at.utc.iso8601) }
+  end
+
   describe 'with 3 work packages but no columns' do
     let(:work_packages) { [
       FactoryGirl.build(:work_package,


### PR DESCRIPTION
[`* `#14750` Wrong time in work package table and details pane`](https://www.openproject.org/work_packages/14750)
