### PR TITLE
Startup Times: Output to STDERR

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,11 +39,11 @@ module SimpleBenchmark
   # (user cpu time + system cpu time + user and system cpu time of children)
   # This is not wallclock time.
   def self.bench(title)
-    print "#{title}... "
+    $stderr.print "#{title}... "
     result = Benchmark.measure do
       yield
     end
-    print "%.03fs\n" % result.total
+    $stderr.printf "%.03fs\n", result.total
   end
 end
 


### PR DESCRIPTION
This allows discarding the benchmark output by only reading
from STDOUT, e.g. for using `rake secret` in a script.
