### PR TITLE
Development seeds: Make number of users configurable

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -39,6 +39,8 @@ rescue Redmine::DefaultData::DataAlreadyLoaded
   puts "Redmine Default-Data already loaded"
 end
 
+user_count = ENV.fetch('SEED_USER_COUNT', 3).to_i
+
 # Careful: The seeding recreates the seeded project before it runs, so any changes on the seeded project will be lost.
 puts "Creating seeded project..."
 if delete_me=Project.find_by_identifier("seeded_project")
@@ -104,11 +106,11 @@ repository = Repository::Filesystem.create! project: project,
 
 
 print "Creating objects for..."
-30.times do |count|
+user_count.times do |count|
   login = "#{Faker::Name.first_name}#{rand(10000)}"
 
   puts
-  print "...for user number #{count} (#{login})"
+  print "...for user number #{count + 1}/#{user_count} (#{login})"
 
   user = User.find_by_login(login)
 


### PR DESCRIPTION
Also, reduce default to 3 users instead of 30. I'm not into waiting 5 minutes
after setting up a new development database.

Set a SEED_USER_COUNT env var if you want more users.
