### PR TITLE
[#8520] remove branches from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,6 @@ language: ruby
 rvm:
   - 2.1
 sudo: false
-branches:
-  only:
-    - dev
-    - stable
-    - release/3.0
 env:
   # mysql2
   - "TEST_SUITE=cucumber CI=true RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"


### PR DESCRIPTION
https://www.openproject.org/work_packages/8520

This pull request is accepted in
https://github.com/DerekTBrown/openproject_openshift/pull/1

It is too hard to run travis on forked repositories.
It disturbs pull request process.

Travis does not run Pull Request for Pull Request.
https://github.com/opf/openproject/pull/1392

For keeping clean revision history.
https://github.com/opf/openproject/pull/1338#issuecomment-44260428

OpenProject members break their rules.
https://www.openproject.org/projects/openproject/wiki/Git_Workflow

> Fork Openproject on GitHub

DVCS standard rule is very simple.
https://help.github.com/articles/fork-a-repo

OpenProject stupid _undocumented_ rule:
http://marutosi.bitbucket.org/RxTstudy-20130622/one-html/html/index.html#gitbarepush

DVCS standard rule:
http://marutosi.bitbucket.org/RxTstudy-20130622/one-html/html/index.html#id236

Git-flow defined only "master" and "develop" branches on _remote repository_.
http://nvie.com/posts/a-successful-git-branching-model/

And "release" and "hotfix" is local.
These local branches are _deleted_ after pushing to remote repository.
OpenProject undocumented workflow is very _stupid_.

OpenProject undocumented stupid workflow takes much time.
Simple and standard DVCS workflow save much time.

There is no branches on Rails .travis.yml.
https://github.com/rails/rails/blob/2367dfeb8d7c4596263e/.travis.yml
Rails has many pull request.
https://github.com/rails/rails/pulls
Rails travis build is not bottleneck.
https://travis-ci.org/rails/rails/builds
So, OpenProject undocumented workflow is very stupid.

https://github.com/opf/openproject/pull/1362
