### PR TITLE
Fix API to use JSON encoding for the body of non-GET requests

### DIFF
--- a/app/assets/javascripts/angular/services/activity-service.js
+++ b/app/assets/javascripts/angular/services/activity-service.js
@@ -37,7 +37,8 @@ angular.module('openproject.services')
       var options = {
         ajax: {
           method: "POST",
-          data: { comment: comment }
+          data: JSON.stringify({ comment: comment }),
+          contentType: "application/json; charset=utf-8"
         }
       };
 
@@ -48,7 +49,8 @@ angular.module('openproject.services')
       var options = {
         ajax: {
           method: 'PATCH',
-          data: { comment: comment }
+          data: JSON.stringify({ comment: comment }),
+          contentType: "application/json; charset=utf-8"
         }
       };
 

--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -136,7 +136,8 @@ angular.module('openproject.services')
         headers: {
           Accept: "application/hal+json"
         },
-        data: data
+        data: JSON.stringify(data),
+        contentType: "application/json; charset=utf-8"
       }};
       return workPackage.links.update.fetch(options).then(function(workPackage) {
         return workPackage;
@@ -146,10 +147,11 @@ angular.module('openproject.services')
     addWorkPackageRelation: function(workPackage, toId, relationType) {
       var options = { ajax: {
         method: "POST",
-        data: {
+        data: JSON.stringify({
           to_id: toId,
           relation_type: relationType
-        }
+        }),
+        contentType: "application/json; charset=utf-8"
       } };
       return workPackage.links.addRelation.fetch(options).then(function(relation){
         return relation;

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -42,6 +42,7 @@ module API
     end
 
     content_type 'hal+json', 'application/hal+json'
+    content_type :json,      'application/json'
     format 'hal+json'
     formatter 'hal+json', Formatter.new
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -55,7 +55,7 @@ module API
 
             patch do
               authorize(:edit_work_packages, context: @work_package.project)
-              @representer.from_json(request.POST.to_json)
+              @representer.from_json(env['api.request.input'])
               @representer.represented.sync
               if @representer.represented.model.valid? && @representer.represented.save
                 @representer

--- a/spec/api/watcher_resource_spec.rb
+++ b/spec/api/watcher_resource_spec.rb
@@ -53,7 +53,7 @@ describe 'API v3 Watcher resource', :type => :request do
     let(:new_watcher) { available_watcher }
 
     before do
-      post post_path, user_id: new_watcher.id
+      post post_path, %{{"user_id": #{new_watcher.id}}},  { 'CONTENT_TYPE' => 'application/json' }
     end
 
     context 'authorized user' do

--- a/spec/api/work_package_resource_spec.rb
+++ b/spec/api/work_package_resource_spec.rb
@@ -210,7 +210,7 @@ h4. things we like
     let(:patch_path) { "/api/v3/work_packages/#{work_package.id}" }
     before(:each) do
       allow(User).to receive(:current).and_return current_user
-      patch patch_path, params
+      patch patch_path, params.to_json, { 'CONTENT_TYPE' => 'application/json' }
     end
     subject(:response) { last_response }
 

--- a/spec/requests/activities_api_spec.rb
+++ b/spec/requests/activities_api_spec.rb
@@ -64,7 +64,7 @@ describe API::V3::Activities::ActivitiesAPI, :type => :request do
 
     shared_context "edit activity" do
       before { patch "/api/v3/activities/#{journal.id}",
-                   comment: comment }
+                   { comment: comment }.to_json, { 'CONTENT_TYPE' => 'application/json' } }
     end
 
     it_behaves_like "safeguarded API" do

--- a/spec/requests/work_packages_api_spec.rb
+++ b/spec/requests/work_packages_api_spec.rb
@@ -39,7 +39,7 @@ describe API::V3::WorkPackages::WorkPackagesAPI, :type => :request do
     describe "POST /api/v3/work_packages/:id/activities" do
       shared_context "create activity" do
         before { post "/api/v3/work_packages/#{work_package.id}/activities",
-                      comment: comment }
+                      { comment: comment }.to_json, { 'CONTENT_TYPE' => 'application/json' } }
       end
 
       it_behaves_like "safeguarded API" do


### PR DESCRIPTION
See 6c36487 for why.

This Pull Request should make the API behaviour consistent with our own specification. For example: https://github.com/opf/op-api-v3-documentation/blob/master/apiary.apib#L234

Note: This does not currently test `RelationsAPI` (there was never any spec coverage for this resource)
