### PR TITLE
[Hotfix] 13789 apiv2 ids parameter ignored for planning elements

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -259,6 +259,9 @@ module Api
                                    .changed_since(@since)
                                    .includes(:status, :project, :type, :custom_values)
 
+        wp_ids = parse_work_package_ids
+        work_packages = work_packages.where(id: wp_ids) if wp_ids
+
         if params[:f]
           #we need a project to make project-specific custom fields work
           project = timeline_to_project(params[:timeline])
@@ -340,6 +343,10 @@ module Api
 
       def parse_changed_since
         @since = Time.at(Float(params[:changed_since] || 0).to_i) rescue render_400
+      end
+
+      def parse_work_package_ids
+        params[:ids] ? params[:ids].split(',') : nil
       end
     end
   end


### PR DESCRIPTION
[`* `#13789` Ids parameter ignored in API v2's planning elements endpoint`](https://www.openproject.org/work_packages/13789)

:exclamation: This is a backport of #1578 
