### PR TITLE
removes no longer required before filter

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -40,7 +40,6 @@ module Api
       before_filter :find_project_by_project_id,
                     :authorize, :except => [:index]
       before_filter :parse_changed_since, only: [:index]
-      before_filter :assign_planning_elements, :except => [:index, :update, :create]
 
       # Attention: find_all_projects_by_project_id needs to mimic all of the above
       #            before filters !!!


### PR DESCRIPTION
The only action requiring the call to assign_planning_elements is the
index action. This action receives it's work packages by calling the
assign_planning_elements method from other methods.

https://www.openproject.org/work_packages/15194
