### PR TITLE
Meets #14520: Timeline displays work packages with a diff of one day

### DIFF
--- a/app/assets/javascripts/angular/models/timelines/planning_element.js
+++ b/app/assets/javascripts/angular/models/timelines/planning_element.js
@@ -160,7 +160,7 @@ angular.module('openproject.timelines.models')
         this.start_date = this.due_date;
       }
       if (this.start_date_object === undefined && this.start_date !== undefined) {
-        this.start_date_object = Date.parse(this.start_date);
+        this.start_date_object = moment(this.start_date).toDate();
       }
       return this.start_date_object;
     },
@@ -171,7 +171,7 @@ angular.module('openproject.timelines.models')
         this.due_date = this.start_date;
       }
       if (this.due_date_object=== undefined && this.due_date !== undefined) {
-        this.due_date_object = Date.parse(this.due_date);
+        this.due_date_object = moment(this.due_date).toDate();
       }
       return this.due_date_object;
     },

--- a/app/assets/javascripts/angular/models/timelines/timeline.js
+++ b/app/assets/javascripts/angular/models/timelines/timeline.js
@@ -379,14 +379,25 @@ angular.module('openproject.timelines.models')
     lastDateSeen: null,
 
     getBeginning: function() {
-      return (Date.parse(this.options.timeframe_start) ||
-                (this.firstDateSeen && this.firstDateSeen.clone() ||
-                 new Date()).last().monday());
+      if (this.options.timeframe_start) {
+        return moment(this.options.timeframe_start).toDate();
+      }
+      var startDate = new Date();
+      if (this.firstDateSeen) {
+        startDate = this.firstDateSeen.clone();
+      }
+      return startDate.last().monday();
     },
     getEnd: function() {
-      return (Date.parse(this.options.timeframe_end) ||
-                (this.lastDateSeen && this.lastDateSeen.clone() ||
-                 new Date()).addWeeks(1).next().sunday());
+      if (this.options.timeframe_end) {
+        return moment(this.options.timeframe_end).toDate();
+      }
+      var endDate = new Date();
+      if (this.lastDateSeen) {
+        endDate = this.lastDateSeen.clone();
+      }
+      return endDate.addWeeks(1).next().sunday();
+
     },
     getDaysBetween: function(a, b) {
       // some meat around date calculations that will be floored out again


### PR DESCRIPTION
[`* `#14520` Timeline displays work packages with a diff of one day`](https://www.openproject.org/work_packages/14520)
