### PR TITLE
add inline code documentation quality badge (inch-ci.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [<img src="https://travis-ci.org/opf/openproject.svg?branch=dev" alt="Build Status" />](https://travis-ci.org/opf/openproject)
 [<img src="https://gemnasium.com/opf/openproject.png" alt="Dependency Status" />](https://gemnasium.com/opf/openproject)
+[![Inline docs](http://inch-ci.org/github/opf/openproject.png?branch=dev)](http://inch-ci.org/github/opf/openproject)
 
 OpenProject is a web-based project management software. Its key features are:
 


### PR DESCRIPTION
a badge indicating the quality of inline code documentation based on [inch](http://trivelop.de/inch/) and [inch ci](http://inch-ci.org/).

after merging we most likely want to configure a webhook for https://github.com/opf/openproject. this is described here http://inch-ci.org/howto/webhook.

and then we should improve out docs!
