### PR TITLE
Fix/wp filter helper options

### DIFF
--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -29,73 +29,73 @@
 
 module WorkPackagesFilterHelper
   # General
-  def project_property_path(project, property, property_id)
+  def project_property_path(project, property, property_id, options = {})
     query = {
       f: [
         filter_object(property, "=", property_id),
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
 
   # Links for my page
-  def work_packages_assigned_to_me_path
+  def work_packages_assigned_to_me_path(options = {})
     query = {
       f: [ filter_object("assigned_to_id", "=", "me") ],
       t: 'priority:desc,updated_at:desc'
     }
-    work_packages_with_query_path(query)
+    work_packages_with_query_path(query, options)
   end
 
-  def work_packages_reported_by_me_path
+  def work_packages_reported_by_me_path(options = {})
     query = {
       f: [ filter_object("author_id", "=", "me") ],
       t: 'updated_at:desc'
     }
-    work_packages_with_query_path(query)
+    work_packages_with_query_path(query, options)
   end
 
-  def work_packages_responsible_for_path
+  def work_packages_responsible_for_path(options = {})
     query = {
       f: [ filter_object("responsible_id", "=", "me") ],
       t: 'priority:desc,updated_at:desc'
     }
-    work_packages_with_query_path(query)
+    work_packages_with_query_path(query, options)
   end
 
-  def work_packages_watched_path
+  def work_packages_watched_path(options = {})
     query = {
       f: [ filter_object("watcher_id", "=", "me") ],
       t: 'updated_at:desc'
     }
-    work_packages_with_query_path(query)
+    work_packages_with_query_path(query, options)
   end
 
   # Links for project overview
-  def project_work_packages_closed_version_path(version)
+  def project_work_packages_closed_version_path(version, options = {})
     query = {
       f: [
            filter_object("status_id", "c"),
            filter_object("fixed_version_id", "=", version.id)
          ]
     }
-    project_work_packages_with_query_path(version.project, query)
+    project_work_packages_with_query_path(version.project, query, options)
   end
 
-  def project_work_packages_open_version_path(version)
+  def project_work_packages_open_version_path(version, options = {})
     query = {
       f: [
            filter_object("status_id", "o"),
            filter_object("fixed_version_id", "=", version.id)
          ]
     }
-    project_work_packages_with_query_path(version.project, query)
+    project_work_packages_with_query_path(version.project, query, options)
   end
 
   # Links for reports
-  def project_report_property_path(project, property, property_id)
+  def project_report_property_path(project, property, property_id, options = {})
     query = {
       f: [
         filter_object("subproject_id", "!*"),
@@ -103,10 +103,10 @@ module WorkPackagesFilterHelper
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
-  def project_report_property_status_path(project, status_id, property, property_id)
+  def project_report_property_status_path(project, status_id, property, property_id, options = {})
     query = {
       f: [
         filter_object("status_id", "=", status_id),
@@ -115,10 +115,10 @@ module WorkPackagesFilterHelper
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
-  def project_report_property_open_path(project, property, property_id)
+  def project_report_property_open_path(project, property, property_id, options = {})
     query = {
       f: [
         filter_object("status_id", "o"),
@@ -127,10 +127,10 @@ module WorkPackagesFilterHelper
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
-  def project_report_property_closed_path(project, property, property_id)
+  def project_report_property_closed_path(project, property, property_id, options = {})
     query = {
       f: [
         filter_object("status_id", "c"),
@@ -139,10 +139,10 @@ module WorkPackagesFilterHelper
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
-  def project_report_property_any_status_path(project, property, property_id)
+  def project_report_property_any_status_path(project, property, property_id, options = {})
     query = {
       f: [
         filter_object("status_id", "*"),
@@ -151,7 +151,7 @@ module WorkPackagesFilterHelper
       ],
       t: default_sort
     }
-    project_work_packages_with_query_path(project, query)
+    project_work_packages_with_query_path(project, query, options)
   end
 
   private
@@ -160,12 +160,12 @@ module WorkPackagesFilterHelper
     'updated_at:desc'
   end
 
-  def work_packages_with_query_path(query)
-    work_packages_path(query_props: query.to_json)
+  def work_packages_with_query_path(query, options = {})
+    work_packages_path(options.reverse_merge!(query_props: query.to_json))
   end
 
-  def project_work_packages_with_query_path(project, query)
-    project_work_packages_path(project, query_props: query.to_json)
+  def project_work_packages_with_query_path(project, query, options = {})
+    project_work_packages_path(project, options.reverse_merge!(query_props: query.to_json))
   end
 
   def filter_object(property, operator, values = nil)

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -142,16 +142,28 @@ module WorkPackagesFilterHelper
     project_work_packages_with_query_path(project, query, options)
   end
 
-  def project_report_property_any_status_path(project, property, property_id, options = {})
+  def project_report_property_path(project, property_name, property_id, options = {})
     query = {
       f: [
         filter_object("status_id", "*"),
         filter_object("subproject_id", "!*"),
-        filter_object(property, "=", property_id),
+        filter_object(property_name, "=", property_id),
       ],
       t: default_sort
     }
     project_work_packages_with_query_path(project, query, options)
+  end
+
+  def project_version_property_path(version, property_name, property_id, options = {})
+    query = {
+      f: [
+        filter_object("status_id", "*"),
+        filter_object("fixed_version_id", "=", version.id),
+        filter_object(property_name, "=", property_id),
+      ],
+      t: default_sort
+    }
+    project_work_packages_with_query_path(version.project, query, options)
   end
 
   private

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -73,6 +73,40 @@ module WorkPackagesFilterHelper
     work_packages_with_query_path(query, options)
   end
 
+  # Links for My Project Page plugin
+
+  def project_work_packages_assigned_to_me_path(project, options = {})
+    query = {
+      f: [ filter_object("assigned_to_id", "=", "me") ],
+      t: 'priority:desc,updated_at:desc'
+    }
+    project_work_packages_with_query_path(project, query, options)
+  end
+
+  def project_work_packages_reported_by_me_path(project, options = {})
+    query = {
+      f: [ filter_object("author_id", "=", "me") ],
+      t: 'updated_at:desc'
+    }
+    project_work_packages_with_query_path(project, query, options)
+  end
+
+  def project_work_packages_responsible_for_path(project, options = {})
+    query = {
+      f: [ filter_object("responsible_id", "=", "me") ],
+      t: 'priority:desc,updated_at:desc'
+    }
+    project_work_packages_with_query_path(project, query, options)
+  end
+
+  def project_work_packages_watched_path(project, options = {})
+    query = {
+      f: [ filter_object("watcher_id", "=", "me") ],
+      t: 'updated_at:desc'
+    }
+    project_work_packages_with_query_path(project, query, options)
+  end
+
   # Links for project overview
   def project_work_packages_closed_version_path(version, options = {})
     query = {

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -95,11 +95,13 @@ module WorkPackagesFilterHelper
   end
 
   # Links for reports
-  def project_report_property_path(project, property, property_id, options = {})
+
+  def project_report_property_path(project, property_name, property_id, options = {})
     query = {
       f: [
+        filter_object("status_id", "*"),
         filter_object("subproject_id", "!*"),
-        filter_object(property, "=", property_id),
+        filter_object(property_name, "=", property_id),
       ],
       t: default_sort
     }
@@ -136,18 +138,6 @@ module WorkPackagesFilterHelper
         filter_object("status_id", "c"),
         filter_object("subproject_id", "!*"),
         filter_object(property, "=", property_id),
-      ],
-      t: default_sort
-    }
-    project_work_packages_with_query_path(project, query, options)
-  end
-
-  def project_report_property_path(project, property_name, property_id, options = {})
-    query = {
-      f: [
-        filter_object("status_id", "*"),
-        filter_object("subproject_id", "!*"),
-        filter_object(property_name, "=", property_id),
       ],
       t: default_sort
     }

--- a/app/views/my/blocks/_issuesassignedtome.html.erb
+++ b/app/views/my/blocks/_issuesassignedtome.html.erb
@@ -55,7 +55,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :header_tags do %>
 <%= auto_discovery_link_tag(:atom,
-                            {controller: :work_packages, action: :index, set_filter: 1,
-                             assigned_to_id: 'me', format: 'atom', key: User.current.rss_key},
+                            work_packages_assigned_to_me_path({:format => 'atom', :key => User.current.rss_key}),
                             {title: l(:label_assigned_to_me_work_packages)}) %>
 <% end %>

--- a/app/views/my/blocks/_issuesreportedbyme.html.erb
+++ b/app/views/my/blocks/_issuesreportedbyme.html.erb
@@ -49,7 +49,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :header_tags do %>
 <%= auto_discovery_link_tag(:atom,
-                            {controller: :work_packages, action: :index, set_filter: 1,
-                             author_id: 'me', format: 'atom', key: User.current.rss_key},
+                            work_packages_reported_by_me_path({:format => 'atom', :key => User.current.rss_key}),
                             {title: l(:label_reported_work_packages)}) %>
 <% end %>

--- a/app/views/my/blocks/_workpackagesresponsiblefor.html.erb
+++ b/app/views/my/blocks/_workpackagesresponsiblefor.html.erb
@@ -55,7 +55,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :header_tags do %>
 <%= auto_discovery_link_tag(:atom,
-                            {controller: :work_packages, action: :index, set_filter: 1,
-                             responsible_id: 'me', format: 'atom', key: User.current.rss_key},
+                            work_packages_responsible_for_path({:format => 'atom', :key => User.current.rss_key}),
                             {title: l(:label_responsible_for_work_packages)}) %>
 <% end %>

--- a/app/views/versions/_work_package_counts.html.erb
+++ b/app/views/versions/_work_package_counts.html.erb
@@ -53,12 +53,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
           <tr>
             <td width="130px" align="right" >
-                <%= link_to h(count[:group]), {controller: :work_packages,
-                                            action: :index,
-                                            project_id: version.project,
-                                            set_filter: 1,
-                                            status_id: '*',
-                                            fixed_version_id: version}.merge("#{criteria}_id".to_sym => count[:group]) %>
+                <%= link_to h(count[:group]),
+                            project_version_property_path(version, "#{criteria}_id", count[:group].id) %>
             </td>
             <td width="240px">
                 <%= progress_bar((count[:closed].to_f / count[:total])*100,

--- a/app/views/work_packages/reports/_report.html.erb
+++ b/app/views/work_packages/reports/_report.html.erb
@@ -77,7 +77,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <td align="center">
     <%= aggregate_link report.data,
                        { report.field => row.id },
-                       project_report_property_any_status_path((row.is_a?(Project) ? row : @project),
+                       project_report_property_path((row.is_a?(Project) ? row : @project),
                                                                "#{report.field}",
                                                                row.id) %>
   </td>

--- a/spec/helpers/work_packages_filter_helper_spec.rb
+++ b/spec/helpers/work_packages_filter_helper_spec.rb
@@ -1,0 +1,92 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe WorkPackagesFilterHelper, :type => :helper do
+  let(:project) { FactoryGirl.create(:project) }
+
+  describe :general_path_helpers do
+
+    it "should give the path to work packages index with property filter" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"v\":2,\"n\":\"status\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_property_path(project, "status", 2))).to eq expectedDecoded
+    end
+
+  end
+
+  describe :my_page_path_helpers do
+
+    it "should give the path to work packages assigned to me" do
+      expectedDecoded = "/work_packages?query_props={\"f\":[{\"v\":\"me\",\"n\":\"assigned_to_id\",\"o\":\"=\"}],\"t\":\"priority:desc,updated_at:desc\"}"
+      expect(CGI::unescape(helper.work_packages_assigned_to_me_path)).to eq expectedDecoded
+    end
+
+    it "should give the path to work packages reported by me" do
+      expectedDecoded = "/work_packages?query_props={\"f\":[{\"v\":\"me\",\"n\":\"author_id\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.work_packages_reported_by_me_path)).to eq expectedDecoded
+    end
+
+    it "should give the path to work packages I'm responsible for" do
+      expectedDecoded = "/work_packages?query_props={\"f\":[{\"v\":\"me\",\"n\":\"responsible_id\",\"o\":\"=\"}],\"t\":\"priority:desc,updated_at:desc\"}"
+      expect(CGI::unescape(helper.work_packages_responsible_for_path)).to eq expectedDecoded
+    end
+
+    it "should give the path to work packages watched by me" do
+      expectedDecoded = "/work_packages?query_props={\"f\":[{\"v\":\"me\",\"n\":\"watcher_id\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.work_packages_watched_path)).to eq expectedDecoded
+    end
+
+  end
+
+  describe :project_overview_path_helpers do
+    let(:version) { FactoryGirl.create(:version, :project => project) }
+
+    it "should give the path to closed work packages for a project version" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"c\"},{\"v\":" + version.id.to_s + ",\"n\":\"fixed_version_id\",\"o\":\"=\"}]}"
+      expect(CGI::unescape(helper.project_work_packages_closed_version_path(version))).to eq expectedDecoded
+    end
+
+    it "should give the path to open work packages for a project version" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"o\"},{\"v\":" + version.id.to_s + ",\"n\":\"fixed_version_id\",\"o\":\"=\"}]}"
+      expect(CGI::unescape(helper.project_work_packages_open_version_path(version))).to eq expectedDecoded
+    end
+
+  end
+
+  describe :project_reports_path_helpers do
+
+    it "should give the path to work packages for a report property" do
+      property_name = "priority_id"
+      property_id = 5
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"*\"},{\"n\":\"subproject_id\",\"o\":\"!*\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_report_property_path(project, property_name, property_id))).to eq expectedDecoded
+    end
+
+  end
+end

--- a/spec/helpers/work_packages_filter_helper_spec.rb
+++ b/spec/helpers/work_packages_filter_helper_spec.rb
@@ -30,6 +30,7 @@ require 'spec_helper'
 
 describe WorkPackagesFilterHelper, :type => :helper do
   let(:project) { FactoryGirl.create(:project) }
+  let(:version) { FactoryGirl.create(:version, :project => project) }
 
   describe :general_path_helpers do
 
@@ -65,7 +66,6 @@ describe WorkPackagesFilterHelper, :type => :helper do
   end
 
   describe :project_overview_path_helpers do
-    let(:version) { FactoryGirl.create(:version, :project => project) }
 
     it "should give the path to closed work packages for a project version" do
       expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"c\"},{\"v\":" + version.id.to_s + ",\"n\":\"fixed_version_id\",\"o\":\"=\"}]}"
@@ -80,12 +80,33 @@ describe WorkPackagesFilterHelper, :type => :helper do
   end
 
   describe :project_reports_path_helpers do
+    let(:property_name) { "priority_id" }
+    let(:property_id) { 5 }
 
     it "should give the path to work packages for a report property" do
-      property_name = "priority_id"
-      property_id = 5
       expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"*\"},{\"n\":\"subproject_id\",\"o\":\"!*\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
       expect(CGI::unescape(helper.project_report_property_path(project, property_name, property_id))).to eq expectedDecoded
+    end
+
+    it "should give the path to work packages for a report property with status" do
+      status_id = 2
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"v\":" + status_id.to_s + ",\"n\":\"status_id\",\"o\":\"=\"},{\"n\":\"subproject_id\",\"o\":\"!*\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_report_property_status_path(project, status_id, property_name, property_id))).to eq expectedDecoded
+    end
+
+    it "should give the path to open work packages for a report property" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"o\"},{\"n\":\"subproject_id\",\"o\":\"!*\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_report_property_open_path(project, property_name, property_id))).to eq expectedDecoded
+    end
+
+    it "should give the path to closed work packages for a report property" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"c\"},{\"n\":\"subproject_id\",\"o\":\"!*\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_report_property_closed_path(project, property_name, property_id))).to eq expectedDecoded
+    end
+
+    it "should give the path to work packages for a report property belonging to a project version" do
+      expectedDecoded = "/projects/" + project.identifier + "/work_packages?query_props={\"f\":[{\"n\":\"status_id\",\"o\":\"*\"},{\"v\":" + version.id.to_s + ",\"n\":\"fixed_version_id\",\"o\":\"=\"},{\"v\":" + property_id.to_s + ",\"n\":\"" + property_name + "\",\"o\":\"=\"}],\"t\":\"updated_at:desc\"}"
+      expect(CGI::unescape(helper.project_version_property_path(version, property_name, property_id))).to eq expectedDecoded
     end
 
   end


### PR DESCRIPTION
https://www.openproject.org/work_packages/7472
(see comment #36)

Options can be passed to the path helpers which is necessary for the atom links.

Updated the links on the roadmap view to use the new url helpers.

Wrote some specs.
