### PR TITLE
[Feature] 14420 status is not pronounced properly by screenreader

### DIFF
--- a/public/templates/work_packages/query_filters.html
+++ b/public/templates/work_packages/query_filters.html
@@ -20,12 +20,11 @@
 
                   <!-- Name -->
                   <td style="width:200px;">
-                    {{ localisedFilterName(query.availableWorkPackageFilters[filter.name]) }}
+                    <label for="operators-{{filter.name}}">{{ localisedFilterName(query.availableWorkPackageFilters[filter.name]) }}</label>
                   </td>
 
                   <!-- Operator -->
                   <td style="width:150px;">
-                    <label class="hidden-for-sighted" for="operators-{{filter.name}}">{{ I18n.t('js.work_packages.description_filter') }}</label>
                     <select require
                             class="select-small"
                             id="operators-{{filter.name}}"


### PR DESCRIPTION
[`* `#14420` Status is not pronounced properly by screenreader`](https://www.openproject.org/work_packages/14420)

This fixes pronunciation of the filter operator that is missing in #1813.
