### PR TITLE
add code climate badge (second try)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [<img src="https://travis-ci.org/opf/openproject.svg?branch=dev" alt="Build Status" />](https://travis-ci.org/opf/openproject)
 [<img src="https://gemnasium.com/opf/openproject.png" alt="Dependency Status" />](https://gemnasium.com/opf/openproject)
-[![Code Climate](https://codeclimate.com/github/opf/openproject/badges/gpa.svg)](https://codeclimate.com/github/opf/openproject)
+[![Code Climate](https://codeclimate.com/repos/528f351813d637200e02ef84/badges/5ef239a5b086f9e52e52/gpa.svg)](https://codeclimate.com/repos/528f351813d637200e02ef84/feed)
 [![Inline docs](http://inch-ci.org/github/opf/openproject.png?branch=dev)](http://inch-ci.org/github/opf/openproject)
 
 OpenProject is a web-based project management software. Its key features are:


### PR DESCRIPTION
follow up pull request for code climate score badge.

https://github.com/opf/openproject/pull/1828 displays the results for the `master` branch. This PR fixes that and shows the score for `dev` which is 0.3 higher, yay :metal:
