### PR TITLE
Force the generated admin user to change the password on the first login

### DIFF
--- a/db/seeds/all.rb
+++ b/db/seeds/all.rb
@@ -73,6 +73,8 @@ if User.admin.empty?
   user.admin = true
   user.login = "admin"
   user.password = "admin"
+  # force password change on first login
+  user.force_password_change = true
   user.firstname = "OpenProject"
   user.lastname = "Admin"
   user.mail = "admin@example.net"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -27,6 +27,14 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+# remove password-reset flag from admin user
+# (the default password is OK in dev mode)
+admin = User.where(login: 'admin').first
+if admin && admin.force_password_change?
+  admin.force_password_change = false
+  admin.save!
+end
+
 # set some sensible defaults:
 include Redmine::I18n
 


### PR DESCRIPTION
When running `db:seed` we create an admin user with username `admin` and password `admin`. It is dangerous to have such default credentials (because users tend to forget to change the defaults).

This PR aims to make the admin change his password after his/her first login.

relates to: https://www.openproject.org/work_packages/5606
