### PR TITLE
Force ui router to inherit params and set version to version 0.2.11

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/work-packages-list-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/work-packages-list-controller.js
@@ -188,7 +188,8 @@ angular.module('openproject.workPackages.controllers')
   }
 
   function getCurrentStateUrl(){
-    var relativeUri = decodeURIComponent($state.href($state.$current)); // ui-router escapes some of this string for whatever reason
+    // ui-router escapes some of this string for whatever reason
+    var relativeUri = decodeURIComponent($state.href($state.$current, {}, { inherit: true }));
 
     if($scope.query) {
       var queryString = UrlParamsHelper.encodeQueryJsonParams($scope.query);

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "angular-ui-select2": "0.0.5",
     "angular-ui-select2-sortable": "0.0.1",
     "angular-ui-date": "0.0.3",
-    "angular-ui-router": "~0.2.10",
+    "angular-ui-router": "0.2.11",
     "angular-i18n": "~1.3.0",
     "angular-modal": "~0.4.0",
     "angular-sanitize": "~1.2.14",


### PR DESCRIPTION
https://www.openproject.org/work_packages/15151

This is really strange and I'm still looking for an explanation but here is a quick fix which I hope will do the trick in the main time.

Looking in angular-ui-router.js:2836 I see:

$state.href = function href(stateOrName, params, options) {
      options = extend({
        lossy:    true,
        inherit:  true,
        absolute: false,
        relative: $state.$current
      }, options || {});

...and then looking on the QA server in application js I see the definition is slightly different:

$state.href = function href(stateOrName, params, options) {
      options = extend({
        lossy:    true,
        inherit:  false, <------------ hmm?!
        absolute: false,
        relative: $state.$current
      }, options || {});

They are both version 0.2.11. I have no idea how this could be occurring. In the mean time I am forcing it to inherit.
