### PR TITLE
15332 query not active on loading work package list

### DIFF
--- a/app/assets/javascripts/angular/services/work-package-service.js
+++ b/app/assets/javascripts/angular/services/work-package-service.js
@@ -74,7 +74,10 @@ angular.module('openproject.services')
           per_page: paginationOptions.perPage
         });
       } else {
-        angular.extend(params, DEFAULT_PAGINATION_OPTIONS);
+        angular.extend(params, {
+          page: DEFAULT_PAGINATION_OPTIONS.page,
+          per_page: DEFAULT_PAGINATION_OPTIONS.perPage,
+        });
       }
 
       return WorkPackageService.doQuery(url, params);

--- a/app/controllers/api/experimental/concerns/query_loading.rb
+++ b/app/controllers/api/experimental/concerns/query_loading.rb
@@ -64,6 +64,6 @@ module Api::Experimental::Concerns::QueryLoading
   end
 
   def no_query_params_provided?
-    (params.keys & %w(group_by c fields f sort is_public name page per_page display_sums)).empty?
+    (params.keys & %w(group_by c fields f sort is_public name display_sums)).empty?
   end
 end

--- a/spec/controllers/api/experimental/work_packages_controller_spec.rb
+++ b/spec/controllers/api/experimental/work_packages_controller_spec.rb
@@ -97,7 +97,7 @@ describe Api::Experimental::WorkPackagesController, :type => :controller do
         expect(assigns(:query)).to eql expected_query
       end
 
-      %w(group_by c fields f sort is_public name page per_page display_sums).each do |filter_param|
+      %w(group_by c fields f sort is_public name display_sums).each do |filter_param|
         it "assigns a query which does not have the default filter arguments set if the #{filter_param} argument is provided" do
           expected_query = Query.new
           expect(Query).to receive(:new).with(anything, initialize_with_default_filter: false)


### PR DESCRIPTION
[`* `#15332` Query not active on loading work package list`](https://www.openproject.org/work_packages/15332)
