### PR TITLE
make filter operator select focusable and keep track in query filters di...

### DIFF
--- a/app/assets/javascripts/angular/helpers/components/focus-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/focus-helper.js
@@ -29,7 +29,7 @@
 // TODO move to UI components
 angular.module('openproject.uiComponents')
 
-.constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex]')
+.constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex], select')
 
 .service('FocusHelper', ['$timeout', 'FOCUSABLE_SELECTOR', function($timeout, FOCUSABLE_SELECTOR) {
   FocusHelper = {

--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -286,12 +286,12 @@ angular.module('openproject.models')
 
       if (filter) {
         filter.deactivated = false;
+        this.removeFilter(filter.name);
       } else {
         var filterData = this.getExtendedFilterData(angular.extend({name: filterName}, options));
         filter = new Filter(filterData);
-
-        this.filters.push(filter);
       }
+      this.filters.push(filter);
     },
 
     removeFilter: function(filterName) {

--- a/app/assets/javascripts/angular/work_packages/directives/query-filter-directive.js
+++ b/app/assets/javascripts/angular/work_packages/directives/query-filter-directive.js
@@ -46,6 +46,7 @@ angular.module('openproject.workPackages.directives')
       scope.isLoading = false; // shadow isLoading as its used for a different purpose in this context
 
       scope.showValueOptionsAsSelect = !scope.filter.isSingleInputField();
+      scope.$broadcast('updateFocus');
 
       if (scope.showValueOptionsAsSelect) {
         WorkPackageLoadingHelper.withLoading(scope, QueryService.getAvailableFilterValues, [scope.filter.name, scope.projectIdentifier])
@@ -108,6 +109,7 @@ angular.module('openproject.workPackages.directives')
       function valueReset(filter, oldFilter) {
         return oldFilter.hasValues() && !filter.hasValues();
       }
+
     }
   };
 }]);

--- a/app/assets/javascripts/angular/work_packages/directives/query-filters-directive.js
+++ b/app/assets/javascripts/angular/work_packages/directives/query-filters-directive.js
@@ -28,7 +28,7 @@
 
 angular.module('openproject.workPackages.directives')
 
-.directive('queryFilters', ['FiltersHelper', 'I18n', function(FiltersHelper, I18n) {
+.directive('queryFilters', ['FiltersHelper', 'I18n', '$timeout', function(FiltersHelper, I18n, $timeout) {
 
   return {
     restrict: 'E',
@@ -42,10 +42,19 @@ angular.module('openproject.workPackages.directives')
           scope.$watch('filterToBeAdded', function(filterName) {
             if (filterName) {
               scope.query.addFilter(filterName);
+              scope.focussedFilterIndex = scope.query.getActiveFilters().length - 1;
               scope.filterToBeAdded = undefined;
             }
           });
+          scope.focussedFilterIndex = -1;
 
+          scope.deactivateFilter = function(filter) {
+            scope.query.deactivateFilter(filter);
+            scope.focussedFilterIndex = scope.query.getActiveFilters().length - 1;
+            $timeout(function() {
+              scope.$broadcast('updateFocus');
+            });
+          }
         }
       };
     }

--- a/public/templates/work_packages/query_filters.html
+++ b/public/templates/work_packages/query_filters.html
@@ -10,8 +10,7 @@
             <table>
               <tbody>
                 <tr query-filter
-                    ng-repeat="filter in query.filters"
-                    ng-show="!filter.deactivated"
+                    ng-repeat="filter in query.getActiveFilters()"
                     id="tr_{{filter.name}}"
                     class="filter">
 
@@ -25,7 +24,8 @@
 
                   <!-- Operator -->
                   <td style="width:150px;">
-                    <select require
+                    <select focus="$index == focussedFilterIndex"
+                            require
                             class="select-small"
                             id="operators-{{filter.name}}"
                             name="op[{{filter.name}}]"
@@ -132,7 +132,7 @@
 
                   <!-- Delete filter -->
                   <td>
-                    <accessible-by-keyboard execute="query.deactivateFilter(filter)">
+                    <accessible-by-keyboard execute="deactivateFilter(filter)">
                       <icon-wrapper icon-name="delete2"
                                     icon-title="{{I18n.t('js.button_delete')}}"/>
                     </accessible-by-keyboard>


### PR DESCRIPTION
https://www.openproject.org/work_packages/15301

I have made a small change in that now when you add a filter it always gets added as the last filter. Previously if you deleted a filter and then added it again it would have appeared where it was the first time. I changed this purely to make it easier to focus on the last element when you add it but also I think it makes more sense this way.
