### PR TITLE
fix modal in menu setting cannot be closed by pressing ESC

### DIFF
--- a/app/assets/javascripts/angular/controllers/dialogs/columns.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/columns.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'ColumnsModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/columns.html'
+    templateUrl:  '/templates/work_packages/modals/columns.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/export.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/export.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'ExportModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/export.html'
+    templateUrl:  '/templates/work_packages/modals/export.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/group-by.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/group-by.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'GroupByModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/group_by.html'
+    templateUrl:  '/templates/work_packages/modals/group_by.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/save.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/save.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'SaveModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/save.html'
+    templateUrl:  '/templates/work_packages/modals/save.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/settings.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/settings.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'SettingsModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/settings.html'
+    templateUrl:  '/templates/work_packages/modals/settings.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/share.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/share.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'ShareModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/share.html'
+    templateUrl:  '/templates/work_packages/modals/share.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/app/assets/javascripts/angular/controllers/dialogs/sorting.js
+++ b/app/assets/javascripts/angular/controllers/dialogs/sorting.js
@@ -32,7 +32,8 @@ angular.module('openproject.workPackages.controllers')
   return btfModal({
     controller:   'SortingModalController',
     controllerAs: 'modal',
-    templateUrl:  '/templates/work_packages/modals/sorting.html'
+    templateUrl:  '/templates/work_packages/modals/sorting.html',
+    afterFocusOn: '#work-packages-settings-button'
   });
 }])
 

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "angular-ui-date": "0.0.3",
     "angular-ui-router": "0.2.11",
     "angular-i18n": "~1.3.0",
-    "angular-modal": "~0.4.0",
+    "angular-modal": "0xF013/angular-modal#7616ef9b7f16fb6644564e30482d6422804abe22",
     "angular-sanitize": "~1.2.14",
     "angular-truncate": "sparkalow/angular-truncate#fdf60fda265042d12e9414b5354b2cc52f1419de",
     "angular-feature-flags": "mjt01/angular-feature-flags#ca40201e2279777dc3820c783f60f845cefff731",

--- a/public/templates/work_packages.list.html
+++ b/public/templates/work_packages.list.html
@@ -63,7 +63,7 @@
         </label>
         <button id="work-packages-settings-button"
                 title="{{ I18n.t('js.button_settings') }}"
-                class="button last"
+                class="button last work-packages-settings-button"
                 with-dropdown dropdown-id="settingsDropdown">
           <i class="icon-settings"></i>
           <i class="icon-pulldown-arrow1 icon-dropdown"></i>

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -201,7 +201,6 @@ describe 'Work package index accessibility', :type => :feature do
                                             project: project) }
     let!(:yet_another_work_package) { FactoryGirl.create(:work_package,
                                             project: project) }   
-    let(:body) { find("body") }
     before {work_packages_page.visit_index}                                        
 
     context 'focus' do
@@ -213,19 +212,19 @@ describe 'Work package index accessibility', :type => :feature do
       end
 
       it 'navigates with J' do
-        body.native.send_keys('j')
+        find("body").native.send_keys('j')
         expect(page).to have_selector(first_link_selector)
       end
 
       it 'navigates with K' do
-        body.native.send_keys('k')
+        find("body").native.send_keys('k')
         expect(page).to have_selector(second_link_selector)
       end      
     end
 
     context "help" do
       it 'opens help popup with \'?\'' do
-        body.native.send_keys('?')
+        find("body").native.send_keys('?')
         expect(page).to have_selector(".ui-dialog")
       end
     end
@@ -267,6 +266,49 @@ describe 'Work package index accessibility', :type => :feature do
         let(:source_link) { 'table.workpackages-table th:nth-of-type(2) a' }
         let(:target_link) { '#column-context-menu .menu li:first-of-type a' }
         let(:keys) { :enter }
+      end
+    end
+  end
+
+  describe 'settings button', js: true do
+
+    shared_examples_for 'menu setting item' do
+      context 'closable by ESC and remembers focus on gear button' do
+        before do
+          work_packages_page.visit_index
+          find(:css, ".work-packages-settings-button").click
+          anchor.click
+        end
+        it do
+          # expect the modal to be shown
+          expect(page).to have_selector(".ng-modal-window")
+          find("body").native.send_keys(:escape)
+          # expect it to disappear
+          expect(page).to_not have_selector(".ng-modal-window")
+          # expect the gear to be focused
+          expect(page).to have_selector("#work-packages-settings-button:focus")
+        end
+      end
+    end
+
+    context 'gear button' do
+
+      context 'columns popup anchor' do
+        it_behaves_like 'menu setting item' do
+          let (:anchor) { find("#settingsDropdown .dropdown-menu li:nth-child(1) a") }
+        end
+      end
+
+      context 'sorting popup anchor' do
+        it_behaves_like 'menu setting item' do
+          let (:anchor) { find("#settingsDropdown .dropdown-menu li:nth-child(2) a") }
+        end
+      end
+
+      context 'grouping popup anchor' do
+        it_behaves_like 'menu setting item' do
+          let (:anchor) { find("#settingsDropdown .dropdown-menu li:nth-child(3) a") }
+        end
       end
     end
   end


### PR DESCRIPTION
[`* `#15406` modal in menu setting cannot be closed by pressing ESC`](http://www.openproject.org/work_packages/15406)

[`* `#15407` focus lost after closing modal in menu settings`](http://www.openproject.org/work_packages/15407)

I changed a bower.json dependency to my own repository so a bower clean cache and a bower install might be needed
