### PR TITLE
Restore wrong (but performant) possible_watcher impl

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -702,13 +702,6 @@ class WorkPackage < ActiveRecord::Base
     work_package
   end
 
-  # Override of acts_as_watchable#possible_watcher_users
-  # Restricts the result to project members for private as well as public projects
-  def possible_watcher_users
-    users = project.users
-    users.select {|user| possible_watcher?(user)}
-  end
-
   # check if user is allowed to edit WorkPackage Journals.
   # see Redmine::Acts::Journalized::Permissions#journal_editable_by
   def editable_by?(user)

--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
@@ -86,13 +86,13 @@ module Redmine
         end
 
         def possible_watcher_users
-          User.not_builtin.tap do |users|
-            if respond_to?(:visible?)
-              users.select! {|user| possible_watcher?(user)}
-            else
-              warn watching_permitted_to_all_users_message
-            end
-          end
+          # TODO: There might be addable users which are not in the current
+          #       project. But its hard (performance wise) to find them
+          #       correctly. So we only search for users in the project scope.
+          #       Also, the watchable might not be allowed to be seen by all
+          #       users in the project.
+          #       This implementation is so wrong, it makes me sad.
+          project.users
         end
 
         # Returns an array of users that are proposed as watchers


### PR DESCRIPTION
Aims to fix https://www.openproject.org/work_packages/15510

The show page of a WorkPackage takes ages to load when there are _many_ users in the project. This is because of the slow watcher implementation.
This PR restores the old (crappy) watcher code to make things fast again.

A correct _and_ fast implementation is proposed in https://github.com/opf/openproject/pull/1750 -- when this is reviewed and merged, everything is good again.
