### PR TITLE
API v2 PE index: Allow disabling parent rewiring

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -175,6 +175,8 @@ module Api
       # Filters
       def find_all_projects_by_project_id
         if !params[:project_id] and params[:ids] then
+          # WTF. Why do we completely skip rewiring in this case and always provide parent_ids?
+          # This is totally inconistent.
           identifiers = params[:ids].split(/,/).map(&:strip)
           @planning_elements = WorkPackage.visible(User.current).find_all_by_id(identifiers)
         elsif params[:project_id] !~ /,/
@@ -195,7 +197,16 @@ module Api
           @planning_elements = convert_to_struct(current_work_packages(projects))
           # only for current work_packages, the array of child-ids must be reconstructed
           # for historical packages, the re-wiring is not needed
-          rewire_ancestors
+
+          # Allow disabling rewiring - this exposes parent IDs of work packages invisible
+          # to the user.
+          # When requesting single work packages via IDs, the rewiring fails as it assumes
+          # that all visible work packages are loaded, which they might not be. For a work
+          # package with a parent visible to the user, but not included in the requested IDs,
+          # the parent_id would thus be nil.
+          # Disabling rewiring allows fetching work packages with their parent_ids
+          # even when the parents are not included in the list of requested work packages.
+          rewire_ancestors unless params[:rewire_parents] == '0'
         end
 
       end

--- a/spec/controllers/api/v2/planning_elements_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_elements_controller_spec.rb
@@ -178,6 +178,44 @@ describe Api::V2::PlanningElementsController do
               response.should render_template('planning_elements/index', :formats => ["api"])
             end
           end
+
+          describe 'w/ 2 planning elements within a specific project and one PE requested' do
+            context 'with rewire_parents=0' do
+              let!(:wp_parent) { FactoryGirl.create(:work_package, project_id: project.id) }
+              let!(:wp_child)  { FactoryGirl.create(:work_package, project_id: project.id,
+                                                                   parent_id: wp_parent.id) }
+
+              context 'with rewire_parents=0' do
+                before do
+                  get 'index', project_id: project.id,
+                               ids: wp_child.id.to_s,
+                               rewire_parents: '0',
+                               format: 'xml'
+                end
+
+                it "includes the child's parent_id" do
+                  expect(assigns(:planning_elements)[0].parent_id).to eq wp_parent.id
+                end
+              end
+
+              context 'without rewire_parents' do
+                # This is unbelievably inconsistent. When requesting this without a project_id,
+                # the rewiring is not done at all, so the parent_id can be seen with and
+                # without rewiring disabled.
+                # Passing a project_id here, so we can test this with rewiring enabled.
+                before do
+                  get 'index', project_id: project.id,
+                               ids: wp_child.id.to_s,
+                               format: 'xml'
+                end
+
+                it "doesn't include child's parent_id" do
+                  expect(assigns(:planning_elements)[0].parent_id).to eq nil
+                end
+              end
+            end
+          end
+
         end
       end
 
@@ -254,13 +292,32 @@ describe Api::V2::PlanningElementsController do
 
         become_admin { [project1, project2] }
 
-        it 'rewires ancestors correctly' do
-          get 'index', project_id: project1.id, :format => 'xml'
+        context 'without rewire_parents' do  # equivalent to rewire_parents=true
+          it 'rewires ancestors correctly' do
+            get 'index', project_id: project1.id, :format => 'xml'
 
-          # the controller returns structs. We therefore have to filter for those
-          ticket_f_struct = assigns(:planning_elements).detect { |pe| pe.id == ticket_f.id }
+            # the controller returns structs. We therefore have to filter for those
+            ticket_f_struct = assigns(:planning_elements).detect { |pe| pe.id == ticket_f.id }
 
-          expect(ticket_f_struct.parent_id).to eq(ticket_d.id)
+            expect(ticket_f_struct.parent_id).to eq(ticket_d.id)
+          end
+        end
+
+        context 'with rewire_parents=false' do
+          before do
+            get 'index', project_id: project1.id, format: 'xml', rewire_parents: '0'
+          end
+
+          it "doesn't rewire ancestors" do
+            # the controller returns structs. We therefore have to filter for those
+            ticket_f_struct = assigns(:planning_elements).detect { |pe| pe.id == ticket_f.id }
+
+            expect(ticket_f_struct.parent_id).to eq(ticket_e.id)
+          end
+
+          it 'filters out invisible work packages' do
+            expect(assigns(:planning_elements).map(&:id)).to_not include(ticket_e.id)
+          end
         end
       end
 


### PR DESCRIPTION
Allow disabling rewiring - this exposes parent IDs of work packages invisible
to the user.
When requesting single work packages via IDs, the rewiring fails as it assumes
that all visible work packages are loaded, which they might not be. For a work
package with a parent visible to the user, but not included in the requested IDs,
the parent_id would thus be nil.
Disabling rewiring allows fetching work packages with their parent_ids
even when the parents are not included in the list of requested work packages.

There's also a case when rewiring is not used at all: When not providing a project
id and requesting via /api/v2/planning_elements.json?ids=[...]. In this case
parent_ids were and are always shown. This is pretty inconsistent, but that's
the way API v2 is. Btw, planning_elements.json returns 404 when not giving an ids
parameter.

Apparently, the way custom fields are returned is also different between
the general planning elements endpoint and the project-specific one. I didn't
look into this, though.

https://www.openproject.org/work_packages/15243

After merging this, please merge `release/3.0` into `dev`.
