### PR TITLE
Fix board pagination

### DIFF
--- a/app/assets/javascripts/angular/config/work-packages-config.js
+++ b/app/assets/javascripts/angular/config/work-packages-config.js
@@ -72,7 +72,7 @@ angular.module('openproject.workPackages.config')
 .constant('DEFAULT_PAGINATION_OPTIONS', {
   page: 1,
   perPage: 10,
-  perPageOptions: [100, 500, 1000],
+  perPageOptions: [10, 100, 500, 1000],
   maxVisiblePageOptions: 9,
   optionsTruncationSize: 2,
 });

--- a/app/assets/javascripts/angular/controllers/messages-controllers.js
+++ b/app/assets/javascripts/angular/controllers/messages-controllers.js
@@ -46,7 +46,8 @@ angular.module('openproject.messages.controllers')
               {
                 params: {
                           sort: SortService.getSortParam(),
-                          page: PaginationService.getPage()
+                          page: PaginationService.getPage(),
+                          per_page: PaginationService.getPerPage()
                         }
               })
          .success(function(data, status, headers, config) {

--- a/app/assets/javascripts/angular/directives/components/table-pagination-directive.js
+++ b/app/assets/javascripts/angular/directives/components/table-pagination-directive.js
@@ -33,7 +33,8 @@ angular.module('openproject.uiComponents')
     restrict: 'EA',
     templateUrl: '/templates/components/table_pagination.html',
     scope: {
-      totalEntries: '='
+      totalEntries: '=',
+      updateResults: '&'
     },
     link: function(scope, element, attributes) {
       scope.I18n = I18n;
@@ -55,6 +56,7 @@ angular.module('openproject.uiComponents')
 
         scope.$emit('workPackagesRefreshRequired');
         scope.$emit('queryStateChange');
+        scope.updateResults();
       };
 
       /**

--- a/karma/tests/directives/components/table_pagination-test.js
+++ b/karma/tests/directives/components/table_pagination-test.js
@@ -34,12 +34,16 @@ describe('tablePagination Directive', function () {
 
   beforeEach(inject(function ($rootScope, $compile, _I18n_) {
     var html, I18n, t;;
-    html = '<table-pagination total-entries="tableEntries" icon-name="totalResults"></table-pagination>';
+    html = '<table-pagination total-entries="tableEntries" icon-name="totalResults" update-results="noteUpdateResultsCalled()"></table-pagination>';
 
     element = angular.element(html);
     rootScope = $rootScope;
     scope = $rootScope.$new();
     I18n = _I18n_;
+
+    scope.noteUpdateResultsCalled = function() {
+      scope.updateResultsCalled = true;
+    }
 
     compile = function () {
       $compile(element)(scope);
@@ -84,6 +88,26 @@ describe('tablePagination Directive', function () {
       scope.tableEntries = 101;
       scope.$apply();
       expect(numberOfPageNumberLinks()).to.eq(11);
+    });
+  });
+
+  describe('updateResults callback', function () {
+    beforeEach(function() {
+      scope.updateResultsCalled = false;
+      compile();
+    });
+
+    it('calls the callback when showing a different page', function() {
+      element.find('a[rel="next"]:first').click();
+
+      expect(scope.updateResultsCalled).to.eq(true);
+    });
+
+    it('calls the callback when seleceting a different per page option', function() {
+      // click on first per-page anchor (current is not an anchor)
+      element.find('.items-per-page-container .pagination a:eq(0)').click()
+
+      expect(scope.updateResultsCalled).to.eq(true);
     });
   });
 


### PR DESCRIPTION
https://www.openproject.org/work_packages/15477

@myabc Would you care to have a look at my impressive Angular skills? :smile_cat: 

What's still missing here is a sync between the OpenProject items-per-page setting and the default the Angular part uses. This results in the number of messages shown not necessarily matching the number of messages shown in the pagination. After one action with the pagination, this is fixed. This might have to do with passing the messages via gon instead of loading them via an API.

Is there any plan on fixing the items-per-page thing or passing it from OpenProject to the Angular part?

Ah, and is there a good way to write a test for this?
