### PR TITLE
The activate label should have a capital letter

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -61,7 +61,7 @@ en:
     general_text_yes: "yes"
     general_text_No: "No"
     general_text_Yes: "Yes"
-    label_activate: "activate"
+    label_activate: "Activate"
     label_add_columns: "Add selected columns"
     label_add_comment: "Add comment"
     label_add_comment_title: "Add your comments here"


### PR DESCRIPTION
This resolves an issue Björn Blissing created at crowdin.
The activate label in the work package index view should have a capital letter.

![selection_180](https://cloud.githubusercontent.com/assets/206108/4214369/7b6b1be0-38c2-11e4-95b8-a58588dd00c7.png)
