### PR TITLE
correctly concatenates params when flags are present

### DIFF
--- a/app/assets/javascripts/angular/helpers/url-params-helper.js
+++ b/app/assets/javascripts/angular/helpers/url-params-helper.js
@@ -154,13 +154,13 @@ angular.module('openproject.helpers')
       }
 
       return query.exportFormats.map(function(format){
-        var url = relativeUrl + "." + format.format + "?" + "set_filter=1&";
+        var url = relativeUrl + "." + format.format + "?" + "set_filter=1";
         if(format.flags){
           angular.forEach(format.flags, function(flag){
-            url = url + flag + "=" + "true";
+            url = url + "&" + flag + "=" + "true";
           });
         }
-        url = url + query.getQueryString();
+        url = url + "&" + query.getQueryString();
 
         return {
           identifier: format.identifier,


### PR DESCRIPTION
It used to create a url like: 

<pre>http://localhost:3000/projects/2/work_packages.pdf?set_filter=1&show_descriptions=truef%5B%5D=status_id&c%5B%5D=type&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=author&sort=parent%3Adesc&name=_&op%5Bstatus_id%5D=o</pre>


where an & is missing between `show_descriptions=true` and the applied filters.

https://www.openproject.org/work_packages/15609
