### PR TITLE
uses fully qualified route on users memberships

### DIFF
--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -49,7 +49,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <td class="roles">
     <span id="member-<%= membership.id %>-roles"><%=h membership.roles.sort.collect(&:to_s).join(', ') %></span>
     <%= form_for(:membership, :remote => true,
-                              :url => { :action => 'edit_membership', :id => @user, :membership_id => membership },
+                              :url => edit_membership_user_path(:id => @user, :membership_id => membership),
                               :html => { :id => "member-#{membership.id}-roles-form", :style => 'display:none;'}) do %>
         <p><% roles.each do |role| %>
         <label><%= check_box_tag 'membership[role_ids][]', role.id, membership.roles.include?(role),


### PR DESCRIPTION
This avoids problems when other controllers render the partial.

No WP, just something I noticed as problematic when a plugin uses the partial.
