### PR TITLE
fix gravatars have no alt attribute in details pane

### DIFF
--- a/karma/tests/work_packages/tabs/user-activity-directive-test.js
+++ b/karma/tests/work_packages/tabs/user-activity-directive-test.js
@@ -1,0 +1,109 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('userActivity Directive', function() {
+    var compile, element, rootScope, scope;
+
+    beforeEach(angular.mock.module('openproject.workPackages.tabs'));
+    beforeEach(function() {
+      module(
+        'ng-context-menu',
+        'openproject.api',
+        'openproject.workPackages',
+        'openproject.models',
+        'openproject.services',
+        'openproject.config',
+        'templates'
+      );
+      module(function ($provide) {
+        $provide.value('$uiViewScroll', angular.noop);
+      });
+    });
+
+    beforeEach(inject(function($rootScope, $compile, $uiViewScroll, $timeout, $location, I18n, PathHelper, ActivityService, UsersHelper) {
+      var html;
+      html = '<div exclusive-edit class="exclusive-edit"><user-activity work-package="workPackage" activity="activity" activity-no="activityNo" input-element-id="inputElementId"></user-activity></div>';
+
+      element = angular.element(html);
+      rootScope = $rootScope;
+      scope = $rootScope.$new();
+
+      compile = function() {
+        $compile(element)(scope);
+        scope.$apply();
+      };
+    }));
+
+    describe('element', function() {
+      describe('with a valid user', function(){
+        beforeEach(function() {
+          scope.workPackage = {
+            links: {
+              addComment: true
+            }
+          };
+          scope.activity = {
+            links: {
+              update: true,
+              user: {
+                fetch: function() {
+                  return {
+                    then: function(cb) {
+                      cb({
+                        props: {
+                          id: 1,
+                          name: "John Doe",
+                          avatar: 'avatar.png',
+                          status: 1
+                        }
+                      }
+                    )}
+                  }
+                }
+              }
+            }
+          };
+          compile();
+        });
+
+        context("user's avatar", function() {
+          it('should have an alt attribute', function() {
+            expect(element.find('.avatar').attr('alt')).to.equal('Avatar');
+          });
+
+          it("should have the title set to user's name", function() {
+            console.log(element);
+            expect(element.find('.avatar').attr('title')).to.equal('John Doe');
+          });
+
+        });
+      });
+
+
+    });
+});

--- a/karma/tests/work_packages/tabs/user_field-directive-test.js
+++ b/karma/tests/work_packages/tabs/user_field-directive-test.js
@@ -1,0 +1,77 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('userField Directive', function() {
+    var compile, element, rootScope, scope;
+
+    beforeEach(angular.mock.module('openproject.workPackages.tabs'));
+    beforeEach(module('templates', 'openproject.helpers'));
+
+    beforeEach(inject(function($rootScope, $compile, PathHelper) {
+      var html;
+      html = '<user-field user="user"></user-field>';
+
+      element = angular.element(html);
+      rootScope = $rootScope;
+      scope = $rootScope.$new();
+
+      compile = function() {
+        $compile(element)(scope);
+        scope.$digest();
+      };
+    }));
+
+    describe('element', function() {
+      describe('with a valid user', function(){
+        beforeEach(function() {
+          scope.user = {
+            props: {
+              firstName: "John",
+              lastName: "Doe",
+              avatar: "avatar.png"
+            }
+          };
+          compile();
+          scope.$apply();
+        });
+
+        context("user's avatar", function() {
+          it('should have an alt attribute', function() {
+            expect(element.find('.avatar-mini').attr('alt')).to.equal('Avatar');
+          });
+
+          it("should have the title set to user's name", function() {
+            expect(element.find('.avatar-mini').attr('title')).to.equal('John Doe');
+          });
+
+        });
+      });
+
+
+    });
+});

--- a/public/templates/work_packages/tabs/_user_activity.html
+++ b/public/templates/work_packages/tabs/_user_activity.html
@@ -17,7 +17,7 @@
          ng-click="editComment()"></i>
     </div>
   </div>
-  <img class="avatar" ng-src="{{ userAvatar }}" />
+  <img class="avatar" ng-src="{{ userAvatar }}" alt="Avatar" title="{{userName}}" />
   <span class="user" ng-if="userActive"><a ng-href="{{ userPath(userId) }}" name="{{ currentAnchor }}" ng-bind="userName"></a></span>
   <span class="user" ng-if="!userActive">{{ userName }}</span>
   <span class="date">{{ I18n.t('js.label_commented_on') }} <date-time date-time-value="activity.props.createdAt"/></date-time>

--- a/public/templates/work_packages/tabs/_user_field.html
+++ b/public/templates/work_packages/tabs/_user_field.html
@@ -2,7 +2,7 @@
   <span ng-if="userName">
     <img class="avatar-mini"
          ng-if="user.props.avatar"
-         ng-src="{{user.props.avatar}}" />
+         ng-src="{{user.props.avatar}}" alt="Avatar" title="{{userName}}" />
     <span class="user">
       <a ng-href="{{ userPath(user.props.id) }}" ng-bind="user.props.name"
          class="user-field-user-link"/>


### PR DESCRIPTION
[`* `#15405` fix gravatars have no alt attribute in details pane`](http://www.openproject.org/work_packages/15405)

I only made alt='Avatar'. Tell me if you need a separation between alt='Avatar' and alt='Gravatar'
