### PR TITLE
Revert "Mark index pagination Cuke wip (fails on Travis)"

### DIFF
--- a/features/work_packages/index_pagination.feature
+++ b/features/work_packages/index_pagination.feature
@@ -54,7 +54,7 @@ Feature: Paginated work packages index list
     Then I should be on the work packages index page of the project "project1"
     And I should see 1 issue
 
-  @javascript @wip
+  @javascript
   Scenario: Pagination outside a project
     When I go to the global index page of work packages
     Then I should see 3 issues


### PR DESCRIPTION
Failures most likely due to Xvfb settings (see 1267a944)

This reverts commit 5f4a2281bf78c3f372cb21e32bdf70d612f95f1d.
