### PR TITLE
Add parent_id to list of possible filters

### DIFF
--- a/app/models/queries/work_packages/available_filter_options.rb
+++ b/app/models/queries/work_packages/available_filter_options.rb
@@ -106,7 +106,8 @@ module Queries::WorkPackages::AvailableFilterOptions
       start_date:      { type: :date, order: 11 },
       due_date:        { type: :date, order: 12 },
       estimated_hours: { type: :integer, order: 13 },
-      done_ratio:      { type: :integer, order: 14 }
+      done_ratio:      { type: :integer, order: 14 },
+      parent_id:       { type: :integer, order: 15 }
     }.with_indifferent_access
 
     add_readable_names_to_work_package_filters @available_work_package_filters

--- a/app/models/queries/work_packages/filter.rb
+++ b/app/models/queries/work_packages/filter.rb
@@ -37,6 +37,7 @@ class Queries::WorkPackages::Filter < Queries::Filter
      due_date:         :date,
      estimated_hours:  :integer,
      done_ratio:       :integer,
+     parent_id:        :integer,
      project_id:       :list,
      category_id:      :list_optional,
      fixed_version_id: :list_optional,


### PR DESCRIPTION
This allows filtering by parent id using API v2 and possiblly other means using the `Query` class.

https://www.openproject.org/work_packages/15754

@ulferts I don't have too much of an idea of which list of filters means what. There's one in `query.rb`, one in `queries/work_packages/available_filter_options` and one in `queries/work_packages/filter.rb`.
Note also the diescrepancy between the `parent_id` field I added and the `parent` field still listed in `query.rb`. So we should discuss this before merging this.
