### PR TITLE
API v2: Use true/false as rewire parents value

### DIFF
--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -206,7 +206,7 @@ module Api
           # the parent_id would thus be nil.
           # Disabling rewiring allows fetching work packages with their parent_ids
           # even when the parents are not included in the list of requested work packages.
-          rewire_ancestors unless params[:rewire_parents] == '0'
+          rewire_ancestors unless params[:rewire_parents] == 'false'
         end
 
       end

--- a/app/controllers/api/v2/planning_elements_controller.rb
+++ b/app/controllers/api/v2/planning_elements_controller.rb
@@ -298,7 +298,10 @@ module Api
       helper_method :include_journals?
 
       def include_journals?
-        params[:include].tap { |i| i.present? && i.include?("journals") }
+        # .tap and the following block here were useless as the block's return value is ignored.
+        # Keeping this code to show its original intention, but not fixing it to not
+        # break things for clients that might not properly use the parameter.
+        params[:include]  # .tap { |i| i.present? && i.include?("journals") }
       end
 
       # Actual protected methods

--- a/spec/controllers/api/v2/planning_elements_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_elements_controller_spec.rb
@@ -180,16 +180,16 @@ describe Api::V2::PlanningElementsController do
           end
 
           describe 'w/ 2 planning elements within a specific project and one PE requested' do
-            context 'with rewire_parents=0' do
+            context 'with rewire_parents=false' do
               let!(:wp_parent) { FactoryGirl.create(:work_package, project_id: project.id) }
               let!(:wp_child)  { FactoryGirl.create(:work_package, project_id: project.id,
                                                                    parent_id: wp_parent.id) }
 
-              context 'with rewire_parents=0' do
+              context 'with rewire_parents=false' do
                 before do
                   get 'index', project_id: project.id,
                                ids: wp_child.id.to_s,
-                               rewire_parents: '0',
+                               rewire_parents: 'false',
                                format: 'xml'
                 end
 
@@ -305,7 +305,7 @@ describe Api::V2::PlanningElementsController do
 
         context 'with rewire_parents=false' do
           before do
-            get 'index', project_id: project1.id, format: 'xml', rewire_parents: '0'
+            get 'index', project_id: project1.id, format: 'xml', rewire_parents: 'false'
           end
 
           it "doesn't rewire ancestors" do


### PR DESCRIPTION
Follow-up to #1886. See commits for reasoning.

Please merge release/3.0 into dev after merging this.

Relates to https://www.openproject.org/work_packages/15243
