### PR TITLE
Allow horizontal page scrolling in absolute layout mode

### DIFF
--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -41,7 +41,9 @@ body
   background: white
 
   &%absolute-layout-mode
-    overflow: hidden
+    overflow:
+      x: auto
+      y: hidden
 
 #wrapper
   @include default-transition


### PR DESCRIPTION
This is a quick fix to make elements that are currently unreachable, reachable. The problem exists thanks to the `min-width: 1100px` set on the `<html>`-element. A better solution would be to remove this property and take care to make individual page components (especially navigation) work responsively.

See 00506ca.

https://www.openproject.org/work_packages/15885
