### PR TITLE
users allowed new statuses no longer receive an edit menu entry

### DIFF
--- a/app/controllers/api/experimental/concerns/can.rb
+++ b/app/controllers/api/experimental/concerns/can.rb
@@ -70,10 +70,11 @@ module Api
 
         def edit_allowed?(work_package)
           @edit_cache ||= Hash.new do |hash, project|
-            hash[project] = user.allowed_to?(:edit_work_packages, project)
+            hash[project] = user.allowed_to?(:edit_work_packages, project) ||
+                            user.allowed_to?(:add_work_package_notes, project)
           end
 
-          @edit_cache[work_package.project] || work_package.new_statuses_allowed_to(user).present?
+          @edit_cache[work_package.project]
         end
 
         def log_time_allowed?(work_package)

--- a/spec/controllers/api/experimental/concerns/can_spec.rb
+++ b/spec/controllers/api/experimental/concerns/can_spec.rb
@@ -1,0 +1,59 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+
+describe Api::Experimental::Concerns::Can, type: :controller do
+  let(:user)         { FactoryGirl.build_stubbed(:user) }
+  let(:project)      { FactoryGirl.build_stubbed(:project) }
+  let(:work_package) { FactoryGirl.build_stubbed(:work_package, project: project) }
+
+  describe :allowed? do
+    let(:subject) { described_class.new(user) }
+
+    before do
+      allow(user).to receive(:allowed_to?).and_return false
+    end
+
+    it 'is false for edit if the user has no permission in the project' do
+      expect(subject.allowed?(work_package, :edit)).to be_false
+    end
+
+    it 'is true for edit if the user has the edit_work_package permission in the project' do
+      allow(user).to receive(:allowed_to?).with(:edit_work_packages, project)
+                                          .and_return true
+      expect(subject.allowed?(work_package, :edit)).to be_true
+    end
+
+    it 'is true for edit if the user has the add_work_package_notes permission in the project' do
+      allow(user).to receive(:allowed_to?).with(:add_work_package_notes, project)
+                                          .and_return true
+      expect(subject.allowed?(work_package, :edit)).to be_true
+    end
+  end
+end


### PR DESCRIPTION
They are not allowed to call the work_package#edit action anyway

Users having the add_work_package_notes permission on the other hand are allowed to update work packages.

https://www.openproject.org/work_packages/15887
