### PR TITLE
fix add child button displayed on details pane when user has no permissi...

### DIFF
--- a/app/assets/javascripts/angular/work_packages/view_models/relations-handler.js
+++ b/app/assets/javascripts/angular/work_packages/view_models/relations-handler.js
@@ -130,14 +130,12 @@ angular.module('openproject.viewModels')
         handler.type = "child";
         handler.applyCustomExtensions = undefined;
 
-        handler.canAddRelation = function() { return true };
+        handler.canAddRelation = function() { return !!this.workPackage.links.addChild }; 
         handler.canDeleteRelation = function() {
           return !!this.workPackage.links.update;
         };
         handler.addRelation = function() {
-            window.location = PathHelper.staticWorkPackageNewWithParentPath(
-                this.workPackage.props.projectId, this.workPackage.props.id
-            );
+          window.location = this.workPackage.links.addChild.href
         };
         handler.getRelatedWorkPackage = function(workPackage, relation) { return relation.fetch() };
         handler.removeRelation = function(scope) {

--- a/karma/tests/directives/work_packages/work-package-relations-directive-test.js
+++ b/karma/tests/directives/work_packages/work-package-relations-directive-test.js
@@ -27,13 +27,14 @@
 //++
 
 describe('Work Package Relations Directive', function() {
-  var I18n, PathHelper, compile, element, scope;
+  var I18n, PathHelper, compile, element, scope, ChildrenRelationsHandler;
 
   beforeEach(angular.mock.module('openproject.workPackages.tabs',
                                  'openproject.api',
                                  'openproject.helpers',
                                  'openproject.models',
                                  'openproject.services',
+                                 'openproject.viewModels',
                                  'ngSanitize'));
 
   beforeEach(module('templates', function($provide) {
@@ -48,7 +49,8 @@ describe('Work Package Relations Directive', function() {
                              $compile,
                              _I18n_,
                              _PathHelper_,
-                             _WorkPackagesHelper_) {
+                             _WorkPackagesHelper_,
+                             _ChildrenRelationsHandler_) {
     scope = $rootScope.$new();
 
     compile = function(html) {
@@ -57,6 +59,7 @@ describe('Work Package Relations Directive', function() {
     };
 
     I18n = _I18n_;
+    ChildrenRelationsHandler = _ChildrenRelationsHandler_;
     PathHelper = _PathHelper_;
     WorkPackagesHelper = _WorkPackagesHelper_;
 
@@ -131,6 +134,7 @@ describe('Work Package Relations Directive', function() {
       },
       links: {
         self: { href: "/work_packages/1" },
+        addChild: {href: "/add_children_href"},
         addRelation: { href: "/work_packages/1/relations" }
       }
     };
@@ -325,6 +329,28 @@ describe('Work Package Relations Directive', function() {
       expect(addRelationDiv.length).to.eq(0);
     });
   };
+
+  describe('children relation', function() {
+    context('add child link present', function() {
+      beforeEach(function() {
+        scope.relations = new ChildrenRelationsHandler(workPackage1, []);
+        compile(html);
+      });
+      it('"add child" button should be present', function() {
+        expect(angular.element(element.find('.add-work-package-child-button')).length).to.eql(1);
+      });
+    });
+
+    context('add child link missing', function() {
+      beforeEach(function() {
+        scope.relations = new ChildrenRelationsHandler(workPackage2, []);
+        compile(html);
+      });
+      it('"add child" button should be missing', function() {
+        expect(angular.element(element.find('.add-work-package-child-button')).length).to.eql(0);
+      });
+    });
+  });
 
   describe('no element markup', function() {
     beforeEach(function() {

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -168,6 +168,14 @@ module API
           } if current_user_allowed_to(:manage_work_package_relations, represented.model)
         end
 
+        link :addChild do
+          {
+            href: new_project_work_package_path(represented.model.project, work_package: {parent_id: represented.model}),
+            type: 'text/html',
+            title: "Add child of #{represented.subject}"
+          } if current_user_allowed_to(:add_work_packages, represented.model)
+        end
+
         link :addComment do
           {
               href: "#{root_path}api/v3/work_packages/#{represented.model.id}/activities",

--- a/public/templates/work_packages/tabs/_add_work_package_child.html
+++ b/public/templates/work_packages/tabs/_add_work_package_child.html
@@ -1,4 +1,4 @@
-<button class="button"
+<button class="button add-work-package-child-button"
   title="{{ btnTitle }}"
   ng-bind-html="btnIcon + ' ' + btnTitle"
   ng-click="handler.addRelation()">

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -185,6 +185,24 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
       end
 
+      context 'when the user has the permission to add work packages' do
+        before do
+          role.permissions.push(:add_work_packages) and role.save
+        end
+        it 'should have a link to add child' do
+          expect(subject).to have_json_path('_links/addChild/href')
+        end
+      end
+
+      context 'when the user does not have the permission to add work packages' do
+        before do
+          role.permissions.delete(:add_work_packages) and role.save
+        end
+        it 'should not have a link to add child' do
+          expect(subject).to_not have_json_path('_links/addChild/href')
+        end
+      end
+
       describe 'linked relations' do
         let(:project) { FactoryGirl.create(:project, is_public: false) }
         let(:forbidden_project) { FactoryGirl.create(:project, is_public: false) }


### PR DESCRIPTION
[`* `#15888 ` fix add child button displayed on details pane when user has no permissions to add work packages`](http://www.openproject.org/work_packages/15888)
