### PR TITLE
fix saved queries don't update wp lists correctly when removing filters

### DIFF
--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -72,7 +72,8 @@ angular.module('openproject.models')
           'sort': this.getEncodedSortation(),
           'display_sums': this.displaySums,
           'name': this.name,
-          'is_public': this.isPublic
+          'is_public': this.isPublic,
+          'accept_empty_query_fields': this.isDirty(),
         }].concat(this.getActiveConfiguredFilters().map(function(filter) {
           return filter.toParams();
         }))
@@ -90,7 +91,8 @@ angular.module('openproject.models')
           'sort': this.getEncodedSortation(),
           'display_sums': this.displaySums,
           'name': this.name,
-          'is_public': this.isPublic
+          'is_public': this.isPublic,
+          'accept_empty_query_fields': this.isDirty()
         }].concat(this.getActiveConfiguredFilters().map(function(filter) {
           return filter.toParams();
         }))
@@ -299,6 +301,7 @@ angular.module('openproject.models')
     },
 
     deactivateFilter: function(filter) {
+      this.dirty = true;
       filter.deactivated = true;
     },
 

--- a/app/controllers/api/experimental/concerns/query_loading.rb
+++ b/app/controllers/api/experimental/concerns/query_loading.rb
@@ -47,7 +47,7 @@ module Api::Experimental::Concerns::QueryLoading
 
   def prepare_query
     @query.is_public = false unless User.current.allowed_to?(:manage_public_queries, @project) || User.current.admin?
-    view_context.add_filter_from_params if params[:fields] || params[:f]
+    view_context.add_filter_from_params if params[:fields] || params[:f] || params[:accept_empty_query_fields]
     @query.group_by = params[:group_by] if params[:group_by].present?
     @query.sort_criteria = prepare_sort_criteria if params[:sort]
     @query.display_sums = params[:display_sums] if params[:display_sums].present?

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -49,6 +49,7 @@ module QueriesHelper
       cond << " OR project_id = #{@project.id}" if @project
       @query = Query.find(params[:query_id], :conditions => cond)
       @query.project = @project
+      add_filter_from_params if params[:accept_empty_query_fields]
       session[:query] = {:id => @query.id, :project_id => @query.project_id}
       sort_clear
     else

--- a/karma/tests/models/query_test.js
+++ b/karma/tests/models/query_test.js
@@ -47,6 +47,42 @@ describe('Query', function() {
     expect(new Query(queryData)).to.be.an('object');
   });
 
+  describe('toParams, toUpdateParams', function() {
+    beforeEach(function() {
+      query = Factory.build('Query');
+    });
+
+    context('query is dirty', function() {
+      beforeEach(function() {
+        query.id = 1;
+        query.dirty = true;
+      });
+      it("should contain accept_empty_query_fields as true", function() {
+        expect(query.toParams())
+          .to.have.property('accept_empty_query_fields')
+          .and.equal(true);
+        expect(query.toUpdateParams())
+          .to.have.property('accept_empty_query_fields')
+          .and.equal(true);
+      });
+    });
+
+    context('query is dirty', function() {
+      beforeEach(function() {
+        query.id = 1;
+        query.dirty = false;
+      });
+      it("should contain accept_empty_query_fields as true", function() {
+        expect(query.toParams())
+          .to.have.property('accept_empty_query_fields')
+          .and.equal(false);
+        expect(query.toUpdateParams())
+          .to.have.property('accept_empty_query_fields')
+          .and.equal(false);
+      });
+    });
+  });
+
   describe('adding filters', function(){
     beforeEach(function(){
       query = Factory.build('Query', {filters: []});

--- a/spec/controllers/api/experimental/concerns/query_loading_spec.rb
+++ b/spec/controllers/api/experimental/concerns/query_loading_spec.rb
@@ -1,0 +1,60 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+
+describe 'QueryLoading', :type => :controller do
+  include Api::Experimental::Concerns::QueryLoading
+  include QueriesHelper
+
+  describe '#prepare_query' do
+    let!(:query) { FactoryGirl.create :query }
+    let(:view_context) { ActionController::Base.new.view_context }
+
+    before do
+      view_context.stub(:add_filter_from_params)
+    end
+
+    context "accept_empty_query_fields is true" do
+      let(:params) { { accept_empty_query_fields: true, query_id: query.id } }
+      it 'should call add_filter_from_params' do
+        view_context.should_receive :add_filter_from_params
+        init_query
+      end
+    end
+
+    context "accept_empty_query_fields is false or missing" do
+      let(:params) { { accept_empty_query_fields: false, query_id: query.id } }
+      it 'should not call add_filter_from_params' do
+        view_context.should_not_receive :add_filter_from_params
+        init_query
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
[`* `#15604 ` fix saved queries don't update wp lists correctly when removing filters`](http://www.openproject.org/work_packages/15604)
