### PR TITLE
limit overflow visible to show action

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -193,6 +193,6 @@ h1:hover, h2:hover, h3:hover
 .wiki-content
   width: 700px
 
-.controller-wiki
+.controller-wiki.action-show
   #content
     overflow: visible


### PR DESCRIPTION
The reason for the overflow is ensuring that the action menu is never
cut off. Overflow visible however leads to the contents having a form
with p elements, thanks to clear: left, to begin only after the complete
menu. There is no action menu on such pages.
- https://www.openproject.org/work_packages/16038
