### PR TITLE
Tell Hound to allow {} for multi-line blocks

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -26,6 +26,9 @@ Attr:
 BlockNesting:
   Enabled: false
 
+Blocks:
+  Enabled: false
+
 CaseEquality:
   Enabled: false
 


### PR DESCRIPTION
Prefer alternate convention based on semantic intent of block. See:
http://devblog.avdi.org/2011/07/26/the-procedurefunction-block-convention-in-ruby/

See: https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml#L81
