### PR TITLE
after_login can now receive a context variable (usually the controller)

### DIFF
--- a/app/controllers/concerns/omniauth_login.rb
+++ b/app/controllers/concerns/omniauth_login.rb
@@ -60,7 +60,7 @@ module Concerns::OmniauthLogin
     else
       if user.active?
         user.log_successful_login
-        OpenProject::OmniAuth::Authorization.after_login! user, auth_hash
+        OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
       end
       login_user_if_active(user)
     end
@@ -84,7 +84,7 @@ module Concerns::OmniauthLogin
 
     fill_user_fields_from_omniauth user, auth_hash
 
-    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth_hash } }
+    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth_hash, self } }
 
     # Create on the fly
     register_user_according_to_setting(user, opts) do
@@ -106,7 +106,7 @@ module Concerns::OmniauthLogin
     fill_user_fields_from_omniauth(user, auth)
     user.update_attributes(permitted_params.user_register_via_omniauth)
 
-    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth } }
+    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth, self } }
     register_user_according_to_setting user, opts
   end
 

--- a/app/controllers/concerns/omniauth_login.rb
+++ b/app/controllers/concerns/omniauth_login.rb
@@ -84,7 +84,9 @@ module Concerns::OmniauthLogin
 
     fill_user_fields_from_omniauth user, auth_hash
 
-    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth_hash, self } }
+    opts = {
+      after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth_hash, self }
+    }
 
     # Create on the fly
     register_user_according_to_setting(user, opts) do
@@ -106,7 +108,9 @@ module Concerns::OmniauthLogin
     fill_user_fields_from_omniauth(user, auth)
     user.update_attributes(permitted_params.user_register_via_omniauth)
 
-    opts = { after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth, self } }
+    opts = {
+      after_login: ->(u) { OpenProject::OmniAuth::Authorization.after_login! u, auth, self }
+    }
     register_user_according_to_setting user, opts
   end
 

--- a/lib/open_project/omni_auth/authorization.rb
+++ b/lib/open_project/omni_auth/authorization.rb
@@ -52,9 +52,9 @@ module OpenProject
       # Signals that the given user has been logged in.
       #
       # Note: Only call if you know what you are doing.
-      def self.after_login!(user, auth_hash)
+      def self.after_login!(user, auth_hash, context = nil)
         after_login_callbacks.each do |callback|
-          callback.after_login user, auth_hash
+          callback.after_login user, auth_hash, context
         end
       end
 
@@ -171,8 +171,8 @@ module OpenProject
         #
         # @param [User] User who has been logged in.
         # @param [Omniauth::AuthHash] Omniauth authentication info including credentials.
-        def after_login(user, auth_hash)
-          fail "subclass responsibility: after_login(#{user}, #{auth_hash})"
+        def after_login(user, auth_hash, context)
+          fail "subclass responsibility: after_login(#{user}, #{auth_hash}, #{context})"
         end
       end
 
@@ -185,8 +185,8 @@ module OpenProject
           @block = block
         end
 
-        def after_login(user, auth_hash)
-          block.call user, auth_hash
+        def after_login(user, auth_hash, context)
+          block.call user, auth_hash, context
         end
       end
 

--- a/lib/open_project/omni_auth/authorization.rb
+++ b/lib/open_project/omni_auth/authorization.rb
@@ -52,7 +52,7 @@ module OpenProject
       # Signals that the given user has been logged in.
       #
       # Note: Only call if you know what you are doing.
-      def self.after_login!(user, auth_hash, context = nil)
+      def self.after_login!(user, auth_hash, context = self)
         after_login_callbacks.each do |callback|
           callback.after_login user, auth_hash, context
         end

--- a/spec/lib/open_project/omni_auth/authorization_spec.rb
+++ b/spec/lib/open_project/omni_auth/authorization_spec.rb
@@ -33,6 +33,7 @@ describe OpenProject::OmniAuth::Authorization do
     let(:auth_hash) { Struct.new(:uid).new 'bar' }
     let(:user)  { FactoryGirl.create :user, mail: 'foo@bar.de' }
     let(:state) { Struct.new(:number, :user_email, :uid).new 0, nil, nil }
+    let(:collector) { [] }
 
     before do
       OpenProject::OmniAuth::Authorization.after_login_callbacks.clear
@@ -44,6 +45,10 @@ describe OpenProject::OmniAuth::Authorization do
       OpenProject::OmniAuth::Authorization.after_login do |user, auth|
         state.user_email = user.mail
         state.uid = auth.uid
+      end
+
+      OpenProject::OmniAuth::Authorization.after_login do |user, auth, context|
+        collector << context
       end
     end
 
@@ -57,6 +62,12 @@ describe OpenProject::OmniAuth::Authorization do
       expect(state.number).to eq 42
       expect(state.user_email).to eq 'foo@bar.de'
       expect(state.uid).to eq 'bar'
+    end
+
+    it 'it optionally passes in a context' do
+      context = stub(:some_context)
+      OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, context
+      expect(collector).to include(context)
     end
   end
 end

--- a/spec/lib/open_project/omni_auth/authorization_spec.rb
+++ b/spec/lib/open_project/omni_auth/authorization_spec.rb
@@ -47,7 +47,7 @@ describe OpenProject::OmniAuth::Authorization do
         state.uid = auth.uid
       end
 
-      OpenProject::OmniAuth::Authorization.after_login do |user, auth, context|
+      OpenProject::OmniAuth::Authorization.after_login do |_, _, context|
         collector << context
       end
     end
@@ -64,7 +64,7 @@ describe OpenProject::OmniAuth::Authorization do
       expect(state.uid).to eq 'bar'
     end
 
-    it 'it optionally passes in a context' do
+    it "it optionally passes in a context" do
       context = stub(:some_context)
       OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, context
       expect(collector).to include(context)


### PR DESCRIPTION
Provides the controller context to any registered after_login callbacks

NOTE: this is the same as #1961 for `multitenancy` which I would like to have merged soon :)

Entailed by WP [#15646](https://www.openproject.org/work_packages/15646).
