### PR TITLE
remove unneeded String#mb_chars from SearchHelper

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -39,7 +39,6 @@ module SearchHelper
         result << '...'
         break
       end
-      words = words.mb_chars
       if i.even?
         result << h(words.length > 100 ? "#{words.slice(0..44)} ... #{words.slice(-45..-1)}" : words)
       else


### PR DESCRIPTION
Test fails randomly.

<pre>
  1) Error:
SearchHelperTest#test_highlight_multibyte:
ArgumentError: invalid byte sequence in UTF-8
    app/helpers/search_helper.rb:36:in `block in highlight_tokens'
    app/helpers/search_helper.rb:26:in `each'
    app/helpers/search_helper.rb:26:in `each_with_index'
    app/helpers/search_helper.rb:26:in `highlight_tokens'
    test/unit/helpers/search_helper_test.rb:46:in `test_highlight_multibyte'
</pre>


String#mb_chars is for Ruby 1.8 compatibility.
Rails4 dropped Ruby 1.8 support.

--HG--
branch : ../sandbox/rails-4.1
extra : convert_revision : svn%3Ae93f8b46-1217-0410-a6f0-8f06a7374b81/sandbox/rails-4.1%4013414
