### PR TITLE
fix details pane version link leads to 403 when no permissions on parent project

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -78,8 +78,9 @@ angular.module('openproject.workPackages.controllers')
                 if ($scope.workPackage.props.versionId == undefined) {
                     return;
                 }
-                var versionId = $scope.workPackage.props.versionId;
-                return {href: PathHelper.versionPath(versionId), title: $scope.workPackage.props.versionName};
+                var versionId = $scope.workPackage.props.versionId,
+                  versionLinkPresent = !!$scope.workPackage.links.version;
+                return {href: versionLinkPresent ? $scope.workPackage.links.version.href : null, title: $scope.workPackage.props.versionName, viewable: versionLinkPresent};
                 break;
             case USER_TYPE:
                 return $scope.workPackage.embedded[property];

--- a/karma/tests/controllers/details-tab-overview-controller-test.js
+++ b/karma/tests/controllers/details-tab-overview-controller-test.js
@@ -299,17 +299,42 @@ describe('DetailsTabOverviewController', function() {
       describe('is "version"', function() {
         beforeEach(function() {
           workPackage.props.versionName = 'Test version';
-          workPackage.props.versionId = 1
+          workPackage.props.versionId = 1;
+          workPackage.links = workPackage.links || {};
           buildController();
         });
 
-        it('should return the version as a link with correct href', function() {
-          expect(fetchPresentPropertiesWithName('versionName')[0].value.href).to.equal('/versions/1');
+        context('versionViewable is false or missing', function() {
+          beforeEach(function() {
+            buildController();
+          });
+
+          it ('should set the correct viewable property', function() {
+            expect(fetchPresentPropertiesWithName('versionName')[0].value.viewable).to.equal(false);
+          });
         });
 
-        it('should return the version as a link with correct title', function() {
-          expect(fetchPresentPropertiesWithName('versionName')[0].value.title).to.equal('Test version');
+        context('versionViewable is true', function() {
+          beforeEach(function() {
+            workPackage.links.version = {
+              href: "/versions/1"
+            };
+            buildController();
+          });
+
+          it('should return the version as a link with correct href', function() {
+            expect(fetchPresentPropertiesWithName('versionName')[0].value.href).to.equal('/versions/1');
+          });
+
+          it('should return the version as a link with correct title', function() {
+            expect(fetchPresentPropertiesWithName('versionName')[0].value.title).to.equal('Test version');
+          });
+
+          it ('should set the correct viewable property', function() {
+            expect(fetchPresentPropertiesWithName('versionName')[0].value.viewable).to.equal(true);
+          });
         });
+
       });
 
       describe('is "user"', function() {

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -191,6 +191,14 @@ module API
           } unless represented.model.parent.nil? || !represented.model.parent.visible?
         end
 
+        link :version do
+          {
+            href: version_path(represented.model.fixed_version),
+            type: 'text/html',
+            title: "#{represented.model.fixed_version}"
+          } if represented.model.fixed_version && @current_user.allowed_to?({controller: "versions", action: "show"}, represented.model.fixed_version.project, global: false)
+        end
+
         links :children do
           visible_children.map do |child|
             { href: "#{root_path}api/v3/work_packages/#{child.id}", title: child.subject }

--- a/public/templates/work_packages/tabs/overview.html
+++ b/public/templates/work_packages/tabs/overview.html
@@ -20,7 +20,10 @@
                                          html-element="propertyData.value"
                                          work-package="workPackage">
           </span>
-          <span ng-switch-when="version"><a ng-href="{{propertyData.value.href}}">{{propertyData.value.title}}</a></span>
+          <span ng-switch-when="version">
+            <a ng-if="propertyData.value.viewable" ng-href="{{propertyData.value.href}}">{{propertyData.value.title}}</a>
+            <span ng-if="!propertyData.value.viewable">{{propertyData.value.title}}</span>
+          </span>
           <span ng-switch-when="category">{{ propertyData.value.props.name }}</span>
           <span ng-switch-default
             ng-bind="(propertyData.value !== undefined) ? propertyData.value : '-'"

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -75,13 +75,17 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       it { is_expected.to have_json_path('subject') }
       it { is_expected.to have_json_path('type') }
 
-      it { is_expected.to have_json_path('versionId') }
-      it { is_expected.to have_json_path('versionName') }
+
 
       it { is_expected.to have_json_path('createdAt') }
       it { is_expected.to have_json_path('updatedAt') }
 
       it { is_expected.to have_json_path('isClosed') }
+
+      describe 'version' do
+        it { is_expected.to have_json_path('versionId') }
+        it { is_expected.to have_json_path('versionName') }
+      end
     end
 
     describe 'estimatedTime' do
@@ -97,6 +101,30 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       it 'should link to self' do
         expect(subject).to have_json_path('_links/self/href')
         expect(subject).to have_json_path('_links/self/title')
+      end
+
+      describe 'version' do
+        context 'no version set' do
+          it { is_expected.to_not have_json_path('versionViewable') }
+        end
+
+        context 'version set' do
+          let!(:version) { FactoryGirl.create :version, project: project }
+          before do
+            work_package.fixed_version = version
+          end
+
+          it { is_expected.to have_json_path('_links/version/href') }
+
+          context ' but is not accessible due to permissions' do
+            before do
+              current_user.stub(:allowed_to?).and_call_original
+              current_user.stub(:allowed_to?).with({controller: "versions", action: "show"}, project, global: false).and_return(false)
+            end
+
+            it { is_expected.to_not have_json_path('_links/version/href') }
+          end
+        end
       end
 
       context 'when the user has the permission to view work packages' do


### PR DESCRIPTION
[`* `#15274` fix details pane version link leads to 403 when no permissions on parent project`](http://www.openproject.org/work_packages/15274)
