### PR TITLE
Meets #11256: All modules deactivated when only work package tracking is selected

### DIFF
--- a/app/controllers/copy_projects_controller.rb
+++ b/app/controllers/copy_projects_controller.rb
@@ -39,12 +39,12 @@ class CopyProjectsController < ApplicationController
     target_project_name = params[:project][:name]
     @copy_project = Project.new
     @copy_project.safe_attributes = params[:project]
-
     if @copy_project.valid?
+      modules = params[:project][:enabled_module_names] || params[:enabled_modules]
       copy_project_job = CopyProjectJob.new(User.current,
                                             @project,
                                             params[:project],
-                                            params[:enabled_modules],
+                                            modules,
                                             params[:only],
                                             params[:notifications] == '1')
 

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -39,6 +39,7 @@ describe CopyProjectsController, :type => :controller do
       "responsible_id"=>current_user.id,
       "project_type_id" => "",
       "homepage" => "",
+      "enabled_module_names" => ["work_package_tracking", "boards", ""],
       "is_public" => project.is_public,
       "type_ids" => project.types.collect(&:id)
     }
@@ -110,6 +111,10 @@ describe CopyProjectsController, :type => :controller do
     end
 
     it { expect(Project.count).to eq(2) }
+
+    it 'copied project should have enabled modules specified in params' do
+      expect(Project.all.last.enabled_modules.map(&:name)).to match_array(["work_package_tracking", "boards"])
+    end
 
     it_behaves_like 'successful copy' do
       let(:source_project) { project }


### PR DESCRIPTION
[`* `#11256` All modules deactivated when only work package tracking is selected`](https://www.openproject.org/work_packages/11256)
