### PR TITLE
shut up, bothering bower!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - "nvm use 0.10"
   - "travis_retry npm -g install bower@~1.3.8"
   - "travis_retry bower install -F"
-  - "if [[ $TEST_SUITE == 'karma' ]]; then travis_retry npm install --dev --no-optional; fi"
+  - "if [[ $TEST_SUITE == 'karma' ]]; then travis_retry npm install; fi"
 before_script:
   - "if [[ $TEST_SUITE != 'karma' ]]; then RAILS_ENV=production bundle exec rake ci:travis:prepare; fi"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - "nvm use 0.10"
   - "travis_retry npm -g install bower@~1.3.8"
   - "travis_retry bower install -F"
-  - "if [[ $TEST_SUITE == 'karma' ]]; then travis_retry npm install; fi"
+  - "if [[ $TEST_SUITE == 'karma' ]]; then travis_retry npm install --dev --no-optional; fi"
 before_script:
   - "if [[ $TEST_SUITE != 'karma' ]]; then RAILS_ENV=production bundle exec rake ci:travis:prepare; fi"
 notifications:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "scripts": {
     "test": "$(npm bin)/karma start --single-run --browsers Firefox,PhantomJS",
-    "postinstall": "$(npm bin)/bower install"
+    "postinstall": "$(npm bin)/bower install --config.interactive=false"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bower": "~1.3.8"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --single-run --browsers Firefox,PhantomJS",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "test": "$(npm bin)/karma start --single-run --browsers Firefox,PhantomJS",
+    "postinstall": "$(npm bin)/bower install"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bower": "~1.3.8"
   },
   "scripts": {
-    "test": "$(npm bin)/karma start --single-run --browsers Firefox,PhantomJS",
-    "postinstall": "$(npm bin)/bower install --config.interactive=false"
+    "test": "./node_modules/karma/bin/karma start --single-run --browsers Firefox,PhantomJS",
+    "postinstall": "./node_modules/bower/bin/bower install --config.interactive=false"
   }
 }


### PR DESCRIPTION
bower asks for permission to send usage reports, which disturbs the installation process

```
[?] May bower anonymously report usage statistics to improve the tool over time? No
```

tell him to shut up with this

also use npm's bin command to get the local bin folder https://www.npmjs.org/doc/cli/npm-bin.html
