### PR TITLE
Add a warning to pagination settings

### DIFF
--- a/app/views/settings/_general.html.erb
+++ b/app/views/settings/_general.html.erb
@@ -39,8 +39,11 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p><%= setting_text_field :attachment_max_size, :size => 6 %> <%= l(:"number.human.storage_units.units.kb") %></p>
 
-<p><%= setting_text_field :per_page_options, :size => 20 %><br />
-<em><%= l(:text_comma_separated) %></em></p>
+<p>
+  <%= setting_text_field :per_page_options, :size => 20 %><br>
+  <em><%= l(:text_comma_separated) %></em><br>
+  <em><%= l(:text_notice_too_many_values_are_inperformant) %></em>
+</p>
 
 <p><%= setting_text_field :activity_days_default, :size => 6 %> <%= l(:label_day_plural) %></p>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1374,6 +1374,7 @@ de:
     Rollen, Typ, Arbeitspaket-Status und Workflows wurden noch nicht
     konfiguriert. Es ist sehr zu empfehlen, die Standard-Konfiguration
     zu laden. Sobald sie geladen ist, können Sie sie abändern.
+  text_notice_too_many_values_are_inperformant: "Achtung: Das Anzeigen von mehr als 100 Objekten pro Seite kann die Seitenladezeiten erhöhen."
   text_own_membership_delete_confirmation: "Sie sind dabei, einige oder alle Ihre Berechtigungen zu entfernen. Es ist möglich, dass Sie danach das Projekt nicht mehr ansehen oder bearbeiten dürfen.\nSind Sie sicher, dass Sie dies tun möchten?"
   text_plugin_assets_writable: "Verzeichnis für Plugin-Assets beschreibbar"
   text_powered_by: "Powered by %{link}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1360,6 +1360,7 @@ en:
   text_load_default_configuration: "Load the default configuration"
   text_min_max_length_info: "0 means no restriction"
   text_no_configuration_data: "Roles, types, work package statuses and workflow have not been configured yet.\nIt is highly recommended to load the default configuration. You will be able to modify it once loaded."
+  text_notice_too_many_values_are_inperformant: "Note: Displaying more than 100 items per page can increase the page load time."
   text_own_membership_delete_confirmation: "You are about to remove some or all of your permissions and may no longer be able to edit this project after that.\nAre you sure you want to continue?"
   text_plugin_assets_writable: "Plugin assets directory writable"
   text_powered_by: "Powered by %{link}"


### PR DESCRIPTION
For the objects_per_page options.
The warning states that loading more than 100 objects per page can
increaste the page load times.

@ulferts asked me to add this warning
