### PR TITLE
When grouping for '% done' in the WorkPackage table the progress bar has issues

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -98,8 +98,6 @@ table.workpackages-table
   p
     padding: 0 8px
     margin: 0
-  p:hover
-    background: #fff598
 
   .sort-header
     white-space: nowrap

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -142,7 +142,7 @@ de:
     label_sum_for: "Summe für"
     label_this_week: "aktuelle Woche"
     label_today: "heute"
-    label_total_progress: "Gesamtfortschritt"
+    label_total_progress: "%{percent}% Gesamtfortschritt"
     label_visible_for_others: "Seite sichtbar für andere Nutzer"
     label_work_package: "Arbeitspaket"
     label_watch_work_package: "Arbeitspaket beobachten"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -141,7 +141,7 @@ en:
     label_sum_for: "Sum for"
     label_this_week: "this week"
     label_today: "today"
-    label_total_progress: "Total progress"
+    label_total_progress: "%{percent}% Total progress"
     label_visible_for_others: "Page visible for others"
     label_work_package: "Work package"
     label_watch_work_package: "Watch work package"

--- a/public/templates/components/progress_bar.html
+++ b/public/templates/components/progress_bar.html
@@ -7,5 +7,5 @@
       </tr>
     </tbody>
   </table>
-  <p class="progress-bar-legend">{{ legend + ' ' + I18n.t('js.label_total_progress') }}</p>
+  <p class="progress-bar-legend">{{ progressInPercent + '% ' + I18n.t('js.label_total_progress') }}</p>
 </div>

--- a/public/templates/components/progress_bar.html
+++ b/public/templates/components/progress_bar.html
@@ -7,5 +7,5 @@
       </tr>
     </tbody>
   </table>
-  <p class="progress-bar-legend">{{ progressInPercent + '% ' + I18n.t('js.label_total_progress') }}</p>
+  <p class="progress-bar-legend">{{ I18n.t('js.label_total_progress', { percent: progressInPercent }) }}</p>
 </div>


### PR DESCRIPTION
- when hovering over the progress bar in the group-colum, it gets highlighted in yellow (which looks silly)
- the progress is not displayed as text

See: https://www.openproject.org/work_packages/15608

| old | new |
| --- | --- |
| ![pmxmxexqtr](https://cloud.githubusercontent.com/assets/206108/4475966/87106b70-4971-11e4-94c9-5b56a6f08ae1.png) | ![selection_055](https://cloud.githubusercontent.com/assets/206108/4475942/59c39f02-4971-11e4-9375-97460a2c7525.png) |
