### PR TITLE
adds specification for available custom properties

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1819,6 +1819,109 @@ Gets a list of users that can be assigned to the work package as responsible.
 
     [Available Responsibles][]
 
+## AvailableCustomProperties [/work_packages/{work_package_id}/available_custom_properties{?type}]
+
++ Model
+    + Body
+
+            {
+              "_links": {
+                "self": {
+                  "href": "http://localhost:3000/api/v3/work_packages/688/available_custom_properties"
+                },
+                "workPackage": {
+                  "href": "http://localhost:3000/api/v3/work_packages/688"
+                }
+              },
+              "_type": "CustomProperties",
+              "_embedded": {
+                "customProperties": [
+                  {
+                    "_type": "CustomProperty::Text",
+                    "name": "e-mail",
+                    "validations": {
+                      "isRequired": "false",
+                      "minLength": "0",
+                      "maxLength": "100",
+                      "regularExpression": "[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}",
+                    },
+                    "defaultValue": "foo@bar.com"
+                  },
+                  {
+                    "_type": "CustomProperty::List",
+                    "name": "Country",
+                    "validations": {
+                      "availableValues": [
+                        "Ghana",
+                        "Nigeria",
+                        "South Africa"
+                      ],
+                      "isRequired": "true",
+                    },
+                    "defaultValue": "Ghana"
+                  },
+                  {
+                    "_type": "CustomProperty::Date",
+                    "name": "Date of Birth",
+                    "validations": {
+                      "isRequired": "false",
+                    },
+                    "defaultValue": "2000/01/01"
+                  },
+                  {
+                    "_type": "BooleanCustomProperty",
+                    "name": "Funny?",
+                    "validations": {
+                      "isRequired": "true",
+                    },
+                    "defaultValue": "NO"
+                  },
+                  {
+                    "_type": "CustomProperty::User",
+                    "_links": {
+                      "availableValues": {
+                        "href": "http://localhost:3000/api/v3/projects/5/members"
+                      }
+                    },
+                    "name": "Friend",
+                    "validations": {
+                      "isRequired": "false"
+                    },
+                    "defaultValue": ""
+                  },
+                  {
+                    "_type": "CustomProperty::Version",
+                    "_links": {
+                      "availableValues": {
+                        "href": "http://localhost:3000/api/v3/projects/5/versions"
+                      }
+                    },
+                    "name": "State of maturity",
+                    "validations": {
+                      "isRequired": "false"
+                    },
+                    "defaultValue": ""
+                  }
+                ]
+              }
+            }
+
+## Available custom properties [GET]
+
+Gets a list of custom properties that are assignable to the work package.
+
+The list depends on the type of the work package. If the attribute value for
+type is to be changed, the new value can be supplied as a parameter.
+
++ Parameters
+    + work_package_id (required, integer, `1`) ... Work package id
+    + type = `nil` (optional, string, `Bug`) ... Name of the type the work package
+    is going to be changed into
+
++ Response 200 (application/hal+json)
+
+    [AvailableCustomProperties][]
+	
 ## AvailableWatchers [/work_packages/{work_package_id}/available_watchers{?offset,limit,query}]
 
 + Model


### PR DESCRIPTION
This PR is a replication of a PR by @ulferts  against **[opf/op-api-v3-documentation](https://github.com/opf/op-api-v3-documentation)**.

Original PR: https://github.com/opf/op-api-v3-documentation/pull/8

Note that this PR is probably **not safely mergable** as of now.
# Original Description

A few things are unclear to me and I would welcome feedback very much:
- Do we really want to have different types for custom properties? The custom properties are quite different in their properties, so it makes sense to differentiate between them rather than to have a lot of empty properties and a "format" property to differentiate.
- Is is desirable to have the possibleValues in the links section of UserCustomProperties and VersionCustomProperties.
- Do we want to keep the pattern of masking CustomFields in favor of lightweight CustomProperties? It is nice to have for the WorkPackage resource but I see problems once one wants to query for an individual custom property. The question there is of course whether that is intended at all. But once e.g. project management is also exposed to the api the client will need to know the work package types the custom field is active on and whether it serves as a filter. So I guess that we will forfeit the possibility of masking much of the internal custom field workings.  
