### PR TITLE
fix context menus in ie10 not accessible

### DIFF
--- a/app/assets/javascripts/lib/jquery.trap.js
+++ b/app/assets/javascripts/lib/jquery.trap.js
@@ -23,7 +23,7 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
 */
 
 /*jshint boss: true, bitwise: true, curly: true, expr: true, newcap: true, noarg: true, nonew: true, latedef: true, regexdash: true */
-    
+
     var DATA_ISTRAPPING_KEY = "trap.isTrapping";
 
     function onkeypress(e) {
@@ -35,16 +35,15 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
             }
         }
     }
-    
+
     // will return true if we could process the tab event
     // otherwise, return false
     function processTab(container, elt, goReverse) {
         var $focussable = getFocusableElementsInContainer(container),
             curElt = elt,
             index, nextIndex, prevIndex, lastIndex;
-        
+
         do {
-        
             index = $focussable.index(curElt);
             nextIndex = index + 1;
             prevIndex = index - 1;
@@ -60,42 +59,44 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
                     nextIndex = 0;
                     break;
             }
-                            
+
             if (goReverse) {
                 nextIndex = prevIndex;
             }
-            
+
             curElt = $focussable.get(nextIndex);
-            // IE sometimes throws when an element is not visible
+            if (!curElt || curElt === elt) { return true; }
+
             try {
                 curElt.focus();
-            } catch(e) {
+            } catch(e) { // IE sometimes throws when an element is not visible
+                return true;
             }
-        
-        } while (elt === elt.ownerDocument.activeElement);
 
-        return true;        
+        } while ($focussable.length > 1 && elt === elt.ownerDocument.activeElement);
+
+        return true;
     }
-    
+
     function filterKeepSpeciallyFocusable() {
         return this.tabIndex > 0;
     }
-    
+
     function filterKeepNormalElements() {
         return !this.tabIndex; // true if no tabIndex or tabIndex == 0
     }
-    
+
     function sortFocusable(a, b) {
         return (a.t - b.t) || (a.i - b.i);
     }
-    
+
     function getFocusableElementsInContainer(container) {
         var $container = $(container);
         var result = [],
             cnt = 0;
 
         fixIndexSelector.enable && fixIndexSelector.enable();
-        
+
         // leaving away command and details for now
         $container.find("a[href], link[href], [draggable=true], [contenteditable=true], :input:enabled, [tabindex=0]")
             .filter(":visible")
@@ -107,7 +108,7 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
                     i: cnt++ // index for stable sort
                 });
             });
-            
+
         $container
             .find("[tabindex]")
             .filter(":visible")
@@ -121,34 +122,34 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
             });
 
         fixIndexSelector.disable && fixIndexSelector.disable();
-        
+
         result = $.map(result.sort(sortFocusable), // needs stable sort
             function(val) {
                 return val.v;
             }
         );
-            
-        
+
+
         return $(result);
-        
+
     }
-    
+
     function trap() {
         this.keydown(onkeypress);
         this.data(DATA_ISTRAPPING_KEY, true);
         return this;
     }
-    
+
     function untrap() {
         this.unbind('keydown', onkeypress);
         this.removeData(DATA_ISTRAPPING_KEY);
         return this;
     }
-    
+
     function isTrapping() {
         return !!this.data(DATA_ISTRAPPING_KEY);
     }
-    
+
     $.fn.extend({
         trap: trap,
         untrap: untrap,
@@ -159,7 +160,7 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
     // this triggers problems for tabindex attribute
     // selectors in IE7-
     // see https://github.com/julienw/jquery-trap-input/issues/3
-    
+
    var fixIndexSelector = {};
 
    if ($.find.find && $.find.attr !== $.attr) {
@@ -168,7 +169,7 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
        (function() {
             var tabindexKey = "tabindex";
             var sizzleAttrHandle = $.expr.attrHandle;
-                
+
             // this function comes directly from jQuery 1.7.2 (propHooks.tabIndex.get)
             // we have to put it here if we want to support jQuery < 1.6 which
             // doesn't have an attrHooks object to reference.
@@ -181,18 +182,18 @@ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
                     parseInt( attributeNode.value, 10 ) :
                     undefined;
             }
-            
+
             function fixSizzleAttrHook() {
                 // in jQ <= 1.6.x, we add to Sizzle the attrHook from jQuery's attr method
                 sizzleAttrHandle[tabindexKey] = sizzleAttrHandle.tabIndex = getTabindexAttr;
             }
-            
+
             function unfixSizzleAttrHook() {
                 delete sizzleAttrHandle[tabindexKey];
                 delete sizzleAttrHandle.tabIndex;
             }
 
-            
+
             fixIndexSelector = {
                 enable: fixSizzleAttrHook,
                 disable: unfixSizzleAttrHook

--- a/public/templates/work_packages/column_context_menu.html
+++ b/public/templates/work_packages/column_context_menu.html
@@ -2,55 +2,51 @@
      class="action-menu dropdown-relative"
      ng-class="{'dropdown-anchor-right': column && column.name !== 'id'}">
   <ul class="menu">
-    <li ng-if="canSort()" ng-click="sortAscending(column.name)">
-      <a focus href>
+    <li ng-if="canSort()">
+      <a focus href="" ng-click="sortAscending(column.name)">
         <i class="icon-action-menu icon-sort-ascending"></i>
         <span ng-bind="I18n.t('js.work_packages.query.sort_ascending')"/>
       </a>
     </li>
 
-    <li ng-if="canSort()" ng-click="sortDescending(column.name)">
+    <li ng-if="canSort()">
       <i class="icon-action-menu icon-sort-descending"></i>
-      <a href>
+      <a href="" ng-click="sortDescending(column.name)">
         <span ng-bind="I18n.t('js.work_packages.query.sort_descending')"/>
       </a>
     </li>
 
-    <li ng-click="groupBy(column.name)"
-        ng-if="isGroupable">
+    <li ng-if="isGroupable">
       <i class="icon-action-menu icon-group-by2"></i>
-      <a focus="focusFeature('group')" href>
+      <a focus="focusFeature('group')" href="" ng-click="groupBy(column.name)">
         <span ng-bind="I18n.t('js.work_packages.query.group')"/>
       </a>
     </li>
 
-    <li ng-click="moveLeft(column.name)"
-        ng-if="canMoveLeft()">
+    <li ng-if="canMoveLeft()">
       <i class="icon-action-menu icon-column-left"></i>
-      <a focus="focusFeature('moveLeft')" href>
+      <a focus="focusFeature('moveLeft')" href="" ng-click="moveLeft(column.name)">
         <span ng-bind="I18n.t('js.work_packages.query.move_column_left')"/>
       </a>
     </li>
 
-    <li ng-click="moveRight(column.name)"
-        ng-if="canMoveRight()">
+    <li ng-if="canMoveRight()">
       <i class="icon-action-menu icon-column-right"></i>
-      <a focus="focusFeature('moveRight')" href>
+      <a focus="focusFeature('moveRight')" href="" ng-click="moveRight(column.name)">
         <span ng-bind="I18n.t('js.work_packages.query.move_column_right')"/>
       </a>
     </li>
 
-    <li ng-if="canBeHidden()"
-        ng-click="hideColumn(column.name)">
+    <li ng-if="canBeHidden()" >
     <i class="icon-action-menu icon-delete2"></i>
-      <a focus="focusFeature('hide')" href>
+      <a focus="focusFeature('hide')" href=""ng-click="hideColumn(column.name)">
         <span ng-bind="I18n.t('js.work_packages.query.hide_column')"/>
       </a>
     </li>
 
-    <li ng-click="insertColumns()">
+    <li>
     <i class="icon-action-menu icon-columns"></i>
-      <a focus="focusFeature('insert')" href>
+      <a focus="focusFeature('insert')" href="" ng-click="insertColumns()">
         <span ng-bind="I18n.t('js.work_packages.query.insert_columns')"/>
       </a>
     </li>

--- a/public/templates/work_packages/work_package_context_menu.html
+++ b/public/templates/work_packages/work_package_context_menu.html
@@ -1,7 +1,7 @@
 <div id="work-package-context-menu" class="action-menu">
   <ul class="menu">
     <li class="open">
-      <a focus href
+      <a focus href=""
          ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
         <i ng-class="['icon-action-menu', 'icon-table-detail-view']"></i>
         <span ng-bind="I18n.t('js.button_open_details')"/>
@@ -10,22 +10,22 @@
     <li ng-repeat="(action, link) in permittedActions"
         ng-click="triggerContextMenuAction(action, link)"
         class="{{action}}">
-      <a href ng-click="deleteWorkPackages()">
+      <a href="" ng-click="deleteWorkPackages()">
         <i ng-class="['icon-action-menu', 'icon-' + action]"></i>
         <span ng-bind="I18n.t('js.button_' + action)"/>
       </a>
     </li>
 
     <li class="folder priority" ng-hide="hideResourceActions">
-      <a href class="context_item">TODO Priority</a>
+      <a href="" class="context_item">TODO Priority</a>
       <i class="icon-pulldown-arrow4 icon-submenu"></i>
       <ul class="sub-menu">
-        <li><a href class=" disabled">Immediate</a></li>
-        <li><a href class=" disabled">Urgent</a></li>
-        <li><a href class=" disabled">High</a></li>
-        <li><a href class=" disabled">Normal</a></li>
-        <li><a href class=" disabled">Low</a></li>
-        <li><a href class=" disabled">Pointless</a></li>
+        <li><a href="" class=" disabled">Immediate</a></li>
+        <li><a href="" class=" disabled">Urgent</a></li>
+        <li><a href="" class=" disabled">High</a></li>
+        <li><a href="" class=" disabled">Normal</a></li>
+        <li><a href="" class=" disabled">Low</a></li>
+        <li><a href="" class=" disabled">Pointless</a></li>
       </ul>
       <div class="submenu"></div>
     </li>


### PR DESCRIPTION
[`* `#16028 ` context menus in ie10 not accessible`](http://www.openproject.org/work_packages/16028)

I am not sure how we should go on with this. IE10 allows only for specific elements to be focused (inputs, anchors), and not divs. I'll look into the focusing divs, not sure at the moment. This is the reason I didn't touch the right menu (the one with queries), as it focuses on divs and if I change it to anchors, it'll look uglier.
