### PR TITLE
add a README-file for the doc subdirectory

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,13 @@
+Documentation
+=======================
+
+About the APIv3 Documentation
+-----------------------------
+
+The documentation for APIv3 is written in the [API Blueprint Format](http://apiblueprint.org/).
+
+You can use [aglio](https://github.com/danielgtaylor/aglio) to generate HTML documentation, e.g. using the following command:
+
+```bash
+aglio -i apiary.apib -o api.html
+```


### PR DESCRIPTION
While migrating the APIv3 documentation from https://github.com/opf/op-api-v3-documentation, the readme-file was lost.

This PR adds a README for the `doc` subdirectory, which primarily contains the contents of the old APIv3 README.

GitHub should be able to render this readme-file as soon as you [enter the doc-subdirectory](https://github.com/opf/openproject/tree/8d535a4e124e7ceec2ec3e9fd3fefe7204fe620a/doc).
