### PR TITLE
Fixed spelling error in js-en.yml

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -255,7 +255,7 @@ en:
         all:         "Show all"
       project_status: "Project status"
       project_type: "Project type"
-      really_close_dialog: "Do you really want to close the dialog and loose the entered data?"
+      really_close_dialog: "Do you really want to close the dialog and lose the entered data?"
       responsible: "Responsible"
       save: Save
       start_date: "Start date"


### PR DESCRIPTION
Replaced "loose data" with "lose data."  "Loose" means not fastened. "Lose" means to no longer have.
