### PR TITLE
Fixed email options hash map keys

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -265,7 +265,8 @@ class MailHandler < ActionMailer::Base
       @keywords[attr]
     else
       @keywords[attr] = begin
-        if (options[:override] || @@handler_options[:allow_override].include?(attr.to_s)) &&
+        if (options[:override] ||
+           @@handler_options[:allow_override].include?(attr.to_s)) &&
            (v = extract_keyword!(plain_text_body, attr.to_s, options[:format]))
           v
         elsif !@@handler_options[:issue][attr].blank?

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -260,18 +260,16 @@ class MailHandler < ActionMailer::Base
   end
 
   def get_keyword(attr, options={})
-    attr = attr.to_s
-
     @keywords ||= {}
     if @keywords.has_key?(attr)
       @keywords[attr]
     else
       @keywords[attr] = begin
-        if (options[:override] || @@handler_options[:allow_override].include?(attr)) &&
-           (v = extract_keyword!(plain_text_body, attr, options[:format]))
+        if (options[:override] || @@handler_options[:allow_override].include?(attr.to_s)) &&
+           (v = extract_keyword!(plain_text_body, attr.to_s, options[:format]))
           v
-        elsif !@@handler_options[:issue][attr.to_sym].blank?
-          @@handler_options[:issue][attr.to_sym]
+        elsif !@@handler_options[:issue][attr].blank?
+          @@handler_options[:issue][attr]
         end
       end
     end

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -260,18 +260,17 @@ class MailHandler < ActionMailer::Base
   end
 
   def get_keyword(attr, options={})
-    attr = attr.to_s
-
     @keywords ||= {}
     if @keywords.has_key?(attr)
       @keywords[attr]
     else
       @keywords[attr] = begin
-        if (options[:override] || @@handler_options[:allow_override].include?(attr)) &&
-           (v = extract_keyword!(plain_text_body, attr, options[:format]))
+        if (options[:override] ||
+           @@handler_options[:allow_override].include?(attr.to_s)) &&
+           (v = extract_keyword!(plain_text_body, attr.to_s, options[:format]))
           v
-        elsif !@@handler_options[:issue][attr.to_sym].blank?
-          @@handler_options[:issue][attr.to_sym]
+        elsif !@@handler_options[:issue][attr].blank?
+          @@handler_options[:issue][attr]
         end
       end
     end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -78,7 +78,7 @@ END_DESC
       options = { :issue => {} }
       default_fields = (ENV['default_fields'] || "").split
       default_fields |= %w[project status type category priority fixed_version]
-      default_fields.each{ |field| options[:issue][field] = ENV[field] if ENV[field] }
+      default_fields.each{ |field| options[:issue][field.to_sym] = ENV[field] if ENV[field] }
 
       options[:allow_override] = ENV['allow_override'] if ENV['allow_override']
       options[:unknown_user] = ENV['unknown_user'] if ENV['unknown_user']

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -84,7 +84,7 @@ END_DESC
       options[:unknown_user] = ENV['unknown_user'] if ENV['unknown_user']
       options[:no_permission_check] = ENV['no_permission_check'] if ENV['no_permission_check']
 
-      MailHandler.receive(File.read('/home/pacs/edv01/users/openproject/dummy.txt'), options)
+      MailHandler.receive(STDIN.read, options)
     end
 
     desc <<-END_DESC

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -78,13 +78,13 @@ END_DESC
       options = { :issue => {} }
       default_fields = (ENV['default_fields'] || "").split
       default_fields |= %w[project status type category priority fixed_version]
-      default_fields.each{ |field| options[:issue][field] = ENV[field] if ENV[field] }
+      default_fields.each{ |field| options[:issue][field.to_sym] = ENV[field] if ENV[field] }
 
       options[:allow_override] = ENV['allow_override'] if ENV['allow_override']
       options[:unknown_user] = ENV['unknown_user'] if ENV['unknown_user']
       options[:no_permission_check] = ENV['no_permission_check'] if ENV['no_permission_check']
 
-      MailHandler.receive(STDIN.read, options)
+      MailHandler.receive(File.read('/home/pacs/edv01/users/openproject/dummy.txt'), options)
     end
 
     desc <<-END_DESC


### PR DESCRIPTION
There was some mixup between symbols and strings that were used
as hash map indexes inside the mail handler. As a result at least
the argument or environment variable "project" was ignored.

This was cleaned up by using symbols all the way.
