### PR TITLE
Show waiting-spinner outside of the wp-table

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -46,11 +46,6 @@ $work-packages-table--footer-height: 34px
   &.-with-footer
     padding-bottom: $work-packages-table--footer-height
 
-  .cg-busy
-    z-index:    9
-  .cg-busy-default-wrapper
-    z-index:    10
-
 .work-packages-table--container-inner
   height:       100%
   overflow:

--- a/app/assets/stylesheets/layout/_angular-busy.sass
+++ b/app/assets/stylesheets/layout/_angular-busy.sass
@@ -23,15 +23,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * See doc/COPYRIGHT.rdoc for more details.  ++
- */
+ * See doc/COPYRIGHT.rdoc for more details.  ++*/
 
-@import layout/base
-@import layout/top_menu
-@import layout/breadcrumb
-@import layout/main_menu
-@import layout/footer
-@import layout/drop_down
-@import layout/toolbar
-@import layout/work_package
-@import layout/angular-busy
+.cg-busy
+  z-index: 10
+
+  .cg-busy-default-wrapper
+    z-index: 11
+

--- a/public/templates/work_packages.list.html
+++ b/public/templates/work_packages.list.html
@@ -125,10 +125,9 @@
 
 
 <div class="work-packages--split-view">
-  <div class="work-packages--list" cg-busy="settingUpPage">
+  <div class="work-packages--list" cg-busy="[settingUpPage,refreshWorkPackages]">
     <div class="work-packages--list-table-area">
       <work-packages-table ng-if="rows && columns"
-                           cg-busy="refreshWorkPackages"
                            project-identifier="projectIdentifier"
                            columns="columns"
                            rows="rows"


### PR DESCRIPTION
This circumvents issues whith horizontal scrolling in the table (at the same place where the "initializing WP table"-spinner is).

See: https://www.openproject.org/work_packages/16480
