### PR TITLE
15525 Preserve query properties on tab activation

### DIFF
--- a/app/assets/javascripts/angular/routing.js
+++ b/app/assets/javascripts/angular/routing.js
@@ -35,7 +35,7 @@ angular.module('openproject')
 
   $stateProvider
     .state('work-packages', {
-      url: '{projectPath:.*}/work_packages?query_id',
+      url: '{projectPath:.*}/work_packages?query_id&query_props',
       abstract: true,
       templateUrl: "/templates/work_packages.html",
       controller: 'WorkPackagesController',

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "jquery-migrate": "~1.2.1",
     "momentjs": "~2.7.0",
     "moment-timezone": "~0.2.0",
-    "angular-context-menu": "finnlabs/angular-context-menu#v0.1.6",
+    "angular-context-menu": "finnlabs/angular-context-menu#v0.1.7",
     "angular-busy": "~4.0.4",
     "hyperagent": "manwithtwowatches/hyperagent#v0.4.2",
     "lodash": "~2.4.1"

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -259,27 +259,17 @@ describe 'Work package index accessibility', :type => :feature do
           before do
             expect(page).to have_selector(target_link)
             element = find(target_link)
-            element.native.send_keys(:enter)
+            element.native.send_keys(:escape)
             expect(page).not_to have_selector(target_link)
           end
 
           it { expect(page).to have_selector(source_link + ':focus') }
-
-          after do
-            cleanup if defined?(cleanup)
-          end
         end
 
       end
     end
 
     describe 'work package context menu', js: true do
-      let(:cleanup) do
-        # ensure work package queried by context menu is fully loaded.
-        expect(page).to have_selector('.work-packages--details h2', text: work_package.subject,
-                                                                    visible: false)
-      end
-
       it_behaves_like 'context menu' do
         let(:target_link) { '#work-package-context-menu li.open a' }
         let(:source_link) { ".workpackages-table tr.issue td.id a" }

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -260,6 +260,7 @@ describe 'Work package index accessibility', :type => :feature do
             expect(page).to have_selector(target_link)
             element = find(target_link)
             element.native.send_keys(:enter)
+            expect(page).not_to have_selector(target_link)
           end
 
           it { expect(page).to have_selector(source_link + ':focus') }


### PR DESCRIPTION
[`* `#15525` Filters and other settings not persisted after activating details pane`](https://www.openproject.org/work_packages/15525)
