### PR TITLE
16543 ineffective menu entry open details view in context menu on small viewports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script: "if [[ $TEST_SUITE == 'karma' ]]; then npm test; else bundle exec rake $
 before_install:
   - "echo `firefox -v`"
   - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1366x768x16"
+  - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
   - "echo `xdpyinfo -display :99 | grep 'dimensions' | awk '{ print $2 }'`"
   - "nvm use 0.10"
   - "travis_retry npm -g install bower@~1.3.8"

--- a/app/assets/javascripts/angular/work_packages/work-package-context-menu.js
+++ b/app/assets/javascripts/angular/work_packages/work-package-context-menu.js
@@ -65,6 +65,9 @@ angular.module('openproject.workPackages')
     $scope.permittedActions = WorkPackageContextMenuHelper.getPermittedActions(getSelectedWorkPackages(), PERMITTED_CONTEXT_MENU_ACTIONS);
   });
 
+  $scope.isDetailsViewLinkVisible = function() {
+    return angular.element('#work-package-context-menu li.open').is(':visible');
+  };
 
   $scope.triggerContextMenuAction = function(action, link) {
     if (action === 'delete') {

--- a/public/templates/work_packages/work_package_context_menu.html
+++ b/public/templates/work_packages/work_package_context_menu.html
@@ -1,6 +1,6 @@
 <div id="work-package-context-menu" class="action-menu">
   <ul class="menu">
-    <li class="open">
+    <li class="open" feature-flag="detailsView">
       <a focus href
          ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
         <i ng-class="['icon-action-menu', 'icon-table-detail-view']"></i>

--- a/public/templates/work_packages/work_package_context_menu.html
+++ b/public/templates/work_packages/work_package_context_menu.html
@@ -1,7 +1,7 @@
 <div id="work-package-context-menu" class="action-menu">
   <ul class="menu">
     <li class="open" feature-flag="detailsView">
-      <a focus href
+      <a focus="isDetailsViewLinkVisible()" href
          ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
         <i ng-class="['icon-action-menu', 'icon-table-detail-view']"></i>
         <span ng-bind="I18n.t('js.button_open_details')"/>
@@ -10,7 +10,7 @@
     <li ng-repeat="(action, link) in permittedActions"
         ng-click="triggerContextMenuAction(action, link)"
         class="{{action}}">
-      <a href ng-click="deleteWorkPackages()">
+      <a focus="$index == 0 && !isDetailsViewLinkVisible()" href ng-click="deleteWorkPackages()">
         <i ng-class="['icon-action-menu', 'icon-' + action]"></i>
         <span ng-bind="I18n.t('js.button_' + action)"/>
       </a>

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -243,7 +243,12 @@ describe 'Work package index accessibility', :type => :feature do
 
   describe 'context menus' do
 
-    before { visit_index_page }
+    before do
+      window = Capybara.current_session.driver.browser.manage.window
+      window.maximize
+
+      visit_index_page
+    end
 
     shared_examples_for 'context menu' do
       describe 'focus' do


### PR DESCRIPTION
[`* `#16543` Ineffective menu entry "Open Details View" in context menu on small viewports`](https://www.openproject.org/work_packages/16543)
