### PR TITLE
13962 disabling work package status does not work for details pane

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -63,6 +63,8 @@ class WorkPackagesController < ApplicationController
 
   # The order in here is actually important for the angular client.
   # The first 6 are always to be displayed.
+  # Beware that 'percentageDone' may be removed if the related setting is
+  # disabled.
   DEFAULT_WORK_PACKAGE_PROPERTIES = [:status, :assignee, :responsible,
                                      :date, :percentageDone, :priority,
                                      :category, :estimatedTime, :versionName, :spentTime]
@@ -460,7 +462,15 @@ class WorkPackagesController < ApplicationController
     parse_preview_data_helper :work_package, [:notes, :description]
   end
 
-  def hook_overview_attributes(initial_attributes = DEFAULT_WORK_PACKAGE_PROPERTIES)
+  def enabled_default_work_package_properties
+    @enabled_default_work_package_properties ||= begin
+                                                   properties = DEFAULT_WORK_PACKAGE_PROPERTIES
+                                                   properties.delete(:percentageDone) if Setting.work_package_done_ratio == 'disabled'
+                                                   properties
+                                                 end
+  end
+
+  def hook_overview_attributes(initial_attributes = enabled_default_work_package_properties)
     attributes = initial_attributes
     call_hook(:work_packages_overview_attributes,
               project: @project,

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -61,7 +61,7 @@ class WorkPackagesController < ApplicationController
                 :protect_from_unauthorized_export, :only => [:index, :all, :preview]
   before_filter :load_query, :only => :index
 
-  # The order in here is actually imporant for the angular client.
+  # The order in here is actually important for the angular client.
   # The first 6 are always to be displayed.
   DEFAULT_WORK_PACKAGE_PROPERTIES = [:status, :assignee, :responsible,
                                      :date, :percentageDone, :priority,

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -30,12 +30,6 @@
 module WorkPackagesHelper
   include AccessibilityHelper
 
-  def work_package_api_done_ratio_if_enabled(api, issue)
-    if Setting.work_package_done_ratio != 'disabled'
-      api.done_ratio  issue.done_ratio
-    end
-  end
-
   def work_package_breadcrumb
     full_path = if !@project.nil?
                   link_to(I18n.t(:label_work_package_plural), project_path(@project, {:jump => current_menu_item}))

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -270,7 +270,7 @@ module API
         end
 
         def percentage_done
-          (Setting.work_package_done_ratio == 'disabled') ? nil : represented.percentage_done
+          represented.percentage_done unless Setting.work_package_done_ratio == 'disabled'
         end
       end
     end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -216,7 +216,10 @@ module API
         property :start_date, getter: -> (*) { model.start_date.to_datetime.utc.iso8601 unless model.start_date.nil? }, render_nil: true
         property :due_date, getter: -> (*) { model.due_date.to_datetime.utc.iso8601 unless model.due_date.nil? }, render_nil: true
         property :estimated_time, render_nil: true
-        property :percentage_done, render_nil: true, exec_context: :decorator
+        property :percentage_done,
+                 render_nil: true,
+                 exec_context: :decorator,
+                 setter: -> (value, *) { represented.percentage_done = value }
         property :version_id, getter: -> (*) { model.fixed_version.try(:id) }, render_nil: true
         property :version_name,  getter: -> (*) { model.fixed_version.try(:name) }, render_nil: true
         property :project_id, getter: -> (*) { model.project.id }

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -216,7 +216,7 @@ module API
         property :start_date, getter: -> (*) { model.start_date.to_datetime.utc.iso8601 unless model.start_date.nil? }, render_nil: true
         property :due_date, getter: -> (*) { model.due_date.to_datetime.utc.iso8601 unless model.due_date.nil? }, render_nil: true
         property :estimated_time, render_nil: true
-        property :percentage_done, render_nil: true
+        property :percentage_done, render_nil: true, exec_context: :decorator
         property :version_id, getter: -> (*) { model.fixed_version.try(:id) }, render_nil: true
         property :version_name,  getter: -> (*) { model.fixed_version.try(:name) }, render_nil: true
         property :project_id, getter: -> (*) { model.project.id }
@@ -264,6 +264,10 @@ module API
 
         def visible_children
           @visible_children ||= represented.model.children.find_all { |child| child.visible? }
+        end
+
+        def percentage_done
+          (Setting.work_package_done_ratio == 'disabled') ? nil : represented.percentage_done
         end
       end
     end

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -151,6 +151,28 @@ describe WorkPackagesController, :type => :controller do
         allow(query).to receive(:as_json).and_return("")
       end
 
+      describe 'settings passed to front-end client' do
+        describe 'visible attributes' do
+          let(:call_action) { get('index', :project_id => project.id) }
+
+          context 'all attributes visible' do
+            before { call_action }
+
+            it { expect(assigns(:enabled_default_work_package_properties)).to match_array(WorkPackagesController::DEFAULT_WORK_PACKAGE_PROPERTIES) }
+          end
+
+          context 'done ratio is disabled' do
+            before do
+              allow(Setting).to receive(:work_package_done_ratio).and_return('disabled')
+
+              call_action
+            end
+
+            it { expect(assigns(:enabled_default_work_package_properties)).not_to include(:percentageDone) }
+          end
+        end
+      end
+
       describe 'html' do
         let(:call_action) { get('index', :project_id => project.id) }
         before { call_action }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -39,7 +39,8 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       id: 42,
       created_at: DateTime.now,
       updated_at: DateTime.now,
-      category:   category
+      category:   category,
+      done_ratio: 50
     )
   }
   let(:category) { FactoryGirl.build(:category) }
@@ -93,6 +94,20 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
       it { is_expected.to have_json_path('estimatedTime/units') }
       it { is_expected.to have_json_path('estimatedTime/value') }
+    end
+
+    describe 'percentageDone' do
+      describe 'work package done ratio setting behavior' do
+        context 'setting enabled' do
+          it { expect(parse_json(subject)['percentageDone']).to eq(50) }
+        end
+
+        context 'setting disabled' do
+          before { allow(Setting).to receive(:work_package_done_ratio).and_return('disabled') }
+
+          it { expect(parse_json(subject)['percentageDone']).to be_nil }
+        end
+      end
     end
 
     describe '_links' do


### PR DESCRIPTION
[`* `#13962`Disabling work package status does not work in details pane`](https://www.openproject.org/work_packages/13962)
