### PR TITLE
16650 impossible to unpublicize query by other user even when permission is assigned

### DIFF
--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -136,7 +136,7 @@ module Api::Experimental
 
     def authorize_update_on_query
       original_query = Query.find(params[:id])
-      actions = [params[:action].to_sym]
+      actions = [:update]
       changed = @query.changed
 
       if @query.changed.include? 'is_public'

--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -132,7 +132,32 @@ module Api::Experimental
     end
 
     def authorize_on_query
-      deny_access unless QueryPolicy.new(current_user).allowed?(@query, params[:action].to_sym)
+      deny_access unless action_on_query_allowed?(params[:action])
+    end
+
+    def action_on_query_allowed?(action)
+      actions = [action]
+
+      if actions.include? 'update'
+        original_query = Query.find(params[:id])
+        actions << ((original_query.is_public) ? :depublicize : :publicize) if @query.is_public != original_query.is_public
+
+        actions.delete('update') if actions.length > 1 && !query_changed(original_query)
+      end
+
+      allowed = actions.map(&:to_sym)
+                       .map { |action| QueryPolicy.new(current_user).allowed?(original_query || @query, action) }
+                       .reduce(:&)
+      allowed
+    end
+
+    def query_changed(query)
+      changed = [:group_by, :sort_criteria, :display_sums, :column_names, :name].each_with_object([]) do |attribute, l|
+        l << (@query.send(attribute) != query.send(attribute))
+      end.reduce(:|)
+
+      changed |= @query.filters.map(&:to_hash) != query.filters.map(&:to_hash)
+      changed
     end
 
     def visible_queries

--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -139,7 +139,7 @@ module Api::Experimental
       actions = [:update]
       changed = @query.changed
 
-      if @query.changed.include? 'is_public'
+      if changed.include? 'is_public'
         changed -= ['is_public', 'filters']
 
         actions << ((@query.changed_attributes['is_public']) ? :depublicize : :publicize)

--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -140,11 +140,11 @@ module Api::Experimental
       changed = @query.changed
 
       if changed.include? 'is_public'
-        changed -= ['is_public', 'filters']
+        changed.delete('is_public')
+        changed.delete('filters') if @query.filters == original_query.filters
 
-        actions << ((@query.changed_attributes['is_public']) ? :depublicize : :publicize)
-        filters_changed = @query.filters != original_query.filters
-        actions.delete(:update) if changed.empty? && !filters_changed
+        actions << (@query.is_public ? :publicize : :depublicize)
+        actions.delete(:update) if changed.empty?
       end
 
       allowed = actions.map(&:to_sym)

--- a/app/models/queries/filter.rb
+++ b/app/models/queries/filter.rb
@@ -119,6 +119,10 @@ class Queries::Filter
     self.filter_types_by_field[field]
   end
 
+  def ==(filter)
+    filter.attributes_hash == attributes_hash
+  end
+
   protected
 
   def attributes_hash

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -53,7 +53,7 @@ module API
             end
 
             patch :star do
-              #TODO Replace by QueryPolicy
+              # TODO Replace by QueryPolicy
               authorize({ controller: :queries, action: :star }, context: @query.project, allow: allowed_to_manage_stars?)
               normalized_query_name = @query.name.parameterize.underscore
               query_menu_item = MenuItems::QueryMenuItem.find_or_initialize_by_name_and_navigatable_id(
@@ -64,7 +64,7 @@ module API
             end
 
             patch :unstar do
-              #TODO Replace by QueryPolicy
+              # TODO Replace by QueryPolicy
               authorize({ controller: :queries, action: :unstar }, context: @query.project, allow: allowed_to_manage_stars?)
               query_menu_item = @query.query_menu_item
               return @representer if @query.query_menu_item.nil?

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -53,6 +53,7 @@ module API
             end
 
             patch :star do
+              #TODO Replace by QueryPolicy
               authorize({ controller: :queries, action: :star }, context: @query.project, allow: allowed_to_manage_stars?)
               normalized_query_name = @query.name.parameterize.underscore
               query_menu_item = MenuItems::QueryMenuItem.find_or_initialize_by_name_and_navigatable_id(
@@ -63,6 +64,7 @@ module API
             end
 
             patch :unstar do
+              #TODO Replace by QueryPolicy
               authorize({ controller: :queries, action: :unstar }, context: @query.project, allow: allowed_to_manage_stars?)
               query_menu_item = @query.query_menu_item
               return @representer if @query.query_menu_item.nil?

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -253,22 +253,44 @@ describe Api::Experimental::QueriesController, :type => :controller do
             it_behaves_like 'valid query update'
           end
 
-          context 'with public state only' do
-            let(:admin) { FactoryGirl.create(:admin) }
+          describe 'with public state only' do
+            context 'publicize' do
+              let(:admin) { FactoryGirl.create(:admin) }
 
-            include_context 'expects policy to be followed', :publicize
+              include_context 'expects policy to be followed', :publicize
 
-            it_behaves_like 'valid query update' do
-              let(:valid_params) do
-               { 'f' => ['status_id'],
-                 'is_public' => 'true',
-                 'name' => query.name,
-                 'op' => { 'status_id' => 'o' },
-                 'v' => { 'status_id' => [''] },
-                 'query_id' => query.id,
-                 'id' => query.id,
-                 'project_id' => project.id,
-                 'format' => 'json' }
+              it_behaves_like 'valid query update' do
+                let(:valid_params) do
+                 { 'f' => ['status_id'],
+                   'is_public' => 'true',
+                   'name' => query.name,
+                   'op' => { 'status_id' => 'o' },
+                   'v' => { 'status_id' => [''] },
+                   'query_id' => query.id,
+                   'id' => query.id,
+                   'project_id' => project.id,
+                   'format' => 'json' }
+                end
+              end
+            end
+
+            context 'depublicize' do
+              let(:query) { FactoryGirl.create(:query, project: project, is_public: true) }
+
+              include_context 'expects policy to be followed', :depublicize
+
+              it_behaves_like 'valid query update' do
+                let(:valid_params) do
+                 { 'f' => ['status_id'],
+                   'is_public' => 'false',
+                   'name' => query.name,
+                   'op' => { 'status_id' => 'o' },
+                   'v' => { 'status_id' => [''] },
+                   'query_id' => query.id,
+                   'id' => query.id,
+                   'project_id' => project.id,
+                   'format' => 'json' }
+                end
               end
             end
           end

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -44,7 +44,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
   end
 
   shared_context 'expects policy to be followed' do |allowed_actions|
-    let(:called_with_expected_args) { { called: false } }
+    let(:called_with_expected_args) { [] }
 
     before do
       policy = double('QueryPolicy').as_null_object
@@ -54,14 +54,14 @@ describe Api::Experimental::QueriesController, :type => :controller do
 
         if received_query.id == query.id &&
            Array(allowed_actions).include?(received_action)
-          called_with_expected_args[:called] = true
+          called_with_expected_args << received_action
         end
 
       end.at_least(1).times.and_return(true)
     end
 
     after do
-      expect(called_with_expected_args[:called]).to be_truthy
+      expect(called_with_expected_args.uniq).to match_array(Array(allowed_actions))
     end
   end
 

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -43,7 +43,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
     allow(User).to receive(:current).and_return(current_user)
   end
 
-  shared_context 'expects policy to be followed' do |action|
+  shared_context 'expects policy to be followed' do |allowed_actions|
     let(:called_with_expected_args) { { called: false } }
 
     before do
@@ -53,7 +53,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
       expect(policy).to receive(:allowed?) do |received_query, received_action|
 
         if received_query.id == query.id &&
-           received_action == action
+           Array(allowed_actions).include?(received_action)
           called_with_expected_args[:called] = true
         end
 
@@ -246,7 +246,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
           before { allow(User).to receive(:current).and_return(user) }
 
           context 'with public state' do
-            include_context 'expects policy to be followed', :update
+            include_context 'expects policy to be followed', [:update, :publicize]
 
             before { valid_params['is_public'] = true.to_s }
 

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -254,7 +254,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
 
           before { allow(User).to receive(:current).and_return(user) }
 
-          context 'with public state' do
+          context 'with other changes' do
             include_context 'expects policy to be followed', [:update, :publicize]
 
             before { valid_params['is_public'] = true.to_s }
@@ -262,7 +262,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
             it_behaves_like 'valid query update'
           end
 
-          describe 'with public state only' do
+          describe 'w/o other changes' do
             context 'publicize' do
               let(:admin) { FactoryGirl.create(:admin) }
               let(:valid_params) do

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -263,19 +263,21 @@ describe Api::Experimental::QueriesController, :type => :controller do
           end
 
           describe 'w/o other changes' do
+            let(:change_public_state_only_params) do
+             { 'f' => ['status_id'],
+               'is_public' => 'true',
+               'name' => query.name,
+               'op' => { 'status_id' => 'o' },
+               'v' => { 'status_id' => [''] },
+               'query_id' => query.id,
+               'id' => query.id,
+               'project_id' => project.id,
+               'format' => 'json' }
+            end
+
             context 'publicize' do
               let(:admin) { FactoryGirl.create(:admin) }
-              let(:valid_params) do
-               { 'f' => ['status_id'],
-                 'is_public' => 'true',
-                 'name' => query.name,
-                 'op' => { 'status_id' => 'o' },
-                 'v' => { 'status_id' => [''] },
-                 'query_id' => query.id,
-                 'id' => query.id,
-                 'project_id' => project.id,
-                 'format' => 'json' }
-              end
+              let(:valid_params) { change_public_state_only_params }
 
               context 'allowed policy' do
                 include_context 'expects policy to be followed', :publicize
@@ -292,17 +294,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
 
             context 'depublicize' do
               let(:query) { FactoryGirl.create(:query, project: project, is_public: true) }
-              let(:valid_params) do
-               { 'f' => ['status_id'],
-                 'is_public' => 'false',
-                 'name' => query.name,
-                 'op' => { 'status_id' => 'o' },
-                 'v' => { 'status_id' => [''] },
-                 'query_id' => query.id,
-                 'id' => query.id,
-                 'project_id' => project.id,
-                 'format' => 'json' }
-              end
+              let(:valid_params) { change_public_state_only_params.merge({ 'is_public' => 'false' }) }
 
               context 'allowed policy' do
                 include_context 'expects policy to be followed', :depublicize

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -70,7 +70,7 @@ describe Api::Experimental::QueriesController, :type => :controller do
       policy = double('QueryPolicy').as_null_object
       allow(QueryPolicy).to receive(:new).and_return(policy)
 
-      expect(policy).not_to receive(:allowed?).with(anything, :update).and_return(false)
+      expect(policy).not_to receive(:allowed?).with(anything, ignored_action).and_return(false)
     end
   end
 


### PR DESCRIPTION
[`* `#16650` Impossible to unpublicize query by other user even when permission is assigned`](https://www.openproject.org/work_packages/16560)
