### PR TITLE
WP details pane: don't show avatar if not provided

### DIFF
--- a/karma/tests/work_packages/tabs/user-activity-directive-test.js
+++ b/karma/tests/work_packages/tabs/user-activity-directive-test.js
@@ -101,9 +101,32 @@ describe('userActivity Directive', function() {
             expect(element.find('.avatar').attr('title')).to.equal('John Doe');
           });
 
+          describe('when being empty', function() {
+            beforeEach(function() {
+              scope.activity.links.user.fetch = function() {
+                return {
+                  then: function(cb) {
+                    cb({
+                      props: {
+                        id: 1,
+                        name: "John Doe",
+                        avatar: '',
+                        status: 1
+                      }
+                    });
+                  }
+                };
+              };
+              compile();
+            });
+
+            it('should not be rendered', function() {
+              expect(element.find('.avatar')).to.have.length(0);
+            });
+          });
+
         });
       });
-
 
     });
 });

--- a/public/templates/work_packages/tabs/_user_activity.html
+++ b/public/templates/work_packages/tabs/_user_activity.html
@@ -17,7 +17,7 @@
          ng-click="editComment()"></i>
     </div>
   </div>
-  <img class="avatar" ng-src="{{ userAvatar }}" alt="Avatar" title="{{userName}}" />
+  <img class="avatar" ng-src="{{ userAvatar }}" alt="Avatar" title="{{userName}}" ng-if="userAvatar" />
   <span class="user" ng-if="userActive"><a ng-href="{{ userPath(userId) }}" name="{{ currentAnchor }}" ng-bind="userName"></a></span>
   <span class="user" ng-if="!userActive">{{ userName }}</span>
   <span class="date">{{ I18n.t('js.label_commented_on') }} <date-time date-time-value="activity.props.createdAt"/></date-time>


### PR DESCRIPTION
https://www.openproject.org/work_packages/16552

Fixes a broken image being shown for deleted users and in case
Gravatar images are disabled.
