### PR TITLE
Fix/api v2 planning element type authorization

### DIFF
--- a/app/controllers/api/v2/planning_element_types_controller.rb
+++ b/app/controllers/api/v2/planning_element_types_controller.rb
@@ -29,17 +29,13 @@
 
 module Api
   module V2
-
     class PlanningElementTypesController < TypesController
-
       include ::Api::V2::ApiController
 
-      before_filter {|controller| controller.find_optional_project_and_raise_error('types') }
-      before_filter :check_project_exists
-
-      # before filters are inherited from TypesController
-      skip_before_filter :require_admin, only: [:index]
-      before_filter :find_optional_project, only: [:index]
+      # Before filters are inherited from TypesController.
+      # However we do want non admins to access the actions.
+      skip_before_filter :require_admin
+      before_filter :find_optional_project
 
       accept_key_auth :index, :show
 
@@ -52,22 +48,20 @@ module Api
       end
 
       def show
-        @type = (@project.nil?) ? Type.find(params[:id])
-                                : @project.types.find(params[:id])
+        @type = if @project.nil?
+                  Type.find_by_id(params[:id])
+                else
+                  @project.types.find_by_id(params[:id])
+                end
 
-        respond_to do |format|
-          format.api
-        end
-      end
-
-      private
-
-      def check_project_exists
-        if params.has_key? :project_id && @project.nil?
-          raise ActiveRecord::RecordNotFound
+        if @type
+          respond_to do |format|
+            format.api
+          end
+        else
+          render_404
         end
       end
     end
-
   end
 end

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -65,7 +65,6 @@ end
 Redmine::AccessControl.map do |map|
   map.permission :view_project,
                  {
-                   :types => [:index, :show],
                    :projects => [:show],
                    :projects => [:show],
                    :activities => [:index]
@@ -118,7 +117,8 @@ Redmine::AccessControl.map do |map|
                                          :'api/experimental/work_packages' => [:index,
                                                                                :column_data],
                                          # This is api/v2/planning_element_types
-                                         :'planning_element_types' => [:index] }
+                                         :'planning_element_types' => [:index,
+                                                                       :show] }
     map.permission :export_work_packages, {:'work_packages' => [:index, :all]}
     map.permission :add_work_packages, { :issues => [:new, :create, :update_form],
                                          :'issues/previews' => :create,

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -66,7 +66,6 @@ Redmine::AccessControl.map do |map|
   map.permission :view_project,
                  {
                    :projects => [:show],
-                   :projects => [:show],
                    :activities => [:index]
                  },
                  :public => true

--- a/spec/controllers/api/v2/planning_element_types_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_element_types_controller_spec.rb
@@ -57,10 +57,10 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
       it_should_behave_like "a controller action which needs project permissions"
 
       describe 'with unknown project' do
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          expect {
-            get 'index', :project_id => 'blah', :format => 'xml'
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns 404' do
+          get 'index', project_id: 'blah', format: 'xml'
+
+          expect(response.response_code).to eql 404
         end
       end
 
@@ -111,7 +111,8 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
     end
 
     describe 'show.xml' do
-      let(:current_user) { admin }
+      let(:current_user) { non_admin_user }
+      let(:permission) { :view_work_packages }
 
       def fetch
         @available_type = FactoryGirl.create(:type, :id => '1337')
@@ -119,21 +120,21 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
 
         get 'show', :project_id => project.identifier, :id => '1337', :format => 'xml'
       end
-      it_should_behave_like 'a controller action with require_admin'
+      it_should_behave_like 'a controller action which needs project permissions'
 
       describe 'with unknown project' do
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          expect {
-            get 'show', :project_id => 'blah', :id => '1337', :format => 'xml'
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns 404' do
+          get 'show', project_id: 'blah', id: '1337', format: 'xml'
+
+          expect(response.response_code).to eql 404
         end
       end
 
       describe 'with unknown planning element type' do
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          expect {
-            get 'show', :project_id => project.identifier, :id => '1337', :format => 'xml'
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns 404' do
+          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+
+          expect(response.response_code).to eql 404
         end
       end
 
@@ -142,10 +143,10 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
           FactoryGirl.create(:type, :id => '1337')
         end
 
-        it 'raises ActiveRecord::RecordNotFound errors' do
-          expect {
-            get 'show', :project_id => project.identifier, :id => '1337', :format => 'xml'
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'returns 404' do
+          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+
+          expect(response.response_code).to eql 404
         end
       end
 
@@ -214,28 +215,14 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
     end
 
     describe 'show.xml' do
-      let(:current_user) { admin }
+      let(:current_user) { non_admin_user }
+      let(:permission) { :view_work_packages }
 
       describe 'with unknown planning element type' do
-        if false # would like to write it this way
-          it 'returns status code 404' do
-            get 'show', :id => '1337', :format => 'xml'
+        it 'returns 404' do
+          get 'show', id: '1337', format: 'xml'
 
-            expect(response.status).to eq('404 Not Found')
-          end
-
-          it 'returns an empty body' do
-            get 'show', :id => '1337', :format => 'xml'
-
-            expect(response.body).to be_empty
-          end
-
-        else # but have to write it that way
-          it 'raises ActiveRecord::RecordNotFound errors' do
-            expect {
-              get 'show', :id => '1337', :format => 'xml'
-            }.to raise_error(ActiveRecord::RecordNotFound)
-          end
+          expect(response.response_code).to eql 404
         end
       end
 
@@ -247,7 +234,7 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         def fetch
           get 'show', :id => '1337', :format => 'xml'
         end
-        it_should_behave_like 'a controller action with require_admin'
+        it_should_behave_like 'a controller action which needs project permissions'
 
         it 'assigns the available planning element type' do
           get 'show', :id => '1337', :format => 'xml'


### PR DESCRIPTION
https://www.openproject.org/work_packages/16645

Took the chance to also clean up the controller. It used to raise ActiveRecord::RecordNotFound which doesn't make sense for a controller to make public to the user. It now renders 404 when the project or the type isn't found. 

Trivia:
[I know I've made some very poor decisions recently, but I can give you my complete assurance that my work will be back to normal. I've still got the greatest enthusiasm and confidence in the mission. And I want to help you.](http://www.imdb.com/title/tt0062622/trivia?item=qt0396925)
