### PR TITLE
fix workpackage collapse icon is covered by scrollbar on windows system

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -63,10 +63,12 @@ $toggler-width: 40px
   @include default-transition
 
   %absolute-layout-mode &
-    position: absolute
+    position: relative
     height:   100%
-    +allow-vertical-scrolling
-
+    #menu-sidebar
+      height:   100%
+      +allow-vertical-scrolling
+      -ms-overflow-style: -ms-autohiding-scrollbar
   ul
     margin: 0
     padding: 0


### PR DESCRIPTION
[`* `#16129` workpackage collapse icon is covered by scrollbar on windows system`](http://community.openproject.org/work_packages/16129)
