### PR TITLE
Revert "WP Index: Fix total sums overlaying WPs in Firefox"

### DIFF
--- a/public/templates/work_packages/work_packages_table.html
+++ b/public/templates/work_packages/work_packages_table.html
@@ -176,6 +176,7 @@
 
     <tr work-package-total-sums
         ng-if="displaySums"
+        cg-busy="fetchTotalSums"
         class="sum group all issue work_package">
       <td colspan="{{2  - (!!hideWorkPackageDetails * 1)}}">
         <div class="work-packages-table--footer-outer">


### PR DESCRIPTION
https://community.openproject.org/work_packages/16679
Also related to https://community.openproject.org/work_packages/16609

Reverts opf/openproject#2012 as this breaks compatibility with Firefox 24 and thus our internal CI. We'll have to decide whether we want to continue to support Firefox 24 now that Firefox 31 is the newest ESR release and then either adapt the fix for Firefox 24.
