### PR TITLE
fix wp details pane project name not displayed in front of inherited ver...

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -79,8 +79,10 @@ angular.module('openproject.workPackages.controllers')
                     return;
                 }
                 var versionId = $scope.workPackage.props.versionId,
-                  versionLinkPresent = !!$scope.workPackage.links.version;
-                return {href: versionLinkPresent ? $scope.workPackage.links.version.href : null, title: $scope.workPackage.props.versionName, viewable: versionLinkPresent};
+                    versionLinkPresent = !!$scope.workPackage.links.version;
+                var versionTitle = versionLinkPresent ? $scope.workPackage.links.version.props.title : $scope.workPackage.props.versionName,
+                    versionHref  = versionLinkPresent ? $scope.workPackage.links.version.href : null;
+                return {href: versionHref, title: versionTitle, viewable: versionLinkPresent};
                 break;
             case USER_TYPE:
                 return $scope.workPackage.embedded[property];

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,11 +131,7 @@ module ApplicationHelper
   end
 
   def format_version_name(version)
-    if version.project == @project
-      h(version)
-    else
-      h("#{version.project} - #{version}")
-    end
+    h(version.to_s_for_project(@project))
   end
 
   def due_date_distance_in_words(date)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -177,6 +177,14 @@ class Version < ActiveRecord::Base
     "#{project} - #{name}"
   end
 
+  def to_s_for_project(other_project)
+    if other_project == project
+      name
+    else
+      to_s_with_project
+    end
+  end
+
   # Versions are sorted by effective_date and "Project Name - Version name"
   # Those with no effective_date are at the end, sorted by "Project Name - Version name"
   def <=>(version)

--- a/karma/tests/controllers/details-tab-overview-controller-test.js
+++ b/karma/tests/controllers/details-tab-overview-controller-test.js
@@ -312,13 +312,19 @@ describe('DetailsTabOverviewController', function() {
           it ('should set the correct viewable property', function() {
             expect(fetchPresentPropertiesWithName('versionName')[0].value.viewable).to.equal(false);
           });
+          it('should set the given title', function() {
+            expect(fetchPresentPropertiesWithName('versionName')[0].value.title).to.equal('Test version');
+          });
         });
 
         context('versionViewable is true', function() {
           beforeEach(function() {
-            workPackage.links.version = {
-              href: "/versions/1"
-            };
+          workPackage.links.version = {
+            href: "/versions/1",
+            props: {
+              title: 'Test version'
+            }
+          };
             buildController();
           });
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -195,7 +195,7 @@ module API
           {
             href: version_path(represented.model.fixed_version),
             type: 'text/html',
-            title: "#{represented.model.fixed_version}"
+            title: "#{represented.model.fixed_version.to_s_for_project(represented.model.project)}"
           } if represented.model.fixed_version && @current_user.allowed_to?({controller: "versions", action: "show"}, represented.model.fixed_version.project, global: false)
         end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -42,6 +42,18 @@ describe Version, :type => :model do
     expect(version.errors_on(:effective_date).size).to eq(1)
   end
 
+  context '#to_s_for_project' do
+    let(:other_project) { FactoryGirl.build(:project) }
+
+    it 'returns only the version for the same project' do
+      expect(version.to_s_for_project(version.project)).to eq("#{version.name}")
+    end
+
+    it 'returns the project name and the version name for a different project' do
+      expect(version.to_s_for_project(other_project)).to eq("#{version.project.name} - #{version.name}")
+    end
+  end
+
   context 'deprecated methods' do
     it { is_expected.to respond_to :completed_pourcent }
     it { is_expected.to respond_to :closed_pourcent    }


### PR DESCRIPTION
[`* `#15280` fix wp details pane project name not displayed in front of inherited version`](http://www.openproject.org/work_packages/15280)
