### PR TITLE
16028 settings and more context menu not accessible in ie10

### DIFF
--- a/public/templates/work_packages.list.html
+++ b/public/templates/work_packages.list.html
@@ -80,6 +80,8 @@
 </div>
 
 <div options-dropdown class="dropdown dropdown-relative dropdown-anchor-right" id="settingsDropdown">
+  <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
+  properly. Thus, don't remove the hrefs or the empty URLs! -->
   <ul class="dropdown-menu">
     <li><a href="" ng-click="showColumnsModal()"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a></li>
     <li><a href="" ng-click="showSortingModal()"><i class="icon-action-menu icon-sort-by2"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>

--- a/public/templates/work_packages.list.html
+++ b/public/templates/work_packages.list.html
@@ -81,11 +81,11 @@
 
 <div options-dropdown class="dropdown dropdown-relative dropdown-anchor-right" id="settingsDropdown">
   <ul class="dropdown-menu">
-    <li><a href ng-click="showColumnsModal()"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a></li>
-    <li><a href ng-click="showSortingModal()"><i class="icon-action-menu icon-sort-by2"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>
-    <li><a href ng-click="showGroupingModal()"><i class="icon-action-menu icon-group-by2"></i>{{ I18n.t('js.toolbar.settings.group_by') }}</a></li>
+    <li><a href="" ng-click="showColumnsModal()"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a></li>
+    <li><a href="" ng-click="showSortingModal()"><i class="icon-action-menu icon-sort-by2"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>
+    <li><a href="" ng-click="showGroupingModal()"><i class="icon-action-menu icon-group-by2"></i>{{ I18n.t('js.toolbar.settings.group_by') }}</a></li>
     <li>
-      <a href ng-click="toggleDisplaySums()">
+      <a href="" ng-click="toggleDisplaySums()">
         <i ng-if="query.displaySums" class="icon-action-menu icon-yes"></i><i ng-if="!query.displaySums" class="icon-action-menu no-icon"></i>
         <accessible-element visible-text="I18n.t('js.toolbar.settings.display_sums')"
                             readable-text="displaySumsLabel">
@@ -93,23 +93,23 @@
       </a>
     </li>
     <li class="dropdown-divider"></li>
-    <li><a href ng-click="saveQuery($event)"
+    <li><a href="" ng-click="saveQuery($event)"
            ng-class="{'inactive': (!query.isDirty() && cannot('query', 'update')) || (query.isNew() && cannot('query', 'create'))}">
         <i class="icon-action-menu icon-save1"></i>{{ I18n.t('js.toolbar.settings.save') }}</a>
     </li>
-    <li><a href ng-click="showSaveAsModal($event)" ng-class="{'inactive': query.isNew() || cannot('query', 'create')}">
+    <li><a href="" ng-click="showSaveAsModal($event)" ng-class="{'inactive': query.isNew() || cannot('query', 'create')}">
       <i class="icon-action-menu icon-save1"></i>{{ I18n.t('js.toolbar.settings.save_as') }}</a>
     </li>
-    <li><a href ng-click="deleteQuery($event)" ng-class="{'inactive': cannot('query', 'delete')}">
+    <li><a href="" ng-click="deleteQuery($event)" ng-class="{'inactive': cannot('query', 'delete')}">
       <i class="icon-action-menu icon-delete"></i>{{ I18n.t('js.toolbar.settings.delete') }}</a>
     </li>
-    <li><a href ng-click="showExportModal($event)" ng-class="{'inactive': cannot('work_package', 'export')}">
+    <li><a href="" ng-click="showExportModal($event)" ng-class="{'inactive': cannot('work_package', 'export')}">
       <i class="icon-action-menu icon-export"></i>{{ I18n.t('js.toolbar.settings.export') }}</a>
     </li>
-    <li><a href ng-click="showShareModal($event)" ng-class="{'inactive': (cannot('query', 'publicize') && cannot('query', 'star'))}">
+    <li><a href="" ng-click="showShareModal($event)" ng-class="{'inactive': (cannot('query', 'publicize') && cannot('query', 'star'))}">
       <i class="icon-action-menu icon-publish"></i>{{ I18n.t('js.toolbar.settings.share') }}</a>
     </li>
-    <li><a href ng-click="showSettingsModal($event)" ng-class="{'inactive': cannot('query', 'update')}">
+    <li><a href="" ng-click="showSettingsModal($event)" ng-class="{'inactive': cannot('query', 'update')}">
       <i class="icon-action-menu icon-settings"></i>{{ I18n.t('js.toolbar.settings.page_settings') }}</a>
     </li>
   </ul>

--- a/public/templates/work_packages/work_package_details_toolbar.html
+++ b/public/templates/work_packages/work_package_details_toolbar.html
@@ -14,6 +14,8 @@
     <li ng-repeat="(action, properties) in permittedActions"
         ng-click="triggerMoreMenuAction(action, properties.link)"
         class="{{action}}">
+      <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
+      properly. Thus, don't remove the hrefs or the empty URLs! -->
       <a href=""
          ng-class="['icon-context'].concat(properties.css)"
          ng-bind="I18n.t('js.button_' + action)">

--- a/public/templates/work_packages/work_package_details_toolbar.html
+++ b/public/templates/work_packages/work_package_details_toolbar.html
@@ -14,7 +14,7 @@
     <li ng-repeat="(action, properties) in permittedActions"
         ng-click="triggerMoreMenuAction(action, properties.link)"
         class="{{action}}">
-      <a href
+      <a href=""
          ng-class="['icon-context'].concat(properties.css)"
          ng-bind="I18n.t('js.button_' + action)">
       </a>


### PR DESCRIPTION
[`* `#16028`Context menus in IE10 not accessible`](https://www.openproject.org/work_packages/16028)

This is a follow up branch of #2001 and fixes the tabbing for the settings and more menu (see [comment in the related ticket](https://community.openproject.org/work_packages/16028#note-16)).
