### PR TITLE
15979 Tabbing is missing for WP details view in IE 10

### DIFF
--- a/public/templates/work_packages.list.details.html
+++ b/public/templates/work_packages.list.details.html
@@ -1,5 +1,7 @@
 <div id="tabs">
   <ul class="tabrow">
+    <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
+    properly. Thus, don't remove the hrefs or the empty URLs! -->
     <li ui-sref="work-packages.list.details.overview({})"
         ui-sref-active="selected">
       <a href="" ng-bind="I18n.t('js.work_packages.tabs.overview')"/>

--- a/public/templates/work_packages.list.details.html
+++ b/public/templates/work_packages.list.details.html
@@ -2,24 +2,24 @@
   <ul class="tabrow">
     <li ui-sref="work-packages.list.details.overview({})"
         ui-sref-active="selected">
-      <a href ng-bind="I18n.t('js.work_packages.tabs.overview')"/>
+      <a href="" ng-bind="I18n.t('js.work_packages.tabs.overview')"/>
     </li>
     <li ui-sref="work-packages.list.details.activity({})"
         ui-sref-active="selected">
-      <a href ng-bind="I18n.t('js.work_packages.tabs.activity')"/>
+      <a href="" ng-bind="I18n.t('js.work_packages.tabs.activity')"/>
     </li>
     <li ui-sref="work-packages.list.details.relations({})"
         ui-sref-active="selected">
-      <a href ng-bind="I18n.t('js.work_packages.tabs.relations')"/>
+      <a href="" ng-bind="I18n.t('js.work_packages.tabs.relations')"/>
     </li>
     <li ng-if="canViewWorkPackageWatchers()"
         ui-sref="work-packages.list.details.watchers({})"
         ui-sref-active="selected">
-      <a href ng-bind="I18n.t('js.work_packages.tabs.watchers')"/>
+      <a href="" ng-bind="I18n.t('js.work_packages.tabs.watchers')"/>
     </li>
     <li ui-sref="work-packages.list.details.attachments({})"
         ui-sref-active="selected">
-      <a href ng-bind="I18n.t('js.work_packages.tabs.attachments')"/>
+      <a href="" ng-bind="I18n.t('js.work_packages.tabs.attachments')"/>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
[`* `#15979` Tabbing is missing for WP details view in IE 10`](https://community.openproject.org/work_packages/15979)
