### PR TITLE
16733 Focus not set on modal when opening columns from context menu in Firefox

### DIFF
--- a/app/assets/javascripts/angular/helpers/components/focus-helper.js
+++ b/app/assets/javascripts/angular/helpers/components/focus-helper.js
@@ -56,9 +56,19 @@ angular.module('openproject.uiComponents')
     },
 
     focusSelect2Element: function(element) {
-      $timeout(function() {
-        element.select2('focus');
-      });
+      var focusSelect2ElementRecursiv = function(retries) {
+        $timeout(function() {
+          element.select2('focus');
+
+          var isSelect2Focused = angular.element(document.activeElement).hasClass('select2-input');
+
+          if (!isSelect2Focused && retries > 0) {
+            focusSelect2ElementRecursiv(--retries);
+          }
+        });
+      }
+
+      focusSelect2ElementRecursiv(3);
     }
   };
 

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "jquery-migrate": "~1.2.1",
     "momentjs": "~2.7.0",
     "moment-timezone": "~0.2.0",
-    "angular-context-menu": "finnlabs/angular-context-menu#v0.1.7",
+    "angular-context-menu": "finnlabs/angular-context-menu#v0.1.8",
     "angular-busy": "~4.0.4",
     "hyperagent": "manwithtwowatches/hyperagent#v0.4.2",
     "lodash": "~2.4.1"


### PR DESCRIPTION
[`* `#16733` Focus not set on modal when opening columns from context menu in Firefox`](https://community.openproject.org/work_packages/16733)
