### PR TITLE
Get APIv3 Specification up-to-date with its implementation

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -415,8 +415,8 @@ A user must have the permission to **edit journals** to update an activity. A
 |  Link  | Description | Type | Constraints | Supported operations |
 |:------:|-------------| ---- | ----------- | -------------------- |
 | self   | This project | Project | not null | READ |
-| categories | Categories available in this project | Category[] | not null | READ |
-| versions | Versions available in this project | Version[] | not null | READ |
+| categories | Categories available in this project | Categories | not null | READ |
+| versions | Versions available in this project | Versions | not null | READ |
 
 ## Properties:
 | Property | Description | Type | Constraints | Example | Supported operations |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1370,6 +1370,8 @@ Updates an activity's comment and, on success, returns the updated activity.
 
 ## Edit WorkPackage [PATCH]
 
+**NOT IMPLEMENTED**
+
 + Parameters
     + id (required, integer, `1`) ... Work package id
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -139,6 +139,13 @@ This allows you to see exactly what went wrong and inform the user.
 
 **TODO**
 
+# Authentication
+
+For now the API only supports **session-based authentication**. This means you have to login to OpenProject via
+the Web-Interface to be authenticated in the API. This method is well-suited for clients acting within the browser,
+like the Angular-Client built into OpenProject.
+
+However for the future we plan to add authentication modes that are more suitable for **external clients** too.
 
 # Allowed HTTP methods
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -253,21 +253,21 @@ Updates an activity's comment and, on success, returns the updated activity.
 + Response 403 (application/hal+json)
 
     Returned if the client does not have sufficient permissions.
-	
-	**Required permission:** edit journals
+    
+    **Required permission:** edit journals
 
     + Body
-		
-		TBD
+        
+        TBD
 
-	
+    
 + Response 422 (application/hal+json)
 
     Returned if the client tries to modify a read-only property.
 
     + Body
-		
-		TBD
+        
+        TBD
 
 # Group Attachments
 
@@ -335,34 +335,34 @@ Updates an activity's comment and, on success, returns the updated activity.
 ## Categories by Project [/projects/{project_id}/categories]
 
 + Model
-	+ Body
-	
-			{
-				_links:
-				{
-					self:
-					{
-						href: "/api/v3/projects/11/categories"
-					}
-				},
-				_type: "Categories",
-				_embedded:
-				{
-					categories: [
-						{
-							_type: "Category",
-							id: 10,
-							name: "Foo"
-						},
-						{
-							_type: "Category",
-							id: 11,
-							name: "Bar"
-						}
-					]
-				}
-			}
-			
+    + Body
+    
+            {
+                _links:
+                {
+                    self:
+                    {
+                        href: "/api/v3/projects/11/categories"
+                    }
+                },
+                _type: "Categories",
+                _embedded:
+                {
+                    categories: [
+                        {
+                            _type: "Category",
+                            id: 10,
+                            name: "Foo"
+                        },
+                        {
+                            _type: "Category",
+                            id: 11,
+                            name: "Bar"
+                        }
+                    ]
+                }
+            }
+            
 ## List categories of a project [GET]
 
 + Parameters
@@ -370,8 +370,8 @@ Updates an activity's comment and, on success, returns the updated activity.
 
 + Response 200 (application/hal+json)
 
-	[Categories by Project][]
-	
+    [Categories by Project][]
+    
 # Group Priorities
 
 ## Properties
@@ -383,54 +383,54 @@ Updates an activity's comment and, on success, returns the updated activity.
 ## Priorities [/priorities]
 
 + Model
-	+ Body
-	
-			{
-				_links:
-				{
-					self:
-					{
-						href: "/api/v3/priorities"
-					}
-				},
-				_type: "Priorities",
-				_embedded:
-				{
-					priorities: [
-						{
-							_type: "Priority",
-							id: 1,
-							name: "Low"
-						},
-						{
-							_type: "Priority",
-							id: 2,
-							name: "Normal"
-						},
-						{
-							_type: "Priority",
-							id: 3,
-							name: "High"
-						},
-						{
-							_type: "Priority",
-							id: 4,
-							name: "Urgent"
-						},
-						{
-							_type: "Priority",
-							id: 5,
-							name: "Immediate"
-						}
-					]
-				}
-			}
-			
+    + Body
+    
+            {
+                _links:
+                {
+                    self:
+                    {
+                        href: "/api/v3/priorities"
+                    }
+                },
+                _type: "Priorities",
+                _embedded:
+                {
+                    priorities: [
+                        {
+                            _type: "Priority",
+                            id: 1,
+                            name: "Low"
+                        },
+                        {
+                            _type: "Priority",
+                            id: 2,
+                            name: "Normal"
+                        },
+                        {
+                            _type: "Priority",
+                            id: 3,
+                            name: "High"
+                        },
+                        {
+                            _type: "Priority",
+                            id: 4,
+                            name: "Urgent"
+                        },
+                        {
+                            _type: "Priority",
+                            id: 5,
+                            name: "Immediate"
+                        }
+                    ]
+                }
+            }
+            
 ## List all Priorities [GET]
 
 + Response 200 (application/hal+json)
 
-	[Priorities][]
+    [Priorities][]
 
 # Group Projects
 
@@ -716,60 +716,60 @@ Updates an activity's comment and, on success, returns the updated activity.
 ## Statuses [/statuses]
 
 + Model
-	+ Body
-	
-			{
-				_links:
-				{
-					self:
-					{
-						href: "/api/v3/statuses"
-					}
-				},
-				_type: "Statuses",
-				_embedded:
-				{
-					statuses: [
-						{
-							_type: "Status",
-							id: 1,
-							name: "New"
-						},
-						{
-							_type: "Status",
-							id: 3,
-							name: "Resolved"
-						},
-						{
-							_type: "Status",
-							id: 4,
-							name: "Feedback"
-						},
-						{
-							_type: "Status",
-							id: 5,
-							name: "Closed"
-						},
-						{
-							_type: "Status",
-							id: 6,
-							name: "Rejected"
-						},
-						{
-							_type: "Status",
-							id: 2,
-							name: "In Progress"
-						}
-					]
-				}
-			}
-			
+    + Body
+    
+            {
+                _links:
+                {
+                    self:
+                    {
+                        href: "/api/v3/statuses"
+                    }
+                },
+                _type: "Statuses",
+                _embedded:
+                {
+                    statuses: [
+                        {
+                            _type: "Status",
+                            id: 1,
+                            name: "New"
+                        },
+                        {
+                            _type: "Status",
+                            id: 3,
+                            name: "Resolved"
+                        },
+                        {
+                            _type: "Status",
+                            id: 4,
+                            name: "Feedback"
+                        },
+                        {
+                            _type: "Status",
+                            id: 5,
+                            name: "Closed"
+                        },
+                        {
+                            _type: "Status",
+                            id: 6,
+                            name: "Rejected"
+                        },
+                        {
+                            _type: "Status",
+                            id: 2,
+                            name: "In Progress"
+                        }
+                    ]
+                }
+            }
+            
 ## List all Statuses [GET]
 
 + Response 200 (application/hal+json)
 
-	[Statuses][]
-	
+    [Statuses][]
+    
 # Group Users
 
 ## Properties:
@@ -829,39 +829,39 @@ Updates an activity's comment and, on success, returns the updated activity.
 ## Versions by Project [/projects/{project_id}/versions]
 
 + Model
-	+ Body
-	
-			{
-				_links:
-				{
-					self:
-					{
-						href: "/api/v3/projects/11/versions"
-					}
-				},
-				_type: "Versions",
-				_embedded:
-				{
-					versions: [
-						{
-							_type: "Version",
-							id: 11,
-							name: "v3.0 Alpha"
-						},
-						{
-							_type: "Version",
-							id: 12,
-							name: "v2.0"
-						},
-						{
-							_type: "Version",
-							id: 10,
-							name: "v1.0"
-						}
-					]
-				}
-			}
-			
+    + Body
+    
+            {
+                _links:
+                {
+                    self:
+                    {
+                        href: "/api/v3/projects/11/versions"
+                    }
+                },
+                _type: "Versions",
+                _embedded:
+                {
+                    versions: [
+                        {
+                            _type: "Version",
+                            id: 11,
+                            name: "v3.0 Alpha"
+                        },
+                        {
+                            _type: "Version",
+                            id: 12,
+                            name: "v2.0"
+                        },
+                        {
+                            _type: "Version",
+                            id: 10,
+                            name: "v1.0"
+                        }
+                    ]
+                }
+            }
+            
 ## List versions available in a project [GET]
 
 + Parameters
@@ -869,8 +869,8 @@ Updates an activity's comment and, on success, returns the updated activity.
 
 + Response 200 (application/hal+json)
 
-	[Versions by Project][]
-	
+    [Versions by Project][]
+    
 # Group Work packages
 
 ## Links:
@@ -1395,9 +1395,9 @@ Updates an activity's comment and, on success, returns the updated activity.
     Returned if the client tries to modify a read-only property.
 
     + Body
-		
-		TBD
-	
+        
+        TBD
+    
 ## Add Watcher [/work_packages/{work_package_id}/watchers]
 
 + Model

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -562,6 +562,8 @@ Updates an activity's comment and, on success, returns the updated activity.
 
 ## View query [GET]
 
+**NOT IMPLEMENTED**
+
 + Parameters
     + id (required, integer, `1`) ... Query id
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -567,6 +567,71 @@ A user must have the permission to **edit journals** to update an activity. A
 
     [Unstar Query][]
 
+# Group Statuses
+
+## Properties
+| Property | Description | Type    | Constraints | Example | Supported operations |
+|:--------:|-------------| ------- | ----------- | ------- | -------------------- |
+| id       | Status id   | Integer | Must be a positive integer | 12 | READ |
+| name     | Status name | String  |             | Closed  | READ |
+
+## Statuses [/statuses]
+
++ Model
+	+ Body
+	
+			{
+				_links:
+				{
+					self:
+					{
+						href: "/api/v3/statuses"
+					}
+				},
+				_type: "Statuses",
+				_embedded:
+				{
+					statuses: [
+						{
+							_type: "Status",
+							id: 1,
+							name: "New"
+						},
+						{
+							_type: "Status",
+							id: 3,
+							name: "Resolved"
+						},
+						{
+							_type: "Status",
+							id: 4,
+							name: "Feedback"
+						},
+						{
+							_type: "Status",
+							id: 5,
+							name: "Closed"
+						},
+						{
+							_type: "Status",
+							id: 6,
+							name: "Rejected"
+						},
+						{
+							_type: "Status",
+							id: 2,
+							name: "In Progress"
+						}
+					]
+				}
+			}
+			
+## List all Statuses [GET]
+
++ Response 200 (application/hal+json)
+
+	[Statuses][]
+	
 # Group Users
 
 ## Properties:

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -237,9 +237,6 @@ Activity can be either _type Activity or _type Activity::Comment.
 
 Updates an activity's comment and, on success, returns the updated activity.
 
-A user must have the permission to **edit journals** to update an activity. A
-``403`` is returned otherwise.
-
 + Parameters
     + id (required, integer, `1`) ... Activity id
 
@@ -252,6 +249,25 @@ A user must have the permission to **edit journals** to update an activity. A
 + Response 200 (application/hal+json)
 
     [Activity][]
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+	
+	**Required permission:** edit journals
+
+    + Body
+		
+		TBD
+
+	
++ Response 422 (application/hal+json)
+
+    Returned if the client tries to modify a read-only property.
+
+    + Body
+		
+		TBD
 
 # Group Attachments
 
@@ -1370,6 +1386,14 @@ A user must have the permission to **edit journals** to update an activity. A
 
     [WorkPackage][]
 
++ Response 422 (application/hal+json)
+
+    Returned if the client tries to modify a read-only property.
+
+    + Body
+		
+		TBD
+	
 ## Add Watcher [/work_packages/{work_package_id}/watchers]
 
 + Model

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1,15 +1,16 @@
 FORMAT: 1A
 
 # OpenProject API v3
-TODO: Description
 
-# Group Hypermedia
+# Group General
+
+# Hypermedia
 TODO: Description & Resources
 
-# Group Formats
+# Formats
 TODO: Description and why only JSON
 
-# Group HAL+JSON
+# HAL+JSON
 HAL is a simple format that gives a consistent and easy way to hyperlink between resources in your API.
 Read more: http://stateless.co/hal_specification.html
 
@@ -22,7 +23,7 @@ Read more: http://stateless.co/hal_specification.html
     - `_count` - number of records fetched in the response
     - `_total` - number of available records
 
-# Group API response structure
+# API response structure
 Depending on the performed request, the OpenProject API will return a response in one of the following possible structures:
 
 - As a **simple HAL+JSON object** (e.g.: GET /projects/:id)
@@ -132,14 +133,14 @@ This allows you to see exactly what went wrong and inform the user.
 **TODO**
 
 
-# Group Allowed HTTP methods
+# Allowed HTTP methods
 
 - `GET` - Get a single resource or collection of resources
 - `POST` - Create a new resource or perform
 - `PATCH` - Update a resource
 - `DELETE` - Delete a resource
 
-# Group Response codes
+# Response codes
 
 - `200 OK` - Standard response for successful HTTP requests. The actual response will depend on the request method used. In a GET request, the response will contain an entity corresponding to the requested resource.
 - `201 Created` - The request has been fulfilled and resulted in a new resource being created
@@ -161,9 +162,6 @@ This allows you to see exactly what went wrong and inform the user.
 - `500 Internal Server Error` - A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
 - `501 Not Implemented` - The server either does not recognize the request method, or it lacks the ability to fulfill the request. Usually this implies future availability.
 - `503 Service Unavailable` - The server is currently unavailable (because it is overloaded or down for maintenance).
-
-# OpenProject API error objects
-**TODO**
 
 # Group Activities
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -294,6 +294,66 @@ A user must have the permission to **edit journals** to update an activity. A
 
     [Attachment][]
 
+# Group Priorities
+
+## Properties
+| Property | Description | Type    | Constraints | Example | Supported operations |
+|:--------:|-------------| ------- | ----------- | ------- | -------------------- |
+| id       | Priority id   | Integer | Must be a positive integer | 12 | READ |
+| name     | Priority name | String  |             | High  | READ |
+
+## Priorities [/priorities]
+
++ Model
+	+ Body
+	
+			{
+				_links:
+				{
+					self:
+					{
+						href: "/api/v3/priorities"
+					}
+				},
+				_type: "Priorities",
+				_embedded:
+				{
+					priorities: [
+						{
+							_type: "Priority",
+							id: 1,
+							name: "Low"
+						},
+						{
+							_type: "Priority",
+							id: 2,
+							name: "Normal"
+						},
+						{
+							_type: "Priority",
+							id: 3,
+							name: "High"
+						},
+						{
+							_type: "Priority",
+							id: 4,
+							name: "Urgent"
+						},
+						{
+							_type: "Priority",
+							id: 5,
+							name: "Immediate"
+						}
+					]
+				}
+			}
+			
+## List all Priorities [GET]
+
++ Response 200 (application/hal+json)
+
+	[Priorities][]
+
 # Group Projects
 
 ## Links:

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -294,6 +294,54 @@ A user must have the permission to **edit journals** to update an activity. A
 
     [Attachment][]
 
+# Group Categories
+
+## Properties
+| Property | Description | Type    | Constraints | Example | Supported operations |
+|:--------:|-------------| ------- | ----------- | ------- | -------------------- |
+| id       | Category id   | Integer | Must be a positive integer | 12 | READ |
+| name     | Category name | String  |             | Category Name  | READ |
+
+## Categories by Project [/projects/{project_id}/categories]
+
++ Model
+	+ Body
+	
+			{
+				_links:
+				{
+					self:
+					{
+						href: "/api/v3/projects/11/categories"
+					}
+				},
+				_type: "Categories",
+				_embedded:
+				{
+					categories: [
+						{
+							_type: "Category",
+							id: 10,
+							name: "Foo"
+						},
+						{
+							_type: "Category",
+							id: 11,
+							name: "Bar"
+						}
+					]
+				}
+			}
+			
+## List categories of a project [GET]
+
++ Parameters
+    + project_id (required, integer, `1`) ... ID of the project whoose categories will be listed
+
++ Response 200 (application/hal+json)
+
+	[Categories by Project][]
+	
 # Group Priorities
 
 ## Properties

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -576,6 +576,7 @@ A user must have the permission to **edit journals** to update an activity. A
 | login | User's login name | String | | j.sheppard | READ / WRITE |
 | firstName | User's first name | String | | John | READ / WRITE |
 | lastName | User's last name | String | | Sheppard | READ / WRITE |
+| name | User's full name, formatting depends on instance settings | String | | Sheppard, John | READ |
 | mail | User's email | String | | shep@mail.com | READ / WRITE |
 | avatar | URL to user's avatar | String | | https://gravatar/avatar | READ |
 | createdAt | | Timestamp | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ | | READ |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -865,7 +865,7 @@ A user must have the permission to **edit journals** to update an activity. A
 | status | | String | **REQUIRED** ... | New | READ / WRITE |
 | priority | | String | Must be one of the activated priorities | High | READ / WRITE |
 | startDate | | Date | Must be a date in format YYYY-MM-DD and must be equal or greater than the soonest possible start date | 2014-05-21T08:51:20Z | READ / WRITE |
-| dueDate | | Date | Must be a date in format YYYY-MM-DD and must be greater then start date | READ / WRITE |
+| dueDate | | Date | Must be a date in format YYYY-MM-DD and must be greater then start date | | READ / WRITE |
 | estimatedTime | | Object | Must be in form of a json object with "units" and "value" as keys and value must be an integer or a decimal | { "units": "hours", "value": 12 } | READ / WRITE |
 | percentageDone | | Integer | Must be an integer between 0 and 100 | 50 | READ / WRITE |
 | createdAt | | Timestamp | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ | | READ |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -226,7 +226,7 @@ Activity can be either _type Activity or _type Activity::Comment.
 
     [Activity][]
 
-## Update activity [PUT]
+## Update activity [PATCH]
 
 Updates an activity's comment and, on success, returns the updated activity.
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -848,6 +848,12 @@ A user must have the permission to **edit journals** to update an activity. A
 	
 # Group Work packages
 
+## Links:
+|  Link  | Description | Type | Constraints | Supported operations |
+|:------:|-------------| ---- | ----------- | -------------------- |
+| self   | This work package | WorkPackage | not null | READ |
+| author | The person that created the work package | User | not null | READ |
+
 ## Properties:
 | Property | Description | Type | Constraints | Example | Supported operations |
 |:---------:|-------------| ---- | ----------- | ------- | -------------------- |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -786,6 +786,59 @@ A user must have the permission to **edit journals** to update an activity. A
 
     [User][]
 
+# Group Versions
+
+## Properties
+| Property | Description | Type    | Constraints | Example | Supported operations |
+|:--------:|-------------| ------- | ----------- | ------- | -------------------- |
+| id       | Version id   | Integer | Must be a positive integer | 12 | READ |
+| name     | Version name | String  |             | Version 1.0  | READ |
+
+## Versions by Project [/projects/{project_id}/versions]
+
++ Model
+	+ Body
+	
+			{
+				_links:
+				{
+					self:
+					{
+						href: "/api/v3/projects/11/versions"
+					}
+				},
+				_type: "Versions",
+				_embedded:
+				{
+					versions: [
+						{
+							_type: "Version",
+							id: 11,
+							name: "v3.0 Alpha"
+						},
+						{
+							_type: "Version",
+							id: 12,
+							name: "v2.0"
+						},
+						{
+							_type: "Version",
+							id: 10,
+							name: "v1.0"
+						}
+					]
+				}
+			}
+			
+## List versions available in a project [GET]
+
++ Parameters
+    + project_id (required, integer, `1`) ... ID of the project whoose versions will be listed
+
++ Response 200 (application/hal+json)
+
+	[Versions by Project][]
+	
 # Group Watchers
 
 ## Add Watcher [/work_packages/{work_package_id}/watchers]

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -4,6 +4,13 @@ FORMAT: 1A
 
 # Group General
 
+This is the current **DRAFT** of the specification for OpenProject APIv3.
+
+Please note that everything in this document might be **subject to change** in a future version of OpenProject. We intend to keep this specification
+as accurate as possible, however as long as the APIv3 is not in a stable state it is possible that there are intermediary differences between
+this specification and the real implementation. While we try to only specify what we want to keep, it might also happen that parts of this
+specification will be replaced **incompatibly** until the APIv3 is considered *stable*.
+
 # Hypermedia
 TODO: Description & Resources
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -659,6 +659,12 @@ A user must have the permission to **edit journals** to update an activity. A
 
 # Group Work packages
 
+## Links:
+|  Link  | Description | Type | Constraints | Supported operations |
+|:------:|-------------| ---- | ----------- | -------------------- |
+| self   | This work package | WorkPackage | not null | READ |
+| author | The person that created the work package | User | not null | READ |
+
 ## Properties:
 | Property | Description | Type | Constraints | Example | Supported operations |
 |:---------:|-------------| ---- | ----------- | ------- | -------------------- |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -477,7 +477,7 @@ A user must have the permission to **edit journals** to update an activity. A
 | sortCriteria | | String | | | READ / WRITE |
 | groupBy | | String | | | READ / WRITE |
 | displaySums | | Boolean | | true | READ / WRITE |
-| isStarred | | Boolean | | true | READ / WRITE |
+| isStarred | | Boolean | | true | READ |
 
 ## Query [/queries/{id}]
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -298,6 +298,13 @@ A user must have the permission to **edit journals** to update an activity. A
 
 # Group Projects
 
+## Links:
+|  Link  | Description | Type | Constraints | Supported operations |
+|:------:|-------------| ---- | ----------- | -------------------- |
+| self   | This project | Project | not null | READ |
+| categories | Categories available in this project | Category[] | not null | READ |
+| versions | Versions available in this project | Version[] | not null | READ |
+
 ## Properties:
 | Property | Description | Type | Constraints | Example | Supported operations |
 |:---------:|-------------| ---- | ----------- | ------- | -------------------- |

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -55,6 +55,7 @@ module API
 
             # disabled to prevent security risks caused by missing setter restrictions
             # see https://community.openproject.org/work_packages/16768
+            # don't forget to re-enable the tests after uncommenting ;-)
             #patch do
             #  authorize(:edit_work_packages, context: @work_package.project)
             #  @representer.from_json(env['api.request.input'])

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -53,8 +53,8 @@ module API
               @representer
             end
 
-			##disabled to prevent security risks caused by missing setter restrictions
-			##see https://community.openproject.org/work_packages/16768
+            # disabled to prevent security risks caused by missing setter restrictions
+            # see https://community.openproject.org/work_packages/16768
             #patch do
             #  authorize(:edit_work_packages, context: @work_package.project)
             #  @representer.from_json(env['api.request.input'])

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -53,16 +53,18 @@ module API
               @representer
             end
 
-            patch do
-              authorize(:edit_work_packages, context: @work_package.project)
-              @representer.from_json(env['api.request.input'])
-              @representer.represented.sync
-              if @representer.represented.model.valid? && @representer.represented.save
-                @representer
-              else
-                fail Errors::Validation.new(@representer.represented.model)
-              end
-            end
+			##disabled to prevent security risks caused by missing setter restrictions
+			##see https://community.openproject.org/work_packages/16768
+            #patch do
+            #  authorize(:edit_work_packages, context: @work_package.project)
+            #  @representer.from_json(env['api.request.input'])
+            #  @representer.represented.sync
+            #  if @representer.represented.model.valid? && @representer.represented.save
+            #    @representer
+            #  else
+            #    fail Errors::Validation.new(@representer.represented.model)
+            #  end
+            #end
 
             resource :activities do
 

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -206,6 +206,7 @@ h4. things we like
 
   end
 
+  # disabled the its below because the implementation was temporarily disabled
   describe '#patch' do
     let(:patch_path) { "/api/v3/work_packages/#{work_package.id}" }
     before(:each) do
@@ -227,21 +228,21 @@ h4. things we like
           }
         end
 
-        it 'should respond with 200' do
+        xit 'should respond with 200' do
           expect(response.status).to eq(200)
         end
 
-        it 'should respond with updated work package' do
+        xit 'should respond with updated work package' do
           expect(subject.body).to be_json_eql('Updated subject'.to_json).at_path('subject')
           expect(subject.body).to be_json_eql(params[:priority].to_json).at_path('priority')
         end
 
-        it 'should update the dates in iso8601 format' do
+        xit 'should update the dates in iso8601 format' do
           expect(subject.body).to be_json_eql(params[:startDate].to_json).at_path('startDate')
           expect(subject.body).to be_json_eql(params[:dueDate].to_json).at_path('dueDate')
         end
 
-        it 'should allow html in raw description' do
+        xit 'should allow html in raw description' do
           expect(subject.body).to be_json_eql('<h1>Updated description</h1>'.to_json).at_path('rawDescription')
         end
 
@@ -261,11 +262,11 @@ h4. things we like
           }
         end
 
-        it 'should respond with 422' do
+        xit 'should respond with 422' do
           expect(response.status).to eq 422
         end
 
-         it 'should respond with explanatory error message' do
+        xit 'should respond with explanatory error message' do
           parsed_errors = JSON.parse(last_response.body)['errors']
           parsed_errors.should eq(["Subject can't be blank", "Type is not included in the list"])
         end


### PR DESCRIPTION
This PR brings specification and actual implementation closer together.
The specification still goes further than the implementation in some places, but it should be quite managable and understandable now. (If I did not miss anything)

This PR also temporarily disables the PATCH-Endpoint for Work Packages, as it poses a security risk in its current implementation. This should make us safe for Release 4.0 and can be fixed in a later release.
