### PR TITLE
Show unsupported browser notice for Firefox 10-30

### DIFF
--- a/app/assets/javascripts/unsupported-browsers.js
+++ b/app/assets/javascripts/unsupported-browsers.js
@@ -31,8 +31,8 @@
   $(function() {
 
     var agent = navigator.userAgent;
-
-    if (agent.match(/MSIE [789]\.0/) === null) {
+    if (agent.match(/MSIE [789]\.0/) === null &&                // IE 7-9
+        agent.match(/Firefox\/(([1-2][0-9]|30)\.)/) === null) { // Firefox 10-30
       return;
     }
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/16743

We only support Firefox >= 31 (latest ESR) now. As we previously
supported older Firefox versions, especially 24, we show an
unsupported browser notice for them now.
