### PR TITLE
Revert "Revert "WP Index: Fix total sums overlaying WPs in Firefox""

### DIFF
--- a/public/templates/work_packages/work_packages_table.html
+++ b/public/templates/work_packages/work_packages_table.html
@@ -176,7 +176,6 @@
 
         <tr work-package-total-sums
             ng-if="displaySums"
-            cg-busy="fetchTotalSums"
             class="sum group all issue work_package">
           <td colspan="{{2  - (!!hideWorkPackageDetails * 1)}}">
             <div class="work-packages-table--footer-outer">


### PR DESCRIPTION
https://community.openproject.org/work_packages/16679
Also related to https://community.openproject.org/work_packages/16609

See also #2012 and #2020.

Original Commit: 4e245da297b0da5380b19b612047ea7b10bc4ad5

Original Commit Message:

cg-busy adds a 'position: relative' to the CSS which makes Firefox
position the absolutely positioned div with the sums relative to the
total sum table row, which has height 0 due to no content (the div is
ignored for 'position: absolute').

Chrome seems to ignore the 'position: relative'.

Removing cg-busy for the total sums as the loading indicator doesn't
seem to be shown anyway.
