### PR TITLE
fix firefox watcher icon hover incorrect

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/work-package-details-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/work-package-details-controller.js
@@ -107,8 +107,8 @@ angular.module('openproject.workPackages.controllers')
     function setWorkPackageScopeProperties(workPackage){
       $scope.workPackage = workPackage;
 
-      $scope.isWatched = !!workPackage.links.unwatch;
-      $scope.toggleWatchLink = workPackage.links.watch === undefined ? workPackage.links.unwatch : workPackage.links.watch;
+      $scope.isWatched = !!workPackage.links.unwatchChanges;
+      $scope.toggleWatchLink = workPackage.links.watchChanges === undefined ? workPackage.links.unwatchChanges : workPackage.links.watchChanges;
       $scope.watchers = workPackage.embedded.watchers;
 
       // activities and latest activities

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -132,7 +132,7 @@ module API
           }
         end
 
-        link :watch do
+        link :watchChanges do
           {
             href: "#{root_path}api/v3/work_packages/#{represented.model.id}/watchers",
             method: :post,
@@ -143,7 +143,7 @@ module API
             !represented.model.watcher_users.include?(@current_user)
         end
 
-        link :unwatch do
+        link :unwatchChanges do
           {
             href: "#{root_path}api/v3/work_packages/#{represented.model.id}/watchers/#{@current_user.id}",
             method: :delete,

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -145,11 +145,11 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       context 'when the user has the permission to view work packages' do
         context 'and the user is not watching the work package' do
           it 'should have a link to watch' do
-            expect(subject).to have_json_path('_links/watch/href')
+            expect(subject).to have_json_path('_links/watchChanges/href')
           end
 
           it 'should not have a link to unwatch' do
-            expect(subject).to_not have_json_path('_links/unwatch/href')
+            expect(subject).to_not have_json_path('_links/unwatchChanges/href')
           end
         end
 
@@ -159,11 +159,11 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
           end
 
           it 'should have a link to watch' do
-            expect(subject).to have_json_path('_links/unwatch/href')
+            expect(subject).to have_json_path('_links/unwatchChanges/href')
           end
 
           it 'should not have a link to watch' do
-            expect(subject).to_not have_json_path('_links/watch/href')
+            expect(subject).to_not have_json_path('_links/watchChanges/href')
           end
         end
       end
@@ -172,11 +172,11 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         let(:current_user) { FactoryGirl.create :user }
 
         it 'should not have a link to unwatch' do
-          expect(subject).to_not have_json_path('_links/unwatch/href')
+          expect(subject).to_not have_json_path('_links/unwatchChanges/href')
         end
 
         it 'should not have a link to watch' do
-          expect(subject).to_not have_json_path('_links/watch/href')
+          expect(subject).to_not have_json_path('_links/watchChanges/href')
         end
       end
 


### PR DESCRIPTION
[`* `#15418` firefox watcher icon hover incorrect`](http://community.openproject.org/work_packages/15418)

Apparently Firefox has watch and unwatch as base methods of the object prototype, meaning they are not overrided by the links watch and unwatch properties. I renamed them
