### PR TITLE
Add option to svnadmin to create pre 1.6 compatible repositories

### DIFF
--- a/extra/svn/reposman.rb
+++ b/extra/svn/reposman.rb
@@ -66,7 +66,7 @@ module SCM
 
   module Subversion
     def self.create(path)
-      system_or_raise "svnadmin create #{path}"
+      system_or_raise "svnadmin create #{path} --pre-1.6-compatible"
     end
   end
 

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -53,7 +53,7 @@ namespace :test do
       desc "Creates a test subversion repository"
       task :subversion => :create_dir do
         repo_path = "tmp/test/subversion_repository"
-        system "svnadmin create #{repo_path}"
+        system "svnadmin create #{repo_path} --pre-1.6-compatible"
         system "gunzip < test/fixtures/repositories/subversion_repository.dump.gz | svnadmin load #{repo_path}"
       end
 


### PR DESCRIPTION
This change is necessary to handle svn client (warnings) regarding the repository format:

```
post commit FS processing had error:
couldn't open rep-cache database
```

svnadmin man page:

--pre-1.6-compatible
  When creating a new repository, use a format that is compatible with
  versions of Subversion earlier than Subversion 1.6.
