### PR TITLE
fix watcher disappears from selection modal when hovering

### DIFF
--- a/app/assets/stylesheets/select2_customizing.css.erb
+++ b/app/assets/stylesheets/select2_customizing.css.erb
@@ -111,7 +111,7 @@ See doc/COPYRIGHT.rdoc for more details.
   color: #000;
 }
 
-.controller-work_packages.action-index .select2-drop:not(.project-search-results) .select2-results .select2-result-selectable:hover, .controller-work_packages.action-index .select2-drop:not(.project-search-results) .select2-results .select2-result-selectable.select2-highlighted {
+.controller-work_packages.action-index .select2-drop:not(.project-search-results) .select2-results .select2-result-selectable.select2-highlighted {
   color: #fff;
   font-weight: bold;
 }


### PR DESCRIPTION
[`* `#16732` watcher disappears from selection modal when hovering`](http://www.openproject.org/work_packages/16732)
