### PR TITLE
14721 Tooltips for truncated description missing

### DIFF
--- a/public/templates/work_packages/tabs/_attachments_table.html
+++ b/public/templates/work_packages/tabs/_attachments_table.html
@@ -14,7 +14,7 @@
       <td attachment-title-cell attachment="attachment"></td>
       <td attachment-file-size attachment="attachment"></td>
       <td attachment-user-cell attachment="attachment"></td>
-      <td>{{ attachment.props.description }}</td>
+      <td title="{{ attachment.props.description }}" ng-bind="attachment.props.description"></td>
       <td><date-time date-time-value="attachment.props.createdAt"></date-time></td>
     </tr>
   </tbody>


### PR DESCRIPTION
[`* `#14721` Tooltip for truncated attachment description missing`](https://community.openproject.org/work_packages/14721)
