### PR TITLE
force ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,7 @@ OpenProject::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug


### PR DESCRIPTION
we should force ssl in the app and don’t rely on the webserver’s redirect rules.
