### PR TITLE
fix wp lines jump when hover over grouping

### DIFF
--- a/app/assets/stylesheets/legacy/_01_tables.sass
+++ b/app/assets/stylesheets/legacy/_01_tables.sass
@@ -287,9 +287,10 @@ tr.group
     color: #aaa
     font-size: 80%
     font-weight: normal
-    display: none
-  &:hover a.toggle-all
     display: inline
+    visibility: hidden
+  &:hover a.toggle-all
+    visibility: visible
 
 a.toggle-all:hover
   text-decoration: none


### PR DESCRIPTION
[`* `#16817` wp lines jump when hover over grouping`](http://community.openproject.org/work_packages/16817)

I had the same on chrome on mac. I think the problem is related to rounding of height depending on the font-size. This can be fixed either by setting the font-size of the link to 74% or 90% or by changing the display: none/inline to visibility: hidden/visible (this way the element will be invisible but will occupy the same space on the page rendering the same size of the TD
