### PR TITLE
Allow attribute mapping through flexible strategy 

### DIFF
--- a/app/controllers/concerns/omniauth_login.rb
+++ b/app/controllers/concerns/omniauth_login.rb
@@ -118,13 +118,22 @@ module Concerns::OmniauthLogin
 
   def omniauth_hash_to_user_attributes(auth)
     info = auth[:info]
-    {
+
+    attribute_map = {
       login:        info[:email],
       mail:         info[:email],
       firstname:    info[:first_name] || info[:name],
       lastname:     info[:last_name],
       identity_url: identity_url_from_omniauth(auth)
     }
+
+    # Allow strategies to override mapping
+    strategy = request.env['omniauth.strategy']
+    if strategy.respond_to?(:omniauth_hash_to_user_attributes)
+      attribute_map.merge(strategy.omniauth_hash_to_user_attributes(auth))
+    else
+      attribute_map
+    end
   end
 
   def identity_url_from_omniauth(auth)


### PR DESCRIPTION
OpenProject currently employs a fixed attribute mapping schema for
userdata extracted from OmniAuth::AuthHash.

For some strategies (e.g., LDAP), various attribute names are used to
determine user attributes. Thus, an override to the fixed mapping from
within a strategy is desirable.

This feature allows the attribute mapping hash to be merged with
attribute overrides from within an OmniAuth strategy.

The attribute mapping steps are as follows:
1. Create the default/fxied attribute map in `omniauth_hash_to_user_attributes` as before.
2. Check whether `omniauth_hash_to_user_attributes` also exists in the used strategy class ([This is contained in the counterpart implementation in `openproject-auth_plugins`](https://github.com/opf/openproject-auth_plugins/pull/2)).
3. If it exists, merge the default hash with the strategy mapping, thus allowing overrides to all user attributes.

The motivation for this feature arises from my OmniAuth strategy integrations for `CAS` Single-Sign On and `LDAP`, which both require patches to override the mapping at the moment. 
- [The respective discussion in the boards can be found here](https://community.openproject.org/topics/3107)
- [The corresponding work package](https://community.openproject.org/work_packages/16841)
