### PR TITLE
mypage work package list displays wrong context menu icon on hover

### DIFF
--- a/app/assets/stylesheets/content/_my_page.sass
+++ b/app/assets/stylesheets/content/_my_page.sass
@@ -60,3 +60,6 @@ div.mypage-box p.summary
 
 div.mypage-box div.overview p.author
   margin-bottom: 7px
+
+div.mypage-box .hascontextmenu
+  cursor: auto


### PR DESCRIPTION
[`* `#16454` work package list displays wrong context menu icon on hover`](http://community.openproject.org/work_packages/16454)
