### PR TITLE
Add specific Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ end
 
 source 'https://rubygems.org'
 
+ruby '2.1.3'
+
 gem "rails", "~> 3.2.19"
 
 gem "coderay", "~> 1.0.5"


### PR DESCRIPTION
I added the ruby version so that services like packager.io can use this information to build packages according to our dependencies. Version 2.1.3 is the current stable so I think we should use this version. 

We recommend 2.1.0 on our [system requirements](https://community.openproject.org/projects/openproject/wiki/systemrequirements) page on OpenProject. So we might want to use this version instead?
