### PR TITLE
suppresses action dispatch routing errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -506,6 +506,8 @@ class ApplicationController < ActionController::Base
     false
   end
 
+  public(:render_404)
+
   def render_500(options = {})
     message = t(:notice_internal_server_error, :app_title => Setting.app_title)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,8 @@ end
 
 require File.dirname(__FILE__) + '/../lib/open_project/configuration'
 
+require 'open_project/routed_exceptions'
+
 module OpenProject
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -80,6 +82,9 @@ module OpenProject
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
     config.autoload_paths << Rails.root.join('lib')
+
+    config.routed_exceptions.non_fatal_routing_errors = true
+    config.routed_exceptions.in_app_errors = '404'
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ OpenProject::Application.routes.draw do
   match '/wp(/)'    => redirect("#{rails_relative_url_root}/work_packages")
   match '/wp/*rest' => redirect { |params, req| "#{rails_relative_url_root}/work_packages/#{URI.escape(params[:rest])}" }
 
+  match '/404', to: 'application#render_404'
+
   scope :controller => 'account' do
     get '/account/force_password_change', :action => 'force_password_change'
     post '/account/change_password', :action => 'change_password'

--- a/lib/open_project/routed_exceptions.rb
+++ b/lib/open_project/routed_exceptions.rb
@@ -1,0 +1,4 @@
+require 'open_project/routed_exceptions/configuration'
+require 'open_project/routed_exceptions/rails_configuration_patch'
+require 'open_project/routed_exceptions/selective_debug'
+require 'open_project/routed_exceptions/selective_public'

--- a/lib/open_project/routed_exceptions/configuration.rb
+++ b/lib/open_project/routed_exceptions/configuration.rb
@@ -1,0 +1,48 @@
+module OpenProject::RoutedExceptions
+  class Configuration
+    attr_accessor :non_fatal_routing_errors,
+                  :in_app_errors,
+                  :application_config
+
+    def initialize(application_config)
+      @application_config = application_config
+      @in_app_errors      = []
+    end
+
+    def non_fatal_routing_errors=(active)
+      @non_fatal_routing_errors = active
+
+      if active
+        application_config.middleware.swap ActionDispatch::DebugExceptions,
+                                           ::OpenProject::RoutedExceptions::SelectiveDebug
+      else
+        application_config.middleware.swap ::OpenProject::RoutedExceptions::SelectiveDebug,
+                                           ActionDispatch::DebugExceptions
+      end
+    end
+
+    def in_app_errors=(codes)
+      @in_app_errors = Array(codes)
+
+      if @in_app_errors.empty?
+        noisy_exceptions
+      else
+        silent_exceptions
+      end
+    end
+
+    private
+
+    def exceptions_app=(debugger)
+      application_config.exceptions_app = debugger
+    end
+
+    def silent_exceptions
+      self.exceptions_app = ::OpenProject::RoutedExceptions::SelectivePublic.new(Rails.public_path)
+    end
+
+    def noisy_exceptions
+      self.exceptions_app = ActinDispatch::DebugExceptions.new(Rails.public_path)
+    end
+  end
+end

--- a/lib/open_project/routed_exceptions/rails_configuration_patch.rb
+++ b/lib/open_project/routed_exceptions/rails_configuration_patch.rb
@@ -1,0 +1,17 @@
+module OpenProject::RoutedExceptions
+  module RailsConfigurationPatch
+    def self.included(base)
+      base.include(InstanceMethods)
+    end
+
+    module InstanceMethods
+      def routed_exceptions
+        @routed_exceptions_config ||= OpenProject::RoutedExceptions::Configuration.new(self)
+      end
+    end
+  end
+end
+
+unless Rails::Application::Configuration.included_modules.include?(OpenProject::RoutedExceptions::RailsConfigurationPatch)
+  Rails::Application::Configuration.include(OpenProject::RoutedExceptions::RailsConfigurationPatch)
+end

--- a/lib/open_project/routed_exceptions/selective_debug.rb
+++ b/lib/open_project/routed_exceptions/selective_debug.rb
@@ -1,0 +1,20 @@
+class OpenProject::RoutedExceptions::SelectiveDebug < ActionDispatch::DebugExceptions
+  def log_error(env, wrapper)
+    exception = wrapper.exception
+
+    super unless logging_disabled?(exception)
+  end
+
+  private
+
+  def logging_disabled?(exception)
+    disabled_exceptions.any? do |klass|
+      exception.is_a?(klass)
+    end
+  end
+
+  def disabled_exceptions
+    [AbstractController::ActionNotFound,
+     ActionController::RoutingError]
+  end
+end

--- a/lib/open_project/routed_exceptions/selective_public.rb
+++ b/lib/open_project/routed_exceptions/selective_public.rb
@@ -1,0 +1,23 @@
+class OpenProject::RoutedExceptions::SelectivePublic < ActionDispatch::PublicExceptions
+  def call(env)
+    if routed_error?(env)
+      OpenProject::Application.routes.call env
+    else
+      super
+    end
+  end
+
+  private
+
+  def routed_error?(env)
+    routed_errors.include?(status(env))
+  end
+
+  def status(env)
+    env['PATH_INFO'][1..-1]
+  end
+
+  def routed_errors
+    Rails.application.config.routed_exceptions.in_app_errors
+  end
+end


### PR DESCRIPTION
The errors:
- AbstractController::ActionNotFound
- ActionController::RoutingError
  are no longer being logged and are displayed as an error native to the
  application.

This prevents bots looking for weaknesses from causing huge amounts of
errors which might trigger application monitoring to raise alarms.

Additionally, the error pages displayed to genuine users can be
presented as part of the application.

For now, this is just a POC to trigger comments. Ideally, this would be put into it's own gem which OpenProject would only mount. 

To test, one must set:
config.consider_all_requests_local = false
in config/environments/development.rb
