### PR TITLE
remove obnoxious warning about old bundler version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,22 +26,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.5.0')
-  abort <<-Message
-
-  *****************************************************
-  *                                                   *
-  *   OpenProject requires bundler version >= 1.5.0   *
-  *                                                   *
-  *   Please install bundler with:                    *
-  *                                                   *
-  *   gem install bundler                             *
-  *                                                   *
-  *****************************************************
-
-  Message
-end
-
 source 'https://rubygems.org'
 
 gem "rails", "~> 3.2.19"


### PR DESCRIPTION
bundler 1.5 is almost a year old now.
