### PR TITLE
release 3.0: pdf: fix failure exporting issue pdf with UTF-8 U+FFFD (#1918)

### DIFF
--- a/app/models/work_package/pdf_exporter.rb
+++ b/app/models/work_package/pdf_exporter.rb
@@ -377,7 +377,7 @@ module WorkPackage::PdfExporter
     end
 
     def fix_text_encoding(txt)
-      txt
+      txt.force_encoding('ASCII-8BIT')
     end
 
     def Footer

--- a/app/models/work_package/pdf_exporter.rb
+++ b/app/models/work_package/pdf_exporter.rb
@@ -368,8 +368,17 @@ module WorkPackage::PdfExporter
       end
     end
 
-    alias RDMCell Cell
-    alias RDMMultiCell MultiCell
+    def RDMCell(w,h=0,txt='',border=0,ln=0,align='',fill=0,link='')
+        Cell(w,h,fix_text_encoding(txt),border,ln,align,fill,link)
+    end
+
+    def RDMMultiCell(w,h=0,txt='',border=0,align='',fill=0)
+        MultiCell(w,h,fix_text_encoding(txt),border,align,fill)
+    end
+
+    def fix_text_encoding(txt)
+      txt
+    end
 
     def Footer
       SetFont(@font_for_footer, 'I', 8)

--- a/app/models/work_package/pdf_exporter.rb
+++ b/app/models/work_package/pdf_exporter.rb
@@ -438,11 +438,14 @@ module WorkPackage::PdfExporter
         # 0x5c char handling
         txtar = txt.split('\\')
         txtar << '' if txt[-1] == ?\\
-        txtar.collect {|x| x.encode(l(:general_pdf_encoding), 'UTF-8')}.join('\\').gsub(/\\/, "\\\\\\\\")
+        txtar.collect {|x|
+          Redmine::CodesetUtil.from_utf8(x, l(:general_pdf_encoding)).
+            force_encoding('ASCII-8BIT')
+        }.join('\\').gsub(/\\/, "\\\\\\\\")
       rescue
-        txt
-      end || ''
-      return txt
+        txt.force_encoding('ASCII-8BIT')
+      end || ''.force_encoding('ASCII-8BIT')
+      return txt.force_encoding('ASCII-8BIT')
     end
 
     def RDMCell(w,h=0,txt='',border=0,ln=0,align='',fill=0,link='')

--- a/app/models/work_package/pdf_exporter.rb
+++ b/app/models/work_package/pdf_exporter.rb
@@ -434,12 +434,21 @@ module WorkPackage::PdfExporter
     def fix_text_encoding(txt)
       # these quotation marks are not correctly rendered in the pdf
       txt = txt.gsub(/[â€œâ€�]/, '"') if txt
+      encoding = case current_language.to_s.downcase
+        when 'ko'    then "CP949"
+        when 'ja'    then "CP932"
+        when 'zh'    then "gb18030"
+        when 'zh-tw' then "Big5"
+        when 'th'    then "cp874"
+        else
+          raise
+        end
       txt = begin
         # 0x5c char handling
         txtar = txt.split('\\')
         txtar << '' if txt[-1] == ?\\
         txtar.collect {|x|
-          Redmine::CodesetUtil.from_utf8(x, l(:general_pdf_encoding)).
+          Redmine::CodesetUtil.from_utf8(x, encoding).
             force_encoding('ASCII-8BIT')
         }.join('\\').gsub(/\\/, "\\\\\\\\")
       rescue

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -573,7 +573,6 @@ de:
   general_csv_separator: ";"
   general_first_day_of_week: "1"
   general_lang_name: "Deutsch"
-  general_pdf_encoding: "ISO-8859-1"
   general_text_No: "Nein"
   general_text_Yes: "Ja"
   general_text_no: "nein"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,7 +570,6 @@ en:
   general_csv_separator: ","
   general_first_day_of_week: "7"
   general_lang_name: "English"
-  general_pdf_encoding: "ISO-8859-1"
   general_text_No: "No"
   general_text_Yes: "Yes"
   general_text_no: "no"

--- a/lib/plugins/rfpdf/lib/tcpdf.rb
+++ b/lib/plugins/rfpdf/lib/tcpdf.rb
@@ -1,4 +1,5 @@
-#-- encoding: UTF-8
+# encoding: ascii-8bit
+
 #============================================================+
 # File name   : tcpdf.rb
 # Begin       : 2002-08-03


### PR DESCRIPTION
> When users add special characters to issues (often by copy/pasting text from terminals to issue journals), they cannot export these issues to PDF and get an error (invalid byte sequence in UTF-8).

added by @linki
