### PR TITLE
fix wp list progress text in percent done is cut by scroll

### DIFF
--- a/app/assets/javascripts/angular/work_packages/directives/work-packages-table-directive.js
+++ b/app/assets/javascripts/angular/work_packages/directives/work-packages-table-directive.js
@@ -79,7 +79,7 @@ angular.module('openproject.workPackages.directives')
       }
 
       function getInnerContainer() {
-        return element.find('.work-packages-table--container-inner');
+        return element.find('.work-packages-table--results-container');
       }
 
       function getBackgrounds() {


### PR DESCRIPTION
[`* `#16651` wp list progress text in percent done is cut by scroll`](http://community.openproject.org/work_packages/16651)

 https://community.openproject.org/work_packages/16856 
