### PR TITLE
rake task to backup and restore the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 /log/*.log
 /tmp
 
+/backup
 /.project
 /.loadpath
 /config/additional_environment.rb

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -52,7 +52,11 @@ namespace :backup do
           user = config.values_at('user', 'username').compact.first
           pg_dump_call << "--username=#{user}" if user
 
-          Kernel.system({'PGPASSFILE' => config_file}, *pg_dump_call)
+          if config['password']
+            Kernel.system({'PGPASSFILE' => config_file}, *pg_dump_call)
+          else
+            Kernel.system(*pg_dump_call)
+          end
         end
       when /MySQL2/i
         with_mysql_config(config) do |config_file|
@@ -89,7 +93,11 @@ namespace :backup do
           pg_restore_call << "--username=#{user}" if user
           pg_restore_call << "#{args[:path_to_backup]}"
 
-          Kernel.system({'PGPASSFILE' => config_file}, *pg_restore_call)
+          if config['password']
+            Kernel.system({'PGPASSFILE' => config_file}, *pg_restore_call)
+          else
+            Kernel.system(*pg_restore_call)
+          end
         end
       when /MySQL2/i
         with_mysql_config(config) do |config_file|

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -32,7 +32,7 @@ require 'fileutils'
 
 namespace :backup do
   namespace :database do
-    desc "Creates a database dump which can be used as a backup.\n"
+    desc 'Creates a database dump which can be used as a backup.'
     task :create, [:path_to_backup] => [:environment] do |task, args|
       args.with_defaults(:path_to_backup => default_db_filename)
       FileUtils.mkdir_p(Pathname.new(args[:path_to_backup]).dirname)
@@ -69,9 +69,9 @@ namespace :backup do
       end
     end
 
-    desc "Restores a database dump created by the :create task.\n"
+    desc 'Restores a database dump created by the :create task.'
     task :restore, [:path_to_backup] => [:environment] do |task, args|
-      raise "You must provide the path to the database dump" unless args[:path_to_backup]
+      raise 'You must provide the path to the database dump' unless args[:path_to_backup]
       raise "File '#{args[:path_to_backup]}' is not readable" unless File.readable?(args[:path_to_backup])
 
       config = database_configuration

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -65,7 +65,7 @@ namespace :backup do
                         '--single-transaction',
                         '--add-drop-table',
                         '--add-locks',
-                        "--result-file=#{args[:path_to_backup]}.sql",
+                        "--result-file=#{args[:path_to_backup]}",
                         "#{config['database']}"
         end
       else
@@ -142,7 +142,14 @@ namespace :backup do
     end
 
     def default_db_filename
-      Rails.root.join('backup', sanitize_filename("openproject-#{Rails.env.to_s}-db-#{date_string}"))
+      filename = "openproject-#{Rails.env.to_s}-db-#{date_string}"
+      case database_configuration['adapter']
+      when /PostgreSQL/i
+        filename << '.backup'
+      else
+        filename << '.sql'
+      end
+      Rails.root.join('backup', sanitize_filename(filename))
     end
 
     def date_string

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -134,12 +134,11 @@ namespace :backup do
     end
 
     def default_db_filename
-      Rails.root.join('backup', "openproject-#{sanitize_filename(Rails.env.to_s)}-db-#{date_string}")
+      Rails.root.join('backup', sanitize_filename("openproject-#{Rails.env.to_s}-db-#{date_string}"))
     end
 
     def date_string
-      time = Time.now.strftime('%Y%m%dT%H%M%S%z') # e.g. "20141020T165335+0200"
-      sanitize_filename(time)
+      Time.now.strftime('%Y%m%dT%H%M%S%z') # e.g. "20141020T165335+0200"
     end
 
     def sanitize_filename(filename)

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,0 +1,110 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'tempfile'
+require 'fileutils'
+
+namespace :backup do
+  namespace :database do
+    desc "Creates a database dump which can be used as a backup.\n"
+    task :create, [:path_to_backup] => [:environment] do |task, args|
+      args.with_defaults(:path_to_backup => default_db_filename)
+      FileUtils.mkdir_p(Pathname.new(args[:path_to_backup]).dirname)
+
+      conn = ActiveRecord::Base.connection
+      case conn.adapter_name
+      when /PotsgreSQL/i
+        raise "Database '#{conn.adapter_name}' not supported."
+      when /MySQL2/i
+        with_mysql_config do |config_file|
+          system "mysqldump --defaults-file=\"#{config_file}\" --single-transaction \"#{database_name}\" | gzip > \"#{args[:path_to_backup]}\""
+        end
+      else
+        raise "Database '#{conn.adapter_name}' not supported."
+      end
+    end
+
+    desc "Restores a database dump created by the :create task.\n"
+    task :restore, [:path_to_backup] => [:environment] do |task, args|
+      raise "You must provide the path to the database dump" unless args[:path_to_backup]
+      raise "File '#{args[:path_to_backup]}' is not readable" unless File.readable?(args[:path_to_backup])
+
+      conn = ActiveRecord::Base.connection
+      case conn.adapter_name
+      when /PotsgreSQL/i
+        raise "Database '#{conn.adapter_name}' not supported."
+      when /MySQL2/i
+        with_mysql_config do |config_file|
+          system "gzip -d < \"#{args[:path_to_backup]}\" | mysql --defaults-file=\"#{config_file}\" \"#{database_name}\""
+        end
+      else
+        raise "Database '#{conn.adapter_name}' not supported."
+      end
+    end
+
+    private
+    def with_mysql_config(&blk)
+        file = Tempfile.new('op_mysql_config')
+        file.write sql_dump_tempfile
+        file.close
+        blk.yield file.path
+        file.unlink
+    end
+
+    def database_name
+      ActiveRecord::Base.configurations[Rails.env]['database']
+    end
+
+    def sql_dump_tempfile
+      config = ActiveRecord::Base.configurations[Rails.env]
+      t =  "[client]\n"
+      t << "password=\"#{config['password']}\"\n"
+      t << "user=\"#{config.values_at('user', 'username').compact.first}\"\n"
+      t << "host=\"#{config['host'] || '127.0.0.1'}\"\n"
+      t << "port=\"#{config['port']}\"\n" if config['port']
+      t << "ssl-key=\"#{config['sslkey']}\"\n" if config['sslkey']
+      t << "ssl-cert=\"#{config['sslcert']}\"\n" if config['sslcert']
+      t << "ssl-ca=\"#{config['sslca']}\"\n" if config['sslca']
+      t
+    end
+
+    def default_db_filename
+      Rails.root.join('backup', "openproject-#{sanitize_filename(Rails.env.to_s)}-db-#{date_string}.sql.zip")
+    end
+
+    def date_string
+      time = Time.now.strftime('%Y%m%dT%H%M%S%z') # e.g. "20141020T165335+0200"
+      sanitize_filename(time)
+    end
+
+    def sanitize_filename(filename)
+      filename.gsub(/[^0-9A-Za-z.-]/, '_')
+    end
+  end
+end

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -45,12 +45,12 @@ namespace :backup do
                           '--clean',
                           "--file=#{args[:path_to_backup]}",
                           '--format=custom',
-                          '--no-owner',
-                          "#{config['database']}"]
+                          '--no-owner']
           pg_dump_call << "--host=#{config['host']}" if config['host']
           pg_dump_call << "--port=#{config['port']}" if config['port']
           user = config.values_at('user', 'username').compact.first
           pg_dump_call << "--username=#{user}" if user
+          pg_dump_call << "#{config['database']}"
 
           if config['password']
             Kernel.system({'PGPASSFILE' => config_file}, *pg_dump_call)

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -52,17 +52,17 @@ namespace :backup do
           user = config.values_at('user', 'username').compact.first
           pg_dump_call << "--username=#{user}" if user
 
-          system({'PGPASSFILE' => config_file}, *pg_dump_call)
+          Kernel.system({'PGPASSFILE' => config_file}, *pg_dump_call)
         end
       when /MySQL2/i
         with_mysql_config(config) do |config_file|
-          system 'mysqldump',
-                 "--defaults-file=#{config_file}",
-                 '--single-transaction',
-                 '--add-drop-table',
-                 '--add-locks',
-                 "--result-file=#{args[:path_to_backup]}.sql",
-                 "#{config['database']}"
+          Kernel.system 'mysqldump',
+                        "--defaults-file=#{config_file}",
+                        '--single-transaction',
+                        '--add-drop-table',
+                        '--add-locks',
+                        "--result-file=#{args[:path_to_backup]}.sql",
+                        "#{config['database']}"
         end
       else
         raise "Database '#{config['adapter']}' not supported."
@@ -89,11 +89,11 @@ namespace :backup do
           pg_restore_call << "--username=#{user}" if user
           pg_restore_call << "#{args[:path_to_backup]}"
 
-          system({'PGPASSFILE' => config_file}, *pg_restore_call)
+          Kernel.system({'PGPASSFILE' => config_file}, *pg_restore_call)
         end
       when /MySQL2/i
         with_mysql_config(config) do |config_file|
-          system "mysql --defaults-file=\"#{config_file}\" \"#{config['database']}\" < \"#{args[:path_to_backup]}\""
+          Kernel.system "mysql --defaults-file=\"#{config_file}\" \"#{config['database']}\" < \"#{args[:path_to_backup]}\""
         end
       else
         raise "Database '#{config['adapter']}' not supported."

--- a/spec/support/shared/rake.rb
+++ b/spec/support/shared/rake.rb
@@ -1,0 +1,50 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Origins from http://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+# Author: Josh Clayton
+
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/shared/rake.rb
+++ b/spec/support/shared/rake.rb
@@ -29,16 +29,16 @@
 # Origins from http://robots.thoughtbot.com/test-rake-tasks-like-a-boss
 # Author: Josh Clayton
 
-require "rake"
+require 'rake'
 
-shared_context "rake" do
+shared_context 'rake' do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.description }
-  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
   subject         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
-    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+    $".reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
   end
 
   before do

--- a/spec/tasks/backup_specs.rb
+++ b/spec/tasks/backup_specs.rb
@@ -46,14 +46,14 @@ describe 'mysql' do
 
     it 'calls the mysqldump binary' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args.first).to eql('mysqldump') 
+        expect(args.first).to eql('mysqldump')
       end
       subject.invoke
     end
 
     it 'writes the mysql config file' do
       expect(Kernel).to receive(:system) do |*args|
-        defaults_file = args.find {|s| s.starts_with? '--defaults-file='}
+        defaults_file = args.find { |s| s.starts_with? '--defaults-file=' }
         defaults_file = defaults_file[('--defaults-file='.length)..-1]
         expect(File.readable?(defaults_file)).to be true
 
@@ -67,8 +67,8 @@ describe 'mysql' do
     it 'uses the first task parameter as the target filename' do
       custom_file_path = './foo/bar/testfile.sql'
       expect(Kernel).to receive(:system) do |*args|
-        result_file = args.find {|s| s.starts_with? '--result-file='}
-        expect(result_file).to include(custom_file_path) 
+        result_file = args.find { |s| s.starts_with? '--result-file=' }
+        expect(result_file).to include(custom_file_path)
       end
       subject.invoke custom_file_path
     end
@@ -87,7 +87,7 @@ describe 'mysql' do
 
     it 'calls the mysql binary' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args.first).to start_with('mysql') 
+        expect(args.first).to start_with('mysql')
       end
       subject.invoke backup_file.path
     end
@@ -106,7 +106,7 @@ describe 'mysql' do
 
     it 'uses the first task parameter as the target filename' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args.first).to include(backup_file.path) 
+        expect(args.first).to include(backup_file.path)
       end
       subject.invoke backup_file.path
     end
@@ -135,7 +135,7 @@ describe 'postgresql' do
 
     it 'calls the pg_dump binary' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args[1]).to eql('pg_dump') 
+        expect(args[1]).to eql('pg_dump')
       end
       subject.invoke
     end
@@ -154,8 +154,8 @@ describe 'postgresql' do
     it 'uses the first task parameter as the target filename' do
       custom_file_path = './foo/bar/testfile.sql'
       expect(Kernel).to receive(:system) do |*args|
-        result_file = args.find {|s| s.to_s.starts_with? '--file='}
-        expect(result_file).to include(custom_file_path) 
+        result_file = args.find { |s| s.to_s.starts_with? '--file=' }
+        expect(result_file).to include(custom_file_path)
       end
       subject.invoke custom_file_path
     end
@@ -174,7 +174,7 @@ describe 'postgresql' do
 
     it 'calls the pg_restore binary' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args[1]).to start_with('pg_restore') 
+        expect(args[1]).to start_with('pg_restore')
       end
       subject.invoke backup_file.path
     end
@@ -192,7 +192,7 @@ describe 'postgresql' do
 
     it 'uses the first task parameter as the target filename' do
       expect(Kernel).to receive(:system) do |*args|
-        expect(args.last).to eql(backup_file.path) 
+        expect(args.last).to eql(backup_file.path)
       end
       subject.invoke backup_file.path
     end

--- a/spec/tasks/backup_specs.rb
+++ b/spec/tasks/backup_specs.rb
@@ -1,0 +1,204 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'mysql' do
+  let(:database_config) do
+    {'adapter' => 'mysql2',
+     'database' => 'openproject-database',
+     'username' => 'testuser',
+     'password' => 'testpassword'}
+  end
+
+  before do
+    expect(ActiveRecord::Base).to receive(:configurations).at_least(:once).and_return('test' => database_config)
+    allow(FileUtils).to receive(:mkdir_p).and_return(nil)
+  end
+
+  describe 'backup:database:create' do
+    include_context 'rake'
+
+    it 'calls the mysqldump binary' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args.first).to eql('mysqldump') 
+      end
+      subject.invoke
+    end
+
+    it 'writes the mysql config file' do
+      expect(Kernel).to receive(:system) do |*args|
+        defaults_file = args.find {|s| s.starts_with? '--defaults-file='}
+        defaults_file = defaults_file[('--defaults-file='.length)..-1]
+        expect(File.readable?(defaults_file)).to be true
+
+        file_contents = File.read defaults_file
+        expect(file_contents).to include('testuser')
+        expect(file_contents).to include('testpassword')
+      end
+      subject.invoke
+    end
+
+    it 'uses the first task parameter as the target filename' do
+      custom_file_path = './foo/bar/testfile.sql'
+      expect(Kernel).to receive(:system) do |*args|
+        result_file = args.find {|s| s.starts_with? '--result-file='}
+        expect(result_file).to include(custom_file_path) 
+      end
+      subject.invoke custom_file_path
+    end
+  end
+
+  describe 'backup:database:restore' do
+    include_context 'rake'
+
+    let(:backup_file) do
+      Tempfile.new('test_backup')
+    end
+
+    after do
+      backup_file.unlink
+    end
+
+    it 'calls the mysql binary' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args.first).to start_with('mysql') 
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'writes the mysql config file' do
+      expect(Kernel).to receive(:system) do |*args|
+        defaults_file = args.first[/--defaults-file="(?<file>[^"]+)"/, :file]
+        expect(File.readable?(defaults_file)).to be true
+
+        file_contents = File.read defaults_file
+        expect(file_contents).to include('testuser')
+        expect(file_contents).to include('testpassword')
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'uses the first task parameter as the target filename' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args.first).to include(backup_file.path) 
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'throws an error when called without a parameter' do
+      expect { subject.invoke }.to raise_error
+    end
+  end
+end
+
+describe 'postgresql' do
+  let(:database_config) do
+    {'adapter' => 'postgresql',
+     'database' => 'openproject-database',
+     'username' => 'testuser',
+     'password' => 'testpassword'}
+  end
+
+  before do
+    expect(ActiveRecord::Base).to receive(:configurations).at_least(:once).and_return('test' => database_config)
+    allow(FileUtils).to receive(:mkdir_p).and_return(nil)
+  end
+
+  describe 'backup:database:create' do
+    include_context 'rake'
+
+    it 'calls the pg_dump binary' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args[1]).to eql('pg_dump') 
+      end
+      subject.invoke
+    end
+
+    it 'writes the pg password file' do
+      expect(Kernel).to receive(:system) do |*args|
+        pass_file = args.first['PGPASSFILE']
+        expect(File.readable?(pass_file)).to be true
+
+        file_contents = File.read pass_file
+        expect(file_contents).to include('testpassword')
+      end
+      subject.invoke
+    end
+
+    it 'uses the first task parameter as the target filename' do
+      custom_file_path = './foo/bar/testfile.sql'
+      expect(Kernel).to receive(:system) do |*args|
+        result_file = args.find {|s| s.to_s.starts_with? '--file='}
+        expect(result_file).to include(custom_file_path) 
+      end
+      subject.invoke custom_file_path
+    end
+  end
+
+  describe 'backup:database:restore' do
+    include_context 'rake'
+
+    let(:backup_file) do
+      Tempfile.new('test_backup')
+    end
+
+    after do
+      backup_file.unlink
+    end
+
+    it 'calls the pg_restore binary' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args[1]).to start_with('pg_restore') 
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'writes the pg password file' do
+      expect(Kernel).to receive(:system) do |*args|
+        pass_file = args.first['PGPASSFILE']
+        expect(File.readable?(pass_file)).to be true
+
+        file_contents = File.read pass_file
+        expect(file_contents).to include('testpassword')
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'uses the first task parameter as the target filename' do
+      expect(Kernel).to receive(:system) do |*args|
+        expect(args.last).to eql(backup_file.path) 
+      end
+      subject.invoke backup_file.path
+    end
+
+    it 'throws an error when called without a parameter' do
+      expect { subject.invoke }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a rake task for backing up the database. It is aware of what kind of db is used and uses the appropriate command line tools available (dbms specific). Right now it supports postgresql and mysql. 
