### PR TITLE
Fix db setup in installation doc

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -76,9 +76,6 @@ These are generic (and condensed) installation instructions for the **current de
 
 3. Create databases, schemas and populate with seed data:
 
-        bundle exec rake db:setup
-
-        # - OR - in multiple steps:
         # bundle exec rake db:create:all
         # bundle exec rake db:migrate
         # bundle exec rake db:seed


### PR DESCRIPTION
It was:

``` markdown
3. Create databases, schemas and populate with seed data:
- bundle exec rake db:setup
-
- # - OR - in multiple steps:
# bundle exec rake db:create:all
# bundle exec rake db:migrate
# bundle exec rake db:seed
```

However, `bundle exec rake db:setup` results in the execution of the following commands:
- db:create
- db:schema:load
- db:seed

We don't commit the `schema.rb` file. Thus, `db:setup` won't work.
