### PR TITLE
fix timeline float behavior

### DIFF
--- a/app/assets/stylesheets/timelines.css.erb
+++ b/app/assets/stylesheets/timelines.css.erb
@@ -40,7 +40,7 @@ li.select2-result.select2-visible-selected-parent {
 }
 
 .timeline {
-  clear: both;
+  clear: right; /* we only want to clear the 'float: right' of the .tl-toolbar */
   overflow: auto;
   border: 1px solid black;
 }


### PR DESCRIPTION
When we clear both, the float of the project menu is also factored in.

https://community.openproject.org/work_packages/16981

Will also need to be merged into release/4.0 and dev.
