### PR TITLE
updates api gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,9 +179,8 @@ group :development, :test do
 end
 
 # API gems
-gem 'grape', '~> 0.7.0'
-gem 'representable', git: 'https://github.com/finnlabs/representable'
-gem 'roar',   '~> 0.12.6'
+gem 'grape', '~> 0.9.0'
+gem 'roar',   '~> 0.12.9'
 gem 'reform', '~> 1.0.4', require: false
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,6 @@ GIT
       rack
 
 GIT
-  remote: https://github.com/finnlabs/representable
-  revision: 5f8fbcb1e61720699135c39be3f36a725ca870ad
-  specs:
-    representable (1.8.1)
-      multi_json
-      nokogiri
-      uber
-
-GIT
   remote: https://github.com/finnlabs/rspec-example_disabler.git
   revision: deb9c38e3f4e3688724583ac1ff58e1ae8aba409
   specs:
@@ -174,10 +165,10 @@ GEM
     gon (4.0.0)
       actionpack (>= 2.3.0)
       json
-    grape (0.7.0)
+    grape (0.9.0)
       activesupport
       builder
-      hashie (>= 1.2.0)
+      hashie (>= 2.1.0)
       multi_json (>= 1.3.2)
       multi_xml (>= 0.5.2)
       rack (>= 1.3.0)
@@ -226,7 +217,7 @@ GEM
     multi_xml (0.5.5)
     mysql2 (0.3.11)
     net-ldap (0.2.2)
-    nokogiri (1.6.2.1)
+    nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     non-stupid-digest-assets (1.0.4)
     object-daddy (1.1.1)
@@ -308,9 +299,13 @@ GEM
       disposable (~> 0.0.4)
       representable (~> 1.8.1)
       uber (~> 0.0.4)
+    representable (1.8.5)
+      multi_json
+      nokogiri
+      uber
     request_store (1.0.5)
-    roar (0.12.7)
-      representable (>= 1.6.0)
+    roar (0.12.9)
+      representable (>= 1.6.0, < 2.0.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -384,7 +379,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.38)
-    uber (0.0.4)
+    uber (0.0.10)
     uglifier (2.1.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
@@ -392,11 +387,11 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    virtus (1.0.2)
+    virtus (1.0.3)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
-      descendants_tracker (~> 0.0.3)
-      equalizer (~> 0.0.9)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     websocket (1.2.1)
     will_paginate (3.0.5)
     xpath (2.0.0)
@@ -431,7 +426,7 @@ DEPENDENCIES
   faker
   globalize
   gon (~> 4.0)
-  grape (~> 0.7.0)
+  grape (~> 0.9.0)
   gravatar_image_tag (~> 1.2.0)
   htmldiff
   i18n (>= 0.6.8)
@@ -468,9 +463,8 @@ DEPENDENCIES
   rb-readline (~> 0.5.1)
   rdoc (>= 2.4.2)
   reform (~> 1.0.4)
-  representable!
   request_store
-  roar (~> 0.12.6)
+  roar (~> 0.12.9)
   rspec (~> 2.99.0)
   rspec-activemodel-mocks
   rspec-example_disabler!

--- a/config/initializers/representable_patch.rb
+++ b/config/initializers/representable_patch.rb
@@ -1,0 +1,27 @@
+require 'representable'
+
+module OpenProject::RepresentablePatch
+  def self.included(base)
+    base.class_eval do
+      def self.as_strategy=(strategy)
+        raise 'The :as_strategy option should respond to #call?' unless strategy.respond_to?(:call)
+
+        @as_strategy = strategy
+      end
+
+      def self.as_strategy
+        @as_strategy
+      end
+
+      def self.property(name, options = {}, &block)
+        options = { as: as_strategy.call(name.to_s) }.merge(options) if as_strategy
+
+        super
+      end
+    end
+  end
+end
+
+unless Representable::Decorator.included_modules.include?(OpenProject::RepresentablePatch)
+  Representable::Decorator.include(OpenProject::RepresentablePatch)
+end

--- a/spec/lib/representable_spec.rb
+++ b/spec/lib/representable_spec.rb
@@ -1,0 +1,78 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+require 'spec_helper'
+require 'representable/json'
+
+describe Representable do
+  let(:object) { Struct.new(:title).new('test') }
+
+  class ReverseNamingStrategy
+    def call(name)
+      name.reverse
+    end
+  end
+
+  describe 'as_strategy with lambda' do
+    class UpcaseRepresenter < Representable::Decorator
+      include Representable::JSON
+
+      self.as_strategy = ->(name) { name.upcase }
+
+      property :title
+    end
+
+    it { expect(UpcaseRepresenter.new(object).to_json).to eql("{\"TITLE\":\"test\"}") }
+  end
+
+  describe 'as_strategy with class responding to #call?' do
+    class ReverseRepresenter < Representable::Decorator
+      include Representable::JSON
+
+      self.as_strategy = ReverseNamingStrategy.new
+
+      property :title
+    end
+
+    it { expect(ReverseRepresenter.new(object).to_json).to eql("{\"eltit\":\"test\"}") }
+  end
+
+  describe 'as_strategy with class not responding to #call?' do
+    it 'raises error' do
+      expect {
+        class FailRepresenter < Representable::Decorator
+          include Representable::JSON
+
+          self.as_strategy = Object.new
+
+          property :title
+        end
+      }.to raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
- roar  still needs representable < 2.0.0 so it is not possible to
  update reform to 1.1.1 which requires representable ~> 2.1
- removed dependency from finnlabs/representable
