### PR TITLE
UX Clarify 'Password' prompts as 'Current Password', most relevant in the 'Change Password' form.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,7 @@ en:
     login: "Login"
     mail: "Email"
     name: "Name"
-    password: "Password"
+    password: "Current Password"
     project: "Project"
     role: "Role"
     start_date: "Start date"


### PR DESCRIPTION
There should be a visual grouping of the "New Password" and "Confirmation" inputs together. The criteria text on the middle field cause the first and second fields to be inappropriately grouped. Since there is no way i know to do this in the framework provided, I've opted to modify the label text instead to be more clear.

The way I intuitively parse the labels are as:
- Password (to apply)
- New Password (label not read, assumed grouped inputs are confirmation field)
- Confirmation (Current password to confirm authority to change password)
