### PR TITLE
send private #include

### DIFF
--- a/config/initializers/representable_patch.rb
+++ b/config/initializers/representable_patch.rb
@@ -23,5 +23,5 @@ module OpenProject::RepresentablePatch
 end
 
 unless Representable::Decorator.included_modules.include?(OpenProject::RepresentablePatch)
-  Representable::Decorator.include(OpenProject::RepresentablePatch)
+  Representable::Decorator.send(:include, OpenProject::RepresentablePatch)
 end


### PR DESCRIPTION
The `RepresentablePatch` in the initializers does not work when running in production.
