### PR TITLE
Fixed email options hash map keys

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -260,18 +260,16 @@ class MailHandler < ActionMailer::Base
   end
 
   def get_keyword(attr, options={})
-    attr = attr.to_s
-
     @keywords ||= {}
     if @keywords.has_key?(attr)
       @keywords[attr]
     else
       @keywords[attr] = begin
-        if (options[:override] || @@handler_options[:allow_override].include?(attr)) &&
-           (v = extract_keyword!(plain_text_body, attr, options[:format]))
-          v
-        elsif !@@handler_options[:issue][attr.to_sym].blank?
-          @@handler_options[:issue][attr.to_sym]
+        if (options[:override] ||
+           @@handler_options[:allow_override].include?(attr)) &&
+           (v = extract_keyword!(plain_text_body, attr.to_s, options[:format]))
+        elsif !@@handler_options[:issue][attr].blank?
+          @@handler_options[:issue][attr]
         end
       end
     end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -78,7 +78,7 @@ END_DESC
       options = { :issue => {} }
       default_fields = (ENV['default_fields'] || "").split
       default_fields |= %w[project status type category priority fixed_version]
-      default_fields.each{ |field| options[:issue][field] = ENV[field] if ENV[field] }
+      default_fields.each{ |field| options[:issue][field.to_sym] = ENV[field] if ENV[field] }
 
       options[:allow_override] = ENV['allow_override'] if ENV['allow_override']
       options[:unknown_user] = ENV['unknown_user'] if ENV['unknown_user']


### PR DESCRIPTION
There was some mixup between symbols and strings that were used
as hash map indexes inside the mail handler. As a result at least
the argument or environment variable "project" was ignored.

This was cleaned up by using symbols all the way.
