### PR TITLE
Make Webpack and its loaders non-dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "0.1.0",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "bower": "~1.3.8",
     "chai": "~1.9.1",
     "chai-as-promised": "^4.1.1",
     "exec": "0.0.6",
-    "exports-loader": "^0.6.2",
     "express": "^4.9.7",
     "glob": "^4.0.6",
     "gulp": "^3.8.9",
@@ -15,7 +13,6 @@
     "gulp-protractor": "0.0.11",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-webpack": "^1.0.0",
-    "json-loader": "^0.5.1",
     "json2htmlcov": "~0.1.1",
     "karma": "~0.12.3",
     "karma-chai": "~0.1.0",
@@ -34,13 +31,15 @@
     "rimraf": "~2.2.5",
     "sinon": "~1.9.1",
     "sinon-chai": "~2.5.0",
-    "webpack": "^1.4.8",
-    "webpack-dev-server": "^1.6.5",
-    "yaml-loader": "^0.1.0"
+    "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {
     "URIjs": "^1.14.1",
-    "bower": "~1.3.8"
+    "bower": "~1.3.8",
+    "exports-loader": "^0.6.2",
+    "json-loader": "^0.5.1",
+    "webpack": "^1.4.9",
+    "yaml-loader": "^0.1.0"
   },
   "scripts": {
     "test": "npm run karma && npm run protractor",


### PR DESCRIPTION
Build-packs used by Packager.io run `npm install` with the
`--production` flag.

These are the minimum dependencies necessary for Webpack to build its
bundle prior to Sprockets assets precompilation.
