### PR TITLE
Add separate npm Karma script, invoked by npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "bower": "~1.3.8"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --single-run --browsers Firefox,PhantomJS",
+    "test": "npm run karma",
+    "karma": "./node_modules/karma/bin/karma start --single-run --browsers Firefox,PhantomJS",
     "postinstall": "./node_modules/bower/bin/bower install"
   }
 }


### PR DESCRIPTION
This change is so our internal CI can run Karma tests using `npm run karma` consistently for both 4.x releases und dev.
