### PR TITLE
Hotfix to set ruby version for packager

### DIFF
--- a/packaging/setup
+++ b/packaging/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo "ruby '2.1.3'" > Gemfile.local
+echo "ruby '2.1.4'" > Gemfile.local
 
 cp -f packaging/conf/configuration.yml config/configuration.yml
 sed -i "s|config.serve_static_assets = false|config.serve_static_assets = true|" config/environments/production.rb

--- a/packaging/setup
+++ b/packaging/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+echo "ruby '2.1.3'" > Gemfile.local
 
 cp -f packaging/conf/configuration.yml config/configuration.yml
 sed -i "s|config.serve_static_assets = false|config.serve_static_assets = true|" config/environments/production.rb


### PR DESCRIPTION
This release includes security fixes for the following vulnerabilities:
- CVE-2014-8080: Denial of Service XML Expansion
- Changed default settings of ext/openssl related to CVE-2014-3566

And there are some bug-fixes.

See [news on ruby-lang.org](https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-1-4-released/)
