### PR TITLE
disable password choice config

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -173,7 +173,7 @@ class UsersController < ApplicationController
     if @user.change_password_allowed?
       if params[:user][:assign_random_password]
         @user.random_password!
-      elsif params[:user][:password].present?
+      elsif set_password? params
         @user.password = params[:user][:password]
         @user.password_confirmation = params[:user][:password_confirmation]
       end
@@ -358,5 +358,9 @@ class UsersController < ApplicationController
 
   def block_if_password_login_disabled
     render_404 if OpenProject::Configuration.disable_password_login?
+  end
+
+  def set_password?(params)
+    params[:user][:password].present? && !OpenProject::Configuration.disable_password_choice?
   end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -84,19 +84,22 @@ See doc/COPYRIGHT.rdoc for more details.
                             "1",
                             assign_random_password_enabled) %>
         </p>
-        <p>
-          <%= f.password_field :password,
-                               :required => true,
-                               :size => 25,
-                               :disabled => assign_random_password_enabled %><br />
-          <%= password_complexity_requirements %>
-        </p>
-        <p>
-          <%= f.password_field :password_confirmation,
-                               :required => true,
-                               :size => 25,
-                               :disabled => assign_random_password_enabled %>
-        </p>
+
+        <% unless OpenProject::Configuration.disable_password_choice? %>
+          <p>
+            <%= f.password_field :password,
+                                 :required => true,
+                                 :size => 25,
+                                 :disabled => assign_random_password_enabled %><br />
+            <%= password_complexity_requirements %>
+          </p>
+          <p>
+            <%= f.password_field :password_confirmation,
+                                 :required => true,
+                                 :size => 25,
+                                 :disabled => assign_random_password_enabled %>
+          </p>
+        <% end %>
         <p>
           <%= f.check_box :force_password_change,
                           :disabled => assign_random_password_enabled %>

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -189,6 +189,12 @@ default:
   #
   # disable_password_login: true
 
+  # If enabled a user's password cannot be set to an arbitrary value.
+  # The respective form elements will be removed from the user edit view.
+  # Instead, if the password needs to be changed, a random, temporary password can be
+  # generated and sent to the user who then has to change their password upon login.
+  disable_password_choice: false
+
 # specific configuration options for production environment
 # that overrides the default ones
 # production:

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -68,7 +68,9 @@ module OpenProject
       'sendmail_arguments' => '-i',
 
       'disable_password_login' => false,
-      'omniauth_direct_login_provider' => nil
+      'omniauth_direct_login_provider' => nil,
+
+      'disable_password_choice' => false
     }
 
     @config = nil

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -36,9 +36,21 @@ module OpenProject
       ##
       # Activating this leaves omniauth as the only way to authenticate.
       def disable_password_login?
-        value = self['disable_password_login']
+        true? self['disable_password_login']
+      end
 
-        ['true', true].include? value # former to accommodate ENV
+      ##
+      # If this is true a user's password cannot be chosen when editing a user.
+      # The only way to change the password is to generate a random one which is sent
+      # to the user who then has to change it immediately.
+      def disable_password_choice?
+        true? self['disable_password_choice']
+      end
+
+      private
+
+      def true?(value)
+        ['true', true].include? value # check string to accommodate ENV override
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -512,6 +512,22 @@ describe UsersController, :type => :controller do
         expect(user.check_password?('newpassPASS!')).to be_truthy
       end
     end
+
+    context 'with disabled_password_choice' do
+      before do
+        expect(OpenProject::Configuration).to receive(:disable_password_choice?).and_return(true)
+      end
+
+      it 'ignores password parameters and leaves the password unchanged' do
+        as_logged_in_user(admin) do
+          put :update,
+              id: user.id,
+              user: { password: 'changedpass!', password_confirmation: 'changedpass!' }
+        end
+
+        expect(user.reload.check_password?('changedpass!')).to be false
+      end
+    end
   end
 
   describe "update memberships" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -116,6 +116,34 @@ describe 'users/edit', :type => :view do
           expect(rendered).to have_selector('#user_auth_source_id')
         end
       end
+
+      context 'with password choice enabled' do
+        before do
+          expect(OpenProject::Configuration)
+            .to receive(:disable_password_choice?)
+            .and_return(false)
+        end
+
+        it 'shows the password and password confirmation fields' do
+          render
+
+          expect(rendered).to have_text('Password')
+          expect(rendered).to have_text('Confirmation')
+        end
+      end
+
+      context 'with password choice enabled' do
+        before do
+          expect(OpenProject::Configuration).to receive(:disable_password_choice?).and_return(true)
+        end
+
+        it 'doesn not show the password and password confirmation fields' do
+          render
+
+          expect(rendered).not_to have_text('Password')
+          expect(rendered).not_to have_text('Password confirmation')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
WP [#15247](https://community.openproject.org/work_packages/15247)

Couldn't come up with a better name for the setting than `disable_password_choice`. If you have better ideas feel free to change it.
