### PR TITLE
use private sprockets fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :production do
   gem 'dalli'
 end
 
-gem 'sprockets',        '2.2.2.backport2'
+gem 'sprockets',        git: 'https://github.com/tessi/sprockets.git', branch: '2_2_2_backport2'
 gem 'sprockets-rails',  git: 'https://github.com/finnlabs/sprockets-rails.git', branch: 'backport'
 gem 'non-stupid-digest-assets'
 gem 'sass-rails',        git: 'https://github.com/guilleiguaran/sass-rails.git', branch: 'backport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,17 @@ GIT
   specs:
     prototype_legacy_helper (0.0.0)
 
+GIT
+  remote: https://github.com/tessi/sprockets.git
+  revision: 1e56fd0a92a9fda93dab4550ab3cf82138d097ac
+  branch: 2_2_2_backport2
+  specs:
+    sprockets (2.2.2.backport2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -358,11 +369,6 @@ GEM
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
     slop (3.5.0)
-    sprockets (2.2.2.backport2)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.7)
     strong_parameters (0.2.1)
       actionpack (~> 3.0)
@@ -484,7 +490,7 @@ DEPENDENCIES
   shoulda
   shoulda-matchers
   simplecov (= 0.8.0.pre)
-  sprockets (= 2.2.2.backport2)
+  sprockets!
   sprockets-rails!
   sqlite3
   strong_parameters


### PR DESCRIPTION
The sprockets maintainer yanked the sprockets version we
use from rubygems. It happened that I had the specific sprockets version
at my harddrive.

We really should update sprockets, but until this happens, the fork can
be used.

This is a clone of #2128.
