### PR TITLE
Add ubuntu and centos distributions

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,20 +1,24 @@
 user: openproject
 group: openproject
 targets:
-  debian-7:
+  debian-7: &debian
     build_dependencies:
       - libmagickwand-dev
       - libsqlite3-dev
-  fedora-20:
+  ubuntu-14.04:
+    <<: *debian
+  fedora-20: &redhat
     build_dependencies:
       - ImageMagick-devel
+  centos-6:
+    <<: *redhat
 before_precompile: "packaging/setup"
 crons:
   - packaging/cron/openproject-clear-old-sessions
   - packaging/cron/openproject-create-svn-repositories
 services:
   - postgres
-installer: true
+installer: https://github.com/pkgr/installer.git#master
 wizards:
   - https://github.com/pkgr/addon-legacy-installer.git#installer
   - https://github.com/pkgr/addon-mysql.git#installer


### PR DESCRIPTION
This PR adds Ubuntu and Centos support for packager.io.
