### PR TITLE
Fix for rake ci:travis:prepare task

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -68,8 +68,10 @@ namespace :ci do
         'database' => 'chiliproject_test'
       }.merge(db_info)
 
-      File.open("config/database.yml", 'w') do |f|
-        YAML.dump({"test" => database_yml, 'development' => database_yml}, f)
+      File.open('config/database.yml', 'w') do |f|
+        YAML.dump({ 'test'        => database_yml,
+                    'development' => database_yml,
+                    'production'  => database_yml }, f)
       end
 
       # Create and migrate the database

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -68,8 +68,8 @@ namespace :ci do
         'database' => 'chiliproject_test'
       }.merge(db_info)
 
-      File.open('config/database.yml', 'w') do |f|
-        YAML.dump({ 'test' => database_yml }, f)
+      File.open("config/database.yml", 'w') do |f|
+        YAML.dump({"test" => database_yml, 'development' => database_yml}, f)
       end
 
       # Create and migrate the database


### PR DESCRIPTION
Satisfy `rake db:create` wanting to create a development database.
