### PR TITLE
Fix LegacyIssuesToWorkPackages for AR API change

### DIFF
--- a/db/migrate/20130916094339_legacy_issues_to_work_packages.rb
+++ b/db/migrate/20130916094339_legacy_issues_to_work_packages.rb
@@ -57,7 +57,7 @@ class LegacyIssuesToWorkPackages < ActiveRecord::Migration
       FROM work_packages
     SQL
 
-    if existing_work_packages.size > 0
+    if existing_work_packages.length > 0
       raise ExistingWorkPackagesError, <<-MESSAGE.split("\n").map(&:strip!).join(' ') + "\n"
         There are already entries in the work_packages table.
         This migration assumes that there are none.


### PR DESCRIPTION
On Rails4,  #select_all returns a ActiveRecord::Result.

http://www.ruby-doc.org/core-2.1.4/Array.html#method-i-length

Signed-off-by: Alex Coles alex@alexbcoles.com
