### PR TITLE
fix text below subject jumps when hovering over subject

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -20,6 +20,8 @@
     height: auto
     float: inherit
   .editing-link-wrapper
+    position: absolute
+    margin-left: 4px
     a
       @extend .hidden-but-focusable
       &:focus


### PR DESCRIPTION
[`* `#17215 ` text below subject jumps when hovering over subject`](http://community.openproject.org/work_packages/17215)
