### PR TITLE
TimeEntries spent_on date display bug.

### DIFF
--- a/app/assets/javascripts/angular/ui_components/date/date-directive.js
+++ b/app/assets/javascripts/angular/ui_components/date/date-directive.js
@@ -33,10 +33,12 @@ module.exports = function(TimezoneService) {
     scope: { dateValue: '=', hideTitle: '@' },
     template: '<span title="{{ dateTitle }}">{{date}}</span>',
     link: function(scope, element, attrs) {
-      scope.date = TimezoneService.formattedDate(scope.dateValue);
-      if (!scope.hideTitle) {
-        scope.dateTitle = scope.date;
-      }
+      attrs.$observe('date', function(value) {
+        scope.date = TimezoneService.formattedDate(scope.value);
+        if (!scope.hideTitle) {
+          scope.dateTitle = scope.date;
+        }
+      });
     }
   };
 }

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </thead>
   <tbody>
     <tr class="time-entry" ng-repeat="timeEntry in timeEntries" ng-class-even="'even'" ng-class-odd="'odd'">
-      <td class="spent_on" date="timeEntry.spent_on"></td>
+      <td class="spent_on" date="{{ timeEntry.spent_on }}"></td>
       <td class="user"><a ng-href="{{PathHelper.userPath(timeEntry.user.id)}}">{{timeEntry.user.name}}</a></td>
       <td class="activity">{{timeEntry.activity.name}}</td>
       <td class="project"><a ng-href="{{PathHelper.projectPath(timeEntry.project.id)}}">{{timeEntry.project.name}}</a></td>


### PR DESCRIPTION
The detail view of logged time entries does not show the logged date
(spent_on), but instead displays the current time.

I believe this is an error in the data passing in the angular scope. The parameter `scope.dateValue` is empty, and thus undefined is passed to

```
scope.date = TimezoneService.formattedDate(scope.dateValue);
```

which in turn results in the date always set to today.
The issue appears to be fixed when adding a data observer to the custom directive.

The following example contains a time entry with `spent_on` set to 2014-11-02:

![Edit date correct](https://dl.dropboxusercontent.com/u/270758/op_spent_on_fe.png)

yet, the detail view shows the current date.

![Displays incorrectly](https://dl.dropboxusercontent.com/u/270758/op_spent_on_f.png)

This commit appears to fix the issue. Angular isn't one of my strong suits, so maybe this isn't the correct / optimal solution, even though it fixes the error.

I've also added this as a work package at https://community.openproject.org/work_packages/17222
