### PR TITLE
TimeEntries spent_on date display fix.

### DIFF
--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </thead>
   <tbody>
     <tr class="time-entry" ng-repeat="timeEntry in timeEntries" ng-class-even="'even'" ng-class-odd="'odd'">
-      <td class="spent_on" date="timeEntry.spent_on"></td>
+      <td class="spent_on"><date date-value="timeEntry.spent_on"></date></td>
       <td class="user"><a ng-href="{{PathHelper.userPath(timeEntry.user.id)}}">{{timeEntry.user.name}}</a></td>
       <td class="activity">{{timeEntry.activity.name}}</td>
       <td class="project"><a ng-href="{{PathHelper.projectPath(timeEntry.project.id)}}">{{timeEntry.project.name}}</a></td>


### PR DESCRIPTION
The detail view of logged time entries does not show the logged date
(spent_on), but instead displays the current time.

Using the date directive as an element tag with date-value set
seems to fix the issue.

The following example contains a time entry with `spent_on` set to 2014-11-02:

![Edit date correct](https://dl.dropboxusercontent.com/u/270758/op_spent_on_fe.png)

yet, the detail view shows the current date.

![Displays incorrectly](https://dl.dropboxusercontent.com/u/270758/op_spent_on_f.png)

I've also added this as a work package at https://community.openproject.org/work_packages/17222
