### PR TITLE
Revert "Temp. silence deprecation warnings in test env"

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,7 +62,7 @@ OpenProject::Application.configure do
   config.active_record.mass_assignment_sanitizer = :strict
 
   # Print deprecation notices to the stderr
-  config.active_support.deprecation = :silence
+  config.active_support.deprecation = :stderr
 
   # we use per process memory for caching in the test environment
   config.cache_store = :memory_store


### PR DESCRIPTION
This reverts commit d4444cfe5ed82dd921d134696703cf1ad633e43a.

Duplication warning says behavior change.
You should remove deprecation warnings at first.
