### PR TITLE
Hotfix/i18n testing as specs

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -110,8 +110,7 @@ module Redmine
     end
 
     def find_language(lang)
-      @@languages_lookup = valid_languages.inject({}) {|k, v| k[v.to_s.downcase] = v; k }
-      @@languages_lookup[lang.to_s.downcase]
+      valid_languages.detect { |l| l =~ /#{lang}/i }
     end
 
     def set_language_if_valid(lang)

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -70,14 +70,83 @@ module OpenProject
       end
     end
 
-    describe :all_languages do
-      it 'should at least return en' do
-        # using this to ensure that the files are evaluated
+    describe 'all_languages' do
+
+      # Those are the two languages we support
+      it 'includes en' do
         expect(all_languages).to include(:en)
+      end
+      it 'includes de' do
+        expect(all_languages).to include(:de)
       end
 
       it 'should return no js language as they are duplicates of the rest of the other language' do
-        expect(all_languages.any?{ |l| /\Ajs-/.match(l.to_s) }).to be_false
+        expect(all_languages.any? { |l| /\Ajs-/.match(l.to_s) }).to be_falsey
+      end
+
+      # it is OK if more languages exist
+      it 'has a language for every language file' do
+        lang_files_count = Dir.glob(Rails.root.join('config/locales/*.yml'))
+                              .map { |f| File.basename(f) }
+                              .reject { |b| b.starts_with? 'js' }
+                              .size
+
+        expect(all_languages.size).to eql lang_files_count
+      end
+    end
+
+    describe 'valid_languages' do
+      it 'allows only languages that are available' do
+        allow(Setting).to receive(:available_languages).and_return([:en])
+
+        expect(valid_languages).to eql [:en]
+      end
+
+      it 'allows only languages that exist' do
+        allow(Setting).to receive(:available_languages).and_return([:'123'])
+
+        expect(valid_languages).to be_empty
+      end
+    end
+
+    describe 'set_language_if_valid' do
+      before do
+        allow(Setting).to receive(:available_languages).and_return(Setting.all_languages)
+      end
+
+      Setting.all_languages.each do |lang|
+        it "should set I18n.locale to #{lang}" do
+          allow(I18n).to receive(:locale=)
+          expect(I18n).to receive(:locale=).with(lang)
+
+          set_language_if_valid(lang)
+        end
+      end
+
+      it 'should not set I18n.locale to an invalid language' do
+        allow(Setting).to receive(:available_languages).and_return([:en])
+
+        expect(I18n).to_not receive(:locale=).with(:de)
+      end
+    end
+
+    describe 'find_language' do
+      it 'is nil if language is not active' do
+        allow(Setting).to receive(:available_languages).and_return([:de])
+
+        expect(find_language(:en)).to be_nil
+      end
+
+      it 'is the language if it is active' do
+        allow(Setting).to receive(:available_languages).and_return([:de])
+
+        expect(find_language(:de)).to eql :de
+      end
+
+      it 'can be found by uppercase if it is active' do
+        allow(Setting).to receive(:available_languages).and_return([:de])
+
+        expect(find_language(:DE)).to eql :de
       end
     end
   end

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -42,20 +42,6 @@ class ApplicationControllerTest < ActionController::TestCase
     @response   = ActionController::TestResponse.new
   end
 
-  # check that all language files are valid
-  def test_localization
-    lang_files_count = Dir.glob(Rails.root.join('config/locales/*.yml'))
-                          .map { |f| File.basename(f) }
-                          .reject { |b| b.starts_with? 'js' }
-                          .size
-    Setting.available_languages = Setting.all_languages
-    assert_equal lang_files_count, valid_languages.size
-    valid_languages.each do |lang|
-      assert set_language_if_valid(lang)
-    end
-    set_language_if_valid('en')
-  end
-
   def test_call_hook_mixed_in
     assert @controller.respond_to?(:call_hook)
   end

--- a/test/unit/lib/redmine/i18n_test.rb
+++ b/test/unit/lib/redmine/i18n_test.rb
@@ -133,23 +133,6 @@ class Redmine::I18nTest < ActiveSupport::TestCase
     end
   end
 
-  def test_valid_languages
-    assert valid_languages.is_a?(Array)
-    assert valid_languages.first.is_a?(Symbol)
-  end
-
-  def test_valid_language
-    Setting.available_languages = [:de, :zh]
-
-    to_test = {'de' => :de,
-               'DE' => :de,
-               'De' => :de,
-               'de-ZZ' => nil,
-               'zh' => nil }
-
-    to_test.each {|lang, expected| assert_equal expected, find_language(lang)}
-  end
-
   def test_fallback
     ::I18n.backend.store_translations(:en, {:untranslated => "Untranslated string"})
     ::I18n.locale = 'en'


### PR DESCRIPTION
Rewritten all the tests regarding languages as specs, removed test_unit tests. That should make it possible to deactivate them if necessary.
