### PR TITLE
17246 German translations for inplace edit

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -385,3 +385,9 @@ de:
     relations:
       empty: Keine bestehenden Beziehungen
       delete: Beziehung löschen
+    inplace:
+      button_edit: "Bearbeiten"
+      button_save: "Speichern"
+      button_save_and_send: "Speichern mit E-Mail-Benachrichtigung"
+      button_cancel: "Abbrechen"
+      link_formatting_help: "Textformatierung"


### PR DESCRIPTION
[`* `#17246`Missing German translations for inplace edit confirmation box`](https://community.openproject.org/work_packages/17246)

Fixes also https://community.openproject.org/work_packages/17255.
