### PR TITLE
17244 WP attributes with zero value are not shown in split view

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -197,4 +197,8 @@ module.exports = function($scope,
       return $scope.isGroupEmpty(element);
     }).length > 0;
   };
+
+  $scope.isPropertyEmpty = function(property) {
+    return property === undefined || property === null;
+  };
 }

--- a/public/templates/work_packages/tabs/overview.html
+++ b/public/templates/work_packages/tabs/overview.html
@@ -14,12 +14,12 @@
 
     <dl>
       <dt ng-repeat-start="propertyData in group.attributes"
-          ng-show="propertyData.value || !toggleStates.hideAllAttributes"
+          ng-show="!(isPropertyEmpty(propertyData.value) && toggleStates.hideAllAttributes)"
           ng-bind="propertyData.label"
           class="work-package-attributes--label">
       </dt>
       <dd ng-repeat-end
-          ng-show="propertyData.value || !toggleStates.hideAllAttributes"
+          ng-show="!(isPropertyEmpty(propertyData.value) && toggleStates.hideAllAttributes)"
           ng-switch="propertyData.value"
           class="work-package-attributes--value-container">
         <div ng-switch-when="null" class="work-package-attributes--value">


### PR DESCRIPTION
[`* `#17244` Work package attributes with zero value are not shown in split view`](https://community.openproject.org/work_packages/17244)
