### PR TITLE
Remove various implicit globals in Angular app

### DIFF
--- a/app/assets/javascripts/angular/helpers/custom-field-helper.js
+++ b/app/assets/javascripts/angular/helpers/custom-field-helper.js
@@ -31,7 +31,7 @@ angular.module('openproject.helpers')
 .constant('CUSTOM_FIELD_PREFIX', 'cf_')
 .service('CustomFieldHelper', ['CUSTOM_FIELD_PREFIX', 'I18n', function(CUSTOM_FIELD_PREFIX, I18n) {
 
-  CustomFieldHelper = {
+  var CustomFieldHelper = {
     isCustomFieldKey: function(key) {
       return key.substr(0, CUSTOM_FIELD_PREFIX.length) === CUSTOM_FIELD_PREFIX;
     },

--- a/app/assets/javascripts/angular/helpers/path-helper.js
+++ b/app/assets/javascripts/angular/helpers/path-helper.js
@@ -30,7 +30,7 @@
 angular.module('openproject.helpers')
 
 .service('PathHelper', [function() {
-  PathHelper = {
+  var PathHelper = {
     apiV2: '/api/v2',
     apiExperimental: '/api/experimental',
     apiV3: '/api/v3',

--- a/app/assets/javascripts/angular/helpers/svg-helper.js
+++ b/app/assets/javascripts/angular/helpers/svg-helper.js
@@ -129,7 +129,7 @@ angular.module('openproject.helpers')
   jQuery.each([SVGSVGElement, SVGRectElement, SVGPathElement,
       SVGTextElement], function (i, klass) {
     klass.prototype.attr = function(attributeHash) {
-      for (key in attributeHash) {
+      for (var key in attributeHash) {
         if (attributeHash.hasOwnProperty(key)) {
           this.setAttribute(key, attributeHash[key]);
         }

--- a/app/assets/javascripts/angular/models/filter.js
+++ b/app/assets/javascripts/angular/models/filter.js
@@ -31,7 +31,7 @@ angular.module('openproject.models')
 .constant('OPERATORS_NOT_REQUIRING_VALUES', ['o', 'c', '!*', '*', 't', 'w'])
 .constant('SELECTABLE_FILTER_TYPES', ['list', 'list_optional', 'list_status', 'list_subprojects', 'list_model'])
 .factory('Filter', ['OPERATORS_NOT_REQUIRING_VALUES', 'SELECTABLE_FILTER_TYPES', function(OPERATORS_NOT_REQUIRING_VALUES, SELECTABLE_FILTER_TYPES) {
-  Filter = function (data) {
+  var Filter = function (data) {
     angular.extend(this, data);
 
     // Experimental API controller will always give back strings even for numeric values so need to parse them

--- a/app/assets/javascripts/angular/models/query.js
+++ b/app/assets/javascripts/angular/models/query.js
@@ -34,7 +34,7 @@ angular.module('openproject.models')
                    'INITIALLY_SELECTED_COLUMNS',
                    function(Filter, Sortation, UrlParamsHelper, INITIALLY_SELECTED_COLUMNS) {
 
-  Query = function (queryData, options) {
+  var Query = function (queryData, options) {
     angular.extend(this, queryData, options);
 
     this.filters = [];

--- a/app/assets/javascripts/angular/models/sortation.js
+++ b/app/assets/javascripts/angular/models/sortation.js
@@ -70,7 +70,7 @@ angular.module('openproject.models')
   };
 
   Sortation.prototype.removeSortElement = function(elementName) {
-    index = this.sortElements.map(function(sortation){
+    var index = this.sortElements.map(function(sortation){
       return sortation.field;
     }).indexOf(elementName);
 
@@ -112,7 +112,7 @@ angular.module('openproject.models')
 
   Sortation.prototype.decodeEncodedSortation = function(encodedSortation) {
     return encodedSortation.split(',').map(function(sortParam) {
-      fieldAndDirection = sortParam.split(':');
+      var fieldAndDirection = sortParam.split(':');
       return { field: fieldAndDirection[0], direction: fieldAndDirection[1] || defaultSortDirection};
     });
   };

--- a/app/assets/javascripts/angular/services/hook-service.js
+++ b/app/assets/javascripts/angular/services/hook-service.js
@@ -31,7 +31,7 @@ angular.module('openproject.services')
 .service('HookService', [function() {
   var hooks = { };
 
-  HookService = {
+  var HookService = {
     register: function(id, callback) {
       if (callback && typeof(callback) == "function") {
         if (!hooks[id]) {

--- a/app/assets/javascripts/angular/services/pagination-service.js
+++ b/app/assets/javascripts/angular/services/pagination-service.js
@@ -37,7 +37,7 @@ angular.module('openproject.services')
     optionsTruncationSize: DEFAULT_PAGINATION_OPTIONS.optionsTruncationSize
   };
 
-  PaginationService = {
+  var PaginationService = {
     getPaginationOptions: function() {
       return paginationOptions;
     },

--- a/app/assets/javascripts/angular/services/sort-service.js
+++ b/app/assets/javascripts/angular/services/sort-service.js
@@ -33,7 +33,7 @@ angular.module('openproject.services')
     column: "",
     direction: ""
   };
-  SortService = {
+  var SortService = {
     getColumn: function() {
       return sortOptions.column;
     },

--- a/app/assets/javascripts/angular/services/timezone-service.js
+++ b/app/assets/javascripts/angular/services/timezone-service.js
@@ -29,7 +29,7 @@
 angular.module('openproject.services')
 
 .service('TimezoneService', ['ConfigurationService', 'I18n', function(ConfigurationService, I18n) {
-  TimezoneService = {
+  var TimezoneService = {
     parseDate: function(date) {
       var d = moment.utc(date);
 

--- a/app/assets/javascripts/angular/timelines/directives/timeline-container-directive.js
+++ b/app/assets/javascripts/angular/timelines/directives/timeline-container-directive.js
@@ -29,8 +29,8 @@
 angular.module('openproject.timelines.directives')
 
 .directive('timelineContainer', ['$window', 'Timeline', function($window, Timeline) {
-  getInitialOutlineExpansion = function(timelineOptions) {
-    initialOutlineExpansion = timelineOptions.initial_outline_expansion;
+  var getInitialOutlineExpansion = function(timelineOptions) {
+    var initialOutlineExpansion = timelineOptions.initial_outline_expansion;
     if (initialOutlineExpansion && initialOutlineExpansion >= 0) {
       return initialOutlineExpansion;
     } else {

--- a/app/assets/javascripts/angular/timelines/directives/timeline-table-container-directive.js
+++ b/app/assets/javascripts/angular/timelines/directives/timeline-table-container-directive.js
@@ -101,7 +101,7 @@ angular.module('openproject.timelines.directives')
           timeline.secondLevelGroupingAdjustments();
         }
 
-        tree = timeline.getLefthandTree();
+        var tree = timeline.getLefthandTree();
 
         if (tree.containsPlanningElements() || tree.containsProjects()) {
           timeline.adjustForPlanningElements();
@@ -114,7 +114,7 @@ angular.module('openproject.timelines.directives')
       }
 
       function drawChart(tree) {
-        timeline = scope.timeline;
+        var timeline = scope.timeline;
 
         try {
           window.clearTimeout(timeline.safetyHook);

--- a/app/assets/javascripts/angular/timelines/helpers/filter-query-string-builder.js
+++ b/app/assets/javascripts/angular/timelines/helpers/filter-query-string-builder.js
@@ -41,7 +41,7 @@ angular.module('openproject.timelines.helpers')
 
 .factory('FilterQueryStringBuilder', [function() {
 
-  FilterQueryStringBuilder = (function() {
+  var FilterQueryStringBuilder = (function() {
 
     /**
      * FilterQueryStringBuilder

--- a/app/assets/javascripts/angular/timelines/helpers/timeline-table-helper.js
+++ b/app/assets/javascripts/angular/timelines/helpers/timeline-table-helper.js
@@ -47,7 +47,7 @@ angular.module('openproject.timelines.helpers')
     return this.hiddenOrFilteredOut(node) || this.memberOfHiddenOtherGroup(node);
   };
 
-  TimelineTableHelper = {
+  var TimelineTableHelper = {
     flattenTimelineTree: function(root, filterCallback, processNodeCallback){
       var nodes = [];
 
@@ -74,7 +74,7 @@ angular.module('openproject.timelines.helpers')
       }
 
       // first level group
-      isNested = node.level >= 2;
+      var isNested = node.level >= 2;
       if (node.payload.objectType === 'Project' && !isNested) {
         node.firstLevelGroup        = node.payload.getFirstLevelGrouping();
         node.firstLevelGroupingName = node.payload.getFirstLevelGroupingName();
@@ -85,12 +85,12 @@ angular.module('openproject.timelines.helpers')
     },
 
     getTableRowsFromTimelineTree: function(tree, options) {
-      nodeFilter = new NodeFilter(options);
+      var nodeFilter = new NodeFilter(options);
 
       // add relevant information to tree root serving as first row
       TimelineTableHelper.addRowDataToNode(tree);
 
-      rows = TimelineTableHelper.flattenTimelineTree(tree, function(node) { return nodeFilter.nodeExcluded(node); }, TimelineTableHelper.addRowDataToNode);
+      var rows = TimelineTableHelper.flattenTimelineTree(tree, function(node) { return nodeFilter.nodeExcluded(node); }, TimelineTableHelper.addRowDataToNode);
       rows.unshift(tree);
 
       return rows;
@@ -98,7 +98,7 @@ angular.module('openproject.timelines.helpers')
 
     setLastVisible: function(rows) {
       var set = false;
-      i = rows.length - 1;
+      var i = rows.length - 1;
       while(i >= 0){
         if(!set && rows[i].visible){
           rows[i].setLastVisible();

--- a/app/assets/javascripts/angular/timelines/models/mixins/constants.js
+++ b/app/assets/javascripts/angular/timelines/models/mixins/constants.js
@@ -41,7 +41,7 @@ angular.module('openproject.timelines.models')
 
 .factory('Constants', [function() {
 
-  Constants = {
+  var Constants = {
     //constants and defaults
     LOAD_ERROR_TIMEOUT: 60000,
     DISPLAY_ERROR_DELAY: 2000,

--- a/app/assets/javascripts/angular/timelines/models/mixins/ui.js
+++ b/app/assets/javascripts/angular/timelines/models/mixins/ui.js
@@ -45,7 +45,7 @@ angular.module('openproject.timelines.models')
   // │ UI and Plotting                                                   │
   // ╰───────────────────────────────────────────────────────────────────╯
 
-  UI = {
+  var UI = {
 
     DEFAULT_COLOR: '#999999',
     DEFAULT_FILL_COLOR_IN_COMPARISONS: 'none',

--- a/app/assets/javascripts/angular/timelines/services/timeline-loader-service.js
+++ b/app/assets/javascripts/angular/timelines/services/timeline-loader-service.js
@@ -985,7 +985,7 @@ angular.module('openproject.timelines.services')
     var results = [];
 
     var i, userFields = [], cf = this.data.custom_fields;
-    for (attr in cf) {
+    for (var attr in cf) {
       if (cf.hasOwnProperty(attr) && cf[attr].field_format === "user") {
           userFields.push("cf_" + cf[attr].id);
       }
@@ -1136,15 +1136,15 @@ angular.module('openproject.timelines.services')
   };
 
 
-  TimelineLoaderService = {
+  var TimelineLoaderService = {
     createTimelineLoader: function(timeline) {
       return new TimelineLoader(timeline, timeline.getTimelineLoaderOptions());
     },
     loadTimelineData: function(timeline) {
       // console.log('- TimelineLoaderService: loadTimelineData');
 
-      deferred = $q.defer();
-      timelineLoader = null;
+      var deferred = $q.defer();
+      var timelineLoader = null;
 
       try {
         // prerequisites (3rd party libs)

--- a/app/assets/javascripts/angular/ui_components/focus-helper.js
+++ b/app/assets/javascripts/angular/ui_components/focus-helper.js
@@ -32,7 +32,7 @@ angular.module('openproject.uiComponents')
 .constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex], select')
 
 .service('FocusHelper', ['$timeout', 'FOCUSABLE_SELECTOR', function($timeout, FOCUSABLE_SELECTOR) {
-  FocusHelper = {
+  var FocusHelper = {
     getFocusableElement: function(element) {
       var focusable = element;
 

--- a/app/assets/javascripts/angular/ui_components/with-dropdown-directive.js
+++ b/app/assets/javascripts/angular/ui_components/with-dropdown-directive.js
@@ -47,7 +47,7 @@ angular.module('openproject.uiComponents')
 
       // Position the dropdown relative-to-parent or relative-to-document
       if (dropdown.hasClass('dropdown-relative')) {
-        leftPosition = dropdown.hasClass('dropdown-anchor-right') ?
+        var leftPosition = dropdown.hasClass('dropdown-anchor-right') ?
             trigger.position().left - (dropdown.outerWidth(true) - trigger.outerWidth(true)) - parseInt(trigger.css('margin-right')) + hOffset :
             trigger.position().left + parseInt(trigger.css('margin-left')) + hOffset;
 

--- a/app/assets/javascripts/angular/ui_components/zoom-slider-directive.js
+++ b/app/assets/javascripts/angular/ui_components/zoom-slider-directive.js
@@ -68,7 +68,7 @@ angular.module('openproject.uiComponents')
       scope.$watch('currentScaleIndex', function(newIndex){
         scope.currentScaleIndex = newIndex;
 
-        newScaleName = Timeline.ZOOM_SCALES[newIndex];
+        var newScaleName = Timeline.ZOOM_SCALES[newIndex];
         if (scope.currentScaleName !== newScaleName) {
           scope.currentScaleName = newScaleName;
         }

--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -189,7 +189,7 @@ angular.module('openproject.workPackages.controllers')
 
   function addWorkPackageProperty(property, index) {
     var label  = I18n.t('js.work_packages.properties.' + property),
-        format = getPropertyFormat(property);
+        format = getPropertyFormat(property),
         value  = getPropertyValue(property, format);
 
     if (!(value === null || value === undefined) ||

--- a/app/assets/javascripts/angular/work_packages/controllers/dialogs/group-by.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/dialogs/group-by.js
@@ -49,7 +49,7 @@ angular.module('openproject.workPackages.controllers')
   this.closeMe = groupingModal.deactivate;
 
   $scope.getGroupableColumnsData = function(term, result) {
-    var filtered = $filter('filter')($scope.groupableColumnsData, { label: term });
+    var filtered = $filter('filter')($scope.groupableColumnsData, { label: term }),
         sorted = $filter('orderBy')(filtered, 'label');
 
     return result(sorted);

--- a/app/assets/javascripts/angular/work_packages/controllers/dialogs/sorting.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/dialogs/sorting.js
@@ -68,7 +68,7 @@ angular.module('openproject.workPackages.controllers')
   // functions exposing available options to select2
 
   $scope.getAvailableColumnsData = function(term, result) {
-    var filtered = $filter('filter')(getRemainingAvailableColumnsData(), { label: term });
+    var filtered = $filter('filter')(getRemainingAvailableColumnsData(), { label: term }),
         sorted = $filter('orderBy')(filtered, 'label');
 
     return result(sorted);

--- a/app/assets/javascripts/angular/work_packages/controllers/work-packages-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/work-packages-controller.js
@@ -33,7 +33,8 @@ angular.module('openproject.workPackages.controllers')
     '$state',
     '$stateParams',
     'QueryService',
-    function($scope, $state, $stateParams, QueryService) {
+    'PathHelper',
+    function($scope, $state, $stateParams, QueryService, PathHelper) {
 
   // Setup
   $scope.$state = $state;

--- a/app/assets/javascripts/angular/work_packages/helpers/filters-helper.js
+++ b/app/assets/javascripts/angular/work_packages/helpers/filters-helper.js
@@ -51,7 +51,7 @@ angular.module('openproject.workPackages.helpers')
 
     indentedName: function(name, level){
       var indentation = '';
-      for(i = 0; i < level; i++){
+      for(var i = 0; i < level; i++){
         indentation = indentation + '--';
       }
       return indentation + " " + name;

--- a/app/assets/javascripts/angular/work_packages/models/work-package-authorization.js
+++ b/app/assets/javascripts/angular/work_packages/models/work-package-authorization.js
@@ -30,7 +30,7 @@ angular.module('openproject.workPackages.models')
 
 .factory('WorkPackageAuthorization', [function() {
 
-  WorkPackageAuthorization = function (workPackage) {
+  var WorkPackageAuthorization = function (workPackage) {
     this.workPackage = workPackage;
   };
 

--- a/app/assets/javascripts/angular/work_packages/tabs/user-activity-directive.js
+++ b/app/assets/javascripts/angular/work_packages/tabs/user-activity-directive.js
@@ -112,7 +112,7 @@ angular.module('openproject.workPackages.tabs')
       };
 
       function quotedText(rawComment) {
-        quoted = rawComment.split("\n")
+        var quoted = rawComment.split("\n")
           .map(function(line){ return "\n> " + line; })
           .join('');
         return scope.userName + " wrote:" + quoted;

--- a/karma/tests/helpers/url-params-helper-test.js
+++ b/karma/tests/helpers/url-params-helper-test.js
@@ -29,11 +29,12 @@
 /*jshint expr: true*/
 
 describe('UrlParamsHelper', function() {
-  var UrlParamsHelper;
+  var UrlParamsHelper, Query;
 
-  beforeEach(module('openproject.helpers'));
-  beforeEach(inject(function(_UrlParamsHelper_) {
+  beforeEach(module('openproject.helpers', 'openproject.models'));
+  beforeEach(inject(function(_UrlParamsHelper_, _Query_) {
     UrlParamsHelper = _UrlParamsHelper_;
+    Query = _Query_;
   }));
 
   describe('buildQueryString', function() {

--- a/karma/tests/timelines/helpers/timeline-table-helper-test.js
+++ b/karma/tests/timelines/helpers/timeline-table-helper-test.js
@@ -29,11 +29,12 @@
 /*jshint expr: true*/
 
 describe('Timeline table helper', function() {
-  var TimelineTableHelper;
+  var TimelineTableHelper, TreeNode;
 
-  beforeEach(module('openproject.timelines.helpers'));
-  beforeEach(inject(function(_TimelineTableHelper_) {
+  beforeEach(module('openproject.timelines.helpers', 'openproject.timelines.models'));
+  beforeEach(inject(function(_TimelineTableHelper_, _TreeNode_) {
     TimelineTableHelper = _TimelineTableHelper_;
+    TreeNode = _TreeNode_;
   }));
 
   describe('setRowLevelVisibility', function() {

--- a/karma/tests/timelines/models/project-test.js
+++ b/karma/tests/timelines/models/project-test.js
@@ -378,6 +378,13 @@ describe('Project', function(){
 });
 
 describe('Helper Functions', function () {
+  var Timeline;
+
+  beforeEach(module('openproject.timelines.models'));
+  beforeEach(inject(function(_Timeline_) {
+    Timeline = _Timeline_;
+  }));
+
   describe('id in Array', function () {
     it('should return true if element in array', function () {
       expect(Timeline.idInArray(["5", "4"], {id: 4})).to.be.true;

--- a/karma/tests/work_packages/directives/options-dropdown-directive-test.js
+++ b/karma/tests/work_packages/directives/options-dropdown-directive-test.js
@@ -27,7 +27,7 @@
 //++
 
 describe('optionsDropdown Directive', function() {
-    var compile, element, rootScope, scope, I18n, stateParams = {};
+    var compile, element, rootScope, scope, Query, I18n, stateParams = {};
 
     beforeEach(angular.mock.module('openproject.workPackages.directives'));
     beforeEach(module('openproject.models',
@@ -63,8 +63,9 @@ describe('optionsDropdown Directive', function() {
       };
     }));
 
-    beforeEach(inject(function(_AuthorisationService_, _I18n_){
+    beforeEach(inject(function(_AuthorisationService_, _Query_, _I18n_){
       AuthorisationService = _AuthorisationService_;
+      Query = _Query_;
 
       I18n = _I18n_;
 

--- a/karma/tests/work_packages/directives/sort-header-directive-test.js
+++ b/karma/tests/work_packages/directives/sort-header-directive-test.js
@@ -61,9 +61,10 @@ describe('sortHeader Directive', function() {
     }));
 
     describe('element', function() {
-      var Sortation;
-      beforeEach(inject(function(_Sortation_) {
+      var Sortation, Query;
+      beforeEach(inject(function(_Sortation_, _Query_) {
         Sortation = _Sortation_;
+        Query = _Query_;
       }));
 
       describe('rendering multiple headers', function(){


### PR DESCRIPTION
This PR does not remove globals used by timelines model: removing these accidental globals would require addressing a number of circular dependencies, e.g. between `Timeline` and `Project` objects.
