### PR TITLE
17304 view time entries permission not respected on wp spent hours

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -457,9 +457,8 @@ class WorkPackage < ActiveRecord::Base
   # Example:
   #   spent_hours => 0.0
   #   spent_hours => 50.2
-  def spent_hours
-    @spent_hours ||= self_and_descendants.joins(:time_entries)
-                                         .sum("#{TimeEntry.table_name}.hours").to_f || 0.0
+  def spent_hours(usr = User.current)
+    @spent_hours ||= compute_spent_hours(usr)
   end
 
   # Moves/copies an work_package to a new project and type
@@ -1053,5 +1052,15 @@ class WorkPackage < ActiveRecord::Base
       work_package.add_journal User.current, journal_note
       work_package.save!
     end
+  end
+
+  def compute_spent_hours(usr = User.current)
+    return 0.0 unless usr.allowed_to?(:view_time_entries, project)
+
+    spent_time = TimeEntry.visible(usr)
+      .on_work_packages(self_and_descendants.visible(usr))
+      .sum(:hours)
+
+    spent_time || 0.0
   end
 end

--- a/features/work_packages/log_time_on_update.feature
+++ b/features/work_packages/log_time_on_update.feature
@@ -40,6 +40,7 @@ Feature: Logging time on work package update
       | edit_work_packages |
       | view_work_packages |
       | log_time           |
+      | view_time_entries  |
     And I am working in project "ecookbook"
     And the user "manager" is a "manager"
     And there are the following status:

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1440,5 +1440,86 @@ describe WorkPackage do
       it { expect(subject).to match_array([work_package]) }
     end
   end
+
+  describe 'spent_hours' do
+    let(:project) { FactoryGirl.create(:project) }
+    let(:work_package) { FactoryGirl.create(:work_package, project: project) }
+    let!(:time_entry1) {
+      FactoryGirl.create(:time_entry,
+                         project: project,
+                         work_package: work_package,
+                         hours: 2.0)
+    }
+    let!(:time_entry2) {
+      FactoryGirl.create(:time_entry,
+                         project: project,
+                         work_package: work_package,
+                         hours: 42.0)
+    }
+
+    shared_examples_for 'returns spent hours' do |hours|
+      before { User.stub(:current).and_return(user) }
+
+      subject { work_package.spent_hours }
+
+      it { expect(subject).to eql(hours) }
+    end
+
+    context 'user with permission to view time entries' do
+      let(:permissions) { [:view_work_packages, :view_time_entries] }
+      let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+      let(:user) {
+        FactoryGirl.create(:user,
+                           member_in_project: project,
+                           member_through_role: role)
+      }
+
+      it_behaves_like 'returns spent hours', 44.0
+
+      context 'cross project work packages allowed' do
+        let(:other_work_package) { FactoryGirl.create(:work_package) }
+        let(:other_visible_work_package) { FactoryGirl.create(:work_package) }
+        let(:other_role) { FactoryGirl.create(:role, permissions: [:view_work_packages]) }
+        let!(:member) {
+          FactoryGirl.create(:member,
+                             user: user,
+                             project: other_visible_work_package.project,
+                             roles: [other_role])
+        }
+        let!(:time_entry3) {
+          FactoryGirl.create(:time_entry,
+                             project: other_work_package.project,
+                             work_package: other_work_package,
+                             hours: 99.0)
+        }
+        let!(:time_entry4) {
+          FactoryGirl.create(:time_entry,
+                             project: other_visible_work_package.project,
+                             work_package: other_visible_work_package,
+                             hours: 100.0)
+        }
+
+        before do
+          Setting.stub(:cross_project_work_package_relations?).and_return(true)
+
+          other_work_package.parent = work_package
+          other_work_package.save!
+
+          other_visible_work_package.parent = other_work_package
+          other_visible_work_package.save!
+
+          work_package.reload
+        end
+
+        it_behaves_like 'returns spent hours', 44.0
+      end
+    end
+
+    context 'user w/o permission to view time entries' do
+      let(:user) { FactoryGirl.create(:user, member_in_project: project) }
+
+      it_behaves_like 'returns spent hours', 0.0
+    end
+  end
 end
 


### PR DESCRIPTION
[`* `#17304` View time entries permission not respected for work package's spent hours attribute`](https://community.openproject.org/work_packages/17304)
