### PR TITLE
17304 view time entries permission not respected on wp spent hours

### DIFF
--- a/features/work_packages/log_time_on_update.feature
+++ b/features/work_packages/log_time_on_update.feature
@@ -40,6 +40,7 @@ Feature: Logging time on work package update
       | edit_work_packages |
       | view_work_packages |
       | log_time           |
+      | view_time_entries  |
     And I am working in project "ecookbook"
     And the user "manager" is a "manager"
     And there are the following status:


### PR DESCRIPTION
[`* `#17304` View time entries permission not respected for work package's spent hours attribute`](https://community.openproject.org/work_packages/17304)
