### PR TITLE
Add a development Procfile, document in INSTALL

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -9,4 +9,4 @@ stage:
     - bundle exec rake db:create db:migrate
     - bundle exec rake db:seed RAILS_ENV=development
 
-  run: foreman start -c web=1,worker=1
+  run: foreman start -f Procfile.dev

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: bundle exec unicorn --config-file config/unicorn.rb --host ${HOST:="127.0.0.1"} --port ${PORT:="8080"} --env ${RAILS_ENV:="development"}
+assets: $(npm bin)/webpack --colors --watch --progress
+worker: bundle exec rake jobs:work

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -56,6 +56,10 @@ These are generic (and condensed) installation instructions for the **current de
 
         npm install
 
+3. Install `foreman` gem:
+
+        [sudo] gem install foreman
+
 ### Configure Rails
 
 1. Copy `config/database.yml.example` to `config/database.yml`:
@@ -84,17 +88,9 @@ These are generic (and condensed) installation instructions for the **current de
 
 ### Run!
 
-1. In development, bundle JavaScript assets using Webpack:
+1. Start OpenProject in development mode:
 
-        ./node_modules/webpack/bin/webpack.js
-
-   Pass the `-w` flag to keep Webpack watching for changes.
-
-   In production, this step is executed as part of `rake assets:precompile` task.
-
-2. Start Rails:
-
-        bundle exec rails server
+        foreman start -f Procfile.dev
 
 
 [Node.js]:http://nodejs.org/


### PR DESCRIPTION
Since introducing Webpack (commit 66f796c0), there is an additional process required to watch and rebuild Angular app assets.

A separate development `Procfile` is one solution to make things work better _out-of-the-box_, although not necessarily the solution recommended by the maintainer of foreman (see https://github.com/ddollar/foreman/issues/358#issuecomment-17556894).
