### PR TITLE
Really outdated net-ldap gem fails with Apache DS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,7 +159,7 @@ group :test do
 end
 
 group :ldap do
-  gem "net-ldap", '~> 0.2.2'
+  gem "net-ldap", '~> 0.8.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     multi_test (0.0.2)
     multi_xml (0.5.5)
     mysql2 (0.3.11)
-    net-ldap (0.2.2)
+    net-ldap (0.8.0)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
     non-stupid-digest-assets (1.0.4)
@@ -449,7 +449,7 @@ DEPENDENCIES
   livingstyleguide (~> 1.2.0)
   multi_json
   mysql2 (~> 0.3.11)
-  net-ldap (~> 0.2.2)
+  net-ldap (~> 0.8.0)
   nokogiri (>= 1.5.11)
   non-stupid-digest-assets
   object-daddy (~> 1.1.0)


### PR DESCRIPTION
The really outdated net-ldap gem fails with Apache DS.
See https://community.openproject.org/topics/1013.
