### PR TITLE
Really outdated net-ldap gem fails with Apache DS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,7 +175,7 @@ group :test do
 end
 
 group :ldap do
-  gem "net-ldap", '~> 0.2.2'
+  gem "net-ldap", '~> 0.8.0'
 end
 
 group :openid do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     multi_json (1.10.1)
     multi_test (0.0.2)
     mysql2 (0.3.11)
-    net-ldap (0.2.2)
+    net-ldap (0.8.0)
     nokogiri (1.5.11)
     object-daddy (1.1.1)
     oj (2.1.6)
@@ -405,7 +405,7 @@ DEPENDENCIES
   letter_opener (~> 1.0.0)
   multi_json
   mysql2 (~> 0.3.11)
-  net-ldap (~> 0.2.2)
+  net-ldap (~> 0.8.0)
   nokogiri (>= 1.5.11)
   object-daddy (~> 1.1.0)
   oj


### PR DESCRIPTION
The really outdated net-ldap gem fails with Apache DS.
See https://community.openproject.org/topics/1013.
