### PR TITLE
Enable Protractor directConnect

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ gulp.task('express', function() {
 gulp.task('webdriver:update', webdriverUpdate);
 gulp.task('webdriver:standalone', ['webdriver:update'], webdriverStandalone);
 
-gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express'], function(done) {
+gulp.task('tests:protractor', ['webpack', 'sass', 'express'], function(done) {
   gulp.src('protractor/**/*_spec.js')
     .pipe(protractor({
       configFile: 'protractor/conf.js',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "~1.18.2",
     "mocha-jenkins-reporter": "^0.1.2",
     "phantomjs": "~1.9.2",
-    "protractor": "~1.3.1",
+    "protractor": "^1.4.0",
     "rimraf": "~2.2.5",
     "sinon": "~1.9.1",
     "sinon-chai": "~2.5.0",

--- a/protractor/conf.js
+++ b/protractor/conf.js
@@ -35,6 +35,8 @@ exports.config = {
     'browserName': 'firefox'
   },
 
+  directConnect: true,
+
   specs: ['work-packages-spec.js', 'work-package-details-spec.js'],
 
   allScriptsTimeout: 40000,


### PR DESCRIPTION
This allows Protractor to test against Chrome, Firefox directly, without
the need for a running Selenium Webdriver server. See:
https://github.com/angular/protractor/blob/master/docs/server-setup.md#connecting-directly-to-browser-drivers

_This _may_ obviate an issue where Protractor is not able to connect to the Selenium Webdriver server on some internal CI slaves._
