### PR TITLE
Feature/linked time entries on wp pane

### DIFF
--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -47,34 +47,48 @@ module.exports = function($scope,
 
   $scope.userPath = PathHelper.staticUserPath;
 
-    function getPropertyValue(property, format) {
-      switch(format) {
-      case VERSION_TYPE:
-        if ($scope.workPackage.props.versionId === undefined) {
-            return;
-        }
-        var versionLinkPresent = !!$scope.workPackage.links.version;
-        var versionTitle = versionLinkPresent ?
-                              $scope.workPackage.links.version.props.title :
-                              $scope.workPackage.props.versionName,
-            versionHref  = versionLinkPresent ?
-                              $scope.workPackage.links.version.href :
-                              null;
-        return {href: versionHref, title: versionTitle, viewable: versionLinkPresent};
-      case USER_TYPE:
-        return $scope.workPackage.embedded[property];
-      case CATEGORY_TYPE:
-        return $scope.workPackage.embedded[property];
-      case TIME_ENTRY_TYPE:
-        var spentTime = $scope.workPackage.props.spentTime,
-            timeLinkPresent = !!$scope.workPackage.links.timeEntries,
-            formattedValue = WorkPackagesHelper.formatWorkPackageProperty(spentTime, property),
-            timeHref  = PathHelper.timeEntriesPath(null, $scope.workPackage.props.id);
-        return {href: timeHref, title: formattedValue, viewable: timeLinkPresent};
-      default:
-        return getFormattedPropertyValue(property);
+  function getPropertyValue(property, format) {
+    switch(format) {
+    case VERSION_TYPE:
+      if ($scope.workPackage.props.versionId === undefined) {
+          return;
       }
+      var versionLinkPresent = !!$scope.workPackage.links.version;
+      var versionTitle = versionLinkPresent ?
+                            $scope.workPackage.links.version.props.title :
+                            $scope.workPackage.props.versionName,
+          versionHref  = versionLinkPresent ?
+                            $scope.workPackage.links.version.href :
+                            null;
+      return {href: versionHref, title: versionTitle, viewable: versionLinkPresent};
+    case USER_TYPE:
+      return $scope.workPackage.embedded[property];
+    case CATEGORY_TYPE:
+      return $scope.workPackage.embedded[property];
+    case TIME_ENTRY_TYPE:
+      return getLinkedTimeEntryValue(property);
+    default:
+      return getFormattedPropertyValue(property);
     }
+  }
+
+  function getLinkedTimeEntryValue(property) {
+    var hasLink = !!$scope.workPackage.links.timeEntries,
+        link = '',
+        value = 0;
+
+    if (hasLink) {
+      link = $scope.workPackage.links.timeEntries.href;
+    }
+
+    if (hasLink && $scope.workPackage.props.spentTime !== undefined) {
+      value = $scope.workPackage.props.spentTime;
+    }
+
+    var formattedValue = WorkPackagesHelper.formatWorkPackageProperty(value, property);
+
+    return {href: link, title: formattedValue, viewable: link !== ''};
+  }
 
   function getFormattedPropertyValue(property) {
     if (property === 'date') {

--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -33,6 +33,7 @@ module.exports = function($scope,
            VERSION_TYPE,
            CATEGORY_TYPE,
            USER_TYPE,
+           TIME_ENTRY_TYPE,
            USER_FIELDS,
            CustomFieldHelper,
            WorkPackagesHelper,
@@ -64,6 +65,12 @@ module.exports = function($scope,
             case CATEGORY_TYPE:
                 return $scope.workPackage.embedded[property];
                 break;
+            case TIME_ENTRY_TYPE:
+                var spentTime = $scope.workPackage.props.spentTime,
+                    timeLinkPresent = !!$scope.workPackage.links.timeEntries,
+                    formattedValue = WorkPackagesHelper.formatWorkPackageProperty(spentTime, property),
+                    timeHref  = PathHelper.timeEntriesPath(null, $scope.workPackage.props.id);
+                return {href: timeHref, title: formattedValue, viewable: timeLinkPresent};
             default:
                 return getFormattedPropertyValue(property);
         }
@@ -150,11 +157,16 @@ module.exports = function($scope,
   }
 
   function getPropertyFormat(property) {
-    var format = USER_FIELDS.indexOf(property) === -1 ? TEXT_TYPE : USER_TYPE;
-    format = (property === 'versionName') ? VERSION_TYPE : format;
-    format = (property === 'category') ? CATEGORY_TYPE : format;
-
-    return format;
+    switch(property) {
+    case 'versionName':
+      return VERSION_TYPE;
+    case 'category':
+      return CATEGORY_TYPE;
+    case 'spentTime':
+      return TIME_ENTRY_TYPE;
+    default:
+      return USER_FIELDS.indexOf(property) === -1 ? TEXT_TYPE : USER_TYPE;
+    }
   }
 
   function getCustomPropertyValue(property) {

--- a/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/details-tab-overview-controller.js
@@ -48,32 +48,32 @@ module.exports = function($scope,
   $scope.userPath = PathHelper.staticUserPath;
 
     function getPropertyValue(property, format) {
-        switch(format) {
-            case VERSION_TYPE:
-                if ($scope.workPackage.props.versionId == undefined) {
-                    return;
-                }
-                var versionId = $scope.workPackage.props.versionId,
-                    versionLinkPresent = !!$scope.workPackage.links.version;
-                var versionTitle = versionLinkPresent ? $scope.workPackage.links.version.props.title : $scope.workPackage.props.versionName,
-                    versionHref  = versionLinkPresent ? $scope.workPackage.links.version.href : null;
-                return {href: versionHref, title: versionTitle, viewable: versionLinkPresent};
-                break;
-            case USER_TYPE:
-                return $scope.workPackage.embedded[property];
-                break;
-            case CATEGORY_TYPE:
-                return $scope.workPackage.embedded[property];
-                break;
-            case TIME_ENTRY_TYPE:
-                var spentTime = $scope.workPackage.props.spentTime,
-                    timeLinkPresent = !!$scope.workPackage.links.timeEntries,
-                    formattedValue = WorkPackagesHelper.formatWorkPackageProperty(spentTime, property),
-                    timeHref  = PathHelper.timeEntriesPath(null, $scope.workPackage.props.id);
-                return {href: timeHref, title: formattedValue, viewable: timeLinkPresent};
-            default:
-                return getFormattedPropertyValue(property);
+      switch(format) {
+      case VERSION_TYPE:
+        if ($scope.workPackage.props.versionId === undefined) {
+            return;
         }
+        var versionLinkPresent = !!$scope.workPackage.links.version;
+        var versionTitle = versionLinkPresent ?
+                              $scope.workPackage.links.version.props.title :
+                              $scope.workPackage.props.versionName,
+            versionHref  = versionLinkPresent ?
+                              $scope.workPackage.links.version.href :
+                              null;
+        return {href: versionHref, title: versionTitle, viewable: versionLinkPresent};
+      case USER_TYPE:
+        return $scope.workPackage.embedded[property];
+      case CATEGORY_TYPE:
+        return $scope.workPackage.embedded[property];
+      case TIME_ENTRY_TYPE:
+        var spentTime = $scope.workPackage.props.spentTime,
+            timeLinkPresent = !!$scope.workPackage.links.timeEntries,
+            formattedValue = WorkPackagesHelper.formatWorkPackageProperty(spentTime, property),
+            timeHref  = PathHelper.timeEntriesPath(null, $scope.workPackage.props.id);
+        return {href: timeHref, title: formattedValue, viewable: timeLinkPresent};
+      default:
+        return getFormattedPropertyValue(property);
+      }
     }
 
   function getFormattedPropertyValue(property) {

--- a/app/assets/javascripts/angular/work_packages/controllers/index.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/index.js
@@ -45,6 +45,7 @@ angular.module('openproject.workPackages.controllers')
     'USER_FIELDS',
     'CustomFieldHelper',
     'WorkPackagesHelper',
+    'AuthorisationService',
     'PathHelper',
     'UserService',
     'VersionService',

--- a/app/assets/javascripts/angular/work_packages/controllers/index.js
+++ b/app/assets/javascripts/angular/work_packages/controllers/index.js
@@ -31,6 +31,7 @@ angular.module('openproject.workPackages.controllers')
   .constant('VERSION_TYPE', 'version')
   .constant('CATEGORY_TYPE', 'category')
   .constant('USER_TYPE', 'user')
+  .constant('TIME_ENTRY_TYPE', 'time_entry')
   .constant('USER_FIELDS', ['assignee', 'author', 'responsible'])
   .controller('DetailsTabOverviewController', [
     '$scope',
@@ -40,6 +41,7 @@ angular.module('openproject.workPackages.controllers')
     'VERSION_TYPE',
     'CATEGORY_TYPE',
     'USER_TYPE',
+    'TIME_ENTRY_TYPE',
     'USER_FIELDS',
     'CustomFieldHelper',
     'WorkPackagesHelper',

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -1093,8 +1093,6 @@ class WorkPackage < ActiveRecord::Base
   end
 
   def compute_spent_hours(usr = User.current)
-    return 0.0 unless usr.allowed_to?(:view_time_entries, project)
-
     spent_time = TimeEntry.visible(usr)
       .on_work_packages(self_and_descendants.visible(usr))
       .sum(:hours)

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1601,31 +1601,32 @@ The request body is the actual string that shall be rendered as HTML string.
 
 ## Linked Properties:
 
-| Link         | Description                                             | Type        | Constraints | Supported operations |
-|:------------:|---------------------------------------------------------| ----------- | ----------- | -------------------- |
-| self         | This work package                                       | WorkPackage | not null    | READ                 |
-| author       | The person that created the work package                | User        | not null    | READ                 |
-| assignee     | The person that is intended to work on the work package | User        |             | READ / WRITE         |
-| priority     | The priority of the work package                        | Priority    | not null    | READ / WRITE         |
-| responsible  | The person that is responsible for the overall outcome  | User        |             | READ / WRITE         |
-| status       | The current status of the work package                  | Status      | not null    | READ / WRITE         |
+| Link         | Description                                             | Type        | Constraints | Supported operations | Condition                        |
+|:------------:|---------------------------------------------------------| ----------- | ----------- | -------------------- | -------------------------------- |
+| self         | This work package                                       | WorkPackage | not null    | READ                 |                                  |
+| author       | The person that created the work package                | User        | not null    | READ                 |                                  |
+| assignee     | The person that is intended to work on the work package | User        |             | READ / WRITE         |                                  |
+| priority     | The priority of the work package                        | Priority    | not null    | READ / WRITE         |                                  |
+| responsible  | The person that is responsible for the overall outcome  | User        |             | READ / WRITE         |                                  |
+| status       | The current status of the work package                  | Status      | not null    | READ / WRITE         |                                  |
+| timeEntries  | All time entries logged on the work package. Please note that this is a link to an HTML resource for now and as such, the link is subject to change. | N/A        |             | READ          | **Permission** view time entries |
 
 ## Properties:
-| Property | Description | Type | Constraints | Example | Supported operations |
-|:---------:|-------------| ---- | ----------- | ------- | -------------------- |
-| id | Work package id | Integer | Must be a positive integer | 12 | READ |
-| lockVersion | The version of the item as used for optimistic locking | Integer | | 12 | READ |
-| subject | Work package subject | String | not null; 1 <= length <= 255 | Refactor projecs module | READ / WRITE |
-| type | | String | **REQUIRED** Must be one of the types enabled for the current work package's project | Feature | READ |
-| description | The work package description | Formatable | | | READ / WRITE |
-| parentId | Parent work package id | Integer | Must be an id of an existing and visible (in respect to the API user) work package | 42 | READ / WRITE |
-| startDate | | Date | Must be a date in format YYYY-MM-DD and must be equal or greater than the soonest possible start date | 2014-05-21T08:51:20Z | READ |
-| dueDate | | Date | Must be a date in format YYYY-MM-DD and must be greater then start date | | READ |
-| estimatedTime | | Object | ISO 8601 duration | P1DT18H  | READ |
-| spentTime | | Object | ISO 8601 duration | PT1H | READ |
-| percentageDone | | Integer | Must be an integer between 0 and 100 | 50 | READ |
-| createdAt | | Timestamp | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ | | READ |
-| updatedAt | | Timestamp | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ | | READ |
+| Property       | Description                                            | Type       | Constraints                                                                                           | Example                 | Supported operations | Condition                        |
+| :---------:    | -------------                                          | ----       | -----------                                                                                           | -------                 | -------------------- | --------------------             |
+| id             | Work package id                                        | Integer    | Must be a positive integer                                                                            | 12                      | READ                 |                                  |
+| lockVersion    | The version of the item as used for optimistic locking | Integer    |                                                                                                       | 12                      | READ                 |                                  |
+| subject        | Work package subject                                   | String     | not null; 1 <= length <= 255                                                                          | Refactor projecs module | READ / WRITE         |                                  |
+| type           |                                                        | String     | **REQUIRED** Must be one of the types enabled for the current work package's project                  | Feature                 | READ                 |                                  |
+| description    | The work package description                           | Formatable |                                                                                                       |                         | READ / WRITE         |                                  |
+| parentId       | Parent work package id                                 | Integer    | Must be an id of an existing and visible (in respect to the API user) work package                    | 42                      | READ / WRITE         |                                  |
+| startDate      |                                                        | Date       | Must be a date in format YYYY-MM-DD and must be equal or greater than the soonest possible start date | 2014-05-21T08:51:20Z    | READ                 |                                  |
+| dueDate        |                                                        | Date       | Must be a date in format YYYY-MM-DD and must be greater then start date                               |                         | READ                 |                                  |
+| estimatedTime  |                                                        | Object     | ISO 8601 duration                                                                                     | P1DT18H                 | READ                 |                                  |
+| spentTime      |                                                        | Object     | ISO 8601 duration                                                                                     | PT1H                    | READ                 | **Permission** view time entries |
+| percentageDone |                                                        | Integer    | Must be an integer between 0 and 100                                                                  | 50                      | READ                 |                                  |
+| createdAt      |                                                        | Timestamp  | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ                                                    |                         | READ                 |                                  |
+| updatedAt      |                                                        | Timestamp  | Returned in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ                                                    |                         | READ                 |                                  |
 
 ## WorkPackage [/api/v3/work_packages/{id}{?notify}]
 
@@ -1730,7 +1731,13 @@ The request body is the actual string that shall be rendered as HTML string.
                             "href": "/api/v3/work_packages/1529",
                             "title": "Write API documentation"
                         }
-                    ]
+                    ],
+                    "timeEntries": {
+                        "href": "/work_packages/1528/time_entries",
+                        "type": "text/html",
+                        "title": "Time entries"
+
+                    }
                 },
                 "id": 1528,
                 "subject": "Develop API",

--- a/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -245,7 +245,7 @@ describe('DetailsTabOverviewController', function() {
     });
 
     describe('durations', function() {
-      var shouldBehaveLikeValidHourDescription = function(property, hours) {
+      var prepareHourDescription = function(property) {
         beforeEach(function() {
           sinon.stub(I18n, 't', function(locale, parameter) {
             if (locale == 'js.work_packages.properties.' + property) {
@@ -261,11 +261,36 @@ describe('DetailsTabOverviewController', function() {
         afterEach(function() {
           I18n.t.restore();
         });
+      };
+      var shouldBehaveLikeValidHourDescription = function(property, hours) {
+        workPackage.links = {
+          spentTime: {
+            href: '/time_entries'
+          }
+        };
+
+        prepareHourDescription(property);
 
         it('should show hours', function() {
           var description = fetchPresentPropertiesWithName(property)[0].value;
 
           expect(description).to.equal(hours);
+        });
+      };
+
+      var shouldBehaveLikeValidLinkedHourDescription = function(property, hours, link) {
+        prepareHourDescription(property);
+
+        it('should show hours', function() {
+          var description = fetchPresentPropertiesWithName(property)[0].value.title;
+
+          expect(description).to.equal(hours);
+        });
+
+        it('should have a link', function() {
+          var href = fetchPresentPropertiesWithName(property)[0].value.href;
+
+          expect(href).to.equal(link);
         });
       };
 
@@ -285,7 +310,7 @@ describe('DetailsTabOverviewController', function() {
 
       describe('spent time', function() {
         context('default value', function() {
-          shouldBehaveLikeValidHourDescription('spentTime', 0);
+          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '/time_entries');
         });
 
         context('time set', function() {
@@ -293,7 +318,7 @@ describe('DetailsTabOverviewController', function() {
             workPackage.props.spentTime = 'P2DT4H';
           });
 
-          shouldBehaveLikeValidHourDescription('estimatedTime', 52);
+          shouldBehaveLikeValidLinkedHourDescription('spentTime', 52, '/time_entries');
         });
       });
     });

--- a/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -174,6 +174,47 @@ describe('DetailsTabOverviewController', function() {
       });
     });
 
+    describe ('unallowed property', function() {
+      beforeEach(function() {
+        buildController();
+      });
+
+      it('removes spentTime if link not present', function() {
+        var group = _.find(scope.groupedAttributes, function(group) {
+          return group.groupName === 'estimatesAndTime';
+        });
+
+        expect(group['spentTime']).to.equal(undefined);
+      });
+    });
+
+    describe ('allowed property', function() {
+      beforeEach(function() {
+        workPackage.links = {
+          timeEntries: {
+            href: 'bogus'
+          }
+        };
+        buildController();
+      });
+
+      // This here is bad. For whatever reasons, we are altering
+      // the workPackage variable with each test
+      // generating dependencies between our tests.
+      afterEach(function() {
+        workPackage.links = {
+        };
+      });
+
+      it('has spentTime if link is present', function() {
+        var group = _.find(scope.groupedAttributes, function(group) {
+          return group.groupName === 'estimatesAndTime';
+        });
+
+        expect(group['spentTime']).to.equal(undefined);
+      });
+    });
+
     describe('when the property has NO value', function() {
       beforeEach(function() {
         buildController();
@@ -293,6 +334,16 @@ describe('DetailsTabOverviewController', function() {
         });
       };
 
+      var shouldBehaveLikeItNotExists = function(property) {
+        prepareHourDescription(property);
+
+        it('should should not exist', function() {
+          var property = fetchPresentPropertiesWithName(property);
+
+          expect(property.length).to.equal(0);
+        });
+      };
+
       describe('estimated time', function() {
         context('default value', function() {
           shouldBehaveLikeValidHourDescription('estimatedTime', 0);
@@ -347,11 +398,12 @@ describe('DetailsTabOverviewController', function() {
 
       context('without a link to timeEntries', function() {
         context('default value', function() {
+
           beforeEach(function() {
             workPackage.props.spentTime = undefined;
           });
 
-          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '');
+          shouldBehaveLikeItNotExists('spentTime');
         });
 
         context('time set', function() {
@@ -359,7 +411,7 @@ describe('DetailsTabOverviewController', function() {
             workPackage.props.spentTime = 'P2DT4H';
           });
 
-          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '');
+          shouldBehaveLikeItNotExists('spentTime');
         });
       });
     });

--- a/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/karma/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -54,6 +54,7 @@ describe('DetailsTabOverviewController', function() {
           percentageDone: 0,
           estimatedTime: 'PT0S',
           spentTime: 'PT0S',
+          id: '0815',
           customProperties: [
             { format: 'text', name: 'color', value: 'red' },
             { format: 'text', name: 'Width', value: '' },
@@ -64,6 +65,8 @@ describe('DetailsTabOverviewController', function() {
           activities: [],
           watchers: [],
           attachments: []
+        },
+        links: {
         },
       };
   var $q;
@@ -94,7 +97,7 @@ describe('DetailsTabOverviewController', function() {
 
     buildController = function() {
       scope = $rootScope.$new();
-      scope.workPackage = workPackage;
+      scope.workPackage = angular.copy(workPackage);
 
       ctrl = $controller("DetailsTabOverviewController", {
         $scope:  scope,
@@ -262,12 +265,8 @@ describe('DetailsTabOverviewController', function() {
           I18n.t.restore();
         });
       };
+
       var shouldBehaveLikeValidHourDescription = function(property, hours) {
-        workPackage.links = {
-          spentTime: {
-            href: '/time_entries'
-          }
-        };
 
         prepareHourDescription(property);
 
@@ -309,8 +308,50 @@ describe('DetailsTabOverviewController', function() {
       });
 
       describe('spent time', function() {
+        context('with a link to timeEntries', function() {
+          var spentTimeLink = '/work_packages/' + workPackage.props.id + '/time_entries';
+
+          beforeEach(function() {
+            workPackage.links = {
+              timeEntries: {
+                href: spentTimeLink
+              }
+            };
+          });
+
+          // This here is bad. For whatever reasons, we are altering
+          // the workPackage variable with each test
+          // generating dependencies between our tests.
+          afterEach(function() {
+            workPackage.links = {
+            };
+          });
+
+          context('default value', function() {
+            beforeEach(function() {
+              workPackage.props.spentTime = undefined;
+            });
+
+            shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, spentTimeLink);
+          });
+
+          context('time set', function() {
+            beforeEach(function() {
+              workPackage.props.spentTime = 'P2DT4H';
+            });
+
+            shouldBehaveLikeValidLinkedHourDescription('spentTime', 52, spentTimeLink);
+          });
+        });
+      });
+
+      context('without a link to timeEntries', function() {
         context('default value', function() {
-          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '/time_entries');
+          beforeEach(function() {
+            workPackage.props.spentTime = undefined;
+          });
+
+          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '');
         });
 
         context('time set', function() {
@@ -318,7 +359,7 @@ describe('DetailsTabOverviewController', function() {
             workPackage.props.spentTime = 'P2DT4H';
           });
 
-          shouldBehaveLikeValidLinkedHourDescription('spentTime', 52, '/time_entries');
+          shouldBehaveLikeValidLinkedHourDescription('spentTime', 0, '');
         });
       });
     });

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -209,6 +209,14 @@ module API
           } unless represented.parent.nil? || !represented.parent.visible?
         end
 
+        link :timeEntries do
+          {
+            href: work_package_time_entries_path(represented.id),
+            type: 'text/html',
+            title: 'Time entries'
+          } if current_user_allowed_to(:view_time_entries)
+        end
+
         link :version do
           {
             href: version_path(represented.fixed_version),

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -250,8 +250,10 @@ module API
                  render_nil: true,
                  writeable: false
         property :spent_time,
-                 getter: -> (*) { Duration.new(hours: spent_hours).iso8601 },
-                 writeable: false
+                 getter: -> (*) { Duration.new(hours: represented.spent_hours).iso8601 },
+                 writeable: false,
+                 exec_context: :decorator,
+                 if: -> (_) { current_user_allowed_to(:view_time_entries) }
         property :percentage_done,
                  render_nil: true,
                  exec_context: :decorator,

--- a/public/templates/work_packages/tabs/overview.html
+++ b/public/templates/work_packages/tabs/overview.html
@@ -41,6 +41,10 @@
               <a ng-if="propertyData.value.viewable" title="{{propertyData.value.title}}" ng-href="{{propertyData.value.href}}">{{propertyData.value.title}}</a>
               <span ng-if="!propertyData.value.viewable" title="{{propertyData.value.title}}">{{propertyData.value.title}}</span>
             </span>
+            <span ng-switch-when="time_entry">
+              <a ng-if="propertyData.value.viewable" title="{{propertyData.value.title}}" ng-href="{{propertyData.value.href}}">{{propertyData.value.title}}</a>
+              <span ng-if="!propertyData.value.viewable" title="{{propertyData.value.title}}">{{propertyData.value.title}}</span>
+            </span>
             <span ng-switch-when="category">{{ propertyData.value.props.name }}</span>
             <span ng-switch-default
               ng-bind="(propertyData.value !== undefined) ? propertyData.value : '-'"

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -121,9 +121,25 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
                              member_in_project: wp.project,
                              member_through_role: role)
         }
-        let(:representer)  { described_class.new(wp, current_user: current_user) }
+        let(:representer)  { described_class.new(wp, current_user: user) }
 
-        before { allow(User).to receive(:current).and_return(user) }
+        before do
+          allow(User).to receive(:current).and_return(user)
+
+          allow(user).to receive(:allowed_to?).and_return(false)
+          allow(user).to receive(:allowed_to?).with(:view_time_entries, anything)
+                                              .and_return(true)
+        end
+
+        context 'no view_time_entries permission' do
+          before do
+            allow(user).to receive(:allowed_to?).with(:view_time_entries, anything)
+                                                .and_return(false)
+
+          end
+
+          it { is_expected.to_not have_json_path('spentTime') }
+        end
 
         context 'no time entry' do
           it { is_expected.to be_json_eql('PT0S'.to_json).at_path('spentTime') }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -330,6 +330,24 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
       end
 
+      context 'when the user has the permission to view time entries' do
+        before do
+          role.permissions.push(:view_time_entries) and role.save
+        end
+        it 'should have a link to add child' do
+          expect(subject).to have_json_path('_links/timeEntries/href')
+        end
+      end
+
+      context 'when the user does not have the permission to view time entries' do
+        before do
+          role.permissions.delete(:view_time_entries) and role.save
+        end
+        it 'should not have a link to timeEntries' do
+          expect(subject).to_not have_json_path('_links/timeEntries/href')
+        end
+      end
+
       describe 'linked relations' do
         let(:project) { FactoryGirl.create(:project, is_public: false) }
         let(:forbidden_project) { FactoryGirl.create(:project, is_public: false) }


### PR DESCRIPTION
Before, the link only existed when the costs plugin was loaded. Now, there is always a link (if the user has the permission).

I had to remove an additional allowed_to statement to get costs working with https://github.com/finnlabs/openproject-costs/pull/114. That statement was redundant anyway.
