### PR TITLE
17485 Relation auto-completion broken with relative URL

### DIFF
--- a/app/assets/javascripts/angular/helpers/path-helper.js
+++ b/app/assets/javascripts/angular/helpers/path-helper.js
@@ -278,6 +278,10 @@ angular.module('openproject.helpers')
     staticWorkPackagesPath: function() {
       return PathHelper.staticBase + PathHelper.workPackagesPath();
     },
+    staticWorkPackageAutoCompletePath: function(projectId, workPackageId) {
+      return PathHelper.staticBase
+        + PathHelper.workPackageAutoCompletePath(projectId, workPackageId);
+    },
   };
 
   return PathHelper;

--- a/app/assets/javascripts/angular/work_packages/view_models/relations-handler.js
+++ b/app/assets/javascripts/angular/work_packages/view_models/relations-handler.js
@@ -34,8 +34,13 @@ angular.module('openproject.viewModels')
     '$timeout',
     'WorkPackageService',
     'ApiHelper',
+    'PathHelper',
     'MAX_AUTOCOMPLETER_ADDITION_ITERATIONS',
-    function($timeout, WorkPackageService, ApiHelper, MAX_AUTOCOMPLETER_ADDITION_ITERATIONS) {
+    function($timeout,
+             WorkPackageService,
+             ApiHelper,
+             PathHelper,
+             MAX_AUTOCOMPLETER_ADDITION_ITERATIONS) {
   function CommonRelationsHandler(workPackage,
                                   relations,
                                   relationsId) {
@@ -97,9 +102,12 @@ angular.module('openproject.viewModels')
     },
 
     addAutocompleter: function(retries, workPackage, relationsId) {
+      var projectId = workPackage.props.projectId;
+      var workPackageId = workPackage.props.id;
+
       if (angular.element('#relation_to_id-' + relationsId).size() === 1) {
         // Massive hack alert - Using old prototype autocomplete ///////////
-        var url = PathHelper.workPackageAutoCompletePath(workPackage.props.projectId, workPackage.props.id);
+        var url = PathHelper.staticWorkPackageAutoCompletePath(projectId, workPackageId);
         new Ajax.Autocompleter('relation_to_id-' + relationsId,
                                'related_issue_candidates-' + relationsId,
                                url,


### PR DESCRIPTION
[`* `#17485` Relation auto-completion broken with relative URL`](https://community.openproject.org/work_packages/17485)
