### PR TITLE
Fix/work package index performance

### DIFF
--- a/app/controllers/api/experimental/concerns/column_data.rb
+++ b/app/controllers/api/experimental/concerns/column_data.rb
@@ -34,7 +34,7 @@ module Api::Experimental::Concerns::ColumnData
         sortable: column.sortable,
         groupable: column.groupable,
         custom_field: column.is_a?(QueryCustomFieldColumn) &&
-                      column.custom_field.as_json(only: [:id, :field_format]),
+          column.custom_field.as_json(only: [:id, :field_format]),
         meta_data: get_column_meta(column)
       }
     end
@@ -43,39 +43,172 @@ module Api::Experimental::Concerns::ColumnData
   private
 
   def get_column_meta(column)
-    # This is where we want to add column specific behaviour to instruct the front end how to deal with it
-    # Needs to be things like user link,project link, datetime
+    # This is where we want to add column specific behaviour to instruct the
+    # front end how to deal with it. Needs to be things like user link, project
+    # link, datetime
     {
       data_type: column_data_type(column),
-      link: !!(link_meta()[column.name]) ? link_meta()[column.name] : { display: false }
+      link: link_meta[column.name] || { display: false }
     }
   end
 
   def link_meta
     {
-      subject: { display: true, model_type: "work_package" },
+      subject: { display: true, model_type: 'work_package' },
       type: { display: false },
       status: { display: false },
       priority: { display: false },
-      parent: { display: true, model_type: "work_package" },
-      assigned_to: { display: true, model_type: "user" },
-      responsible: { display: true, model_type: "user" },
-      author: { display: true, model_type: "user" },
-      project: { display: true, model_type: "project" }
+      parent: { display: true, model_type: 'work_package' },
+      assigned_to: { display: true, model_type: 'user' },
+      responsible: { display: true, model_type: 'user' },
+      author: { display: true, model_type: 'user' },
+      project: { display: true, model_type: 'project' }
     }
   end
 
   def column_data_type(column)
     if column.is_a?(QueryCustomFieldColumn)
-      return column.custom_field.field_format
+      column.custom_field.field_format
     elsif column.class.to_s =~ /CurrencyQueryColumn/
-      return 'currency'
-    elsif (c = WorkPackage.columns_hash[column.name.to_s] and !c.nil?)
-      return c.type.to_s
-    elsif (c = WorkPackage.columns_hash[column.name.to_s + "_id"] and !c.nil?)
-      return "object"
+      'currency'
+    elsif c = WorkPackage.columns_hash[column.name.to_s]
+      c.type.to_s
+    elsif WorkPackage.columns_hash[column.name.to_s + '_id']
+      'object'
     else
-      return "default"
+      'default'
+    end
+  end
+
+  def separate_columns_by_custom_fields(columns)
+    cf_columns, non_cf_columns = columns.partition { |name| custom_field_id_in(name) }
+
+    cf_columns_id = cf_columns.map { |name| custom_field_id_in(name) }
+
+    [non_cf_columns, cf_columns_id]
+  end
+
+  def columns_total_sums(column_names, work_packages)
+    column_names.map do |column_name|
+      column_sum(column_name, work_packages)
+    end
+  end
+
+  def column_sum(column_name, work_packages)
+    if column_should_be_summed_up?(column_name)
+      column_data = fetch_column_data(column_name, work_packages, false)
+
+      column_data.map { |c| c.nil? ? 0 : c }
+        .compact
+        .sum
+    end
+  end
+
+  def columns_group_sums(column_names, work_packages, group_by)
+    # NOTE RS: This is basically the grouped_sums method from sums.rb but we
+    # have no query to play with here
+    return unless group_by
+    column_names.map do |column_name|
+      work_packages.map { |wp| wp.send(group_by) }
+        .uniq
+        .inject({}) do |group_sums, current_group|
+          work_packages_in_current_group = work_packages.select do |wp|
+            wp.send(group_by) == current_group
+          end
+
+          group_sums.merge current_group => column_sum(column_name, work_packages_in_current_group)
+        end
+    end
+  end
+
+  def includes_for_columns(column_names)
+    column_names = Array(column_names)
+    includes = (WorkPackage.reflections.keys & column_names)
+
+    if column_names.any? { |c| custom_field_id_in(c) }
+      includes << { custom_values: :custom_field }
+    end
+
+    includes
+  end
+
+  def fetch_columns_data(column_names, work_packages)
+    column_names, custom_field_column_ids = separate_columns_by_custom_fields(column_names)
+
+    columns = column_names.map do |column_name|
+      fetch_non_custom_field_column_data(column_name, work_packages)
+    end
+
+    columns += custom_field_column_ids.map do |cf_id|
+      fetch_custom_field_column_data(cf_id, work_packages)
+    end
+
+    columns
+  end
+
+  def fetch_column_data(column_name, work_packages, display = true)
+    if custom_field_id = custom_field_id_in(column_name)
+      fetch_custom_field_column_data(custom_field_id, work_packages, display)
+    else
+      fetch_non_custom_field_column_data(column_name, work_packages)
+    end
+  end
+
+  def fetch_custom_field_column_data(custom_field_id, work_packages, display = true)
+    custom_field_data = work_packages.map do |wp|
+      wp.custom_values_display_data(custom_field_id)
+    end
+
+    if display
+      custom_field_data.flatten
+    else
+      custom_field_data.flatten.map { |d| d.nil? ? nil : d[:value] }
+    end
+  end
+
+  def fetch_non_custom_field_column_data(column_name, work_packages)
+    work_packages.map do |work_package|
+      # Note: Doing as_json here because if we just take the
+      # value.attributes then we can't get any methods later.  Name and
+      # subject are the default properties that the front end currently
+      # looks for to summarize an object.
+      value = work_package.send(column_name)
+
+      if value.is_a?(ActiveRecord::Base)
+        value.as_json(only: 'id', methods: [:name, :subject])
+      else
+        value
+      end
+    end
+  end
+
+  def column_should_be_summed_up?(column_name)
+    # see ::Query::Sums mix in
+    column_is_numeric?(column_name) &&
+      Setting.work_package_list_summable_columns.include?(column_name.to_s)
+  end
+
+  def column_is_numeric?(column_name)
+    # TODO RS: We want to leave out ids even though they are numeric
+    [:int, :integer, :float].include? column_type(column_name)
+  end
+
+  def custom_field_id_in(name)
+    groups = name.to_s.scan(/cf_(\d+)/).flatten
+
+    if groups
+      groups[0]
+    else
+      nil
+    end
+  end
+
+  def column_type(column_name)
+    if id = custom_field_id_in(column_name)
+      CustomField.find(id).field_format.to_sym
+    else
+      column = WorkPackage.columns_hash[column_name]
+      column.nil? ? :none : column.type
     end
   end
 end

--- a/app/controllers/api/experimental/concerns/column_data.rb
+++ b/app/controllers/api/experimental/concerns/column_data.rb
@@ -80,6 +80,17 @@ module Api::Experimental::Concerns::ColumnData
     end
   end
 
+  def valid_columns(columns)
+    column_names, custom_field_column_ids = separate_columns_by_custom_fields(columns)
+
+    # This here should be restricted more to only allow AR methods on Work
+    # Package and associated objects.
+    valid_column_names = Query.available_columns.map { |c| c.name.to_s } & column_names
+
+    # keep order of provided columns
+    columns & (valid_column_names + custom_field_column_ids)
+  end
+
   def separate_columns_by_custom_fields(columns)
     cf_columns, non_cf_columns = columns.partition { |name| custom_field_id_in(name) }
 

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -73,7 +73,9 @@ module Api
 
         column_names = params[:column_names]
         ids = params[:ids].map(&:to_i)
-        work_packages = Array.wrap(WorkPackage.visible.find(*ids)).sort {|a,b| ids.index(a.id) <=> ids.index(b.id)}
+        scope = WorkPackage.visible.includes(:custom_values)
+
+        work_packages = Array.wrap(scope.find(*ids)).sort { |a, b| ids.index(a.id) <=> ids.index(b.id) }
 
         @columns_data = fetch_columns_data(column_names, work_packages)
         @columns_meta = {
@@ -128,7 +130,12 @@ module Api
         sort_init(@query.sort_criteria.empty? ? [DEFAULT_SORT_ORDER] : @query.sort_criteria)
         sort_update(@query.sortable_columns)
 
-        results = @query.results include: [:assigned_to, :type, :priority, :category, :fixed_version],
+        results = @query.results include: [:assigned_to,
+                                           :type,
+                                           :priority,
+                                           :category,
+                                           :fixed_version,
+                                           { custom_values: :custom_field }],
                                  order: sort_clause
 
         work_packages = results.work_packages
@@ -143,7 +150,12 @@ module Api
 
       def all_query_work_packages
         # Note: Do not apply pagination. Used to obtain total query meta data.
-        results = @query.results include: [:assigned_to, :type, :priority, :category, :fixed_version]
+        results = @query.results include: [:assigned_to,
+                                           :type,
+                                           :priority,
+                                           :category,
+                                           :fixed_version,
+                                           { custom_values: :custom_field }]
         work_packages = results.work_packages.all
       end
 

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -75,7 +75,7 @@ module Api
         column_names = params[:column_names]
         scope = WorkPackage.visible.includes(includes_for_columns(column_names))
 
-        work_packages = Array.wrap(scope.find(*ids)).sort { |a, b| ids.index(a.id) <=> ids.index(b.id) }
+        work_packages = Array.wrap(scope.find(*ids)).sort_by { |wp| ids.index wp.id }
 
         work_packages = ::API::Experimental::WorkPackageDecorator.decorate(work_packages)
         @columns_data = fetch_columns_data(column_names, work_packages)

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -63,7 +63,9 @@ module Api
         setup_context_menu_actions
 
         respond_to do |format|
-          format.api
+          format.api {
+            @work_packages = ::API::Experimental::WorkPackageDecorator.decorate(@work_packages)
+          }
         end
       end
 

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -64,11 +64,7 @@ module Api
 
         setup_context_menu_actions
 
-        respond_to do |format|
-          format.api {
-            @work_packages = ::API::Experimental::WorkPackageDecorator.decorate(@work_packages)
-          }
-        end
+        @work_packages = ::API::Experimental::WorkPackageDecorator.decorate(@work_packages)
       end
 
       def column_data

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -62,11 +62,10 @@ module Api
       end
 
       def column_data
+        column_names = valid_columns(params[:column_names] || [])
+        raise 'API Error: No column names' if column_names.empty?
         raise 'API Error: No IDs' unless params[:ids]
-        raise 'API Error: No column names' unless params[:column_names]
-
         ids = params[:ids].map(&:to_i)
-        column_names = params[:column_names]
 
         work_packages = work_packages_of_ids(ids, column_names)
         work_packages = ::API::Experimental::WorkPackageDecorator.decorate(work_packages)
@@ -79,9 +78,9 @@ module Api
       end
 
       def column_sums
-        raise 'API Error' unless params[:column_names]
+        column_names = valid_columns(params[:column_names] || [])
+        raise 'API Error' if column_names.empty?
 
-        column_names = params[:column_names]
         work_packages = work_packages_of_query(@query, column_names)
         work_packages = ::API::Experimental::WorkPackageDecorator.decorate(work_packages)
         @column_sums = columns_total_sums(column_names, work_packages)

--- a/app/decorators/api/experimental/work_package_decorator.rb
+++ b/app/decorators/api/experimental/work_package_decorator.rb
@@ -5,10 +5,11 @@ class API::Experimental::WorkPackageDecorator < SimpleDelegator
     end
   end
 
-  def custom_values_display_data(field_names)
-    field_names.map do |field_name|
+  def custom_values_display_data(field_ids)
+    field_ids = Array(field_ids)
+    field_ids.map do |field_id|
       value = custom_values.detect do |cv|
-        cv.custom_field_id == field_name.to_s.gsub('cf_', '').to_i
+        cv.custom_field_id == field_id.to_i
       end
 
       get_cast_custom_value_with_meta(value)

--- a/app/decorators/api/experimental/work_package_decorator.rb
+++ b/app/decorators/api/experimental/work_package_decorator.rb
@@ -1,0 +1,36 @@
+class API::Experimental::WorkPackageDecorator < SimpleDelegator
+  def self.decorate(collection)
+    collection.map do |wp|
+      new(wp)
+    end
+  end
+
+  def custom_values_display_data(field_names)
+    field_names.map do |field_name|
+      value = custom_values.detect do |cv|
+        cv.custom_field_id == field_name.to_s.gsub('cf_', '').to_i
+      end
+
+      get_cast_custom_value_with_meta(value)
+    end
+  end
+
+  private
+
+  def get_cast_custom_value_with_meta(custom_value)
+    return unless custom_value
+
+    custom_field = custom_value.custom_field
+    value = if custom_field.field_format == 'user'
+              custom_field.cast_value(custom_value.value).as_json(methods: :name)
+            else
+              custom_field.cast_value(custom_value.value)
+            end
+
+    {
+      custom_field_id: custom_field.id,
+      field_format: custom_field.field_format, # TODO just return the cast value
+      value: value
+    }
+  end
+end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -710,31 +710,6 @@ class WorkPackage < ActiveRecord::Base
     return allowed
   end
 
-
-  def get_cast_custom_value_with_meta(custom_value, custom_field=nil)
-    return unless custom_value
-
-    custom_field ||= custom_value.custom_field
-    {
-      custom_field_id: custom_field.id,
-      field_format: custom_field.field_format, # TODO just return the cast value
-      value: custom_field.field_format == 'user' ? custom_field.cast_value(custom_value.value).as_json(methods: :name) : custom_field.cast_value(custom_value.value)
-    }
-  end
-
-  # Begin Custom Value Display Helper Methods
-  # TODO RS: This probably isn't the right place for display helpers. It's convenient though to have
-  #          the method on the model so that it can be used in the rabl template.
-  def get_custom_value_display_data(custom_field)
-    custom_value_display(custom_values.find_by_custom_field_id(custom_field.id))
-  end
-
-  def custom_values_display_data(field_names)
-    field_names.map do |field_name|
-      get_cast_custom_value_with_meta(custom_values.find_by_custom_field_id(field_name.to_s.gsub('cf_','')))
-    end
-  end
-
   protected
 
   def recalculate_attributes_for(work_package_id)

--- a/app/views/api/experimental/work_packages/index.api.rabl
+++ b/app/views/api/experimental/work_packages/index.api.rabl
@@ -53,7 +53,7 @@ child @work_packages => :work_packages do
   end
 
   node(:custom_values) do |wp|
-    wp.custom_values_display_data @custom_field_column_names
+    wp.custom_values_display_data @custom_field_column_ids
   end
 
   # add parent id by default to make hierarchies transparent

--- a/spec/controllers/api/experimental/work_packages_controller_spec.rb
+++ b/spec/controllers/api/experimental/work_packages_controller_spec.rb
@@ -229,7 +229,7 @@ describe Api::Experimental::WorkPackagesController, :type => :controller do
         allow(Setting).to receive(:work_package_list_summable_columns).and_return(
           %w(estimated_hours done_ratio)
         )
-        WorkPackage.stub_chain(:visible, :find) {
+        WorkPackage.stub_chain(:visible, :includes, :find) {
           FactoryGirl.create_list(:work_package, 2, estimated_hours: 5, done_ratio: 33)
         }
       end

--- a/spec/controllers/api/experimental/work_packages_controller_spec.rb
+++ b/spec/controllers/api/experimental/work_packages_controller_spec.rb
@@ -235,7 +235,7 @@ describe Api::Experimental::WorkPackagesController, :type => :controller do
       end
 
       it 'handles incorrect column names' do
-        expect { get :column_data, format: 'json', ids: [1, 2], column_names: %w(non_existent status) }.to raise_error(/API Error/)
+        expect { get :column_data, format: 'json', ids: [1, 2], column_names: %w(non_existent) }.to raise_error(/API Error/)
       end
 
       it 'assigns column data' do

--- a/spec/decorators/api/experimental/work_package_decorator_spec.rb
+++ b/spec/decorators/api/experimental/work_package_decorator_spec.rb
@@ -1,0 +1,91 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require File.expand_path('../../../../spec_helper', __FILE__)
+
+describe API::Experimental::WorkPackageDecorator, type: :model do
+  let(:wp1) { FactoryGirl.build_stubbed(:work_package) }
+  let(:wp2) { FactoryGirl.build_stubbed(:work_package) }
+  let(:dwp1) { described_class.new(wp1) }
+  let(:custom_field) { FactoryGirl.build_stubbed(:text_issue_custom_field) }
+  let(:custom_value) do
+    FactoryGirl.build_stubbed(:custom_value,
+                              custom_field: custom_field)
+  end
+
+  describe '#decorate' do
+
+    it 'returns an array' do
+      packages = [wp1, wp2]
+
+      expect(described_class.decorate(packages)).to eql packages
+    end
+
+    it 'adds methods to the object' do
+      decorated = described_class.decorate([wp1]).first
+
+      expect(decorated).to respond_to :custom_values_display_data
+    end
+  end
+
+  describe '#custom_values_display_data' do
+    it 'returns a hash with a subset of information about the custom value' do
+      allow(dwp1).to receive(:custom_values).and_return [custom_value]
+
+      returned = dwp1.custom_values_display_data(["cf_#{custom_field.id}"])
+
+      expected = [{
+        custom_field_id: custom_field.id,
+        field_format: custom_field.field_format,
+        value: nil
+      }]
+
+      expect(returned).to eql (expected)
+    end
+
+    it 'returns a hash with a subset of information about the custom value' do
+      field = FactoryGirl.build_stubbed(:user_issue_custom_field)
+      custom_value.custom_field = field
+      user = FactoryGirl.build_stubbed(:user)
+      custom_value.value = user.id.to_s
+      allow(User).to receive(:find_by_id).with(user.id).and_return(user)
+
+      allow(dwp1).to receive(:custom_values).and_return [custom_value]
+
+      returned = dwp1.custom_values_display_data(["cf_#{field.id}"])
+
+      expected = [{
+        custom_field_id: field.id,
+        field_format: field.field_format,
+        value: user.as_json(methods: :name)
+      }]
+
+      expect(returned).to eql (expected)
+    end
+  end
+end

--- a/spec/decorators/api/experimental/work_package_decorator_spec.rb
+++ b/spec/decorators/api/experimental/work_package_decorator_spec.rb
@@ -57,7 +57,7 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
     it 'returns a hash with a subset of information about the custom value' do
       allow(dwp1).to receive(:custom_values).and_return [custom_value]
 
-      returned = dwp1.custom_values_display_data(["cf_#{custom_field.id}"])
+      returned = dwp1.custom_values_display_data(custom_field.id)
 
       expected = [{
         custom_field_id: custom_field.id,
@@ -77,7 +77,7 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
 
       allow(dwp1).to receive(:custom_values).and_return [custom_value]
 
-      returned = dwp1.custom_values_display_data(["cf_#{field.id}"])
+      returned = dwp1.custom_values_display_data(field.id)
 
       expected = [{
         custom_field_id: field.id,

--- a/spec/views/api/experimental/work_packages/index_api_json_spec.rb
+++ b/spec/views/api/experimental/work_packages/index_api_json_spec.rb
@@ -29,6 +29,21 @@
 require File.expand_path('../../../../../spec_helper', __FILE__)
 
 describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
+  let(:work_package) do
+    FactoryGirl.build_stubbed(:work_package,
+                              created_at: DateTime.now,
+                              updated_at: DateTime.now)
+  end
+  let(:work_package2) do
+    FactoryGirl.build_stubbed(:work_package,
+                              created_at: DateTime.now,
+                              updated_at: DateTime.now)
+  end
+  let(:work_package3) do
+    FactoryGirl.build_stubbed(:work_package,
+                              created_at: DateTime.now,
+                              updated_at: DateTime.now)
+  end
 
   def self.stub_can(permissions)
     default_permissions = [:edit, :log_time, :move, :copy, :delete, :duplicate]
@@ -55,7 +70,9 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   before do
     params[:format] = 'json'
 
-    assign(:work_packages, work_packages)
+    packages = ::API::Experimental::WorkPackageDecorator.decorate(Array(work_packages))
+
+    assign(:work_packages, packages)
     assign(:column_names, column_names)
     assign(:custom_field_column_names, custom_field_column_names)
     assign(:can, can)
@@ -77,10 +94,11 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   end
 
   describe 'created/updated at' do
-    let(:wp) { FactoryGirl.build(:work_package,
-                                 created_at: DateTime.now,
-                                 updated_at: (DateTime.now + 1.day)) }
-    let(:work_packages) { [ wp ] }
+    let(:wp) do
+      work_package.updated_at += 1.day
+      work_package
+    end
+    let(:work_packages) { ([wp]) }
     let(:column_names) { [] }
     let(:custom_field_column_names) { [] }
 
@@ -89,17 +107,9 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   end
 
   describe 'with 3 work packages but no columns' do
-    let(:work_packages) { [
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now),
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now),
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now)
-    ] }
+    let(:work_packages) do
+      [work_package, work_package2, work_package3]
+    end
     let(:column_names)       { [] }
     let(:custom_field_column_names) { [] }
 
@@ -110,14 +120,9 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   end
 
   describe 'with 2 work packages and columns' do
-    let(:work_packages) { [
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now),
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now)
-    ] }
+    let(:work_packages) do
+      [work_package, work_package2]
+    end
     let(:column_names)       { %w(subject description due_date) }
     let(:custom_field_column_names) { [] }
 
@@ -131,11 +136,7 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   end
 
   describe 'with project column' do
-    let(:work_packages) { [
-      FactoryGirl.build(:work_package,
-                        created_at: DateTime.now,
-                        updated_at: DateTime.now)
-    ] }
+    let(:work_packages) { work_package }
     let(:column_names) { %w(subject project) }
     let(:custom_field_column_names) { [] }
 
@@ -144,7 +145,7 @@ describe 'api/experimental/work_packages/index.api.rabl', :type => :view do
   end
 
   context 'with actions, links based on permissions' do
-    let(:work_packages) { [FactoryGirl.create(:work_package)] }
+    let(:work_packages) { work_package }
     let(:column_names) { %w(subject project) }
     let(:custom_field_column_names) { [] }
 


### PR DESCRIPTION
Dynamically includes the columns required for the fields in the response to various experimental work packages actions to be eager loaded.

This removes some n+1 queries, those when custom fields are involved in particular. In addition, it also does no longer load data that is not used later on.

https://community.openproject.org/work_packages/17550
- [x] version cf broken on wp index #2276
