### PR TITLE
Support Ruby 2.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@
 
 language: ruby
 rvm:
+  - 2.0
   - 2.1
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@
 
 language: ruby
 rvm:
-  - 2.0
   - 2.1
 sudo: false
 cache: bundler
@@ -49,6 +48,16 @@ env:
   - "TEST_SUITE=cucumber CI=true RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
   - "TEST_SUITE=test     CI=true RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
   - "TEST_SUITE=spec     CI=true RAILS_ENV=test DB=postgres BUNDLE_WITHOUT=rmagick:mysql:mysql2:sqlite:development"
+
+matrix:
+  include:
+    - rvm: 2.0
+      env: "TEST_SUITE=cucumber CI=true RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+    - rvm: 2.0
+      env: "TEST_SUITE=test     CI=true RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+    - rvm: 2.0
+      env: "TEST_SUITE=spec     CI=true RAILS_ENV=test DB=mysql2   BUNDLE_WITHOUT=rmagick:mysql:postgres:sqlite:development"
+
 script: "if [[ $TEST_SUITE == 'karma' ]]; then npm test; else bundle exec rake $TEST_SUITE; fi"
 before_install:
   - "echo `firefox -v`"

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -39,7 +39,7 @@ module API
           end
 
           get do
-            CategoryCollectionRepresenter.new(@categories, project: @project)
+            CategoryCollectionRepresenter.new(@categories, @project)
           end
         end
 

--- a/lib/api/v3/categories/category_collection_representer.rb
+++ b/lib/api/v3/categories/category_collection_representer.rb
@@ -42,7 +42,7 @@ module API
 
         attr_reader :project
 
-        def initialize(model, project:)
+        def initialize(model, project)
           @project = project
           super(model)
         end

--- a/lib/api/v3/versions/version_collection_representer.rb
+++ b/lib/api/v3/versions/version_collection_representer.rb
@@ -42,7 +42,7 @@ module API
 
         attr_reader :project
 
-        def initialize(model, project:)
+        def initialize(model, project)
           @project = project
           super(model)
         end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -39,7 +39,7 @@ module API
           end
 
           get do
-            VersionCollectionRepresenter.new(@versions, project: @project)
+            VersionCollectionRepresenter.new(@versions, @project)
           end
         end
 

--- a/spec/lib/api/v3/categories/category_collection_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_collection_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Categories::CategoryCollectionRepresenter do
   let(:models)     { categories.map { |category|
     ::API::V3::Categories::CategoryModel.new(category)
   } }
-  let(:representer) { described_class.new(models, project: project) }
+  let(:representer) { described_class.new(models, project) }
 
   describe '#initialize' do
     context 'with incorrect parameters' do

--- a/spec/lib/api/v3/versions/version_collection_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_collection_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Versions::VersionCollectionRepresenter do
   let(:models)   { versions.map { |version|
     ::API::V3::Versions::VersionModel.new(version)
   } }
-  let(:representer) { described_class.new(models, project: project) }
+  let(:representer) { described_class.new(models, project) }
 
   describe '#initialize' do
     context 'with incorrect parameters' do


### PR DESCRIPTION
NOTE: this is marked as **Feature** rather than **Hotfix**, as we need a deliberate decision as to what level of support we should offer for 4.0 on Ruby 2.0.

:warning: This will not merge cleanly back into dev – we also probably want to remove support for Ruby 2.0 in 4.1.
