### PR TITLE
Remove required keyword args to support Ruby 2.0.x

### DIFF
--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -39,7 +39,7 @@ module API
           end
 
           get do
-            CategoryCollectionRepresenter.new(@categories, project: @project)
+            CategoryCollectionRepresenter.new(@categories, @project)
           end
         end
 

--- a/lib/api/v3/categories/category_collection_representer.rb
+++ b/lib/api/v3/categories/category_collection_representer.rb
@@ -42,7 +42,7 @@ module API
 
         attr_reader :project
 
-        def initialize(model, project:)
+        def initialize(model, project)
           @project = project
           super(model)
         end

--- a/lib/api/v3/versions/version_collection_representer.rb
+++ b/lib/api/v3/versions/version_collection_representer.rb
@@ -42,7 +42,7 @@ module API
 
         attr_reader :project
 
-        def initialize(model, project:)
+        def initialize(model, project)
           @project = project
           super(model)
         end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -39,7 +39,7 @@ module API
           end
 
           get do
-            VersionCollectionRepresenter.new(@versions, project: @project)
+            VersionCollectionRepresenter.new(@versions, @project)
           end
         end
 

--- a/spec/lib/api/v3/categories/category_collection_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_collection_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Categories::CategoryCollectionRepresenter do
   let(:models)     { categories.map { |category|
     ::API::V3::Categories::CategoryModel.new(category)
   } }
-  let(:representer) { described_class.new(models, project: project) }
+  let(:representer) { described_class.new(models, project) }
 
   describe '#initialize' do
     context 'with incorrect parameters' do

--- a/spec/lib/api/v3/versions/version_collection_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_collection_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Versions::VersionCollectionRepresenter do
   let(:models)   { versions.map { |version|
     ::API::V3::Versions::VersionModel.new(version)
   } }
-  let(:representer) { described_class.new(models, project: project) }
+  let(:representer) { described_class.new(models, project) }
 
   describe '#initialize' do
     context 'with incorrect parameters' do


### PR DESCRIPTION
This is not duplicate of #2267.

Signed-off-by: Alex Coles alex@alexbcoles.com
