### PR TITLE
Fix/version cf in wp list

### DIFF
--- a/app/assets/javascripts/angular/helpers/custom-field-helper.js
+++ b/app/assets/javascripts/angular/helpers/custom-field-helper.js
@@ -43,6 +43,27 @@ angular.module('openproject.helpers')
         return value === '0' ? I18n.t('js.general_text_No') : I18n.t('js.general_text_Yes');
       }
     },
+    userCustomFieldValue: function(value, users) {
+      if (users && users[value] && users[value].name) {
+        // try to look up users, assume value is an id
+        return users[value].name;
+      }
+
+      return CustomFieldHelper.nestedCustomFieldValue(value);
+    },
+    versionCustomFieldValue: function(value) {
+      // I am pretty sure that we need to have the same behavior here as
+      // we have for the user custom fields.
+      // However, there is no code that would be using it so ...
+      return CustomFieldHelper.nestedCustomFieldValue(value);
+    },
+    nestedCustomFieldValue: function(value) {
+      if (value && value.name) {
+        return value.name;
+      }
+
+      return '';
+    },
     parseNumeric: function(value, parseMethod){
       if(value && ((typeof(value) == "string" && value.length > 0) || typeof(value) == "number") && !isNaN(value)){
         return parseMethod(value);
@@ -54,15 +75,9 @@ angular.module('openproject.helpers')
         case 'bool':
           return CustomFieldHelper.booleanCustomFieldValue(value);
         case 'user':
-          // not the nicest piece of code, but to be discarded soon
-          if (users) {
-            // try to look up users, assume value is an id
-            if (users[value]) return users[value].name;
-          } else {
-            // assume value is already a user object
-            if (value) return value.name;
-          }
-          break;
+          return CustomFieldHelper.userCustomFieldValue(value, users);
+        case 'version':
+          return CustomFieldHelper.versionCustomFieldValue(value);
         case 'int':
           return CustomFieldHelper.parseNumeric(value, parseInt);
         case 'float':

--- a/app/assets/javascripts/angular/work_packages/helpers/work-packages-helper.js
+++ b/app/assets/javascripts/angular/work_packages/helpers/work-packages-helper.js
@@ -89,23 +89,43 @@ angular.module('openproject.workPackages.helpers')
     },
 
     getColumnDataId: function(object, column) {
-      var id;
+      var custom_field_id = column.name.match(/^cf_(\d+)$/);
 
+      if (custom_field_id) {
+        custom_field_id = parseInt(custom_field_id[1]);
+
+        return WorkPackagesHelper.getCFColumnDataId(object, custom_field_id);
+      }
+      else {
+        return WorkPackagesHelper.getStaticColumnDataId(object, column);
+      }
+    },
+
+    getCFColumnDataId: function(object, custom_field_id) {
+
+      var custom_value = _.find(object.custom_values, function(elem) {
+        return elem && (elem.custom_field_id === custom_field_id);
+      });
+
+      if(custom_value && custom_value.value) {
+        return custom_value.value.id;
+      }
+      else {
+        return null;
+      }
+    },
+
+    getStaticColumnDataId: function(object, column) {
       switch (column.name) {
         case 'parent':
-          id = object.parent_id;
-          break;
+          return object.parent_id;
         case 'project':
-          id = object.project.identifier;
-          break;
+          return object.project.identifier;
         case 'subject':
-          id = object.id;
-          break;
+          return object.id;
         default:
-          id = (object[column.name]) ? object[column.name].id : null;
+          return (object[column.name]) ? object[column.name].id : null;
       }
-
-      return id;
     },
 
     getFormattedColumnData: function(object, column) {

--- a/app/controllers/api/experimental/concerns/column_data.rb
+++ b/app/controllers/api/experimental/concerns/column_data.rb
@@ -48,11 +48,23 @@ module Api::Experimental::Concerns::ColumnData
     # link, datetime
     {
       data_type: column_data_type(column),
-      link: link_meta[column.name] || { display: false }
+      link: link_meta(column)
     }
   end
 
-  def link_meta
+  def link_meta(column)
+    link_meta = static_link_meta[column.name]
+
+    if link_meta
+      link_meta
+    elsif column.respond_to?(:custom_field)
+      linked_custom_field_meta(column)
+    else
+      { display: false }
+    end
+  end
+
+  def static_link_meta
     {
       subject: { display: true, model_type: 'work_package' },
       type: { display: false },
@@ -64,6 +76,15 @@ module Api::Experimental::Concerns::ColumnData
       author: { display: true, model_type: 'user' },
       project: { display: true, model_type: 'project' }
     }
+  end
+
+  def linked_custom_field_meta(column)
+    case column.custom_field.field_format
+    when 'user', 'version'
+      { display: true, model_type: column.custom_field.field_format }
+    else
+      { display: false }
+    end
   end
 
   def column_data_type(column)

--- a/karma/tests/helpers/custom-field-helper-test.js
+++ b/karma/tests/helpers/custom-field-helper-test.js
@@ -121,8 +121,45 @@ describe('Custom field helper', function() {
       });
     });
 
-    xdescribe('with a user type', function() {
+    describe('with a user type', function() {
+      it('should return the value of value.name', function() {
+        expect(formatCustomFieldValue({ name: 'blubs' }, 'user')).to.equal('blubs');
+      });
+
+      it('should handle undefined and null values', function() {
+        expect(formatCustomFieldValue(undefined, 'user')).to.equal('');
+        expect(formatCustomFieldValue(null, 'user')).to.equal('');
+        expect(formatCustomFieldValue({ name: undefined }, 'user')).to.equal('');
+        expect(formatCustomFieldValue({ name: null }, 'user')).to.equal('');
+      });
+
+      it('should return the name of the user out of a list of provided users', function() {
+        expect(formatCustomFieldValue( 5 , 'user', { '5': { name: 'blubs' }})).to.equal('blubs');
+      });
+
+      it('should return empty string if the user does not exists in list of provided users', function() {
+        expect(formatCustomFieldValue( 4 , 'user', { '5': { name: 'blubs' }})).to.equal('');
+      });
+
+      it('should handle undefined and null values in list of provided users', function() {
+        expect(formatCustomFieldValue( 5 , 'user', { '5': { name: null }})).to.equal('');
+        expect(formatCustomFieldValue( 5 , 'user', { '5': { name: undefined }})).to.equal('');
+        expect(formatCustomFieldValue( 5 , 'user', { '5': undefined })).to.equal('');
+        expect(formatCustomFieldValue( 5 , 'user', { '5': null })).to.equal('');
+      });
     });
 
+    describe('with a version type', function() {
+      it('should return the value of value.name', function() {
+        expect(formatCustomFieldValue({ name: 'blubs' }, 'version')).to.equal('blubs');
+      });
+
+      it('should handle undefined and null values', function() {
+        expect(formatCustomFieldValue(undefined, 'version')).to.equal('');
+        expect(formatCustomFieldValue(null, 'version')).to.equal('');
+        expect(formatCustomFieldValue({ name: undefined }, 'version')).to.equal('');
+        expect(formatCustomFieldValue({ name: null }, 'version')).to.equal('');
+      });
+    });
   });
 });

--- a/spec/controllers/api/experimental/concerns/column_data_spec.rb
+++ b/spec/controllers/api/experimental/concerns/column_data_spec.rb
@@ -28,8 +28,11 @@
 
 require File.expand_path('../../../../../spec_helper', __FILE__)
 
-describe 'ColumnData', :type => :controller do
+describe 'ColumnData', type: :controller do
   include Api::Experimental::Concerns::ColumnData
+
+  let(:field_format) { 'user' }
+  let(:field) { double('field', id: 1, order_statement: '', field_format: field_format) }
 
   describe '#column_data_type' do
     it 'should recognise custom field columns based on field format' do
@@ -49,4 +52,43 @@ describe 'ColumnData', :type => :controller do
     xit 'should test the full gamut of types'
   end
 
+  describe '#link_meta' do
+    let(:cf_column) { ::QueryCustomFieldColumn.new(field) }
+
+    describe 'for version custom fields' do
+      let(:field_format) { 'version' }
+
+      it 'has display true' do
+        expect(link_meta(cf_column)[:display]).to be_truthy
+      end
+
+      it 'has the model_type set to "version"' do
+        expect(link_meta(cf_column)[:model_type]).to eql(field_format)
+      end
+    end
+
+    describe 'for user custom fields' do
+      let(:field_format) { 'user' }
+
+      it 'has display true' do
+        expect(link_meta(cf_column)[:display]).to be_truthy
+      end
+
+      it 'has the model_type set to "user"' do
+        expect(link_meta(cf_column)[:model_type]).to eql(field_format)
+      end
+    end
+
+    describe 'for int custom fields' do
+      let(:field_format) { 'int' }
+
+      it 'has display false' do
+        expect(link_meta(cf_column)[:display]).to be_falsey
+      end
+
+      it 'lacks a model_type' do
+        expect(link_meta(cf_column)[:model_type]).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
fixes displaying version custom fields in the work packages table. 

Additionally, both user and version custom fields are now linked correctly.
