### PR TITLE
Add maximum number of events in activity stream

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -34,6 +34,7 @@ class ActivitiesController < ApplicationController
 
   def index
     @days = Setting.activity_days_default.to_i
+    @event_limit = Setting.activity_events_default.to_i
 
     if params[:from]
       begin; @date_to = params[:from].to_date + 1; rescue; end
@@ -50,7 +51,7 @@ class ActivitiesController < ApplicationController
 
     set_activity_scope
 
-    events = @activity.events(@date_from, @date_to)
+    events = @activity.events(@date_from, @date_to, {limit: @event_limit})
     censor_events_from_projects_with_disabled_activity!(events) unless @project
 
     if events.empty? || stale?(etag: [@activity.scope, @date_to, @date_from, @with_subprojects, @author, events.first, User.current, current_language])

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,6 +85,9 @@ work_packages_export_limit:
 activity_days_default:
   format: int
   default: 30
+activity_events_default:
+  format: int
+  default: 200
 per_page_options:
   default: '10, 20, 50, 100'
 mail_from:


### PR DESCRIPTION
We are facing the problem that after regular imports, the activity stream takes too long to load, because there are too many items in. Currently the limit is set by days, not number of records.
