### PR TITLE
Tell Protractor to maximise Browser window

### DIFF
--- a/frontend/tests/integration/protractor.conf.js
+++ b/frontend/tests/integration/protractor.conf.js
@@ -46,5 +46,9 @@ exports.config = {
     reporter: 'mocha-jenkins-reporter'
   },
 
-  baseUrl: 'http://localhost:8080'
+  baseUrl: 'http://localhost:8080',
+
+  onPrepare: function() {
+    browser.driver.manage().window().maximize();
+  }
 };


### PR DESCRIPTION
Later we may want to set the Browser window to specific sizes, for
example when testing responsive parts of the application (in other
words, media queries).
