### PR TITLE
Remove unused openproject-ui_components dependency

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -59,9 +59,11 @@ require('angular-busy/dist/angular-busy.css');
 
 require('angular-context-menu');
 
-require('openproject-ui_components');
-
 // global
+angular.module('openproject.uiComponents', ['ui.select2'])
+.run(['$rootScope', function($rootScope){
+  $rootScope.I18n = I18n;
+}]);
 angular.module('openproject.config', []);
 angular.module(
   'openproject.services', [

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -7,7 +7,6 @@
     "jquery-ui": "~1.10.4",
     "select2": "3.3.2",
     "jquery.atwho": "0.5.1",
-    "openproject-ui_components": "opf/openproject-ui_components#with-bower",
     "angular": "~1.3.6",
     "angular-animate": "~1.3.6",
     "angular-ui-select2": "0.0.5",


### PR DESCRIPTION
:warning: ~~**Includes commits from #2279. Please review, merge first.**~~

YAGNI. We are not currently loading an UI components from this library. We should revisit extracting out UI components once our front-end codebase matures.
