### PR TITLE
allows 'none' as authentication mode

### DIFF
--- a/packaging/scripts/send-test-email
+++ b/packaging/scripts/send-test-email
@@ -27,12 +27,9 @@ if delivery_method == "sendmail"
   File.open(tmpfile.path, "w+") {|f| f << msgstr}
   system("cat #{tmpfile.path} | sendmail -i -t") || exit(1)
 else
-  smtp_authentication = ENV.fetch('SMTP_AUTHENTICATION')
-  if smtp_authentication == "none"
-    smtp_authentication = nil
-  else
-    smtp_authentication = smtp_authentication.to_sym
-  end
+  smtp_authentication = ENV.fetch('SMTP_AUTHENTICATION', "none").to_sym
+  #set authentication to nil because :none is not supported by SMTP module
+  smtp_authentication = nil if smtp_authentication == :none
   puts "sending test email using SMTP..."
   Net::SMTP.start(
     ENV.fetch('SMTP_HOST'),

--- a/packaging/scripts/send-test-email
+++ b/packaging/scripts/send-test-email
@@ -27,14 +27,20 @@ if delivery_method == "sendmail"
   File.open(tmpfile.path, "w+") {|f| f << msgstr}
   system("cat #{tmpfile.path} | sendmail -i -t") || exit(1)
 else
+  smtp_authentication = ENV.fetch('SMTP_AUTHENTICATION')
+  if smtp_authentication == "none"
+    smtp_authentication = nil
+  else
+    smtp_authentication = smtp_authentication.to_sym
+  end
   puts "sending test email using SMTP..."
   Net::SMTP.start(
     ENV.fetch('SMTP_HOST'),
     ENV.fetch('SMTP_PORT'),
     ENV.fetch('SMTP_DOMAIN'),
-    ENV.fetch('SMTP_USERNAME'),
-    ENV.fetch('SMTP_PASSWORD'),
-    :login
+    ENV.fetch('SMTP_USERNAME',nil),
+    ENV.fetch('SMTP_PASSWORD',nil),
+    smtp_authentication
   ) do |smtp|
     smtp.send_message msgstr, from, admin_email
   end


### PR DESCRIPTION
Fixes Packager wizard smtp addon to support 'none' as authentication mode.
