### PR TITLE
Specify null links

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -55,6 +55,37 @@ However for the future we plan to add authentication modes that are more suitabl
 
 # Group Basic Objects
 
+# Links
+
+Links to other resources in the API are represented uniformly by link objects.
+
+## Properties
+
+| Property  | Description                                                              | Type    | Required | Nullable | Default |
+|:---------:| ------------------------------------------------------------------------ | ------- |:--------:|:--------:| ------- |
+| href      | URL to the referenced resource (might be relative)                       | String  |    ✓    |    ✓    |         |
+| title     | Representative label for the resource                                    | String  |          |          |         |
+| templated | If true the `href` contains parts that need to be replaced by the client | Boolean |          |          | false   |
+| method    | The HTTP verb to use when requesting the resource                        | String  |          |          | GET     |
+
+All link objects *must* contain the `href` property, though it might be `null`. Thus the following is a valid
+link object:
+
+    {
+        "href": null
+    }
+
+whereas `{ }` is not a valid link object. The meaning of `"href": null` is that **no** resource is referenced.
+For example a work package without an assignee will still have an assignee link, but its `href` will be `null`.
+
+If a `title` is present, the client can display the title to the user when referring to the resource.
+
+Templated links are links that contain client replacable parts. Replaceable parts are enclosed in braces. For example
+the link `api/v3/example/{id}` is not complete in itself, but the client needs to replace the string `{id}` itself.
+As of now the API does not indicate the valid replacement values.
+
+The `method` indicates which HTTP verb the client *must* use when following the link for the intended purpose.
+
 # Errors
 
 In case of an error, the API will respond with an apropriate HTTP status code.

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -70,7 +70,7 @@ Error objects shall give the client additional details about the cause of an err
     * The "List of Error Identifiers" defines the possible mappings between HTTP status and error identifier
 * The `message` contains a human readable concise message describing the error
     * It *optionally* includes specific information, for example which permission would have been needed to perform an action
-    * It it localized depending on the users preferences
+    * It is localized depending on the users preferences
     * It *must not* include HTML or other kind of markup
     * Error messages form complete sentences including punctuation
 
@@ -729,7 +729,7 @@ and objects describing the corresponding property as values. The values are call
 **Remarks**
 
 The `allowedValues` can either contain a list of canonical links or just a single link to a collection resource.
-This is an optimization to allow efficient handling of both small resource lists (that be be enumerated inline) and large
+This is an optimization to allow efficient handling of both small resource lists (that can be enumerated inline) and large
 resource lists (requiring one or more separate requests).
 
 A call to **validate** and **commit** does not need to include all properties that were defined in the `payload` section.

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -57,7 +57,7 @@ However for the future we plan to add authentication modes that are more suitabl
 
 # Links
 
-Links to other resources in the API are represented uniformly by link objects.
+Links to other resources in the API are represented uniformly by so called link objects.
 
 ## Properties
 
@@ -85,6 +85,9 @@ the link `api/v3/example/{id}` is not complete in itself, but the client needs t
 As of now the API does not indicate the valid replacement values.
 
 The `method` indicates which HTTP verb the client *must* use when following the link for the intended purpose.
+
+Note: When writing links (e.g. during a `PATCH` operation) only changes to `href` are accepted.
+Changes to all other properties will be **silently ignored**.
 
 # Errors
 


### PR DESCRIPTION
## OpenProject work packages
- https://community.openproject.org/work_packages/17600
## Changes (compared to implementation)

When getting a resource where a link is not set (e.g. no assignee) there is a link object present, but its `href` is `null`. The link is **not hidden**.
