### PR TITLE
Use default branch for all pkgr addons

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -20,11 +20,11 @@ services:
   - postgres
 installer: https://github.com/pkgr/installer.git#master
 wizards:
-  - https://github.com/pkgr/addon-legacy-installer.git#installer
-  - https://github.com/pkgr/addon-mysql.git#installer
-  - https://github.com/pkgr/addon-apache2.git#installer
-  - https://github.com/pkgr/addon-svn-dav.git#installer
-  - https://github.com/pkgr/addon-smtp.git#installer
-  - https://github.com/pkgr/addon-memcached.git#installer
-  - https://github.com/pkgr/addon-openproject.git#installer
+  - https://github.com/pkgr/addon-legacy-installer.git
+  - https://github.com/pkgr/addon-mysql.git
+  - https://github.com/pkgr/addon-apache2.git
+  - https://github.com/pkgr/addon-svn-dav.git
+  - https://github.com/pkgr/addon-smtp.git
+  - https://github.com/pkgr/addon-memcached.git
+  - https://github.com/pkgr/addon-openproject.git
 buildpack: https://github.com/ddollar/heroku-buildpack-multi.git


### PR DESCRIPTION
We used the installer branch for the pkgr addons because of the old debian wizard on the default branch. Now the old wizard is gone and we can use the new platform independent wizard available on the default branch.
