### PR TITLE
API V3 failing resource parsing

### DIFF
--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -28,24 +28,22 @@
 #++
 
 module API
-  module V3
-    module Utilities
-      module ResourceLinkParser
-        def self.parse(resource_link)
-          API::V3::Root.routes.each do |route|
-            route_options = route.instance_variable_get(:@options)
-            match = route_options[:compiled].match(resource_link)
+  module Utilities
+    module ResourceLinkParser
+      def self.parse(resource_link)
+        ::API::Root.routes.each do |route|
+          route_options = route.instance_variable_get(:@options)
+          match = route_options[:compiled].match(resource_link)
 
-            if match
-              return {
-                ns: /\/(?<ns>\w+)\//.match(route_options[:namespace])[:ns],
-                id: match[:id]
-              }
-            end
+          if match
+            return {
+              ns: /\/(?<ns>\w+)\//.match(route_options[:namespace])[:ns],
+              id: match[:id]
+            }
           end
-
-          nil
         end
+
+        nil
       end
     end
   end

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -80,7 +80,7 @@ module API
             end
 
             def parse_context
-              context = ::API::V3::Utilities::ResourceLinkParser.parse(params[:context])
+              context = ::API::Utilities::ResourceLinkParser.parse(params[:context])
 
               if context.nil?
                 fail API::Errors::InvalidRenderContext.new(

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -83,7 +83,7 @@ module API
           def parse_resource(property, ns, href)
             return nil unless href
 
-            resource = ::API::V3::Utilities::ResourceLinkParser.parse href
+            resource = ::API::Utilities::ResourceLinkParser.parse href
 
             if resource.nil? || resource[:ns] != ns.to_s
               actual_ns = resource ? resource[:ns] : nil

--- a/lib/api/v3/work_packages/link_to_object_extractor.rb
+++ b/lib/api/v3/work_packages/link_to_object_extractor.rb
@@ -33,7 +33,7 @@ module API
       module LinkToObjectExtractor
         def self.parse_links(links)
           links.keys.each_with_object({}) do |attribute, h|
-            resource = ::API::V3::Utilities::ResourceLinkParser.parse links[attribute]['href']
+            resource = ::API::Utilities::ResourceLinkParser.parse links[attribute]['href']
 
             if resource
               case resource[:ns]


### PR DESCRIPTION
The API V3 routes tend to forget about their prefix ('api'). Manual tests showed
that the API root routes reliably set their prefix.
