### PR TITLE
Revert "Bring in legacy styles with require directive"

### DIFF
--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -25,8 +25,6 @@
  *
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
-//= require_self
-//= require legacy/main
 
 @import bourbon
 @import global/all
@@ -81,3 +79,5 @@
 @import content/journal
 @import content/pagination
 @import content/progress_bar
+
+@import legacy/main


### PR DESCRIPTION
The change is in conflict with the themes.

As themes import the default.css.sass again in order to have their
styles applied to the rules, the complete css should be handled by saas.

Otherwise, files handled via sprockets are not included as an include
will not contain "require" files.

This reverts commit 240c7eeb884afba35a34fa7f04cf0896acfb4605.

https://community.openproject.org/work_packages/17762
