### PR TITLE
Fix misleading upgrade-browser translation

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -270,8 +270,8 @@ de:
       zooms: "Zoomstufe"
       outlines: "Hierarchie-Stufe"
     unsupported_browser:
-      title: "Ihr Browser wird nicht unterstützt"
-      message: "Sie verwenden einen veralteten Browser. OpenProject unterstützt diesen Browser nicht länger. Bitte aktualisieren Sie Ihren Browser."
+      title: "Ihre Browserversion wird nicht unterstützt"
+      message: "Sie verwenden einen veralteten Browser. OpenProject unterstützt diese Version des Browsers nicht länger. Bitte aktualisieren Sie Ihren Browser."
       learn_more: "Mehr erfahren"
     wiki_formatting:
       strong: "Fett"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -272,8 +272,8 @@ en:
       zooms: "Zoom level"
       outlines: "Hierarchy level"
     unsupported_browser:
-      title: "Your browser is not supported"
-      message: "The browser you are using is no longer supported by OpenProject. Please update your browser."
+      title: "Your browser version is not supported"
+      message: "The browser version you are using is no longer supported by OpenProject. Please update your browser."
       learn_more: "Learn more"
     wiki_formatting:
       strong: "Strong"


### PR DESCRIPTION
We were told that our browser is not supported, when in fact
the browser **version** is not supported.

This issue was raised in
https://crowdin.com/translate/openproject/19/en-da#11749 by the fellow
translator Mogelbjerg. All praise goes to him :)
