### PR TITLE
make attachment specs more realistic

### DIFF
--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -43,7 +43,10 @@ describe MessagesController, type: :controller do
     FactoryGirl.create(:board,
                        project: project)
   }
-  let(:filename) { 'test1.test' }
+
+  let(:filename) { 'testfile.txt' }
+  let(:file) { File.open(Rails.root.join('test/fixtures/files', filename)) }
+  let(:uploaded_file) { ActionDispatch::Http::UploadedFile.new(tempfile: file, type: 'text/plain', filename: filename) }
 
   before { allow(User).to receive(:current).and_return user }
 
@@ -60,8 +63,8 @@ describe MessagesController, type: :controller do
           post 'create', board_id: board.id,
                          message: { subject: 'Test created message',
                                     content: 'Messsage body' },
-                         attachments: { file: { file: filename,
-                                                description: '' } }
+                         attachments: { '1' => { 'file' => uploaded_file,
+                                                 'description' => '' } }
         end
 
         describe :journal do
@@ -96,8 +99,8 @@ describe MessagesController, type: :controller do
     let(:attachment_id) { "attachments_#{message.attachments.first.id}" }
     let(:params) {
       { id: message.id,
-        attachments: { '1' => { file: filename,
-                                description: '' } } }
+        attachments: { '1' => { 'file' => uploaded_file,
+                                'description' => '' } } }
     }
 
     describe :add do

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -887,7 +887,9 @@ describe WorkPackagesController, type: :controller do
     end
   end
 
-  let(:filename) { 'test1.test' }
+  let(:filename) { 'testfile.txt' }
+  let(:file) { File.open(Rails.root.join('test/fixtures/files', filename)) }
+  let(:uploaded_file) { ActionDispatch::Http::UploadedFile.new(tempfile: file, type: 'text/plain', filename: filename) }
 
   describe :create do
     let(:type) { FactoryGirl.create :type }
@@ -932,8 +934,8 @@ describe WorkPackagesController, type: :controller do
       }
       let(:params) {
         { project_id: project.id,
-          attachments: { file: { file: filename,
-                                 description: '' } } }
+          attachments: { '1' => { 'file' => uploaded_file,
+                                  'description' => '' } } }
       }
 
       before do
@@ -1004,8 +1006,8 @@ describe WorkPackagesController, type: :controller do
       }
       let(:params) {
         { id: work_package.id,
-          work_package: { attachments: { '1' =>  { file: filename,
-                                                   description: '' } } } }
+          work_package: { attachments: { '1' => { 'file' => uploaded_file,
+                                                  'description' => '' } } } }
       }
 
       before do


### PR DESCRIPTION
the sent params to not match the ones that are actually sent when running the server.
change them to mirror the real world better

`:params` in tests

```
[1] pry(#<WorkPackagesController>)> params
=> {"attachments"=>{"file"=>{"file"=>"test1.test", "description"=>""}},
 "project_id"=>"15",
 "controller"=>"work_packages",
 "action"=>"create"}
```

`:params` when really uploading stuff

```
[1] pry(#<WorkPackagesController>)> params
=> ...
 "attachments"=>
  {"1"=>
    {"file"=>
      #<ActionDispatch::Http::UploadedFile:0x007fb6c297d238
       @content_type="text/plain",
       @headers=
        "Content-Disposition: form-data; name=\"attachments[1][file]\"; filename=\"karsten.txt\"\r\nContent-Type: text/plain\r\n",
       @original_filename="karsten.txt",
       @tempfile=
        #<File:/var/folders/vy/8c6gt6bx2cv8v3ynzyby9mw80000gp/T/RackMultipart20141218-56776-4qhw4r>>,
     "description"=>""}},
```

with this pr:

`:params` in tests

```
[1] pry(#<WorkPackagesController>)> params
=> {"attachments"=>
  {"1"=>
    {"file"=>
      #<ActionDispatch::Http::UploadedFile:0x007fc81c041eb0
       @content_type="text/plain",
       @headers=nil,
       @original_filename=nil,
       @tempfile=
        #<File:/Users/Martin/code/opf/openproject-attachments/test/fixtures/files/testfile.txt>>,
     "description"=>""}},
 "project_id"=>"2",
 "controller"=>"work_packages",
 "action"=>"create"}
```
