### PR TITLE
Stay on karma-webpack 1.3.x

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "karma-junit-reporter": "~0.2.2",
     "karma-mocha": "~0.1.3",
     "karma-phantomjs-launcher": "~0.1.4",
-    "karma-webpack": "^1.3.1",
+    "karma-webpack": "~1.3.1",
     "mocha": "~1.18.2",
     "mocha-jenkins-reporter": "^0.1.2",
     "phantomjs": "~1.9.2",


### PR DESCRIPTION
Use stricter ~ prefix for specifying version.

1.4.x does not appear to be compatible with our Webpack/Karma config.
