### PR TITLE
no longer use sort criteria of session for wp index

### DIFF
--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -98,8 +98,7 @@ module Api
       end
 
       def current_work_packages
-        sort_init(@query.sort_criteria.empty? ? [DEFAULT_SORT_ORDER] : @query.sort_criteria)
-        sort_update(@query.sortable_columns)
+        initialize_sort
 
         results = @query.results include: includes_for_columns(all_query_columns(@query)),
                                  order: sort_clause
@@ -112,6 +111,15 @@ module Api
         set_work_packages_meta_data(@query, results, work_packages)
 
         work_packages
+      end
+
+      def initialize_sort
+        # The session contains the previous sort criteria.
+        # For the WP#index, this behaviour is not supported by the frontend, therefore
+        # we remove the session stored sort criteria and only take what is provided.
+        sort_clear
+        sort_init(@query.sort_criteria.empty? ? [DEFAULT_SORT_ORDER] : @query.sort_criteria)
+        sort_update(@query.sortable_columns)
       end
 
       def all_query_columns(query)


### PR DESCRIPTION
This is not supported by the frontend so the information displayed was inconsistent.

https://community.openproject.org/work_packages/17814
