### PR TITLE
update roar to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,7 +179,7 @@ end
 
 # API gems
 gem 'grape', '~> 0.9.0'
-gem 'roar',   '~> 1.0.0.beta2'
+gem 'roar',   '~> 1.0.0'
 gem 'reform', '~> 1.1.1', require: false
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       nokogiri
       uber (~> 0.0.7)
     request_store (1.1.0)
-    roar (1.0.0.beta2)
+    roar (1.0.0)
       representable (>= 2.0.1, <= 3.0.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
@@ -470,7 +470,7 @@ DEPENDENCIES
   rdoc (>= 2.4.2)
   reform (~> 1.1.1)
   request_store
-  roar (~> 1.0.0.beta2)
+  roar (~> 1.0.0)
   rspec (~> 2.99.0)
   rspec-activemodel-mocks
   rspec-example_disabler!


### PR DESCRIPTION
Thanks to @apotonick, we can get rid of the beta suffix. 
