### PR TITLE
updates api gems + dependent ones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,9 +178,9 @@ group :development, :test do
 end
 
 # API gems
-gem 'grape', '~> 0.9.0'
+gem 'grape', '~> 0.10.1'
 gem 'roar',   '~> 1.0.0'
-gem 'reform', '~> 1.1.1', require: false
+gem 'reform', '~> 1.2.4', require: false
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on
 # board to compile the native ones.  Note, that their use is discouraged, since

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    disposable (0.0.8)
+    disposable (0.0.9)
       representable (~> 2.0)
       uber
     equalizer (0.0.9)
@@ -176,7 +176,7 @@ GEM
     gon (4.0.0)
       actionpack (>= 2.3.0)
       json
-    grape (0.9.0)
+    grape (0.10.1)
       activesupport
       builder
       hashie (>= 2.1.0)
@@ -192,7 +192,7 @@ GEM
     hooks (0.3.3)
     htmldiff (0.0.1)
     i18n (0.6.11)
-    ice_nine (0.11.0)
+    ice_nine (0.11.1)
     interception (0.3)
     iso8601 (0.8.2)
     journey (1.0.4)
@@ -218,7 +218,7 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     minisyntax (0.2.3)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -227,8 +227,8 @@ GEM
     multi_xml (0.5.5)
     mysql2 (0.3.11)
     net-ldap (0.8.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
     non-stupid-digest-assets (1.0.4)
     object-daddy (1.1.1)
     oj (2.1.6)
@@ -304,12 +304,12 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.0.0)
-    reform (1.1.1)
+    reform (1.2.4)
       activemodel
       disposable (~> 0.0.5)
-      representable (~> 2.0.3)
-      uber (~> 0.0.8)
-    representable (2.0.4)
+      representable (~> 2.1.0)
+      uber (~> 0.0.11)
+    representable (2.1.3)
       multi_json
       nokogiri
       uber (~> 0.0.7)
@@ -387,7 +387,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.42)
-    uber (0.0.10)
+    uber (0.0.12)
     uglifier (2.1.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
@@ -395,7 +395,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    virtus (1.0.3)
+    virtus (1.0.4)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
@@ -433,7 +433,7 @@ DEPENDENCIES
   faker
   globalize
   gon (~> 4.0)
-  grape (~> 0.9.0)
+  grape (~> 0.10.1)
   gravatar_image_tag (~> 1.2.0)
   htmldiff
   i18n (>= 0.6.8)
@@ -468,7 +468,7 @@ DEPENDENCIES
   rails_autolink
   rb-readline (~> 0.5.1)
   rdoc (>= 2.4.2)
-  reform (~> 1.1.1)
+  reform (~> 1.2.4)
   request_store
   roar (~> 1.0.0)
   rspec (~> 2.99.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,6 @@
 
 OpenProject::Application.routes.draw do
   root to: 'welcome#index', as: 'home'
-  mount API::Root => '/'
   rails_relative_url_root = OpenProject::Configuration['rails_relative_url_root'] || ''
 
   # Redirect deprecated issue links to new work packages uris
@@ -156,6 +155,13 @@ OpenProject::Application.routes.draw do
       resources :users, only: [:index]
     end
   end
+
+  # Because of https://github.com/intridea/grape/pull/853/files this has to be
+  # placed behind handling the deprecated v1 because otherwise, a 405 is
+  # returned for all routes for which the v3 has also resources. Grape does
+  # remove the prefix (v3) before checking whether the method is supported. I
+  # don't understand why that should make sense.
+  mount API::Root => '/'
 
   match '/roles/workflow/:id/:role_id/:type_id' => 'roles#workflow'
   match '/help/:ctrl/:page' => 'help#index'

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -65,7 +65,9 @@ describe 'API v3 Render resource' do
           context 'content type' do
             let(:content_type) { 'application/json' }
             let(:post_path) { path }
-            let(:params) { "Hello World! Have a look at ##{work_package.id}" }
+            let(:params) {
+              { 'text' => "Hello World! Have a look at ##{work_package.id}" }.to_json
+            }
 
             it_behaves_like 'invalid request body',
                             I18n.t('api_v3.errors.invalid_content_type',


### PR DESCRIPTION
Updates grape and reform to their current head version.

As a result other gems are updated as well. As I could see no harm in updating them, I didn't check whether every update was strictly necessary.
