### PR TITLE
adds i18n for id

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -313,6 +313,7 @@ de:
     firstname: "Vorname"
     group: "Gruppe"
     groupname: "Gruppenname"
+    id: "ID"
     is_default: "Standardeinstellung"
     is_for_all: "Für alle Projekte"
     is_public: "Öffentlich"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,6 +312,7 @@ en:
     firstname: "First name"
     group: "Group"
     groupname: "Group name"
+    id: "ID"
     is_default: "Default value"
     is_for_all: "For all projects"
     is_public: "Public"


### PR DESCRIPTION
I am not aware of the attribute being displayed anywhere in the application. But a lot of tests seem to make use of the attribute which causes a barrage of warnings being displayed by the patch for human_attribute_name in 10-patches.

We should get rid of that patch but doing this requires to first check if the plugins all follow the correct AR i18n schema which should be easier once this is merged.
