### PR TITLE
Extend apiv3 blueprint for user (un-)locking

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1941,6 +1941,12 @@ This endpoint lists the types that are *available* in a given project.
 
 # Group Users
 
+## Actions:
+| Link                | Description                                                          | Condition                                 |
+|:-------------------:| -------------------------------------------------------------------- | ----------------------------------------- |
+| lock                | Restrict the user from logging in and performing any actions         | not locked; **Permission**: Administrator |
+| unlock              | Allow a locked user to login and act again                           | locked; **Permission**: Administrator     |
+
 ## Properties:
 | Property    | Description                                               | Type     | Constraints | Supported operations |
 | :---------: | -------------                                             | ----     | ----------- | -------------------- |
@@ -1983,7 +1989,8 @@ This endpoint lists the types that are *available* in a given project.
                 "mail": "shep@mail.com",
                 "avatar": "https://gravatar/avatar",
                 "createdAt": "2014-05-21T08:51:20Z",
-                "updatedAt": "2014-05-21T08:51:20Z"
+                "updatedAt": "2014-05-21T08:51:20Z",
+                "status": "active"
             }
 
 ## View user [GET]
@@ -2054,65 +2061,14 @@ Permanently deletes the specified user account.
 
 **NOT IMPLEMENTED**
 
-## Lock Status [GET]
+## Set Lock [POST]
 
 + Parameters
     + id (required, integer, `1`) ... User id
 
 + Response 200 (application/hal+json)
 
-    + Body
-
-            {
-                "_links": {
-                    "self": { "href": "/api/v3/users/1/lock" },
-                    "user": {
-                        "href": "/api/v3/users/1",
-                        "title": "John Sheppard - admin"
-                    }
-                },
-                "_type": "LockStatus",
-                "locked": true
-            }
-
-+ Response 403 (application/hal+json)
-
-    Returned if the client does not have sufficient permissions for viewing the
-    lock status of a user.
-
-    **Required permission:** Administrators only
-
-    + Body
-
-            {
-                "_type": "Error",
-                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
-                "message": "You are not allowed to view the account lock status of this user."
-            }
-
-+ Response 404 (application/hal+json)
-
-    Returned if the user does not exist.
-
-    + Body
-
-            {
-                "_type": "Error",
-                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
-                "message": "The specified user does not exist."
-            }
-
-
-## Set Lock [POST]
-
-+ Parameters
-    + id (required, integer, `1`) ... User id
-
-+ Response 204
-
-    Returned if the account was locked successfully.
-
-    + Body
+    [User][]
 
 + Response 403 (application/hal+json)
 
@@ -2145,11 +2101,9 @@ Permanently deletes the specified user account.
 + Parameters
     + id (required, integer, `1`) ... User id
 
-+ Response 204
++ Response 200 (application/hal+json)
 
-    Returned if the account was unlocked successfully.
-
-    + Body
+    [User][]
 
 + Response 403 (application/hal+json)
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2041,6 +2041,130 @@ Permanently deletes the specified user account.
                 "message": "The specified user does not exist."
             }
 
+
+## User Account Locking [/api/v3/users/{id}/lock]
+
+**NOT IMPLEMENTED**
+
+## Lock Status [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... User id
+
++ Response 200 (application/hal+json)
+
+    + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/api/v3/users/1/lock" },
+                    "user": {
+                        "href": "/api/v3/users/1",
+                        "title": "John Sheppard - admin"
+                    }
+                },
+                "_type": "Lock Status",
+                "locked": true,
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions for viewing the
+    lock status of a user.
+
+    **Required permission:** Administrators only
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to view the account lock status of this user."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the user does not exist.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The specified user does not exist."
+            }
+
+
+## Set Lock [POST]
+
++ Parameters
+    + id (required, integer, `1`) ... User id
+
++ Response 204
+
+    Returned if the account was locked successfully.
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions for locking a user.
+
+    **Required permission:** Administrators only
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to lock the account of this user."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the user does not exist.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The specified user does not exist."
+            }
+
+## Remove Lock [DELETE]
+
++ Parameters
+    + id (required, integer, `1`) ... User id
+
++ Response 204
+
+    Returned if the account was unlocked successfully.
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions for unlocking a user.
+
+    **Required permission:** Administrators only
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to lock the account of this user."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the user does not exist.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The specified user does not exist."
+            }
+
 # Group Versions
 
 ## Linked Properties:

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1966,6 +1966,14 @@ This endpoint lists the types that are *available* in a given project.
                     "self": {
                         "href": "/api/v3/users/1",
                         "title": "John Sheppard - j.sheppard"
+                    },
+                    "lock": {
+                        "href": "/api/v3/users/1/lock",
+                        "method": "POST"
+                    },
+                    "delete": {
+                        "href": "/api/v3/users/1",
+                        "method": "DELETE"
                     }
                 },
                 "id": 1,
@@ -2063,8 +2071,8 @@ Permanently deletes the specified user account.
                         "title": "John Sheppard - admin"
                     }
                 },
-                "_type": "Lock Status",
-                "locked": true,
+                "_type": "LockStatus",
+                "locked": true
             }
 
 + Response 403 (application/hal+json)
@@ -2154,7 +2162,7 @@ Permanently deletes the specified user account.
             {
                 "_type": "Error",
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
-                "message": "You are not allowed to lock the account of this user."
+                "message": "You are not allowed to unlock the account of this user."
             }
 
 + Response 404 (application/hal+json)

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2104,6 +2104,8 @@ Permanently deletes the specified user account.
 
     Returned if the account was locked successfully.
 
+    + Body
+
 + Response 403 (application/hal+json)
 
     Returned if the client does not have sufficient permissions for locking a user.
@@ -2138,6 +2140,8 @@ Permanently deletes the specified user account.
 + Response 204
 
     Returned if the account was unlocked successfully.
+
+    + Body
 
 + Response 403 (application/hal+json)
 

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -173,6 +173,7 @@ embedded errors or simply state that multiple errors occured.
 
 * `urn:openproject-org:api:v3:errors:InvalidRequestBody` (**HTTP 400**) - The format of the request body did not match the servers expectation
 * `urn:openproject-org:api:v3:errors:InvalidRenderContext` (**HTTP 400**) - The client specified a rendering context that does not exist
+* `urn:openproject-org:api:v3:errors:InvalidUserStatusTransition` (**HTTP 400**) The client used an invalid transition in the attempt to change the status of a user account.
 * `urn:openproject-org:api:v3:errors:MissingPermission` (**HTTP 401** / **HTTP 403**) - The client does not have the needed permissions to perform the requested action
 * `urn:openproject-org:api:v3:errors:NotFound` (**HTTP 404**) - Default for HTTP 404 when no further information is available
 * `urn:openproject-org:api:v3:errors:UpdateConflict` (**HTTP 409**) - The resource changed between GET-ing it and performing an update on it
@@ -2070,6 +2071,20 @@ Permanently deletes the specified user account.
 
     [User][]
 
++ Response 400 (application/hal+json)
+
+    Returned if the client tries to lock a user account whose current status does not allow this transition.
+
+    **Required permission:** Administrators only
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidUserStatusTransition",
+                "message": "The current user account status does not allow this operation."
+            }
+
 + Response 403 (application/hal+json)
 
     Returned if the client does not have sufficient permissions for locking a user.
@@ -2104,6 +2119,20 @@ Permanently deletes the specified user account.
 + Response 200 (application/hal+json)
 
     [User][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client tries to unlock a user account whose current status does not allow this transition.
+
+    **Required permission:** Administrators only
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidUserStatusTransition",
+                "message": "The current user account status does not allow this operation."
+            }
 
 + Response 403 (application/hal+json)
 


### PR DESCRIPTION
With OmniAuth, we now have external services authenticate
users in an asnychronous manner. With this change, proper means
to manage the status based from these services become a necessity.
Particularly, deleting and locking users based on outer events are
a requirement for timely account administration.

As the API(v3) already provides the functionality to remove user
accounts, this commit suggests an extension to provide locking
and unlocking user accounts through the API.

Given the current api organization, two options came to mind:
1. PATCHing the user resource `/api/v3/users/{id}` with a flag the corresponds to the lock status
2. Adding a resource  `/api/v3/users/{id}/lock`, for which `GET` returns the current status, `POST` performs the lock and `DELETE` removes it.

This PR suggests the latter, as I believe the former is ambiguous (and PATCH should be reserved for updating a subset of simple user attributes). 

I apologize for any blatant errors in the blueprint, the apib schema was unknown to me until now :fearful: 

The discussion leading up to this PR: https://community.openproject.org/topics/3706
The relevant WP: https://community.openproject.org/work_packages/18122
