### PR TITLE
Feature/api version read

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -117,7 +117,7 @@ class Project < ActiveRecord::Base
   scope :has_module, lambda { |mod| { conditions: ["#{Project.table_name}.id IN (SELECT em.project_id FROM #{EnabledModule.table_name} em WHERE em.name=?)", mod.to_s] } }
   scope :active, lambda { |*_args| where(status: STATUS_ACTIVE) }
   scope :public, lambda { |*_args| where(is_public: true) }
-  scope :visible, lambda { { conditions: Project.visible_by(User.current) } }
+  scope :visible, ->(user = User.current) { { conditions: Project.visible_by(user) } }
 
   # timelines stuff
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -31,6 +31,8 @@ class Version < ActiveRecord::Base
   include Redmine::SafeAttributes
   extend DeprecatedAlias
 
+  include Version::ProjectSharing
+
   after_update :update_issues_from_sharing_change
   belongs_to :project
   has_many :fixed_issues, class_name: 'WorkPackage', foreign_key: 'fixed_version_id', dependent: :nullify

--- a/app/models/version/project_sharing.rb
+++ b/app/models/version/project_sharing.rb
@@ -1,0 +1,157 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Version::ProjectSharing
+  # Returns all projects the version is available in
+  def projects
+    Project.scoped.joins(project_sharing_join)
+  end
+
+  private
+
+  def project_sharing_join
+    projects = Project.scoped
+    projects_table = projects.arel_table
+    versions_table = Version.scoped.arel_table
+
+    sharing_inner_select = project_sharing_select(versions_table)
+
+    join_condition = project_sharing_join_condition(sharing_inner_select, projects_table)
+    join_on = projects_table.create_on(join_condition)
+
+    projects_table.create_join(sharing_inner_select, join_on)
+  end
+
+  def project_sharing_select(versions_table)
+    sharing_select = if sharing == 'tree'
+                       project_sharing_tree_select(versions_table)
+                     else
+                       project_sharing_default_select(versions_table)
+                     end
+
+    sharing_id_condition = versions_table[:id].eq(id)
+
+    sharing_select
+      .where(sharing_id_condition)
+      .as('sharing')
+  end
+
+  def project_sharing_tree_select(versions_table)
+    hierarchy_table = Project.scoped.arel_table
+
+    roots_table = Project.arel_table.alias('roots')
+    roots_join_condition = project_sharing_tree_root_join_condition(roots_table, hierarchy_table)
+    sharing_select = join_project_and_version(hierarchy_table, versions_table)
+
+    sharing_select
+      .join(roots_table)
+      .on(roots_join_condition)
+
+    necessary_sharing_fields(sharing_select,
+                             roots_table,
+                             versions_table)
+  end
+
+  def project_sharing_default_select(versions_table)
+    hierarchy_table = Project.scoped.arel_table
+
+    sharing_select = join_project_and_version(hierarchy_table, versions_table)
+
+    necessary_sharing_fields(sharing_select,
+                             hierarchy_table,
+                             versions_table)
+  end
+
+  def necessary_sharing_fields(sharing_select, projects_table, versions_table)
+    sharing_select
+      .project(projects_table[:id],
+               versions_table[:id].as('version_id'),
+               projects_table[:lft],
+               projects_table[:rgt],
+               versions_table[:sharing])
+  end
+
+  def join_project_and_version(projects_table, versions_table)
+    join_condition = projects_table[:id].eq(versions_table[:project_id])
+
+    projects_table
+      .join(versions_table)
+      .on(join_condition)
+  end
+
+  def project_sharing_tree_root_join_condition(roots_table, hierarchy_table)
+    roots_table[:lft].lteq(hierarchy_table[:lft])
+      .and(roots_table[:rgt].gteq(hierarchy_table[:rgt]))
+      .and(roots_table[:parent_id].eq(nil))
+  end
+
+  def project_sharing_join_condition(sharing_table, projects_table)
+    case self[:sharing]
+    when 'tree'
+      project_sharing_tree_join_condition(sharing_table, projects_table)
+    when 'descendants'
+      project_sharing_descendants_join_condition(sharing_table, projects_table)
+    when 'hierarchy'
+      project_sharing_hierarchy_join_condition(sharing_table, projects_table)
+    when 'system'
+      Arel::Nodes::True.new
+    else
+      sharing_table[:id].eq(projects_table[:id])
+    end
+  end
+
+  def project_sharing_tree_join_condition(sharing_table, projects_table)
+    projects_table[:lft].gteq(sharing_table[:lft])
+      .and(projects_table[:rgt].lteq(sharing_table[:rgt]))
+  end
+
+  def project_sharing_descendants_join_condition(sharing_table, projects_table)
+    project_sharing_equal_condition(sharing_table, projects_table)
+      .or(project_sharing_below_condition(sharing_table, projects_table))
+  end
+
+  def project_sharing_hierarchy_join_condition(sharing_table, projects_table)
+    project_sharing_descendants_join_condition(sharing_table, projects_table)
+      .or(project_sharing_above_condition(sharing_table, projects_table))
+  end
+
+  def project_sharing_equal_condition(sharing_table, projects_table)
+    sharing_table[:id].eq(projects_table[:id])
+  end
+
+  def project_sharing_above_condition(sharing_table, projects_table)
+    projects_table[:lft].lt(sharing_table[:lft])
+      .and(projects_table[:rgt].gt(sharing_table[:rgt]))
+  end
+
+  def project_sharing_below_condition(sharing_table, projects_table)
+    projects_table[:lft].gt(sharing_table[:lft])
+      .and(projects_table[:rgt].lt(sharing_table[:rgt]))
+  end
+end

--- a/app/policies/version_policy.rb
+++ b/app/policies/version_policy.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class VersionPolicy < BasePolicy
+  private
+
+  def cache
+    @cache ||= Hash.new do |hash, version|
+      # copy checks for the move_work_packages permission. This makes
+      # sense only because the work_packages/moves controller handles
+      # copying multiple work packages.
+      hash[version] = {
+        show: show_allowed?(version)
+      }
+    end
+  end
+
+  def show_allowed?(version)
+    @show_cache ||= Hash.new do |hash, queried_version|
+      permissions = [:view_work_packages, :manage_versions]
+
+      hash[queried_version] = permissions.any? do |permission|
+        allowed_condition = Project.allowed_to_condition(user, permission)
+
+        queried_version.projects.where(allowed_condition).exists?
+      end
+    end
+
+    @show_cache[version]
+  end
+end

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2450,7 +2450,8 @@ Note that due to sharing this might be more than the versions *defined* by that 
                         "title": "New"
                     },
                     "version": {
-                        "href": "/api/v3/versions/1"
+                        "href": "/api/v3/versions/1",
+                        "title": "Version 1"
                     },
                     "availableWatchers": {
                         "href": "/api/v3/work_packages/1528/available_watchers",

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -31,40 +31,23 @@ require 'roar/decorator'
 require 'roar/json/hal'
 
 module API
-  module V3
-    module Projects
-      class ProjectRepresenter < ::API::Decorators::Single
-        link :self do
-          {
-            href: api_v3_paths.project(represented.id),
-            title: "#{represented.name}"
-          }
-        end
+  module Decorators
+    class Single < Roar::Decorator
+      include Roar::JSON::HAL
+      include Roar::Hypermedia
+      include API::V3::Utilities::PathHelper
 
-        link 'categories' do
-          { href: api_v3_paths.categories(represented.id) }
-        end
+      attr_reader :context
+      class_attribute :as_strategy
+      self.as_strategy = API::Utilities::CamelCasingStrategy.new
 
-        link 'versions' do
-          { href: api_v3_paths.versions(represented.id) }
-        end
+      def initialize(model, context = {})
+        @context = context
 
-        property :id, render_nil: true
-        property :identifier,   render_nil: true
-
-        property :name,         render_nil: true
-        property :description,  render_nil: true
-        property :homepage
-
-        property :created_on,   render_nil: true
-        property :updated_on,   render_nil: true
-
-        property :type, getter: -> (*) { project_type.try(:name) }, render_nil: true
-
-        def _type
-          'Project'
-        end
+        super(model)
       end
+
+      property :_type, exec_context: :decorator
     end
   end
 end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -80,6 +80,8 @@ module API
       # any of the provided permission in any of the provided
       # projects
       def authorize_any(permissions, projects, user: current_user)
+        projects = Array(projects)
+
         authorized = permissions.any? do |permission|
           allowed_condition = Project.allowed_to_condition(user, permission)
           allowed_projects = Project.where(allowed_condition)

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -75,6 +75,21 @@ module API
         raise API::Errors::Unauthorized unless is_authorized && allow
         is_authorized
       end
+
+      # checks whether the user has
+      # any of the provided permission in any of the provided
+      # projects
+      def authorize_any(permissions, projects, user: current_user)
+        authorized = permissions.any? do |permission|
+          allowed_condition = Project.allowed_to_condition(user, permission)
+          allowed_projects = Project.where(allowed_condition)
+
+          !(allowed_projects & projects).empty?
+        end
+
+        raise API::Errors::Unauthorized unless authorized
+        authorized
+      end
     end
 
     rescue_from ActiveRecord::RecordNotFound do |e|

--- a/lib/api/v3/categories/category_collection_representer.rb
+++ b/lib/api/v3/categories/category_collection_representer.rb
@@ -27,17 +27,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json/collection'
-require 'roar/json/hal'
-
 module API
   module V3
     module Categories
       class CategoryCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Categories::CategoryRepresenter)
-        end
+        element_decorator ::API::V3::Categories::CategoryRepresenter
       end
     end
   end

--- a/lib/api/v3/categories/category_representer.rb
+++ b/lib/api/v3/categories/category_representer.rb
@@ -33,15 +33,7 @@ require 'roar/json/hal'
 module API
   module V3
     module Categories
-      class CategoryRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include OpenProject::StaticRouting::UrlHelpers
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        property :_type, exec_context: :decorator
-
+      class CategoryRepresenter < ::API::Decorators::Single
         property :id, render_nil: true
         property :name, render_nil: true
 

--- a/lib/api/v3/priorities/priority_collection_representer.rb
+++ b/lib/api/v3/priorities/priority_collection_representer.rb
@@ -27,17 +27,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json/collection'
-require 'roar/json/hal'
-
 module API
   module V3
     module Priorities
       class PriorityCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Priorities::PriorityRepresenter)
-        end
+        element_decorator ::API::V3::Priorities::PriorityRepresenter
       end
     end
   end

--- a/lib/api/v3/priorities/priority_representer.rb
+++ b/lib/api/v3/priorities/priority_representer.rb
@@ -33,15 +33,7 @@ require 'roar/json/hal'
 module API
   module V3
     module Priorities
-      class PriorityRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include OpenProject::StaticRouting::UrlHelpers
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        property :_type, exec_context: :decorator
-
+      class PriorityRepresenter < ::API::Decorators::Single
         property :id, render_nil: true
         property :name
 

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -36,9 +36,7 @@ module API
   module V3
     module Projects
       class ProjectCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Projects::ProjectRepresenter)
-        end
+        element_decorator ::API::V3::Projects::ProjectRepresenter
       end
     end
   end

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -27,36 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'roar/decorator'
+require 'roar/json'
+require 'roar/json/collection'
+require 'roar/json/hal'
+
 module API
   module V3
-    module Versions
-      class VersionsAPI < Grape::API
-        resources :versions do
-
-          namespace ':id' do
-
-            before do
-              @version = Version.find(params[:id])
-
-              authorized_for_version?(@version)
-            end
-
-            helpers do
-              def authorized_for_version?(version)
-                projects = version.projects
-
-                permissions = [:view_work_packages, :manage_versions]
-
-                authorize_any(permissions, projects, user: current_user)
-              end
-            end
-
-            get do
-              VersionRepresenter.new(@version)
-            end
-
-            mount API::V3::Versions::VersionsProjectsAPI
-          end
+    module Projects
+      class ProjectCollectionRepresenter < ::API::Decorators::Collection
+        def initialize(models, total, self_link)
+          super(models, total, self_link, ::API::V3::Projects::ProjectRepresenter)
         end
       end
     end

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -48,7 +48,7 @@ module API
             mount API::V3::Projects::AvailableAssigneesAPI
             mount API::V3::Projects::AvailableResponsiblesAPI
             mount API::V3::Categories::CategoriesAPI
-            mount API::V3::Versions::VersionsAPI
+            mount API::V3::Versions::ProjectsVersionsAPI
           end
         end
       end

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -33,15 +33,7 @@ require 'roar/json/hal'
 module API
   module V3
     module Queries
-      class QueryRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include API::V3::Utilities::PathHelper
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        property :_type, exec_context: :decorator
-
+      class QueryRepresenter < ::API::Decorators::Single
         link :self do
           {
             href: api_v3_paths.query(represented.id),

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -44,6 +44,7 @@ module API
       mount ::API::V3::Render::RenderAPI
       mount ::API::V3::Statuses::StatusesAPI
       mount ::API::V3::Users::UsersAPI
+      mount ::API::V3::Versions::VersionsAPI
       mount ::API::V3::WorkPackages::WorkPackagesAPI
 
       get '/' do

--- a/lib/api/v3/statuses/status_collection_representer.rb
+++ b/lib/api/v3/statuses/status_collection_representer.rb
@@ -35,9 +35,7 @@ module API
   module V3
     module Statuses
       class StatusCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Statuses::StatusRepresenter)
-        end
+        element_decorator ::API::V3::Statuses::StatusRepresenter
       end
     end
   end

--- a/lib/api/v3/statuses/status_representer.rb
+++ b/lib/api/v3/statuses/status_representer.rb
@@ -27,21 +27,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json/hal'
-
 module API
   module V3
     module Statuses
-      class StatusRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include API::V3::Utilities::PathHelper
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        property :_type, exec_context: :decorator
-
+      class StatusRepresenter < ::API::Decorators::Single
         link :self do
           {
             href: api_v3_paths.status(represented.id),

--- a/lib/api/v3/users/user_collection_representer.rb
+++ b/lib/api/v3/users/user_collection_representer.rb
@@ -31,9 +31,7 @@ module API
   module V3
     module Users
       class UserCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Users::UserRepresenter)
-        end
+        element_decorator ::API::V3::Users::UserRepresenter
       end
     end
   end

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -33,23 +33,8 @@ require 'roar/json/hal'
 module API
   module V3
     module Users
-      class UserRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include API::V3::Utilities::PathHelper
+      class UserRepresenter < ::API::Decorators::Single
         include AvatarHelper
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        def initialize(model, options = {}, *expand)
-          @current_user = options[:current_user]
-          @work_package = options[:work_package]
-          @expand = expand
-
-          super(model)
-        end
-
-        property :_type, exec_context: :decorator
 
         link :self do
           {
@@ -76,10 +61,10 @@ module API
 
         link :removeWatcher do
           {
-            href: api_v3_paths.watcher(represented.id, @work_package.id),
+            href: api_v3_paths.watcher(represented.id, work_package.id),
             method: :delete,
             title: 'Remove watcher'
-          } if @work_package && current_user_allowed_to(:delete_work_package_watchers, @work_package)
+          } if work_package && current_user_allowed_to(:delete_work_package_watchers, work_package)
         end
 
         property :id, render_nil: true
@@ -101,11 +86,21 @@ module API
         end
 
         def current_user_is_admin
-          @current_user && @current_user.admin?
+          current_user && current_user.admin?
         end
 
         def current_user_allowed_to(permission, work_package)
-          @current_user && @current_user.allowed_to?(permission, work_package.project)
+          current_user && current_user.allowed_to?(permission, work_package.project)
+        end
+
+        private
+
+        def current_user
+          context[:current_user]
+        end
+
+        def work_package
+          context[:work_package]
         end
       end
     end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -110,6 +110,10 @@ module API
             "#{project(project_id)}/versions"
           end
 
+          def self.versions_projects(version_id)
+            "#{root}/versions/#{version_id}/projects"
+          end
+
           def self.watcher(id, work_package_id)
             "#{work_package(work_package_id)}/watchers/#{id}"
           end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -106,12 +106,16 @@ module API
             "#{user(id)}/lock"
           end
 
+          def self.version(version_id)
+            "#{root}/versions/#{version_id}"
+          end
+
           def self.versions(project_id)
             "#{project(project_id)}/versions"
           end
 
           def self.versions_projects(version_id)
-            "#{root}/versions/#{version_id}/projects"
+            "#{version(version_id)}/projects"
           end
 
           def self.watcher(id, work_package_id)

--- a/lib/api/v3/versions/projects_versions_api.rb
+++ b/lib/api/v3/versions/projects_versions_api.rb
@@ -34,6 +34,8 @@ module API
         resources :versions do
           before do
             @versions = @project.shared_versions.all
+
+            authorize_any [:view_work_packages, :manage_versions], @project
           end
 
           get do

--- a/lib/api/v3/versions/projects_versions_api.rb
+++ b/lib/api/v3/versions/projects_versions_api.rb
@@ -1,7 +1,7 @@
 #-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,17 +27,20 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json'
-require 'roar/json/collection'
-require 'roar/json/hal'
-
 module API
   module V3
     module Versions
-      class VersionCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Versions::VersionRepresenter)
+      class ProjectsVersionsAPI < Grape::API
+        resources :versions do
+          before do
+            @versions = @project.shared_versions.all
+          end
+
+          get do
+            VersionCollectionRepresenter.new(@versions,
+                                             @versions.count,
+                                             api_v3_paths.versions(@project.identifier))
+          end
         end
       end
     end

--- a/lib/api/v3/versions/projects_versions_api.rb
+++ b/lib/api/v3/versions/projects_versions_api.rb
@@ -41,7 +41,8 @@ module API
           get do
             VersionCollectionRepresenter.new(@versions,
                                              @versions.count,
-                                             api_v3_paths.versions(@project.identifier))
+                                             api_v3_paths.versions(@project.identifier),
+                                             context: { current_user: current_user })
           end
         end
       end

--- a/lib/api/v3/versions/version_collection_representer.rb
+++ b/lib/api/v3/versions/version_collection_representer.rb
@@ -36,9 +36,7 @@ module API
   module V3
     module Versions
       class VersionCollectionRepresenter < ::API::Decorators::Collection
-        def initialize(models, total, self_link)
-          super(models, total, self_link, ::API::V3::Versions::VersionRepresenter)
-        end
+        element_decorator ::API::V3::Versions::VersionRepresenter
       end
     end
   end

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -44,7 +44,7 @@ module API
         link :definingProject do
           {
             href: api_v3_paths.project(represented.project.id),
-            title: "#{represented.project.name}"
+            title: represented.project.name
           } if represented.project.visible?(current_user)
         end
 

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -33,23 +33,7 @@ require 'roar/json/hal'
 module API
   module V3
     module Versions
-      class VersionRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include API::V3::Utilities::PathHelper
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        attr_reader :current_user
-
-        def initialize(model, options = {})
-          @current_user = options[:current_user]
-
-          super(model)
-        end
-
-        property :_type, exec_context: :decorator
-
+      class VersionRepresenter < ::API::Decorators::Single
         link :self do
           {
             href: api_v3_paths.version(represented.id),
@@ -91,6 +75,12 @@ module API
 
         def _type
           'Version'
+        end
+
+        private
+
+        def current_user
+          context[:current_user]
         end
       end
     end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -49,10 +49,14 @@ module API
 
                 authorize_any(permissions, projects, user: current_user)
               end
+
+              def context
+                { current_user: current_user }
+              end
             end
 
             get do
-              VersionRepresenter.new(@version)
+              VersionRepresenter.new(@version, context)
             end
 
             mount API::V3::Versions::VersionsProjectsAPI

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -32,14 +32,16 @@ module API
     module Versions
       class VersionsAPI < Grape::API
         resources :versions do
-          before do
-            @versions = @project.shared_versions.all
-          end
 
-          get do
-            VersionCollectionRepresenter.new(@versions,
-                                             @versions.count,
-                                             api_v3_paths.versions(@project.identifier))
+          namespace ':id' do
+
+            before do
+              @version = Version.find(params[:id])
+            end
+
+            get do
+              VersionRepresenter.new(@version)
+            end
           end
         end
       end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -37,6 +37,18 @@ module API
 
             before do
               @version = Version.find(params[:id])
+
+              authorized_for_version?(@version)
+            end
+
+            helpers do
+              def authorized_for_version?(version)
+                projects = version.projects
+
+                permissions = [:view_work_packages, :manage_versions]
+
+                authorize_any(permissions, projects, user: current_user)
+              end
             end
 
             get do

--- a/lib/api/v3/versions/versions_projects_api.rb
+++ b/lib/api/v3/versions/versions_projects_api.rb
@@ -1,7 +1,7 @@
 #-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -30,32 +30,19 @@
 module API
   module V3
     module Versions
-      class VersionsAPI < Grape::API
-        resources :versions do
+      class VersionsProjectsAPI < Grape::API
+        resources :projects do
+          before do
+            @projects = @version.projects.visible(current_user).all
 
-          namespace ':id' do
+            # Authorization for accessing the version is done in the versions
+            # endpoint into which this endpoint is embedded.
+          end
 
-            before do
-              @version = Version.find(params[:id])
-
-              authorized_for_version?(@version)
-            end
-
-            helpers do
-              def authorized_for_version?(version)
-                projects = version.projects
-
-                permissions = [:view_work_packages, :manage_versions]
-
-                authorize_any(permissions, projects, user: current_user)
-              end
-            end
-
-            get do
-              VersionRepresenter.new(@version)
-            end
-
-            mount API::V3::Versions::VersionsProjectsAPI
+          get do
+            Projects::ProjectCollectionRepresenter.new(@projects,
+                                                       @projects.count,
+                                                       api_v3_paths.versions_projects(@version.id))
           end
         end
       end

--- a/lib/api/v3/work_packages/relation_representer.rb
+++ b/lib/api/v3/work_packages/relation_representer.rb
@@ -33,23 +33,7 @@ require 'roar/json/hal'
 module API
   module V3
     module WorkPackages
-      class RelationRepresenter < Roar::Decorator
-        include Roar::JSON::HAL
-        include Roar::Hypermedia
-        include API::V3::Utilities::PathHelper
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        def initialize(model, options = {}, *expand)
-          @current_user = options[:current_user]
-          @work_package = options[:work_package]
-          @expand = expand
-
-          super(model)
-        end
-
-        property :_type, exec_context: :decorator
-
+      class RelationRepresenter < ::API::Decorators::Single
         link :self do
           { href: api_v3_paths.relation(represented.id) }
         end
@@ -79,11 +63,19 @@ module API
         private
 
         def current_user_allowed_to(permission)
-          @current_user && @current_user.allowed_to?(permission, represented.from.project)
+          current_user && current_user.allowed_to?(permission, represented.from.project)
         end
 
         def relation_type
-          represented.relation_type_for(@work_package).camelize
+          represented.relation_type_for(work_package).camelize
+        end
+
+        def work_package
+          context[:work_package]
+        end
+
+        def current_user
+          context[:current_user]
         end
       end
     end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -206,7 +206,8 @@ module API
           {
             href: api_v3_paths.version(represented.fixed_version.id),
             title: "#{represented.fixed_version.to_s_for_project(represented.project)}"
-          } if represented.fixed_version && current_user.allowed_to?({ controller: 'versions', action: 'show' }, represented.fixed_version.project, global: false)
+          } if represented.fixed_version &&
+               version_policy.allowed?(represented.fixed_version, :show)
         end
 
         links :children do
@@ -342,6 +343,10 @@ module API
 
         def current_user
           context[:current_user]
+        end
+
+        def version_policy
+          @version_policy ||= ::VersionPolicy.new(current_user)
         end
       end
     end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -204,8 +204,7 @@ module API
 
         link :version do
           {
-            href: version_path(represented.fixed_version),
-            type: 'text/html',
+            href: api_v3_paths.version(represented.fixed_version.id),
             title: "#{represented.fixed_version.to_s_for_project(represented.project)}"
           } if represented.fixed_version && current_user.allowed_to?({ controller: 'versions', action: 'show' }, represented.fixed_version.project, global: false)
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -275,6 +275,12 @@ module API
         property :category, embedded: true, class: ::Category, decorator: ::API::V3::Categories::CategoryRepresenter, if: -> (*) { !category.nil? }
 
         property :activities, embedded: true, exec_context: :decorator
+
+        property :version,
+                 embedded: true,
+                 exec_context: :decorator,
+                 if: ->(*) { represented.fixed_version.present? }
+
         property :watchers, embedded: true, exec_context: :decorator, if: -> (*) { current_user_allowed_to(:view_work_package_watchers) }
         collection :attachments, embedded: true, class: ::Attachment, decorator: ::API::V3::Attachments::AttachmentRepresenter
         property :relations, embedded: true, exec_context: :decorator
@@ -296,6 +302,10 @@ module API
           relations = represented.relations
           visible_relations = relations.select { |relation| relation.other_work_package(represented).visible? }
           visible_relations.map { |relation| RelationRepresenter.new(relation, work_package: represented, current_user: current_user) }
+        end
+
+        def version
+          Versions::VersionRepresenter.new(represented.fixed_version, current_user: current_user)
         end
 
         def custom_properties

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -76,12 +76,13 @@ module API
 
             before do
               @work_package = WorkPackage.find(params[:id])
-              @representer = ::API::V3::WorkPackages::WorkPackageRepresenter
-                .new(work_package, { current_user: current_user }, :activities, :users)
+              @representer = WorkPackageRepresenter.new(work_package,
+                                                        current_user: current_user)
             end
 
             get do
-              authorize({ controller: :work_packages_api, action: :get }, context: @work_package.project)
+              authorize({ controller: :work_packages_api, action: :get },
+                        context: @work_package.project)
               @representer
             end
 

--- a/spec/lib/api/v3/projects/project_collection_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_collection_representer_spec.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,38 +26,16 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Versions
-      class VersionsAPI < Grape::API
-        resources :versions do
+require 'spec_helper'
 
-          namespace ':id' do
+describe ::API::V3::Projects::ProjectCollectionRepresenter do
+  let(:self_link) { '/api/v3/versions/1/projects' }
+  let(:projects) { FactoryGirl.build_list(:project, 3) }
+  let(:representer) { described_class.new(projects, 42, self_link) }
 
-            before do
-              @version = Version.find(params[:id])
+  context 'generation' do
+    subject(:collection) { representer.to_json }
 
-              authorized_for_version?(@version)
-            end
-
-            helpers do
-              def authorized_for_version?(version)
-                projects = version.projects
-
-                permissions = [:view_work_packages, :manage_versions]
-
-                authorize_any(permissions, projects, user: current_user)
-              end
-            end
-
-            get do
-              VersionRepresenter.new(@version)
-            end
-
-            mount API::V3::Versions::VersionsProjectsAPI
-          end
-        end
-      end
-    end
+    it_behaves_like 'API V3 collection decorated', 42, 3, 'versions/1/projects', 'Project'
   end
 end

--- a/spec/lib/api/v3/support/api_v3_formattable.rb
+++ b/spec/lib/api/v3/support/api_v3_formattable.rb
@@ -35,5 +35,9 @@ shared_examples_for 'API V3 formattable' do |property|
 
   it { is_expected.to be_json_eql(raw.to_json).at_path(property + '/raw') }
 
-  it { is_expected.to be_json_eql(html.to_json).at_path(property + '/html') }
+  it do
+    if defined?(html)
+      is_expected.to be_json_eql(html.to_json).at_path(property + '/html')
+    end
+  end
 end

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -76,7 +76,7 @@ describe ::API::V3::Users::UserRepresenter do
       end
 
       context 'when current_user is admin' do
-        let(:current_user) { FactoryGirl.create(:admin) }
+        let(:current_user) { FactoryGirl.build_stubbed(:admin) }
 
         it 'should link to lock' do
           expect(subject).to have_json_path('_links/lock/href')

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -177,6 +177,14 @@ describe ::API::V3::Utilities::PathHelper do
     it { is_expected.to match(/^\/api\/v3\/users\/1/) }
   end
 
+  describe '#version' do
+    subject { helper.version 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/versions\/42/) }
+  end
+
   describe '#versions' do
     subject { helper.versions 42 }
 

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -185,6 +185,14 @@ describe ::API::V3::Utilities::PathHelper do
     it { is_expected.to match(/^\/api\/v3\/projects\/42\/versions/) }
   end
 
+  describe '#versions_projects' do
+    subject { helper.versions_projects 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/versions\/42\/projects/) }
+  end
+
   describe 'work packages paths' do
     shared_examples_for 'api v3 work packages path' do
       it { is_expected.to match(/^\/api\/v3\/work_packages/) }

--- a/spec/lib/api/v3/versions/version_collection_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_collection_representer_spec.rb
@@ -31,7 +31,9 @@ require 'spec_helper'
 describe ::API::V3::Versions::VersionCollectionRepresenter do
   let(:self_link) { '/api/v3/projects/1/versions' }
   let(:versions) { FactoryGirl.build_list(:version, 3) }
-  let(:representer) { described_class.new(versions, 42, self_link) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:context) { { current_user: user } }
+  let(:representer) { described_class.new(versions, 42, self_link, context: context) }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/versions/version_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_spec.rb
@@ -29,22 +29,68 @@
 require 'spec_helper'
 
 describe ::API::V3::Versions::VersionRepresenter do
-  let(:version) { FactoryGirl.build(:version) }
-  let(:representer) { described_class.new(version) }
+  let(:version) { FactoryGirl.build_stubbed(:version) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) { described_class.new(version, current_user: user) }
+
+  include API::V3::Utilities::PathHelper
 
   context 'generation' do
     subject(:generated) { representer.to_json }
 
     it { should include_json('Version'.to_json).at_path('_type') }
 
-    xit { should have_json_type(Object).at_path('_links') }
-    xit 'should link to self' do
-      expect(subject).to have_json_path('_links/self/href')
+    context 'links' do
+
+      it { should have_json_type(Object).at_path('_links') }
+
+      it 'to self' do
+        path = api_v3_paths.version(version.id)
+
+        expect(subject).to be_json_eql(path.to_json).at_path('_links/self/href')
+      end
+
+      context 'to the defining project' do
+        let(:path) { api_v3_paths.project(version.project.id) }
+
+        it 'exists if the user has the permission to see the project' do
+          allow(version.project).to receive(:visible?).with(user).and_return(true)
+
+          subject = representer.to_json
+
+          expect(subject).to be_json_eql(path.to_json).at_path('_links/definingProject/href')
+        end
+
+        it 'does not exist if the user lacks the permission to see the project' do
+          allow(version.project).to receive(:visible?).with(user).and_return(false)
+
+          subject = representer.to_json
+
+          expect(subject).to_not have_json_path('_links/definingProject/href')
+        end
+      end
+
+      it 'to available projects' do
+        path = api_v3_paths.versions_projects(version.project.id)
+
+        expect(subject).to be_json_eql(path.to_json).at_path('_links/availableInProjects/href')
+      end
     end
 
     describe 'version' do
-      it { should have_json_path('id') }
-      it { should have_json_path('name') }
+      it { is_expected.to be_json_eql(version.id.to_json).at_path('id') }
+      it { is_expected.to be_json_eql(version.name.to_json).at_path('name') }
+
+      it_behaves_like 'API V3 formattable', 'description' do
+        let(:format) { 'plain' }
+        let(:raw) { version.description }
+      end
+
+      it { is_expected.to be_json_eql(version.start_date.to_json).at_path('startDate') }
+      it { is_expected.to be_json_eql(version.due_date.to_json).at_path('endDate') }
+      it { is_expected.to be_json_eql(version.status.to_json).at_path('status') }
+      it { is_expected.to be_json_eql(version.created_on.to_json).at_path('createdAt') }
+      it { is_expected.to be_json_eql(version.updated_on.to_json).at_path('updatedAt') }
     end
   end
 end

--- a/spec/lib/api/v3/versions/version_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_spec.rb
@@ -31,7 +31,8 @@ require 'spec_helper'
 describe ::API::V3::Versions::VersionRepresenter do
   let(:version) { FactoryGirl.build_stubbed(:version) }
   let(:user) { FactoryGirl.build_stubbed(:user) }
-  let(:representer) { described_class.new(version, current_user: user) }
+  let(:context) { { current_user: user } }
+  let(:representer) { described_class.new(version, context) }
 
   include API::V3::Utilities::PathHelper
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -270,8 +270,9 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
           context ' but is not accessible due to permissions' do
             before do
-              current_user.stub(:allowed_to?).and_call_original
-              current_user.stub(:allowed_to?).with({ controller: 'versions', action: 'show' }, project, global: false).and_return(false)
+              policy = double('VersionPolicy')
+              allow(policy).to receive(:allowed?).with(version, :show).and_return(false)
+              representer.instance_variable_set(:@version_policy, policy)
             end
 
             it 'has no version linked' do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -29,6 +29,8 @@
 require 'spec_helper'
 
 describe ::API::V3::WorkPackages::WorkPackageRepresenter do
+  include ::API::V3::Utilities::PathHelper
+
   let(:member) { FactoryGirl.create(:user,  member_in_project: project, member_through_role: role) }
   let(:current_user) { member }
 
@@ -242,7 +244,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
         context 'version set' do
           let!(:version) { FactoryGirl.create :version, project: project }
-          let(:expected_url) { "/versions/#{version.id}".to_json }
+          let(:expected_url) { api_v3_paths.version(version.id).to_json }
 
           before do
             work_package.fixed_version = version
@@ -251,8 +253,6 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
           it {
             is_expected.to be_json_eql(expected_url).at_path('_links/version/href')
           }
-
-          it { is_expected.to be_json_eql('text/html'.to_json).at_path('_links/version/type') }
 
           context ' but is not accessible due to permissions' do
             before do

--- a/spec/requests/api/v3/projects/version_resource_spec.rb
+++ b/spec/requests/api/v3/projects/version_resource_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'rack/test'
 
-describe 'API v3 Version resource' do
+describe "API v3 project's versions resource" do
   include Rack::Test::Methods
 
   let(:current_user) do
@@ -44,68 +44,31 @@ describe 'API v3 Version resource' do
   let(:role) { FactoryGirl.create(:role, permissions: [:view_work_packages]) }
   let(:project) { FactoryGirl.create(:project, is_public: false) }
   let(:other_project) { FactoryGirl.create(:project, is_public: false) }
-  let(:version_in_project) { FactoryGirl.build(:version, project: project) }
-  let(:version_in_other_project) do
-    FactoryGirl.build(:version, project: other_project,
-                                sharing: 'system')
-  end
+  let(:versions) { FactoryGirl.create_list(:version, 4, project: project) }
+  let(:other_versions) { FactoryGirl.create_list(:version, 2) }
 
   subject(:response) { last_response }
 
-  describe '#get (:id)' do
-    let(:get_path) { "/api/v3/versions/#{version_in_project.id}" }
+  describe '#get (index)' do
+    let(:get_path) { "/api/v3/projects/#{project.id}/versions" }
 
-    context 'logged in user with permissions' do
+    context 'logged in user' do
       before do
-        version_in_project.save!
         current_user
+
+        versions
+        other_versions
 
         get get_path
       end
 
-      it 'responds with 200' do
-        expect(last_response.status).to eq(200)
-      end
-
-      it 'returns the work package' do
-        expected = {
-          _type: 'Version',
-          name: version_in_project.name
-        }.to_json
-
-        expect(last_response.body).to be_json_eql(expected)
-      end
-    end
-
-    context 'logged in user with permission on project a version is shared with' do
-      let(:get_path) { "/api/v3/versions/#{version_in_other_project.id}" }
-
-      before do
-        version_in_other_project.save!
-        current_user
-
-        get get_path
-      end
-
-      it 'responds with 200' do
-        expect(last_response.status).to eq(200)
-      end
-
-      it 'returns the work package' do
-        expected = {
-          _type: 'Version',
-          name: version_in_other_project.name
-        }.to_json
-
-        expect(last_response.body).to be_json_eql(expected)
-      end
+      it_behaves_like 'API V3 collection response', 4, 4, 'Version'
     end
 
     context 'logged in user without permission' do
       let(:role) { FactoryGirl.create(:role, permissions: []) }
 
-      before(:each) do
-        version_in_project.save!
+      before do
         current_user
 
         get get_path

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -55,6 +55,17 @@ describe 'API v3 Version resource' do
   describe '#get (:id)' do
     let(:get_path) { "/api/v3/versions/#{version_in_project.id}" }
 
+    shared_examples_for 'successful response' do
+      it 'responds with 200' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'returns the version' do
+        expect(last_response.body).to be_json_eql('Version'.to_json).at_path('_type')
+        expect(last_response.body).to be_json_eql(expected_version.id.to_json).at_path('id')
+      end
+    end
+
     context 'logged in user with permissions' do
       before do
         version_in_project.save!
@@ -63,17 +74,8 @@ describe 'API v3 Version resource' do
         get get_path
       end
 
-      it 'responds with 200' do
-        expect(last_response.status).to eq(200)
-      end
-
-      it 'returns the work package' do
-        expected = {
-          _type: 'Version',
-          name: version_in_project.name
-        }.to_json
-
-        expect(last_response.body).to be_json_eql(expected)
+      it_should_behave_like 'successful response' do
+        let(:expected_version) { version_in_project }
       end
     end
 
@@ -87,17 +89,8 @@ describe 'API v3 Version resource' do
         get get_path
       end
 
-      it 'responds with 200' do
-        expect(last_response.status).to eq(200)
-      end
-
-      it 'returns the work package' do
-        expected = {
-          _type: 'Version',
-          name: version_in_other_project.name
-        }.to_json
-
-        expect(last_response.body).to be_json_eql(expected)
+      it_should_behave_like 'successful response' do
+        let(:expected_version) { version_in_other_project }
       end
     end
 

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -38,11 +38,12 @@ describe 'API v3 Version resource' do
   let(:versions) { FactoryGirl.create_list(:version, 4, project: project) }
   let(:other_versions) { FactoryGirl.create_list(:version, 2) }
 
-  describe '#get' do
-    subject(:response) { last_response }
+  subject(:response) { last_response }
+
+  describe '#get (index)' do
+    let(:get_path) { "/api/v3/projects/#{project.id}/versions" }
 
     context 'logged in user' do
-      let(:get_path) { "/api/v3/projects/#{project.id}/versions" }
       before do
         allow(User).to receive(:current).and_return current_user
         member = FactoryGirl.build(:member, user: current_user, project: project)
@@ -56,6 +57,49 @@ describe 'API v3 Version resource' do
       end
 
       it_behaves_like 'API V3 collection response', 4, 4, 'Version'
+    end
+  end
+
+  describe '#get (:id)' do
+    let(:version_in_project) { FactoryGirl.build(:version, project: project) }
+
+    let(:get_path) { "/api/v3/versions/#{version_in_project.id}" }
+
+    let(:expected_response) do
+      {
+        '_type' => 'Version'
+      }
+    end
+
+    context 'logged in user with permissions' do
+      let(:current_user) do
+        user = FactoryGirl.create(:user,
+                                  member_in_project: project,
+                                  member_through_role: role)
+
+        allow(User).to receive(:current).and_return user
+
+        user
+      end
+
+      before do
+        version_in_project.save!
+
+        get get_path
+      end
+
+      it 'responds with 200' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'returns the work package' do
+        expected = {
+          _type: 'Version',
+          name: version_in_project.name
+        }.to_json
+
+        expect(last_response.body).to be_json_eql(expected)
+      end
     end
   end
 end

--- a/spec/requests/api/v3/versions/project_resource_spec.rb
+++ b/spec/requests/api/v3/versions/project_resource_spec.rb
@@ -1,0 +1,97 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe "API v3 version's projects resource" do
+  include Rack::Test::Methods
+
+  let(:current_user) do
+    user = FactoryGirl.create(:user,
+                              member_in_project: project,
+                              member_through_role: role)
+
+    allow(User).to receive(:current).and_return user
+
+    user
+  end
+  let(:role) { FactoryGirl.create(:role, permissions: [:view_work_packages]) }
+  let(:role_without_permissions) { FactoryGirl.create(:role, permissions: []) }
+  let(:project) { FactoryGirl.create(:project, is_public: false) }
+  let(:project2) { FactoryGirl.create(:project, is_public: false) }
+  let(:project3) { FactoryGirl.create(:project, is_public: false) }
+  let(:project4) { FactoryGirl.create(:project, is_public: false) }
+  let(:version) { FactoryGirl.create(:version, project: project, sharing: 'system') }
+
+  subject(:response) { last_response }
+
+  describe '#get (index)' do
+    let(:get_path) { "/api/v3/versions/#{version.id}/projects" }
+
+    context 'logged in user with permissions' do
+      before do
+        current_user
+
+        # this is to be included
+        FactoryGirl.create(:member, user: current_user,
+                                    project: project2,
+                                    roles: [role])
+        # this is to be included as the user is a member of the project, the
+        # lack of permissions is irrelevant.
+        FactoryGirl.create(:member, user: current_user,
+                                    project: project3,
+                                    roles: [role_without_permissions])
+        # project4 should NOT be included
+        project4
+
+        get get_path
+      end
+
+      it_behaves_like 'API V3 collection response', 3, 3, 'Project'
+
+      it 'includes only the projects which the user can see' do
+        id_in_response = JSON.parse(response.body)['_embedded']['elements'].map { |p| p['id'] }
+
+        expect(id_in_response).to match_array [project.id, project2.id, project3.id]
+      end
+    end
+
+    context 'logged in user without permissions' do
+      let(:role) { role_without_permissions }
+
+      before do
+        current_user
+
+        get get_path
+      end
+
+      it_behaves_like 'unauthorized access'
+    end
+  end
+end


### PR DESCRIPTION
Covers all read functionality for version via the [API as specified](https://github.com/opf/openproject/pull/2241/files#diff-3451225d299c8e39c92f206f79d55491R1890). It does not include writing a work package's version attribute.

This includes a harmonisation of all api decorators which receive a uniform superclass. Doing that allows to harmonise the initializers and reduces code. Every decorator can now take a context, which is along the line of the standard decorator pattern. A context can include the current user and other objects that are necessary to determine how to render the represented object.

In addition, a scope is added to version in order to determine the projects, the version is shared with. This is used for authorization right now, so that we can quickly determine wether the user has the necessary permission in at least one project the version is shared with.

On top of what https://community.openproject.org/work_packages/17407 states, two additional endpoints have been added:
/api/v3/versions/:id/projects
/api/v3/projects/:id/versions
as they where requested by the documentation.

Despite the removal of the attributes "versionId" and "versionName" from the work package resource in the documentation, those are not removed in the code as the angular client depends on them.
