### PR TITLE
apiv3: User (Un-)Locking functionality

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -103,6 +103,22 @@ class Principal < ActiveRecord::Base
     'active'
   end
 
+  ##
+  # Allows the API and other sources to determine locking actions
+  # on represented collections of children of Principals.
+  # Must be overriden by User
+  def lockable?
+    false
+  end
+
+  ##
+  # Allows the API and other sources to determine unlocking actions
+  # on represented collections of children of Principals.
+  # Must be overriden by User
+  def activatable?
+    false
+  end
+
   def <=>(principal)
     if self.class.name == principal.class.name
       to_s.downcase <=> principal.to_s.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,6 +328,15 @@ class User < Principal
     status == STATUSES[:locked]
   end
 
+  ##
+  # Allows the API and other sources to determine locking actions
+  # on represented collections of children of Principals.
+  # This only covers the transition from:
+  # lockable?: active -> locked.
+  # activatable?: locked -> active.
+  alias_method :lockable?, :active?
+  alias_method :activatable?, :locked?
+
   def activate
     self.status = STATUSES[:active]
   end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1667,6 +1667,7 @@ de:
       code_409: "Die Ressource konnte wegen parallelen Zugriffs nicht aktualisiert werden."
       invalid_content_type:
         "Es wird der CONTENT-TYPE '%{content_type}' erwartet, es wurde aber der CONTENT-TYP '%{actual}' gesandt."
+      invalid_user_status_transition: "Für diesen Nutzeraccount ist die angeforderte Statusänderung nicht zulässig."
       invalid_resource:
         "Für die Eigenschaft '%{property}' wird eine Ressource vom Typ '%{expected}' erwartet. Gesandt wurde der Typ '%{actual}'."
       multiple_errors: "Die Integrität mehrerer Eigenschaften wurde verletzt."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1660,6 +1660,7 @@ en:
       invalid_content_type: "Expected CONTENT-TYPE to be '%{content_type}' but got '%{actual}'."
       invalid_resource:
         "For property '%{property}' a resource of type '%{expected}' is expected but got a resource of type '%{actual}'."
+      invalid_user_status_transition: "The current user account status does not allow this operation."
       multiple_errors: "Multiple fields violated their constraints."
       parse_error: "The request body was neither empty, nor did it contain a single JSON object."
       writing_read_only_attributes: "You must not write a read-only attribute."

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1976,10 +1976,12 @@ This endpoint lists the types that are *available* in a given project.
                     },
                     "lock": {
                         "href": "/api/v3/users/1/lock",
+                        "title": "Set lock on j.sheppard"
                         "method": "POST"
                     },
                     "delete": {
                         "href": "/api/v3/users/1",
+                        "title": "Delete j.sheppard"
                         "method": "DELETE"
                     }
                 },

--- a/lib/api/errors/invalid_user_status_transition.rb
+++ b/lib/api/errors/invalid_user_status_transition.rb
@@ -1,0 +1,38 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module Errors
+    class InvalidUserStatusTransition < ErrorBase
+      def initialize
+        super 400, I18n.t('api_v3.errors.invalid_user_status_transition')
+      end
+    end
+  end
+end

--- a/lib/api/v3/errors/error_representer.rb
+++ b/lib/api/v3/errors/error_representer.rb
@@ -70,6 +70,8 @@ module API
             'urn:openproject-org:api:v3:errors:PropertyConstraintViolation'
           when ::API::Errors::InvalidRenderContext
             'urn:openproject-org:api:v3:errors:InvalidRenderContext'
+          when ::API::Errors::InvalidUserStatusTransition
+            'urn:openproject-org:api:v3:errors:InvalidUserStatusTransition'
           when ::API::Errors::InvalidRequestBody
             'urn:openproject-org:api:v3:errors:InvalidRequestBody'
           end

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -63,7 +63,7 @@ module API
             href: api_v3_paths.user_lock(represented.id),
             title: "Set lock on #{represented.login}",
             method: :post
-          } if current_user_is_admin && represented.status == User::STATUSES[:active]
+          } if current_user_is_admin && represented.lockable?
         end
 
         link :unlock do
@@ -71,7 +71,7 @@ module API
             href: api_v3_paths.user_lock(represented.id),
             title: "Remove lock on #{represented.login}",
             method: :delete
-          } if current_user_is_admin && represented.status == User::STATUSES[:locked]
+          } if current_user_is_admin && represented.activatable?
         end
 
         link :removeWatcher do

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -58,6 +58,22 @@ module API
           }
         end
 
+        link :lock do
+          {
+            href: api_v3_paths.user_lock(represented.id),
+            title: "Set lock on #{represented.login}",
+            method: :post
+          } if current_user_is_admin && represented.status == User::STATUSES[:active]
+        end
+
+        link :unlock do
+          {
+            href: api_v3_paths.user_lock(represented.id),
+            title: "Remove lock on #{represented.login}",
+            method: :delete
+          } if current_user_is_admin && represented.status == User::STATUSES[:locked]
+        end
+
         link :removeWatcher do
           {
             href: api_v3_paths.watcher(represented.id, @work_package.id),
@@ -78,10 +94,14 @@ module API
                           exec_context: :decorator
         property :created_at, getter: -> (*) { created_on.utc.iso8601 }, render_nil: true
         property :updated_at, getter: -> (*) { updated_on.utc.iso8601 }, render_nil: true
-        property :status, getter: -> (*) { status }, render_nil: true
+        property :status, getter: -> (*) { status_name }, render_nil: true
 
         def _type
           'User'
+        end
+
+        def current_user_is_admin
+          @current_user && @current_user.admin?
         end
 
         def current_user_allowed_to(permission, work_package)

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -52,6 +52,42 @@ module API
                 fail ::API::Errors::Unauthorized
               end
             end
+
+            namespace :lock do
+
+              # Authenticate lock transitions
+              before do
+                if !User.current.admin?
+                  fail ::API::Errors::Unauthorized
+                end
+              end
+
+              desc 'Set lock on user account'
+              post do
+                # Silently ignore lock -> lock transition
+                if @user.active? || @user.locked?
+                  @user.lock! unless @user.locked?
+
+                  status 200
+                  UserRepresenter.new(@user)
+                else
+                  fail ::API::Errors::InvalidUserStatusTransition
+                end
+              end
+
+              desc 'Remove lock on user account'
+              delete do
+                # Silently ignore active -> active transition
+                if @user.locked? || @user.active?
+                  @user.activate! unless @user.active?
+
+                  status 200
+                  UserRepresenter.new(@user)
+                else
+                  fail ::API::Errors::InvalidUserStatusTransition
+                end
+              end
+            end
           end
 
         end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -102,6 +102,10 @@ module API
             "#{users}/#{id}"
           end
 
+          def self.user_lock(id)
+            "#{user(id)}/lock"
+          end
+
           def self.versions(project_id)
             "#{project(project_id)}/versions"
           end

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::Users::UserRepresenter do
                               status: 1)
   }
   let(:current_user) { FactoryGirl.create(:user) }
-  let(:representer) { described_class.new(user, { current_user: current_user }) }
+  let(:representer) { described_class.new(user, current_user: current_user) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -35,7 +35,7 @@ describe ::API::V3::Users::UserRepresenter do
                               updated_on: Time.now,
                               status: 1)
   }
-  let(:current_user) { FactoryGirl.create(:user) }
+  let(:current_user) { FactoryGirl.build_stubbed(:user) }
   let(:representer) { described_class.new(user, current_user: current_user) }
 
   context 'generation' do

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 UserLock resource', type: :request do
+  include Rack::Test::Methods
+
+  let(:current_user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:model) { ::API::V3::Users::UserModel.new(user) }
+  let(:representer) { ::API::V3::Users::UserRepresenter.new(model) }
+  let(:lock_path) { "/api/v3/users/#{user.id}/lock" }
+
+  describe '#post' do
+    subject(:response) { last_response }
+
+    before do
+      allow(User).to receive(:current).and_return current_user
+      allow(User).to receive(:lock!)
+      post lock_path
+      # lock manually
+      user.lock
+    end
+
+    # Locking is only available for admins
+    context 'when logged in as admin' do
+      let(:current_user) { FactoryGirl.create(:admin) }
+
+      context 'user account can be locked' do
+
+        it 'should respond with 200' do
+          expect(subject.status).to eq(200)
+        end
+
+        it 'should respond with an updated lock status in the user model' do
+          expect(parse_json(subject.body, 'status')).to eq 'locked'
+        end
+      end
+
+      context 'user account is incompatible' do
+        let(:user) { FactoryGirl.create(:user, status: User::STATUSES[:registered] )}
+        it 'should fail for invalid transitions' do
+          expect(subject.status).to eq(400)
+        end
+      end
+    end
+
+    context 'requesting nonexistent user' do
+      let(:lock_path) { '/api/v3/users/9999/lock' }
+      it_behaves_like 'not found', 9999, 'User'
+    end
+
+
+    context 'non-admin user' do
+      it 'should respond with 403' do
+        expect(subject.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -65,7 +65,7 @@ describe 'API v3 UserLock resource', type: :request do
       end
 
       context 'user account is incompatible' do
-        let(:user) { FactoryGirl.create(:user, status: User::STATUSES[:registered] )}
+        let(:user) { FactoryGirl.create(:user, status: User::STATUSES[:registered]) }
         it 'should fail for invalid transitions' do
           expect(subject.status).to eq(400)
         end
@@ -76,7 +76,6 @@ describe 'API v3 UserLock resource', type: :request do
       let(:lock_path) { '/api/v3/users/9999/lock' }
       it_behaves_like 'not found', 9999, 'User'
     end
-
 
     context 'non-admin user' do
       it 'should respond with 403' do

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -62,8 +62,9 @@ describe 'API v3 UserLock resource', type: :request do
       end
 
       context 'user account is incompatible' do
-        let(:user) { FactoryGirl.create(:user,
-          status: User::STATUSES[:registered]) }
+        let(:user) {
+          FactoryGirl.create(:user, status: User::STATUSES[:registered])
+        }
         it 'should fail for invalid transitions' do
           expect(subject.status).to eq(400)
         end
@@ -105,8 +106,9 @@ describe 'API v3 UserLock resource', type: :request do
       end
 
       context 'user account is incompatible' do
-        let(:user) { FactoryGirl.create(:user,
-          status: User::STATUSES[:registered]) }
+        let(:user) {
+          FactoryGirl.create(:user, status: User::STATUSES[:registered])
+        }
         it 'should fail for invalid transitions' do
           expect(subject.status).to eq(400)
         end


### PR DESCRIPTION
This commit implements the proposed user locking/unlocking functionality
in https://github.com/opf/openproject/pull/2401.

The APIv3 is extended with a resource `/user/:id/lock` with the following properties:
- `POST /lock`: Set the lock of user(:id), if its account status is 'active'.
- `DELETE /lock`: Remove an active lock of user(:id), if its account status is 'locked'.

This commit also implements the following changes to `UserRepresenter`:
- Replaced the integer status field with the textual status name (i.e., 'active')
- Added two entries to __links_ for admin users: `lock`, `unlock`.

The work package containing this user story: https://community.openproject.org/work_packages/18122
