### PR TITLE
Feature/api version wp write

### DIFF
--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -63,8 +63,8 @@ module WorkPackage::Validations
   end
 
   def validate_fixed_version_is_assignable
-    if fixed_version
-      errors.add :fixed_version_id, :inclusion unless assignable_versions.include?(fixed_version)
+    if fixed_version_id && !assignable_versions.map(&:id).include?(fixed_version_id)
+      errors.add :fixed_version_id, :inclusion
     end
   end
 

--- a/lib/api/decorators/allowed_links_representer.rb
+++ b/lib/api/decorators/allowed_links_representer.rb
@@ -31,21 +31,30 @@ require 'roar/decorator'
 require 'roar/json/hal'
 
 module API
-  module V3
-    module WorkPackages
-      module Form
-        class SchemaAllowedVersionsRepresenter < Decorators::SchemaAllowedValuesRepresenter
-          self.value_representer = Versions::VersionRepresenter
+  module Decorators
+    class AllowedLinksRepresenter < Roar::Decorator
+      include API::V3::Utilities::PathHelper
+      include Roar::JSON::HAL
 
-          self.links_factory = -> (version) do
-            extend API::V3::Utilities::PathHelper
+      def initialize(represented, link_factory)
+        super(represented)
+        @link_factory = link_factory
+      end
 
-            { href: api_v3_paths.version(version.id), title: version.name }
-          end
+      self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
-          self.type = 'Version'
+      property :allowed_values,
+               exec_context: :decorator
+
+      private
+
+      def allowed_values
+        represented.map do |version|
+          link_factory.call(version)
         end
       end
+
+      attr_reader :link_factory
     end
   end
 end

--- a/lib/api/decorators/allowed_links_representer.rb
+++ b/lib/api/decorators/allowed_links_representer.rb
@@ -49,8 +49,8 @@ module API
       private
 
       def allowed_values
-        represented.map do |version|
-          link_factory.call(version)
+        represented.map do |object|
+          link_factory.call(object)
         end
       end
 

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -47,7 +47,13 @@ module API
         super(model)
       end
 
-      property :_type, exec_context: :decorator
+      property :_type,
+               exec_context: :decorator,
+               render_nil: false
+
+      private
+
+      def _type; end
     end
   end
 end

--- a/lib/api/v3/work_packages/form/schema_allowed_statuses_representer.rb
+++ b/lib/api/v3/work_packages/form/schema_allowed_statuses_representer.rb
@@ -31,32 +31,19 @@ require 'roar/decorator'
 require 'roar/json/hal'
 
 module API
-  module Decorators
-    class SchemaAllowedValuesRepresenter < Single
-      property :links,
-               as: :_links,
-               exec_context: :decorator
+  module V3
+    module WorkPackages
+      module Form
+        class SchemaAllowedStatusesRepresenter < Decorators::SchemaAllowedValuesRepresenter
+          self.value_representer = Statuses::StatusRepresenter
 
-      property :type,
-               exec_context: :decorator
+          self.links_factory = -> (status) do
+            extend API::V3::Utilities::PathHelper
 
-      collection :allowed_values,
-                 exec_context: :decorator,
-                 embedded: true
+            { href: api_v3_paths.status(status.id), title: status.name }
+          end
 
-      private
-
-      class_attribute :value_representer,
-                      :links_factory,
-                      :type
-
-      def links
-        AllowedLinksRepresenter.new(represented, links_factory)
-      end
-
-      def allowed_values
-        represented.map do |object|
-          value_representer.new(object, current_user: context[:current_user])
+          self.type = 'Status'
         end
       end
     end

--- a/lib/api/v3/work_packages/form/schema_allowed_versions_representer.rb
+++ b/lib/api/v3/work_packages/form/schema_allowed_versions_representer.rb
@@ -1,0 +1,71 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'roar/decorator'
+require 'roar/json/hal'
+
+module API
+  module V3
+    module WorkPackages
+      module Form
+        class SchemaAllowedVersionsRepresenter < Roar::Decorator
+          include Roar::JSON::HAL
+
+          self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
+
+          property :links_to_allowed_versions,
+                   as: :_links,
+                   getter: -> (*) { self } do
+            include API::V3::Utilities::PathHelper
+
+            self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
+
+            property :allowed_values, exec_context: :decorator
+
+            def allowed_values
+              represented[:versions].map do |version|
+                { href: api_v3_paths.version(version.id), title: version.name }
+              end
+            end
+          end
+
+          property :type, getter: -> (*) { 'Version' }
+
+          collection :allowed_values,
+                     embedded: true,
+                     getter: -> (*) {
+                       self[:versions].map do |version|
+                         Versions::VersionRepresenter.new(version, current_user: self[:current_user])
+                       end
+                     }
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -78,6 +78,19 @@ module API
                      represented.responsible_id = user_id
                    }
 
+          property :version,
+                   exec_context: :decorator,
+                   getter: -> (*) {
+                     id = represented.fixed_version_id
+
+                     { href: (api_v3_paths.version(id) if id) }
+                   },
+                   setter: -> (value, *) {
+                     resource = parse_resource(:version, :versions, value['href'])
+
+                     represented.fixed_version_id = resource[:id] if resource
+                   }
+
           private
 
           def parse_resource(property, ns, href)

--- a/lib/api/v3/work_packages/form/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_schema_representer.rb
@@ -142,6 +142,19 @@ module API
 
             property :type, getter: -> (*) { 'User' }
           end
+
+          property :version,
+                   decorator: SchemaAllowedVersionsRepresenter,
+                   exec_context: :decorator,
+                   getter: -> (*) {
+                     version_origin = represented
+
+                     if represented.persisted? && represented.fixed_version_id_changed?
+                       version_origin = represented.class.find(represented.id)
+                     end
+
+                     { versions: version_origin.assignable_versions, current_user: @current_user }
+                   }
         end
       end
     end

--- a/lib/api/v3/work_packages/form/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_schema_representer.rb
@@ -144,7 +144,6 @@ module API
           end
 
           property :version,
-                   decorator: SchemaAllowedVersionsRepresenter,
                    exec_context: :decorator,
                    getter: -> (*) {
                      version_origin = represented
@@ -153,7 +152,8 @@ module API
                        version_origin = represented.class.find(represented.id)
                      end
 
-                     { versions: version_origin.assignable_versions, current_user: @current_user }
+                     SchemaAllowedVersionsRepresenter.new(version_origin.assignable_versions,
+                                                          current_user: @current_user)
                    }
         end
       end

--- a/lib/api/v3/work_packages/form/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_schema_representer.rb
@@ -34,19 +34,7 @@ module API
   module V3
     module WorkPackages
       module Form
-        class WorkPackageSchemaRepresenter < Roar::Decorator
-          include Roar::JSON::HAL
-          include Roar::Hypermedia
-          include API::V3::Utilities::PathHelper
-
-          self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
-
-          def initialize(model, options = {})
-            @current_user = options[:current_user]
-
-            super(model)
-          end
-
+        class WorkPackageSchemaRepresenter < ::API::Decorators::Single
           property :_type,
                    getter: -> (*) { { type: 'MetaType', required: true, writable: false } },
                    writeable: false
@@ -68,80 +56,27 @@ module API
                        status_origin = represented.class.find(represented.id)
                      end
 
-                     status_origin.new_statuses_allowed_to(@current_user)
-                   } do
-            include Roar::JSON::HAL
+                     new_statuses = status_origin.new_statuses_allowed_to(current_user)
 
-            self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
+                     SchemaAllowedStatusesRepresenter.new(new_statuses,
+                                                          current_user: current_user)
+                   }
 
-            property :links_to_allowed_statuses,
-                     as: :_links,
-                     getter: -> (*) { self } do
-              include API::V3::Utilities::PathHelper
+          property :assignee,
+                   exec_context: :decorator,
+                   getter: -> (*) {
+                     link = api_v3_paths.available_assignees(represented.project.id)
 
-              self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
+                     ::API::Decorators::AllowedReferenceLinkRepresenter.new(link, 'User')
+                   }
 
-              property :allowed_values, exec_context: :decorator
+          property :responsible,
+                   exec_context: :decorator,
+                   getter: -> (*) {
+                     link = api_v3_paths.available_responsibles(represented.project.id)
 
-              def allowed_values
-                represented.map do |status|
-                  { href: api_v3_paths.status(status.id), title: status.name }
-                end
-              end
-            end
-
-            property :type, getter: -> (*) { 'Status' }
-
-            collection :allowed_values,
-                       embedded: true,
-                       class: ::Status,
-                       decorator: ::API::V3::Statuses::StatusRepresenter,
-                       getter: -> (*) { self }
-          end
-
-          property :assignee, getter: -> (*) { self } do
-            include Roar::JSON::HAL
-
-            self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
-
-            property :links_to_available_assignees,
-                     as: :_links,
-                     getter: -> (*) { self } do
-              include API::V3::Utilities::PathHelper
-
-              self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
-
-              property :allowed_values,
-                       getter: -> (*) {
-                         { href: api_v3_paths.available_assignees(represented.project.id) }
-                       },
-                       exec_context: :decorator
-            end
-
-            property :type, getter: -> (*) { 'User' }
-          end
-
-          property :responsible, getter: -> (*) { self } do
-            include Roar::JSON::HAL
-
-            self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
-
-            property :links_to_available_responsibles,
-                     as: :_links,
-                     getter: -> (*) { self } do
-              include API::V3::Utilities::PathHelper
-
-              self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
-
-              property :allowed_values,
-                       getter: -> (*) {
-                         { href: api_v3_paths.available_responsibles(represented.project.id) }
-                       },
-                       exec_context: :decorator
-            end
-
-            property :type, getter: -> (*) { 'User' }
-          end
+                     ::API::Decorators::AllowedReferenceLinkRepresenter.new(link, 'User')
+                   }
 
           property :version,
                    exec_context: :decorator,
@@ -153,8 +88,16 @@ module API
                      end
 
                      SchemaAllowedVersionsRepresenter.new(version_origin.assignable_versions,
-                                                          current_user: @current_user)
+                                                          current_user: current_user)
                    }
+
+          def current_user
+            context[:current_user]
+          end
+
+          def _type
+            'MetaType'
+          end
         end
       end
     end

--- a/lib/api/v3/work_packages/work_package_contract.rb
+++ b/lib/api/v3/work_packages/work_package_contract.rb
@@ -41,7 +41,8 @@ module API
           'description',
           'status_id',
           'assigned_to_id',
-          'responsible_id'
+          'responsible_id',
+          'fixed_version_id'
         ].freeze
 
         def initialize(object, user)

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -95,6 +95,14 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
           it_behaves_like 'linked property', 'responsible', '/api/v3/users/42'
         end
       end
+
+      describe 'version' do
+        let(:version) { FactoryGirl.build(:version, id: 42) }
+
+        before { work_package.fixed_version = version }
+
+        it_behaves_like 'linked property', 'version', '/api/v3/versions/42'
+      end
     end
   end
 end

--- a/spec/models/work_package/work_package_validations_spec.rb
+++ b/spec/models/work_package/work_package_validations_spec.rb
@@ -98,9 +98,9 @@ describe WorkPackage, type: :model do
   end
 
   describe 'validations of versions' do
+    let(:wp) { FactoryGirl.build(:work_package) }
 
     it 'validate, that versions of the project can be assigned to workpackages' do
-      wp = FactoryGirl.build(:work_package)
       assignable_version   = FactoryGirl.create(:version, project: wp.project)
 
       wp.fixed_version = assignable_version
@@ -111,7 +111,6 @@ describe WorkPackage, type: :model do
       other_project = FactoryGirl.create(:project)
       non_assignable_version = FactoryGirl.create(:version, project: other_project)
 
-      wp = FactoryGirl.build(:work_package)
       wp.fixed_version = non_assignable_version
 
       expect(wp).not_to be_valid
@@ -119,7 +118,6 @@ describe WorkPackage, type: :model do
     end
 
     it 'validate, that closed or locked versions cannot be assigned' do
-      wp = FactoryGirl.build(:work_package)
       non_assignable_version   = FactoryGirl.create(:version, project: wp.project)
 
       %w{locked closed}.each do |status|
@@ -129,6 +127,11 @@ describe WorkPackage, type: :model do
         expect(wp).not_to be_valid
         expect(wp.errors_on(:fixed_version_id).size).to eq(1)
       end
+    end
+
+    it 'validates, that inexistent ids are erroneous' do
+      wp.fixed_version_id = 0
+      expect(wp).to_not be_valid
     end
 
     describe 'validations of enabled types' do

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -455,6 +455,37 @@ describe 'API v3 Work package form resource', type: :request do
               it_behaves_like 'handling people', 'responsible'
             end
 
+            describe 'version' do
+              let(:path) { '_embedded/payload/_links/version/href' }
+              let(:target_version) { FactoryGirl.create(:version, project: project) }
+              let(:other_version) { FactoryGirl.create(:version, project: project) }
+              let(:version_link) { "/api/v3/versions/#{target_version.id}" }
+              let(:other_version_link) { "/api/v3/versions/#{other_version.id}" }
+              let(:version_parameter) { { _links: { version: { href: version_link } } } }
+              let(:params) { valid_params.merge(version_parameter) }
+
+              describe 'allowed values' do
+                include_context 'post request'
+
+                it 'should list all versions available for the project' do
+                  expect(subject.body).to be_json_eql(other_version_link.to_json)
+                    .at_path('_embedded/schema/versions/_links/allowedValues/1/href')
+                end
+              end
+
+              context 'valid version' do
+                include_context 'post request'
+
+                it_behaves_like 'valid payload'
+
+                it_behaves_like 'having no errors'
+
+                it 'should respond with updated work package version' do
+                  expect(subject.body).to be_json_eql(version_link.to_json).at_path(path)
+                end
+              end
+            end
+
             describe 'multiple errors' do
               let(:user_link) { '/api/v3/users/42' }
               let(:status_link) { '/api/v3/statuses/-1' }

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -465,11 +465,17 @@ describe 'API v3 Work package form resource', type: :request do
               let(:params) { valid_params.merge(version_parameter) }
 
               describe 'allowed values' do
+                before do
+                  other_version
+                end
+
                 include_context 'post request'
 
                 it 'should list all versions available for the project' do
+                  expect(subject.body).to be_json_eql(version_link.to_json)
+                    .at_path('_embedded/schema/version/_links/allowedValues/1/href')
                   expect(subject.body).to be_json_eql(other_version_link.to_json)
-                    .at_path('_embedded/schema/versions/_links/allowedValues/1/href')
+                    .at_path('_embedded/schema/version/_links/allowedValues/0/href')
                 end
               end
 


### PR DESCRIPTION
_based on #2402 - merge first_

Adds functionality to change a work package's version. The wp schema and the patch functionality is extended for that. 

There is still some room for refactoring here. I propose having a distinct object for the work package's business logic. Right now that logic is scattered around various objects: model, schema representer, wp api. A single object could take that logic. It's responsibilities would then be:
- update the work package
- validate before updating (it could still be separated into a contract for the validation to be reused but the object should be asked for whether the update is valid.)
- values valid for updating the package. That interface could then be used so that the object gets represented in the schema.

However, the PR in itself has a reasonable scope and already refactors some of what has been there.

https://community.openproject.org/work_packages/17405
https://community.openproject.org/work_packages/17406
