### PR TITLE
APIv3: Towards OAuth2 authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,6 +181,7 @@ end
 gem 'grape', '~> 0.10.1'
 gem 'roar',   '~> 1.0.0'
 gem 'reform', '~> 1.2.4', require: false
+gem 'doorkeeper', '~> 2.0.1'
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on
 # board to compile the native ones.  Note, that their use is discouraged, since

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     disposable (0.0.9)
       representable (~> 2.0)
       uber
+    doorkeeper (2.0.1)
+      railties (>= 3.1)
     equalizer (0.0.9)
     erubis (2.7.0)
     eventmachine (1.0.3)
@@ -429,6 +431,7 @@ DEPENDENCIES
   database_cleaner (~> 1.2.0)
   date_validator
   delayed_job_active_record (= 0.3.3)
+  doorkeeper (~> 2.0.1)
   factory_girl_rails (~> 4.0)
   faker
   globalize

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -28,20 +28,17 @@
 #++
 
 class OauthController < ApplicationController
-
   before_filter :require_login
-  before_filter :app_template , only: [:index, :register]
+  before_filter :app_template, only: [:index, :register]
 
   # Set 'my' page for account page
   layout 'my', only: :index
   menu_item :oauth_applications, only: :index
-  before_filter :set_user , only: [:index]
-
+  before_filter :set_user, only: [:index]
 
   ##
   # List my OAuth grants and registered applications
   def index
-
     @grants = User.current.oauth_grants
 
     if User.current.admin?
@@ -90,5 +87,4 @@ class OauthController < ApplicationController
   def oauth_application_params
     params.require(:doorkeeper_application).permit(:name, :redirect_uri)
   end
-
 end

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -1,0 +1,94 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class OauthController < ApplicationController
+
+  before_filter :require_login
+  before_filter :app_template , only: [:index, :register]
+
+  # Set 'my' page for account page
+  layout 'my', only: :index
+  menu_item :oauth_applications, only: :index
+  before_filter :set_user , only: [:index]
+
+
+  ##
+  # List my OAuth grants and registered applications
+  def index
+
+    @grants = User.current.oauth_grants
+
+    if User.current.admin?
+      # Show all registered applications
+      @applications = Doorkeeper::Application.all
+      render locals: { show_owners: true }
+    else
+      @applications = User.current.oauth_applications
+    end
+  end
+
+  def register
+    if request.post?
+      @new_app.attributes = oauth_application_params
+      @new_app.owner = User.current
+      if @new_app.save
+        flash[:notice] = l(:notice_successful_create)
+      end
+    end
+
+    redirect_to action: :index
+  end
+
+  # Destroy an oauth application
+  def destroy_application
+    @app = Doorkeeper::Application.find(params[:id])
+    if @app.owner == User.current || User.current.admin?
+      @app.destroy
+      flash[:notice] = l(:notice_successful_delete)
+    end
+    redirect_to action: :index
+  end
+
+  private
+
+  def app_template
+    @new_app = Doorkeeper::Application.new
+  end
+
+  ##
+  # Sets @user for the 'my'-layout
+  def set_user
+    @user = User.current
+  end
+
+  def oauth_application_params
+    params.require(:doorkeeper_application).permit(:name, :redirect_uri)
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,6 +105,12 @@ class User < Principal
   has_one :api_token, dependent: :destroy, class_name: 'Token', conditions: "action='api'"
   belongs_to :auth_source
 
+  # Authorized OAuth grants
+  has_many :oauth_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: 'resource_owner_id'
+
+  # User-defined oauth applications
+  has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
+
   # TODO: this is from Principal. the inheritance doesn't work correctly
   # note: it doesn't fail in development mode
   # see: https://github.com/rails/rails/issues/3847

--- a/app/views/oauth/_grants.html.erb
+++ b/app/views/oauth/_grants.html.erb
@@ -1,0 +1,38 @@
+<h2><%=l('oauth.my_application_grants')%></h2>
+
+<%= error_messages_for 'user' %>
+
+<% if grants.nil? || grants.empty? %>
+  <p><%= l('oauth.no_grants_given') %></p>
+<% else %>
+  <table class="list">
+      <thead>
+        <tr>
+          <th><%= l('oauth.application_details') %></th>
+          <th><%= l('oauth.grants.created_date') %>
+          <th><%= l('oauth.grants.scopes') %>
+          <th></th>
+      </thead>
+      <tbody>
+      <% grants.each do |grant| %>
+        <tr>
+          <td class="center">
+            <%= grant.application.name %>
+            <br/>
+            <strong><%= l('oauth.client_id') %></strong>: <%= grant.application.uid %>
+          </td>
+          <td class="center"><%= grant.created_at %></td>
+          <td class="center"><%= grant.scopes %></td>
+          <td class="center buttons">
+            <%= link_to l('oauth.grants.revoke'),
+                   { :controller => :oauth, :action => 'revoke', :id => grant.id },
+                   :method => :delete,
+                   :class   => 'icon icon-delete',
+                   :confirm => l('oauth.grants.revoke_confirmation', app_uid: grant.application.uid,
+                    app_name: grant.application.name) %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+  </table>
+<% end %>

--- a/app/views/oauth/_register_form.html.erb
+++ b/app/views/oauth/_register_form.html.erb
@@ -1,0 +1,22 @@
+<h3><%=l('oauth.register_application')%></h3>
+<p><%= l('oauth.help-text.register_intro') %></p>
+
+<%= labelled_tabular_form_for(app,
+          :url  => { :controller => :oauth, :action => 'register' },
+          :method => :post ) do |f| %>
+  <div class="box">
+    <p>
+      <%= f.text_field :name, :label => Doorkeeper::Application.human_attribute_name(:name), :required => true %>
+      <br/>
+      <span class="help-block"><%= l('oauth.help-text.name') %></span>
+    </p>
+    <p>
+      <%= f.text_field :redirect_uri, :label => Doorkeeper::Application.human_attribute_name(:redirect_uri), :required => true %>
+      <br/>
+      <span class="help-block">
+        <%= raw l('oauth.help-text.redirect_uri', native_default: "<strong>#{Doorkeeper.configuration.native_redirect_uri}</strong>") %>
+      </span>
+    </p>
+  </div>
+  <%= submit_tag l(:button_create) %>
+<% end %>

--- a/app/views/oauth/_registered_list.html.erb
+++ b/app/views/oauth/_registered_list.html.erb
@@ -1,0 +1,49 @@
+<h2><%=l('oauth.my_registered_applications')%></h2>
+
+<%= error_messages_for 'user' %>
+
+<% if applications.nil? || applications.empty? %>
+  <p><%= l('oauth.no_applications_text') %></p>
+<% else %>
+  <table class="list">
+      <thead>
+        <tr>
+          <th><%= Doorkeeper::Application.human_attribute_name(:name) %></th>
+          <% if show_owners %>
+          <th><%= l('oauth.application_owner') %></th>
+          <% end %>
+          <th><%= Doorkeeper::Application.human_attribute_name(:redirect_uri) %></th>
+          <th><%= l('oauth.application_details')%></th>
+          <th></th>
+      </thead>
+      <tbody>
+      <% applications.each do |app| %>
+        <tr>
+          <td class="center"><%= app.name %></td>
+          <% if show_owners %>
+          <td class="center">
+            <% if app.owner.nil? %>
+            -
+            <% else %>
+            <%= link_to h(app.owner.login), edit_user_path(app.owner) %>
+            <% end %>
+          </td>
+          <% end %>
+          <td class="center"><%= app.redirect_uri %></td>
+          <td class="center">
+            <strong><%= Doorkeeper::Application.human_attribute_name(:uid) %></strong>: <%= app.uid %>
+            <br/>
+            <strong><%= Doorkeeper::Application.human_attribute_name(:secret) %></strong>: <%= app.secret %>
+          </td>
+          <td class="buttons">
+            <%= link_to l(:button_delete),
+                   { :controller => :oauth, :action => 'destroy_application', :id => app.id },
+                   :method => :delete,
+                   :class   => 'icon icon-delete',
+                   :confirm => l('oauth.application_destroy_confirmation', :appname => app.name) %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+  </table>
+<% end %>

--- a/app/views/oauth/index.html.erb
+++ b/app/views/oauth/index.html.erb
@@ -1,0 +1,40 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<% html_title l('oauth.my_oauth') %>
+
+<%= render partial: 'oauth/grants', locals: {grants: @grants} %>
+
+<hr/>
+
+<%= render partial: 'oauth/registered_list', locals: {applications: @applications, show_owners: local_assigns[:show_owners]} %>
+
+<hr/>
+
+<%= render partial: 'oauth/register_form', locals: {app: @new_app} %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -6,7 +6,8 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    user = if env['rack.session']
+    user =
+    if env['rack.session']
       User.find(env['rack.session']['user_id'])
     else
       nil
@@ -15,7 +16,8 @@ Doorkeeper.configure do
     user || User.anonymous
   end
 
-  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  # If you want to restrict access to the web interface for adding oauth authorized applications,
+  # you need to declare the block below.
   admin_authenticator do
     User.current.admin?
   end
@@ -34,10 +36,12 @@ Doorkeeper.configure do
   # Issue access tokens with refresh token (disabled by default)
   # use_refresh_token
 
-  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Provide support for an owner to be assigned to each registered application
+  # (disabled by default)
   # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
   # a registered application
-  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the
+  # necessary support
   enable_application_owner :confirmation => true
 
   # Define access token scopes for your provider
@@ -59,9 +63,11 @@ Doorkeeper.configure do
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
 
   # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  # When clients register with the following redirect uri, they won't be redirected to any server
+  # and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled,
+  # clients must provide a valid URL (Similar behaviour:
+  # https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
   #
   # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,100 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use.
+  # Currently supported options are :active_record, :mongoid2, :mongoid3,
+  # :mongoid4, :mongo_mapper
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    user = if env['rack.session']
+      User.find(env['rack.session']['user_id'])
+    else
+      nil
+    end
+
+    user || User.anonymous
+  end
+
+  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  admin_authenticator do
+    User.current.admin?
+  end
+
+  # Authorization Code expiration time (default 10 minutes).
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
+  # access_token_expires_in 2.hours
+
+  # Reuse access token for the same resource owner within an application (disabled by default)
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  # reuse_access_token
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # a registered application
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  enable_application_owner :confirmation => true
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+  default_scopes  :readonly
+  optional_scopes :user, :project, :work_packages
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the native redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  #
+  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables all the four grant flows.
+  #
+  # grant_flows %w(authorization_code implicit password client_credentials)
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with trusted a application.
+  skip_authorization do
+    false
+  end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+
+  # Allow dynamic query parameters (disabled by default)
+  # Some applications require dynamic query parameters on their request_uri
+  # set to true if you want this to be allowed
+  # wildcard_redirect_uri false
+end

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -75,6 +75,10 @@ Redmine::MenuManager.map :my_menu do |menu|
             param: :user_id,
             if: Proc.new { Setting.users_deletable_by_self? },
             html: { class: 'icon2 icon-delete' }
+  menu.push :oauth_applications,
+            { :controller => '/oauth', :action => 'index'},
+            caption: I18n.t('oauth.my_oauth'),
+            html: { class: 'icon2 icon-key' }
 end
 
 Redmine::MenuManager.map :admin_menu do |menu|

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1151,7 +1151,26 @@ de:
     precision:
       format:
         delimiter: ""
-
+  oauth:
+    app: "API-Anwendung"
+    application_owner: "Besitzer"
+    application_details: "API Details"
+    application_destroy_confirmation: "Möchten Sie die API-Anwendung '%{appname}' wirklich löschen?"
+    client_id: "Client-ID"
+    grants:
+      created_date: "Erlaubt am"
+      scopes: "Berechtigungen"
+      revoke: "Zugriff widerrufen"
+    help-text:
+      name: "Der Name Ihrer API-Anwendung. Diese wird Ihnen und anderen Nutzern im Autorisierungsdialog angezeigt."
+      redirect_uri: "Die URL, an die Nutzer nach Autorisierung weitergeleitet werden. Wenn Sie eine Desktop-Anwendung registrieren, verwenden Sie diese spezielle URL: %{native_default}"
+      register_intro: "Wenn Sie eine eigene API-Anwendung mit OAuth für OpenProject entwickeln, können Sie die Anwendung über dieses Formular registrieren und damit anderen Nutzern zur Verfügung stellen."
+    my_application_grants: "API-Anwendungen mit Zugriffsberechtigung"
+    my_oauth: "OAuth Zugriffe und eigene API-Anwendungen"
+    my_registered_applications: "Ihre eigenen registrierten API-Anwendungen"
+    no_applications_text: "Sie haben keine API-Anwendung mit OpenProject registriert."
+    no_grants_given: "Sie haben bisher keiner API-Anwendung Zugriff auf Ihr Konto gewährt."
+    register_application: "OAuth API-Anwendung registrieren"
   permission_add_work_package_notes: "Kommentare hinzufügen"
   permission_add_work_packages: "Arbeitspakete hinzufügen"
   permission_add_messages: "Forenbeiträge hinzufügen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1141,6 +1141,27 @@ en:
           mb: "MB"
           tb: "TB"
 
+  oauth:
+    app: "API Application"
+    application_owner: "Owner"
+    application_details: "API Details"
+    application_destroy_confirmation: "Really delete OAuth application '%{appname}'?"
+    client_id: "Client ID"
+    grants:
+      created_date: "Approved on"
+      scopes: "Permissions"
+      revoke: "Revoke access"
+    help-text:
+      name: "The name of your application. This will be displayed to other users upon authorization."
+      redirect_uri: "The URL authorized users are redirected to. If you're registering a desktop application, use this URL: %{native_default}"
+      register_intro: "If you are developing an OAuth API client application for OpenProject, you can register it using this form for all users to use."
+    my_application_grants: "Granted applications"
+    my_oauth: "OAuth Grants and Apps"
+    my_registered_applications: "Registered OAuth applications"
+    no_applications_text: "You have not registered any applications."
+    no_grants_given: "No applications have been granted access to your user account."
+    register_application: "Register OAuth application"
+
   permission_add_work_package_notes: "Add notes"
   permission_add_work_packages: "Add work packages"
   permission_add_messages: "Post messages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -528,6 +528,20 @@ OpenProject::Application.routes.draw do
     post '/my/change_password', action: 'change_password'
     match '/my/first_login', action: 'first_login', via: [:get, :put]
     get '/my/page', action: 'page'
+
+    # A user's own oauth applications
+    get '/my/oauth' => 'oauth#index'
+  end
+
+  # OAuth authorization routes
+  use_doorkeeper do
+    # Do not add global application controller
+    skip_controllers :applications, :authorized_applications
+  end
+  namespace :oauth do
+    # Use our own application controller
+    post '/applications', action: 'register'
+    delete '/applications/:id', action: 'delete_application'
   end
 
   get 'authentication' => 'authentication#index'

--- a/db/migrate/20150104221826_create_doorkeeper_tables.rb
+++ b/db/migrate/20150104221826_create_doorkeeper_tables.rb
@@ -1,0 +1,47 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         null: false
+      t.string  :uid,          null: false
+      t.string  :secret,       null: false
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      # Allow regular users to register custom applications
+      # on their page
+      t.integer :owner_id,       null: true
+      t.string  :owner_type,     null: true
+      t.timestamps
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, null: false
+      t.integer  :application_id,    null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.integer  :application_id
+      t.string   :token,             null: false
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,        null: false
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+    add_index :oauth_applications, [:owner_id, :owner_type]
+  end
+end

--- a/lib/api/oauth_adapter.rb
+++ b/lib/api/oauth_adapter.rb
@@ -1,0 +1,102 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Adapter for Doorkeeper to add a second,
+# OAuth-based authentication flow
+
+module API
+  class OauthAdapter
+
+      attr_reader :token
+
+      ##
+      # Initialize the adapter for a grape request environment
+      def initialize env
+        @context = env
+
+        # Recover token once for scope of request
+        @token = authenticate!
+      end
+
+      ##
+      # Return the grape API endpoint from current context
+      def endpoint
+        @context['api.endpoint']
+      end
+
+      ##
+      # We store route oauth parameters as a route_setting with the key 'oauth'
+      def options
+        endpoint.route_setting(:oauth)
+      end
+
+      ##
+      # Convert Grape handled request to an ActionDispatch::Request
+      def doorkeeper_formatted_request
+        ActionDispatch::Request.new(@context)
+      end
+
+
+      ##
+      # Pass the current request as an ActionDispatch::Request to doorkeeper
+      # to possibly recover an access token from the defined token methods.
+      #
+      # Test the returned token (if any) against the route scopes defined in the grape api endpoint.
+      # Returns true iff the doorkeeper token is fresh and valid for the requested route.
+      def authenticated?
+        if @token
+          @token.acceptable?(*route_scopes)
+        else
+          false
+        end
+      end
+
+      ##
+      # Test whether this route needs oauth token authentication
+      def route_protected?
+        !!options[:disable_auth]
+      end
+
+      ##
+      # Reads all defined scope for the current api endpoint
+      def route_scopes
+        options[:scopes] || Doorkeeper.configuration.default_scopes
+      end
+
+      private
+
+      ##
+      # Recover the oauth token from the api request and returns
+      # the authentication status.
+      def authenticate!
+        Doorkeeper.authenticate(doorkeeper_formatted_request, Doorkeeper.configuration.access_token_methods)
+      end
+
+  end
+end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -60,19 +60,30 @@ module API
     parser :json, Parser.new
 
     helpers do
+
       def current_user
         return User.current if Rails.env.test?
-        user_id = env['rack.session']['user_id']
+
+        if @oauth_adapter.authenticated?
+          user_id = @oauth_adapter.resource_owner_id
+        else
+          user_id = env['rack.session']['user_id']
+        end
+
         User.current = user_id ? User.find(user_id) : User.anonymous
       end
 
       def authenticate
-        raise API::Errors::Unauthenticated if current_user.nil? || current_user.anonymous? if Setting.login_required?
+        # Check for valid oauth token for the given scope(s)
+        return if @oauth_adapter.authenticated?
+
+        # Fallback to Session-based authentication
+        raise ::API::Errors::Unauthenticated if current_user.nil? || current_user.anonymous? if Setting.login_required?
       end
 
       def authorize(permission, context: nil, global: false, user: current_user, allow: true)
         is_authorized = AuthorizationService.new(permission, context: context, global: global, user: user).call
-        raise API::Errors::Unauthorized unless is_authorized && allow
+        raise ::API::Errors::Unauthorized unless is_authorized && allow
         is_authorized
       end
     end
@@ -96,6 +107,7 @@ module API
 
     # run authentication before each request
     before do
+      @oauth_adapter = OauthAdapter.new(env)
       authenticate
     end
 

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -41,6 +41,7 @@ module API
               @user  = User.find(params[:id])
             end
 
+            # route_setting :oauth, scope: ['read-only']
             get do
               UserRepresenter.new(@user)
             end


### PR DESCRIPTION
This PR is intented as a starting point for a discussion towards OAuth2-based authentication provision for the OpenProject API v3 without breaking the existing Session-based authentication and to provide a partial implementation.
## 

The current application of the v3 API within the angular frontend is authenticated trivially with a session-based scheme, as it is always delivered to logged-in users anyway. Nonetheless, working with the user credentials to establish session-based authentication in external API applications is infeasible.

[Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) is an abstract, [almost feature-complete](https://github.com/applicake/doorkeeper/wiki/Supported-Features) OAuth2 provider with reasonably easy integration into the current OpenProject authentication flow.

This PR currently provides the following _new_ features:
1. OAuth-based API authentication routes with access_tokens based on headers, params.
2. Scopes: Fine-grained access control / permissions definition per API endpoint (e.g., `read-only` , `write`, …) using Grape `route_setting` (available since 24f496a9a08f8eb0af88feb6599a8554dd856562 merged grape 0.10)
3. Global API applications: (Admin) Register API applications available to users.
4. User-owned API applications: Users may optionally register indivdual applications to receive API credentials (client id, client secret).
5. Manage Grants / Registered applications from `/my/account` page.
6. Fallback to Session-based authentication when no access token is available
### Preview

The following screenshot shows the User's OAuth management page (linked under `/my/account`). It allows to review or revoke access to previous granted applications (top), register and view their own API applications. Admins may review / manage all existing API applications of other users.
![My Account Page -- OAuth Grants and Apps](https://dl.dropboxusercontent.com/u/270758/oauth_grants.png)
### Issues / Missing or incomplete specification
- Determination of `User.current` given the access_token (resource owner). The given initializer of Doorkeeper has access to the app's model, but not the ApplicationController. I believe all methods manipulating the current_user should be decoupled -- currently the API provides their own current_user and the full path and implications of the authentication flow is unclear.
- API endpoints have to be updated / extended to include scope information. As  an example, I've annotated the scope `GET /api/v3/users/:id` route as a comment.
- Spec/Tests, obviously. Irrelevant until a route/scope and authentication specification is agreed upon
