### PR TITLE
Fix/textile macros in api

### DIFF
--- a/app/assets/stylesheets/content/_flash_messages.sass
+++ b/app/assets/stylesheets/content/_flash_messages.sass
@@ -28,7 +28,7 @@
 
 @import global/all
 
-#errorExplanation, div.flash, .nodata, .warning
+#errorExplanation, .flash, .nodata, .warning
   padding: 4px
   margin: 0 0 10px 0
   color: $content_flash_msg_font_color
@@ -36,13 +36,13 @@
   %absolute-layout-mode &
     height: $content-flash-height
 
-div.flash.error a:link, div.flash.warning a:link, div.flash.notice a:link, #errorExplanation a:link,
-div.flash.error a:hover, div.flash.warning a:hover, div.flash.notice a:hover, #errorExplanation a:hover
+.flash.error a:link, .flash.warning a:link, .flash.notice a:link, #errorExplanation a:link,
+.flash.error a:hover, .flash.warning a:hover, .flash.notice a:hover, #errorExplanation a:hover
   @include default-font-normal($content_flash_msg_font_color)
   text-decoration: none
   cursor: default
 
-div.flash
+.flash
   display: none
 
   &.ng-leave
@@ -61,11 +61,14 @@ div.flash
   h2, p
     @extend .hidden-for-sighted
 
-div.flash.error, #errorExplanation
+.flash.error, #errorExplanation
   background-color: $content_flash_error_msg_bg_color
 
-div.flash.notice
+.flash.notice
   background-color: $content_flash_notice_msg_bg_color
 
-div.flash.warning, .nodata, .warning
+.flash.warning, .nodata, .warning
   background-color: $content_flash_warning_msg_bg_color
+
+.flash.permanent
+  display: block

--- a/lib/api/utilities/renderer/textile_renderer.rb
+++ b/lib/api/utilities/renderer/textile_renderer.rb
@@ -39,10 +39,11 @@ module API
         def initialize(text, object = nil)
           @text = text
           @object = object
+          @project = object.project if object.respond_to?(:project)
         end
 
         def to_html
-          format_text(@text, object: @object)
+          format_text(@text, object: @object, project: @project)
         end
 
         def controller; end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -37,7 +37,6 @@ module API
         include Roar::JSON::HAL
         include Roar::Hypermedia
         include API::V3::Utilities::PathHelper
-        include OpenProject::TextFormatting
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new
 
@@ -85,7 +84,7 @@ module API
                    {
                      format: 'textile',
                      raw: represented.notes,
-                     html: format_text(represented.notes, object: represented.journable)
+                     html: notes_renderer.to_html
                    }
                  },
                  setter: -> (value, *) { represented.notes = value['raw'] },
@@ -112,6 +111,11 @@ module API
         end
 
         private
+
+        def notes_renderer
+          ::API::Utilities::Renderer::TextileRenderer.new(represented.notes,
+                                                          represented.journable)
+        end
 
         def current_user_allowed_to_edit?
           (current_user_allowed_to(:edit_own_work_package_notes, represented.journable) && represented.editable_by?(@current_user)) || current_user_allowed_to(:edit_work_package_notes, represented.journable)

--- a/lib/api/v3/work_packages/form/form_representer.rb
+++ b/lib/api/v3/work_packages/form/form_representer.rb
@@ -38,7 +38,6 @@ module API
           include Roar::JSON::HAL
           include Roar::Hypermedia
           include API::V3::Utilities::PathHelper
-          include OpenProject::TextFormatting
 
           self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -37,11 +37,10 @@ module API
         class WorkPackagePayloadRepresenter < Roar::Decorator
           include Roar::JSON::HAL
           include Roar::Hypermedia
-          include OpenProject::TextFormatting
 
           self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
-          def initialize(represented, options={})
+          def initialize(represented, options = {})
             if options[:enforce_lock_version_validation]
               # enforces availibility validation of lock_version
               represented.lock_version = nil
@@ -71,7 +70,7 @@ module API
                      {
                        format: 'textile',
                        raw: represented.description,
-                       html: format_text(represented, :description)
+                       html: description_renderer.to_html
                      }
                    },
                    setter: -> (value, *) { represented.description = value['raw'] },
@@ -104,6 +103,10 @@ module API
 
           def work_package_attribute_links_representer(represented)
             ::API::V3::WorkPackages::Form::WorkPackageAttributeLinksRepresenter.new represented
+          end
+
+          def description_renderer
+            ::API::Utilities::Renderer::TextileRenderer.new(represented.description, represented)
           end
         end
       end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -37,7 +37,6 @@ module API
         include Roar::JSON::HAL
         include Roar::Hypermedia
         include API::V3::Utilities::PathHelper
-        include OpenProject::TextFormatting
 
         self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
@@ -240,7 +239,7 @@ module API
                    {
                      format: 'textile',
                      raw: represented.description,
-                     html: format_text(represented, :description)
+                     html: description_renderer.to_html
                    }
                  },
                  setter: -> (value, *) { represented.description = value['raw'] },
@@ -333,6 +332,10 @@ module API
         end
 
         private
+
+        def description_renderer
+          ::API::Utilities::Renderer::TextileRenderer.new(represented.description, represented)
+        end
 
         def hours_and_minutes(hours)
           hours = hours.to_f

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -82,7 +82,12 @@ module OpenProject
       project = options[:project] || @project || (obj && obj.respond_to?(:project) ? obj.project : nil)
       only_path = options.delete(:only_path) == false ? false : true
 
-      text = Redmine::WikiFormatting.to_html(Setting.text_formatting, text, object: obj, attribute: attr, edit: edit) { |macro, args| exec_macro(macro, obj, args, view: self, edit: edit) }
+      text = Redmine::WikiFormatting.to_html(Setting.text_formatting, text,
+                                             object: obj,
+                                             attribute: attr,
+                                             edit: edit) do |macro, macro_args|
+        exec_macro(macro, obj, macro_args, view: self, edit: edit, project: project)
+      end
 
       # TODO: transform modifications into WikiFormatting Helper, or at least ask the helper if he wants his stuff to be modified
       @parsed_headings = []

--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -103,9 +103,13 @@ module Redmine
             begin
               macros_runner.call(macro, args)
             rescue => e
-              "<div class=\"flash error\">#{::I18n.t(:macro_execution_error, macro_name: macro)} (#{e})</div>"
+              "<span class=\"flash error permanent\">\
+              #{::I18n.t(:macro_execution_error, macro_name: macro)} (#{e})\
+              </span>".squish
             rescue NotImplementedError
-              "<div class=\"flash error macro-unavailable\">#{::I18n.t(:macro_unavailable, macro_name: macro)}</div>"
+              "<span class=\"flash error macro-unavailable permanent\">\
+              #{::I18n.t(:macro_unavailable, macro_name: macro)}\
+              </span>".squish
             end || all
           else
             all


### PR DESCRIPTION
Fixes macro execution in the details pane by:
- provide the project context to the api's textile renderer
- fix macro exception's dom
- fix macro exception's css (they where simply hidden)

https://community.openproject.org/work_packages/17330

Additionally, it fixes a bug where inlined images cause a missing method error (url_for).

All representers now use the api's textile renderer which should make the API more robust when it comes to missing include statements.
