### PR TITLE
keep going if the file column already exists

### DIFF
--- a/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
+++ b/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
@@ -1,6 +1,6 @@
 class MigrateAttachmentsToCarrierWave < ActiveRecord::Migration
   def up
-    add_column :attachments, :file, :string
+    add_column_if_missing :attachments, :file, :string
 
     count = Attachment.count
 
@@ -32,6 +32,12 @@ class MigrateAttachmentsToCarrierWave < ActiveRecord::Migration
     end
 
     remove_column :attachments, :file
+  end
+
+  ##
+  # Adds a column to the a table unless the column already exists.
+  def add_column_if_missing(table, column, type)
+    add_column table, column, type unless column_exists?(table, column, type)
   end
 
   ##


### PR DESCRIPTION
If the database has actually already been migrated nothing bad will come of it so don't choke on an already existing file column.

To explain: If the database was already migrated the 'disk_filename' column will be empty and consequently nothing will happen at all.
