### PR TITLE
Fix and/or accept corrupt attachments.

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -139,7 +139,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def filename
-    file.file.filename if file.file
+    attributes['file']
   end
 
   def file=(file)

--- a/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
+++ b/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
@@ -100,7 +100,11 @@ class MigrateAttachmentsToCarrierWave < ActiveRecord::Migration
         FileUtils.move file, old_file
         attachment.update_column :file, nil
         attachment.update_column :filename, Pathname(file).basename.to_s
-        attachment.update_column :disk_filename, Pathname(old_file).basename.to_s
+
+        # keep original disk filename if it was preserved
+        if attachment.disk_filename.blank?
+          attachment.update_column :disk_filename, Pathname(old_file).basename.to_s
+        end
 
         FileUtils.rmdir Pathname(file).dirname
       end

--- a/db/migrate/20150116095004_patch_corrupt_attachments.rb
+++ b/db/migrate/20150116095004_patch_corrupt_attachments.rb
@@ -1,0 +1,49 @@
+##
+# Goes through all attachments looking for ones whose 'file' column, which is the new column
+# used by the carrierwave-based attachments, is not set.
+#
+# For every one of those attachments the migration then sets the 'file' column to
+# whatever the value of the legacy column 'filename' is. If that one is empty too
+# it falls back to the 'disk_filename' column. This one was not meant to be displayed
+# to users but it's better than nothing, especially when trying to identify corrupt attachments.
+#
+# If *that* column is empty too, the attachment is broken beyond repair and will be dropped.
+#
+# Note: Just because the 'file' column is restored doesn't mean the actual file exists.
+#       Rather the 'file' column being empty means precisely that the file is missing.
+#       By still writing the filename into the file column the attachment can at least
+#       be displayed, if not downloaded.
+#
+# Important: The migration is irreversible.
+class PatchCorruptAttachments < ActiveRecord::Migration
+  def up
+    Attachment.all.each do |attachment|
+      patch_attachment attachment
+    end
+  end
+
+  def down
+    puts "Can't revert this migration as it would mean breaking valid attachments. \
+          Even if we wanted to do that we can't know which ones were broken before \
+          to only break those again.".squish
+  end
+
+  def patch_attachment(attachment)
+    attributes = attachment.attributes
+    if attributes['file'].blank?
+      # fall back to disk filename if necessary
+      file = attributes['filename'].presence || attributes['disk_filename'].presence
+
+      if file
+        attachment.update_column :file, file
+        puts "updated attachment #{attachment.id}'s file column: #{file}"
+      else
+        # this really shouldn't happen - but just in case it does, it is more sensible
+        # to just delete the attachment because it will just break things
+        puts "could not patch #{attachment.inspect} - missing file name information - \
+              it's hopeless ... deleting it".squish
+        attachment.destroy
+      end
+    end
+  end
+end

--- a/db/migrate/20150116095004_patch_corrupt_attachments.rb
+++ b/db/migrate/20150116095004_patch_corrupt_attachments.rb
@@ -23,9 +23,9 @@ class PatchCorruptAttachments < ActiveRecord::Migration
   end
 
   def down
-    puts "Can't revert this migration as it would mean breaking valid attachments. \
-          Even if we wanted to do that we can't know which ones were broken before \
-          to only break those again.".squish
+    puts "Won't revert this migration as it would mean breaking valid attachments. \
+          We could break the attachments with missing files again by deleting their
+          file column to restore the state before the migration. But that doesn't help.".squish
   end
 
   def patch_attachment(attachment)

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -105,6 +105,10 @@ describe AttachmentsController, type: :controller do
     let(:work_package) { FactoryGirl.create :work_package, project: project }
     let(:uploader) { nil }
 
+    ##
+    # Stubs an attachment instance of the respective uploader.
+    # It's an anonymous subclass of Attachment and can therefore
+    # not be saved.
     let(:attachment) do
       clazz = Class.new Attachment
       clazz.mount_uploader :file, uploader
@@ -118,6 +122,7 @@ describe AttachmentsController, type: :controller do
       att = clazz.new container: work_package, author: user, file: file
       att.id = 42
       att.file.store!
+      att.send :write_attribute, :file, file.original_filename
       att
     end
 


### PR DESCRIPTION
Also use file column for filename: the uploader uses that one too, anyway
This way things don't break when the file is missing.

Fixes complications with WP [#18106](https://community.openproject.org/work_packages/18106)
