### PR TITLE
Make file_store cache work

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -47,7 +47,7 @@ module OpenProject
       'scm_subversion_command'  => nil,
       'disable_browser_cache'   => true,
       # default cache_store is :file_store in production and :memory_store in development
-      'rails_cache_store'       => nil,
+      'rails_cache_store'       => :file_store,
       'cache_expires_in_seconds' => nil,
       'cache_namespace' => nil,
       # use dalli defaults for memcache

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -191,6 +191,8 @@ module OpenProject
           cache_config = [:dalli_store]
           cache_config << @config['cache_memcache_server'] \
             if @config['cache_memcache_server']
+        elsif cache_store == :file_store
+          cache_config = [:file_store, Rails.root.join('tmp/cache/store')]
         else
           cache_config = [cache_store]
         end

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -192,7 +192,7 @@ module OpenProject
           cache_config << @config['cache_memcache_server'] \
             if @config['cache_memcache_server']
         elsif cache_store == :file_store
-          cache_config = [:file_store, Rails.root.join('tmp/cache/store')]
+          cache_config = [:file_store, Rails.root.join('tmp/cache')]
         else
           cache_config = [cache_store]
         end


### PR DESCRIPTION
Apparently, we're supposed to be able to set the `rails_cache_store` config to `file_store` instead of `memcache` ([source](https://github.com/opf/openproject/blob/dev/doc/CONFIGURATION.md)). However, when I tried doing that I ended up with the following error:

```
wrong number of arguments (0 for 1..2) (ArgumentError)
/opt/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/cache/file_store.rb:19:in `initialize'
/opt/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/cache.rb:69:in `new'
/opt/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/cache.rb:69:in `lookup_store'
```

The cache store is initialized in OpenProject::Configuration, and it looks like it is not taking into account the `file_store` case properly, since the file cache store requires at least one argument specifying where the cache files will be stored on disk.

This PR fixes the issue by initializing a file cache store in `tmp/cache/store`. A working file cache store is required in case a user chooses not to install a memcached server (e.g. when using the installation wizard in the packaged version).

/cc @kgalli
