### PR TITLE
Make Ruby style consistent in test-unit tests

### DIFF
--- a/test/exemplars/attachment_exemplar.rb
+++ b/test/exemplars/attachment_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Attachment < ActiveRecord::Base
-  generator_for :container, :method => :generate_project
-  generator_for :file, :method => :generate_file
-  generator_for :author, :method => :generate_author
+  generator_for :container, method: :generate_project
+  generator_for :file, method: :generate_file
+  generator_for :author, method: :generate_author
 
   def self.generate_project
     Project.generate!

--- a/test/exemplars/auth_source_exemplar.rb
+++ b/test/exemplars/auth_source_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class AuthSource < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Auth0'

--- a/test/exemplars/board_exemplar.rb
+++ b/test/exemplars/board_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Board < ActiveRecord::Base
-  generator_for :name, :method => :next_name
-  generator_for :description, :method => :next_description
-  generator_for :project, :method => :generate_project
+  generator_for :name, method: :next_name
+  generator_for :description, method: :next_description
+  generator_for :project, method: :generate_project
 
   def self.next_name
     @last_name ||= 'A Forum'

--- a/test/exemplars/change_exemplar.rb
+++ b/test/exemplars/change_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Change < ActiveRecord::Base
-  generator_for :action => 'A'
-  generator_for :path, :method => :next_path
-  generator_for :changeset, :method => :generate_changeset
+  generator_for action: 'A'
+  generator_for :path, method: :next_path
+  generator_for :changeset, method: :generate_changeset
 
   def self.next_path
     @last_path ||= 'test/dir/aaa0001'

--- a/test/exemplars/changeset_exemplar.rb
+++ b/test/exemplars/changeset_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Changeset < ActiveRecord::Base
-  generator_for :revision, :method => :next_revision
-  generator_for :committed_on => Date.today
-  generator_for :repository, :method => :generate_repository
+  generator_for :revision, method: :next_revision
+  generator_for committed_on: Date.today
+  generator_for :repository, method: :generate_repository
 
   def self.next_revision
     @last_revision ||= '1'

--- a/test/exemplars/comment_exemplar.rb
+++ b/test/exemplars/comment_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Comment < ActiveRecord::Base
-  generator_for :commented, :method => :generate_news
-  generator_for :author, :method => :generate_author
-  generator_for :comments => 'What great news this is.'
+  generator_for :commented, method: :generate_news
+  generator_for :author, method: :generate_author
+  generator_for comments: 'What great news this is.'
 
   def self.generate_news
     News.generate!

--- a/test/exemplars/custom_field_exemplar.rb
+++ b/test/exemplars/custom_field_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class CustomField < ActiveRecord::Base
-  generator_for :name, :method => :next_name
-  generator_for :field_format => 'string'
+  generator_for :name, method: :next_name
+  generator_for field_format: 'string'
 
   def self.next_name
     @last_name ||= 'CustomField0'

--- a/test/exemplars/custom_value_exemplar.rb
+++ b/test/exemplars/custom_value_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class CustomValue < ActiveRecord::Base
-  generator_for :custom_field, :method => :generate_custom_field
+  generator_for :custom_field, method: :generate_custom_field
 
   def self.generate_custom_field
     CustomField.generate!

--- a/test/exemplars/enabled_module_exemplar.rb
+++ b/test/exemplars/enabled_module_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class EnabledModule < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'module_001'

--- a/test/exemplars/enabled_module_exemplar.rb
+++ b/test/exemplars/enabled_module_exemplar.rb
@@ -35,5 +35,4 @@ class EnabledModule < ActiveRecord::Base
     @last_name.succ!
     @last_name
   end
-
 end

--- a/test/exemplars/enumeration_exemplar.rb
+++ b/test/exemplars/enumeration_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Enumeration < ActiveRecord::Base
-  generator_for :name, :method => :next_name
-  generator_for :type => 'TimeEntryActivity'
+  generator_for :name, method: :next_name
+  generator_for type: 'TimeEntryActivity'
 
   def self.next_name
     @last_name ||= 'Enumeration0'

--- a/test/exemplars/group_exemplar.rb
+++ b/test/exemplars/group_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Group < Principal
-  generator_for :lastname, :method => :next_lastname
+  generator_for :lastname, method: :next_lastname
 
   def self.next_lastname
     @last_lastname ||= 'Group'

--- a/test/exemplars/group_exemplar.rb
+++ b/test/exemplars/group_exemplar.rb
@@ -35,5 +35,4 @@ class Group < Principal
     @last_lastname.succ!
     @last_lastname
   end
-
 end

--- a/test/exemplars/issue_category_exemplar.rb
+++ b/test/exemplars/issue_category_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Category < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Category 0001'

--- a/test/exemplars/issue_exemplar.rb
+++ b/test/exemplars/issue_exemplar.rb
@@ -45,5 +45,4 @@ class Issue < WorkPackage
   def self.fetch_priority
     IssuePriority.first || IssuePriority.generate!
   end
-
 end

--- a/test/exemplars/issue_exemplar.rb
+++ b/test/exemplars/issue_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Issue < WorkPackage
-  generator_for :subject, :method => :next_subject
-  generator_for :author, :method => :next_author
-  generator_for :priority, :method => :fetch_priority
+  generator_for :subject, method: :next_subject
+  generator_for :author, method: :next_author
+  generator_for :priority, method: :fetch_priority
 
   def self.next_subject
     @last_subject ||= 'Subject 0'

--- a/test/exemplars/issue_priority_exemplar.rb
+++ b/test/exemplars/issue_priority_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class IssuePriority < Enumeration
-  generator_for :name, :method => :next_name
-  generator_for :type => 'IssuePriority'
+  generator_for :name, method: :next_name
+  generator_for type: 'IssuePriority'
 
   def self.next_name
     @last_name ||= 'IssuePriority0'

--- a/test/exemplars/journal_exemplar.rb
+++ b/test/exemplars/journal_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Journal < ActiveRecord::Base
-  generator_for :journaled, :method => :generate_issue
-  generator_for :user, :method => :generate_user
+  generator_for :journaled, method: :generate_issue
+  generator_for :user, method: :generate_user
 
   def self.generate_issue
     project = Project.generate!

--- a/test/exemplars/member_exemplar.rb
+++ b/test/exemplars/member_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Member < ActiveRecord::Base
-  generator_for :roles, :method => :generate_roles
-  generator_for :principal, :method => :generate_user
+  generator_for :roles, method: :generate_roles
+  generator_for :principal, method: :generate_user
 
   def self.generate_roles
     [Role.generate!]

--- a/test/exemplars/member_role_exemplar.rb
+++ b/test/exemplars/member_role_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class MemberRole < ActiveRecord::Base
-  generator_for :member, :method => :generate_member
-  generator_for :role, :method => :generate_role
+  generator_for :member, method: :generate_member
+  generator_for :role, method: :generate_role
 
   def self.generate_role
     Role.generate!

--- a/test/exemplars/message_exemplar.rb
+++ b/test/exemplars/message_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class Message < ActiveRecord::Base
-  generator_for :subject, :method => :next_subject
-  generator_for :content, :method => :next_content
-  generator_for :board, :method => :generate_board
+  generator_for :subject, method: :next_subject
+  generator_for :content, method: :next_content
+  generator_for :board, method: :generate_board
 
   def self.next_subject
     @last_subject ||= 'A Message'

--- a/test/exemplars/news_exemplar.rb
+++ b/test/exemplars/news_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class News < ActiveRecord::Base
-  generator_for :title, :method => :next_title
-  generator_for :description, :method => :next_description
+  generator_for :title, method: :next_title
+  generator_for :description, method: :next_description
 
   def self.next_title
     @last_title ||= 'A New Item'

--- a/test/exemplars/project_exemplar.rb
+++ b/test/exemplars/project_exemplar.rb
@@ -28,10 +28,10 @@
 #++
 
 class Project < ActiveRecord::Base
-  generator_for :name, :method => :next_name
-  generator_for :identifier, :method => :next_identifier_from_object_daddy
-  generator_for :enabled_modules, :method => :all_modules
-  generator_for :types, :method => :next_type
+  generator_for :name, method: :next_name
+  generator_for :identifier, method: :next_identifier_from_object_daddy
+  generator_for :enabled_modules, method: :all_modules
+  generator_for :types, method: :next_type
 
   def self.next_name
     @last_name ||= 'Project 0'
@@ -49,7 +49,7 @@ class Project < ActiveRecord::Base
   def self.all_modules
     [].tap do |modules|
       Redmine::AccessControl.available_project_modules.each do |name|
-        modules << EnabledModule.new(:name => name.to_s)
+        modules << EnabledModule.new(name: name.to_s)
       end
     end
   end

--- a/test/exemplars/query_exemplar.rb
+++ b/test/exemplars/query_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Query < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Query 0'

--- a/test/exemplars/repository_exemplar.rb
+++ b/test/exemplars/repository_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Repository < ActiveRecord::Base
-  generator_for :type => 'Repository::Subversion'
-  generator_for :url, :method => :next_url
+  generator_for type: 'Repository::Subversion'
+  generator_for :url, method: :next_url
 
   def self.next_url
     @last_url ||= 'file:///test/svn'

--- a/test/exemplars/repository_exemplar.rb
+++ b/test/exemplars/repository_exemplar.rb
@@ -36,5 +36,4 @@ class Repository < ActiveRecord::Base
     @last_url.succ!
     @last_url
   end
-
 end

--- a/test/exemplars/role_exemplar.rb
+++ b/test/exemplars/role_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Role < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Role0'

--- a/test/exemplars/status_exemplar.rb
+++ b/test/exemplars/status_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Status < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Status 0'

--- a/test/exemplars/subversion_repository_exemplar.rb
+++ b/test/exemplars/subversion_repository_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Repository::Subversion < Repository
-  generator_for :type, :method => 'Subversion'
-  generator_for :url, :method => :next_url
+  generator_for :type, method: 'Subversion'
+  generator_for :url, method: :next_url
 
   def self.next_url
     @last_url ||= 'file:///test/svn'

--- a/test/exemplars/subversion_repository_exemplar.rb
+++ b/test/exemplars/subversion_repository_exemplar.rb
@@ -36,5 +36,4 @@ class Repository::Subversion < Repository
     @last_url.succ!
     @last_url
   end
-
 end

--- a/test/exemplars/time_entry_activity.rb
+++ b/test/exemplars/time_entry_activity.rb
@@ -28,8 +28,8 @@
 #++
 
 class TimeEntryActivity < Enumeration
-  generator_for :name, :method => :next_name
-  generator_for :type => 'TimeEntryActivity'
+  generator_for :name, method: :next_name
+  generator_for type: 'TimeEntryActivity'
 
   def self.next_name
     @last_name ||= 'TimeEntryActivity0'

--- a/test/exemplars/time_entry_exemplar.rb
+++ b/test/exemplars/time_entry_exemplar.rb
@@ -35,5 +35,4 @@ class TimeEntry < ActiveRecord::Base
   def self.generate_user
     User.generate_with_protected!
   end
-
 end

--- a/test/exemplars/time_entry_exemplar.rb
+++ b/test/exemplars/time_entry_exemplar.rb
@@ -30,7 +30,7 @@
 class TimeEntry < ActiveRecord::Base
   generator_for(:spent_on) { Date.today }
   generator_for(:hours) { (rand * 10).round(2) } # 0.01 to 9.99
-  generator_for :user, :method => :generate_user
+  generator_for :user, method: :generate_user
 
   def self.generate_user
     User.generate_with_protected!

--- a/test/exemplars/type_exemplar.rb
+++ b/test/exemplars/type_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Type < ActiveRecord::Base
-  generator_for :name, :method => :next_name
+  generator_for :name, method: :next_name
 
   def self.next_name
     @last_name ||= 'Type 0'

--- a/test/exemplars/user_exemplar.rb
+++ b/test/exemplars/user_exemplar.rb
@@ -28,10 +28,10 @@
 #++
 
 class User < Principal
-  generator_for :login, :method => :next_login
-  generator_for :mail, :method => :next_email
-  generator_for :firstname, :method => :next_firstname
-  generator_for :lastname, :method => :next_lastname
+  generator_for :login, method: :next_login
+  generator_for :mail, method: :next_email
+  generator_for :firstname, method: :next_firstname
+  generator_for :lastname, method: :next_lastname
 
   def self.next_login
     @gen_login ||= 'user1'

--- a/test/exemplars/version_exemplar.rb
+++ b/test/exemplars/version_exemplar.rb
@@ -36,5 +36,4 @@ class Version < ActiveRecord::Base
     @last_name.succ!
     @last_name
   end
-
 end

--- a/test/exemplars/version_exemplar.rb
+++ b/test/exemplars/version_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Version < ActiveRecord::Base
-  generator_for :name, :method => :next_name
-  generator_for :status => 'open'
+  generator_for :name, method: :next_name
+  generator_for status: 'open'
 
   def self.next_name
     @last_name ||= 'Version 1.0.0'

--- a/test/exemplars/watcher_exemplar.rb
+++ b/test/exemplars/watcher_exemplar.rb
@@ -28,7 +28,7 @@
 #++
 
 class Watcher < ActiveRecord::Base
-  generator_for :user, :method => :generate_user
+  generator_for :user, method: :generate_user
 
   def self.generate_user
     User.generate_with_protected!

--- a/test/exemplars/wiki_content_exemplar.rb
+++ b/test/exemplars/wiki_content_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class WikiContent < ActiveRecord::Base
-  generator_for :text => 'Some content'
-  generator_for :page, :method => :generate_page
+  generator_for text: 'Some content'
+  generator_for :page, method: :generate_page
 
   def self.generate_page
     WikiPage.generate!

--- a/test/exemplars/wiki_exemplar.rb
+++ b/test/exemplars/wiki_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class Wiki < ActiveRecord::Base
-  generator_for :start_page => 'Start'
-  generator_for :project, :method => :generate_project
+  generator_for start_page: 'Start'
+  generator_for :project, method: :generate_project
 
   def self.generate_project
     Project.generate!

--- a/test/exemplars/wiki_page_exemplar.rb
+++ b/test/exemplars/wiki_page_exemplar.rb
@@ -28,8 +28,8 @@
 #++
 
 class WikiPage < ActiveRecord::Base
-  generator_for :title, :method => :next_title
-  generator_for :wiki, :method => :generate_wiki
+  generator_for :title, method: :next_title
+  generator_for :wiki, method: :generate_wiki
 
   def self.next_title
     @last_title ||= 'AWikiPage'

--- a/test/exemplars/wiki_redirect_exemplar.rb
+++ b/test/exemplars/wiki_redirect_exemplar.rb
@@ -28,9 +28,9 @@
 #++
 
 class WikiRedirect < ActiveRecord::Base
-  generator_for :title, :method => :next_title
-  generator_for :redirects_to, :method => :next_redirects_to
-  generator_for :wiki, :method => :generate_wiki
+  generator_for :title, method: :next_title
+  generator_for :redirects_to, method: :next_redirects_to
+  generator_for :wiki, method: :generate_wiki
 
   def self.next_title
     @last_title ||= 'AWikiPage'

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -47,7 +47,7 @@ class AccountControllerTest < ActionController::TestCase
     post :login, username: 'admin', password: 'bad'
     assert_response :success
     assert_template 'login'
-    assert_select "div.flash.error.icon.icon-error", /Invalid user or password/
+    assert_select 'div.flash.error.icon.icon-error', /Invalid user or password/
   end
 
   def test_login

--- a/test/functional/account_controller_test.rb
+++ b/test/functional/account_controller_test.rb
@@ -44,7 +44,7 @@ class AccountControllerTest < ActionController::TestCase
   end
 
   def test_login_with_wrong_password
-    post :login, :username => 'admin', :password => 'bad'
+    post :login, username: 'admin', password: 'bad'
     assert_response :success
     assert_template 'login'
     assert_select "div.flash.error.icon.icon-error", /Invalid user or password/
@@ -58,7 +58,7 @@ class AccountControllerTest < ActionController::TestCase
   def test_login_should_reset_session
     @controller.should_receive(:reset_session).once
 
-    post :login, :username => 'jsmith', :password => 'jsmith'
+    post :login, username: 'jsmith', password: 'jsmith'
     assert_response 302
   end
 

--- a/test/functional/activities_controller_test.rb
+++ b/test/functional/activities_controller_test.rb
@@ -52,7 +52,7 @@ class ActivitiesControllerTest < ActionController::TestCase
                                                status_id: 1)
     FactoryGirl.create :work_package_journal,
                        journable_id: issue.id,
-                       notes: "Some notes with Redmine links: #2, r2.",
+                       notes: 'Some notes with Redmine links: #2, r2.',
                        created_at: 1.days.ago.to_date.to_s(:db),
                        data: FactoryGirl.build(:journal_work_package_journal,
                                                subject: issue.subject,
@@ -65,13 +65,13 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag tag: "h3",
+    assert_tag tag: 'h3',
                content: /#{1.day.ago.to_date.day}/,
-               sibling: { tag: "dl",
-                 child: { tag: "dt",
-                   attributes: { class: /work_package/ },
-                   child: { tag: "a",
-                     content: /#{ERB::Util.html_escape(Status.find(2).name)}/
+               sibling: { tag: 'dl',
+                          child: { tag: 'dt',
+                                   attributes: { class: /work_package/ },
+                                   child: { tag: 'a',
+                                            content: /#{ERB::Util.html_escape(Status.find(2).name)}/
                    }
                  }
                }
@@ -93,13 +93,13 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag tag: "h3",
+    assert_tag tag: 'h3',
                content: /#{3.day.ago.to_date.day}/,
-               sibling: { tag: "dl",
-                 child: { tag: "dt",
-                   attributes: { class: /work_package/ },
-                   child: { tag: "a",
-                     content: /#{ERB::Util.html_escape(issue.subject)}/
+               sibling: { tag: 'dl',
+                          child: { tag: 'dt',
+                                   attributes: { class: /work_package/ },
+                                   child: { tag: 'a',
+                                            content: /#{ERB::Util.html_escape(issue.subject)}/
                    }
                  }
                }
@@ -122,13 +122,13 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag tag: "h3",
+    assert_tag tag: 'h3',
                content: /#{3.day.ago.to_date.day}/,
-               sibling: { tag: "dl",
-                 child: { tag: "dt",
-                   attributes: { class: /work_package/ },
-                   child: { tag: "a",
-                     content: /#{ERB::Util.html_escape(WorkPackage.find(1).subject)}/
+               sibling: { tag: 'dl',
+                          child: { tag: 'dt',
+                                   attributes: { class: /work_package/ },
+                                   child: { tag: 'a',
+                                            content: /#{ERB::Util.html_escape(WorkPackage.find(1).subject)}/
                    }
                  }
                }

--- a/test/functional/activities_controller_test.rb
+++ b/test/functional/activities_controller_test.rb
@@ -60,18 +60,18 @@ class ActivitiesControllerTest < ActionController::TestCase
                                                type_id: issue.type_id,
                                                project_id: issue.project_id)
 
-    get :index, :id => 1, :with_subprojects => 0
+    get :index, id: 1, with_subprojects: 0
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag :tag => "h3",
-               :content => /#{1.day.ago.to_date.day}/,
-               :sibling => { :tag => "dl",
-                 :child => { :tag => "dt",
-                   :attributes => { :class => /work_package/ },
-                   :child => { :tag => "a",
-                     :content => /#{ERB::Util.html_escape(Status.find(2).name)}/
+    assert_tag tag: "h3",
+               content: /#{1.day.ago.to_date.day}/,
+               sibling: { tag: "dl",
+                 child: { tag: "dt",
+                   attributes: { class: /work_package/ },
+                   child: { tag: "a",
+                     content: /#{ERB::Util.html_escape(Status.find(2).name)}/
                    }
                  }
                }
@@ -88,18 +88,18 @@ class ActivitiesControllerTest < ActionController::TestCase
                                                type_id: issue.type_id,
                                                project_id: issue.project_id)
 
-    get :index, :id => 1, :from => 3.days.ago.to_date
+    get :index, id: 1, from: 3.days.ago.to_date
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag :tag => "h3",
-               :content => /#{3.day.ago.to_date.day}/,
-               :sibling => { :tag => "dl",
-                 :child => { :tag => "dt",
-                   :attributes => { :class => /work_package/ },
-                   :child => { :tag => "a",
-                     :content => /#{ERB::Util.html_escape(issue.subject)}/
+    assert_tag tag: "h3",
+               content: /#{3.day.ago.to_date.day}/,
+               sibling: { tag: "dl",
+                 child: { tag: "dt",
+                   attributes: { class: /work_package/ },
+                   child: { tag: "a",
+                     content: /#{ERB::Util.html_escape(issue.subject)}/
                    }
                  }
                }
@@ -117,18 +117,18 @@ class ActivitiesControllerTest < ActionController::TestCase
                                                type_id: issue.type_id,
                                                project_id: issue.project_id)
 
-    get :index, :user_id => 2
+    get :index, user_id: 2
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:events_by_day)
 
-    assert_tag :tag => "h3",
-               :content => /#{3.day.ago.to_date.day}/,
-               :sibling => { :tag => "dl",
-                 :child => { :tag => "dt",
-                   :attributes => { :class => /work_package/ },
-                   :child => { :tag => "a",
-                     :content => /#{ERB::Util.html_escape(WorkPackage.find(1).subject)}/
+    assert_tag tag: "h3",
+               content: /#{3.day.ago.to_date.day}/,
+               sibling: { tag: "dl",
+                 child: { tag: "dt",
+                   attributes: { class: /work_package/ },
+                   child: { tag: "a",
+                     content: /#{ERB::Util.html_escape(WorkPackage.find(1).subject)}/
                    }
                  }
                }

--- a/test/functional/activities_controller_test.rb
+++ b/test/functional/activities_controller_test.rb
@@ -71,7 +71,7 @@ class ActivitiesControllerTest < ActionController::TestCase
                           child: { tag: 'dt',
                                    attributes: { class: /work_package/ },
                                    child: { tag: 'a',
-                                            content: /#{ERB::Util.html_escape(Status.find(2).name)}/
+                                            content: /#{ERB::Util.h(Status.find(2).name)}/
                    }
                  }
                }
@@ -99,7 +99,7 @@ class ActivitiesControllerTest < ActionController::TestCase
                           child: { tag: 'dt',
                                    attributes: { class: /work_package/ },
                                    child: { tag: 'a',
-                                            content: /#{ERB::Util.html_escape(issue.subject)}/
+                                            content: /#{ERB::Util.h(issue.subject)}/
                    }
                  }
                }
@@ -128,7 +128,7 @@ class ActivitiesControllerTest < ActionController::TestCase
                           child: { tag: 'dt',
                                    attributes: { class: /work_package/ },
                                    child: { tag: 'a',
-                                            content: /#{ERB::Util.html_escape(WorkPackage.find(1).subject)}/
+                                            content: /#{ERB::Util.h(WorkPackage.find(1).subject)}/
                    }
                  }
                }

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -63,7 +63,7 @@ class AdminControllerTest < ActionController::TestCase
     assert_template 'projects'
     assert_not_nil assigns(:projects)
     # active projects only
-    assert_nil assigns(:projects).detect {|u| !u.active?}
+    assert_nil assigns(:projects).detect { |u| !u.active? }
   end
 
   def test_projects_with_name_filter
@@ -109,7 +109,7 @@ class AdminControllerTest < ActionController::TestCase
       author 'John Smith'
       description 'This is a test plugin'
       version '0.0.1'
-      settings default: {'sample_setting' => 'value', 'foo'=>'bar'}, partial: 'foo/settings'
+      settings default: { 'sample_setting' => 'value', 'foo' => 'bar' }, partial: 'foo/settings'
     end
     Redmine::Plugin.register :bar do
     end

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -46,15 +46,15 @@ class AdminControllerTest < ActionController::TestCase
 
   def test_index
     get :index
-    assert_no_tag :tag => 'div',
-                  :attributes => { :class => /nodata/ }
+    assert_no_tag tag: 'div',
+                  attributes: { class: /nodata/ }
   end
 
   def test_index_with_no_configuration_data
     delete_configuration_data
     get :projects
-    assert_tag :tag => 'div',
-               :attributes => { :class => /nodata/ }
+    assert_tag tag: 'div',
+               attributes: { class: /nodata/ }
   end
 
   def test_projects
@@ -67,7 +67,7 @@ class AdminControllerTest < ActionController::TestCase
   end
 
   def test_projects_with_name_filter
-    get :projects, :name => 'store', :status => ''
+    get :projects, name: 'store', status: ''
     assert_response :success
     assert_template 'projects'
     projects = assigns(:projects)
@@ -79,7 +79,7 @@ class AdminControllerTest < ActionController::TestCase
   def test_load_default_configuration_data
     Setting.available_languages = [:de]
     delete_configuration_data
-    post :default_configuration, :lang => 'de'
+    post :default_configuration, lang: 'de'
     assert_response :redirect
     assert_nil flash[:error]
     assert Status.find_by_name('neu')
@@ -109,7 +109,7 @@ class AdminControllerTest < ActionController::TestCase
       author 'John Smith'
       description 'This is a test plugin'
       version '0.0.1'
-      settings :default => {'sample_setting' => 'value', 'foo'=>'bar'}, :partial => 'foo/settings'
+      settings default: {'sample_setting' => 'value', 'foo'=>'bar'}, partial: 'foo/settings'
     end
     Redmine::Plugin.register :bar do
     end
@@ -118,8 +118,8 @@ class AdminControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'plugins'
 
-    assert_tag :td, :child => { :tag => 'span', :content => 'Foo plugin' }
-    assert_tag :td, :child => { :tag => 'span', :content => 'Bar' }
+    assert_tag :td, child: { tag: 'span', content: 'Foo plugin' }
+    assert_tag :td, child: { tag: 'span', content: 'Bar' }
   end
 
   def test_info
@@ -131,16 +131,16 @@ class AdminControllerTest < ActionController::TestCase
   def test_admin_menu_plugin_extension
     Redmine::MenuManager.map :admin_menu do |menu|
       menu.push :test_admin_menu_plugin_extension,
-                { :controller => 'projects', :action => 'index' },
-                :caption => 'Test'
+                { controller: 'projects', action: 'index' },
+                caption: 'Test'
     end
 
     User.current = User.find(1)
 
     get :projects
     assert_response :success
-    assert_tag :a, :attributes => { :href => '/projects' },
-                   :content => 'Test'
+    assert_tag :a, attributes: { href: '/projects' },
+                   content: 'Test'
 
     Redmine::MenuManager.map :admin_menu do |menu|
       menu.delete :test_admin_menu_plugin_extension

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -47,35 +47,35 @@ class AttachmentsControllerTest < ActionController::TestCase
   end
 
   def test_show_diff
-    get :show, :id => 14 # 060719210727_changeset_utf8.diff
+    get :show, id: 14 # 060719210727_changeset_utf8.diff
     assert_response :success
     assert_template 'diff'
     assert_equal 'text/html', @response.content_type
 
     assert_tag 'th',
-      :attributes => {:class => /filename/},
-      :content => /issues_controller.rb\t\(révision 1484\)/
+      attributes: {class: /filename/},
+      content: /issues_controller.rb\t\(révision 1484\)/
     assert_tag 'td',
-      :attributes => {:class => /line-code/},
-      :content => /Demande créée avec succès/
+      attributes: {class: /line-code/},
+      content: /Demande créée avec succès/
   end
 
   def test_show_diff_should_strip_non_utf8_content
-    get :show, :id => 5 # 060719210727_changeset_iso8859-1.diff
+    get :show, id: 5 # 060719210727_changeset_iso8859-1.diff
     assert_response :success
     assert_template 'diff'
     assert_equal 'text/html', @response.content_type
 
     assert_tag 'th',
-      :attributes => {:class => /filename/},
-      :content => /issues_controller.rb\t\(rvision 1484\)/
+      attributes: {class: /filename/},
+      content: /issues_controller.rb\t\(rvision 1484\)/
     assert_tag 'td',
-      :attributes => {:class => /line-code/},
-      :content => /Demande cre avec succs/
+      attributes: {class: /line-code/},
+      content: /Demande cre avec succs/
   end
 
   def test_show_text_file
-    get :show, :id => 4
+    get :show, id: 4
     assert_response :success
     assert_template 'file'
     assert_equal 'text/html', @response.content_type
@@ -85,41 +85,41 @@ class AttachmentsControllerTest < ActionController::TestCase
     Setting.file_max_size_displayed = 512
     Attachment.find(4).update_attribute :filesize, 754.kilobyte
 
-    get :show, :id => 4
+    get :show, id: 4
     assert_redirected_to 'http://test.host/attachments/4/download/source.rb'
 
-    get :download, :id => 4
+    get :download, id: 4
     assert_response :success
     assert_equal 'text/x-ruby', @response.content_type
   end
 
   def test_show_other
-    get :show, :id => 6
+    get :show, id: 6
 
     assert_redirected_to 'http://test.host/attachments/6/download/archive.zip'
 
-    get :download, :id => 6
+    get :download, id: 6
     assert_equal 'application/zip', @response.content_type
   end
 
   def test_download_text_file
-    get :download, :id => 4
+    get :download, id: 4
     assert_response :success
     assert_equal 'text/x-ruby', @response.content_type
   end
 
   def test_download_missing_file
-    get :download, :id => 2
+    get :download, id: 2
     assert_response 404
   end
 
   def test_anonymous_on_private_private
-    get :download, :id => 7
+    get :download, id: 7
     assert_redirected_to '/login?back_url=http%3A%2F%2Ftest.host%2Fattachments%2F7%2Fdownload'
   end
 
   def test_destroy_without_permission
-    delete :destroy, :id => 3
+    delete :destroy, id: 3
     assert_redirected_to '/login?back_url=http%3A%2F%2Ftest.host%2Fattachments%2F3'
     assert Attachment.find_by_id(3)
   end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -33,7 +33,6 @@ require 'attachments_controller'
 # Re-raise errors caught by the controller.
 class AttachmentsController; def rescue_action(e) raise e end; end
 
-
 class AttachmentsControllerTest < ActionController::TestCase
   fixtures :all
 
@@ -53,11 +52,11 @@ class AttachmentsControllerTest < ActionController::TestCase
     assert_equal 'text/html', @response.content_type
 
     assert_tag 'th',
-      attributes: {class: /filename/},
-      content: /issues_controller.rb\t\(révision 1484\)/
+               attributes: { class: /filename/ },
+               content: /issues_controller.rb\t\(révision 1484\)/
     assert_tag 'td',
-      attributes: {class: /line-code/},
-      content: /Demande créée avec succès/
+               attributes: { class: /line-code/ },
+               content: /Demande créée avec succès/
   end
 
   def test_show_diff_should_strip_non_utf8_content
@@ -67,11 +66,11 @@ class AttachmentsControllerTest < ActionController::TestCase
     assert_equal 'text/html', @response.content_type
 
     assert_tag 'th',
-      attributes: {class: /filename/},
-      content: /issues_controller.rb\t\(rvision 1484\)/
+               attributes: { class: /filename/ },
+               content: /issues_controller.rb\t\(rvision 1484\)/
     assert_tag 'td',
-      attributes: {class: /line-code/},
-      content: /Demande cre avec succs/
+               attributes: { class: /line-code/ },
+               content: /Demande cre avec succs/
   end
 
   def test_show_text_file

--- a/test/functional/boards_controller_test.rb
+++ b/test/functional/boards_controller_test.rb
@@ -68,7 +68,7 @@ class BoardsControllerTest < ActionController::TestCase
   def test_create
     @request.session[:user_id] = 2
     assert_difference 'Board.count' do
-      post :create, project_id: 1, board: { name: 'Testing', description: 'Testing board creation'}
+      post :create, project_id: 1, board: { name: 'Testing', description: 'Testing board creation' }
     end
     assert_redirected_to '/projects/ecookbook/settings/boards'
   end
@@ -94,7 +94,7 @@ class BoardsControllerTest < ActionController::TestCase
   def test_update
     @request.session[:user_id] = 2
     assert_no_difference 'Board.count' do
-      put :update, project_id: 1, id: 2, board: { name: 'Testing', description: 'Testing board update'}
+      put :update, project_id: 1, id: 2, board: { name: 'Testing', description: 'Testing board update' }
     end
     assert_redirected_to '/projects/ecookbook/settings/boards'
     assert_equal 'Testing', Board.find(2).name

--- a/test/functional/boards_controller_test.rb
+++ b/test/functional/boards_controller_test.rb
@@ -44,7 +44,7 @@ class BoardsControllerTest < ActionController::TestCase
   end
 
   def test_index
-    get :index, :project_id => 1
+    get :index, project_id: 1
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:boards)
@@ -52,14 +52,14 @@ class BoardsControllerTest < ActionController::TestCase
   end
 
   def test_index_not_found
-    get :index, :project_id => 97
+    get :index, project_id: 97
     assert_response 404
   end
 
   def test_index_should_show_messages_if_only_one_board
     Project.find(1).boards.slice(1..-1).each(&:destroy)
 
-    get :index, :project_id => 1
+    get :index, project_id: 1
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:topics)
@@ -68,13 +68,13 @@ class BoardsControllerTest < ActionController::TestCase
   def test_create
     @request.session[:user_id] = 2
     assert_difference 'Board.count' do
-      post :create, :project_id => 1, :board => { :name => 'Testing', :description => 'Testing board creation'}
+      post :create, project_id: 1, board: { name: 'Testing', description: 'Testing board creation'}
     end
     assert_redirected_to '/projects/ecookbook/settings/boards'
   end
 
   def test_show
-    get :show, :project_id => 1, :id => 1
+    get :show, project_id: 1, id: 1
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:board)
@@ -83,7 +83,7 @@ class BoardsControllerTest < ActionController::TestCase
   end
 
   def test_show_atom
-    get :show, :project_id => 1, :id => 1, :format => 'atom'
+    get :show, project_id: 1, id: 1, format: 'atom'
     assert_response :success
     assert_template 'common/feed'
     assert_not_nil assigns(:board)
@@ -94,7 +94,7 @@ class BoardsControllerTest < ActionController::TestCase
   def test_update
     @request.session[:user_id] = 2
     assert_no_difference 'Board.count' do
-      put :update, :project_id => 1, :id => 2, :board => { :name => 'Testing', :description => 'Testing board update'}
+      put :update, project_id: 1, id: 2, board: { name: 'Testing', description: 'Testing board update'}
     end
     assert_redirected_to '/projects/ecookbook/settings/boards'
     assert_equal 'Testing', Board.find(2).name
@@ -103,7 +103,7 @@ class BoardsControllerTest < ActionController::TestCase
   def test_post_destroy
     @request.session[:user_id] = 2
     assert_difference 'Board.count', -1 do
-      post :destroy, :project_id => 1, :id => 2
+      post :destroy, project_id: 1, id: 2
     end
     assert_redirected_to '/projects/ecookbook/settings/boards'
     assert_nil Board.find_by_id(2)
@@ -112,7 +112,7 @@ class BoardsControllerTest < ActionController::TestCase
   def test_index_should_404_with_no_board
     Project.find(1).boards.each(&:destroy)
 
-    get :index, :project_id => 1
+    get :index, project_id: 1
     assert_response 404
   end
 end

--- a/test/functional/custom_fields_controller_test.rb
+++ b/test/functional/custom_fields_controller_test.rb
@@ -49,19 +49,19 @@ class CustomFieldsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'new'
     assert_tag :select,
-      attributes: {name: 'custom_field[field_format]'},
-      child: {
-        tag: 'option',
-        attributes: {value: 'user'},
-        content: 'User'
-      }
+               attributes: { name: 'custom_field[field_format]' },
+               child: {
+                 tag: 'option',
+                 attributes: { value: 'user' },
+                 content: 'User'
+               }
     assert_tag :select,
-      attributes: {name: 'custom_field[field_format]'},
-      child: {
-        tag: 'option',
-        attributes: {value: 'version'},
-        content: 'Version'
-      }
+               attributes: { name: 'custom_field[field_format]' },
+               child: {
+                 tag: 'option',
+                 attributes: { value: 'version' },
+                 content: 'Version'
+               }
   end
 
   def test_get_new_with_invalid_custom_field_class_should_redirect_to_list
@@ -71,24 +71,24 @@ class CustomFieldsControllerTest < ActionController::TestCase
 
   def test_post_new_list_custom_field
     assert_difference 'CustomField.count' do
-      post :create, type: "WorkPackageCustomField",
-                    custom_field: {name: "test_post_new_list",
-                                      default_value: "",
-                                      min_length: "0",
-                                      searchable: "0",
-                                      regexp: "",
-                                      is_for_all: "1",
-                                      possible_values: "0.1\n0.2\n",
-                                      max_length: "0",
-                                      is_filter: "0",
-                                      is_required:"0",
-                                      field_format: "list",
-                                      type_ids: ["1", ""]}
+      post :create, type: 'WorkPackageCustomField',
+                    custom_field: { name: 'test_post_new_list',
+                                    default_value: '',
+                                    min_length: '0',
+                                    searchable: '0',
+                                    regexp: '',
+                                    is_for_all: '1',
+                                    possible_values: "0.1\n0.2\n",
+                                    max_length: '0',
+                                    is_filter: '0',
+                                    is_required: '0',
+                                    field_format: 'list',
+                                    type_ids: ['1', ''] }
     end
     assert_redirected_to '/custom_fields?tab=WorkPackageCustomField'
     field = WorkPackageCustomField.find_by_name('test_post_new_list')
     assert_not_nil field
-    assert_equal ["0.1", "0.2"], field.possible_values
+    assert_equal ['0.1', '0.2'], field.possible_values
     assert_equal 1, field.types.size
   end
 end

--- a/test/functional/custom_fields_controller_test.rb
+++ b/test/functional/custom_fields_controller_test.rb
@@ -45,45 +45,45 @@ class CustomFieldsControllerTest < ActionController::TestCase
   end
 
   def test_get_new_issue_custom_field
-    get :new, :type => 'WorkPackageCustomField'
+    get :new, type: 'WorkPackageCustomField'
     assert_response :success
     assert_template 'new'
     assert_tag :select,
-      :attributes => {:name => 'custom_field[field_format]'},
-      :child => {
-        :tag => 'option',
-        :attributes => {:value => 'user'},
-        :content => 'User'
+      attributes: {name: 'custom_field[field_format]'},
+      child: {
+        tag: 'option',
+        attributes: {value: 'user'},
+        content: 'User'
       }
     assert_tag :select,
-      :attributes => {:name => 'custom_field[field_format]'},
-      :child => {
-        :tag => 'option',
-        :attributes => {:value => 'version'},
-        :content => 'Version'
+      attributes: {name: 'custom_field[field_format]'},
+      child: {
+        tag: 'option',
+        attributes: {value: 'version'},
+        content: 'Version'
       }
   end
 
   def test_get_new_with_invalid_custom_field_class_should_redirect_to_list
-    get :new, :type => 'UnknownCustomField'
+    get :new, type: 'UnknownCustomField'
     assert_redirected_to '/custom_fields'
   end
 
   def test_post_new_list_custom_field
     assert_difference 'CustomField.count' do
-      post :create, :type => "WorkPackageCustomField",
-                    :custom_field => {:name => "test_post_new_list",
-                                      :default_value => "",
-                                      :min_length => "0",
-                                      :searchable => "0",
-                                      :regexp => "",
-                                      :is_for_all => "1",
-                                      :possible_values => "0.1\n0.2\n",
-                                      :max_length => "0",
-                                      :is_filter => "0",
-                                      :is_required =>"0",
-                                      :field_format => "list",
-                                      :type_ids => ["1", ""]}
+      post :create, type: "WorkPackageCustomField",
+                    custom_field: {name: "test_post_new_list",
+                                      default_value: "",
+                                      min_length: "0",
+                                      searchable: "0",
+                                      regexp: "",
+                                      is_for_all: "1",
+                                      possible_values: "0.1\n0.2\n",
+                                      max_length: "0",
+                                      is_filter: "0",
+                                      is_required:"0",
+                                      field_format: "list",
+                                      type_ids: ["1", ""]}
     end
     assert_redirected_to '/custom_fields?tab=WorkPackageCustomField'
     field = WorkPackageCustomField.find_by_name('test_post_new_list')

--- a/test/functional/enumerations_controller_test.rb
+++ b/test/functional/enumerations_controller_test.rb
@@ -50,21 +50,21 @@ class EnumerationsControllerTest < ActionController::TestCase
   end
 
   def test_destroy_enumeration_not_in_use
-    post :destroy, :id => 7
+    post :destroy, id: 7
     assert_redirected_to enumerations_path
     assert_nil Enumeration.find_by_id(7)
   end
 
   def test_destroy_enumeration_in_use
-    post :destroy, :id => 4
+    post :destroy, id: 4
     assert_response :success
     assert_template 'destroy'
     assert_not_nil Enumeration.find_by_id(4)
   end
 
   def test_destroy_enumeration_in_use_with_reassignment
-    issue = WorkPackage.find(:first, :conditions => {:priority_id => 4})
-    post :destroy, :id => 4, :reassign_to_id => 6
+    issue = WorkPackage.find(:first, conditions: {priority_id: 4})
+    post :destroy, id: 4, reassign_to_id: 6
     assert_redirected_to enumerations_path
     assert_nil Enumeration.find_by_id(4)
     # check that the issue was reassign

--- a/test/functional/enumerations_controller_test.rb
+++ b/test/functional/enumerations_controller_test.rb
@@ -63,7 +63,7 @@ class EnumerationsControllerTest < ActionController::TestCase
   end
 
   def test_destroy_enumeration_in_use_with_reassignment
-    issue = WorkPackage.find(:first, conditions: {priority_id: 4})
+    issue = WorkPackage.find(:first, conditions: { priority_id: 4 })
     post :destroy, id: 4, reassign_to_id: 6
     assert_redirected_to enumerations_path
     assert_nil Enumeration.find_by_id(4)

--- a/test/functional/groups_controller_test.rb
+++ b/test/functional/groups_controller_test.rb
@@ -51,7 +51,7 @@ class GroupsControllerTest < ActionController::TestCase
   end
 
   def test_show
-    get :show, :id => 10
+    get :show, id: 10
     assert_response :success
     assert_template 'show'
   end
@@ -64,61 +64,61 @@ class GroupsControllerTest < ActionController::TestCase
 
   def test_create
     assert_difference 'Group.count' do
-      post :create, :group => {:lastname => 'New group'}
+      post :create, group: {lastname: 'New group'}
     end
     assert_redirected_to groups_path
   end
 
   def test_edit
-    get :edit, :id => 10
+    get :edit, id: 10
     assert_response :success
     assert_template 'edit'
   end
 
   def test_update
-    put :update, :id => 10, :group => {:lastname => 'new name'}
+    put :update, id: 10, group: {lastname: 'new name'}
     assert_redirected_to groups_path
   end
 
   def test_destroy
     assert_difference 'Group.count', -1 do
-      delete :destroy, :id => 10
+      delete :destroy, id: 10
     end
     assert_redirected_to groups_path
   end
 
   def test_add_users
     assert_difference 'Group.find(10).users.count', 2 do
-      post :add_users, :id => 10, :user_ids => ['2', '3']
+      post :add_users, id: 10, user_ids: ['2', '3']
     end
   end
 
   def test_remove_user
     assert_difference 'Group.find(10).users.count', -1 do
-      delete :remove_user, :id => 10, :user_id => '8'
+      delete :remove_user, id: 10, user_id: '8'
     end
   end
 
   def test_create_membership
     assert_difference 'Group.find(10).members.count' do
-      post :create_memberships, :id => 10, :membership => { :project_id => 2, :role_ids => ['1', '2']}
+      post :create_memberships, id: 10, membership: { project_id: 2, role_ids: ['1', '2']}
     end
   end
 
   def test_edit_membership
     assert_no_difference 'Group.find(10).members.count' do
-      put :edit_membership, :id => 10, :membership_id => 6, :membership => { :role_ids => ['1', '3']}
+      put :edit_membership, id: 10, membership_id: 6, membership: { role_ids: ['1', '3']}
     end
   end
 
   def test_destroy_membership
     assert_difference 'Group.find(10).members.count', -1 do
-      delete :destroy_membership, :id => 10, :membership_id => 6
+      delete :destroy_membership, id: 10, membership_id: 6
     end
   end
 
   def test_autocomplete_for_user
-    get :autocomplete_for_user, :id => 10, :q => 'mis'
+    get :autocomplete_for_user, id: 10, q: 'mis'
     assert_response :success
     users = assigns(:users)
     assert_not_nil users

--- a/test/functional/groups_controller_test.rb
+++ b/test/functional/groups_controller_test.rb
@@ -64,7 +64,7 @@ class GroupsControllerTest < ActionController::TestCase
 
   def test_create
     assert_difference 'Group.count' do
-      post :create, group: {lastname: 'New group'}
+      post :create, group: { lastname: 'New group' }
     end
     assert_redirected_to groups_path
   end
@@ -76,7 +76,7 @@ class GroupsControllerTest < ActionController::TestCase
   end
 
   def test_update
-    put :update, id: 10, group: {lastname: 'new name'}
+    put :update, id: 10, group: { lastname: 'new name' }
     assert_redirected_to groups_path
   end
 
@@ -101,13 +101,13 @@ class GroupsControllerTest < ActionController::TestCase
 
   def test_create_membership
     assert_difference 'Group.find(10).members.count' do
-      post :create_memberships, id: 10, membership: { project_id: 2, role_ids: ['1', '2']}
+      post :create_memberships, id: 10, membership: { project_id: 2, role_ids: ['1', '2'] }
     end
   end
 
   def test_edit_membership
     assert_no_difference 'Group.find(10).members.count' do
-      put :edit_membership, id: 10, membership_id: 6, membership: { role_ids: ['1', '3']}
+      put :edit_membership, id: 10, membership_id: 6, membership: { role_ids: ['1', '3'] }
     end
   end
 

--- a/test/functional/help_controller_test.rb
+++ b/test/functional/help_controller_test.rb
@@ -30,15 +30,15 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class HelpControllerTest < ActionController::TestCase
-  test "renders wiki_syntax properly" do
-    get "wiki_syntax"
+  test 'renders wiki_syntax properly' do
+    get 'wiki_syntax'
 
-    assert_select "h1", "Wiki Syntax Quick Reference"
+    assert_select 'h1', 'Wiki Syntax Quick Reference'
   end
 
-  test "renders wiki_syntax_detailed properly" do
-    get "wiki_syntax_detailed"
+  test 'renders wiki_syntax_detailed properly' do
+    get 'wiki_syntax_detailed'
 
-    assert_select "h1", "Wiki Formatting"
+    assert_select 'h1', 'Wiki Formatting'
   end
 end

--- a/test/functional/journals_controller_test.rb
+++ b/test/functional/journals_controller_test.rb
@@ -95,6 +95,4 @@ class JournalsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:journals)
     assert_equal 'application/atom+xml', @response.content_type
   end
-
-
 end

--- a/test/functional/journals_controller_test.rb
+++ b/test/functional/journals_controller_test.rb
@@ -50,7 +50,7 @@ class JournalsControllerTest < ActionController::TestCase
     identifier = "journal-#{journal.id}"
 
     @request.session[:user_id] = 1
-    xhr :get, :edit, :id => journal.id
+    xhr :get, :edit, id: journal.id
     assert_response :success
     assert_select_rjs :insert, :after, "#{identifier}-notes" do
       assert_select "form[id=#{identifier}-form]"
@@ -66,7 +66,7 @@ class JournalsControllerTest < ActionController::TestCase
     identifier = "journal-#{journal.id}-notes"
 
     @request.session[:user_id] = 1
-    xhr :post, :update, :id => journal.id, :notes => 'Updated notes'
+    xhr :post, :update, id: journal.id, notes: 'Updated notes'
     assert_response :success
     assert_select_rjs :replace, identifier
     assert_equal 'Updated notes', Journal.find(journal.id).notes
@@ -83,14 +83,14 @@ class JournalsControllerTest < ActionController::TestCase
     identifier = "change-#{journal.id}"
 
     @request.session[:user_id] = 1
-    xhr :post, :update, :id => journal.id, :notes => ''
+    xhr :post, :update, id: journal.id, notes: ''
     assert_response :success
     assert_select_rjs :remove, identifier
     assert_nil Journal.find_by_id(journal.id)
   end
 
   def test_index
-    get :index, :project_id => 1, :format => :atom
+    get :index, project_id: 1, format: :atom
     assert_response :success
     assert_not_nil assigns(:journals)
     assert_equal 'application/atom+xml', @response.content_type

--- a/test/functional/mail_handler_controller_test.rb
+++ b/test/functional/mail_handler_controller_test.rb
@@ -50,7 +50,7 @@ class MailHandlerControllerTest < ActionController::TestCase
     Setting.mail_handler_api_enabled = 1
     Setting.mail_handler_api_key = 'secret'
 
-    post :index, :key => 'secret', :email => IO.read(File.join(FIXTURES_PATH, 'ticket_on_given_project.eml'))
+    post :index, key: 'secret', email: IO.read(File.join(FIXTURES_PATH, 'ticket_on_given_project.eml'))
     assert_response 201
   end
 
@@ -59,7 +59,7 @@ class MailHandlerControllerTest < ActionController::TestCase
     Setting.mail_handler_api_enabled = 0
     Setting.mail_handler_api_key = 'secret'
 
-    post :index, :key => 'secret', :email => IO.read(File.join(FIXTURES_PATH, 'ticket_on_given_project.eml'))
+    post :index, key: 'secret', email: IO.read(File.join(FIXTURES_PATH, 'ticket_on_given_project.eml'))
     assert_response 403
   end
 end

--- a/test/functional/messages_controller_test.rb
+++ b/test/functional/messages_controller_test.rb
@@ -57,7 +57,7 @@ class MessagesControllerTest < ActionController::TestCase
     assert_difference 'Message.count', 110 do
       110.times do
         m = Message.new
-        m.force_attributes = {subject: 'Reply', content: 'Reply body', author_id: 2, board_id: 1}
+        m.force_attributes = { subject: 'Reply', content: 'Reply body', author_id: 2, board_id: 1 }
         message.children << m
       end
     end
@@ -98,7 +98,7 @@ class MessagesControllerTest < ActionController::TestCase
 
     post :create, board_id: 1,
                   message: { subject: 'Test created message',
-                                content: 'Message body'}
+                             content: 'Message body' }
     message = Message.find_by_subject('Test created message')
     assert_not_nil message
     assert_redirected_to topic_path(message)
@@ -107,7 +107,7 @@ class MessagesControllerTest < ActionController::TestCase
     assert_equal 1, message.board_id
 
     # author
-    mails_to_author = ActionMailer::Base.deliveries.select {|m| m.to.include?('jsmith@somenet.foo') }
+    mails_to_author = ActionMailer::Base.deliveries.select { |m| m.to.include?('jsmith@somenet.foo') }
     assert_equal 1, mails_to_author.length
     mail = mails_to_author.first
     assert mail.to.include?('jsmith@somenet.foo')
@@ -116,7 +116,7 @@ class MessagesControllerTest < ActionController::TestCase
     assert mail.body.encoded.include?('Message body')
 
     # project member
-    mails_to_member = ActionMailer::Base.deliveries.select {|m| m.to.include?('dlopper@somenet.foo') }
+    mails_to_member = ActionMailer::Base.deliveries.select { |m| m.to.include?('dlopper@somenet.foo') }
     assert_equal 1, mails_to_member.length
     assert mails_to_member.first.to.include?('dlopper@somenet.foo')
   end
@@ -132,7 +132,7 @@ class MessagesControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     put :update, id: 1,
                  message: { subject: 'New subject',
-                               content: 'New body' }
+                            content: 'New body' }
     message = Message.find(1)
     assert_redirected_to topic_path(message)
     assert_equal 'New subject', message.subject
@@ -150,7 +150,7 @@ class MessagesControllerTest < ActionController::TestCase
   def test_destroy_topic
     @request.session[:user_id] = 2
     delete :destroy, id: 1
-    assert_redirected_to project_board_path("ecookbook", 1)
+    assert_redirected_to project_board_path('ecookbook', 1)
     assert_nil Message.find_by_id(1)
   end
 

--- a/test/functional/messages_controller_test.rb
+++ b/test/functional/messages_controller_test.rb
@@ -44,7 +44,7 @@ class MessagesControllerTest < ActionController::TestCase
   end
 
   def test_show
-    get :show, :board_id => 1, :id => 1
+    get :show, board_id: 1, id: 1
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:board)
@@ -57,7 +57,7 @@ class MessagesControllerTest < ActionController::TestCase
     assert_difference 'Message.count', 110 do
       110.times do
         m = Message.new
-        m.force_attributes = {:subject => 'Reply', :content => 'Reply body', :author_id => 2, :board_id => 1}
+        m.force_attributes = {subject: 'Reply', content: 'Reply body', author_id: 2, board_id: 1}
         message.children << m
       end
     end
@@ -66,27 +66,27 @@ class MessagesControllerTest < ActionController::TestCase
     assert_template 'show'
     replies = assigns(:replies)
     assert_not_nil replies
-    assert !replies.include?(message.children.first(:order => 'id'))
-    assert replies.include?(message.children.last(:order => 'id'))
+    assert !replies.include?(message.children.first(order: 'id'))
+    assert replies.include?(message.children.last(order: 'id'))
   end
 
   def test_show_with_reply_permission
     @request.session[:user_id] = 2
-    get :show, :board_id => 1, :id => 1
+    get :show, board_id: 1, id: 1
     assert_response :success
     assert_template 'show'
-    assert_tag :div, :attributes => { :id => 'reply' },
-                     :descendant => { :tag => 'textarea', :attributes => { :id => 'message_content' } }
+    assert_tag :div, attributes: { id: 'reply' },
+                     descendant: { tag: 'textarea', attributes: { id: 'message_content' } }
   end
 
   def test_show_message_not_found
-    get :show, :board_id => 1, :id => 99999
+    get :show, board_id: 1, id: 99999
     assert_response 404
   end
 
   def test_get_new
     @request.session[:user_id] = 2
-    get :new, :board_id => 1
+    get :new, board_id: 1
     assert_response :success
     assert_template 'new'
   end
@@ -96,9 +96,9 @@ class MessagesControllerTest < ActionController::TestCase
     ActionMailer::Base.deliveries.clear
     Setting.notified_events = ['message_posted']
 
-    post :create, :board_id => 1,
-                  :message => { :subject => 'Test created message',
-                                :content => 'Message body'}
+    post :create, board_id: 1,
+                  message: { subject: 'Test created message',
+                                content: 'Message body'}
     message = Message.find_by_subject('Test created message')
     assert_not_nil message
     assert_redirected_to topic_path(message)
@@ -123,16 +123,16 @@ class MessagesControllerTest < ActionController::TestCase
 
   def test_get_edit
     @request.session[:user_id] = 2
-    get :edit, :id => 1
+    get :edit, id: 1
     assert_response :success
     assert_template 'edit'
   end
 
   def test_put_update
     @request.session[:user_id] = 2
-    put :update, :id => 1,
-                 :message => { :subject => 'New subject',
-                               :content => 'New body' }
+    put :update, id: 1,
+                 message: { subject: 'New subject',
+                               content: 'New body' }
     message = Message.find(1)
     assert_redirected_to topic_path(message)
     assert_equal 'New subject', message.subject
@@ -141,22 +141,22 @@ class MessagesControllerTest < ActionController::TestCase
 
   def test_reply
     @request.session[:user_id] = 2
-    post :reply, :board_id => 1, :id => 1, :reply => { :content => 'This is a test reply', :subject => 'Test reply' }
-    reply = Message.find(:first, :order => 'id DESC')
-    assert_redirected_to topic_path(1, :r => reply)
+    post :reply, board_id: 1, id: 1, reply: { content: 'This is a test reply', subject: 'Test reply' }
+    reply = Message.find(:first, order: 'id DESC')
+    assert_redirected_to topic_path(1, r: reply)
     assert Message.find_by_subject('Test reply')
   end
 
   def test_destroy_topic
     @request.session[:user_id] = 2
-    delete :destroy, :id => 1
+    delete :destroy, id: 1
     assert_redirected_to project_board_path("ecookbook", 1)
     assert_nil Message.find_by_id(1)
   end
 
   def test_quote
     @request.session[:user_id] = 2
-    xhr :get, :quote, :board_id => 1, :id => 3
+    xhr :get, :quote, board_id: 1, id: 3
     assert_response :success
     assert_select_rjs :show, 'reply'
   end

--- a/test/functional/my_controller_test.rb
+++ b/test/functional/my_controller_test.rb
@@ -63,17 +63,17 @@ class MyControllerTest < ActionController::TestCase
     assert_template 'account'
     assert_equal User.find(2), assigns(:user)
 
-    assert_no_tag :input, :attributes => { :name => 'user[custom_field_values][4]'}
+    assert_no_tag :input, attributes: { name: 'user[custom_field_values][4]'}
   end
 
   def test_update_account
     put :account,
-      :user => {
-        :firstname => "Joe",
-        :login => "root", # should not be allowed
-        :admin => 1,
-        :group_ids => ['10'],
-        :custom_field_values => {"4" => "0100562500"}
+      user: {
+        firstname: "Joe",
+        login: "root", # should not be allowed
+        admin: 1,
+        group_ids: ['10'],
+        custom_field_values: {"4" => "0100562500"}
       }
 
     assert_redirected_to '/my/account'
@@ -94,19 +94,19 @@ class MyControllerTest < ActionController::TestCase
   end
 
   def test_add_block
-    xhr :post, :add_block, :block => 'issuesreportedbyme'
+    xhr :post, :add_block, block: 'issuesreportedbyme'
     assert_response :success
     assert User.find(2).pref[:my_page_layout]['top'].include?('issuesreportedbyme')
   end
 
   def test_remove_block
-    xhr :post, :remove_block, :block => 'issuesassignedtome'
+    xhr :post, :remove_block, block: 'issuesassignedtome'
     assert_response :success
     assert !User.find(2).pref[:my_page_layout].values.flatten.include?('issuesassignedtome')
   end
 
   def test_order_blocks
-    xhr :post, :order_blocks, :group => 'left', 'list-left' => ['documents', 'calendar', 'latestnews']
+    xhr :post, :order_blocks, group: 'left', 'list-left' => ['documents', 'calendar', 'latestnews']
     assert_response :success
     assert_equal ['documents', 'calendar', 'latestnews'], User.find(2).pref[:my_page_layout]['left']
   end

--- a/test/functional/my_controller_test.rb
+++ b/test/functional/my_controller_test.rb
@@ -63,25 +63,25 @@ class MyControllerTest < ActionController::TestCase
     assert_template 'account'
     assert_equal User.find(2), assigns(:user)
 
-    assert_no_tag :input, attributes: { name: 'user[custom_field_values][4]'}
+    assert_no_tag :input, attributes: { name: 'user[custom_field_values][4]' }
   end
 
   def test_update_account
     put :account,
-      user: {
-        firstname: "Joe",
-        login: "root", # should not be allowed
-        admin: 1,
-        group_ids: ['10'],
-        custom_field_values: {"4" => "0100562500"}
-      }
+        user: {
+          firstname: 'Joe',
+          login: 'root', # should not be allowed
+          admin: 1,
+          group_ids: ['10'],
+          custom_field_values: { '4' => '0100562500' }
+        }
 
     assert_redirected_to '/my/account'
     user = User.find(2)
     assert_equal user, assigns(:user)
-    assert_equal "Joe", user.firstname
-    assert_equal "jsmith", user.login
-    assert_equal "0100562500", user.custom_value_for(4).value
+    assert_equal 'Joe', user.firstname
+    assert_equal 'jsmith', user.login
+    assert_equal '0100562500', user.custom_value_for(4).value
     # ignored
     assert !user.admin?
     assert user.groups.empty?
@@ -111,71 +111,71 @@ class MyControllerTest < ActionController::TestCase
     assert_equal ['documents', 'calendar', 'latestnews'], User.find(2).pref[:my_page_layout]['left']
   end
 
-  context "POST to reset_rss_key" do
-    context "with an existing rss_token" do
+  context 'POST to reset_rss_key' do
+    context 'with an existing rss_token' do
       setup do
         @previous_token_value = User.find(2).rss_key # Will generate one if it's missing
         post :reset_rss_key
       end
 
-      should "destroy the existing token" do
+      should 'destroy the existing token' do
         assert_not_equal @previous_token_value, User.find(2).rss_key
       end
 
-      should "create a new token" do
+      should 'create a new token' do
         assert User.find(2).rss_token
       end
 
       should set_the_flash.to /reset/
-      should redirect_to('my account') {'/my/account' }
+      should redirect_to('my account') { '/my/account' }
     end
 
-    context "with no rss_token" do
+    context 'with no rss_token' do
       setup do
         assert_nil User.find(2).rss_token
         post :reset_rss_key
       end
 
-      should "create a new token" do
+      should 'create a new token' do
         assert User.find(2).rss_token
       end
 
       should set_the_flash.to /reset/
-      should redirect_to('my account') {'/my/account' }
+      should redirect_to('my account') { '/my/account' }
     end
   end
 
-  context "POST to reset_api_key" do
-    context "with an existing api_token" do
+  context 'POST to reset_api_key' do
+    context 'with an existing api_token' do
       setup do
         @previous_token_value = User.find(2).api_key # Will generate one if it's missing
         post :reset_api_key
       end
 
-      should "destroy the existing token" do
+      should 'destroy the existing token' do
         assert_not_equal @previous_token_value, User.find(2).api_key
       end
 
-      should "create a new token" do
+      should 'create a new token' do
         assert User.find(2).api_token
       end
 
       should set_the_flash.to /reset/
-      should redirect_to('my account') {'/my/account' }
+      should redirect_to('my account') { '/my/account' }
     end
 
-    context "with no api_token" do
+    context 'with no api_token' do
       setup do
         assert_nil User.find(2).api_token
         post :reset_api_key
       end
 
-      should "create a new token" do
+      should 'create a new token' do
         assert User.find(2).api_token
       end
 
       should set_the_flash.to /reset/
-      should redirect_to('my account') {'/my/account' }
+      should redirect_to('my account') { '/my/account' }
     end
   end
 end

--- a/test/functional/project_enumerations_controller_test.rb
+++ b/test/functional/project_enumerations_controller_test.rb
@@ -42,7 +42,7 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2 # manager
     billable_field = TimeEntryActivityCustomField.find_by_name("Billable")
 
-    put :update, :project_id => 1, :enumerations => {
+    put :update, project_id: 1, enumerations: {
       "9"=> {"parent_id"=>"9", "custom_field_values"=>{"7" => "1"}, "active"=>"0"}, # Design, De-activate
       "10"=> {"parent_id"=>"10", "custom_field_values"=>{"7"=>"0"}, "active"=>"1"}, # Development, Change custom value
       "14"=>{"parent_id"=>"14", "custom_field_values"=>{"7"=>"1"}, "active"=>"1"}, # Inactive Activity, Activate with custom value
@@ -92,22 +92,22 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2 # manager
 
     project_activity = TimeEntryActivity.new({
-                                               :name => 'Project Specific',
-                                               :parent => TimeEntryActivity.find(:first),
-                                               :project => Project.find(1),
-                                               :active => true
+                                               name: 'Project Specific',
+                                               parent: TimeEntryActivity.find(:first),
+                                               project: Project.find(1),
+                                               active: true
                                              })
     assert project_activity.save
     project_activity_two = TimeEntryActivity.new({
-                                                   :name => 'Project Specific Two',
-                                                   :parent => TimeEntryActivity.find(:last),
-                                                   :project => Project.find(1),
-                                                   :active => true
+                                                   name: 'Project Specific Two',
+                                                   parent: TimeEntryActivity.find(:last),
+                                                   project: Project.find(1),
+                                                   active: true
                                                  })
     assert project_activity_two.save
 
 
-    put :update, :project_id => 1, :enumerations => {
+    put :update, project_id: 1, enumerations: {
       project_activity.id => {"custom_field_values"=>{"7" => "1"}, "active"=>"0"}, # De-activate
       project_activity_two.id => {"custom_field_values"=>{"7" => "1"}, "active"=>"0"} # De-activate
     }
@@ -134,7 +134,7 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size
 
     @request.session[:user_id] = 2 # manager
-    put :update, :project_id => 1, :enumerations => {
+    put :update, project_id: 1, enumerations: {
       "9"=> {"parent_id"=>"9", "custom_field_values"=>{"7" => "1"}, "active"=>"0"} # Design, De-activate
     }
     assert_response :redirect
@@ -152,23 +152,23 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     # second one is a duplicate
     # parent = TimeEntryActivity.find(9)
     parent = TimeEntryActivity.new
-    parent.force_attributes = { :name => parent.name, :project_id => 1, :position => parent.position, :active => true }
-    parent.save(:validate => false)
+    parent.force_attributes = { name: parent.name, project_id: 1, position: parent.position, active: true }
+    parent.save(validate: false)
 
     project = Project.find(1)
-    project.time_entries.create!(:hours => 1.0,
-                                 :user => User.find(1),
-                                 :work_package_id => 3,
-                                 :activity_id => 10,
-                                 :spent_on => '2009-01-01')
+    project.time_entries.create!(hours: 1.0,
+                                 user: User.find(1),
+                                 work_package_id: 3,
+                                 activity_id: 10,
+                                 spent_on: '2009-01-01')
 
     assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size
     assert_equal 1, TimeEntry.find_all_by_activity_id_and_project_id(10, 1).size
 
     @request.session[:user_id] = 2 # manager
 
-    put :update, :project_id => 1,
-                 :enumerations => { "9" => { "parent_id" => parent.id,
+    put :update, project_id: 1,
+                 enumerations: { "9" => { "parent_id" => parent.id,
                                              "custom_field_values" => { "7" => "1" },
                                              "active" => "0" } }
     assert_response :redirect
@@ -182,21 +182,21 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
   def test_destroy
     @request.session[:user_id] = 2 # manager
     project_activity = TimeEntryActivity.new({
-                                               :name => 'Project Specific',
-                                               :parent => TimeEntryActivity.find(:first),
-                                               :project => Project.find(1),
-                                               :active => true
+                                               name: 'Project Specific',
+                                               parent: TimeEntryActivity.find(:first),
+                                               project: Project.find(1),
+                                               active: true
                                              })
     assert project_activity.save
     project_activity_two = TimeEntryActivity.new({
-                                                   :name => 'Project Specific Two',
-                                                   :parent => TimeEntryActivity.find(:last),
-                                                   :project => Project.find(1),
-                                                   :active => true
+                                                   name: 'Project Specific Two',
+                                                   parent: TimeEntryActivity.find(:last),
+                                                   project: Project.find(1),
+                                                   active: true
                                                  })
     assert project_activity_two.save
 
-    delete :destroy, :project_id => 1
+    delete :destroy, project_id: 1
     assert_response :redirect
     assert_redirected_to '/projects/ecookbook/settings/activities'
 
@@ -207,16 +207,16 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
   def test_destroy_should_reassign_time_entries_back_to_the_system_activity
     @request.session[:user_id] = 2 # manager
     project_activity = TimeEntryActivity.new({
-                                               :name => 'Project Specific Design',
-                                               :parent => TimeEntryActivity.find(9),
-                                               :project => Project.find(1),
-                                               :active => true
+                                               name: 'Project Specific Design',
+                                               parent: TimeEntryActivity.find(9),
+                                               project: Project.find(1),
+                                               active: true
                                              })
     assert project_activity.save
     assert TimeEntry.update_all("activity_id = '#{project_activity.id}'", ["project_id = ? AND activity_id = ?", 1, 9])
     assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(project_activity.id, 1).size
 
-    delete :destroy, :project_id => 1
+    delete :destroy, project_id: 1
     assert_response :redirect
     assert_redirected_to '/projects/ecookbook/settings/activities'
 

--- a/test/functional/project_enumerations_controller_test.rb
+++ b/test/functional/project_enumerations_controller_test.rb
@@ -40,13 +40,13 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
 
   def test_update_to_override_system_activities
     @request.session[:user_id] = 2 # manager
-    billable_field = TimeEntryActivityCustomField.find_by_name("Billable")
+    billable_field = TimeEntryActivityCustomField.find_by_name('Billable')
 
     put :update, project_id: 1, enumerations: {
-      "9"=> {"parent_id"=>"9", "custom_field_values"=>{"7" => "1"}, "active"=>"0"}, # Design, De-activate
-      "10"=> {"parent_id"=>"10", "custom_field_values"=>{"7"=>"0"}, "active"=>"1"}, # Development, Change custom value
-      "14"=>{"parent_id"=>"14", "custom_field_values"=>{"7"=>"1"}, "active"=>"1"}, # Inactive Activity, Activate with custom value
-      "11"=>{"parent_id"=>"11", "custom_field_values"=>{"7"=>"1"}, "active"=>"1"} # QA, no changes
+      '9' => { 'parent_id' => '9', 'custom_field_values' => { '7' => '1' }, 'active' => '0' }, # Design, De-activate
+      '10' => { 'parent_id' => '10', 'custom_field_values' => { '7' => '0' }, 'active' => '1' }, # Development, Change custom value
+      '14' => { 'parent_id' => '14', 'custom_field_values' => { '7' => '1' }, 'active' => '1' }, # Inactive Activity, Activate with custom value
+      '11' => { 'parent_id' => '11', 'custom_field_values' => { '7' => '1' }, 'active' => '1' } # QA, no changes
     }
 
     assert_response :redirect
@@ -56,8 +56,8 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     project = Project.find('ecookbook')
 
     # ... Design
-    design = project.time_entry_activities.find_by_name("Design")
-    assert design, "Project activity not found"
+    design = project.time_entry_activities.find_by_name('Design')
+    assert design, 'Project activity not found'
 
     assert_equal 9, design.parent_id # Relate to the system activity
     assert_not_equal design.parent.id, design.id # Different records
@@ -65,51 +65,50 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     assert !design.active?
 
     # ... Development
-    development = project.time_entry_activities.find_by_name("Development")
-    assert development, "Project activity not found"
+    development = project.time_entry_activities.find_by_name('Development')
+    assert development, 'Project activity not found'
 
     assert_equal 10, development.parent_id # Relate to the system activity
     assert_not_equal development.parent.id, development.id # Different records
     assert_equal development.parent.name, development.name # Same name
     assert development.active?
-    assert_equal "0", development.custom_value_for(billable_field).value
+    assert_equal '0', development.custom_value_for(billable_field).value
 
     # ... Inactive Activity
-    previously_inactive = project.time_entry_activities.find_by_name("Inactive Activity")
-    assert previously_inactive, "Project activity not found"
+    previously_inactive = project.time_entry_activities.find_by_name('Inactive Activity')
+    assert previously_inactive, 'Project activity not found'
 
     assert_equal 14, previously_inactive.parent_id # Relate to the system activity
     assert_not_equal previously_inactive.parent.id, previously_inactive.id # Different records
     assert_equal previously_inactive.parent.name, previously_inactive.name # Same name
     assert previously_inactive.active?
-    assert_equal "1", previously_inactive.custom_value_for(billable_field).value
+    assert_equal '1', previously_inactive.custom_value_for(billable_field).value
 
     # ... QA
-    assert_equal nil, project.time_entry_activities.find_by_name("QA"), "Custom QA activity created when it wasn't modified"
+    assert_equal nil, project.time_entry_activities.find_by_name('QA'), "Custom QA activity created when it wasn't modified"
   end
 
   def test_update_will_update_project_specific_activities
     @request.session[:user_id] = 2 # manager
 
-    project_activity = TimeEntryActivity.new({
+    project_activity = TimeEntryActivity.new(
                                                name: 'Project Specific',
                                                parent: TimeEntryActivity.find(:first),
                                                project: Project.find(1),
                                                active: true
-                                             })
+                                             )
     assert project_activity.save
-    project_activity_two = TimeEntryActivity.new({
+    project_activity_two = TimeEntryActivity.new(
                                                    name: 'Project Specific Two',
                                                    parent: TimeEntryActivity.find(:last),
                                                    project: Project.find(1),
                                                    active: true
-                                                 })
+                                                 )
     assert project_activity_two.save
 
-
     put :update, project_id: 1, enumerations: {
-      project_activity.id => {"custom_field_values"=>{"7" => "1"}, "active"=>"0"}, # De-activate
-      project_activity_two.id => {"custom_field_values"=>{"7" => "1"}, "active"=>"0"} # De-activate
+      project_activity.id => { 'custom_field_values' => { '7' => '1' }, 'active' => '0' }, # De-activate
+      project_activity_two.id => { 'custom_field_values' => { '7' => '1' }, 'active' => '0' } # De-activate
     }
 
     assert_response :redirect
@@ -120,12 +119,12 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     assert_equal 2, project.time_entry_activities.count
 
     activity_one = project.time_entry_activities.find_by_name(project_activity.name)
-    assert activity_one, "Project activity not found"
+    assert activity_one, 'Project activity not found'
     assert_equal project_activity.id, activity_one.id
     assert !activity_one.active?
 
     activity_two = project.time_entry_activities.find_by_name(project_activity_two.name)
-    assert activity_two, "Project activity not found"
+    assert activity_two, 'Project activity not found'
     assert_equal project_activity_two.id, activity_two.id
     assert !activity_two.active?
   end
@@ -135,15 +134,15 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
 
     @request.session[:user_id] = 2 # manager
     put :update, project_id: 1, enumerations: {
-      "9"=> {"parent_id"=>"9", "custom_field_values"=>{"7" => "1"}, "active"=>"0"} # Design, De-activate
+      '9' => { 'parent_id' => '9', 'custom_field_values' => { '7' => '1' }, 'active' => '0' } # Design, De-activate
     }
     assert_response :redirect
 
     # No more TimeEntries using the system activity
-    assert_equal 0, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, "Time Entries still assigned to system activities"
+    assert_equal 0, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, 'Time Entries still assigned to system activities'
     # All TimeEntries using project activity
     project_specific_activity = TimeEntryActivity.find_by_parent_id_and_project_id(9, 1)
-    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(project_specific_activity.id, 1).size, "No Time Entries assigned to the project activity"
+    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(project_specific_activity.id, 1).size, 'No Time Entries assigned to the project activity'
   end
 
   def test_update_when_creating_new_activities_will_not_convert_existing_data_if_an_exception_is_raised
@@ -168,32 +167,32 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2 # manager
 
     put :update, project_id: 1,
-                 enumerations: { "9" => { "parent_id" => parent.id,
-                                             "custom_field_values" => { "7" => "1" },
-                                             "active" => "0" } }
+                 enumerations: { '9' => { 'parent_id' => parent.id,
+                                          'custom_field_values' => { '7' => '1' },
+                                          'active' => '0' } }
     assert_response :redirect
 
     # TimeEntries shouldn't have been reassigned on the failed record
-    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, "Time Entries are not assigned to system activities"
+    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, 'Time Entries are not assigned to system activities'
     # TimeEntries shouldn't have been reassigned on the saved record either
-    assert_equal 1, TimeEntry.find_all_by_activity_id_and_project_id(10, 1).size, "Time Entries are not assigned to system activities"
+    assert_equal 1, TimeEntry.find_all_by_activity_id_and_project_id(10, 1).size, 'Time Entries are not assigned to system activities'
   end
 
   def test_destroy
     @request.session[:user_id] = 2 # manager
-    project_activity = TimeEntryActivity.new({
+    project_activity = TimeEntryActivity.new(
                                                name: 'Project Specific',
                                                parent: TimeEntryActivity.find(:first),
                                                project: Project.find(1),
                                                active: true
-                                             })
+                                             )
     assert project_activity.save
-    project_activity_two = TimeEntryActivity.new({
+    project_activity_two = TimeEntryActivity.new(
                                                    name: 'Project Specific Two',
                                                    parent: TimeEntryActivity.find(:last),
                                                    project: Project.find(1),
                                                    active: true
-                                                 })
+                                                 )
     assert project_activity_two.save
 
     delete :destroy, project_id: 1
@@ -206,14 +205,14 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
 
   def test_destroy_should_reassign_time_entries_back_to_the_system_activity
     @request.session[:user_id] = 2 # manager
-    project_activity = TimeEntryActivity.new({
+    project_activity = TimeEntryActivity.new(
                                                name: 'Project Specific Design',
                                                parent: TimeEntryActivity.find(9),
                                                project: Project.find(1),
                                                active: true
-                                             })
+                                             )
     assert project_activity.save
-    assert TimeEntry.update_all("activity_id = '#{project_activity.id}'", ["project_id = ? AND activity_id = ?", 1, 9])
+    assert TimeEntry.update_all("activity_id = '#{project_activity.id}'", ['project_id = ? AND activity_id = ?', 1, 9])
     assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(project_activity.id, 1).size
 
     delete :destroy, project_id: 1
@@ -221,8 +220,7 @@ class ProjectEnumerationsControllerTest < ActionController::TestCase
     assert_redirected_to '/projects/ecookbook/settings/activities'
 
     assert_nil TimeEntryActivity.find_by_id(project_activity.id)
-    assert_equal 0, TimeEntry.find_all_by_activity_id_and_project_id(project_activity.id, 1).size, "TimeEntries still assigned to project specific activity"
-    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, "TimeEntries still assigned to project specific activity"
+    assert_equal 0, TimeEntry.find_all_by_activity_id_and_project_id(project_activity.id, 1).size, 'TimeEntries still assigned to project specific activity'
+    assert_equal 3, TimeEntry.find_all_by_activity_id_and_project_id(9, 1).size, 'TimeEntries still assigned to project specific activity'
   end
-
 end

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -52,11 +52,11 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:projects)
 
-    assert_tag :ul, child: {tag: 'li',
-                               descendant: {tag: 'a', content: 'eCookbook'},
-                               child: { tag: 'ul',
-                                           descendant: { tag: 'a',
-                                                            content: 'Child of private child'
+    assert_tag :ul, child: { tag: 'li',
+                             descendant: { tag: 'a', content: 'eCookbook' },
+                             child: { tag: 'ul',
+                                      descendant: { tag: 'a',
+                                                    content: 'Child of private child'
                                                            }
                                           }
                                }
@@ -72,103 +72,101 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_select 'feed>entry', count: Project.count(conditions: Project.visible_by(User.current))
   end
 
-  context "#index" do
-    context "by non-admin user with view_time_entries permission" do
+  context '#index' do
+    context 'by non-admin user with view_time_entries permission' do
       setup do
         @request.session[:user_id] = 3
       end
-      should "show overall spent time link" do
+      should 'show overall spent time link' do
         get :index
         assert_template 'index'
-        assert_tag :a, attributes: {href: '/time_entries'}
+        assert_tag :a, attributes: { href: '/time_entries' }
       end
     end
 
-    context "by non-admin user without view_time_entries permission" do
+    context 'by non-admin user without view_time_entries permission' do
       setup do
         Role.find(2).remove_permission! :view_time_entries
         Role.non_member.remove_permission! :view_time_entries
         Role.anonymous.remove_permission! :view_time_entries
         @request.session[:user_id] = 3
       end
-      should "not show overall spent time link" do
+      should 'not show overall spent time link' do
         get :index
         assert_template 'index'
-        assert_no_tag :a, attributes: {href: '/time_entries'}
+        assert_no_tag :a, attributes: { href: '/time_entries' }
       end
     end
   end
 
-  context "#new" do
-    context "by admin user" do
+  context '#new' do
+    context 'by admin user' do
       setup do
         @request.session[:user_id] = 1
       end
 
-      should "accept get" do
+      should 'accept get' do
         get :new
         assert_response :success
         assert_template 'new'
       end
-
     end
 
-    context "by non-admin user with add_project permission" do
+    context 'by non-admin user with add_project permission' do
       setup do
         Role.non_member.add_permission! :add_project
         @request.session[:user_id] = 9
       end
 
-      should "accept get" do
+      should 'accept get' do
         get :new
         assert_response :success
         assert_template 'new'
-        assert_no_tag :select, attributes: {name: 'project[parent_id]'}
+        assert_no_tag :select, attributes: { name: 'project[parent_id]' }
       end
     end
 
-    context "by non-admin user with add_subprojects permission" do
+    context 'by non-admin user with add_subprojects permission' do
       setup do
         Role.find(1).remove_permission! :add_project
         Role.find(1).add_permission! :add_subprojects
         @request.session[:user_id] = 2
       end
 
-      should "accept get" do
+      should 'accept get' do
         get :new, parent_id: 'ecookbook'
         assert_response :success
         assert_template 'new'
         # parent project selected
-        assert_tag :select, attributes: {name: 'project[parent_id]'},
-                            child: {tag: 'option', attributes: {value: '1', selected: 'selected'}}
+        assert_tag :select, attributes: { name: 'project[parent_id]' },
+                            child: { tag: 'option', attributes: { value: '1', selected: 'selected' } }
         # no empty value
-        assert_no_tag :select, attributes: {name: 'project[parent_id]'},
-                               child: {tag: 'option', attributes: {value: ''}}
+        assert_no_tag :select, attributes: { name: 'project[parent_id]' },
+                               child: { tag: 'option', attributes: { value: '' } }
       end
     end
-
   end
 
-  context "POST :create" do
-    context "by admin user" do
+  context 'POST :create' do
+    context 'by admin user' do
       setup do
         @request.session[:user_id] = 1
       end
 
-      should "create a new project" do
+      should 'create a new project' do
         post :create,
-          project: {
-            name: "blog",
-            description: "weblog",
-            homepage: 'http://weblog',
-            identifier: "blog",
-            is_public: 1,
-            custom_field_values: { '3' => 'Beta' },
-            type_ids: ['1', '3'],
-            # an issue custom field that is not for all project
-            work_package_custom_field_ids: ['9'],
-            enabled_module_names: ['work_package_tracking', 'news', 'repository']
-          }
+             project: {
+               name: 'blog',
+               description: 'weblog',
+               homepage: 'http://weblog',
+               identifier: 'blog',
+               is_public: 1,
+               custom_field_values: { '3' => 'Beta' },
+               type_ids: ['1', '3'],
+               # an issue custom field that is not for all project
+               work_package_custom_field_ids: ['9'],
+               enabled_module_names: ['work_package_tracking', 'news', 'repository']
+             }
         assert_redirected_to '/projects/blog/settings'
 
         project = Project.find_by_name('blog')
@@ -184,10 +182,10 @@ class ProjectsControllerTest < ActionController::TestCase
         assert project.work_package_custom_fields.include?(WorkPackageCustomField.find(9))
       end
 
-      should "create a new subproject" do
-        post :create, project: { name: "blog",
-                                 description: "weblog",
-                                 identifier: "blog",
+      should 'create a new subproject' do
+        post :create, project: { name: 'blog',
+                                 description: 'weblog',
+                                 identifier: 'blog',
                                  is_public: 1,
                                  custom_field_values: { '3' => 'Beta' },
                                  parent_id: 1
@@ -200,16 +198,16 @@ class ProjectsControllerTest < ActionController::TestCase
       end
     end
 
-    context "by non-admin user with add_project permission" do
+    context 'by non-admin user with add_project permission' do
       setup do
         Role.non_member.add_permission! :add_project
         @request.session[:user_id] = 9
       end
 
-      should "accept create a Project" do
-        post :create, project: { name: "blog",
-                                 description: "weblog",
-                                 identifier: "blog",
+      should 'accept create a Project' do
+        post :create, project: { name: 'blog',
+                                 description: 'weblog',
+                                 identifier: 'blog',
                                  is_public: 1,
                                  custom_field_values: { '3' => 'Beta' },
                                  type_ids: ['1', '3'],
@@ -230,11 +228,11 @@ class ProjectsControllerTest < ActionController::TestCase
         assert_equal 1, project.members.size
       end
 
-      should "fail with parent_id" do
+      should 'fail with parent_id' do
         assert_no_difference 'Project.count' do
-          post :create, project: { name: "blog",
-                                   description: "weblog",
-                                   identifier: "blog",
+          post :create, project: { name: 'blog',
+                                   description: 'weblog',
+                                   identifier: 'blog',
                                    is_public: 1,
                                    custom_field_values: { '3' => 'Beta' },
                                    parent_id: 1
@@ -247,17 +245,17 @@ class ProjectsControllerTest < ActionController::TestCase
       end
     end
 
-    context "by non-admin user with add_subprojects permission" do
+    context 'by non-admin user with add_subprojects permission' do
       setup do
         Role.find(1).remove_permission! :add_project
         Role.find(1).add_permission! :add_subprojects
         @request.session[:user_id] = 2
       end
 
-      should "create a project with a parent_id" do
-        post :create, project: { name: "blog",
-                                 description: "weblog",
-                                 identifier: "blog",
+      should 'create a project with a parent_id' do
+        post :create, project: { name: 'blog',
+                                 description: 'weblog',
+                                 identifier: 'blog',
                                  is_public: 1,
                                  custom_field_values: { '3' => 'Beta' },
                                  parent_id: 1
@@ -266,11 +264,11 @@ class ProjectsControllerTest < ActionController::TestCase
         project = Project.find_by_name('blog')
       end
 
-      should "fail without parent_id" do
+      should 'fail without parent_id' do
         assert_no_difference 'Project.count' do
-          post :create, project: { name: "blog",
-                                   description: "weblog",
-                                   identifier: "blog",
+          post :create, project: { name: 'blog',
+                                   description: 'weblog',
+                                   identifier: 'blog',
                                    is_public: 1,
                                    custom_field_values: { '3' => 'Beta' }
                                   }
@@ -281,12 +279,12 @@ class ProjectsControllerTest < ActionController::TestCase
         refute_empty project.errors[:parent_id]
       end
 
-      should "fail with unauthorized parent_id" do
+      should 'fail with unauthorized parent_id' do
         assert !User.find(2).member_of?(Project.find(6))
         assert_no_difference 'Project.count' do
-          post :create, project: { name: "blog",
-                                   description: "weblog",
-                                   identifier: "blog",
+          post :create, project: { name: 'blog',
+                                   description: 'weblog',
+                                   identifier: 'blog',
                                    is_public: 1,
                                    custom_field_values: { '3' => 'Beta' },
                                    parent_id: 6
@@ -305,8 +303,8 @@ class ProjectsControllerTest < ActionController::TestCase
       @request.session[:user_id] = 1
       assert_no_difference 'Project.count' do
         post :create, project: {
-          name: "blog",
-          identifier: "",
+          name: 'blog',
+          identifier: '',
           enabled_module_names: %w(work_package_tracking news)
         }
       end
@@ -387,8 +385,8 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_update
     @request.session[:user_id] = 2 # manager
-    put :update, id: 1, project: {name: 'Test changed name',
-                                       issue_custom_field_ids: ['']}
+    put :update, id: 1, project: { name: 'Test changed name',
+                                   issue_custom_field_ids: [''] }
     assert_redirected_to '/projects/ecookbook/settings'
     project = Project.find(1)
     assert_equal 'Test changed name', project.name
@@ -463,8 +461,8 @@ class ProjectsControllerTest < ActionController::TestCase
   def test_hook_response
     Redmine::Hook.add_listener(ProjectBasedTemplate)
     get :show, id: 1
-    assert_tag tag: 'link', attributes: {href: '/assets/ecookbook.css'},
-                               parent: {tag: 'head'}
+    assert_tag tag: 'link', attributes: { href: '/assets/ecookbook.css' },
+               parent: { tag: 'head' }
 
     Redmine::Hook.clear_listeners
   end

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -52,24 +52,24 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:projects)
 
-    assert_tag :ul, :child => {:tag => 'li',
-                               :descendant => {:tag => 'a', :content => 'eCookbook'},
-                               :child => { :tag => 'ul',
-                                           :descendant => { :tag => 'a',
-                                                            :content => 'Child of private child'
+    assert_tag :ul, child: {tag: 'li',
+                               descendant: {tag: 'a', content: 'eCookbook'},
+                               child: { tag: 'ul',
+                                           descendant: { tag: 'a',
+                                                            content: 'Child of private child'
                                                            }
                                           }
                                }
 
-    assert_no_tag :a, :content => /Private child of eCookbook/
+    assert_no_tag :a, content: /Private child of eCookbook/
   end
 
   def test_index_atom
-    get :index, :format => 'atom'
+    get :index, format: 'atom'
     assert_response :success
     assert_template 'common/feed'
-    assert_select 'feed>title', :text => 'OpenProject: Latest projects'
-    assert_select 'feed>entry', :count => Project.count(:conditions => Project.visible_by(User.current))
+    assert_select 'feed>title', text: 'OpenProject: Latest projects'
+    assert_select 'feed>entry', count: Project.count(conditions: Project.visible_by(User.current))
   end
 
   context "#index" do
@@ -80,7 +80,7 @@ class ProjectsControllerTest < ActionController::TestCase
       should "show overall spent time link" do
         get :index
         assert_template 'index'
-        assert_tag :a, :attributes => {:href => '/time_entries'}
+        assert_tag :a, attributes: {href: '/time_entries'}
       end
     end
 
@@ -94,7 +94,7 @@ class ProjectsControllerTest < ActionController::TestCase
       should "not show overall spent time link" do
         get :index
         assert_template 'index'
-        assert_no_tag :a, :attributes => {:href => '/time_entries'}
+        assert_no_tag :a, attributes: {href: '/time_entries'}
       end
     end
   end
@@ -123,7 +123,7 @@ class ProjectsControllerTest < ActionController::TestCase
         get :new
         assert_response :success
         assert_template 'new'
-        assert_no_tag :select, :attributes => {:name => 'project[parent_id]'}
+        assert_no_tag :select, attributes: {name: 'project[parent_id]'}
       end
     end
 
@@ -135,15 +135,15 @@ class ProjectsControllerTest < ActionController::TestCase
       end
 
       should "accept get" do
-        get :new, :parent_id => 'ecookbook'
+        get :new, parent_id: 'ecookbook'
         assert_response :success
         assert_template 'new'
         # parent project selected
-        assert_tag :select, :attributes => {:name => 'project[parent_id]'},
-                            :child => {:tag => 'option', :attributes => {:value => '1', :selected => 'selected'}}
+        assert_tag :select, attributes: {name: 'project[parent_id]'},
+                            child: {tag: 'option', attributes: {value: '1', selected: 'selected'}}
         # no empty value
-        assert_no_tag :select, :attributes => {:name => 'project[parent_id]'},
-                               :child => {:tag => 'option', :attributes => {:value => ''}}
+        assert_no_tag :select, attributes: {name: 'project[parent_id]'},
+                               child: {tag: 'option', attributes: {value: ''}}
       end
     end
 
@@ -157,17 +157,17 @@ class ProjectsControllerTest < ActionController::TestCase
 
       should "create a new project" do
         post :create,
-          :project => {
-            :name => "blog",
-            :description => "weblog",
-            :homepage => 'http://weblog',
-            :identifier => "blog",
-            :is_public => 1,
-            :custom_field_values => { '3' => 'Beta' },
-            :type_ids => ['1', '3'],
+          project: {
+            name: "blog",
+            description: "weblog",
+            homepage: 'http://weblog',
+            identifier: "blog",
+            is_public: 1,
+            custom_field_values: { '3' => 'Beta' },
+            type_ids: ['1', '3'],
             # an issue custom field that is not for all project
-            :work_package_custom_field_ids => ['9'],
-            :enabled_module_names => ['work_package_tracking', 'news', 'repository']
+            work_package_custom_field_ids: ['9'],
+            enabled_module_names: ['work_package_tracking', 'news', 'repository']
           }
         assert_redirected_to '/projects/blog/settings'
 
@@ -185,12 +185,12 @@ class ProjectsControllerTest < ActionController::TestCase
       end
 
       should "create a new subproject" do
-        post :create, :project => { :name => "blog",
-                                 :description => "weblog",
-                                 :identifier => "blog",
-                                 :is_public => 1,
-                                 :custom_field_values => { '3' => 'Beta' },
-                                 :parent_id => 1
+        post :create, project: { name: "blog",
+                                 description: "weblog",
+                                 identifier: "blog",
+                                 is_public: 1,
+                                 custom_field_values: { '3' => 'Beta' },
+                                 parent_id: 1
                                 }
         assert_redirected_to '/projects/blog/settings'
 
@@ -207,13 +207,13 @@ class ProjectsControllerTest < ActionController::TestCase
       end
 
       should "accept create a Project" do
-        post :create, :project => { :name => "blog",
-                                 :description => "weblog",
-                                 :identifier => "blog",
-                                 :is_public => 1,
-                                 :custom_field_values => { '3' => 'Beta' },
-                                 :type_ids => ['1', '3'],
-                                 :enabled_module_names => ['work_package_tracking', 'news', 'repository']
+        post :create, project: { name: "blog",
+                                 description: "weblog",
+                                 identifier: "blog",
+                                 is_public: 1,
+                                 custom_field_values: { '3' => 'Beta' },
+                                 type_ids: ['1', '3'],
+                                 enabled_module_names: ['work_package_tracking', 'news', 'repository']
                                 }
 
         assert_redirected_to '/projects/blog/settings'
@@ -232,12 +232,12 @@ class ProjectsControllerTest < ActionController::TestCase
 
       should "fail with parent_id" do
         assert_no_difference 'Project.count' do
-          post :create, :project => { :name => "blog",
-                                   :description => "weblog",
-                                   :identifier => "blog",
-                                   :is_public => 1,
-                                   :custom_field_values => { '3' => 'Beta' },
-                                   :parent_id => 1
+          post :create, project: { name: "blog",
+                                   description: "weblog",
+                                   identifier: "blog",
+                                   is_public: 1,
+                                   custom_field_values: { '3' => 'Beta' },
+                                   parent_id: 1
                                   }
         end
         assert_response :success
@@ -255,12 +255,12 @@ class ProjectsControllerTest < ActionController::TestCase
       end
 
       should "create a project with a parent_id" do
-        post :create, :project => { :name => "blog",
-                                 :description => "weblog",
-                                 :identifier => "blog",
-                                 :is_public => 1,
-                                 :custom_field_values => { '3' => 'Beta' },
-                                 :parent_id => 1
+        post :create, project: { name: "blog",
+                                 description: "weblog",
+                                 identifier: "blog",
+                                 is_public: 1,
+                                 custom_field_values: { '3' => 'Beta' },
+                                 parent_id: 1
                                 }
         assert_redirected_to '/projects/blog/settings'
         project = Project.find_by_name('blog')
@@ -268,11 +268,11 @@ class ProjectsControllerTest < ActionController::TestCase
 
       should "fail without parent_id" do
         assert_no_difference 'Project.count' do
-          post :create, :project => { :name => "blog",
-                                   :description => "weblog",
-                                   :identifier => "blog",
-                                   :is_public => 1,
-                                   :custom_field_values => { '3' => 'Beta' }
+          post :create, project: { name: "blog",
+                                   description: "weblog",
+                                   identifier: "blog",
+                                   is_public: 1,
+                                   custom_field_values: { '3' => 'Beta' }
                                   }
         end
         assert_response :success
@@ -284,12 +284,12 @@ class ProjectsControllerTest < ActionController::TestCase
       should "fail with unauthorized parent_id" do
         assert !User.find(2).member_of?(Project.find(6))
         assert_no_difference 'Project.count' do
-          post :create, :project => { :name => "blog",
-                                   :description => "weblog",
-                                   :identifier => "blog",
-                                   :is_public => 1,
-                                   :custom_field_values => { '3' => 'Beta' },
-                                   :parent_id => 6
+          post :create, project: { name: "blog",
+                                   description: "weblog",
+                                   identifier: "blog",
+                                   is_public: 1,
+                                   custom_field_values: { '3' => 'Beta' },
+                                   parent_id: 6
                                   }
         end
         assert_response :success
@@ -301,13 +301,13 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   def test_create_should_preserve_modules_on_validation_failure
-    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
+    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
       @request.session[:user_id] = 1
       assert_no_difference 'Project.count' do
-        post :create, :project => {
-          :name => "blog",
-          :identifier => "",
-          :enabled_module_names => %w(work_package_tracking news)
+        post :create, project: {
+          name: "blog",
+          identifier: "",
+          enabled_module_names: %w(work_package_tracking news)
         }
       end
       assert_response :success
@@ -317,36 +317,36 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   def test_show_by_id
-    get :show, :id => 1
+    get :show, id: 1
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:project)
   end
 
   def test_show_by_identifier
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:project)
     assert_equal Project.find_by_identifier('ecookbook'), assigns(:project)
 
-    assert_tag 'li', :content => /Development status/
+    assert_tag 'li', content: /Development status/
   end
 
   def test_show_should_not_display_hidden_custom_fields
     ProjectCustomField.find_by_name('Development status').update_attribute :visible, false
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:project)
 
-    assert_no_tag 'li', :content => /Development status/
+    assert_no_tag 'li', content: /Development status/
   end
 
   def test_show_should_not_fail_when_custom_values_are_nil
     project = Project.find_by_identifier('ecookbook')
     project.custom_values.first.update_attribute(:value, nil)
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:project)
@@ -357,38 +357,38 @@ class ProjectsControllerTest < ActionController::TestCase
     project = Project.find_by_identifier('ecookbook')
     project.archive!
 
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response 403
     assert_nil assigns(:project)
-    assert_tag :tag => 'p', :content => /archived/
+    assert_tag tag: 'p', content: /archived/
   end
 
   def test_private_subprojects_hidden
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response :success
     assert_template 'show'
-    assert_no_tag :tag => 'a', :content => /Private child/
+    assert_no_tag tag: 'a', content: /Private child/
   end
 
   def test_private_subprojects_visible
     @request.session[:user_id] = 2 # manager who is a member of the private subproject
-    get :show, :id => 'ecookbook'
+    get :show, id: 'ecookbook'
     assert_response :success
     assert_template 'show'
-    assert_tag :tag => 'a', :content => /Private child/
+    assert_tag tag: 'a', content: /Private child/
   end
 
   def test_settings
     @request.session[:user_id] = 2 # manager
-    get :settings, :id => 1
+    get :settings, id: 1
     assert_response :success
     assert_template 'settings'
   end
 
   def test_update
     @request.session[:user_id] = 2 # manager
-    put :update, :id => 1, :project => {:name => 'Test changed name',
-                                       :issue_custom_field_ids => ['']}
+    put :update, id: 1, project: {name: 'Test changed name',
+                                       issue_custom_field_ids: ['']}
     assert_redirected_to '/projects/ecookbook/settings'
     project = Project.find(1)
     assert_equal 'Test changed name', project.name
@@ -398,14 +398,14 @@ class ProjectsControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     Project.find(1).enabled_module_names = ['work_package_tracking', 'news']
 
-    put :modules, :id => 1, :enabled_module_names => ['work_package_tracking', 'repository']
+    put :modules, id: 1, enabled_module_names: ['work_package_tracking', 'repository']
     assert_redirected_to '/projects/ecookbook/settings/modules'
     assert_equal ['repository', 'work_package_tracking'], Project.find(1).enabled_module_names.sort
   end
 
   def test_get_destroy_info
     @request.session[:user_id] = 1 # admin
-    get :destroy_info, :id => 1
+    get :destroy_info, id: 1
     assert_response :success
     assert_template 'destroy_info'
     assert_not_nil Project.find_by_id(1)
@@ -413,14 +413,14 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_post_destroy
     @request.session[:user_id] = 1 # admin
-    delete :destroy, :id => 1, :confirm => 1
+    delete :destroy, id: 1, confirm: 1
     assert_redirected_to '/admin/projects'
     assert_nil Project.find_by_id(1)
   end
 
   def test_archive
     @request.session[:user_id] = 1 # admin
-    put :archive, :id => 1
+    put :archive, id: 1
     assert_redirected_to '/admin/projects'
     assert !Project.find(1).active?
   end
@@ -428,24 +428,24 @@ class ProjectsControllerTest < ActionController::TestCase
   def test_unarchive
     @request.session[:user_id] = 1 # admin
     Project.find(1).archive
-    put :unarchive, :id => 1
+    put :unarchive, id: 1
     assert_redirected_to '/admin/projects'
     assert Project.find(1).active?
   end
 
   def test_jump_should_redirect_to_active_tab
-    get :show, :id => 1, :jump => 'work_packages'
+    get :show, id: 1, jump: 'work_packages'
     assert_redirected_to controller: :work_packages, action: :index, project_id: 'ecookbook'
   end
 
   def test_jump_should_not_redirect_to_inactive_tab
-    get :show, :id => 3, :jump => 'news'
+    get :show, id: 3, jump: 'news'
     assert_response :success
     assert_template 'show'
   end
 
   def test_jump_should_not_redirect_to_unknown_tab
-    get :show, :id => 3, :jump => 'foobar'
+    get :show, id: 3, jump: 'foobar'
     assert_response :success
     assert_template 'show'
   end
@@ -462,9 +462,9 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_hook_response
     Redmine::Hook.add_listener(ProjectBasedTemplate)
-    get :show, :id => 1
-    assert_tag :tag => 'link', :attributes => {:href => '/assets/ecookbook.css'},
-                               :parent => {:tag => 'head'}
+    get :show, id: 1
+    assert_tag tag: 'link', attributes: {href: '/assets/ecookbook.css'},
+                               parent: {tag: 'head'}
 
     Redmine::Hook.clear_listeners
   end

--- a/test/functional/repositories_controller_test.rb
+++ b/test/functional/repositories_controller_test.rb
@@ -54,25 +54,25 @@ class RepositoriesControllerTest < ActionController::TestCase
     get :revision, project_id: 1, rev: 1
     assert_response :success
     assert_not_nil assigns(:changeset)
-    assert_equal "1", assigns(:changeset).revision
+    assert_equal '1', assigns(:changeset).revision
   end
 
   def test_revision_with_before_nil_and_after_normal
-    get :revision, {project_id: 1, rev: 1}
+    get :revision, project_id: 1, rev: 1
     assert_response :success
     assert_template 'revision'
-    assert_no_tag tag: "ul", attributes: { class: /action_menu_specific/ },
-      child: { tag: "a", attributes: { href: @controller.url_for(only_path: true,
+    assert_no_tag tag: 'ul', attributes: { class: /action_menu_specific/ },
+                  child: { tag: 'a', attributes: { href: @controller.url_for(only_path: true,
                                                                              controller: 'repositories',
                                                                              action: 'revision',
                                                                              project_id: 'ecookbook',
                                                                              rev: '0') } }
-    assert_tag tag: "ul", attributes: { class: /action_menu_specific/ },
-      child: { tag: "a", attributes: { href: @controller.url_for(only_path: true,
-                                                                             controller: 'repositories',
-                                                                             action: 'revision',
-                                                                             project_id: 'ecookbook',
-                                                                             rev: '2') } }
+    assert_tag tag: 'ul', attributes: { class: /action_menu_specific/ },
+               child: { tag: 'a', attributes: { href: @controller.url_for(only_path: true,
+                                                                          controller: 'repositories',
+                                                                          action: 'revision',
+                                                                          project_id: 'ecookbook',
+                                                                          rev: '2') } }
   end
 
   def test_graph_commits_per_month
@@ -98,15 +98,15 @@ class RepositoriesControllerTest < ActionController::TestCase
 
     assert_tag :td, content: 'dlopper',
                     sibling: { tag: 'td',
-                                  child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} },
-                                                                child: { tag: 'option', content: 'Dave Lopper',
-                                                                                              attributes: { value: '3', selected: 'selected' }}}}
+                               child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} },
+                                        child: { tag: 'option', content: 'Dave Lopper',
+                                                 attributes: { value: '3', selected: 'selected' } } } }
     assert_tag :td, content: 'foo',
                     sibling: { tag: 'td',
-                                  child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} }}}
+                               child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} } } }
     assert_no_tag :td, content: 'foo',
                        sibling: { tag: 'td',
-                                     descendant: { tag: 'option', attributes: { selected: 'selected' }}}
+                                  descendant: { tag: 'option', attributes: { selected: 'selected' } } }
   end
 
   def test_map_committers
@@ -120,7 +120,7 @@ class RepositoriesControllerTest < ActionController::TestCase
             comments: 'Committed by foo.'
           )
     assert_no_difference "Changeset.count(:conditions => 'user_id = 3')" do
-      post :committers, project_id: 1, committers: { '0' => ['foo', '2'], '1' => ['dlopper', '3']}
+      post :committers, project_id: 1, committers: { '0' => ['foo', '2'], '1' => ['dlopper', '3'] }
       assert_redirected_to '/projects/ecookbook/repository/committers'
       assert_equal User.find(2), c.reload.user
     end

--- a/test/functional/repositories_controller_test.rb
+++ b/test/functional/repositories_controller_test.rb
@@ -44,39 +44,39 @@ class RepositoriesControllerTest < ActionController::TestCase
   end
 
   def test_revisions
-    get :revisions, :project_id => 1
+    get :revisions, project_id: 1
     assert_response :success
     assert_template 'revisions'
     assert_not_nil assigns(:changesets)
   end
 
   def test_revision
-    get :revision, :project_id => 1, :rev => 1
+    get :revision, project_id: 1, rev: 1
     assert_response :success
     assert_not_nil assigns(:changeset)
     assert_equal "1", assigns(:changeset).revision
   end
 
   def test_revision_with_before_nil_and_after_normal
-    get :revision, {:project_id => 1, :rev => 1}
+    get :revision, {project_id: 1, rev: 1}
     assert_response :success
     assert_template 'revision'
-    assert_no_tag :tag => "ul", :attributes => { :class => /action_menu_specific/ },
-      :child => { :tag => "a", :attributes => { :href => @controller.url_for(:only_path => true,
-                                                                             :controller => 'repositories',
-                                                                             :action => 'revision',
-                                                                             :project_id => 'ecookbook',
-                                                                             :rev => '0') } }
-    assert_tag :tag => "ul", :attributes => { :class => /action_menu_specific/ },
-      :child => { :tag => "a", :attributes => { :href => @controller.url_for(:only_path => true,
-                                                                             :controller => 'repositories',
-                                                                             :action => 'revision',
-                                                                             :project_id => 'ecookbook',
-                                                                             :rev => '2') } }
+    assert_no_tag tag: "ul", attributes: { class: /action_menu_specific/ },
+      child: { tag: "a", attributes: { href: @controller.url_for(only_path: true,
+                                                                             controller: 'repositories',
+                                                                             action: 'revision',
+                                                                             project_id: 'ecookbook',
+                                                                             rev: '0') } }
+    assert_tag tag: "ul", attributes: { class: /action_menu_specific/ },
+      child: { tag: "a", attributes: { href: @controller.url_for(only_path: true,
+                                                                             controller: 'repositories',
+                                                                             action: 'revision',
+                                                                             project_id: 'ecookbook',
+                                                                             rev: '2') } }
   end
 
   def test_graph_commits_per_month
-    get :graph, :project_id => 1, :graph => 'commits_per_month'
+    get :graph, project_id: 1, graph: 'commits_per_month'
     assert_response :success
     assert_equal 'image/svg+xml', @response.content_type
   end
@@ -85,42 +85,42 @@ class RepositoriesControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     # add a commit with an unknown user
     Changeset.create!(
-        :repository => Project.find(1).repository,
-        :committer  => 'foo',
-        :committed_on => Time.now,
-        :revision => 100,
-        :comments => 'Committed by foo.'
+        repository: Project.find(1).repository,
+        committer:  'foo',
+        committed_on: Time.now,
+        revision: 100,
+        comments: 'Committed by foo.'
      )
 
-    get :committers, :project_id => 1
+    get :committers, project_id: 1
     assert_response :success
     assert_template 'committers'
 
-    assert_tag :td, :content => 'dlopper',
-                    :sibling => { :tag => 'td',
-                                  :child => { :tag => 'select', :attributes => { :name => %r{^committers\[\d+\]\[\]$} },
-                                                                :child => { :tag => 'option', :content => 'Dave Lopper',
-                                                                                              :attributes => { :value => '3', :selected => 'selected' }}}}
-    assert_tag :td, :content => 'foo',
-                    :sibling => { :tag => 'td',
-                                  :child => { :tag => 'select', :attributes => { :name => %r{^committers\[\d+\]\[\]$} }}}
-    assert_no_tag :td, :content => 'foo',
-                       :sibling => { :tag => 'td',
-                                     :descendant => { :tag => 'option', :attributes => { :selected => 'selected' }}}
+    assert_tag :td, content: 'dlopper',
+                    sibling: { tag: 'td',
+                                  child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} },
+                                                                child: { tag: 'option', content: 'Dave Lopper',
+                                                                                              attributes: { value: '3', selected: 'selected' }}}}
+    assert_tag :td, content: 'foo',
+                    sibling: { tag: 'td',
+                                  child: { tag: 'select', attributes: { name: %r{^committers\[\d+\]\[\]$} }}}
+    assert_no_tag :td, content: 'foo',
+                       sibling: { tag: 'td',
+                                     descendant: { tag: 'option', attributes: { selected: 'selected' }}}
   end
 
   def test_map_committers
     @request.session[:user_id] = 2
     # add a commit with an unknown user
     c = Changeset.create!(
-            :repository => Project.find(1).repository,
-            :committer  => 'foo',
-            :committed_on => Time.now,
-            :revision => 100,
-            :comments => 'Committed by foo.'
+            repository: Project.find(1).repository,
+            committer:  'foo',
+            committed_on: Time.now,
+            revision: 100,
+            comments: 'Committed by foo.'
           )
     assert_no_difference "Changeset.count(:conditions => 'user_id = 3')" do
-      post :committers, :project_id => 1, :committers => { '0' => ['foo', '2'], '1' => ['dlopper', '3']}
+      post :committers, project_id: 1, committers: { '0' => ['foo', '2'], '1' => ['dlopper', '3']}
       assert_redirected_to '/projects/ecookbook/repository/committers'
       assert_equal User.find(2), c.reload.user
     end

--- a/test/functional/repositories_filesystem_controller_test.rb
+++ b/test/functional/repositories_filesystem_controller_test.rb
@@ -100,13 +100,12 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
         get :entry, project_id: PRJ_ID, path: 'japanese/utf-16.txt'
         assert_response :success
 
-        assert_select "tr" do
-          assert_select "th.line-num" do
-            assert_select "a", text: /2/
+        assert_select 'tr' do
+          assert_select 'th.line-num' do
+            assert_select 'a', text: /2/
           end
-          assert_select "td", content: /japanese/
+          assert_select 'td', content: /japanese/
         end
-
       end
     end
 
@@ -118,7 +117,7 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
       end
     end
   else
-    puts "Filesystem test repository NOT FOUND. Skipping functional tests !!!"
+    puts 'Filesystem test repository NOT FOUND. Skipping functional tests !!!'
     def test_fake; assert true end
   end
 end

--- a/test/functional/repositories_filesystem_controller_test.rb
+++ b/test/functional/repositories_filesystem_controller_test.rb
@@ -47,9 +47,9 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
     User.current = nil
     Setting.enabled_scm = Setting.enabled_scm.dup << 'Filesystem' unless Setting.enabled_scm.include?('Filesystem')
     @repository = Repository::Filesystem.create(
-                      :project => Project.find(PRJ_ID),
-                      :url     => REPOSITORY_PATH,
-                      :path_encoding => nil
+                      project: Project.find(PRJ_ID),
+                      url:     REPOSITORY_PATH,
+                      path_encoding: nil
                       )
     assert @repository
   end
@@ -58,7 +58,7 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
     def test_browse_root
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => PRJ_ID
+      get :show, project_id: PRJ_ID
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -68,51 +68,51 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
     end
 
     def test_show_no_extension
-      get :entry, :project_id => PRJ_ID, :path => 'test'
+      get :entry, project_id: PRJ_ID, path: 'test'
       assert_response :success
       assert_template 'entry'
-      assert_tag :tag => 'th',
-                 :content => '1',
-                 :attributes => { :class => 'line-num' },
-                 :sibling => { :tag => 'td', :content => /TEST CAT/ }
+      assert_tag tag: 'th',
+                 content: '1',
+                 attributes: { class: 'line-num' },
+                 sibling: { tag: 'td', content: /TEST CAT/ }
     end
 
     def test_entry_download_no_extension
-      get :entry, :project_id => PRJ_ID, :path => 'test', :format => 'raw'
+      get :entry, project_id: PRJ_ID, path: 'test', format: 'raw'
       assert_response :success
       assert_equal 'application/octet-stream', @response.content_type
     end
 
     def test_show_non_ascii_contents
-      with_settings :repositories_encodings => 'UTF-8,EUC-JP' do
-        get :entry, :project_id => PRJ_ID, :path => 'japanese/euc-jp.txt'
+      with_settings repositories_encodings: 'UTF-8,EUC-JP' do
+        get :entry, project_id: PRJ_ID, path: 'japanese/euc-jp.txt'
         assert_response :success
         assert_template 'entry'
-        assert_tag :tag => 'th',
-                   :content => '2',
-                   :attributes => { :class => 'line-num' },
-                   :sibling => { :tag => 'td', :content => /japanese/ }
+        assert_tag tag: 'th',
+                   content: '2',
+                   attributes: { class: 'line-num' },
+                   sibling: { tag: 'td', content: /japanese/ }
       end
     end
 
     def test_show_utf16
-      with_settings :repositories_encodings => 'UTF-16' do
-        get :entry, :project_id => PRJ_ID, :path => 'japanese/utf-16.txt'
+      with_settings repositories_encodings: 'UTF-16' do
+        get :entry, project_id: PRJ_ID, path: 'japanese/utf-16.txt'
         assert_response :success
 
         assert_select "tr" do
           assert_select "th.line-num" do
-            assert_select "a", :text => /2/
+            assert_select "a", text: /2/
           end
-          assert_select "td", :content => /japanese/
+          assert_select "td", content: /japanese/
         end
 
       end
     end
 
     def test_show_text_file_should_send_if_too_big
-      with_settings :file_max_size_displayed => 1 do
-        get :entry, :project_id => PRJ_ID, :path => 'japanese/big-file.txt'
+      with_settings file_max_size_displayed: 1 do
+        get :entry, project_id: PRJ_ID, path: 'japanese/big-file.txt'
         assert_response :success
         assert_equal 'text/plain', @response.content_type
       end

--- a/test/functional/repositories_git_controller_test.rb
+++ b/test/functional/repositories_git_controller_test.rb
@@ -46,9 +46,9 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     @response   = ActionController::TestResponse.new
     User.current = nil
     @repository = Repository::Git.create(
-                      :project => Project.find(3),
-                      :url     => REPOSITORY_PATH,
-                      :path_encoding => 'ISO-8859-1'
+                      project: Project.find(3),
+                      url:     REPOSITORY_PATH,
+                      path_encoding: 'ISO-8859-1'
                       )
 
     # see repositories_subversion_controller_test.rb
@@ -64,7 +64,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_browse_root
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => 3
+      get :show, project_id: 3
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -85,7 +85,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_browse_branch
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => 3, :rev => 'test_branch'
+      get :show, project_id: 3, rev: 'test_branch'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -105,7 +105,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
         "tag00.lightweight",
         "tag01.annotated",
        ].each do |t1|
-        get :show, :project_id => 3, :rev => t1
+        get :show, project_id: 3, rev: t1
         assert_response :success
         assert_template 'show'
         assert_not_nil assigns(:entries)
@@ -118,7 +118,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_browse_directory
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => 3, :path => 'images'
+      get :show, project_id: 3, path: 'images'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -134,7 +134,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_browse_at_given_revision
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => 3, :path => 'images', :rev => '7234cb2750b63f47bff735edc50a1c0a433c2518'
+      get :show, project_id: 3, path: 'images', rev: '7234cb2750b63f47bff735edc50a1c0a433c2518'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -144,32 +144,32 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     end
 
     def test_changes
-      get :changes, :project_id => 3, :path => 'images/edit.png'
+      get :changes, project_id: 3, path: 'images/edit.png'
       assert_response :success
       assert_template 'changes'
-      assert_tag :tag => 'h2', :content => 'edit.png'
+      assert_tag tag: 'h2', content: 'edit.png'
     end
 
     def test_entry_show
-      get :entry, :project_id => 3, :path => 'sources/watchers_controller.rb'
+      get :entry, project_id: 3, path: 'sources/watchers_controller.rb'
       assert_response :success
       assert_template 'entry'
       # Line 19
-      assert_tag :tag => 'th',
-                 :content => /11/,
-                 :attributes => { :class => /line-num/ },
-                 :sibling => { :tag => 'td', :content => /WITHOUT ANY WARRANTY/ }
+      assert_tag tag: 'th',
+                 content: /11/,
+                 attributes: { class: /line-num/ },
+                 sibling: { tag: 'td', content: /WITHOUT ANY WARRANTY/ }
     end
 
     def test_entry_download
-      get :entry, :project_id => 3, :path => 'sources/watchers_controller.rb', :format => 'raw'
+      get :entry, project_id: 3, path: 'sources/watchers_controller.rb', format: 'raw'
       assert_response :success
       # File content
       assert @response.body.include?('WITHOUT ANY WARRANTY')
     end
 
     def test_directory_entry
-      get :entry, :project_id => 3, :path => 'sources'
+      get :entry, project_id: 3, path: 'sources'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entry)
@@ -181,64 +181,64 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       @repository.reload
 
       # Full diff of changeset 2f9c0091
-      get :diff, :project_id => 3, :rev => '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
+      get :diff, project_id: 3, rev: '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
       assert_response :success
       assert_template 'diff'
       # Line 22 removed
-      assert_tag :tag => 'th',
-                 :content => /22/,
-                 :sibling => { :tag => 'td',
-                               :attributes => { :class => /diff_out/ },
-                               :content => /def remove/ }
-      assert_tag :tag => 'h2', :content => /2f9c0091/
+      assert_tag tag: 'th',
+                 content: /22/,
+                 sibling: { tag: 'td',
+                               attributes: { class: /diff_out/ },
+                               content: /def remove/ }
+      assert_tag tag: 'h2', content: /2f9c0091/
     end
 
     def test_diff_two_revs
       @repository.fetch_changesets
       @repository.reload
 
-      get :diff, :project_id => 3, :rev    => '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
-                           :rev_to => '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
+      get :diff, project_id: 3, rev:    '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
+                           rev_to: '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
       assert_response :success
       assert_template 'diff'
 
       diff = assigns(:diff)
       assert_not_nil diff
-      assert_tag :tag => 'h2', :content => /2f9c0091:61b685fb/
+      assert_tag tag: 'h2', content: /2f9c0091:61b685fb/
     end
 
     def test_annotate
-      get :annotate, :project_id => 3, :path => 'sources/watchers_controller.rb'
+      get :annotate, project_id: 3, path: 'sources/watchers_controller.rb'
       assert_response :success
       assert_template 'annotate'
       # Line 23, changeset 2f9c0091
-      assert_tag :tag => 'th', :content => /24/,
-                 :sibling => { :tag => 'td', :child => { :tag => 'a', :content => /2f9c0091/ } },
-                 :sibling => { :tag => 'td', :content => /jsmith/ },
-                 :sibling => { :tag => 'td', :content => /watcher =/ }
+      assert_tag tag: 'th', content: /24/,
+                 sibling: { tag: 'td', child: { tag: 'a', content: /2f9c0091/ } },
+                 sibling: { tag: 'td', content: /jsmith/ },
+                 sibling: { tag: 'td', content: /watcher =/ }
     end
 
     def test_annotate_at_given_revision
       @repository.fetch_changesets
       @repository.reload
-      get :annotate, :project_id => 3, :rev => 'deff7', :path => 'sources/watchers_controller.rb'
+      get :annotate, project_id: 3, rev: 'deff7', path: 'sources/watchers_controller.rb'
       assert_response :success
       assert_template 'annotate'
-      assert_tag :tag => 'h2', :content => /@ deff712f/
+      assert_tag tag: 'h2', content: /@ deff712f/
     end
 
     def test_annotate_binary_file
-      get :annotate, :project_id => 3, :path => 'images/edit.png'
+      get :annotate, project_id: 3, path: 'images/edit.png'
       assert_response 500
-      assert_tag :tag => 'div', :attributes => { :id => /errorExplanation/ },
-                                :content => /cannot be annotated/
+      assert_tag tag: 'div', attributes: { id: /errorExplanation/ },
+                                content: /cannot be annotated/
     end
 
     def test_revision
       @repository.fetch_changesets
       @repository.reload
       ['61b685fbe55ab05b5ac68402d5720c1a6ac973d1', '61b685f'].each do |r|
-        get :revision, :project_id => 3, :rev => r
+        get :revision, project_id: 3, rev: r
         assert_response :success
         assert_template 'revision'
       end
@@ -248,9 +248,9 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       @repository.fetch_changesets
       @repository.reload
       ['', ' ', nil].each do |r|
-        get :revision, :project_id => 3, :rev => r
+        get :revision, project_id: 3, rev: r
         assert_response 404
-        assert_error_tag :content => /was not found/
+        assert_error_tag content: /was not found/
       end
     end
   else

--- a/test/functional/repositories_git_controller_test.rb
+++ b/test/functional/repositories_git_controller_test.rb
@@ -37,7 +37,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
 
   # No '..' in the repository path
   REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
-  REPOSITORY_PATH.gsub!(/\//, "\\") if Redmine::Platform.mswin?
+  REPOSITORY_PATH.gsub!(/\//, '\\') if Redmine::Platform.mswin?
 
   def setup
     super
@@ -54,7 +54,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     # see repositories_subversion_controller_test.rb
     def @repository.reload
       ActiveRecord::Base.connection.clear_query_cache
-      self.class.find(self.id)
+      self.class.find(id)
     end
 
     assert @repository
@@ -69,15 +69,15 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       assert_template 'show'
       assert_not_nil assigns(:entries)
       assert_equal 9, assigns(:entries).size
-      assert assigns(:entries).detect {|e| e.name == 'images' && e.kind == 'dir'}
-      assert assigns(:entries).detect {|e| e.name == 'this_is_a_really_long_and_verbose_directory_name' && e.kind == 'dir'}
-      assert assigns(:entries).detect {|e| e.name == 'sources' && e.kind == 'dir'}
-      assert assigns(:entries).detect {|e| e.name == 'README' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == 'copied_README' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == 'new_file.txt' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == 'renamed_test.txt' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == 'filemane with spaces.txt' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == ' filename with a leading space.txt ' && e.kind == 'file'}
+      assert assigns(:entries).detect { |e| e.name == 'images' && e.kind == 'dir' }
+      assert assigns(:entries).detect { |e| e.name == 'this_is_a_really_long_and_verbose_directory_name' && e.kind == 'dir' }
+      assert assigns(:entries).detect { |e| e.name == 'sources' && e.kind == 'dir' }
+      assert assigns(:entries).detect { |e| e.name == 'README' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == 'copied_README' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == 'new_file.txt' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == 'renamed_test.txt' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == 'filemane with spaces.txt' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == ' filename with a leading space.txt ' && e.kind == 'file' }
       assert_not_nil assigns(:changesets)
       assigns(:changesets).size > 0
     end
@@ -90,10 +90,10 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       assert_template 'show'
       assert_not_nil assigns(:entries)
       assert_equal 4, assigns(:entries).size
-      assert assigns(:entries).detect {|e| e.name == 'images' && e.kind == 'dir'}
-      assert assigns(:entries).detect {|e| e.name == 'sources' && e.kind == 'dir'}
-      assert assigns(:entries).detect {|e| e.name == 'README' && e.kind == 'file'}
-      assert assigns(:entries).detect {|e| e.name == 'test.txt' && e.kind == 'file'}
+      assert assigns(:entries).detect { |e| e.name == 'images' && e.kind == 'dir' }
+      assert assigns(:entries).detect { |e| e.name == 'sources' && e.kind == 'dir' }
+      assert assigns(:entries).detect { |e| e.name == 'README' && e.kind == 'file' }
+      assert assigns(:entries).detect { |e| e.name == 'test.txt' && e.kind == 'file' }
       assert_not_nil assigns(:changesets)
       assigns(:changesets).size > 0
     end
@@ -101,10 +101,10 @@ class RepositoriesGitControllerTest < ActionController::TestCase
     def test_browse_tag
       @repository.fetch_changesets
       @repository.reload
-       [
-        "tag00.lightweight",
-        "tag01.annotated",
-       ].each do |t1|
+      [
+        'tag00.lightweight',
+        'tag01.annotated',
+      ].each do |t1|
         get :show, project_id: 3, rev: t1
         assert_response :success
         assert_template 'show'
@@ -123,7 +123,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       assert_template 'show'
       assert_not_nil assigns(:entries)
       assert_equal ['edit.png'], assigns(:entries).collect(&:name)
-      entry = assigns(:entries).detect {|e| e.name == 'edit.png'}
+      entry = assigns(:entries).detect { |e| e.name == 'edit.png' }
       assert_not_nil entry
       assert_equal 'file', entry.kind
       assert_equal 'images/edit.png', entry.path
@@ -188,8 +188,8 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       assert_tag tag: 'th',
                  content: /22/,
                  sibling: { tag: 'td',
-                               attributes: { class: /diff_out/ },
-                               content: /def remove/ }
+                            attributes: { class: /diff_out/ },
+                            content: /def remove/ }
       assert_tag tag: 'h2', content: /2f9c0091/
     end
 
@@ -198,7 +198,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       @repository.reload
 
       get :diff, project_id: 3, rev:    '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
-                           rev_to: '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
+                 rev_to: '2f9c0091c754a91af7a9c478e36556b4bde8dcf7'
       assert_response :success
       assert_template 'diff'
 
@@ -231,7 +231,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       get :annotate, project_id: 3, path: 'images/edit.png'
       assert_response 500
       assert_tag tag: 'div', attributes: { id: /errorExplanation/ },
-                                content: /cannot be annotated/
+                 content: /cannot be annotated/
     end
 
     def test_revision
@@ -254,7 +254,7 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       end
     end
   else
-    puts "Git test repository NOT FOUND. Skipping functional tests !!!"
+    puts 'Git test repository NOT FOUND. Skipping functional tests !!!'
     def test_fake; assert true end
   end
 end

--- a/test/functional/repositories_subversion_controller_test.rb
+++ b/test/functional/repositories_subversion_controller_test.rb
@@ -47,14 +47,14 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
 
     @project = Project.find(PRJ_ID)
     @repository = Repository::Subversion.create(project: @project,
-               url: self.class.subversion_repository_url)
+                                                url: self.class.subversion_repository_url)
 
     # #reload is broken for repositories because it defines
     # `has_many :changes` which conflicts with AR's #changes method
     # here we implement #reload differently for that single repository instance
     def @repository.reload
       ActiveRecord::Base.connection.clear_query_cache
-      self.class.find(self.id)
+      self.class.find(id)
     end
 
     assert @repository
@@ -78,7 +78,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
-      entry = assigns(:entries).detect {|e| e.name == 'subversion_test'}
+      entry = assigns(:entries).detect { |e| e.name == 'subversion_test' }
       assert_equal 'dir', entry.kind
     end
 
@@ -90,7 +90,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_template 'show'
       assert_not_nil assigns(:entries)
       assert_equal ['[folder_with_brackets]', 'folder', '.project', 'helloworld.c', 'textfile.txt'], assigns(:entries).collect(&:name)
-      entry = assigns(:entries).detect {|e| e.name == 'helloworld.c'}
+      entry = assigns(:entries).detect { |e| e.name == 'helloworld.c' }
       assert_equal 'file', entry.kind
       assert_equal 'subversion_test/helloworld.c', entry.path
       assert_tag :a, content: 'helloworld.c', attributes: { class: /text\-x\-c/ }
@@ -123,8 +123,8 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
         assert_equal 'native', assigns(:properties)['svn:eol-style']
         assert_tag :ul,
                    child: { tag: 'li',
-                               child: { tag: 'b', content: 'svn:eol-style' },
-                               child: { tag: 'span', content: 'native' } }
+                            child: { tag: 'b', content: 'svn:eol-style' },
+                            child: { tag: 'span', content: 'native' } }
       end
     end
 
@@ -167,8 +167,8 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_response :success
       assert_template 'entry'
       # this line was removed in r3 and file was moved in r6
-      assert_tag tag: 'td', attributes: { class: /line-code/},
-                               content: /Here's the code/
+      assert_tag tag: 'td', attributes: { class: /line-code/ },
+                 content: /Here's the code/
     end
 
     def test_entry_not_found
@@ -176,7 +176,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       @repository.reload
       get :entry, project_id: PRJ_ID, path: 'subversion_test/zzz.c'
       assert_tag tag: 'div', attributes: { id: /errorExplanation/ },
-                                content: /The entry or revision was not found in the repository/
+                 content: /The entry or revision was not found in the repository/
     end
 
     def test_entry_download
@@ -207,13 +207,13 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_template 'revision'
       assert_tag tag: 'ul',
                  child: { tag: 'li',
-                             # link to the entry at rev 2
-                             child: { tag: 'a',
-                                         attributes: {href: '/projects/ecookbook/repository/revisions/2/entry/test/some/path/in/the/repo'},
-                                         content: 'repo',
-                                         # link to partial diff
-                                         sibling:  { tag: 'a',
-                                                        attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/test/some/path/in/the/repo' }
+                          # link to the entry at rev 2
+                          child: { tag: 'a',
+                                   attributes: { href: '/projects/ecookbook/repository/revisions/2/entry/test/some/path/in/the/repo' },
+                                   content: 'repo',
+                                   # link to partial diff
+                                   sibling:  { tag: 'a',
+                                               attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/test/some/path/in/the/repo' }
                                                        }
                                         }
                             }
@@ -254,13 +254,13 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_template 'revision'
       assert_tag tag: 'ul',
                  child: { tag: 'li',
-                             # link to the entry at rev 2
-                             child: { tag: 'a',
-                                         attributes: {href: '/projects/ecookbook/repository/revisions/2/entry/path/in/the/repo'},
-                                         content: 'repo',
-                                         # link to partial diff
-                                         sibling:  { tag: 'a',
-                                                        attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/path/in/the/repo' }
+                          # link to the entry at rev 2
+                          child: { tag: 'a',
+                                   attributes: { href: '/projects/ecookbook/repository/revisions/2/entry/path/in/the/repo' },
+                                   content: 'repo',
+                                   # link to partial diff
+                                   sibling:  { tag: 'a',
+                                               attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/path/in/the/repo' }
                                                        }
                                         }
                             }
@@ -308,7 +308,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       assert_tag tag: 'h2', content: /@ 8/
     end
   else
-    puts "Subversion test repository NOT FOUND. Skipping functional tests !!!"
+    puts 'Subversion test repository NOT FOUND. Skipping functional tests !!!'
     def test_fake; assert true end
   end
 end

--- a/test/functional/repositories_subversion_controller_test.rb
+++ b/test/functional/repositories_subversion_controller_test.rb
@@ -46,8 +46,8 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     User.current = nil
 
     @project = Project.find(PRJ_ID)
-    @repository = Repository::Subversion.create(:project => @project,
-               :url => self.class.subversion_repository_url)
+    @repository = Repository::Subversion.create(project: @project,
+               url: self.class.subversion_repository_url)
 
     # #reload is broken for repositories because it defines
     # `has_many :changes` which conflicts with AR's #changes method
@@ -64,7 +64,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_show
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => PRJ_ID
+      get :show, project_id: PRJ_ID
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -74,7 +74,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_browse_root
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => PRJ_ID
+      get :show, project_id: PRJ_ID
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -85,7 +85,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_browse_directory
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => PRJ_ID, :path => 'subversion_test'
+      get :show, project_id: PRJ_ID, path: 'subversion_test'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -93,13 +93,13 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       entry = assigns(:entries).detect {|e| e.name == 'helloworld.c'}
       assert_equal 'file', entry.kind
       assert_equal 'subversion_test/helloworld.c', entry.path
-      assert_tag :a, :content => 'helloworld.c', :attributes => { :class => /text\-x\-c/ }
+      assert_tag :a, content: 'helloworld.c', attributes: { class: /text\-x\-c/ }
     end
 
     def test_browse_at_given_revision
       @repository.fetch_changesets
       @repository.reload
-      get :show, :project_id => PRJ_ID, :path => 'subversion_test', :rev => 4
+      get :show, project_id: PRJ_ID, path: 'subversion_test', rev: 4
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entries)
@@ -109,7 +109,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_file_changes
       @repository.fetch_changesets
       @repository.reload
-      get :changes, :project_id => PRJ_ID, :path => 'subversion_test/folder/helloworld.rb'
+      get :changes, project_id: PRJ_ID, path: 'subversion_test/folder/helloworld.rb'
       assert_response :success
       assert_template 'changes'
 
@@ -122,16 +122,16 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
         assert_not_nil assigns(:properties)
         assert_equal 'native', assigns(:properties)['svn:eol-style']
         assert_tag :ul,
-                   :child => { :tag => 'li',
-                               :child => { :tag => 'b', :content => 'svn:eol-style' },
-                               :child => { :tag => 'span', :content => 'native' } }
+                   child: { tag: 'li',
+                               child: { tag: 'b', content: 'svn:eol-style' },
+                               child: { tag: 'span', content: 'native' } }
       end
     end
 
     def test_directory_changes
       @repository.fetch_changesets
       @repository.reload
-      get :changes, :project_id => PRJ_ID, :path => 'subversion_test/folder'
+      get :changes, project_id: PRJ_ID, path: 'subversion_test/folder'
       assert_response :success
       assert_template 'changes'
 
@@ -143,7 +143,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_entry
       @repository.fetch_changesets
       @repository.reload
-      get :entry, :project_id => PRJ_ID, :path => 'subversion_test/helloworld.c'
+      get :entry, project_id: PRJ_ID, path: 'subversion_test/helloworld.c'
       assert_response :success
       assert_template 'entry'
     end
@@ -152,8 +152,8 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       @repository.fetch_changesets
       @repository.reload
       # no files in the test repo is larger than 1KB...
-      with_settings :file_max_size_displayed => 0 do
-        get :entry, :project_id => PRJ_ID, :path => 'subversion_test/helloworld.c'
+      with_settings file_max_size_displayed: 0 do
+        get :entry, project_id: PRJ_ID, path: 'subversion_test/helloworld.c'
         assert_response :success
         assert_template nil
         assert_equal 'attachment; filename="helloworld.c"', @response.headers['Content-Disposition']
@@ -163,26 +163,26 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_entry_at_given_revision
       @repository.fetch_changesets
       @repository.reload
-      get :entry, :project_id => PRJ_ID, :path => 'subversion_test/helloworld.rb', :rev => 2
+      get :entry, project_id: PRJ_ID, path: 'subversion_test/helloworld.rb', rev: 2
       assert_response :success
       assert_template 'entry'
       # this line was removed in r3 and file was moved in r6
-      assert_tag :tag => 'td', :attributes => { :class => /line-code/},
-                               :content => /Here's the code/
+      assert_tag tag: 'td', attributes: { class: /line-code/},
+                               content: /Here's the code/
     end
 
     def test_entry_not_found
       @repository.fetch_changesets
       @repository.reload
-      get :entry, :project_id => PRJ_ID, :path => 'subversion_test/zzz.c'
-      assert_tag :tag => 'div', :attributes => { :id => /errorExplanation/ },
-                                :content => /The entry or revision was not found in the repository/
+      get :entry, project_id: PRJ_ID, path: 'subversion_test/zzz.c'
+      assert_tag tag: 'div', attributes: { id: /errorExplanation/ },
+                                content: /The entry or revision was not found in the repository/
     end
 
     def test_entry_download
       @repository.fetch_changesets
       @repository.reload
-      get :entry, :project_id => PRJ_ID, :path => 'subversion_test/helloworld.c', :format => 'raw'
+      get :entry, project_id: PRJ_ID, path: 'subversion_test/helloworld.c', format: 'raw'
       assert_response :success
       assert_template nil
       assert_equal 'attachment; filename="helloworld.c"', @response.headers['Content-Disposition']
@@ -191,7 +191,7 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_directory_entry
       @repository.fetch_changesets
       @repository.reload
-      get :entry, :project_id => PRJ_ID, :path => 'subversion_test/folder'
+      get :entry, project_id: PRJ_ID, path: 'subversion_test/folder'
       assert_response :success
       assert_template 'show'
       assert_not_nil assigns(:entry)
@@ -202,18 +202,18 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_revision
       @repository.fetch_changesets
       @repository.reload
-      get :revision, :project_id => 1, :rev => 2
+      get :revision, project_id: 1, rev: 2
       assert_response :success
       assert_template 'revision'
-      assert_tag :tag => 'ul',
-                 :child => { :tag => 'li',
+      assert_tag tag: 'ul',
+                 child: { tag: 'li',
                              # link to the entry at rev 2
-                             :child => { :tag => 'a',
-                                         :attributes => {:href => '/projects/ecookbook/repository/revisions/2/entry/test/some/path/in/the/repo'},
-                                         :content => 'repo',
+                             child: { tag: 'a',
+                                         attributes: {href: '/projects/ecookbook/repository/revisions/2/entry/test/some/path/in/the/repo'},
+                                         content: 'repo',
                                          # link to partial diff
-                                         :sibling =>  { :tag => 'a',
-                                                        :attributes => { :href => '/projects/ecookbook/repository/revisions/2/diff/test/some/path/in/the/repo' }
+                                         sibling:  { tag: 'a',
+                                                        attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/test/some/path/in/the/repo' }
                                                        }
                                         }
                             }
@@ -222,24 +222,24 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_invalid_revision
       @repository.fetch_changesets
       @repository.reload
-      get :revision, :project_id => PRJ_ID, :rev => 'something_weird'
+      get :revision, project_id: PRJ_ID, rev: 'something_weird'
       assert_response 404
-      assert_error_tag :content => /was not found/
+      assert_error_tag content: /was not found/
     end
 
     def test_invalid_revision_diff
-      get :diff, :project_id => PRJ_ID, :rev => '1', :rev_to => 'something_weird'
+      get :diff, project_id: PRJ_ID, rev: '1', rev_to: 'something_weird'
       assert_response 404
-      assert_error_tag :content => /was not found/
+      assert_error_tag content: /was not found/
     end
 
     def test_empty_revision
       @repository.fetch_changesets
       @repository.reload
       ['', ' ', nil].each do |r|
-        get :revision, :project_id => PRJ_ID, :rev => r
+        get :revision, project_id: PRJ_ID, rev: r
         assert_response 404
-        assert_error_tag :content => /was not found/
+        assert_error_tag content: /was not found/
       end
     end
 
@@ -249,18 +249,18 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       # Changes repository url to a subdirectory
       r.update_attribute :url, (r.url + '/test/some')
 
-      get :revision, :project_id => 1, :rev => 2
+      get :revision, project_id: 1, rev: 2
       assert_response :success
       assert_template 'revision'
-      assert_tag :tag => 'ul',
-                 :child => { :tag => 'li',
+      assert_tag tag: 'ul',
+                 child: { tag: 'li',
                              # link to the entry at rev 2
-                             :child => { :tag => 'a',
-                                         :attributes => {:href => '/projects/ecookbook/repository/revisions/2/entry/path/in/the/repo'},
-                                         :content => 'repo',
+                             child: { tag: 'a',
+                                         attributes: {href: '/projects/ecookbook/repository/revisions/2/entry/path/in/the/repo'},
+                                         content: 'repo',
                                          # link to partial diff
-                                         :sibling =>  { :tag => 'a',
-                                                        :attributes => { :href => '/projects/ecookbook/repository/revisions/2/diff/path/in/the/repo' }
+                                         sibling:  { tag: 'a',
+                                                        attributes: { href: '/projects/ecookbook/repository/revisions/2/diff/path/in/the/repo' }
                                                        }
                                         }
                             }
@@ -269,17 +269,17 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_revision_diff
       @repository.fetch_changesets
       @repository.reload
-      get :diff, :project_id => PRJ_ID, :rev => 3
+      get :diff, project_id: PRJ_ID, rev: 3
       assert_response :success
       assert_template 'diff'
 
-      assert_tag :tag => 'h2', :content => /3/
+      assert_tag tag: 'h2', content: /3/
     end
 
     def test_directory_diff
       @repository.fetch_changesets
       @repository.reload
-      get :diff, :project_id => PRJ_ID, :rev => 6, :rev_to => 2, :path => 'subversion_test/folder'
+      get :diff, project_id: PRJ_ID, rev: 6, rev_to: 2, path: 'subversion_test/folder'
       assert_response :success
       assert_template 'diff'
 
@@ -288,13 +288,13 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
       # 2 files modified
       assert_equal 2, Redmine::UnifiedDiff.new(diff).size
 
-      assert_tag :tag => 'h2', :content => /2:6/
+      assert_tag tag: 'h2', content: /2:6/
     end
 
     def test_annotate
       @repository.fetch_changesets
       @repository.reload
-      get :annotate, :project_id => PRJ_ID, :path => 'subversion_test/helloworld.c'
+      get :annotate, project_id: PRJ_ID, path: 'subversion_test/helloworld.c'
       assert_response :success
       assert_template 'annotate'
     end
@@ -302,10 +302,10 @@ class RepositoriesSubversionControllerTest < ActionController::TestCase
     def test_annotate_at_given_revision
       @repository.fetch_changesets
       @repository.reload
-      get :annotate, :project_id => PRJ_ID, :rev => 8, :path => 'subversion_test/helloworld.c'
+      get :annotate, project_id: PRJ_ID, rev: 8, path: 'subversion_test/helloworld.c'
       assert_response :success
       assert_template 'annotate'
-      assert_tag :tag => 'h2', :content => /@ 8/
+      assert_tag tag: 'h2', content: /@ 8/
     end
   else
     puts "Subversion test repository NOT FOUND. Skipping functional tests !!!"

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -53,7 +53,7 @@ class RolesControllerTest < ActionController::TestCase
     assert_equal Role.find(:all, order: 'builtin, position'), assigns(:roles)
 
     assert_tag tag: 'a', attributes: { href: edit_role_path(1) },
-                            content: 'Manager'
+               content: 'Manager'
   end
 
   def test_get_new
@@ -64,8 +64,8 @@ class RolesControllerTest < ActionController::TestCase
 
   def test_post_new_with_validaton_failure
     post :create, role: { name: '',
-                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             assignable: '0' }
+                          permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                          assignable: '0' }
 
     assert_response :success
     assert_template 'new'
@@ -74,8 +74,8 @@ class RolesControllerTest < ActionController::TestCase
 
   def test_post_new_without_workflow_copy
     post :create, role: { name: 'RoleWithoutWorkflowCopy',
-                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             assignable: '0' }
+                          permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                          assignable: '0' }
 
     assert_redirected_to roles_path
     role = Role.find_by_name('RoleWithoutWorkflowCopy')
@@ -86,8 +86,8 @@ class RolesControllerTest < ActionController::TestCase
 
   def test_post_new_with_workflow_copy
     post :create, role: { name: 'RoleWithWorkflowCopy',
-                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             assignable: '0' },
+                          permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                          assignable: '0' },
                   copy_workflow_from: '1'
 
     assert_redirected_to roles_path
@@ -105,9 +105,9 @@ class RolesControllerTest < ActionController::TestCase
 
   def test_put_update
     put :update, id: 1,
-                 role: {name: 'Manager',
-                           permissions: ['edit_project', ''],
-                           assignable: '0'}
+                 role: { name: 'Manager',
+                         permissions: ['edit_project', ''],
+                         assignable: '0' }
 
     assert_redirected_to roles_path
     role = Role.find(1)
@@ -139,18 +139,18 @@ class RolesControllerTest < ActionController::TestCase
     assert_equal Role.find(:all, order: 'builtin, position'), assigns(:roles)
 
     assert_tag tag: 'input', attributes: { type: 'checkbox',
-                                                 name: 'permissions[3][]',
-                                                 value: 'add_work_packages',
-                                                 checked: 'checked' }
+                                           name: 'permissions[3][]',
+                                           value: 'add_work_packages',
+                                           checked: 'checked' }
 
     assert_tag tag: 'input', attributes: { type: 'checkbox',
-                                                 name: 'permissions[3][]',
-                                                 value: 'delete_work_packages',
-                                                 checked: nil }
+                                           name: 'permissions[3][]',
+                                           value: 'delete_work_packages',
+                                           checked: nil }
   end
 
   def test_put_bulk_update
-    put :bulk_update, permissions: { '0' => '', '1' => ['edit_work_packages'], '3' => ['add_work_packages', 'delete_work_packages']}
+    put :bulk_update, permissions: { '0' => '', '1' => ['edit_work_packages'], '3' => ['add_work_packages', 'delete_work_packages'] }
     assert_redirected_to roles_path
 
     assert_equal [:edit_work_packages], Role.find(1).permissions
@@ -165,27 +165,27 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_move_highest
-    put :update, id: 3, role: {move_to: 'highest'}
+    put :update, id: 3, role: { move_to: 'highest' }
     assert_redirected_to roles_path
     assert_equal 1, Role.find(3).position
   end
 
   def test_move_higher
     position = Role.find(3).position
-    put :update, id: 3, role: {move_to: 'higher'}
+    put :update, id: 3, role: { move_to: 'higher' }
     assert_redirected_to roles_path
     assert_equal position - 1, Role.find(3).position
   end
 
   def test_move_lower
     position = Role.find(2).position
-    put :update, id: 2, role: {move_to: 'lower'}
+    put :update, id: 2, role: { move_to: 'lower' }
     assert_redirected_to roles_path
     assert_equal position + 1, Role.find(2).position
   end
 
   def test_move_lowest
-    put :update, id: 2, role: {move_to: 'lowest'}
+    put :update, id: 2, role: { move_to: 'lowest' }
     assert_redirected_to roles_path
     assert_equal Role.count, Role.find(2).position
   end

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -50,10 +50,10 @@ class RolesControllerTest < ActionController::TestCase
     assert_template 'index'
 
     assert_not_nil assigns(:roles)
-    assert_equal Role.find(:all, :order => 'builtin, position'), assigns(:roles)
+    assert_equal Role.find(:all, order: 'builtin, position'), assigns(:roles)
 
-    assert_tag :tag => 'a', :attributes => { :href => edit_role_path(1) },
-                            :content => 'Manager'
+    assert_tag tag: 'a', attributes: { href: edit_role_path(1) },
+                            content: 'Manager'
   end
 
   def test_get_new
@@ -63,19 +63,19 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_post_new_with_validaton_failure
-    post :create, :role => { :name => '',
-                             :permissions => ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             :assignable => '0' }
+    post :create, role: { name: '',
+                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                             assignable: '0' }
 
     assert_response :success
     assert_template 'new'
-    assert_tag :tag => 'div', :attributes => { :id => 'errorExplanation' }
+    assert_tag tag: 'div', attributes: { id: 'errorExplanation' }
   end
 
   def test_post_new_without_workflow_copy
-    post :create, :role => { :name => 'RoleWithoutWorkflowCopy',
-                             :permissions => ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             :assignable => '0' }
+    post :create, role: { name: 'RoleWithoutWorkflowCopy',
+                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                             assignable: '0' }
 
     assert_redirected_to roles_path
     role = Role.find_by_name('RoleWithoutWorkflowCopy')
@@ -85,10 +85,10 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_post_new_with_workflow_copy
-    post :create, :role => { :name => 'RoleWithWorkflowCopy',
-                             :permissions => ['add_work_packages', 'edit_work_packages', 'log_time', ''],
-                             :assignable => '0' },
-                  :copy_workflow_from => '1'
+    post :create, role: { name: 'RoleWithWorkflowCopy',
+                             permissions: ['add_work_packages', 'edit_work_packages', 'log_time', ''],
+                             assignable: '0' },
+                  copy_workflow_from: '1'
 
     assert_redirected_to roles_path
     role = Role.find_by_name('RoleWithWorkflowCopy')
@@ -97,17 +97,17 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_get_edit
-    get :edit, :id => 1
+    get :edit, id: 1
     assert_response :success
     assert_template 'edit'
     assert_equal Role.find(1), assigns(:role)
   end
 
   def test_put_update
-    put :update, :id => 1,
-                 :role => {:name => 'Manager',
-                           :permissions => ['edit_project', ''],
-                           :assignable => '0'}
+    put :update, id: 1,
+                 role: {name: 'Manager',
+                           permissions: ['edit_project', ''],
+                           assignable: '0'}
 
     assert_redirected_to roles_path
     role = Role.find(1)
@@ -115,16 +115,16 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_destroy
-    r = Role.new(:name => 'ToBeDestroyed', :permissions => [:view_wiki_pages])
+    r = Role.new(name: 'ToBeDestroyed', permissions: [:view_wiki_pages])
     assert r.save
 
-    delete :destroy, :id => r
+    delete :destroy, id: r
     assert_redirected_to roles_path
     assert_nil Role.find_by_id(r.id)
   end
 
   def test_destroy_role_in_use
-    delete :destroy, :id => 1
+    delete :destroy, id: 1
     assert_redirected_to roles_path
     assert flash[:error] == 'This role is in use and cannot be deleted.'
     assert_not_nil Role.find_by_id(1)
@@ -136,21 +136,21 @@ class RolesControllerTest < ActionController::TestCase
     assert_template 'report'
 
     assert_not_nil assigns(:roles)
-    assert_equal Role.find(:all, :order => 'builtin, position'), assigns(:roles)
+    assert_equal Role.find(:all, order: 'builtin, position'), assigns(:roles)
 
-    assert_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                 :name => 'permissions[3][]',
-                                                 :value => 'add_work_packages',
-                                                 :checked => 'checked' }
+    assert_tag tag: 'input', attributes: { type: 'checkbox',
+                                                 name: 'permissions[3][]',
+                                                 value: 'add_work_packages',
+                                                 checked: 'checked' }
 
-    assert_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                 :name => 'permissions[3][]',
-                                                 :value => 'delete_work_packages',
-                                                 :checked => nil }
+    assert_tag tag: 'input', attributes: { type: 'checkbox',
+                                                 name: 'permissions[3][]',
+                                                 value: 'delete_work_packages',
+                                                 checked: nil }
   end
 
   def test_put_bulk_update
-    put :bulk_update, :permissions => { '0' => '', '1' => ['edit_work_packages'], '3' => ['add_work_packages', 'delete_work_packages']}
+    put :bulk_update, permissions: { '0' => '', '1' => ['edit_work_packages'], '3' => ['add_work_packages', 'delete_work_packages']}
     assert_redirected_to roles_path
 
     assert_equal [:edit_work_packages], Role.find(1).permissions
@@ -159,33 +159,33 @@ class RolesControllerTest < ActionController::TestCase
   end
 
   def test_clear_all_permissions
-    put :bulk_update, :permissions => { '0' => '' }
+    put :bulk_update, permissions: { '0' => '' }
     assert_redirected_to roles_path
     assert Role.find(1).permissions.empty?
   end
 
   def test_move_highest
-    put :update, :id => 3, :role => {:move_to => 'highest'}
+    put :update, id: 3, role: {move_to: 'highest'}
     assert_redirected_to roles_path
     assert_equal 1, Role.find(3).position
   end
 
   def test_move_higher
     position = Role.find(3).position
-    put :update, :id => 3, :role => {:move_to => 'higher'}
+    put :update, id: 3, role: {move_to: 'higher'}
     assert_redirected_to roles_path
     assert_equal position - 1, Role.find(3).position
   end
 
   def test_move_lower
     position = Role.find(2).position
-    put :update, :id => 2, :role => {:move_to => 'lower'}
+    put :update, id: 2, role: {move_to: 'lower'}
     assert_redirected_to roles_path
     assert_equal position + 1, Role.find(2).position
   end
 
   def test_move_lowest
-    put :update, :id => 2, :role => {:move_to => 'lowest'}
+    put :update, id: 2, role: {move_to: 'lowest'}
     assert_redirected_to roles_path
     assert_equal Role.count, Role.find(2).position
   end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -45,7 +45,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   def test_search_all_projects
-    get :index, :q => 'recipe subproject commit', :submit => 'Search'
+    get :index, q: 'recipe subproject commit', submit: 'Search'
     assert_response :success
     assert_template 'index'
 
@@ -55,11 +55,11 @@ class SearchControllerTest < ActionController::TestCase
 
     assert assigns(:results_by_type).is_a?(Hash)
     assert_equal 5, assigns(:results_by_type)['changesets']
-    assert_tag :a, :content => 'Changesets (5)'
+    assert_tag :a, content: 'Changesets (5)'
   end
 
   def test_search_project_and_subprojects
-    get :index, :project_id => 1, :q => 'recipe subproject', :scope => 'subprojects', :submit => 'Search'
+    get :index, project_id: 1, q: 'recipe subproject', scope: 'subprojects', submit: 'Search'
     assert_response :success
     assert_template 'index'
     assert assigns(:results).include?(WorkPackage.find(1))
@@ -69,18 +69,18 @@ class SearchControllerTest < ActionController::TestCase
   def test_search_without_searchable_custom_fields
     CustomField.update_all "searchable = #{ActiveRecord::Base.connection.quoted_false}"
 
-    get :index, :project_id => 1
+    get :index, project_id: 1
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:project)
 
-    get :index, :project_id => 1, :q => "can"
+    get :index, project_id: 1, q: "can"
     assert_response :success
     assert_template 'index'
   end
 
   def test_search_with_searchable_custom_fields
-    get :index, :project_id => 1, :q => "stringforcustomfield"
+    get :index, project_id: 1, q: "stringforcustomfield"
     assert_response :success
     results = assigns(:results)
     assert_not_nil results
@@ -90,7 +90,7 @@ class SearchControllerTest < ActionController::TestCase
 
   def test_search_all_words
     # 'all words' is on by default
-    get :index, :project_id => 1, :q => 'recipe updating saving'
+    get :index, project_id: 1, q: 'recipe updating saving'
     results = assigns(:results)
     assert_not_nil results
     assert_equal 1, results.size
@@ -98,7 +98,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   def test_search_one_of_the_words
-    get :index, :project_id => 1, :q => 'recipe updating saving', :submit => 'Search'
+    get :index, project_id: 1, q: 'recipe updating saving', submit: 'Search'
     results = assigns(:results)
     assert_not_nil results
     assert_equal 3, results.size
@@ -106,44 +106,44 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   def test_search_titles_only_without_result
-    get :index, :project_id => 1, :q => 'recipe updating saving', :all_words => '1', :titles_only => '1', :submit => 'Search'
+    get :index, project_id: 1, q: 'recipe updating saving', all_words: '1', titles_only: '1', submit: 'Search'
     results = assigns(:results)
     assert_not_nil results
     assert_equal 0, results.size
   end
 
   def test_search_titles_only
-    get :index, :project_id => 1, :q => 'recipe', :titles_only => '1', :submit => 'Search'
+    get :index, project_id: 1, q: 'recipe', titles_only: '1', submit: 'Search'
     results = assigns(:results)
     assert_not_nil results
     assert_equal 2, results.size
   end
 
   def test_search_with_invalid_project_id
-    get :index, :project_id => 195, :q => 'recipe'
+    get :index, project_id: 195, q: 'recipe'
     assert_response 404
     assert_nil assigns(:results)
   end
 
   def test_quick_jump_to_work_packages
     # work_package of a public project
-    get :index, :q => "3"
+    get :index, q: "3"
     assert_redirected_to '/work_packages/3'
 
     # work_package of a private project
-    get :index, :q => "4"
+    get :index, q: "4"
     assert_response :success
     assert_template 'index'
   end
 
   def test_large_integer
-    get :index, :q => '4615713488'
+    get :index, q: '4615713488'
     assert_response :success
     assert_template 'index'
   end
 
   def test_tokens_with_quotes
-    get :index, :project_id => 1, :q => '"good bye" hello "bye bye"'
+    get :index, project_id: 1, q: '"good bye" hello "bye bye"'
     assert_equal ["good bye", "hello", "bye bye"], assigns(:tokens)
   end
 end

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -74,13 +74,13 @@ class SearchControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:project)
 
-    get :index, project_id: 1, q: "can"
+    get :index, project_id: 1, q: 'can'
     assert_response :success
     assert_template 'index'
   end
 
   def test_search_with_searchable_custom_fields
-    get :index, project_id: 1, q: "stringforcustomfield"
+    get :index, project_id: 1, q: 'stringforcustomfield'
     assert_response :success
     results = assigns(:results)
     assert_not_nil results
@@ -127,11 +127,11 @@ class SearchControllerTest < ActionController::TestCase
 
   def test_quick_jump_to_work_packages
     # work_package of a public project
-    get :index, q: "3"
+    get :index, q: '3'
     assert_redirected_to '/work_packages/3'
 
     # work_package of a private project
-    get :index, q: "4"
+    get :index, q: '4'
     assert_response :success
     assert_template 'index'
   end
@@ -144,6 +144,6 @@ class SearchControllerTest < ActionController::TestCase
 
   def test_tokens_with_quotes
     get :index, project_id: 1, q: '"good bye" hello "bye bye"'
-    assert_equal ["good bye", "hello", "bye bye"], assigns(:tokens)
+    assert_equal ['good bye', 'hello', 'bye bye'], assigns(:tokens)
   end
 end

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -58,10 +58,10 @@ class SettingsControllerTest < ActionController::TestCase
   end
 
   def test_post_edit_notifications
-    post :edit, :settings => {:mail_from => 'functional@test.foo',
-                              :bcc_recipients  => '0',
-                              :notified_events => %w(work_package_added work_package_updated news_added),
-                              :emails_footer => 'Test footer'
+    post :edit, settings: {mail_from: 'functional@test.foo',
+                              bcc_recipients:  '0',
+                              notified_events: %w(work_package_added work_package_updated news_added),
+                              emails_footer: 'Test footer'
                               }
     assert_redirected_to '/settings/edit'
     assert_equal 'functional@test.foo', Setting.mail_from

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -58,10 +58,10 @@ class SettingsControllerTest < ActionController::TestCase
   end
 
   def test_post_edit_notifications
-    post :edit, settings: {mail_from: 'functional@test.foo',
-                              bcc_recipients:  '0',
-                              notified_events: %w(work_package_added work_package_updated news_added),
-                              emails_footer: 'Test footer'
+    post :edit, settings: { mail_from: 'functional@test.foo',
+                            bcc_recipients:  '0',
+                            notified_events: %w(work_package_added work_package_updated news_added),
+                            emails_footer: 'Test footer'
                               }
     assert_redirected_to '/settings/edit'
     assert_equal 'functional@test.foo', Setting.mail_from

--- a/test/functional/sys_controller_test.rb
+++ b/test/functional/sys_controller_test.rb
@@ -49,17 +49,17 @@ class SysControllerTest < ActionController::TestCase
     get :projects
     assert_response :success
     assert_equal 'application/xml', @response.content_type
-    with_options :tag => 'projects' do |test|
-      test.assert_tag :children => { :count  => Project.active.has_module(:repository).count }
+    with_options tag: 'projects' do |test|
+      test.assert_tag children: { count:  Project.active.has_module(:repository).count }
     end
   end
 
   def test_create_project_repository
     assert_nil Project.find(4).repository
 
-    post :create_project_repository, :id => 4,
-                                     :vendor => 'Subversion',
-                                     :repository => { :url => 'file:///create/project/repository/subproject2'}
+    post :create_project_repository, id: 4,
+                                     vendor: 'Subversion',
+                                     repository: { url: 'file:///create/project/repository/subproject2'}
     assert_response :created
 
     r = Project.find(4).repository
@@ -75,32 +75,32 @@ class SysControllerTest < ActionController::TestCase
 
   def test_fetch_changesets_one_project
     Repository::Subversion.any_instance.should_receive(:fetch_changesets).and_return(true)
-    get :fetch_changesets, :id => 'ecookbook'
+    get :fetch_changesets, id: 'ecookbook'
     assert_response :success
   end
 
   def test_fetch_changesets_unknown_project
-    get :fetch_changesets, :id => 'unknown'
+    get :fetch_changesets, id: 'unknown'
     assert_response 404
   end
 
   def test_disabled_ws_should_respond_with_403_error
-    with_settings :sys_api_enabled => '0' do
+    with_settings sys_api_enabled: '0' do
       get :projects
       assert_response 403
     end
   end
 
   def test_api_key
-    with_settings :sys_api_key => 'my_secret_key' do
-      get :projects, :key => 'my_secret_key'
+    with_settings sys_api_key: 'my_secret_key' do
+      get :projects, key: 'my_secret_key'
       assert_response :success
     end
   end
 
   def test_wrong_key_should_respond_with_403_error
-    with_settings :sys_api_enabled => 'my_secret_key' do
-      get :projects, :key => 'wrong_key'
+    with_settings sys_api_enabled: 'my_secret_key' do
+      get :projects, key: 'wrong_key'
       assert_response 403
     end
   end

--- a/test/functional/sys_controller_test.rb
+++ b/test/functional/sys_controller_test.rb
@@ -59,7 +59,7 @@ class SysControllerTest < ActionController::TestCase
 
     post :create_project_repository, id: 4,
                                      vendor: 'Subversion',
-                                     repository: { url: 'file:///create/project/repository/subproject2'}
+                                     repository: { url: 'file:///create/project/repository/subproject2' }
     assert_response :created
 
     r = Project.find(4).repository

--- a/test/functional/time_entries/reports_controller_test.rb
+++ b/test/functional/time_entries/reports_controller_test.rb
@@ -33,11 +33,11 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   fixtures :all
 
   def test_report_at_project_level
-    get :show, :project_id => 'ecookbook'
+    get :show, project_id: 'ecookbook'
     assert_response :success
     assert_template 'report'
     assert_tag :form,
-      :attributes => {:action => "/projects/ecookbook/time_entries/report", :id => 'query_form'}
+      attributes: {action: "/projects/ecookbook/time_entries/report", id: 'query_form'}
   end
 
   def test_report_all_projects
@@ -45,7 +45,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'report'
     assert_tag :form,
-      :attributes => {:action => "/time_entries/report", :id => 'query_form'}
+      attributes: {action: "/time_entries/report", id: 'query_form'}
   end
 
   def test_report_all_projects_denied
@@ -58,7 +58,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_all_projects_one_criteria
-    get :show, :columns => 'week', :from => "2007-04-01", :to => "2007-04-30", :criterias => ['project']
+    get :show, columns: 'week', from: "2007-04-01", to: "2007-04-30", criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -66,7 +66,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_all_time
-    get :show, :project_id => 1, :criterias => ['project', 'issue']
+    get :show, project_id: 1, criterias: ['project', 'issue']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -74,16 +74,16 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_all_time_by_day
-    get :show, :project_id => 1, :criterias => ['project', 'issue'], :columns => 'day'
+    get :show, project_id: 1, criterias: ['project', 'issue'], columns: 'day'
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
     assert_equal "162.90", "%.2f" % assigns(:total_hours)
-    assert_tag :tag => 'th', :content => '2007-03-12'
+    assert_tag tag: 'th', content: '2007-03-12'
   end
 
   def test_report_one_criteria
-    get :show, :project_id => 1, :columns => 'week', :from => "2007-04-01", :to => "2007-04-30", :criterias => ['project']
+    get :show, project_id: 1, columns: 'week', from: "2007-04-01", to: "2007-04-30", criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -91,7 +91,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_two_criterias
-    get :show, :project_id => 1, :columns => 'month', :from => "2007-01-01", :to => "2007-12-31", :criterias => ["member", "activity"]
+    get :show, project_id: 1, columns: 'month', from: "2007-01-01", to: "2007-12-31", criterias: ["member", "activity"]
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -99,7 +99,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_one_day
-    get :show, :project_id => 1, :columns => 'day', :from => "2007-03-23", :to => "2007-03-23", :criterias => ["member", "activity"]
+    get :show, project_id: 1, columns: 'day', from: "2007-03-23", to: "2007-03-23", criterias: ["member", "activity"]
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -107,17 +107,17 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_at_issue_level
-    get :show, :project_id => 1, :work_package_id => 1, :columns => 'month', :from => "2007-01-01", :to => "2007-12-31", :criterias => ["member", "activity"]
+    get :show, project_id: 1, work_package_id: 1, columns: 'month', from: "2007-01-01", to: "2007-12-31", criterias: ["member", "activity"]
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
     assert_equal "154.25", "%.2f" % assigns(:total_hours)
     assert_tag :form,
-      :attributes => {:action => work_package_time_entries_report_path(1), :id => 'query_form'}
+      attributes: {action: work_package_time_entries_report_path(1), id: 'query_form'}
   end
 
   def test_report_custom_field_criteria
-    get :show, :project_id => 1, :criterias => ['project', 'cf_1', 'cf_7']
+    get :show, project_id: 1, criterias: ['project', 'cf_1', 'cf_7']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -125,18 +125,18 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_equal 3, assigns(:criterias).size
     assert_equal "162.90", "%.2f" % assigns(:total_hours)
     # Custom field column
-    assert_tag :tag => 'th', :content => 'Database'
+    assert_tag tag: 'th', content: 'Database'
     # Custom field row
-    assert_tag :tag => 'td', :content => 'MySQL',
-                             :sibling => { :tag => 'td', :attributes => { :class => 'hours' },
-                                                         :child => { :tag => 'span', :attributes => { :class => 'hours hours-int' },
-                                                                                     :content => '1' }}
+    assert_tag tag: 'td', content: 'MySQL',
+                             sibling: { tag: 'td', attributes: { class: 'hours' },
+                                                         child: { tag: 'span', attributes: { class: 'hours hours-int' },
+                                                                                     content: '1' }}
     # Second custom field column
-    assert_tag :tag => 'th', :content => 'Billable'
+    assert_tag tag: 'th', content: 'Billable'
   end
 
   def test_report_one_criteria_no_result
-    get :show, :project_id => 1, :columns => 'week', :from => "1998-04-01", :to => "1998-04-30", :criterias => ['project']
+    get :show, project_id: 1, columns: 'week', from: "1998-04-01", to: "1998-04-30", criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
@@ -144,7 +144,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_all_projects_csv_export
-    get :show, :columns => 'month', :from => "2007-01-01", :to => "2007-06-30", :criterias => ["project", "member", "activity"], :format => "csv"
+    get :show, columns: 'month', from: "2007-01-01", to: "2007-06-30", criterias: ["project", "member", "activity"], format: "csv"
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     lines = @response.body.chomp.split("\n")
@@ -155,7 +155,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_csv_export
-    get :show, :project_id => 1, :columns => 'month', :from => "2007-01-01", :to => "2007-06-30", :criterias => ["project", "member", "activity"], :format => "csv"
+    get :show, project_id: 1, columns: 'month', from: "2007-01-01", to: "2007-06-30", criterias: ["project", "member", "activity"], format: "csv"
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     lines = @response.body.chomp.split("\n")

--- a/test/functional/time_entries/reports_controller_test.rb
+++ b/test/functional/time_entries/reports_controller_test.rb
@@ -37,7 +37,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'report'
     assert_tag :form,
-      attributes: {action: "/projects/ecookbook/time_entries/report", id: 'query_form'}
+               attributes: { action: '/projects/ecookbook/time_entries/report', id: 'query_form' }
   end
 
   def test_report_all_projects
@@ -45,7 +45,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'report'
     assert_tag :form,
-      attributes: {action: "/time_entries/report", id: 'query_form'}
+               attributes: { action: '/time_entries/report', id: 'query_form' }
   end
 
   def test_report_all_projects_denied
@@ -58,11 +58,11 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_all_projects_one_criteria
-    get :show, columns: 'week', from: "2007-04-01", to: "2007-04-30", criterias: ['project']
+    get :show, columns: 'week', from: '2007-04-01', to: '2007-04-30', criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "8.65", "%.2f" % assigns(:total_hours)
+    assert_equal '8.65', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_all_time
@@ -70,7 +70,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_all_time_by_day
@@ -78,42 +78,42 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
     assert_tag tag: 'th', content: '2007-03-12'
   end
 
   def test_report_one_criteria
-    get :show, project_id: 1, columns: 'week', from: "2007-04-01", to: "2007-04-30", criterias: ['project']
+    get :show, project_id: 1, columns: 'week', from: '2007-04-01', to: '2007-04-30', criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "8.65", "%.2f" % assigns(:total_hours)
+    assert_equal '8.65', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_two_criterias
-    get :show, project_id: 1, columns: 'month', from: "2007-01-01", to: "2007-12-31", criterias: ["member", "activity"]
+    get :show, project_id: 1, columns: 'month', from: '2007-01-01', to: '2007-12-31', criterias: ['member', 'activity']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_one_day
-    get :show, project_id: 1, columns: 'day', from: "2007-03-23", to: "2007-03-23", criterias: ["member", "activity"]
+    get :show, project_id: 1, columns: 'day', from: '2007-03-23', to: '2007-03-23', criterias: ['member', 'activity']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "4.25", "%.2f" % assigns(:total_hours)
+    assert_equal '4.25', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_at_issue_level
-    get :show, project_id: 1, work_package_id: 1, columns: 'month', from: "2007-01-01", to: "2007-12-31", criterias: ["member", "activity"]
+    get :show, project_id: 1, work_package_id: 1, columns: 'month', from: '2007-01-01', to: '2007-12-31', criterias: ['member', 'activity']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "154.25", "%.2f" % assigns(:total_hours)
+    assert_equal '154.25', '%.2f' % assigns(:total_hours)
     assert_tag :form,
-      attributes: {action: work_package_time_entries_report_path(1), id: 'query_form'}
+               attributes: { action: work_package_time_entries_report_path(1), id: 'query_form' }
   end
 
   def test_report_custom_field_criteria
@@ -123,28 +123,28 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:total_hours)
     assert_not_nil assigns(:criterias)
     assert_equal 3, assigns(:criterias).size
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
     # Custom field column
     assert_tag tag: 'th', content: 'Database'
     # Custom field row
     assert_tag tag: 'td', content: 'MySQL',
-                             sibling: { tag: 'td', attributes: { class: 'hours' },
-                                                         child: { tag: 'span', attributes: { class: 'hours hours-int' },
-                                                                                     content: '1' }}
+               sibling: { tag: 'td', attributes: { class: 'hours' },
+                          child: { tag: 'span', attributes: { class: 'hours hours-int' },
+                                   content: '1' } }
     # Second custom field column
     assert_tag tag: 'th', content: 'Billable'
   end
 
   def test_report_one_criteria_no_result
-    get :show, project_id: 1, columns: 'week', from: "1998-04-01", to: "1998-04-30", criterias: ['project']
+    get :show, project_id: 1, columns: 'week', from: '1998-04-01', to: '1998-04-30', criterias: ['project']
     assert_response :success
     assert_template 'report'
     assert_not_nil assigns(:total_hours)
-    assert_equal "0.00", "%.2f" % assigns(:total_hours)
+    assert_equal '0.00', '%.2f' % assigns(:total_hours)
   end
 
   def test_report_all_projects_csv_export
-    get :show, columns: 'month', from: "2007-01-01", to: "2007-06-30", criterias: ["project", "member", "activity"], format: "csv"
+    get :show, columns: 'month', from: '2007-01-01', to: '2007-06-30', criterias: ['project', 'member', 'activity'], format: 'csv'
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     lines = @response.body.chomp.split("\n")
@@ -155,7 +155,7 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
   end
 
   def test_report_csv_export
-    get :show, project_id: 1, columns: 'month', from: "2007-01-01", to: "2007-06-30", criterias: ["project", "member", "activity"], format: "csv"
+    get :show, project_id: 1, columns: 'month', from: '2007-01-01', to: '2007-06-30', criterias: ['project', 'member', 'activity'], format: 'csv'
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     lines = @response.body.chomp.split("\n")
@@ -164,5 +164,4 @@ class TimeEntries::ReportsControllerTest < ActionController::TestCase
     # Total row
     assert_equal 'Total,"","","","",154.25,8.65,"","",162.90', lines.last
   end
-
 end

--- a/test/functional/timelog_controller_test.rb
+++ b/test/functional/timelog_controller_test.rb
@@ -45,30 +45,30 @@ class TimelogControllerTest < ActionController::TestCase
 
   def test_get_new
     @request.session[:user_id] = 3
-    get :new, :project_id => 1
+    get :new, project_id: 1
     assert_response :success
     assert_template 'edit'
     # Default activity selected
-    assert_tag :tag => 'option', :attributes => { :selected => 'selected' },
-                                 :content => 'Development'
+    assert_tag tag: 'option', attributes: { selected: 'selected' },
+                                 content: 'Development'
   end
 
   def test_get_new_should_only_show_active_time_entry_activities
     @request.session[:user_id] = 3
-    get :new, :project_id => 1
+    get :new, project_id: 1
     assert_response :success
     assert_template 'edit'
-    assert_no_tag :tag => 'option', :content => 'Inactive Activity'
+    assert_no_tag tag: 'option', content: 'Inactive Activity'
 
   end
 
   def test_get_edit_existing_time
     @request.session[:user_id] = 2
-    get :edit, :id => 2, :project_id => nil
+    get :edit, id: 2, project_id: nil
     assert_response :success
     assert_template 'edit'
     # Default activity selected
-    assert_tag :tag => 'form', :attributes => { :action => '/projects/ecookbook/time_entries/2' }
+    assert_tag tag: 'form', attributes: { action: '/projects/ecookbook/time_entries/2' }
   end
 
   def test_get_edit_with_an_existing_time_entry_with_inactive_activity
@@ -77,25 +77,25 @@ class TimelogControllerTest < ActionController::TestCase
     te.save!
 
     @request.session[:user_id] = 1
-    get :edit, :project_id => 1, :id => 1
+    get :edit, project_id: 1, id: 1
     assert_response :success
     assert_template 'edit'
     # Blank option since nothing is pre-selected
-    assert_tag :tag => 'option', :content => '--- Please select ---'
+    assert_tag tag: 'option', content: '--- Please select ---'
   end
 
   def test_post_create
     # TODO: should POST to issues’ time log instead of project. change form
     # and routing
     @request.session[:user_id] = 3
-    post :create, :project_id => 1,
-                :time_entry => {:comments => 'Some work on TimelogControllerTest',
+    post :create, project_id: 1,
+                time_entry: {comments: 'Some work on TimelogControllerTest',
                                 # Not the default activity
-                                :activity_id => '11',
-                                :spent_on => '2008-03-14',
-                                :work_package_id => '1',
-                                :hours => '7.3'}
-    assert_redirected_to :action => 'index', :project_id => 'ecookbook'
+                                activity_id: '11',
+                                spent_on: '2008-03-14',
+                                work_package_id: '1',
+                                hours: '7.3'}
+    assert_redirected_to action: 'index', project_id: 'ecookbook'
 
     i = WorkPackage.find(1)
     t = TimeEntry.find_by_comments('Some work on TimelogControllerTest')
@@ -111,14 +111,14 @@ class TimelogControllerTest < ActionController::TestCase
     # TODO: should POST to issues’ time log instead of project. change form
     # and routing
     @request.session[:user_id] = 3
-    post :create, :project_id => 1,
-                :time_entry => {:comments => 'Some work on TimelogControllerTest',
+    post :create, project_id: 1,
+                time_entry: {comments: 'Some work on TimelogControllerTest',
                                 # Not the default activity
-                                :activity_id => '11',
-                                :work_package_id => '',
-                                :spent_on => '2008-03-14',
-                                :hours => '7.3'}
-    assert_redirected_to :action => 'index', :project_id => 'ecookbook'
+                                activity_id: '11',
+                                work_package_id: '',
+                                spent_on: '2008-03-14',
+                                hours: '7.3'}
+    assert_redirected_to action: 'index', project_id: 'ecookbook'
 
     t = TimeEntry.find_by_comments('Some work on TimelogControllerTest')
     assert_not_nil t
@@ -133,10 +133,10 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal 2, entry.user_id
 
     @request.session[:user_id] = 1
-    put :update, :id => 1,
-                :time_entry => {:work_package_id => '2',
-                                :hours => '8'}
-    assert_redirected_to :action => 'index', :project_id => 'ecookbook'
+    put :update, id: 1,
+                time_entry: {work_package_id: '2',
+                                hours: '8'}
+    assert_redirected_to action: 'index', project_id: 'ecookbook'
     entry.reload
 
     assert_equal 8, entry.hours
@@ -146,8 +146,8 @@ class TimelogControllerTest < ActionController::TestCase
 
   def test_destroy
     @request.session[:user_id] = 2
-    delete :destroy, :id => 1
-    assert_redirected_to :action => 'index', :project_id => 'ecookbook'
+    delete :destroy, id: 1
+    assert_redirected_to action: 'index', project_id: 'ecookbook'
     assert_equal I18n.t(:notice_successful_delete), flash[:notice]
     assert_nil TimeEntry.find_by_id(1)
   end
@@ -160,8 +160,8 @@ class TimelogControllerTest < ActionController::TestCase
     end
 
     @request.session[:user_id] = 2
-    delete :destroy, :id => 1
-    assert_redirected_to :action => 'index', :project_id => 'ecookbook'
+    delete :destroy, id: 1
+    assert_redirected_to action: 'index', project_id: 'ecookbook'
     assert_equal I18n.t(:notice_unable_delete_time_entry), flash[:error]
     assert_not_nil TimeEntry.find_by_id(1)
 
@@ -176,11 +176,11 @@ class TimelogControllerTest < ActionController::TestCase
     assert_not_nil assigns(:total_hours)
     assert_equal "162.90", "%.2f" % assigns(:total_hours)
     assert_tag :form,
-      :attributes => {:action => "/time_entries", :id => 'query_form'}
+      attributes: {action: "/time_entries", id: 'query_form'}
   end
 
   def test_index_at_project_level
-    get :index, :project_id => 'ecookbook'
+    get :index, project_id: 'ecookbook'
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:entries)
@@ -193,11 +193,11 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal '2007-03-12'.to_date, assigns(:from)
     assert_equal '2007-04-22'.to_date, assigns(:to)
     assert_tag :form,
-      :attributes => {:action => "/projects/ecookbook/time_entries", :id => 'query_form'}
+      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
   end
 
   def test_index_at_project_level_with_date_range
-    get :index, :project_id => 'ecookbook', :from => '2007-03-20', :to => '2007-04-30'
+    get :index, project_id: 'ecookbook', from: '2007-03-20', to: '2007-04-30'
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:entries)
@@ -207,11 +207,11 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal '2007-03-20'.to_date, assigns(:from)
     assert_equal '2007-04-30'.to_date, assigns(:to)
     assert_tag :form,
-      :attributes => {:action => "/projects/ecookbook/time_entries", :id => 'query_form'}
+      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
   end
 
   def test_index_at_project_level_with_period
-    get :index, :project_id => 'ecookbook', :period => '7_days'
+    get :index, project_id: 'ecookbook', period: '7_days'
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:entries)
@@ -219,21 +219,21 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal Date.today - 7, assigns(:from)
     assert_equal Date.today, assigns(:to)
     assert_tag :form,
-      :attributes => {:action => "/projects/ecookbook/time_entries", :id => 'query_form'}
+      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
   end
 
   def test_index_one_day
-    get :index, :project_id => 'ecookbook', :from => "2007-03-23", :to => "2007-03-23"
+    get :index, project_id: 'ecookbook', from: "2007-03-23", to: "2007-03-23"
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:total_hours)
     assert_equal "4.25", "%.2f" % assigns(:total_hours)
     assert_tag :form,
-      :attributes => {:action => "/projects/ecookbook/time_entries", :id => 'query_form'}
+      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
   end
 
   def test_index_at_issue_level
-    get :index, :work_package_id => 1
+    get :index, work_package_id: 1
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:entries)
@@ -244,13 +244,13 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal '2007-03-12'.to_date, assigns(:from)
     assert_equal '2007-04-22'.to_date, assigns(:to)
     assert_tag :form,
-      :attributes => {:action => work_package_time_entries_path(1), :id => 'query_form'}
+      attributes: {action: work_package_time_entries_path(1), id: 'query_form'}
   end
 
   def test_index_atom_feed
     TimeEntry.all.each(&:recreate_initial_journal!)
 
-    get :index, :project_id => 1, :format => 'atom'
+    get :index, project_id: 1, format: 'atom'
     assert_response :success
     assert_equal 'application/atom+xml', @response.content_type
     assert_not_nil assigns(:items)
@@ -259,7 +259,7 @@ class TimelogControllerTest < ActionController::TestCase
 
   def test_index_all_projects_csv_export
     Setting.date_format = '%m/%d/%Y'
-    get :index, :format => 'csv'
+    get :index, format: 'csv'
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     assert @response.body.include?("Date,User,Activity,Project,Issue,Type,Subject,Hours,Comment\n")
@@ -268,7 +268,7 @@ class TimelogControllerTest < ActionController::TestCase
 
   def test_index_csv_export
     Setting.date_format = '%m/%d/%Y'
-    get :index, :project_id => 1, :format => 'csv'
+    get :index, project_id: 1, format: 'csv'
     assert_response :success
     assert_match(/text\/csv/, @response.content_type)
     assert @response.body.include?("Date,User,Activity,Project,Issue,Type,Subject,Hours,Comment\n")

--- a/test/functional/timelog_controller_test.rb
+++ b/test/functional/timelog_controller_test.rb
@@ -50,7 +50,7 @@ class TimelogControllerTest < ActionController::TestCase
     assert_template 'edit'
     # Default activity selected
     assert_tag tag: 'option', attributes: { selected: 'selected' },
-                                 content: 'Development'
+               content: 'Development'
   end
 
   def test_get_new_should_only_show_active_time_entry_activities
@@ -59,7 +59,6 @@ class TimelogControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'edit'
     assert_no_tag tag: 'option', content: 'Inactive Activity'
-
   end
 
   def test_get_edit_existing_time
@@ -73,7 +72,7 @@ class TimelogControllerTest < ActionController::TestCase
 
   def test_get_edit_with_an_existing_time_entry_with_inactive_activity
     te = TimeEntry.find(1)
-    te.activity = TimeEntryActivity.find_by_name("Inactive Activity")
+    te.activity = TimeEntryActivity.find_by_name('Inactive Activity')
     te.save!
 
     @request.session[:user_id] = 1
@@ -89,12 +88,12 @@ class TimelogControllerTest < ActionController::TestCase
     # and routing
     @request.session[:user_id] = 3
     post :create, project_id: 1,
-                time_entry: {comments: 'Some work on TimelogControllerTest',
+                  time_entry: { comments: 'Some work on TimelogControllerTest',
                                 # Not the default activity
                                 activity_id: '11',
                                 spent_on: '2008-03-14',
                                 work_package_id: '1',
-                                hours: '7.3'}
+                                hours: '7.3' }
     assert_redirected_to action: 'index', project_id: 'ecookbook'
 
     i = WorkPackage.find(1)
@@ -112,12 +111,12 @@ class TimelogControllerTest < ActionController::TestCase
     # and routing
     @request.session[:user_id] = 3
     post :create, project_id: 1,
-                time_entry: {comments: 'Some work on TimelogControllerTest',
+                  time_entry: { comments: 'Some work on TimelogControllerTest',
                                 # Not the default activity
                                 activity_id: '11',
                                 work_package_id: '',
                                 spent_on: '2008-03-14',
-                                hours: '7.3'}
+                                hours: '7.3' }
     assert_redirected_to action: 'index', project_id: 'ecookbook'
 
     t = TimeEntry.find_by_comments('Some work on TimelogControllerTest')
@@ -134,8 +133,8 @@ class TimelogControllerTest < ActionController::TestCase
 
     @request.session[:user_id] = 1
     put :update, id: 1,
-                time_entry: {work_package_id: '2',
-                                hours: '8'}
+                 time_entry: { work_package_id: '2',
+                               hours: '8' }
     assert_redirected_to action: 'index', project_id: 'ecookbook'
     entry.reload
 
@@ -156,7 +155,7 @@ class TimelogControllerTest < ActionController::TestCase
     # simulate that this fails (e.g. due to a plugin), see #5700
     TimeEntry.class_eval do
       before_destroy :stop_callback_chain
-      def stop_callback_chain ; return false ; end
+      def stop_callback_chain; false; end
     end
 
     @request.session[:user_id] = 2
@@ -166,7 +165,7 @@ class TimelogControllerTest < ActionController::TestCase
     assert_not_nil TimeEntry.find_by_id(1)
 
     # remove the simulation
-    TimeEntry._destroy_callbacks.reject! {|callback| callback.filter == :stop_callback_chain }
+    TimeEntry._destroy_callbacks.reject! { |callback| callback.filter == :stop_callback_chain }
   end
 
   def test_index_all_projects
@@ -174,9 +173,9 @@ class TimelogControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:total_hours)
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
     assert_tag :form,
-      attributes: {action: "/time_entries", id: 'query_form'}
+               attributes: { action: '/time_entries', id: 'query_form' }
   end
 
   def test_index_at_project_level
@@ -188,12 +187,12 @@ class TimelogControllerTest < ActionController::TestCase
     # project and subproject
     assert_equal [1, 3], assigns(:entries).collect(&:project_id).uniq.sort
     assert_not_nil assigns(:total_hours)
-    assert_equal "162.90", "%.2f" % assigns(:total_hours)
+    assert_equal '162.90', '%.2f' % assigns(:total_hours)
     # display all time by default
     assert_equal '2007-03-12'.to_date, assigns(:from)
     assert_equal '2007-04-22'.to_date, assigns(:to)
     assert_tag :form,
-      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
+               attributes: { action: '/projects/ecookbook/time_entries', id: 'query_form' }
   end
 
   def test_index_at_project_level_with_date_range
@@ -203,11 +202,11 @@ class TimelogControllerTest < ActionController::TestCase
     assert_not_nil assigns(:entries)
     assert_equal 3, assigns(:entries).size
     assert_not_nil assigns(:total_hours)
-    assert_equal "12.90", "%.2f" % assigns(:total_hours)
+    assert_equal '12.90', '%.2f' % assigns(:total_hours)
     assert_equal '2007-03-20'.to_date, assigns(:from)
     assert_equal '2007-04-30'.to_date, assigns(:to)
     assert_tag :form,
-      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
+               attributes: { action: '/projects/ecookbook/time_entries', id: 'query_form' }
   end
 
   def test_index_at_project_level_with_period
@@ -219,17 +218,17 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal Date.today - 7, assigns(:from)
     assert_equal Date.today, assigns(:to)
     assert_tag :form,
-      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
+               attributes: { action: '/projects/ecookbook/time_entries', id: 'query_form' }
   end
 
   def test_index_one_day
-    get :index, project_id: 'ecookbook', from: "2007-03-23", to: "2007-03-23"
+    get :index, project_id: 'ecookbook', from: '2007-03-23', to: '2007-03-23'
     assert_response :success
     assert_template 'index'
     assert_not_nil assigns(:total_hours)
-    assert_equal "4.25", "%.2f" % assigns(:total_hours)
+    assert_equal '4.25', '%.2f' % assigns(:total_hours)
     assert_tag :form,
-      attributes: {action: "/projects/ecookbook/time_entries", id: 'query_form'}
+               attributes: { action: '/projects/ecookbook/time_entries', id: 'query_form' }
   end
 
   def test_index_at_issue_level
@@ -244,7 +243,7 @@ class TimelogControllerTest < ActionController::TestCase
     assert_equal '2007-03-12'.to_date, assigns(:from)
     assert_equal '2007-04-22'.to_date, assigns(:to)
     assert_tag :form,
-      attributes: {action: work_package_time_entries_path(1), id: 'query_form'}
+               attributes: { action: work_package_time_entries_path(1), id: 'query_form' }
   end
 
   def test_index_atom_feed

--- a/test/functional/types_controller_test.rb
+++ b/test/functional/types_controller_test.rb
@@ -81,36 +81,36 @@ class TypesControllerTest < ActionController::TestCase
     assert_template 'edit'
 
     assert_tag :input, attributes: { name: 'type[project_ids][]',
-                                        value: '1',
-                                        checked: 'checked' }
+                                     value: '1',
+                                     checked: 'checked' }
 
     assert_tag :input, attributes: { name: 'type[project_ids][]',
-                                        value: '2',
-                                        checked: nil }
+                                     value: '2',
+                                     checked: nil }
 
     assert_tag :input, attributes: { name: 'type[project_ids][]',
-                                        value: '',
-                                        type: 'hidden'}
+                                     value: '',
+                                     type: 'hidden' }
   end
 
   def test_post_update
     post :update, id: 1, type: { name: 'Renamed',
-                                       project_ids: ['1', '2', ''] }
+                                 project_ids: ['1', '2', ''] }
     assert_redirected_to action: 'index'
     assert_equal [1, 2], Type.find(1).project_ids.sort
   end
 
   def test_post_update_without_projects
     post :update, id: 1, type: { name: 'Renamed',
-                                        project_ids: [''] }
+                                 project_ids: [''] }
     assert_redirected_to action: 'index'
     assert Type.find(1).project_ids.empty?
   end
 
   def test_move_lower
-   type = Type.find_by_position(1)
-   post :move, id: 1, type: { move_to: 'lower' }
-   assert_equal 2, type.reload.position
+    type = Type.find_by_position(1)
+    post :move, id: 1, type: { move_to: 'lower' }
+    assert_equal 2, type.reload.position
   end
 
   def test_destroy

--- a/test/functional/types_controller_test.rb
+++ b/test/functional/types_controller_test.rb
@@ -57,8 +57,8 @@ class TypesControllerTest < ActionController::TestCase
   end
 
   def test_post_create
-    post :create, :type => { :name => 'New type', :project_ids => ['1', '', ''], :custom_field_ids => ['1', '6', ''] }
-    assert_redirected_to :action => 'index'
+    post :create, type: { name: 'New type', project_ids: ['1', '', ''], custom_field_ids: ['1', '6', ''] }
+    assert_redirected_to action: 'index'
     type = Type.find_by_name('New type')
     assert_equal [1], type.project_ids.sort
     assert_equal [1, 6], type.custom_field_ids
@@ -66,8 +66,8 @@ class TypesControllerTest < ActionController::TestCase
   end
 
   def test_post_create_with_workflow_copy
-    post :create, :type => { :name => 'New type' }, :copy_workflow_from => 1
-    assert_redirected_to :action => 'index'
+    post :create, type: { name: 'New type' }, copy_workflow_from: 1
+    assert_redirected_to action: 'index'
     type = Type.find_by_name('New type')
     assert_equal 0, type.projects.count
     assert_equal Type.find(1).workflows.count, type.workflows.count
@@ -76,57 +76,57 @@ class TypesControllerTest < ActionController::TestCase
   def test_get_edit
     Type.find(1).project_ids = [1, 3]
 
-    get :edit, :id => 1
+    get :edit, id: 1
     assert_response :success
     assert_template 'edit'
 
-    assert_tag :input, :attributes => { :name => 'type[project_ids][]',
-                                        :value => '1',
-                                        :checked => 'checked' }
+    assert_tag :input, attributes: { name: 'type[project_ids][]',
+                                        value: '1',
+                                        checked: 'checked' }
 
-    assert_tag :input, :attributes => { :name => 'type[project_ids][]',
-                                        :value => '2',
-                                        :checked => nil }
+    assert_tag :input, attributes: { name: 'type[project_ids][]',
+                                        value: '2',
+                                        checked: nil }
 
-    assert_tag :input, :attributes => { :name => 'type[project_ids][]',
-                                        :value => '',
-                                        :type => 'hidden'}
+    assert_tag :input, attributes: { name: 'type[project_ids][]',
+                                        value: '',
+                                        type: 'hidden'}
   end
 
   def test_post_update
-    post :update, :id => 1, :type => { :name => 'Renamed',
-                                       :project_ids => ['1', '2', ''] }
-    assert_redirected_to :action => 'index'
+    post :update, id: 1, type: { name: 'Renamed',
+                                       project_ids: ['1', '2', ''] }
+    assert_redirected_to action: 'index'
     assert_equal [1, 2], Type.find(1).project_ids.sort
   end
 
   def test_post_update_without_projects
-    post :update, :id => 1, :type => { :name => 'Renamed',
-                                        :project_ids => [''] }
-    assert_redirected_to :action => 'index'
+    post :update, id: 1, type: { name: 'Renamed',
+                                        project_ids: [''] }
+    assert_redirected_to action: 'index'
     assert Type.find(1).project_ids.empty?
   end
 
   def test_move_lower
    type = Type.find_by_position(1)
-   post :move, :id => 1, :type => { :move_to => 'lower' }
+   post :move, id: 1, type: { move_to: 'lower' }
    assert_equal 2, type.reload.position
   end
 
   def test_destroy
-    type = Type.create!(:name => 'Destroyable')
+    type = Type.create!(name: 'Destroyable')
     assert_difference 'Type.count', -1 do
-      post :destroy, :id => type.id
+      post :destroy, id: type.id
     end
-    assert_redirected_to :action => 'index'
+    assert_redirected_to action: 'index'
     assert_nil flash[:error]
   end
 
   def test_destroy_type_in_use
     assert_no_difference 'Type.count' do
-      post :destroy, :id => 1
+      post :destroy, id: 1
     end
-    assert_redirected_to :action => 'index'
+    assert_redirected_to action: 'index'
     assert_not_nil flash[:error]
   end
 end

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -100,7 +100,7 @@ class UserMailerTest < ActionMailer::TestCase
       assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "https://mydomain.foo/journals/#{journal.id}/diff/description",
-                    text: "Details"
+                    text: 'Details'
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "https://mydomain.foo/work_packages/#{related_issue.id}",
@@ -141,7 +141,7 @@ class UserMailerTest < ActionMailer::TestCase
       assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
-                    text: "Details"
+                    text: 'Details'
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/work_packages/#{related_issue.id}",
@@ -185,7 +185,7 @@ class UserMailerTest < ActionMailer::TestCase
       assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
-                    text: "Details"
+                    text: 'Details'
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/work_packages/#{related_issue.id}",
@@ -303,7 +303,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_nil mail.references
     assert_select_email do
       # link to the message
-      assert_select "a[href*=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.id}", text: message.subject
+      assert_select 'a[href*=?]', "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.id}", text: message.subject
     end
   end
 
@@ -318,12 +318,12 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match mail.references, UserMailer.generate_message_id(parent, user)
     assert_select_email do
       # link to the reply
-      assert_select "a[href=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.root.id}?r=#{message.id}#message-#{message.id}", text: message.subject
+      assert_select 'a[href=?]', "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.root.id}?r=#{message.id}#message-#{message.id}", text: message.subject
     end
   end
 
-  context("#issue_add") do
-    should "send one email per recipient" do
+  context('#issue_add') do
+    should 'send one email per recipient' do
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
       issue = FactoryGirl.create(:work_package)
       ActionMailer::Base.deliveries.clear
@@ -332,7 +332,7 @@ class UserMailerTest < ActionMailer::TestCase
       assert_equal ['foo@bar.de'], last_email.to
     end
 
-    should "change mail language depending on recipient language" do
+    should 'change mail language depending on recipient language' do
       issue = FactoryGirl.create(:work_package)
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: 'de')
       ActionMailer::Base.deliveries.clear
@@ -348,7 +348,7 @@ class UserMailerTest < ActionMailer::TestCase
       end
     end
 
-    should "falls back to default language if user has no language" do
+    should 'falls back to default language if user has no language' do
       # 1. user's language
       # 2. Setting.default_language
       # 3. I18n.default_locale
@@ -489,11 +489,11 @@ class UserMailerTest < ActionMailer::TestCase
     assert ActionMailer::Base.perform_deliveries
   end
 
-  context "layout" do
-    should "include the emails_header depeding on the locale" do
+  context 'layout' do
+    should 'include the emails_header depeding on the locale' do
       with_settings available_languages: [:en, :de],
-                    emails_header: { "de" => "deutscher header",
-                                        "en" => "english header" } do
+                    emails_header: { 'de' => 'deutscher header',
+                                     'en' => 'english header' } do
         user = FactoryGirl.create(:user, language: :en)
         assert UserMailer.test_mail(user).deliver
         mail = ActionMailer::Base.deliveries.last
@@ -506,7 +506,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
   end
 
-private
+  private
 
   def last_email
     mail = ActionMailer::Base.deliveries.last
@@ -522,15 +522,15 @@ private
     project.save
 
     related_issue = FactoryGirl.create(:work_package,
-        subject: 'My related Ticket',
-        type: type,
-        project: project)
+                                       subject: 'My related Ticket',
+                                       type: type,
+                                       project: project)
 
     issue   = FactoryGirl.create(:work_package,
-        subject: 'My awesome Ticket',
-        type: type,
-        project: project,
-        description: "nothing here yet")
+                                 subject: 'My awesome Ticket',
+                                 type: type,
+                                 project: project,
+                                 description: 'nothing here yet')
 
     # now change the issue, to get a nice journal
     # we create a Filesystem repository for our changeset, so we have to enable it
@@ -539,8 +539,8 @@ private
                                    repository: FactoryGirl.create(:repository, project: project),
                                    comments: 'This commit fixes #1, #2 and references #1 and #3'
     attachment = FactoryGirl.create(:attachment,
-        container: issue,
-        author: issue.author)
+                                    container: issue,
+                                    author: issue.author)
     issue.description = "This is related to issue ##{related_issue.id}\n A reference to a changeset r#{changeset.revision}\n A reference to an attachment attachment:#{attachment.filename}"
     assert issue.save
     issue.reload
@@ -552,7 +552,7 @@ private
   end
 
   def url_for(options)
-    options.merge!({ host: Setting.host_name, protocol: Setting.protocol })
+    options.merge!(host: Setting.host_name, protocol: Setting.protocol)
     Rails.application.routes.url_helpers.url_for options
   end
 end

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -49,7 +49,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_test_mail_sends_a_simple_greeting
-    user = FactoryGirl.create(:user, :mail => 'foo@bar.de')
+    user = FactoryGirl.create(:user, mail: 'foo@bar.de')
 
     mail = UserMailer.test_mail(user)
     assert mail.deliver
@@ -63,8 +63,8 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_issue_add
-    user  = FactoryGirl.create(:user, :mail => 'foo@bar.de')
-    issue = FactoryGirl.create(:work_package, :subject => 'some issue title')
+    user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
+    issue = FactoryGirl.create(:work_package, subject: 'some issue title')
 
     # creating an issue actually sends an email, ohoh
     ActionMailer::Base.deliveries.clear
@@ -95,29 +95,29 @@ class UserMailerTest < ActionMailer::TestCase
       # link to the main ticket
       assert_select 'a[href=?]',
                     "https://mydomain.foo/work_packages/#{issue.id}",
-                    :text => "My Type ##{issue.id}: My awesome Ticket"
+                    text: "My Type ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li', :text => /Description changed/
+      assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "https://mydomain.foo/journals/#{journal.id}/diff/description",
-                    :text => "Details"
+                    text: "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "https://mydomain.foo/work_packages/#{related_issue.id}",
                     "My related Ticket (#{related_issue.status})",
-                    :text => "##{related_issue.id}"
+                    text: "##{related_issue.id}"
       # link to a changeset
       assert_select 'a[href=?][title=?]',
-                    url_for(:controller => 'repositories',
-                            :action => 'revision',
-                            :project_id => project,
-                            :rev => changeset.revision),
+                    url_for(controller: 'repositories',
+                            action: 'revision',
+                            project_id: project,
+                            rev: changeset.revision),
                     'This commit fixes #1, #2 and references #1 and #3',
-                    :text => "r#{changeset.revision}"
+                    text: "r#{changeset.revision}"
       # link to an attachment
       assert_select 'a[href=?]',
                     "https://mydomain.foo/attachments/#{attachment.id}/download",
-                    :text => "#{attachment.filename}"
+                    text: "#{attachment.filename}"
     end
   end
 
@@ -136,29 +136,29 @@ class UserMailerTest < ActionMailer::TestCase
       # link to the main ticket
       assert_select 'a[href=?]',
                     "http://mydomain.foo/rdm/work_packages/#{issue.id}",
-                    :text => "My Type ##{issue.id}: My awesome Ticket"
+                    text: "My Type ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li', :text => /Description changed/
+      assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
-                    :text => "Details"
+                    text: "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/work_packages/#{related_issue.id}",
                     "My related Ticket (#{related_issue.status})",
-                    :text => "##{related_issue.id}"
+                    text: "##{related_issue.id}"
       # link to a changeset
       assert_select 'a[href=?][title=?]',
-                    url_for(:controller => 'repositories',
-                            :action => 'revision',
-                            :project_id => project,
-                            :rev => changeset.revision),
+                    url_for(controller: 'repositories',
+                            action: 'revision',
+                            project_id: project,
+                            rev: changeset.revision),
                     'This commit fixes #1, #2 and references #1 and #3',
-                    :text => "r#{changeset.revision}"
+                    text: "r#{changeset.revision}"
       # link to an attachment
       assert_select 'a[href=?]',
                     "http://mydomain.foo/rdm/attachments/#{attachment.id}/download",
-                    :text => "#{attachment.filename}"
+                    text: "#{attachment.filename}"
     end
   end
 
@@ -180,29 +180,29 @@ class UserMailerTest < ActionMailer::TestCase
       # link to the main ticket
       assert_select 'a[href=?]',
                     "http://mydomain.foo/rdm/work_packages/#{issue.id}",
-                    :text => "My Type ##{issue.id}: My awesome Ticket"
+                    text: "My Type ##{issue.id}: My awesome Ticket"
       # link to a description diff
-      assert_select 'li', :text => /Description changed/
+      assert_select 'li', text: /Description changed/
       assert_select 'li>a[href=?]',
                     "http://mydomain.foo/rdm/journals/#{journal.id}/diff/description",
-                    :text => "Details"
+                    text: "Details"
       # link to a referenced ticket
       assert_select 'a[href=?][title=?]',
                     "http://mydomain.foo/rdm/work_packages/#{related_issue.id}",
                     "My related Ticket (#{related_issue.status})",
-                    :text => "##{related_issue.id}"
+                    text: "##{related_issue.id}"
       # link to a changeset
       assert_select 'a[href=?][title=?]',
-                    url_for(:controller => 'repositories',
-                            :action => 'revision',
-                            :project_id => project,
-                            :rev => changeset.revision),
+                    url_for(controller: 'repositories',
+                            action: 'revision',
+                            project_id: project,
+                            rev: changeset.revision),
                     'This commit fixes #1, #2 and references #1 and #3',
-                    :text => "r#{changeset.revision}"
+                    text: "r#{changeset.revision}"
       # link to an attachment
       assert_select 'a[href=?]',
                     "http://mydomain.foo/rdm/attachments/#{attachment.id}/download",
-                    :text => "#{attachment.filename}"
+                    text: "#{attachment.filename}"
     end
   ensure
     # restore it
@@ -243,7 +243,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   def test_mail_from_with_phrase
     user  = FactoryGirl.create(:user)
-    with_settings :mail_from => 'Redmine app <redmine@example.net>' do
+    with_settings mail_from: 'Redmine app <redmine@example.net>' do
       UserMailer.test_mail(user).deliver
     end
     mail = ActionMailer::Base.deliveries.last
@@ -303,14 +303,14 @@ class UserMailerTest < ActionMailer::TestCase
     assert_nil mail.references
     assert_select_email do
       # link to the message
-      assert_select "a[href*=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.id}", :text => message.subject
+      assert_select "a[href*=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.id}", text: message.subject
     end
   end
 
   def test_reply_posted_message_id
     user    = FactoryGirl.create(:user)
     parent  = FactoryGirl.create(:message)
-    message = FactoryGirl.create(:message, :parent => parent)
+    message = FactoryGirl.create(:message, parent: parent)
     UserMailer.message_posted(user, message).deliver
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail
@@ -318,13 +318,13 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match mail.references, UserMailer.generate_message_id(parent, user)
     assert_select_email do
       # link to the reply
-      assert_select "a[href=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.root.id}?r=#{message.id}#message-#{message.id}", :text => message.subject
+      assert_select "a[href=?]", "#{Setting.protocol}://#{Setting.host_name}/topics/#{message.root.id}?r=#{message.id}#message-#{message.id}", text: message.subject
     end
   end
 
   context("#issue_add") do
     should "send one email per recipient" do
-      user  = FactoryGirl.create(:user, :mail => 'foo@bar.de')
+      user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
       issue = FactoryGirl.create(:work_package)
       ActionMailer::Base.deliveries.clear
       assert UserMailer.work_package_added(user, issue).deliver
@@ -334,9 +334,9 @@ class UserMailerTest < ActionMailer::TestCase
 
     should "change mail language depending on recipient language" do
       issue = FactoryGirl.create(:work_package)
-      user  = FactoryGirl.create(:user, :mail => 'foo@bar.de', :language => 'de')
+      user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: 'de')
       ActionMailer::Base.deliveries.clear
-      with_settings :available_languages => ['en', 'de'] do
+      with_settings available_languages: ['en', 'de'] do
         I18n.locale = 'en'
         assert UserMailer.work_package_added(user, issue).deliver
         assert_equal 1, ActionMailer::Base.deliveries.size
@@ -353,10 +353,10 @@ class UserMailerTest < ActionMailer::TestCase
       # 2. Setting.default_language
       # 3. I18n.default_locale
       issue = FactoryGirl.create(:work_package)
-      user  = FactoryGirl.create(:user, :mail => 'foo@bar.de', :language => '') # (auto)
+      user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: '') # (auto)
       ActionMailer::Base.deliveries.clear
-      with_settings :available_languages => ['en', 'de'],
-                    :default_language => 'de' do
+      with_settings available_languages: ['en', 'de'],
+                    default_language: 'de' do
         I18n.locale = 'de'
         assert UserMailer.work_package_added(user, issue).deliver
         assert_equal 1, ActionMailer::Base.deliveries.size
@@ -391,7 +391,7 @@ class UserMailerTest < ActionMailer::TestCase
   def test_news_comment_added
     user    = FactoryGirl.create(:user)
     news    = FactoryGirl.create(:news)
-    comment = FactoryGirl.create(:comment, :commented => news)
+    comment = FactoryGirl.create(:comment, commented: news)
     assert UserMailer.news_comment_added(user, comment).deliver
   end
 
@@ -420,13 +420,13 @@ class UserMailerTest < ActionMailer::TestCase
 
   def test_lost_password
     user  = FactoryGirl.create(:user)
-    token = FactoryGirl.create(:token, :user => user)
+    token = FactoryGirl.create(:token, user: user)
     assert UserMailer.password_lost(token).deliver
   end
 
   def test_register
     user  = FactoryGirl.create(:user)
-    token = FactoryGirl.create(:token, :user => user)
+    token = FactoryGirl.create(:token, user: user)
     Setting.host_name = 'redmine.foo'
     Setting.protocol = 'https'
 
@@ -436,8 +436,8 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_reminders
-    user  = FactoryGirl.create(:user, :mail => 'foo@bar.de')
-    issue = FactoryGirl.create(:work_package, :due_date => Date.tomorrow, :assigned_to => user, :subject => 'some issue')
+    user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
+    issue = FactoryGirl.create(:work_package, due_date: Date.tomorrow, assigned_to: user, subject: 'some issue')
     ActionMailer::Base.deliveries.clear
     DueIssuesReminder.new(42).remind_users
     assert_equal 1, ActionMailer::Base.deliveries.size
@@ -448,9 +448,9 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_reminders_for_users
-    user1  = FactoryGirl.create(:user, :mail => 'foo1@bar.de')
-    user2  = FactoryGirl.create(:user, :mail => 'foo2@bar.de')
-    issue = FactoryGirl.create(:work_package, :due_date => Date.tomorrow, :assigned_to => user1, :subject => 'some issue')
+    user1  = FactoryGirl.create(:user, mail: 'foo1@bar.de')
+    user2  = FactoryGirl.create(:user, mail: 'foo2@bar.de')
+    issue = FactoryGirl.create(:work_package, due_date: Date.tomorrow, assigned_to: user1, subject: 'some issue')
     ActionMailer::Base.deliveries.clear
 
     DueIssuesReminder.new(42, nil, nil, [user2.id]).remind_users
@@ -466,12 +466,12 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_mailer_should_not_change_locale
-    with_settings :available_languages => ['en', 'de'],
-                  :default_language    => 'en' do
+    with_settings available_languages: ['en', 'de'],
+                  default_language:    'en' do
       # Set current language to english
       I18n.locale = :en
       # Send an email to a german user
-      user = FactoryGirl.create(:user, :language => 'de')
+      user = FactoryGirl.create(:user, language: 'de')
       UserMailer.account_activated(user).deliver
       mail = ActionMailer::Base.deliveries.last
       assert mail.body.encoded.include?('aktiviert')
@@ -491,10 +491,10 @@ class UserMailerTest < ActionMailer::TestCase
 
   context "layout" do
     should "include the emails_header depeding on the locale" do
-      with_settings :available_languages => [:en, :de],
-                    :emails_header => { "de" => "deutscher header",
+      with_settings available_languages: [:en, :de],
+                    emails_header: { "de" => "deutscher header",
                                         "en" => "english header" } do
-        user = FactoryGirl.create(:user, :language => :en)
+        user = FactoryGirl.create(:user, language: :en)
         assert UserMailer.test_mail(user).deliver
         mail = ActionMailer::Base.deliveries.last
         assert mail.body.encoded.include?('english header')
@@ -516,31 +516,31 @@ private
 
   def setup_complex_issue_update
     project = FactoryGirl.create(:valid_project)
-    user    = FactoryGirl.create(:user, :member_in_project => project)
-    type = FactoryGirl.create(:type, :name => 'My Type')
+    user    = FactoryGirl.create(:user, member_in_project: project)
+    type = FactoryGirl.create(:type, name: 'My Type')
     project.types << type
     project.save
 
     related_issue = FactoryGirl.create(:work_package,
-        :subject => 'My related Ticket',
-        :type => type,
-        :project => project)
+        subject: 'My related Ticket',
+        type: type,
+        project: project)
 
     issue   = FactoryGirl.create(:work_package,
-        :subject => 'My awesome Ticket',
-        :type => type,
-        :project => project,
-        :description => "nothing here yet")
+        subject: 'My awesome Ticket',
+        type: type,
+        project: project,
+        description: "nothing here yet")
 
     # now change the issue, to get a nice journal
     # we create a Filesystem repository for our changeset, so we have to enable it
     Setting.enabled_scm = Setting.enabled_scm.dup << 'Filesystem' unless Setting.enabled_scm.include?('Filesystem')
     changeset = FactoryGirl.create :changeset,
-                                   :repository => FactoryGirl.create(:repository, :project => project),
-                                   :comments => 'This commit fixes #1, #2 and references #1 and #3'
+                                   repository: FactoryGirl.create(:repository, project: project),
+                                   comments: 'This commit fixes #1, #2 and references #1 and #3'
     attachment = FactoryGirl.create(:attachment,
-        :container => issue,
-        :author => issue.author)
+        container: issue,
+        author: issue.author)
     issue.description = "This is related to issue ##{related_issue.id}\n A reference to a changeset r#{changeset.revision}\n A reference to an attachment attachment:#{attachment.filename}"
     assert issue.save
     issue.reload
@@ -552,7 +552,7 @@ private
   end
 
   def url_for(options)
-    options.merge!({ :host => Setting.host_name, :protocol => Setting.protocol })
+    options.merge!({ host: Setting.host_name, protocol: Setting.protocol })
     Rails.application.routes.url_helpers.url_for options
   end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -59,7 +59,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:users)
     # active users only
-    assert_nil assigns(:users).detect {|u| !u.active?}
+    assert_nil assigns(:users).detect { |u| !u.active? }
   end
 
   def test_index_with_name_filter
@@ -129,7 +129,7 @@ class UsersControllerTest < ActionController::TestCase
     memberships = assigns(:memberships)
     assert_not_nil memberships
     project_ids = memberships.map(&:project_id)
-    assert project_ids.include?(2) #private project admin can see
+    assert project_ids.include?(2) # private project admin can see
   end
 
   def test_show_current_should_require_authentication
@@ -160,16 +160,16 @@ class UsersControllerTest < ActionController::TestCase
     assert_difference 'User.count' do
       assert_difference 'ActionMailer::Base.deliveries.size' do
         post :create,
-          user: {
-            firstname: 'John',
-            lastname: 'Doe',
-            login: 'jdoe',
-            password: 'adminADMIN!',
-            password_confirmation: 'adminADMIN!',
-            mail: 'jdoe@gmail.com',
-            mail_notification: 'none'
-          },
-          send_information: '1'
+             user: {
+               firstname: 'John',
+               lastname: 'Doe',
+               login: 'jdoe',
+               password: 'adminADMIN!',
+               password_confirmation: 'adminADMIN!',
+               mail: 'jdoe@gmail.com',
+               mail_notification: 'none'
+             },
+             send_information: '1'
       end
     end
 
@@ -211,7 +211,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_update_with_failure
     assert_no_difference 'User.count' do
-      put :update, id: 2, user: {firstname: ''}
+      put :update, id: 2, user: { firstname: '' }
     end
 
     assert_response :success
@@ -219,7 +219,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_update_with_group_ids_should_assign_groups
-    put :update, id: 2, user: {group_ids: ['10']}
+    put :update, id: 2, user: { group_ids: ['10'] }
 
     user = User.find(2)
     assert_equal [10], user.group_ids
@@ -229,7 +229,7 @@ class UsersControllerTest < ActionController::TestCase
     ActionMailer::Base.deliveries.clear
     Setting.bcc_recipients = '1'
 
-    put :update, id: 2, user: {password: 'newpassPASS!', password_confirmation: 'newpassPASS!'}, send_information: '1'
+    put :update, id: 2, user: { password: 'newpassPASS!', password_confirmation: 'newpassPASS!' }, send_information: '1'
     u = User.find(2)
     assert u.check_password?('newpassPASS!')
 
@@ -241,7 +241,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_edit_membership
     post :edit_membership, id: 2, membership_id: 1,
-                           membership: { role_ids: [2]}
+                           membership: { role_ids: [2] }
     assert_redirected_to action: 'edit', id: '2', tab: 'memberships'
     assert_equal [2], Member.find(1).role_ids
   end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -63,7 +63,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_index_with_name_filter
-    get :index, :name => 'john'
+    get :index, name: 'john'
     assert_response :success
     assert_template 'index'
     users = assigns(:users)
@@ -73,7 +73,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_index_with_group_filter
-    get :index, :group_id => '10'
+    get :index, group_id: '10'
     assert_response :success
     assert_template 'index'
     users = assigns(:users)
@@ -84,47 +84,47 @@ class UsersControllerTest < ActionController::TestCase
   def test_show_should_not_display_hidden_custom_fields
     @request.session[:user_id] = nil
     UserCustomField.find_by_name('Phone number').update_attribute :visible, false
-    get :show, :id => 2
+    get :show, id: 2
     assert_response :success
     assert_template 'show'
     assert_not_nil assigns(:user)
 
-    assert_no_tag 'li', :content => /Phone number/
+    assert_no_tag 'li', content: /Phone number/
   end
 
   def test_show_should_not_fail_when_custom_values_are_nil
     user = User.find(2)
 
     # Create a custom field to illustrate the issue
-    custom_field = CustomField.create!(:name => 'Testing', :field_format => 'text')
-    custom_value = user.custom_values.build(:custom_field => custom_field).save!
+    custom_field = CustomField.create!(name: 'Testing', field_format: 'text')
+    custom_value = user.custom_values.build(custom_field: custom_field).save!
 
-    get :show, :id => 2
+    get :show, id: 2
     assert_response :success
   end
 
   def test_show_inactive
     @request.session[:user_id] = nil
-    get :show, :id => 5
+    get :show, id: 5
     assert_response 404
   end
 
   def test_show_should_not_reveal_users_with_no_visible_activity_or_project
     @request.session[:user_id] = nil
-    get :show, :id => 9
+    get :show, id: 9
     assert_response 404
   end
 
   def test_show_inactive_by_admin
     @request.session[:user_id] = 1
-    get :show, :id => 5
+    get :show, id: 5
     assert_response 200
     assert_not_nil assigns(:user)
   end
 
   def test_show_displays_memberships_based_on_project_visibility
     @request.session[:user_id] = 1
-    get :show, :id => 2
+    get :show, id: 2
     assert_response :success
     memberships = assigns(:memberships)
     assert_not_nil memberships
@@ -134,13 +134,13 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_show_current_should_require_authentication
     @request.session[:user_id] = nil
-    get :show, :id => 'current'
+    get :show, id: 'current'
     assert_response 302
   end
 
   def test_show_current
     @request.session[:user_id] = 2
-    get :show, :id => 'current'
+    get :show, id: 'current'
     assert_response :success
     assert_template 'show'
     assert_equal User.find(2), assigns(:user)
@@ -160,20 +160,20 @@ class UsersControllerTest < ActionController::TestCase
     assert_difference 'User.count' do
       assert_difference 'ActionMailer::Base.deliveries.size' do
         post :create,
-          :user => {
-            :firstname => 'John',
-            :lastname => 'Doe',
-            :login => 'jdoe',
-            :password => 'adminADMIN!',
-            :password_confirmation => 'adminADMIN!',
-            :mail => 'jdoe@gmail.com',
-            :mail_notification => 'none'
+          user: {
+            firstname: 'John',
+            lastname: 'Doe',
+            login: 'jdoe',
+            password: 'adminADMIN!',
+            password_confirmation: 'adminADMIN!',
+            mail: 'jdoe@gmail.com',
+            mail_notification: 'none'
           },
-          :send_information => '1'
+          send_information: '1'
       end
     end
 
-    user = User.first(:order => 'id DESC')
+    user = User.first(order: 'id DESC')
     assert_redirected_to edit_user_path(user)
 
     assert_equal 'John', user.firstname
@@ -194,7 +194,7 @@ class UsersControllerTest < ActionController::TestCase
       # Provide at least one user  field, otherwise strong_parameters regards the user parameter
       # as non-existent and raises ActionController::ParameterMissing, which in turn
       # results in a 400.
-      post :create, :user => { :login => 'jdoe' }
+      post :create, user: { login: 'jdoe' }
     end
 
     assert_response :success
@@ -202,7 +202,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_edit
-    get :edit, :id => 2
+    get :edit, id: 2
 
     assert_response :success
     assert_template 'edit'
@@ -211,7 +211,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_update_with_failure
     assert_no_difference 'User.count' do
-      put :update, :id => 2, :user => {:firstname => ''}
+      put :update, id: 2, user: {firstname: ''}
     end
 
     assert_response :success
@@ -219,7 +219,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_update_with_group_ids_should_assign_groups
-    put :update, :id => 2, :user => {:group_ids => ['10']}
+    put :update, id: 2, user: {group_ids: ['10']}
 
     user = User.find(2)
     assert_equal [10], user.group_ids
@@ -229,7 +229,7 @@ class UsersControllerTest < ActionController::TestCase
     ActionMailer::Base.deliveries.clear
     Setting.bcc_recipients = '1'
 
-    put :update, :id => 2, :user => {:password => 'newpassPASS!', :password_confirmation => 'newpassPASS!'}, :send_information => '1'
+    put :update, id: 2, user: {password: 'newpassPASS!', password_confirmation: 'newpassPASS!'}, send_information: '1'
     u = User.find(2)
     assert u.check_password?('newpassPASS!')
 
@@ -240,15 +240,15 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_edit_membership
-    post :edit_membership, :id => 2, :membership_id => 1,
-                           :membership => { :role_ids => [2]}
-    assert_redirected_to :action => 'edit', :id => '2', :tab => 'memberships'
+    post :edit_membership, id: 2, membership_id: 1,
+                           membership: { role_ids: [2]}
+    assert_redirected_to action: 'edit', id: '2', tab: 'memberships'
     assert_equal [2], Member.find(1).role_ids
   end
 
   def test_destroy_membership
-    post :destroy_membership, :id => 2, :membership_id => 1
-    assert_redirected_to :action => 'edit', :id => '2', :tab => 'memberships'
+    post :destroy_membership, id: 2, membership_id: 1
+    assert_redirected_to action: 'edit', id: '2', tab: 'memberships'
     assert_nil Member.find_by_id(1)
   end
 end

--- a/test/functional/watchers_controller_test.rb
+++ b/test/functional/watchers_controller_test.rb
@@ -46,7 +46,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_watch
     @request.session[:user_id] = 3
     assert_difference('Watcher.count') do
-      xhr :post, :watch, :object_type => 'work_package', :object_id => '1'
+      xhr :post, :watch, object_type: 'work_package', object_id: '1'
       assert_response :success
       assert @response.body.include? "$$(\"#watcher\").each"
       assert @response.body.include? "value.replace"
@@ -58,7 +58,7 @@ class WatchersControllerTest < ActionController::TestCase
     Role.find(2).remove_permission! :view_work_packages
     @request.session[:user_id] = 3
     assert_no_difference('Watcher.count') do
-      xhr :post, :watch, :object_type => 'work_package', :object_id => '1'
+      xhr :post, :watch, object_type: 'work_package', object_id: '1'
       assert_response 403
     end
   end
@@ -66,7 +66,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_watch_with_multiple_replacements
     @request.session[:user_id] = 3
     assert_difference('Watcher.count') do
-      xhr :post, :watch, :object_type => 'work_package', :object_id => '1', :replace => ['#watch_item_1','.watch_item_2']
+      xhr :post, :watch, object_type: 'work_package', object_id: '1', replace: ['#watch_item_1','.watch_item_2']
       assert_response :success
       assert @response.body.include? "$$(\"#watch_item_1\").each"
       assert @response.body.include? "$$(\".watch_item_2\").each"
@@ -77,7 +77,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_watch_with_watchers_special_logic
     @request.session[:user_id] = 3
     assert_difference('Watcher.count') do
-      xhr :post, :watch, :object_type => 'work_package', :object_id => '1', :replace => ['#watchers', '.watcher']
+      xhr :post, :watch, object_type: 'work_package', object_id: '1', replace: ['#watchers', '.watcher']
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
       assert @response.body.include? "$$(\".watcher\").each"
@@ -88,7 +88,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_unwatch
     @request.session[:user_id] = 3
     assert_difference('Watcher.count', -1) do
-      xhr :post, :unwatch, :object_type => 'work_package', :object_id => '2'
+      xhr :post, :unwatch, object_type: 'work_package', object_id: '2'
       assert_response :success
       assert @response.body.include? "$$(\"#watcher\").each"
       assert @response.body.include? "value.replace"
@@ -99,7 +99,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_unwatch_with_multiple_replacements
     @request.session[:user_id] = 3
     assert_difference('Watcher.count', -1) do
-      xhr :post, :unwatch, :object_type => 'work_package', :object_id => '2', :replace => ['#watch_item_1', '.watch_item_2']
+      xhr :post, :unwatch, object_type: 'work_package', object_id: '2', replace: ['#watch_item_1', '.watch_item_2']
       assert_response :success
       assert @response.body.include? "$$(\"#watch_item_1\").each"
       assert @response.body.include? "$$(\".watch_item_2\").each"
@@ -111,7 +111,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_unwatch_with_watchers_special_logic
     @request.session[:user_id] = 3
     assert_difference('Watcher.count', -1) do
-      xhr :post, :unwatch, :object_type => 'work_package', :object_id => '2', :replace => ['#watchers', '.watcher']
+      xhr :post, :unwatch, object_type: 'work_package', object_id: '2', replace: ['#watchers', '.watcher']
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
       assert @response.body.include? "$$(\".watcher\").each"
@@ -124,7 +124,7 @@ class WatchersControllerTest < ActionController::TestCase
     Watcher.destroy_all
     @request.session[:user_id] = 2
     assert_difference('Watcher.count') do
-      xhr :post, :new, :object_type => 'work_package', :object_id => '2', :watcher => {:user_id => '3'}
+      xhr :post, :new, object_type: 'work_package', object_id: '2', watcher: {user_id: '3'}
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
     end
@@ -134,7 +134,7 @@ class WatchersControllerTest < ActionController::TestCase
   def test_remove_watcher
     @request.session[:user_id] = 2
     assert_difference('Watcher.count', -1) do
-      xhr :delete, :destroy, :id => Watcher.find_by_user_id_and_watchable_id(3, 2).id
+      xhr :delete, :destroy, id: Watcher.find_by_user_id_and_watchable_id(3, 2).id
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
     end

--- a/test/functional/watchers_controller_test.rb
+++ b/test/functional/watchers_controller_test.rb
@@ -49,7 +49,7 @@ class WatchersControllerTest < ActionController::TestCase
       xhr :post, :watch, object_type: 'work_package', object_id: '1'
       assert_response :success
       assert @response.body.include? "$$(\"#watcher\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
     assert WorkPackage.find(1).watched_by?(User.find(3))
   end
@@ -66,11 +66,11 @@ class WatchersControllerTest < ActionController::TestCase
   def test_watch_with_multiple_replacements
     @request.session[:user_id] = 3
     assert_difference('Watcher.count') do
-      xhr :post, :watch, object_type: 'work_package', object_id: '1', replace: ['#watch_item_1','.watch_item_2']
+      xhr :post, :watch, object_type: 'work_package', object_id: '1', replace: ['#watch_item_1', '.watch_item_2']
       assert_response :success
       assert @response.body.include? "$$(\"#watch_item_1\").each"
       assert @response.body.include? "$$(\".watch_item_2\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
   end
 
@@ -81,7 +81,7 @@ class WatchersControllerTest < ActionController::TestCase
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
       assert @response.body.include? "$$(\".watcher\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
   end
 
@@ -91,7 +91,7 @@ class WatchersControllerTest < ActionController::TestCase
       xhr :post, :unwatch, object_type: 'work_package', object_id: '2'
       assert_response :success
       assert @response.body.include? "$$(\"#watcher\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
     assert !WorkPackage.find(1).watched_by?(User.find(3))
   end
@@ -103,7 +103,7 @@ class WatchersControllerTest < ActionController::TestCase
       assert_response :success
       assert @response.body.include? "$$(\"#watch_item_1\").each"
       assert @response.body.include? "$$(\".watch_item_2\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
     assert !WorkPackage.find(1).watched_by?(User.find(3))
   end
@@ -115,7 +115,7 @@ class WatchersControllerTest < ActionController::TestCase
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
       assert @response.body.include? "$$(\".watcher\").each"
-      assert @response.body.include? "value.replace"
+      assert @response.body.include? 'value.replace'
     end
     assert !WorkPackage.find(1).watched_by?(User.find(3))
   end
@@ -124,7 +124,7 @@ class WatchersControllerTest < ActionController::TestCase
     Watcher.destroy_all
     @request.session[:user_id] = 2
     assert_difference('Watcher.count') do
-      xhr :post, :new, object_type: 'work_package', object_id: '2', watcher: {user_id: '3'}
+      xhr :post, :new, object_type: 'work_package', object_id: '2', watcher: { user_id: '3' }
       assert_response :success
       assert_select_rjs :replace_html, 'watchers'
     end

--- a/test/functional/welcome_controller_test.rb
+++ b/test/functional/welcome_controller_test.rb
@@ -50,7 +50,7 @@ class WelcomeControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:news)
     assert_not_nil assigns(:projects)
-    assert !assigns(:projects).include?(Project.find(:first, :conditions => {:is_public => false}))
+    assert !assigns(:projects).include?(Project.find(:first, conditions: {is_public: false}))
   end
 
   def test_browser_language
@@ -75,7 +75,7 @@ class WelcomeControllerTest < ActionController::TestCase
   end
 
   def test_robots
-    get :robots, :format => :txt
+    get :robots, format: :txt
     assert_response :success
     assert_equal 'text/plain', @response.content_type
     assert @response.body.match(%r{^Disallow: /projects/ecookbook/issues\r?$})

--- a/test/functional/welcome_controller_test.rb
+++ b/test/functional/welcome_controller_test.rb
@@ -50,7 +50,7 @@ class WelcomeControllerTest < ActionController::TestCase
     assert_template 'index'
     assert_not_nil assigns(:news)
     assert_not_nil assigns(:projects)
-    assert !assigns(:projects).include?(Project.find(:first, conditions: {is_public: false}))
+    assert !assigns(:projects).include?(Project.find(:first, conditions: { is_public: false }))
   end
 
   def test_browser_language

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -52,59 +52,59 @@ class WikiControllerTest < ActionController::TestCase
   end
 
   def test_show_start_page
-    get :show, :project_id => 'ecookbook'
+    get :show, project_id: 'ecookbook'
     assert_response :success
     assert_template 'show'
-    assert_tag :tag => 'h1', :content => /CookBook documentation/
+    assert_tag tag: 'h1', content: /CookBook documentation/
 
     # child_pages macro
-    assert_tag :ul, :attributes => { :class => 'pages-hierarchy' },
-               :child => { :tag => 'li',
-                           :child => { :tag => 'a', :attributes => { :href => '/projects/ecookbook/wiki/Page_with_an_inline_image' },
-                                                    :content => 'Page with an inline image' } }
+    assert_tag :ul, attributes: { class: 'pages-hierarchy' },
+               child: { tag: 'li',
+                           child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
+                                                    content: 'Page with an inline image' } }
   end
 
   def test_show_page_with_name
-    get :show, :project_id => 1, :id => 'Another_page'
+    get :show, project_id: 1, id: 'Another_page'
     assert_response :success
     assert_template 'show'
-    assert_tag :tag => 'h1', :content => /Another page/
+    assert_tag tag: 'h1', content: /Another page/
     # Included page with an inline image
-    assert_tag :tag => 'p', :content => /This is an inline image/
-    assert_tag :tag => 'img', :attributes => { :src => '/attachments/3/download',
-                                               :alt => 'This is a logo' }
+    assert_tag tag: 'p', content: /This is an inline image/
+    assert_tag tag: 'img', attributes: { src: '/attachments/3/download',
+                                               alt: 'This is a logo' }
   end
 
   def test_show_with_sidebar
-    page = Project.find(1).wiki.pages.new(:title => 'Sidebar')
-    page.content = WikiContent.new(:text => 'Side bar content for test_show_with_sidebar')
+    page = Project.find(1).wiki.pages.new(title: 'Sidebar')
+    page.content = WikiContent.new(text: 'Side bar content for test_show_with_sidebar')
     page.save!
 
-    get :show, :project_id => 1, :id => 'Another_page'
+    get :show, project_id: 1, id: 'Another_page'
     assert_response :success
-    assert_tag :tag => 'div', :attributes => {:id => 'sidebar'},
-                              :content => /Side bar content for test_show_with_sidebar/
+    assert_tag tag: 'div', attributes: {id: 'sidebar'},
+                              content: /Side bar content for test_show_with_sidebar/
   end
 
   def test_show_unexistent_page_without_edit_right
-    get :show, :project_id => 1, :id => 'Unexistent page'
+    get :show, project_id: 1, id: 'Unexistent page'
     assert_response 404
   end
 
   def test_show_unexistent_page_with_edit_right
     @request.session[:user_id] = 2
-    get :show, :project_id => 1, :id => 'Unexistent page'
+    get :show, project_id: 1, id: 'Unexistent page'
     assert_response :success
     assert_template 'edit'
   end
 
   def test_create_page
     @request.session[:user_id] = 2
-    put :update, :project_id => 1,
-                :id => 'New page',
-                :content => {:comments => 'Created the page',
-                             :text => "h1. New page\n\nThis is a new page" }
-    assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'New_page'
+    put :update, project_id: 1,
+                id: 'New page',
+                content: {comments: 'Created the page',
+                             text: "h1. New page\n\nThis is a new page" }
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'New_page'
     page = wiki.find_page('New page')
     assert !page.new_record?
     assert_not_nil page.content
@@ -115,12 +115,12 @@ class WikiControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     assert_difference 'WikiPage.count' do
       assert_difference 'Attachment.count' do
-        put :update, :project_id => 1,
-                    :id => 'New page',
-                    :content => {:comments => 'Created the page',
-                                 :text => "h1. New page\n\nThis is a new page",
-                                 :lock_version => 0},
-                    :attachments => {'1' => {'file' => uploaded_test_file('testfile.txt', 'text/plain')}}
+        put :update, project_id: 1,
+                    id: 'New page',
+                    content: {comments: 'Created the page',
+                                 text: "h1. New page\n\nThis is a new page",
+                                 lock_version: 0},
+                    attachments: {'1' => {'file' => uploaded_test_file('testfile.txt', 'text/plain')}}
       end
     end
     page = wiki.find_page('New page')
@@ -136,12 +136,12 @@ class WikiControllerTest < ActionController::TestCase
     assert_no_difference 'WikiPage.count' do
       assert_no_difference 'WikiContent.count' do
         assert_difference 'Journal.count' do
-          put :update, :project_id => 1,
-            :id => 'Another_page',
-            :content => {
-              :comments => "my comments",
-              :text => "edited",
-              :lock_version => 2
+          put :update, project_id: 1,
+            id: 'Another_page',
+            content: {
+              comments: "my comments",
+              text: "edited",
+              lock_version: 2
             }
         end
       end
@@ -159,12 +159,12 @@ class WikiControllerTest < ActionController::TestCase
     assert_no_difference 'WikiPage.count' do
       assert_no_difference 'WikiContent.count' do
         assert_no_difference 'Journal.count' do
-          put :update, :project_id => 1,
-            :id => 'Another_page',
-            :content => {
-              :comments => 'a' * 300,  # failure here, comment is too long
-              :text => 'edited',
-              :lock_version => 1
+          put :update, project_id: 1,
+            id: 'Another_page',
+            content: {
+              comments: 'a' * 300,  # failure here, comment is too long
+              text: 'edited',
+              lock_version: 1
             }
           end
         end
@@ -172,9 +172,9 @@ class WikiControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'edit'
 
-    assert_error_tag :descendant => {:content => /Comment is too long/}
-    assert_tag :tag => 'textarea', :attributes => {:id => 'content_text'}, :content => /edited/
-    assert_tag :tag => 'input', :attributes => {:id => 'content_lock_version', :value => '1'}
+    assert_error_tag descendant: {content: /Comment is too long/}
+    assert_tag tag: 'textarea', attributes: {id: 'content_text'}, content: /edited/
+    assert_tag tag: 'input', attributes: {id: 'content_lock_version', value: '1'}
   end
 
   # NOTE: this test seems to depend on other tests in suite
@@ -195,12 +195,12 @@ class WikiControllerTest < ActionController::TestCase
     assert_no_difference 'WikiPage.count' do
       assert_no_difference 'WikiContent.count' do
         assert_no_difference 'Journal.count' do
-          put :update, :project_id => 1,
-            :id => 'Another_page',
-            :content => {
-              :comments => 'My comments',
-              :text => 'Text should not be lost',
-              :lock_version => 1
+          put :update, project_id: 1,
+            id: 'Another_page',
+            content: {
+              comments: 'My comments',
+              text: 'Text should not be lost',
+              lock_version: 1
             }
         end
       end
@@ -208,13 +208,13 @@ class WikiControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'edit'
     assert_tag :div,
-      :attributes => { :class => /error/ },
-      :content => /Information has been updated by at least one other user in the meantime/
+      attributes: { class: /error/ },
+      content: /Information has been updated by at least one other user in the meantime/
     assert_tag 'textarea',
-      :attributes => { :name => 'content[text]' },
-      :content => /Text should not be lost/
+      attributes: { name: 'content[text]' },
+      content: /Text should not be lost/
     assert_tag 'input',
-      :attributes => { :name => 'content[comments]', :value => 'My comments' }
+      attributes: { name: 'content[comments]', value: 'My comments' }
 
     c.reload
     assert_equal 'Previous text', c.text
@@ -235,7 +235,7 @@ class WikiControllerTest < ActionController::TestCase
                        data: FactoryGirl.build(:journal_wiki_content_journal,
                                                text: "h1. CookBook documentation\nSome updated [[documentation]] here...")
 
-    get :history, :project_id => 1, :id => 'CookBook_documentation'
+    get :history, project_id: 1, id: 'CookBook_documentation'
     assert_response :success
     assert_template 'history'
     assert_not_nil assigns(:versions)
@@ -248,7 +248,7 @@ class WikiControllerTest < ActionController::TestCase
                        journable_id: 2,
                        data: FactoryGirl.build(:journal_wiki_content_journal,
                                                text: "h1. Another page\n\n\nthis is a link to ticket: #2")
-    get :history, :project_id => 1, :id => 'Another_page'
+    get :history, project_id: 1, id: 'Another_page'
     assert_response :success
     assert_template 'history'
     assert_not_nil assigns(:versions)
@@ -266,11 +266,11 @@ class WikiControllerTest < ActionController::TestCase
                                     data: FactoryGirl.build(:journal_wiki_content_journal,
                                                             text: "h1. CookBook documentation\n\n\nSome updated [[documentation]] here...")
 
-    get :diff, :project_id => 1, :id => 'CookBook_documentation', :version => journal_to.version, :version_from => journal_from.version
+    get :diff, project_id: 1, id: 'CookBook_documentation', version: journal_to.version, version_from: journal_from.version
     assert_response :success
     assert_template 'diff'
-    assert_tag :tag => 'ins', :attributes => { :class => 'diffins'},
-                              :content => /updated/
+    assert_tag tag: 'ins', attributes: { class: 'diffins'},
+                              content: /updated/
   end
 
   def test_annotate
@@ -283,64 +283,64 @@ class WikiControllerTest < ActionController::TestCase
                                     data: FactoryGirl.build(:journal_wiki_content_journal,
                                                             text: "h1. CookBook documentation\n\n\nSome [[documentation]] here...")
 
-    get :annotate, :project_id => 1, :id =>  'CookBook_documentation', :version => journal_to.version
+    get :annotate, project_id: 1, id:  'CookBook_documentation', version: journal_to.version
     assert_response :success
     assert_template 'annotate'
     # Line 1
-    assert_tag :tag => 'tr', :child => { :tag => 'th', :attributes => {:class => 'line-num'}, :content => '1' },
-                             :child => { :tag => 'td', :attributes => {:class => 'author'}, :content => /John Smith/ },
-                             :child => { :tag => 'td', :content => /h1\. CookBook documentation/ }
+    assert_tag tag: 'tr', child: { tag: 'th', attributes: {class: 'line-num'}, content: '1' },
+                             child: { tag: 'td', attributes: {class: 'author'}, content: /John Smith/ },
+                             child: { tag: 'td', content: /h1\. CookBook documentation/ }
     # Line 2
-    assert_tag :tag => 'tr', :child => { :tag => 'th', :attributes => {:class => 'line-num'}, :content => '2' },
-                             :child => { :tag => 'td', :attributes => {:class => 'author'}, :content => /redMine Admin/ },
-                             :child => { :tag => 'td', :content => /Some updated \[\[documentation\]\] here/ }
+    assert_tag tag: 'tr', child: { tag: 'th', attributes: {class: 'line-num'}, content: '2' },
+                             child: { tag: 'td', attributes: {class: 'author'}, content: /redMine Admin/ },
+                             child: { tag: 'td', content: /Some updated \[\[documentation\]\] here/ }
   end
 
   def test_get_rename
     @request.session[:user_id] = 2
-    get :rename, :project_id => 1, :id => 'Another_page'
+    get :rename, project_id: 1, id: 'Another_page'
     assert_response :success
     assert_template 'rename'
   end
 
   def test_get_rename_child_page
     @request.session[:user_id] = 2
-    get :rename, :project_id => 1, :id => 'Child_1'
+    get :rename, project_id: 1, id: 'Child_1'
     assert_response :success
     assert_template 'rename'
   end
 
   def test_rename_with_redirect
     @request.session[:user_id] = 2
-    put :rename, :project_id => 1, :id => 'Another_page',
-                 :page => { :title => 'Another renamed page',
-                            :redirect_existing_links => 1 }
-    assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_renamed_page'
+    put :rename, project_id: 1, id: 'Another_page',
+                 page: { title: 'Another renamed page',
+                            redirect_existing_links: 1 }
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another_renamed_page'
     # Check redirects
     assert_not_nil wiki.find_page('Another page')
-    assert_nil wiki.find_page('Another page', :with_redirect => false)
+    assert_nil wiki.find_page('Another page', with_redirect: false)
   end
 
   def test_rename_without_redirect
     @request.session[:user_id] = 2
-    put :rename, :project_id => 1, :id => 'Another_page',
-                 :page => { :title => 'Another renamed page',
-                            :redirect_existing_links => "0" }
-    assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_renamed_page'
+    put :rename, project_id: 1, id: 'Another_page',
+                 page: { title: 'Another renamed page',
+                            redirect_existing_links: "0" }
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another_renamed_page'
     # Check that there's no redirects
     assert_nil wiki.find_page('Another page')
   end
 
   def test_destroy_child
     @request.session[:user_id] = 2
-    delete :destroy, :project_id => 1, :id => 'Child_1'
+    delete :destroy, project_id: 1, id: 'Child_1'
     assert_redirected_to action: 'index', project_id: 'ecookbook', id: redirect_page
   end
 
   def test_destroy_parent
     @request.session[:user_id] = 2
     assert_no_difference('WikiPage.count') do
-      delete :destroy, :project_id => 1, :id => 'Another_page'
+      delete :destroy, project_id: 1, id: 'Another_page'
     end
     assert_response :success
     assert_template 'destroy'
@@ -349,7 +349,7 @@ class WikiControllerTest < ActionController::TestCase
   def test_destroy_parent_with_nullify
     @request.session[:user_id] = 2
     assert_difference('WikiPage.count', -1) do
-      delete :destroy, :project_id => 1, :id => 'Another_page', :todo => 'nullify'
+      delete :destroy, project_id: 1, id: 'Another_page', todo: 'nullify'
     end
     assert_redirected_to action: 'index', project_id: 'ecookbook', id: redirect_page
     assert_nil WikiPage.find_by_id(2)
@@ -358,7 +358,7 @@ class WikiControllerTest < ActionController::TestCase
   def test_destroy_parent_with_cascade
     @request.session[:user_id] = 2
     assert_difference('WikiPage.count', -3) do
-      delete :destroy, :project_id => 1, :id => 'Another_page', :todo => 'destroy'
+      delete :destroy, project_id: 1, id: 'Another_page', todo: 'destroy'
     end
     assert_redirected_to action: 'index', project_id: 'ecookbook', id: redirect_page
     assert_nil WikiPage.find_by_id(2)
@@ -368,7 +368,7 @@ class WikiControllerTest < ActionController::TestCase
   def test_destroy_parent_with_reassign
     @request.session[:user_id] = 2
     assert_difference('WikiPage.count', -1) do
-      delete :destroy, :project_id => 1, :id => 'Another_page', :todo => 'reassign', :reassign_to_id => 1
+      delete :destroy, project_id: 1, id: 'Another_page', todo: 'reassign', reassign_to_id: 1
     end
     assert_redirected_to action: 'index', project_id: 'ecookbook', id: redirect_page
     assert_nil WikiPage.find_by_id(2)
@@ -376,7 +376,7 @@ class WikiControllerTest < ActionController::TestCase
   end
 
   def test_index
-    get :index, :project_id => 'ecookbook'
+    get :index, project_id: 'ecookbook'
     assert_response :success
     assert_template 'index'
     pages = assigns(:pages)
@@ -384,27 +384,27 @@ class WikiControllerTest < ActionController::TestCase
     assert_equal wiki.pages.size, pages.size
     assert_equal pages.first.content.updated_on, pages.first.updated_on
 
-    assert_tag :ul, :attributes => { :class => 'pages-hierarchy' },
-                    :child => { :tag => 'li', :child => { :tag => 'a', :attributes => { :href => '/projects/ecookbook/wiki/CookBook_documentation' },
-                                              :content => 'CookBook documentation' },
-                                :child => { :tag => 'ul',
-                                            :child => { :tag => 'li',
-                                                        :child => { :tag => 'a', :attributes => { :href => '/projects/ecookbook/wiki/Page_with_an_inline_image' },
-                                                                                 :content => 'Page with an inline image' } } } },
-                    :child => { :tag => 'li', :child => { :tag => 'a', :attributes => { :href => '/projects/ecookbook/wiki/Another_page' },
-                                                                       :content => 'Another page' } }
+    assert_tag :ul, attributes: { class: 'pages-hierarchy' },
+                    child: { tag: 'li', child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/CookBook_documentation' },
+                                              content: 'CookBook documentation' },
+                                child: { tag: 'ul',
+                                            child: { tag: 'li',
+                                                        child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
+                                                                                 content: 'Page with an inline image' } } } },
+                    child: { tag: 'li', child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Another_page' },
+                                                                       content: 'Another page' } }
   end
 
   def test_index_should_include_atom_link
-    get :index, :project_id => 'ecookbook'
-    assert_tag 'a', :attributes => { :href => '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
+    get :index, project_id: 'ecookbook'
+    assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
   end
 
   context "GET :export" do
     context "with an authorized user to export the wiki" do
       setup do
         @request.session[:user_id] = 2
-        get :export, :project_id => 'ecookbook'
+        get :export, project_id: 'ecookbook'
       end
 
       should respond_with :success
@@ -420,17 +420,17 @@ class WikiControllerTest < ActionController::TestCase
 
     context "with an unauthorized user" do
       setup do
-        get :export, :project_id => 'ecookbook'
+        get :export, project_id: 'ecookbook'
 
         should respond_with :redirect
-        should redirect_to('wiki index') { {:action => 'show', :project_id => @project, :id => nil} }
+        should redirect_to('wiki index') { {action: 'show', project_id: @project, id: nil} }
       end
     end
   end
 
   context "GET :date_index" do
     setup do
-      get :date_index, :project_id => 'ecookbook'
+      get :date_index, project_id: 'ecookbook'
     end
 
     should respond_with :success
@@ -439,12 +439,12 @@ class WikiControllerTest < ActionController::TestCase
     should render_template 'wiki/date_index'
 
     should "include atom link" do
-      assert_tag 'a', :attributes => { :href => '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
+      assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
     end
   end
 
   def test_not_found
-    get :show, :project_id => 999
+    get :show, project_id: 999
     assert_response 404
   end
 
@@ -452,8 +452,8 @@ class WikiControllerTest < ActionController::TestCase
     page = WikiPage.find_by_wiki_id_and_title(1, 'Another_page')
     assert !page.protected?
     @request.session[:user_id] = 2
-    post :protect, :project_id => 1, :id => page.title, :protected => '1'
-    assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'Another_page'
+    post :protect, project_id: 1, id: page.title, protected: '1'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another_page'
     assert page.reload.protected?
   end
 
@@ -461,31 +461,31 @@ class WikiControllerTest < ActionController::TestCase
     page = WikiPage.find_by_wiki_id_and_title(1, 'CookBook_documentation')
     assert page.protected?
     @request.session[:user_id] = 2
-    post :protect, :project_id => 1, :id => page.title, :protected => '0'
-    assert_redirected_to :action => 'show', :project_id => 'ecookbook', :id => 'CookBook_documentation'
+    post :protect, project_id: 1, id: page.title, protected: '0'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'CookBook_documentation'
     assert !page.reload.protected?
   end
 
   def test_show_page_with_edit_link
     @request.session[:user_id] = 2
-    get :show, :project_id => 1
+    get :show, project_id: 1
     assert_response :success
     assert_template 'show'
-    assert_tag :tag => 'a', :attributes => { :href => '/projects/1/wiki/CookBook_documentation/edit' }
+    assert_tag tag: 'a', attributes: { href: '/projects/1/wiki/CookBook_documentation/edit' }
   end
 
   def test_show_page_without_edit_link
     @request.session[:user_id] = 4
-    get :show, :project_id => 1
+    get :show, project_id: 1
     assert_response :success
     assert_template 'show'
-    assert_no_tag :tag => 'a', :attributes => { :href => '/projects/1/wiki/CookBook_documentation/edit' }
+    assert_no_tag tag: 'a', attributes: { href: '/projects/1/wiki/CookBook_documentation/edit' }
   end
 
   def test_edit_unprotected_page
     # Non members can edit unprotected wiki pages
     @request.session[:user_id] = 4
-    get :edit, :project_id => 1, :id => 'Another_page'
+    get :edit, project_id: 1, id: 'Another_page'
     assert_response :success
     assert_template 'edit'
   end
@@ -493,19 +493,19 @@ class WikiControllerTest < ActionController::TestCase
   def test_edit_protected_page_by_nonmember
     # Non members can't edit protected wiki pages
     @request.session[:user_id] = 4
-    get :edit, :project_id => 1, :id => 'CookBook_documentation'
+    get :edit, project_id: 1, id: 'CookBook_documentation'
     assert_response 403
   end
 
   def test_edit_protected_page_by_member
     @request.session[:user_id] = 2
-    get :edit, :project_id => 1, :id => 'CookBook_documentation'
+    get :edit, project_id: 1, id: 'CookBook_documentation'
     assert_response :success
     assert_template 'edit'
   end
 
   def test_history_of_non_existing_page_should_return_404
-    get :history, :project_id => 1, :id => 'Unknown_page'
+    get :history, project_id: 1, id: 'Unknown_page'
     assert_response 404
   end
 end

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -59,9 +59,9 @@ class WikiControllerTest < ActionController::TestCase
 
     # child_pages macro
     assert_tag :ul, attributes: { class: 'pages-hierarchy' },
-               child: { tag: 'li',
-                           child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
-                                                    content: 'Page with an inline image' } }
+                    child: { tag: 'li',
+                             child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
+                                      content: 'Page with an inline image' } }
   end
 
   def test_show_page_with_name
@@ -72,7 +72,7 @@ class WikiControllerTest < ActionController::TestCase
     # Included page with an inline image
     assert_tag tag: 'p', content: /This is an inline image/
     assert_tag tag: 'img', attributes: { src: '/attachments/3/download',
-                                               alt: 'This is a logo' }
+                                         alt: 'This is a logo' }
   end
 
   def test_show_with_sidebar
@@ -82,8 +82,8 @@ class WikiControllerTest < ActionController::TestCase
 
     get :show, project_id: 1, id: 'Another_page'
     assert_response :success
-    assert_tag tag: 'div', attributes: {id: 'sidebar'},
-                              content: /Side bar content for test_show_with_sidebar/
+    assert_tag tag: 'div', attributes: { id: 'sidebar' },
+               content: /Side bar content for test_show_with_sidebar/
   end
 
   def test_show_unexistent_page_without_edit_right
@@ -101,9 +101,9 @@ class WikiControllerTest < ActionController::TestCase
   def test_create_page
     @request.session[:user_id] = 2
     put :update, project_id: 1,
-                id: 'New page',
-                content: {comments: 'Created the page',
-                             text: "h1. New page\n\nThis is a new page" }
+                 id: 'New page',
+                 content: { comments: 'Created the page',
+                            text: "h1. New page\n\nThis is a new page" }
     assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'New_page'
     page = wiki.find_page('New page')
     assert !page.new_record?
@@ -116,11 +116,11 @@ class WikiControllerTest < ActionController::TestCase
     assert_difference 'WikiPage.count' do
       assert_difference 'Attachment.count' do
         put :update, project_id: 1,
-                    id: 'New page',
-                    content: {comments: 'Created the page',
-                                 text: "h1. New page\n\nThis is a new page",
-                                 lock_version: 0},
-                    attachments: {'1' => {'file' => uploaded_test_file('testfile.txt', 'text/plain')}}
+                     id: 'New page',
+                     content: { comments: 'Created the page',
+                                text: "h1. New page\n\nThis is a new page",
+                                lock_version: 0 },
+                     attachments: { '1' => { 'file' => uploaded_test_file('testfile.txt', 'text/plain') } }
       end
     end
     page = wiki.find_page('New page')
@@ -137,21 +137,21 @@ class WikiControllerTest < ActionController::TestCase
       assert_no_difference 'WikiContent.count' do
         assert_difference 'Journal.count' do
           put :update, project_id: 1,
-            id: 'Another_page',
-            content: {
-              comments: "my comments",
-              text: "edited",
-              lock_version: 2
-            }
+                       id: 'Another_page',
+                       content: {
+                         comments: 'my comments',
+                         text: 'edited',
+                         lock_version: 2
+                       }
         end
       end
     end
     assert_redirected_to '/projects/ecookbook/wiki/Another_page'
 
     page.reload
-    assert_equal "edited", page.content.text
+    assert_equal 'edited', page.content.text
     assert_equal page.content.journals.map(&:version).max, page.content.version
-    assert_equal "my comments", page.content.last_journal.notes
+    assert_equal 'my comments', page.content.last_journal.notes
   end
 
   def test_update_page_with_failure
@@ -160,21 +160,21 @@ class WikiControllerTest < ActionController::TestCase
       assert_no_difference 'WikiContent.count' do
         assert_no_difference 'Journal.count' do
           put :update, project_id: 1,
-            id: 'Another_page',
-            content: {
-              comments: 'a' * 300,  # failure here, comment is too long
-              text: 'edited',
-              lock_version: 1
-            }
-          end
+                       id: 'Another_page',
+                       content: {
+                         comments: 'a' * 300,  # failure here, comment is too long
+                         text: 'edited',
+                         lock_version: 1
+                       }
         end
       end
+    end
     assert_response :success
     assert_template 'edit'
 
-    assert_error_tag descendant: {content: /Comment is too long/}
-    assert_tag tag: 'textarea', attributes: {id: 'content_text'}, content: /edited/
-    assert_tag tag: 'input', attributes: {id: 'content_lock_version', value: '1'}
+    assert_error_tag descendant: { content: /Comment is too long/ }
+    assert_tag tag: 'textarea', attributes: { id: 'content_text' }, content: /edited/
+    assert_tag tag: 'input', attributes: { id: 'content_lock_version', value: '1' }
   end
 
   # NOTE: this test seems to depend on other tests in suite
@@ -196,25 +196,25 @@ class WikiControllerTest < ActionController::TestCase
       assert_no_difference 'WikiContent.count' do
         assert_no_difference 'Journal.count' do
           put :update, project_id: 1,
-            id: 'Another_page',
-            content: {
-              comments: 'My comments',
-              text: 'Text should not be lost',
-              lock_version: 1
-            }
+                       id: 'Another_page',
+                       content: {
+                         comments: 'My comments',
+                         text: 'Text should not be lost',
+                         lock_version: 1
+                       }
         end
       end
     end
     assert_response :success
     assert_template 'edit'
     assert_tag :div,
-      attributes: { class: /error/ },
-      content: /Information has been updated by at least one other user in the meantime/
+               attributes: { class: /error/ },
+               content: /Information has been updated by at least one other user in the meantime/
     assert_tag 'textarea',
-      attributes: { name: 'content[text]' },
-      content: /Text should not be lost/
+               attributes: { name: 'content[text]' },
+               content: /Text should not be lost/
     assert_tag 'input',
-      attributes: { name: 'content[comments]', value: 'My comments' }
+               attributes: { name: 'content[comments]', value: 'My comments' }
 
     c.reload
     assert_equal 'Previous text', c.text
@@ -225,7 +225,7 @@ class WikiControllerTest < ActionController::TestCase
     FactoryGirl.create :wiki_content_journal,
                        journable_id: 1,
                        data: FactoryGirl.build(:journal_wiki_content_journal,
-                                               text: "h1. CookBook documentation")
+                                               text: 'h1. CookBook documentation')
     FactoryGirl.create :wiki_content_journal,
                        journable_id: 1,
                        data: FactoryGirl.build(:journal_wiki_content_journal,
@@ -240,7 +240,7 @@ class WikiControllerTest < ActionController::TestCase
     assert_template 'history'
     assert_not_nil assigns(:versions)
     assert_equal 3, assigns(:versions).size
-    assert_select "input[type=submit][name=commit]"
+    assert_select 'input[type=submit][name=commit]'
   end
 
   def test_history_with_one_version
@@ -253,14 +253,14 @@ class WikiControllerTest < ActionController::TestCase
     assert_template 'history'
     assert_not_nil assigns(:versions)
     assert_equal 1, assigns(:versions).size
-    assert_select "input[type=submit][name=commit]", false
+    assert_select 'input[type=submit][name=commit]', false
   end
 
   def test_diff
     journal_from = FactoryGirl.create :wiki_content_journal,
                                       journable_id: 1,
                                       data: FactoryGirl.build(:journal_wiki_content_journal,
-                                                              text: "h1. CookBook documentation")
+                                                              text: 'h1. CookBook documentation')
     journal_to = FactoryGirl.create :wiki_content_journal,
                                     journable_id: 1,
                                     data: FactoryGirl.build(:journal_wiki_content_journal,
@@ -269,15 +269,15 @@ class WikiControllerTest < ActionController::TestCase
     get :diff, project_id: 1, id: 'CookBook_documentation', version: journal_to.version, version_from: journal_from.version
     assert_response :success
     assert_template 'diff'
-    assert_tag tag: 'ins', attributes: { class: 'diffins'},
-                              content: /updated/
+    assert_tag tag: 'ins', attributes: { class: 'diffins' },
+               content: /updated/
   end
 
   def test_annotate
     FactoryGirl.create :wiki_content_journal,
                        journable_id: 1,
                        data: FactoryGirl.build(:journal_wiki_content_journal,
-                                               text: "h1. CookBook documentation")
+                                               text: 'h1. CookBook documentation')
     journal_to = FactoryGirl.create :wiki_content_journal,
                                     journable_id: 1,
                                     data: FactoryGirl.build(:journal_wiki_content_journal,
@@ -287,13 +287,13 @@ class WikiControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'annotate'
     # Line 1
-    assert_tag tag: 'tr', child: { tag: 'th', attributes: {class: 'line-num'}, content: '1' },
-                             child: { tag: 'td', attributes: {class: 'author'}, content: /John Smith/ },
-                             child: { tag: 'td', content: /h1\. CookBook documentation/ }
+    assert_tag tag: 'tr', child: { tag: 'th', attributes: { class: 'line-num' }, content: '1' },
+               child: { tag: 'td', attributes: { class: 'author' }, content: /John Smith/ },
+               child: { tag: 'td', content: /h1\. CookBook documentation/ }
     # Line 2
-    assert_tag tag: 'tr', child: { tag: 'th', attributes: {class: 'line-num'}, content: '2' },
-                             child: { tag: 'td', attributes: {class: 'author'}, content: /redMine Admin/ },
-                             child: { tag: 'td', content: /Some updated \[\[documentation\]\] here/ }
+    assert_tag tag: 'tr', child: { tag: 'th', attributes: { class: 'line-num' }, content: '2' },
+               child: { tag: 'td', attributes: { class: 'author' }, content: /redMine Admin/ },
+               child: { tag: 'td', content: /Some updated \[\[documentation\]\] here/ }
   end
 
   def test_get_rename
@@ -314,7 +314,7 @@ class WikiControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     put :rename, project_id: 1, id: 'Another_page',
                  page: { title: 'Another renamed page',
-                            redirect_existing_links: 1 }
+                         redirect_existing_links: 1 }
     assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another_renamed_page'
     # Check redirects
     assert_not_nil wiki.find_page('Another page')
@@ -325,7 +325,7 @@ class WikiControllerTest < ActionController::TestCase
     @request.session[:user_id] = 2
     put :rename, project_id: 1, id: 'Another_page',
                  page: { title: 'Another renamed page',
-                            redirect_existing_links: "0" }
+                         redirect_existing_links: '0' }
     assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another_renamed_page'
     # Check that there's no redirects
     assert_nil wiki.find_page('Another page')
@@ -386,22 +386,22 @@ class WikiControllerTest < ActionController::TestCase
 
     assert_tag :ul, attributes: { class: 'pages-hierarchy' },
                     child: { tag: 'li', child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/CookBook_documentation' },
-                                              content: 'CookBook documentation' },
-                                child: { tag: 'ul',
-                                            child: { tag: 'li',
-                                                        child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
-                                                                                 content: 'Page with an inline image' } } } },
+                                                 content: 'CookBook documentation' },
+                             child: { tag: 'ul',
+                                      child: { tag: 'li',
+                                               child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Page_with_an_inline_image' },
+                                                        content: 'Page with an inline image' } } } },
                     child: { tag: 'li', child: { tag: 'a', attributes: { href: '/projects/ecookbook/wiki/Another_page' },
-                                                                       content: 'Another page' } }
+                                                 content: 'Another page' } }
   end
 
   def test_index_should_include_atom_link
     get :index, project_id: 'ecookbook'
-    assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
+    assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1' }
   end
 
-  context "GET :export" do
-    context "with an authorized user to export the wiki" do
+  context 'GET :export' do
+    context 'with an authorized user to export the wiki' do
       setup do
         @request.session[:user_id] = 2
         get :export, project_id: 'ecookbook'
@@ -409,26 +409,25 @@ class WikiControllerTest < ActionController::TestCase
 
       should respond_with :success
       should_assign_to :pages
-      should_respond_with_content_type "text/html"
-      should "export all of the wiki pages to a single html file" do
-        assert_select "a[name=?]", "CookBook_documentation"
-        assert_select "a[name=?]", "Another_page"
-        assert_select "a[name=?]", "Page_with_an_inline_image"
+      should_respond_with_content_type 'text/html'
+      should 'export all of the wiki pages to a single html file' do
+        assert_select 'a[name=?]', 'CookBook_documentation'
+        assert_select 'a[name=?]', 'Another_page'
+        assert_select 'a[name=?]', 'Page_with_an_inline_image'
       end
-
     end
 
-    context "with an unauthorized user" do
+    context 'with an unauthorized user' do
       setup do
         get :export, project_id: 'ecookbook'
 
         should respond_with :redirect
-        should redirect_to('wiki index') { {action: 'show', project_id: @project, id: nil} }
+        should redirect_to('wiki index') { { action: 'show', project_id: @project, id: nil } }
       end
     end
   end
 
-  context "GET :date_index" do
+  context 'GET :date_index' do
     setup do
       get :date_index, project_id: 'ecookbook'
     end
@@ -438,8 +437,8 @@ class WikiControllerTest < ActionController::TestCase
     should_assign_to :pages_by_date
     should render_template 'wiki/date_index'
 
-    should "include atom link" do
-      assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1'}
+    should 'include atom link' do
+      assert_tag 'a', attributes: { href: '/projects/ecookbook/activity.atom?show_wiki_edits=1' }
     end
   end
 

--- a/test/functional/wikis_controller_test.rb
+++ b/test/functional/wikis_controller_test.rb
@@ -46,7 +46,7 @@ class WikisControllerTest < ActionController::TestCase
   def test_create
     @request.session[:user_id] = 1
     assert_nil Project.find(3).wiki
-    post :edit, :id => 3, :wiki => { :start_page => 'Start page' }
+    post :edit, id: 3, wiki: { start_page: 'Start page' }
     assert_response :success
     wiki = Project.find(3).wiki
     assert_not_nil wiki
@@ -55,14 +55,14 @@ class WikisControllerTest < ActionController::TestCase
 
   def test_destroy
     @request.session[:user_id] = 1
-    post :destroy, :id => 1, :confirm => 1
-    assert_redirected_to :controller => 'projects', :action => 'settings', :id => 'ecookbook', :tab => 'wiki'
+    post :destroy, id: 1, confirm: 1
+    assert_redirected_to controller: 'projects', action: 'settings', id: 'ecookbook', tab: 'wiki'
     assert_nil Project.find(1).wiki
   end
 
   def test_not_found
     @request.session[:user_id] = 1
-    post :destroy, :id => 999, :confirm => 1
+    post :destroy, id: 999, confirm: 1
     assert_response 404
   end
 end

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -51,7 +51,7 @@ class WorkflowsControllerTest < ActionController::TestCase
 
     count = Workflow.count(:all, conditions: 'role_id = 1 AND type_id = 2')
     assert_tag tag: 'a', content: count.to_s,
-                            attributes: { href: '/workflows/edit?role_id=1&amp;type_id=2' }
+               attributes: { href: '/workflows/edit?role_id=1&amp;type_id=2' }
   end
 
   def test_get_edit
@@ -77,17 +77,17 @@ class WorkflowsControllerTest < ActionController::TestCase
 
     # allowed transitions
     assert_tag tag: 'input', attributes: { type: 'checkbox',
-                                                 name: 'status[3][5][]',
-                                                 value: 'always',
-                                                 checked: 'checked' }
+                                           name: 'status[3][5][]',
+                                           value: 'always',
+                                           checked: 'checked' }
     # not allowed
     assert_tag tag: 'input', attributes: { type: 'checkbox',
-                                                 name: 'status[3][2][]',
-                                                 value: 'always',
-                                                 checked: nil }
+                                           name: 'status[3][2][]',
+                                           value: 'always',
+                                           checked: nil }
     # unused
     assert_no_tag tag: 'input', attributes: { type: 'checkbox',
-                                                    name: 'status[1][1][]' }
+                                              name: 'status[1][1][]' }
   end
 
   def test_get_edit_with_role_and_type_and_all_statuses
@@ -101,53 +101,53 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_equal Status.count, assigns(:statuses).size
 
     assert_tag tag: 'input', attributes: { type: 'checkbox',
-                                                 name: 'status[1][1][]',
-                                                 value: 'always',
-                                                 checked: nil }
+                                           name: 'status[1][1][]',
+                                           value: 'always',
+                                           checked: nil }
   end
 
   def test_post_edit
     post :edit, role_id: 2, type_id: 1,
-      status: {
-        '4' => {'5' => ['always']},
-        '3' => {'1' => ['always'], '2' => ['always']}
-      }
+                status: {
+                  '4' => { '5' => ['always'] },
+                  '3' => { '1' => ['always'], '2' => ['always'] }
+                }
     assert_redirected_to '/workflows/edit?role_id=2&type_id=1'
 
-    assert_equal 3, Workflow.count(conditions: {type_id: 1, role_id: 2})
-    assert_not_nil  Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2})
-    assert_nil      Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 5, new_status_id: 4})
+    assert_equal 3, Workflow.count(conditions: { type_id: 1, role_id: 2 })
+    assert_not_nil Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2 })
+    assert_nil Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 5, new_status_id: 4 })
   end
 
   def test_post_edit_with_additional_transitions
     post :edit, role_id: 2, type_id: 1,
-      status: {
-        '4' => {'5' => ['always']},
-        '3' => {'1' => ['author'], '2' => ['assignee'], '4' => ['author', 'assignee']}
-      }
+                status: {
+                  '4' => { '5' => ['always'] },
+                  '3' => { '1' => ['author'], '2' => ['assignee'], '4' => ['author', 'assignee'] }
+                }
     assert_redirected_to '/workflows/edit?role_id=2&type_id=1'
 
-    assert_equal 4, Workflow.count(conditions: {type_id: 1, role_id: 2})
+    assert_equal 4, Workflow.count(conditions: { type_id: 1, role_id: 2 })
 
-    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 4, new_status_id: 5})
-    assert ! w.author
-    assert ! w.assignee
-    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 1})
+    w = Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 4, new_status_id: 5 })
+    assert !w.author
+    assert !w.assignee
+    w = Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 1 })
     assert w.author
-    assert ! w.assignee
-    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2})
-    assert ! w.author
+    assert !w.assignee
+    w = Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2 })
+    assert !w.author
     assert w.assignee
-    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 4})
+    w = Workflow.find(:first, conditions: { role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 4 })
     assert w.author
     assert w.assignee
   end
 
   def test_clear_workflow
-    assert Workflow.count(conditions: {type_id: 1, role_id: 2}) > 0
+    assert Workflow.count(conditions: { type_id: 1, role_id: 2 }) > 0
 
     post :edit, role_id: 2, type_id: 1
-    assert_equal 0, Workflow.count(conditions: {type_id: 1, role_id: 2})
+    assert_equal 0, Workflow.count(conditions: { type_id: 1, role_id: 2 })
   end
 
   def test_get_copy
@@ -193,6 +193,6 @@ class WorkflowsControllerTest < ActionController::TestCase
   # Returns an array of status transitions that can be compared
   def status_transitions(conditions)
     Workflow.find(:all, conditions: conditions,
-                        order: 'type_id, role_id, old_status_id, new_status_id').collect {|w| [w.old_status, w.new_status_id]}
+                        order: 'type_id, role_id, old_status_id, new_status_id').collect { |w| [w.old_status, w.new_status_id] }
   end
 end

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -49,9 +49,9 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template 'index'
 
-    count = Workflow.count(:all, :conditions => 'role_id = 1 AND type_id = 2')
-    assert_tag :tag => 'a', :content => count.to_s,
-                            :attributes => { :href => '/workflows/edit?role_id=1&amp;type_id=2' }
+    count = Workflow.count(:all, conditions: 'role_id = 1 AND type_id = 2')
+    assert_tag tag: 'a', content: count.to_s,
+                            attributes: { href: '/workflows/edit?role_id=1&amp;type_id=2' }
   end
 
   def test_get_edit
@@ -64,10 +64,10 @@ class WorkflowsControllerTest < ActionController::TestCase
 
   def test_get_edit_with_role_and_type
     Workflow.delete_all
-    Workflow.create!(:role_id => 1, :type_id => 1, :old_status_id => 2, :new_status_id => 3)
-    Workflow.create!(:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 5)
+    Workflow.create!(role_id: 1, type_id: 1, old_status_id: 2, new_status_id: 3)
+    Workflow.create!(role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 5)
 
-    get :edit, :role_id => 2, :type_id => 1
+    get :edit, role_id: 2, type_id: 1
     assert_response :success
     assert_template 'edit'
 
@@ -76,78 +76,78 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_equal [2, 3, 5], assigns(:statuses).collect(&:id)
 
     # allowed transitions
-    assert_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                 :name => 'status[3][5][]',
-                                                 :value => 'always',
-                                                 :checked => 'checked' }
+    assert_tag tag: 'input', attributes: { type: 'checkbox',
+                                                 name: 'status[3][5][]',
+                                                 value: 'always',
+                                                 checked: 'checked' }
     # not allowed
-    assert_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                 :name => 'status[3][2][]',
-                                                 :value => 'always',
-                                                 :checked => nil }
+    assert_tag tag: 'input', attributes: { type: 'checkbox',
+                                                 name: 'status[3][2][]',
+                                                 value: 'always',
+                                                 checked: nil }
     # unused
-    assert_no_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                    :name => 'status[1][1][]' }
+    assert_no_tag tag: 'input', attributes: { type: 'checkbox',
+                                                    name: 'status[1][1][]' }
   end
 
   def test_get_edit_with_role_and_type_and_all_statuses
     Workflow.delete_all
 
-    get :edit, :role_id => 2, :type_id => 1, :used_statuses_only => '0'
+    get :edit, role_id: 2, type_id: 1, used_statuses_only: '0'
     assert_response :success
     assert_template 'edit'
 
     assert_not_nil assigns(:statuses)
     assert_equal Status.count, assigns(:statuses).size
 
-    assert_tag :tag => 'input', :attributes => { :type => 'checkbox',
-                                                 :name => 'status[1][1][]',
-                                                 :value => 'always',
-                                                 :checked => nil }
+    assert_tag tag: 'input', attributes: { type: 'checkbox',
+                                                 name: 'status[1][1][]',
+                                                 value: 'always',
+                                                 checked: nil }
   end
 
   def test_post_edit
-    post :edit, :role_id => 2, :type_id => 1,
-      :status => {
+    post :edit, role_id: 2, type_id: 1,
+      status: {
         '4' => {'5' => ['always']},
         '3' => {'1' => ['always'], '2' => ['always']}
       }
     assert_redirected_to '/workflows/edit?role_id=2&type_id=1'
 
-    assert_equal 3, Workflow.count(:conditions => {:type_id => 1, :role_id => 2})
-    assert_not_nil  Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 2})
-    assert_nil      Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 5, :new_status_id => 4})
+    assert_equal 3, Workflow.count(conditions: {type_id: 1, role_id: 2})
+    assert_not_nil  Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2})
+    assert_nil      Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 5, new_status_id: 4})
   end
 
   def test_post_edit_with_additional_transitions
-    post :edit, :role_id => 2, :type_id => 1,
-      :status => {
+    post :edit, role_id: 2, type_id: 1,
+      status: {
         '4' => {'5' => ['always']},
         '3' => {'1' => ['author'], '2' => ['assignee'], '4' => ['author', 'assignee']}
       }
     assert_redirected_to '/workflows/edit?role_id=2&type_id=1'
 
-    assert_equal 4, Workflow.count(:conditions => {:type_id => 1, :role_id => 2})
+    assert_equal 4, Workflow.count(conditions: {type_id: 1, role_id: 2})
 
-    w = Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 4, :new_status_id => 5})
+    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 4, new_status_id: 5})
     assert ! w.author
     assert ! w.assignee
-    w = Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 1})
+    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 1})
     assert w.author
     assert ! w.assignee
-    w = Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 2})
+    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 2})
     assert ! w.author
     assert w.assignee
-    w = Workflow.find(:first, :conditions => {:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 4})
+    w = Workflow.find(:first, conditions: {role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 4})
     assert w.author
     assert w.assignee
   end
 
   def test_clear_workflow
-    assert Workflow.count(:conditions => {:type_id => 1, :role_id => 2}) > 0
+    assert Workflow.count(conditions: {type_id: 1, role_id: 2}) > 0
 
-    post :edit, :role_id => 2, :type_id => 1
-    assert_equal 0, Workflow.count(:conditions => {:type_id => 1, :role_id => 2})
+    post :edit, role_id: 2, type_id: 1
+    assert_equal 0, Workflow.count(conditions: {type_id: 1, role_id: 2})
   end
 
   def test_get_copy
@@ -157,42 +157,42 @@ class WorkflowsControllerTest < ActionController::TestCase
   end
 
   def test_post_copy_one_to_one
-    source_transitions = status_transitions(:type_id => 1, :role_id => 2)
+    source_transitions = status_transitions(type_id: 1, role_id: 2)
 
-    post :copy, :source_type_id => '1', :source_role_id => '2',
-                :target_type_ids => ['3'], :target_role_ids => ['1']
+    post :copy, source_type_id: '1', source_role_id: '2',
+                target_type_ids: ['3'], target_role_ids: ['1']
     assert_response 302
-    assert_equal source_transitions, status_transitions(:type_id => 3, :role_id => 1)
+    assert_equal source_transitions, status_transitions(type_id: 3, role_id: 1)
   end
 
   def test_post_copy_one_to_many
-    source_transitions = status_transitions(:type_id => 1, :role_id => 2)
+    source_transitions = status_transitions(type_id: 1, role_id: 2)
 
-    post :copy, :source_type_id => '1', :source_role_id => '2',
-                :target_type_ids => ['2', '3'], :target_role_ids => ['1', '3']
+    post :copy, source_type_id: '1', source_role_id: '2',
+                target_type_ids: ['2', '3'], target_role_ids: ['1', '3']
     assert_response 302
-    assert_equal source_transitions, status_transitions(:type_id => 2, :role_id => 1)
-    assert_equal source_transitions, status_transitions(:type_id => 3, :role_id => 1)
-    assert_equal source_transitions, status_transitions(:type_id => 2, :role_id => 3)
-    assert_equal source_transitions, status_transitions(:type_id => 3, :role_id => 3)
+    assert_equal source_transitions, status_transitions(type_id: 2, role_id: 1)
+    assert_equal source_transitions, status_transitions(type_id: 3, role_id: 1)
+    assert_equal source_transitions, status_transitions(type_id: 2, role_id: 3)
+    assert_equal source_transitions, status_transitions(type_id: 3, role_id: 3)
   end
 
   def test_post_copy_many_to_many
-    source_t2 = status_transitions(:type_id => 2, :role_id => 2)
-    source_t3 = status_transitions(:type_id => 3, :role_id => 2)
+    source_t2 = status_transitions(type_id: 2, role_id: 2)
+    source_t3 = status_transitions(type_id: 3, role_id: 2)
 
-    post :copy, :source_type_id => 'any', :source_role_id => '2',
-                :target_type_ids => ['2', '3'], :target_role_ids => ['1', '3']
+    post :copy, source_type_id: 'any', source_role_id: '2',
+                target_type_ids: ['2', '3'], target_role_ids: ['1', '3']
     assert_response 302
-    assert_equal source_t2, status_transitions(:type_id => 2, :role_id => 1)
-    assert_equal source_t3, status_transitions(:type_id => 3, :role_id => 1)
-    assert_equal source_t2, status_transitions(:type_id => 2, :role_id => 3)
-    assert_equal source_t3, status_transitions(:type_id => 3, :role_id => 3)
+    assert_equal source_t2, status_transitions(type_id: 2, role_id: 1)
+    assert_equal source_t3, status_transitions(type_id: 3, role_id: 1)
+    assert_equal source_t2, status_transitions(type_id: 2, role_id: 3)
+    assert_equal source_t3, status_transitions(type_id: 3, role_id: 3)
   end
 
   # Returns an array of status transitions that can be compared
   def status_transitions(conditions)
-    Workflow.find(:all, :conditions => conditions,
-                        :order => 'type_id, role_id, old_status_id, new_status_id').collect {|w| [w.old_status, w.new_status_id]}
+    Workflow.find(:all, conditions: conditions,
+                        order: 'type_id, role_id, old_status_id, new_status_id').collect {|w| [w.old_status, w.new_status_id]}
   end
 end

--- a/test/helper_testcase.rb
+++ b/test/helper_testcase.rb
@@ -29,12 +29,11 @@
 
 # Re-raise errors caught by the controller.
 class StubController < ApplicationController
-  def rescue_action(e) raise e end;
+  def rescue_action(e) raise e end
   attr_accessor :request, :url
 end
 
 class HelperTestCase < ActionView::TestCase
-
   # Add other helpers here if you need them
   include ERB::Util
   include ActionView::Helpers::TagHelper

--- a/test/integration/api_test/disabled_rest_api_test.rb
+++ b/test/integration/api_test/disabled_rest_api_test.rb
@@ -44,10 +44,9 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
     Setting.login_required = '0'
   end
 
-  context "get /api/v2/projects with the API disabled" do
-
-    context "in :xml format" do
-      context "with a valid api token" do
+  context 'get /api/v2/projects with the API disabled' do
+    context 'in :xml format' do
+      context 'with a valid api token' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'api')
@@ -55,13 +54,13 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/xml"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/xml'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
 
-      context "with a valid HTTP authentication" do
+      context 'with a valid HTTP authentication' do
         setup do
           @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
@@ -69,13 +68,13 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/xml"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/xml'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
 
-      context "with a valid HTTP authentication using the API token" do
+      context 'with a valid HTTP authentication using the API token' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'api')
@@ -84,15 +83,15 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/xml"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/xml'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
     end
 
-    context "in :json format" do
-      context "with a valid api token" do
+    context 'in :json format' do
+      context 'with a valid api token' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'api')
@@ -100,13 +99,13 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/json"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/json'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
 
-      context "with a valid HTTP authentication" do
+      context 'with a valid HTTP authentication' do
         setup do
           @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
@@ -114,13 +113,13 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/json"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/json'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
 
-      context "with a valid HTTP authentication using the API token" do
+      context 'with a valid HTTP authentication using the API token' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'api')
@@ -129,12 +128,11 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
         end
 
         should respond_with :unauthorized
-        should_respond_with_content_type "application/json"
-        should "not login as the user" do
+        should_respond_with_content_type 'application/json'
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
-
     end
   end
 end

--- a/test/integration/api_test/disabled_rest_api_test.rb
+++ b/test/integration/api_test/disabled_rest_api_test.rb
@@ -50,7 +50,7 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
       context "with a valid api token" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @token = Token.generate!(user: @user, action: 'api')
           get "/api/v2/projects.xml?key=#{@token.value}"
         end
 
@@ -63,9 +63,9 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
 
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
+          @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
-          get '/api/v2/projects.xml', nil, :authorization => @authorization
+          get '/api/v2/projects.xml', nil, authorization: @authorization
         end
 
         should respond_with :unauthorized
@@ -78,9 +78,9 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
       context "with a valid HTTP authentication using the API token" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @token = Token.generate!(user: @user, action: 'api')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@token.value, 'X')
-          get '/api/v2/projects.xml', nil, :authorization => @authorization
+          get '/api/v2/projects.xml', nil, authorization: @authorization
         end
 
         should respond_with :unauthorized
@@ -95,7 +95,7 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
       context "with a valid api token" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @token = Token.generate!(user: @user, action: 'api')
           get "/api/v2/projects.json?key=#{@token.value}"
         end
 
@@ -108,9 +108,9 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
 
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
+          @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@user.login, 'adminADMIN!')
-          get '/api/v2/projects.json', nil, :authorization => @authorization
+          get '/api/v2/projects.json', nil, authorization: @authorization
         end
 
         should respond_with :unauthorized
@@ -123,9 +123,9 @@ class ApiTest::DisabledRestApiTest < ActionDispatch::IntegrationTest
       context "with a valid HTTP authentication using the API token" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @token = Token.generate!(user: @user, action: 'api')
           @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(@token.value, 'DoesNotMatter')
-          get '/api/v2/projects.json', nil, :authorization => @authorization
+          get '/api/v2/projects.json', nil, authorization: @authorization
         end
 
         should respond_with :unauthorized

--- a/test/integration/api_test/http_accept_auth_test.rb
+++ b/test/integration/api_test/http_accept_auth_test.rb
@@ -44,18 +44,18 @@ class ApiTest::HttpAcceptAuthTest < ActionDispatch::IntegrationTest
     Setting.login_required = '0'
   end
 
-  context "get /planning_elements" do
+  context 'get /planning_elements' do
     setup do
       project = Project.find('onlinestore')
       EnabledModule.create(project: project, name: 'work_package_tracking')
     end
 
-    context "in :xml format" do
-      should_send_correct_authentication_scheme_when_header_authentication_scheme_is_session(:get, "/api/v2/projects/onlinestore/planning_elements.xml")
+    context 'in :xml format' do
+      should_send_correct_authentication_scheme_when_header_authentication_scheme_is_session(:get, '/api/v2/projects/onlinestore/planning_elements.xml')
     end
 
-    context "in :json format" do
-      should_send_correct_authentication_scheme_when_header_authentication_scheme_is_session(:get, "/api/v2/projects/onlinestore/planning_elements.json")
+    context 'in :json format' do
+      should_send_correct_authentication_scheme_when_header_authentication_scheme_is_session(:get, '/api/v2/projects/onlinestore/planning_elements.json')
     end
   end
 end

--- a/test/integration/api_test/http_accept_auth_test.rb
+++ b/test/integration/api_test/http_accept_auth_test.rb
@@ -47,7 +47,7 @@ class ApiTest::HttpAcceptAuthTest < ActionDispatch::IntegrationTest
   context "get /planning_elements" do
     setup do
       project = Project.find('onlinestore')
-      EnabledModule.create(:project => project, :name => 'work_package_tracking')
+      EnabledModule.create(project: project, name: 'work_package_tracking')
     end
 
     context "in :xml format" do

--- a/test/integration/api_test/http_basic_login_test.rb
+++ b/test/integration/api_test/http_basic_login_test.rb
@@ -47,7 +47,7 @@ class ApiTest::HttpBasicLoginTest < ActionDispatch::IntegrationTest
   context "get /api/v2/projects/<ID>/planning_elements" do
     setup do
       project = Project.find('onlinestore')
-      EnabledModule.create(:project => project, :name => 'work_package_tracking')
+      EnabledModule.create(project: project, name: 'work_package_tracking')
     end
 
     context "in :xml format" do

--- a/test/integration/api_test/http_basic_login_test.rb
+++ b/test/integration/api_test/http_basic_login_test.rb
@@ -44,18 +44,18 @@ class ApiTest::HttpBasicLoginTest < ActionDispatch::IntegrationTest
     Setting.login_required = '0'
   end
 
-  context "get /api/v2/projects/<ID>/planning_elements" do
+  context 'get /api/v2/projects/<ID>/planning_elements' do
     setup do
       project = Project.find('onlinestore')
       EnabledModule.create(project: project, name: 'work_package_tracking')
     end
 
-    context "in :xml format" do
-      should_allow_http_basic_auth_with_username_and_password(:get, "/api/v2/projects/onlinestore/planning_elements.xml")
+    context 'in :xml format' do
+      should_allow_http_basic_auth_with_username_and_password(:get, '/api/v2/projects/onlinestore/planning_elements.xml')
     end
 
-    context "in :json format" do
-      should_allow_http_basic_auth_with_username_and_password(:get, "/api/v2/projects/onlinestore/planning_elements.json")
+    context 'in :json format' do
+      should_allow_http_basic_auth_with_username_and_password(:get, '/api/v2/projects/onlinestore/planning_elements.json')
     end
   end
 end

--- a/test/integration/api_test/http_basic_login_with_api_token_test.rb
+++ b/test/integration/api_test/http_basic_login_with_api_token_test.rb
@@ -44,14 +44,13 @@ class ApiTest::HttpBasicLoginWithApiTokenTest < ActionDispatch::IntegrationTest
     Setting.login_required = '0'
   end
 
-  context "get /api/v2/projects" do
-
-    context "in :xml format" do
-      should_allow_http_basic_auth_with_key(:get, "/api/v2/projects.xml")
+  context 'get /api/v2/projects' do
+    context 'in :xml format' do
+      should_allow_http_basic_auth_with_key(:get, '/api/v2/projects.xml')
     end
 
-    context "in :json format" do
-      should_allow_http_basic_auth_with_key(:get, "/api/v2/projects.json")
+    context 'in :json format' do
+      should_allow_http_basic_auth_with_key(:get, '/api/v2/projects.json')
     end
   end
 end

--- a/test/integration/api_test/token_authentication_test.rb
+++ b/test/integration/api_test/token_authentication_test.rb
@@ -44,13 +44,13 @@ class ApiTest::TokenAuthenticationTest < ActionDispatch::IntegrationTest
     Setting.login_required = '0'
   end
 
-  context "get /api/v2/projects" do
-    context "in :xml format" do
-      should_allow_key_based_auth(:get, "/api/v2/projects.xml")
+  context 'get /api/v2/projects' do
+    context 'in :xml format' do
+      should_allow_key_based_auth(:get, '/api/v2/projects.xml')
     end
 
-    context "in :json format" do
-      should_allow_key_based_auth(:get, "/api/v2/projects.json")
+    context 'in :json format' do
+      should_allow_key_based_auth(:get, '/api/v2/projects.json')
     end
   end
 end

--- a/test/integration/application_test.rb
+++ b/test/integration/application_test.rb
@@ -38,13 +38,13 @@ class ApplicationTest < ActionDispatch::IntegrationTest
     Setting.default_language = 'en'
 
     # a french user
-    get 'projects', { }, { 'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'}
+    get 'projects', {},  'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'
     assert_response :success
     assert_tag tag: 'h2', content: 'Projekte'
     assert_equal :de, current_language
 
     # not a supported language: default language should be used
-    get 'projects', { }, 'HTTP_ACCEPT_LANGUAGE' => 'zz'
+    get 'projects', {}, 'HTTP_ACCEPT_LANGUAGE' => 'zz'
     assert_response :success
     assert_tag tag: 'h2', content: 'Projects'
   end

--- a/test/integration/application_test.rb
+++ b/test/integration/application_test.rb
@@ -40,13 +40,13 @@ class ApplicationTest < ActionDispatch::IntegrationTest
     # a french user
     get 'projects', { }, { 'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'}
     assert_response :success
-    assert_tag :tag => 'h2', :content => 'Projekte'
+    assert_tag tag: 'h2', content: 'Projekte'
     assert_equal :de, current_language
 
     # not a supported language: default language should be used
     get 'projects', { }, 'HTTP_ACCEPT_LANGUAGE' => 'zz'
     assert_response :success
-    assert_tag :tag => 'h2', :content => 'Projects'
+    assert_tag tag: 'h2', content: 'Projects'
   end
 
   def test_token_based_access_should_not_start_session

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -38,27 +38,27 @@ class LayoutTest < ActionDispatch::IntegrationTest
     assert_response :not_found
 
     # UsersController uses the admin layout by default
-    assert_select "#main-menu", :count => 0
+    assert_select "#main-menu", count: 0
   end
 
   def test_top_menu_navigation_not_visible_when_login_required
-    with_settings :login_required => '1' do
+    with_settings login_required: '1' do
       get '/'
       assert_select "#account-nav-left", 0
     end
   end
 
   def test_top_menu_navigation_visible_when_login_not_required
-    with_settings :login_required => '0' do
+    with_settings login_required: '0' do
       get '/'
       assert_select "#account-nav-left"
     end
   end
 
   test "page titles should be properly escaped" do
-    project = Project.generate(:name => "C&A", :is_public => true)
+    project = Project.generate(name: "C&A", is_public: true)
 
-    with_settings :app_title => '<3' do
+    with_settings app_title: '<3' do
       get "/projects/#{project.to_param}"
 
       html_node = HTML::Document.new(@response.body)

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -32,39 +32,39 @@ require File.expand_path('../../test_helper', __FILE__)
 class LayoutTest < ActionDispatch::IntegrationTest
   fixtures :all
 
-  test "browsing to a missing page should render the base layout" do
-    get "/users/100000000"
+  test 'browsing to a missing page should render the base layout' do
+    get '/users/100000000'
 
     assert_response :not_found
 
     # UsersController uses the admin layout by default
-    assert_select "#main-menu", count: 0
+    assert_select '#main-menu', count: 0
   end
 
   def test_top_menu_navigation_not_visible_when_login_required
     with_settings login_required: '1' do
       get '/'
-      assert_select "#account-nav-left", 0
+      assert_select '#account-nav-left', 0
     end
   end
 
   def test_top_menu_navigation_visible_when_login_not_required
     with_settings login_required: '0' do
       get '/'
-      assert_select "#account-nav-left"
+      assert_select '#account-nav-left'
     end
   end
 
-  test "page titles should be properly escaped" do
-    project = Project.generate(name: "C&A", is_public: true)
+  test 'page titles should be properly escaped' do
+    project = Project.generate(name: 'C&A', is_public: true)
 
     with_settings app_title: '<3' do
       get "/projects/#{project.to_param}"
 
       html_node = HTML::Document.new(@response.body)
 
-      assert_select html_node.root, "title", /C&amp;A/
-      assert_select html_node.root, "title", /&lt;3/
+      assert_select html_node.root, 'title', /C&amp;A/
+      assert_select html_node.root, 'title', /&lt;3/
     end
   end
 end

--- a/test/integration/lib/redmine/menu_manager_test.rb
+++ b/test/integration/lib/redmine/menu_manager_test.rb
@@ -35,16 +35,16 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
 
   def test_project_menu_with_specific_locale
     Setting.available_languages = [:de, :en]
-    get 'projects/ecookbook', { }, 'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'
+    get 'projects/ecookbook', {}, 'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'
 
     assert_tag :div, attributes: { id: 'main-menu' },
                      descendant: { tag: 'li', child: { tag: 'a', content: ll('de', :label_activity),
-                                                                             attributes: { href: '/projects/ecookbook/activity',
-                                                                                              class: 'icon2 icon-yes activity-menu-item ellipsis' } } }
+                                                       attributes: { href: '/projects/ecookbook/activity',
+                                                                     class: 'icon2 icon-yes activity-menu-item ellipsis' } } }
     assert_tag :div, attributes: { id: 'main-menu' },
                      descendant: { tag: 'li', child: { tag: 'a', content: ll('de', :label_overview),
-                                                                             attributes: { href: '/projects/ecookbook',
-                                                                                              class: 'icon2 icon-list-view2 overview-menu-item ellipsis selected' } } }
+                                                       attributes: { href: '/projects/ecookbook',
+                                                                     class: 'icon2 icon-list-view2 overview-menu-item ellipsis selected' } } }
   end
 
   def test_project_menu_with_additional_menu_items
@@ -53,23 +53,23 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
       Redmine::MenuManager.map :project_menu do |menu|
         menu.push :foo, { controller: 'projects', action: 'show' }, caption: 'Foo'
         menu.push :bar, { controller: 'projects', action: 'show' }, before: :activity
-        menu.push :hello, { controller: 'projects', action: 'show' }, caption: Proc.new {|p| p.name.upcase }, after: :bar
+        menu.push :hello, { controller: 'projects', action: 'show' }, caption: Proc.new { |p| p.name.upcase }, after: :bar
       end
 
       get 'projects/ecookbook'
       assert_tag :div, attributes: { id: 'main-menu' },
                        descendant: { tag: 'li', child: { tag: 'a', content: 'Foo',
-                                                                               attributes: { class: 'foo-menu-item ellipsis' } } }
+                                                         attributes: { class: 'foo-menu-item ellipsis' } } }
 
       assert_tag :div, attributes: { id: 'main-menu' },
                        descendant: { tag: 'li', child: { tag: 'a', content: 'Bar',
-                                                                               attributes: { class: 'bar-menu-item ellipsis' } },
-                                                      before: { tag: 'li', child: { tag: 'a', content: 'ECOOKBOOK' } } }
+                                                         attributes: { class: 'bar-menu-item ellipsis' } },
+                                     before: { tag: 'li', child: { tag: 'a', content: 'ECOOKBOOK' } } }
 
       assert_tag :div, attributes: { id: 'main-menu' },
                        descendant: { tag: 'li', child: { tag: 'a', content: 'ECOOKBOOK',
-                                                                               attributes: { class: 'hello-menu-item ellipsis' } },
-                                                      before: { tag: 'li', child: { tag: 'a', content: 'Activity' } } }
+                                                         attributes: { class: 'hello-menu-item ellipsis' } },
+                                     before: { tag: 'li', child: { tag: 'a', content: 'Activity' } } }
 
       # Remove the menu items
       Redmine::MenuManager.map :project_menu do |menu|
@@ -89,11 +89,11 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
     end
 
     base_size = Redmine::MenuManager.items(:some_menu).size
-    list.push({ name: :foo, url: {controller: 'projects', action: 'show'}, options: {caption: 'Foo'}})
+    list.push(name: :foo, url: { controller: 'projects', action: 'show' }, options: { caption: 'Foo' })
     assert_equal base_size + 1, Redmine::MenuManager.items(:some_menu).size
-    list.push({ name: :bar, url: {controller: 'projects', action: 'show'}, options: {caption: 'Bar'}})
+    list.push(name: :bar, url: { controller: 'projects', action: 'show' }, options: { caption: 'Bar' })
     assert_equal base_size + 2, Redmine::MenuManager.items(:some_menu).size
-    list.push({ name: :hello, url: {controller: 'projects', action: 'show'}, options: {caption: 'Hello'}})
+    list.push(name: :hello, url: { controller: 'projects', action: 'show' }, options: { caption: 'Hello' })
     assert_equal base_size + 3, Redmine::MenuManager.items(:some_menu).size
     list.pop
     assert_equal base_size + 2, Redmine::MenuManager.items(:some_menu).size
@@ -101,7 +101,7 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
 
   def test_dynamic_menu_map_deferred
     assert_no_difference 'Redmine::MenuManager.items(:some_menu).size' do
-      Redmine::MenuManager.map(:some_other_menu).push :baz, {controller: 'projects', action: 'show'}, caption: 'Baz'
+      Redmine::MenuManager.map(:some_other_menu).push :baz, { controller: 'projects', action: 'show' }, caption: 'Baz'
       Redmine::MenuManager.map(:some_other_menu).delete :baz
     end
   end

--- a/test/integration/lib/redmine/menu_manager_test.rb
+++ b/test/integration/lib/redmine/menu_manager_test.rb
@@ -37,39 +37,39 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
     Setting.available_languages = [:de, :en]
     get 'projects/ecookbook', { }, 'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'
 
-    assert_tag :div, :attributes => { :id => 'main-menu' },
-                     :descendant => { :tag => 'li', :child => { :tag => 'a', :content => ll('de', :label_activity),
-                                                                             :attributes => { :href => '/projects/ecookbook/activity',
-                                                                                              :class => 'icon2 icon-yes activity-menu-item ellipsis' } } }
-    assert_tag :div, :attributes => { :id => 'main-menu' },
-                     :descendant => { :tag => 'li', :child => { :tag => 'a', :content => ll('de', :label_overview),
-                                                                             :attributes => { :href => '/projects/ecookbook',
-                                                                                              :class => 'icon2 icon-list-view2 overview-menu-item ellipsis selected' } } }
+    assert_tag :div, attributes: { id: 'main-menu' },
+                     descendant: { tag: 'li', child: { tag: 'a', content: ll('de', :label_activity),
+                                                                             attributes: { href: '/projects/ecookbook/activity',
+                                                                                              class: 'icon2 icon-yes activity-menu-item ellipsis' } } }
+    assert_tag :div, attributes: { id: 'main-menu' },
+                     descendant: { tag: 'li', child: { tag: 'a', content: ll('de', :label_overview),
+                                                                             attributes: { href: '/projects/ecookbook',
+                                                                                              class: 'icon2 icon-list-view2 overview-menu-item ellipsis selected' } } }
   end
 
   def test_project_menu_with_additional_menu_items
     Setting.default_language = 'en'
     assert_no_difference 'Redmine::MenuManager.items(:project_menu).size' do
       Redmine::MenuManager.map :project_menu do |menu|
-        menu.push :foo, { :controller => 'projects', :action => 'show' }, :caption => 'Foo'
-        menu.push :bar, { :controller => 'projects', :action => 'show' }, :before => :activity
-        menu.push :hello, { :controller => 'projects', :action => 'show' }, :caption => Proc.new {|p| p.name.upcase }, :after => :bar
+        menu.push :foo, { controller: 'projects', action: 'show' }, caption: 'Foo'
+        menu.push :bar, { controller: 'projects', action: 'show' }, before: :activity
+        menu.push :hello, { controller: 'projects', action: 'show' }, caption: Proc.new {|p| p.name.upcase }, after: :bar
       end
 
       get 'projects/ecookbook'
-      assert_tag :div, :attributes => { :id => 'main-menu' },
-                       :descendant => { :tag => 'li', :child => { :tag => 'a', :content => 'Foo',
-                                                                               :attributes => { :class => 'foo-menu-item ellipsis' } } }
+      assert_tag :div, attributes: { id: 'main-menu' },
+                       descendant: { tag: 'li', child: { tag: 'a', content: 'Foo',
+                                                                               attributes: { class: 'foo-menu-item ellipsis' } } }
 
-      assert_tag :div, :attributes => { :id => 'main-menu' },
-                       :descendant => { :tag => 'li', :child => { :tag => 'a', :content => 'Bar',
-                                                                               :attributes => { :class => 'bar-menu-item ellipsis' } },
-                                                      :before => { :tag => 'li', :child => { :tag => 'a', :content => 'ECOOKBOOK' } } }
+      assert_tag :div, attributes: { id: 'main-menu' },
+                       descendant: { tag: 'li', child: { tag: 'a', content: 'Bar',
+                                                                               attributes: { class: 'bar-menu-item ellipsis' } },
+                                                      before: { tag: 'li', child: { tag: 'a', content: 'ECOOKBOOK' } } }
 
-      assert_tag :div, :attributes => { :id => 'main-menu' },
-                       :descendant => { :tag => 'li', :child => { :tag => 'a', :content => 'ECOOKBOOK',
-                                                                               :attributes => { :class => 'hello-menu-item ellipsis' } },
-                                                      :before => { :tag => 'li', :child => { :tag => 'a', :content => 'Activity' } } }
+      assert_tag :div, attributes: { id: 'main-menu' },
+                       descendant: { tag: 'li', child: { tag: 'a', content: 'ECOOKBOOK',
+                                                                               attributes: { class: 'hello-menu-item ellipsis' } },
+                                                      before: { tag: 'li', child: { tag: 'a', content: 'Activity' } } }
 
       # Remove the menu items
       Redmine::MenuManager.map :project_menu do |menu|
@@ -89,11 +89,11 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
     end
 
     base_size = Redmine::MenuManager.items(:some_menu).size
-    list.push({ :name => :foo, :url => {:controller => 'projects', :action => 'show'}, :options => {:caption => 'Foo'}})
+    list.push({ name: :foo, url: {controller: 'projects', action: 'show'}, options: {caption: 'Foo'}})
     assert_equal base_size + 1, Redmine::MenuManager.items(:some_menu).size
-    list.push({ :name => :bar, :url => {:controller => 'projects', :action => 'show'}, :options => {:caption => 'Bar'}})
+    list.push({ name: :bar, url: {controller: 'projects', action: 'show'}, options: {caption: 'Bar'}})
     assert_equal base_size + 2, Redmine::MenuManager.items(:some_menu).size
-    list.push({ :name => :hello, :url => {:controller => 'projects', :action => 'show'}, :options => {:caption => 'Hello'}})
+    list.push({ name: :hello, url: {controller: 'projects', action: 'show'}, options: {caption: 'Hello'}})
     assert_equal base_size + 3, Redmine::MenuManager.items(:some_menu).size
     list.pop
     assert_equal base_size + 2, Redmine::MenuManager.items(:some_menu).size
@@ -101,7 +101,7 @@ class MenuManagerTest < ActionDispatch::IntegrationTest
 
   def test_dynamic_menu_map_deferred
     assert_no_difference 'Redmine::MenuManager.items(:some_menu).size' do
-      Redmine::MenuManager.map(:some_other_menu).push :baz, {:controller => 'projects', :action => 'show'}, :caption => 'Baz'
+      Redmine::MenuManager.map(:some_other_menu).push :baz, {controller: 'projects', action: 'show'}, caption: 'Baz'
       Redmine::MenuManager.map(:some_other_menu).delete :baz
     end
   end

--- a/test/integration/lib/redmine/themes_test.rb
+++ b/test/integration/lib/redmine/themes_test.rb
@@ -48,16 +48,16 @@ class ThemesTest < ActionDispatch::IntegrationTest
     get '/'
 
     assert_response :success
-    assert_tag :tag => 'link',
-      :attributes => {:href => '/assets/default.css'}
+    assert_tag tag: 'link',
+      attributes: {href: '/assets/default.css'}
   end
 
   should_eventually 'test_without_theme_js' do
     get '/'
 
     assert_response :success
-    assert_no_tag :tag => 'script',
-      :attributes => {:src => '/assets/default.js'}
+    assert_no_tag tag: 'script',
+      attributes: {src: '/assets/default.js'}
   end
 
   should_eventually 'test_with_theme_js' do
@@ -67,8 +67,8 @@ class ThemesTest < ActionDispatch::IntegrationTest
       get '/'
 
       assert_response :success
-      assert_tag :tag => 'script',
-        :attributes => {:src => '/assets/default.js'}
+      assert_tag tag: 'script',
+        attributes: {src: '/assets/default.js'}
     ensure
       @theme.javascripts.delete 'theme'
     end
@@ -81,10 +81,10 @@ class ThemesTest < ActionDispatch::IntegrationTest
       get '/'
 
       assert_response :success
-      assert_tag :tag => 'link',
-        :attributes => {:src => '/foo/assets/default.js'}
-      assert_tag :tag => 'script',
-        :attributes => {:src => '/foo/assets/default.js'}
+      assert_tag tag: 'link',
+        attributes: {src: '/foo/assets/default.js'}
+      assert_tag tag: 'script',
+        attributes: {src: '/foo/assets/default.js'}
     ensure
       OpenProject::Configuration['rails_relative_url_root'] = ''
     end

--- a/test/integration/lib/redmine/themes_test.rb
+++ b/test/integration/lib/redmine/themes_test.rb
@@ -49,7 +49,7 @@ class ThemesTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_tag tag: 'link',
-      attributes: {href: '/assets/default.css'}
+               attributes: { href: '/assets/default.css' }
   end
 
   should_eventually 'test_without_theme_js' do
@@ -57,7 +57,7 @@ class ThemesTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_no_tag tag: 'script',
-      attributes: {src: '/assets/default.js'}
+                  attributes: { src: '/assets/default.js' }
   end
 
   should_eventually 'test_with_theme_js' do
@@ -68,7 +68,7 @@ class ThemesTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_tag tag: 'script',
-        attributes: {src: '/assets/default.js'}
+                 attributes: { src: '/assets/default.js' }
     ensure
       @theme.javascripts.delete 'theme'
     end
@@ -82,9 +82,9 @@ class ThemesTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_tag tag: 'link',
-        attributes: {src: '/foo/assets/default.js'}
+                 attributes: { src: '/foo/assets/default.js' }
       assert_tag tag: 'script',
-        attributes: {src: '/foo/assets/default.js'}
+                 attributes: { src: '/foo/assets/default.js' }
     ensure
       OpenProject::Configuration['rails_relative_url_root'] = ''
     end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -29,653 +29,645 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class RoutingTest < ActionDispatch::IntegrationTest
-  context "activities" do
-    should route(:get, "/activity").to( controller: 'activities',
-                                        action: 'index' )
-    should route(:get, "/activity.atom").to( controller: 'activities',
-                                             action: 'index',
-                                             format: 'atom' )
+  context 'activities' do
+    should route(:get, '/activity').to(controller: 'activities',
+                                       action: 'index')
+    should route(:get, '/activity.atom').to(controller: 'activities',
+                                            action: 'index',
+                                            format: 'atom')
 
-    should "route /activities to activities#index" do
-      assert_recognizes({ controller: 'activities', action: 'index' }, "/activities")
+    should 'route /activities to activities#index' do
+      assert_recognizes({ controller: 'activities', action: 'index' }, '/activities')
     end
-    should "route /activites.atom to activities#index" do
-      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom' }, "/activities.atom")
+    should 'route /activites.atom to activities#index' do
+      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom' }, '/activities.atom')
     end
 
-    should route(:get, "projects/eCookbook/activity").to( controller: 'activities',
-                                                          action: 'index',
-                                                          project_id: "eCookbook" )
+    should route(:get, 'projects/eCookbook/activity').to(controller: 'activities',
+                                                         action: 'index',
+                                                         project_id: 'eCookbook')
 
-    should route(:get, "projects/eCookbook/activity.atom").to( controller: 'activities',
-                                                               action: 'index',
-                                                               project_id: "eCookbook",
-                                                               format: 'atom')
+    should route(:get, 'projects/eCookbook/activity.atom').to(controller: 'activities',
+                                                              action: 'index',
+                                                              project_id: 'eCookbook',
+                                                              format: 'atom')
 
-    should "route project/eCookbook/activities to activities#index" do
-      assert_recognizes({ controller: 'activities', action: 'index', project_id: "eCookbook" }, "/projects/eCookbook/activities")
+    should 'route project/eCookbook/activities to activities#index' do
+      assert_recognizes({ controller: 'activities', action: 'index', project_id: 'eCookbook' }, '/projects/eCookbook/activities')
     end
-    should "route project/eCookbook/activites.atom to activities#index" do
-      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom', project_id: "eCookbook" }, "/projects/eCookbook/activities.atom")
+    should 'route project/eCookbook/activites.atom to activities#index' do
+      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom', project_id: 'eCookbook' }, '/projects/eCookbook/activities.atom')
     end
   end
 
-  context "attachments" do
-    should route(:get, "/attachments/1").to( controller: 'attachments',
-                                             action: 'show',
-                                             id: '1')
-    should route(:get, "/attachments/1/filename.ext").to( controller: 'attachments',
-                                                          action: 'show',
-                                                          id: '1',
-                                                          filename: 'filename.ext' )
-    should route(:get, "/attachments/1/download").to( controller: 'attachments',
-                                                      action: 'download',
-                                                      id: '1' )
-    should route(:get, "/attachments/1/download/filename.ext").to( controller: 'attachments',
-                                                                   action: 'download',
-                                                                   id: '1',
-                                                                   filename: 'filename.ext' )
-    should "redirect /atttachments/download/1 to /attachments/1/download" do
+  context 'attachments' do
+    should route(:get, '/attachments/1').to(controller: 'attachments',
+                                            action: 'show',
+                                            id: '1')
+    should route(:get, '/attachments/1/filename.ext').to(controller: 'attachments',
+                                                         action: 'show',
+                                                         id: '1',
+                                                         filename: 'filename.ext')
+    should route(:get, '/attachments/1/download').to(controller: 'attachments',
+                                                     action: 'download',
+                                                     id: '1')
+    should route(:get, '/attachments/1/download/filename.ext').to(controller: 'attachments',
+                                                                  action: 'download',
+                                                                  id: '1',
+                                                                  filename: 'filename.ext')
+    should 'redirect /atttachments/download/1 to /attachments/1/download' do
       get '/attachments/download/1'
       assert_redirected_to '/attachments/1/download'
     end
 
-    should "redirect /atttachments/download/1/filename.ext to /attachments/1/download/filename.ext" do
+    should 'redirect /atttachments/download/1/filename.ext to /attachments/1/download/filename.ext' do
       get '/attachments/download/1/filename.ext'
       assert_redirected_to '/attachments/1/download/filename.ext'
     end
 
-    should route(:delete, "/attachments/1").to( controller: 'attachments',
-                                                action: 'destroy',
-                                                id: '1')
+    should route(:delete, '/attachments/1').to(controller: 'attachments',
+                                               action: 'destroy',
+                                               id: '1')
   end
 
-  context "boards" do
-    should route(:get, "/projects/world_domination/boards").to( controller: 'boards',
-                                                                action: 'index',
+  context 'boards' do
+    should route(:get, '/projects/world_domination/boards').to(controller: 'boards',
+                                                               action: 'index',
+                                                               project_id: 'world_domination')
+    should route(:get, '/projects/world_domination/boards/new').to(controller: 'boards',
+                                                                   action: 'new',
+                                                                   project_id: 'world_domination')
+    should route(:post, '/projects/world_domination/boards').to(controller: 'boards',
+                                                                action: 'create',
                                                                 project_id: 'world_domination')
-    should route(:get, "/projects/world_domination/boards/new").to( controller: 'boards',
-                                                                    action: 'new',
-                                                                    project_id: 'world_domination')
-    should route(:post, "/projects/world_domination/boards").to( controller: 'boards',
-                                                                 action: 'create',
-                                                                 project_id: 'world_domination')
-    should route(:get, "/projects/world_domination/boards/44").to( controller: 'boards',
-                                                                   action: 'show',
-                                                                   project_id: 'world_domination',
-                                                                   id: '44')
-    should route(:get, "/projects/world_domination/boards/44.atom").to( controller: 'boards',
-                                                                        action: 'show',
-                                                                        project_id: 'world_domination',
-                                                                        id: '44',
-                                                                        format: 'atom')
-    should route(:get, "/projects/world_domination/boards/44/edit").to( controller: 'boards',
+    should route(:get, '/projects/world_domination/boards/44').to(controller: 'boards',
+                                                                  action: 'show',
+                                                                  project_id: 'world_domination',
+                                                                  id: '44')
+    should route(:get, '/projects/world_domination/boards/44.atom').to(controller: 'boards',
+                                                                       action: 'show',
+                                                                       project_id: 'world_domination',
+                                                                       id: '44',
+                                                                       format: 'atom')
+    should route(:get, '/projects/world_domination/boards/44/edit').to(controller: 'boards',
                                                                        action: 'edit',
                                                                        project_id: 'world_domination',
                                                                        id: '44')
-    should route(:put, "/projects/world_domination/boards/44").to( controller: 'boards',
-                                                                   action: 'update',
-                                                                   project_id: 'world_domination',
-                                                                        id: '44')
-    should route(:delete, "/projects/world_domination/boards/44").to( controller: 'boards',
-                                                                      action: 'destroy',
-                                                                      project_id: 'world_domination',
-                                                                      id: '44')
-
+    should route(:put, '/projects/world_domination/boards/44').to(controller: 'boards',
+                                                                  action: 'update',
+                                                                  project_id: 'world_domination',
+                                                                  id: '44')
+    should route(:delete, '/projects/world_domination/boards/44').to(controller: 'boards',
+                                                                     action: 'destroy',
+                                                                     project_id: 'world_domination',
+                                                                     id: '44')
   end
 
-  context "issues" do
+  context 'issues' do
     # Extra actions
-    should route(:get, "/issues/changes").to( controller: 'journals',
-                                              action: 'index')
+    should route(:get, '/issues/changes').to(controller: 'journals',
+                                             action: 'index')
   end
 
+  context 'enumerations' do
+    context 'within admin' do
+      should route(:get, 'admin/enumerations').to(controller: 'enumerations',
+                                                  action: 'index')
 
-  context "enumerations" do
-    context "within admin" do
-      should route(:get, "admin/enumerations").to( controller: 'enumerations',
-                                                   action: 'index' )
+      should route(:get, 'admin/enumerations/new').to(controller: 'enumerations',
+                                                      action: 'new')
 
-      should route(:get, "admin/enumerations/new").to( controller: 'enumerations',
-                                                      action: 'new' )
+      should route(:post, 'admin/enumerations').to(controller: 'enumerations',
+                                                   action: 'create')
 
-      should route(:post, "admin/enumerations").to( controller: 'enumerations',
-                                                    action: 'create' )
+      should route(:get, 'admin/enumerations/1/edit').to(controller: 'enumerations',
+                                                         action: 'edit',
+                                                         id: '1')
 
-      should route(:get, "admin/enumerations/1/edit").to( controller: 'enumerations',
-                                                          action: 'edit',
-                                                          id: '1' )
+      should route(:put, 'admin/enumerations/1').to(controller: 'enumerations',
+                                                    action: 'update',
+                                                    id: '1')
 
-      should route(:put, "admin/enumerations/1").to( controller: 'enumerations',
-                                                     action: 'update',
-                                                     id: '1' )
-
-      should route(:delete, "admin/enumerations/1").to( controller: 'enumerations',
-                                                        action: 'destroy',
-                                                        id: '1' )
+      should route(:delete, 'admin/enumerations/1').to(controller: 'enumerations',
+                                                       action: 'destroy',
+                                                       id: '1')
     end
   end
 
-  context "roles" do
-    context "witin admin" do
-      should route(:get, "admin/roles").to( controller: 'roles',
-                                            action: 'index' )
+  context 'roles' do
+    context 'witin admin' do
+      should route(:get, 'admin/roles').to(controller: 'roles',
+                                           action: 'index')
 
-      should route(:get, "admin/roles/new").to( controller: 'roles',
-                                                action: 'new' )
+      should route(:get, 'admin/roles/new').to(controller: 'roles',
+                                               action: 'new')
 
-      should route(:post, "admin/roles").to( controller: 'roles',
-                                             action: 'create' )
+      should route(:post, 'admin/roles').to(controller: 'roles',
+                                            action: 'create')
 
-      should route(:get, "admin/roles/1/edit").to( controller: 'roles',
-                                                   action: 'edit',
-                                                   id: '1' )
+      should route(:get, 'admin/roles/1/edit').to(controller: 'roles',
+                                                  action: 'edit',
+                                                  id: '1')
 
-      should route(:put, "admin/roles/1").to( controller: 'roles',
-                                              action: 'update',
-                                              id: '1' )
+      should route(:put, 'admin/roles/1').to(controller: 'roles',
+                                             action: 'update',
+                                             id: '1')
 
-      should route(:delete, "admin/roles/1").to( controller: 'roles',
-                                                 action: 'destroy',
-                                                 id: '1' )
+      should route(:delete, 'admin/roles/1').to(controller: 'roles',
+                                                action: 'destroy',
+                                                id: '1')
 
-      should route(:get, "admin/roles/report").to( controller: 'roles',
-                                                   action: 'report' )
+      should route(:get, 'admin/roles/report').to(controller: 'roles',
+                                                  action: 'report')
 
-      should route(:put, "admin/roles").to( controller: 'roles',
-                                            action: 'bulk_update' )
+      should route(:put, 'admin/roles').to(controller: 'roles',
+                                           action: 'bulk_update')
     end
   end
 
-
-  context "journals" do
-    should route(:get, "/journals/100/diff/description").to( controller: 'journals',
-                                                             action: 'diff',
-                                                             id: '100',
-                                                             field: 'description' )
+  context 'journals' do
+    should route(:get, '/journals/100/diff/description').to(controller: 'journals',
+                                                            action: 'diff',
+                                                            id: '100',
+                                                            field: 'description')
   end
 
-  context "members" do
-    context "project scoped" do
-      should route(:post, "/projects/5234/members").to( controller: 'members',
-                                                        action: 'create',
-                                                        project_id: '5234' )
+  context 'members' do
+    context 'project scoped' do
+      should route(:post, '/projects/5234/members').to(controller: 'members',
+                                                       action: 'create',
+                                                       project_id: '5234')
 
-      should route(:get, "/projects/5234/members/autocomplete").to( controller: 'members',
-                                                                    action: 'autocomplete',
-                                                                    project_id: '5234' )
+      should route(:get, '/projects/5234/members/autocomplete').to(controller: 'members',
+                                                                   action: 'autocomplete',
+                                                                   project_id: '5234')
     end
 
-    should route(:put, "/members/5234").to( controller: 'members',
-                                            action: 'update',
-                                            id: '5234' )
+    should route(:put, '/members/5234').to(controller: 'members',
+                                           action: 'update',
+                                           id: '5234')
 
-    should route(:delete, "/members/5234").to( controller: 'members',
-                                               action: 'destroy',
-                                               id: '5234' )
-  end
-
-  context "messages" do
-    context "project scoped" do
-      should route(:get, "/boards/lala/topics/new").to( controller: 'messages',
-                                                       action: 'new',
-                                                       board_id: 'lala' )
-
-      should route(:post, "/boards/lala/topics").to( controller: 'messages',
-                                                     action: 'create',
-                                                     board_id: 'lala' )
-    end
-
-    should route(:get, "/topics/2").to( controller: 'messages',
-                                        action: 'show',
-                                        id: '2' )
-
-    should route(:get, "/topics/22/edit").to( controller: 'messages',
-                                              action: 'edit',
-                                              id: '22' )
-
-    should route(:put, "/topics/22").to( controller: 'messages',
-                                         action: 'update',
-                                         id: '22' )
-
-    should route(:delete, "/topics/555").to( controller: 'messages',
-                                             action: 'destroy',
-                                             id: '555' )
-
-    should route(:get, "/topics/22/quote").to( controller: 'messages',
-                                               action: 'quote',
-                                               id: '22' )
-
-    should route(:post, "/topics/555/reply").to( controller: 'messages',
-                                                 action: 'reply',
-                                                 id: '555' )
-  end
-
-  context "news" do
-    context "project scoped" do
-      should route(:get, "/projects/567/news").to( controller: 'news',
-                                                   action: 'index',
-                                                   project_id: '567' )
-
-      should route(:get, "/projects/567/news.atom").to( controller: 'news',
-                                                        action: 'index',
-                                                        format: 'atom',
-                                                        project_id: '567' )
-
-      should route(:get, "/projects/567/news/new").to( controller: 'news',
-                                                       action: 'new',
-                                                       project_id: '567' )
-
-      should route(:post, "/projects/567/news").to( controller: 'news',
-                                                    action: 'create',
-                                                    project_id: '567' )
-
-    end
-
-    should route(:get, "/news").to( controller: 'news',
-                                    action: 'index' )
-
-    should route(:get, "/news.atom").to( controller: 'news',
-                                         action: 'index',
-                                         format: 'atom' )
-
-    should route(:get, "/news/2").to( controller: 'news',
-                                      action: 'show',
-                                      id: '2' )
-
-    should route(:get, "/news/234").to( controller: 'news',
-                                        action: 'show',
-                                        id: '234' )
-
-    should route(:get, "/news/567/edit").to( controller: 'news',
-                                             action: 'edit',
-                                             id: '567' )
-
-    should route(:put, "/news/567").to( controller: 'news',
-                                        action: 'update',
-                                        id: '567' )
-
-
-    should route(:delete, "/news/567").to( controller: 'news',
-                                           action: 'destroy',
-                                           id: '567' )
-
-  end
-
-  context "news/comments" do
-    context "news scoped" do
-      should route(:post, "/news/567/comments").to( controller: 'news/comments',
-                                                    action: 'create',
-                                                    news_id: '567' )
-
-    end
-
-    should route(:delete, "/comments/15").to( controller: 'news/comments',
+    should route(:delete, '/members/5234').to(controller: 'members',
                                               action: 'destroy',
-                                              id: '15' )
+                                              id: '5234')
   end
 
-  context "project_enumerations" do
-    context "project_scoped" do
-      should route(:put, "/projects/64/enumerations").to( controller: 'project_enumerations',
-                                                          action: 'update',
-                                                          project_id: '64' )
+  context 'messages' do
+    context 'project scoped' do
+      should route(:get, '/boards/lala/topics/new').to(controller: 'messages',
+                                                       action: 'new',
+                                                       board_id: 'lala')
 
-      should route(:delete, "/projects/64/enumerations").to( controller: 'project_enumerations',
-                                                             action: 'destroy',
-                                                             project_id: '64' )
+      should route(:post, '/boards/lala/topics').to(controller: 'messages',
+                                                    action: 'create',
+                                                    board_id: 'lala')
+    end
+
+    should route(:get, '/topics/2').to(controller: 'messages',
+                                       action: 'show',
+                                       id: '2')
+
+    should route(:get, '/topics/22/edit').to(controller: 'messages',
+                                             action: 'edit',
+                                             id: '22')
+
+    should route(:put, '/topics/22').to(controller: 'messages',
+                                        action: 'update',
+                                        id: '22')
+
+    should route(:delete, '/topics/555').to(controller: 'messages',
+                                            action: 'destroy',
+                                            id: '555')
+
+    should route(:get, '/topics/22/quote').to(controller: 'messages',
+                                              action: 'quote',
+                                              id: '22')
+
+    should route(:post, '/topics/555/reply').to(controller: 'messages',
+                                                action: 'reply',
+                                                id: '555')
+  end
+
+  context 'news' do
+    context 'project scoped' do
+      should route(:get, '/projects/567/news').to(controller: 'news',
+                                                  action: 'index',
+                                                  project_id: '567')
+
+      should route(:get, '/projects/567/news.atom').to(controller: 'news',
+                                                       action: 'index',
+                                                       format: 'atom',
+                                                       project_id: '567')
+
+      should route(:get, '/projects/567/news/new').to(controller: 'news',
+                                                      action: 'new',
+                                                      project_id: '567')
+
+      should route(:post, '/projects/567/news').to(controller: 'news',
+                                                   action: 'create',
+                                                   project_id: '567')
+    end
+
+    should route(:get, '/news').to(controller: 'news',
+                                   action: 'index')
+
+    should route(:get, '/news.atom').to(controller: 'news',
+                                        action: 'index',
+                                        format: 'atom')
+
+    should route(:get, '/news/2').to(controller: 'news',
+                                     action: 'show',
+                                     id: '2')
+
+    should route(:get, '/news/234').to(controller: 'news',
+                                       action: 'show',
+                                       id: '234')
+
+    should route(:get, '/news/567/edit').to(controller: 'news',
+                                            action: 'edit',
+                                            id: '567')
+
+    should route(:put, '/news/567').to(controller: 'news',
+                                       action: 'update',
+                                       id: '567')
+
+    should route(:delete, '/news/567').to(controller: 'news',
+                                          action: 'destroy',
+                                          id: '567')
+  end
+
+  context 'news/comments' do
+    context 'news scoped' do
+      should route(:post, '/news/567/comments').to(controller: 'news/comments',
+                                                   action: 'create',
+                                                   news_id: '567')
+    end
+
+    should route(:delete, '/comments/15').to(controller: 'news/comments',
+                                             action: 'destroy',
+                                             id: '15')
+  end
+
+  context 'project_enumerations' do
+    context 'project_scoped' do
+      should route(:put, '/projects/64/enumerations').to(controller: 'project_enumerations',
+                                                         action: 'update',
+                                                         project_id: '64')
+
+      should route(:delete, '/projects/64/enumerations').to(controller: 'project_enumerations',
+                                                            action: 'destroy',
+                                                            project_id: '64')
     end
   end
 
-  context "timelogs" do
-    should route(:get, "/time_entries").to( controller: 'timelog',
-                                            action: 'index' )
+  context 'timelogs' do
+    should route(:get, '/time_entries').to(controller: 'timelog',
+                                           action: 'index')
 
-    should route(:get, "/time_entries.csv").to( controller: 'timelog',
+    should route(:get, '/time_entries.csv').to(controller: 'timelog',
+                                               action: 'index',
+                                               format: 'csv')
+
+    should route(:get, '/time_entries.atom').to(controller: 'timelog',
                                                 action: 'index',
-                                                format: 'csv' )
+                                                format: 'atom')
 
-    should route(:get, "/time_entries.atom").to( controller: 'timelog',
-                                                 action: 'index',
-                                                 format: 'atom' )
+    should route(:get, '/time_entries/new').to(controller: 'timelog',
+                                               action: 'new')
 
-    should route(:get, "/time_entries/new").to( controller: 'timelog',
-                                               action: 'new' )
+    should route(:get, '/time_entries/22/edit').to(controller: 'timelog',
+                                                   action: 'edit',
+                                                   id: '22')
 
-    should route(:get, "/time_entries/22/edit").to( controller: 'timelog',
-                                                    action: 'edit',
-                                                    id: '22' )
+    should route(:post, '/time_entries').to(controller: 'timelog',
+                                            action: 'create')
 
-    should route(:post, "/time_entries").to( controller: 'timelog',
-                                             action: 'create' )
+    should route(:put, '/time_entries/22').to(controller: 'timelog',
+                                              action: 'update',
+                                              id: '22')
 
-    should route(:put, "/time_entries/22").to( controller: 'timelog',
-                                               action: 'update',
-                                               id: '22' )
+    should route(:delete, '/time_entries/55').to(controller: 'timelog',
+                                                 action: 'destroy',
+                                                 id: '55')
 
-    should route(:delete, "/time_entries/55").to( controller: 'timelog',
-                                                  action: 'destroy',
-                                                  id: '55' )
+    context 'project scoped' do
+      should route(:get, '/projects/567/time_entries').to(controller: 'timelog',
+                                                          action: 'index',
+                                                          project_id: '567')
 
-    context "project scoped" do
-      should route(:get, "/projects/567/time_entries").to( controller: 'timelog',
-                                                           action: 'index',
-                                                           project_id: '567' )
+      should route(:get, '/projects/567/time_entries.csv').to(controller: 'timelog',
+                                                              action: 'index',
+                                                              project_id: '567',
+                                                              format: 'csv')
 
-      should route(:get, "/projects/567/time_entries.csv").to( controller: 'timelog',
+      should route(:get, '/projects/567/time_entries.atom').to(controller: 'timelog',
                                                                action: 'index',
                                                                project_id: '567',
-                                                               format: 'csv' )
+                                                               format: 'atom')
 
-      should route(:get, "/projects/567/time_entries.atom").to( controller: 'timelog',
-                                                                action: 'index',
-                                                                project_id: '567',
-                                                                format: 'atom' )
+      should route(:get, '/projects/567/time_entries/new').to(controller: 'timelog',
+                                                              action: 'new',
+                                                              project_id: '567')
 
-      should route(:get, "/projects/567/time_entries/new").to( controller: 'timelog',
-                                                               action: 'new',
-                                                               project_id: '567' )
+      should route(:get, '/projects/567/time_entries/22/edit').to(controller: 'timelog',
+                                                                  action: 'edit',
+                                                                  id: '22',
+                                                                  project_id: '567')
 
-      should route(:get, "/projects/567/time_entries/22/edit").to( controller: 'timelog',
-                                                                   action: 'edit',
-                                                                   id: '22',
-                                                                   project_id: '567' )
+      should route(:post, '/projects/567/time_entries').to(controller: 'timelog',
+                                                           action: 'create',
+                                                           project_id: '567')
 
-      should route(:post, "/projects/567/time_entries").to( controller: 'timelog',
-                                                            action: 'create',
-                                                            project_id: '567' )
+      should route(:put, '/projects/567/time_entries/22').to(controller: 'timelog',
+                                                             action: 'update',
+                                                             id: '22',
+                                                             project_id: '567')
 
-      should route(:put, "/projects/567/time_entries/22").to( controller: 'timelog',
-                                                              action: 'update',
-                                                              id: '22',
-                                                              project_id: '567' )
-
-      should route(:delete, "/projects/567/time_entries/55").to( controller: 'timelog',
-                                                                 action: 'destroy',
-                                                                 id: '55',
-                                                                 project_id: '567' )
+      should route(:delete, '/projects/567/time_entries/55').to(controller: 'timelog',
+                                                                action: 'destroy',
+                                                                id: '55',
+                                                                project_id: '567')
     end
   end
 
+  context 'time_entries/reports' do
+    should route(:get, '/time_entries/report').to(controller: 'time_entries/reports',
+                                                  action: 'show')
+    should route(:get, '/projects/567/time_entries/report').to(controller: 'time_entries/reports',
+                                                               action: 'show',
+                                                               project_id: '567')
 
-  context "time_entries/reports" do
-    should route(:get, "/time_entries/report").to( controller: 'time_entries/reports',
-                                                   action: 'show' )
-    should route(:get, "/projects/567/time_entries/report").to( controller: 'time_entries/reports',
-                                                                action: 'show',
-                                                                project_id: '567' )
-
-    should route(:get, "/projects/567/time_entries/report.csv").to( controller: 'time_entries/reports',
-                                                                    action: 'show',
-                                                                    project_id: '567',
-                                                                    format: 'csv' )
+    should route(:get, '/projects/567/time_entries/report.csv').to(controller: 'time_entries/reports',
+                                                                   action: 'show',
+                                                                   project_id: '567',
+                                                                   format: 'csv')
   end
 
-  context "users" do
-    should route(:get, "/users").to( controller: 'users',
-                                     action: 'index' )
+  context 'users' do
+    should route(:get, '/users').to(controller: 'users',
+                                    action: 'index')
 
-    should route(:get, "/users.xml").to( controller: 'users',
-                                         action: 'index',
-                                         format: 'xml' )
+    should route(:get, '/users.xml').to(controller: 'users',
+                                        action: 'index',
+                                        format: 'xml')
 
-    should route(:get, "/users/44").to( controller: 'users',
-                                        action: 'show',
-                                        id: '44' )
+    should route(:get, '/users/44').to(controller: 'users',
+                                       action: 'show',
+                                       id: '44')
 
-    should route(:get, "/users/44.xml").to( controller: 'users',
+    should route(:get, '/users/44.xml').to(controller: 'users',
+                                           action: 'show',
+                                           id: '44',
+                                           format: 'xml')
+
+    should route(:get, '/users/current').to(controller: 'users',
                                             action: 'show',
-                                            id: '44',
-                                            format: 'xml' )
+                                            id: 'current')
 
-    should route(:get, "/users/current").to( controller: 'users',
-                                             action: 'show',
-                                             id: 'current' )
+    should route(:get, '/users/current.xml').to(controller: 'users',
+                                                action: 'show',
+                                                id: 'current',
+                                                format: 'xml')
 
-    should route(:get, "/users/current.xml").to( controller: 'users',
-                                                 action: 'show',
-                                                 id: 'current',
-                                                 format: 'xml' )
+    should route(:get, '/users/new').to(controller: 'users',
+                                        action: 'new')
 
-    should route(:get, "/users/new").to( controller: 'users',
-                                         action: 'new' )
+    should route(:get, '/users/444/edit').to(controller: 'users',
+                                             action: 'edit',
+                                             id: '444')
 
-    should route(:get, "/users/444/edit").to( controller: 'users',
-                                              action: 'edit',
-                                              id: '444' )
+    should route(:get, '/users/222/edit/membership').to(controller: 'users',
+                                                        action: 'edit',
+                                                        id: '222',
+                                                        tab: 'membership')
 
-    should route(:get, "/users/222/edit/membership").to( controller: 'users',
-                                                         action: 'edit',
-                                                         id: '222',
-                                                         tab: 'membership' )
+    should route(:post, '/users').to(controller: 'users',
+                                     action: 'create')
 
-    should route(:post, "/users").to( controller: 'users',
-                                      action: 'create' )
+    should route(:post, '/users.xml').to(controller: 'users',
+                                         action: 'create',
+                                         format: 'xml')
 
-    should route(:post, "/users.xml").to( controller: 'users',
-                                          action: 'create',
-                                          format: 'xml' )
+    should route(:post, '/users/123/memberships').to(controller: 'users',
+                                                     action: 'edit_membership',
+                                                     id: '123')
 
-    should route(:post, "/users/123/memberships").to( controller: 'users',
-                                                      action: 'edit_membership',
-                                                      id: '123' )
+    should route(:post, '/users/123/memberships/55').to(controller: 'users',
+                                                        action: 'edit_membership',
+                                                        id: '123',
+                                                        membership_id: '55')
 
-    should route(:post, "/users/123/memberships/55").to( controller: 'users',
-                                                         action: 'edit_membership',
-                                                         id: '123',
-                                                         membership_id: '55' )
+    should route(:post, '/users/567/memberships/12/destroy').to(controller: 'users',
+                                                                action: 'destroy_membership',
+                                                                id: '567',
+                                                                membership_id: '12')
 
-    should route(:post, "/users/567/memberships/12/destroy").to( controller: 'users',
-                                                                 action: 'destroy_membership',
-                                                                 id: '567',
-                                                                 membership_id: '12' )
+    should route(:put, '/users/444').to(controller: 'users',
+                                        action: 'update',
+                                        id: '444')
 
-    should route(:put, "/users/444").to( controller: 'users',
-                                         action: 'update',
-                                         id: '444' )
-
-    should route(:put, "/users/444.xml").to( controller: 'users',
-                                             action: 'update',
-                                             id: '444',
-                                             format: 'xml' )
+    should route(:put, '/users/444.xml').to(controller: 'users',
+                                            action: 'update',
+                                            id: '444',
+                                            format: 'xml')
   end
 
-  context "versions" do
-    should route(:get, "/versions/1").to( controller: 'versions',
-                                          action: 'show',
-                                          id: '1' )
+  context 'versions' do
+    should route(:get, '/versions/1').to(controller: 'versions',
+                                         action: 'show',
+                                         id: '1')
 
-    should route(:get, "/versions/1/edit").to( controller: 'versions',
-                                               action: 'edit',
-                                               id: '1' )
+    should route(:get, '/versions/1/edit').to(controller: 'versions',
+                                              action: 'edit',
+                                              id: '1')
 
-    should route(:put, "/versions/1").to( controller: 'versions',
-                                          action: 'update',
-                                          id: '1' )
+    should route(:put, '/versions/1').to(controller: 'versions',
+                                         action: 'update',
+                                         id: '1')
 
-    should route(:delete, "/versions/1").to( controller: 'versions',
-                                             action: 'destroy',
-                                             id: '1' )
+    should route(:delete, '/versions/1').to(controller: 'versions',
+                                            action: 'destroy',
+                                            id: '1')
 
-    should route(:get, "/versions/1/status_by").to( controller: 'versions',
-                                                    action: 'status_by',
-                                                    id: '1' )
+    should route(:get, '/versions/1/status_by').to(controller: 'versions',
+                                                   action: 'status_by',
+                                                   id: '1')
 
-    context "project" do
-      should route(:get, "/projects/foo/versions/new").to( controller: 'versions',
-                                                           action: 'new',
-                                                           project_id: 'foo' )
+    context 'project' do
+      should route(:get, '/projects/foo/versions/new').to(controller: 'versions',
+                                                          action: 'new',
+                                                          project_id: 'foo')
 
-      should route(:post, "/projects/foo/versions").to( controller: 'versions',
-                                                        action: 'create',
-                                                        project_id: 'foo' )
+      should route(:post, '/projects/foo/versions').to(controller: 'versions',
+                                                       action: 'create',
+                                                       project_id: 'foo')
 
-      should route(:put, "/projects/foo/versions/close_completed").to( controller: 'versions',
-                                                                       action: 'close_completed',
-                                                                       project_id: 'foo' )
+      should route(:put, '/projects/foo/versions/close_completed').to(controller: 'versions',
+                                                                      action: 'close_completed',
+                                                                      project_id: 'foo')
 
-      should route(:get, "/projects/foo/roadmap").to( controller: 'versions',
-                                                      action: 'index',
-                                                      project_id: 'foo' )
+      should route(:get, '/projects/foo/roadmap').to(controller: 'versions',
+                                                     action: 'index',
+                                                     project_id: 'foo')
     end
   end
 
   context "wiki (singular, project's pages)" do
-    context "within project" do
-      should route(:get, "/projects/567/wiki").to( controller: 'wiki',
-                                                   action: 'show',
-                                                   project_id: '567' )
+    context 'within project' do
+      should route(:get, '/projects/567/wiki').to(controller: 'wiki',
+                                                  action: 'show',
+                                                  project_id: '567')
 
-      should route(:get, "/projects/567/wiki/lalala").to( controller: 'wiki',
-                                                          action: 'show',
-                                                          project_id: '567',
-                                                          id: 'lalala' )
+      should route(:get, '/projects/567/wiki/lalala').to(controller: 'wiki',
+                                                         action: 'show',
+                                                         project_id: '567',
+                                                         id: 'lalala')
 
-      should route(:get, "/projects/567/wiki/my_page/edit").to( controller: 'wiki',
-                                                                action: 'edit',
-                                                                project_id: '567',
-                                                                id: 'my_page' )
+      should route(:get, '/projects/567/wiki/my_page/edit').to(controller: 'wiki',
+                                                               action: 'edit',
+                                                               project_id: '567',
+                                                               id: 'my_page')
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/history").to( controller: 'wiki',
-                                                                                action: 'history',
-                                                                                project_id: '1',
-                                                                                id: 'CookBook_documentation' )
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff").to( controller: 'wiki',
-                                                                             action: 'diff',
-                                                                             project_id: '1',
-                                                                             id: 'CookBook_documentation' )
-
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2").to( controller: 'wiki',
-                                                                               action: 'diff',
+      should route(:get, '/projects/1/wiki/CookBook_documentation/history').to(controller: 'wiki',
+                                                                               action: 'history',
                                                                                project_id: '1',
-                                                                               id: 'CookBook_documentation',
-                                                                               version: '2' )
+                                                                               id: 'CookBook_documentation')
+      should route(:get, '/projects/1/wiki/CookBook_documentation/diff').to(controller: 'wiki',
+                                                                            action: 'diff',
+                                                                            project_id: '1',
+                                                                            id: 'CookBook_documentation')
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2/vs/1").to( controller: 'wiki',
-                                                                                    action: 'diff',
-                                                                                    project_id: '1',
-                                                                                    id: 'CookBook_documentation',
-                                                                                    version: '2',
-                                                                                    version_from: '1')
+      should route(:get, '/projects/1/wiki/CookBook_documentation/diff/2').to(controller: 'wiki',
+                                                                              action: 'diff',
+                                                                              project_id: '1',
+                                                                              id: 'CookBook_documentation',
+                                                                              version: '2')
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/annotate/2").to( controller: 'wiki',
-                                                                                   action: 'annotate',
+      should route(:get, '/projects/1/wiki/CookBook_documentation/diff/2/vs/1').to(controller: 'wiki',
+                                                                                   action: 'diff',
                                                                                    project_id: '1',
                                                                                    id: 'CookBook_documentation',
-                                                                                   version: '2' )
+                                                                                   version: '2',
+                                                                                   version_from: '1')
 
-      should route(:get, "/projects/22/wiki/ladida/rename").to( controller: 'wiki',
-                                                                action: 'rename',
-                                                                project_id: '22',
-                                                                id: 'ladida' )
+      should route(:get, '/projects/1/wiki/CookBook_documentation/annotate/2').to(controller: 'wiki',
+                                                                                  action: 'annotate',
+                                                                                  project_id: '1',
+                                                                                  id: 'CookBook_documentation',
+                                                                                  version: '2')
 
-      should route(:get, "/projects/567/wiki/index").to( controller: 'wiki',
-                                                         action: 'index',
-                                                         project_id: '567' )
+      should route(:get, '/projects/22/wiki/ladida/rename').to(controller: 'wiki',
+                                                               action: 'rename',
+                                                               project_id: '22',
+                                                               id: 'ladida')
 
-      should route(:get, "/projects/567/wiki/date_index").to( controller: 'wiki',
-                                                              action: 'date_index',
-                                                              project_id: '567' )
+      should route(:get, '/projects/567/wiki/index').to(controller: 'wiki',
+                                                        action: 'index',
+                                                        project_id: '567')
 
-      should route(:get, "/projects/567/wiki/export").to( controller: 'wiki',
-                                                          action: 'export',
-                                                          project_id: '567' )
+      should route(:get, '/projects/567/wiki/date_index').to(controller: 'wiki',
+                                                             action: 'date_index',
+                                                             project_id: '567')
 
-      should route(:put, "/projects/22/wiki/ladida/rename").to( controller: 'wiki',
-                                                                 action: 'rename',
+      should route(:get, '/projects/567/wiki/export').to(controller: 'wiki',
+                                                         action: 'export',
+                                                         project_id: '567')
+
+      should route(:put, '/projects/22/wiki/ladida/rename').to(controller: 'wiki',
+                                                               action: 'rename',
+                                                               project_id: '22',
+                                                               id: 'ladida')
+
+      should route(:post, '/projects/22/wiki/ladida/protect').to(controller: 'wiki',
+                                                                 action: 'protect',
                                                                  project_id: '22',
-                                                                id: 'ladida' )
+                                                                 id: 'ladida')
 
-      should route(:post, "/projects/22/wiki/ladida/protect").to( controller: 'wiki',
-                                                                  action: 'protect',
-                                                                  project_id: '22',
-                                                                  id: 'ladida' )
+      should route(:post, '/projects/22/wiki/ladida/add_attachment').to(controller: 'wiki',
+                                                                        action: 'add_attachment',
+                                                                        project_id: '22',
+                                                                        id: 'ladida')
 
-      should route(:post, "/projects/22/wiki/ladida/add_attachment").to( controller: 'wiki',
-                                                                         action: 'add_attachment',
-                                                                         project_id: '22',
-                                                                         id: 'ladida' )
+      should route(:put, '/projects/567/wiki/my_page').to(controller: 'wiki',
+                                                          action: 'update',
+                                                          project_id: '567',
+                                                          id: 'my_page')
 
-      should route(:put, "/projects/567/wiki/my_page").to( controller: 'wiki',
-                                                           action: 'update',
-                                                           project_id: '567',
-                                                           id: 'my_page' )
-
-      should route(:delete, "/projects/22/wiki/ladida").to( controller: 'wiki',
-                                                            action: 'destroy',
-                                                            project_id: '22',
-                                                            id: 'ladida' )
+      should route(:delete, '/projects/22/wiki/ladida').to(controller: 'wiki',
+                                                           action: 'destroy',
+                                                           project_id: '22',
+                                                           id: 'ladida')
     end
   end
 
-  context "wikis (plural, admin setup)" do
-    should route(:get, "/projects/ladida/wiki/destroy").to( controller: 'wikis',
+  context 'wikis (plural, admin setup)' do
+    should route(:get, '/projects/ladida/wiki/destroy').to(controller: 'wikis',
+                                                           action: 'destroy',
+                                                           id: 'ladida')
+
+    should route(:post, '/projects/ladida/wiki').to(controller: 'wikis',
+                                                    action: 'edit',
+                                                    id: 'ladida')
+    should route(:post, '/projects/ladida/wiki/destroy').to(controller: 'wikis',
                                                             action: 'destroy',
                                                             id: 'ladida')
-
-    should route(:post, "/projects/ladida/wiki").to( controller: 'wikis',
-                                                     action: 'edit',
-                                                     id: 'ladida')
-    should route(:post, "/projects/ladida/wiki/destroy").to( controller: 'wikis',
-                                                             action: 'destroy',
-                                                             id: 'ladida')
   end
 
-  context "administration panel" do
-    should route(:get, "/admin/projects").to( controller: 'admin', action: 'projects')
+  context 'administration panel' do
+    should route(:get, '/admin/projects').to(controller: 'admin', action: 'projects')
   end
 
-  context "groups" do
-    should route(:get, "/admin/groups").to( controller: 'groups',
-                                            action: 'index' )
+  context 'groups' do
+    should route(:get, '/admin/groups').to(controller: 'groups',
+                                           action: 'index')
 
-    should route(:get, "/admin/groups/new").to( controller: 'groups',
-                                                action: 'new' )
+    should route(:get, '/admin/groups/new').to(controller: 'groups',
+                                               action: 'new')
 
-    should route(:post, "/admin/groups").to( controller: 'groups',
-                                             action: 'create' )
+    should route(:post, '/admin/groups').to(controller: 'groups',
+                                            action: 'create')
 
-    should route(:get, "/admin/groups/4").to( controller: 'groups',
-                                              action: 'show',
-                                              id: '4' )
+    should route(:get, '/admin/groups/4').to(controller: 'groups',
+                                             action: 'show',
+                                             id: '4')
 
-    should route(:get, "/admin/groups/4/edit").to( controller: 'groups',
-                                                   action: 'edit',
-                                                   id: '4' )
+    should route(:get, '/admin/groups/4/edit').to(controller: 'groups',
+                                                  action: 'edit',
+                                                  id: '4')
 
-    should route(:put, "/admin/groups/4").to( controller: 'groups',
-                                              action: 'update',
-                                              id: '4' )
+    should route(:put, '/admin/groups/4').to(controller: 'groups',
+                                             action: 'update',
+                                             id: '4')
 
-    should route(:delete, "/admin/groups/4").to( controller: 'groups',
-                                                 action: 'destroy',
-                                                 id: '4' )
+    should route(:delete, '/admin/groups/4').to(controller: 'groups',
+                                                action: 'destroy',
+                                                id: '4')
 
-    should route(:get, "/admin/groups/4/autocomplete_for_user").to( controller: 'groups',
-                                                                    action: 'autocomplete_for_user',
-                                                                    id: '4' )
+    should route(:get, '/admin/groups/4/autocomplete_for_user').to(controller: 'groups',
+                                                                   action: 'autocomplete_for_user',
+                                                                   id: '4')
 
-    should route(:post, "/admin/groups/4/members").to( controller: 'groups',
-                                                     action: 'add_users',
-                                                     id: '4' )
+    should route(:post, '/admin/groups/4/members').to(controller: 'groups',
+                                                      action: 'add_users',
+                                                      id: '4')
 
-    should route(:delete, "/admin/groups/4/members/5").to( controller: 'groups',
-                                                           action: 'remove_user',
+    should route(:delete, '/admin/groups/4/members/5').to(controller: 'groups',
+                                                          action: 'remove_user',
+                                                          id: '4',
+                                                          user_id: '5')
+
+    should route(:post, '/admin/groups/4/memberships').to(controller: 'groups',
+                                                          action: 'create_memberships',
+                                                          id: '4')
+
+    should route(:put, '/admin/groups/4/memberships/5').to(controller: 'groups',
+                                                           action: 'edit_membership',
                                                            id: '4',
-                                                           user_id: '5' )
+                                                           membership_id: '5')
 
-    should route(:post, "/admin/groups/4/memberships").to( controller: 'groups',
-                                                           action: 'create_memberships',
-                                                           id: '4' )
-
-    should route(:put, "/admin/groups/4/memberships/5").to( controller: 'groups',
-                                                            action: 'edit_membership',
-                                                            id: '4',
-                                                            membership_id: '5' )
-
-    should route(:delete, "/admin/groups/4/memberships/5").to( controller: 'groups',
-                                                               action: 'destroy_membership',
-                                                               id: '4',
-                                                               membership_id: '5' )
+    should route(:delete, '/admin/groups/4/memberships/5').to(controller: 'groups',
+                                                              action: 'destroy_membership',
+                                                              id: '4',
+                                                              membership_id: '5')
   end
 end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -30,51 +30,51 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class RoutingTest < ActionDispatch::IntegrationTest
   context "activities" do
-    should route(:get, "/activity").to( :controller => 'activities',
-                                        :action => 'index' )
-    should route(:get, "/activity.atom").to( :controller => 'activities',
-                                             :action => 'index',
-                                             :format => 'atom' )
+    should route(:get, "/activity").to( controller: 'activities',
+                                        action: 'index' )
+    should route(:get, "/activity.atom").to( controller: 'activities',
+                                             action: 'index',
+                                             format: 'atom' )
 
     should "route /activities to activities#index" do
-      assert_recognizes({ :controller => 'activities', :action => 'index' }, "/activities")
+      assert_recognizes({ controller: 'activities', action: 'index' }, "/activities")
     end
     should "route /activites.atom to activities#index" do
-      assert_recognizes({ :controller => 'activities', :action => 'index', :format => 'atom' }, "/activities.atom")
+      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom' }, "/activities.atom")
     end
 
-    should route(:get, "projects/eCookbook/activity").to( :controller => 'activities',
-                                                          :action => 'index',
-                                                          :project_id => "eCookbook" )
+    should route(:get, "projects/eCookbook/activity").to( controller: 'activities',
+                                                          action: 'index',
+                                                          project_id: "eCookbook" )
 
-    should route(:get, "projects/eCookbook/activity.atom").to( :controller => 'activities',
-                                                               :action => 'index',
-                                                               :project_id => "eCookbook",
-                                                               :format => 'atom')
+    should route(:get, "projects/eCookbook/activity.atom").to( controller: 'activities',
+                                                               action: 'index',
+                                                               project_id: "eCookbook",
+                                                               format: 'atom')
 
     should "route project/eCookbook/activities to activities#index" do
-      assert_recognizes({ :controller => 'activities', :action => 'index', :project_id => "eCookbook" }, "/projects/eCookbook/activities")
+      assert_recognizes({ controller: 'activities', action: 'index', project_id: "eCookbook" }, "/projects/eCookbook/activities")
     end
     should "route project/eCookbook/activites.atom to activities#index" do
-      assert_recognizes({ :controller => 'activities', :action => 'index', :format => 'atom', :project_id => "eCookbook" }, "/projects/eCookbook/activities.atom")
+      assert_recognizes({ controller: 'activities', action: 'index', format: 'atom', project_id: "eCookbook" }, "/projects/eCookbook/activities.atom")
     end
   end
 
   context "attachments" do
-    should route(:get, "/attachments/1").to( :controller => 'attachments',
-                                             :action => 'show',
-                                             :id => '1')
-    should route(:get, "/attachments/1/filename.ext").to( :controller => 'attachments',
-                                                          :action => 'show',
-                                                          :id => '1',
-                                                          :filename => 'filename.ext' )
-    should route(:get, "/attachments/1/download").to( :controller => 'attachments',
-                                                      :action => 'download',
-                                                      :id => '1' )
-    should route(:get, "/attachments/1/download/filename.ext").to( :controller => 'attachments',
-                                                                   :action => 'download',
-                                                                   :id => '1',
-                                                                   :filename => 'filename.ext' )
+    should route(:get, "/attachments/1").to( controller: 'attachments',
+                                             action: 'show',
+                                             id: '1')
+    should route(:get, "/attachments/1/filename.ext").to( controller: 'attachments',
+                                                          action: 'show',
+                                                          id: '1',
+                                                          filename: 'filename.ext' )
+    should route(:get, "/attachments/1/download").to( controller: 'attachments',
+                                                      action: 'download',
+                                                      id: '1' )
+    should route(:get, "/attachments/1/download/filename.ext").to( controller: 'attachments',
+                                                                   action: 'download',
+                                                                   id: '1',
+                                                                   filename: 'filename.ext' )
     should "redirect /atttachments/download/1 to /attachments/1/download" do
       get '/attachments/download/1'
       assert_redirected_to '/attachments/1/download'
@@ -85,597 +85,597 @@ class RoutingTest < ActionDispatch::IntegrationTest
       assert_redirected_to '/attachments/1/download/filename.ext'
     end
 
-    should route(:delete, "/attachments/1").to( :controller => 'attachments',
-                                                :action => 'destroy',
-                                                :id => '1')
+    should route(:delete, "/attachments/1").to( controller: 'attachments',
+                                                action: 'destroy',
+                                                id: '1')
   end
 
   context "boards" do
-    should route(:get, "/projects/world_domination/boards").to( :controller => 'boards',
-                                                                :action => 'index',
-                                                                :project_id => 'world_domination')
-    should route(:get, "/projects/world_domination/boards/new").to( :controller => 'boards',
-                                                                    :action => 'new',
-                                                                    :project_id => 'world_domination')
-    should route(:post, "/projects/world_domination/boards").to( :controller => 'boards',
-                                                                 :action => 'create',
-                                                                 :project_id => 'world_domination')
-    should route(:get, "/projects/world_domination/boards/44").to( :controller => 'boards',
-                                                                   :action => 'show',
-                                                                   :project_id => 'world_domination',
-                                                                   :id => '44')
-    should route(:get, "/projects/world_domination/boards/44.atom").to( :controller => 'boards',
-                                                                        :action => 'show',
-                                                                        :project_id => 'world_domination',
-                                                                        :id => '44',
-                                                                        :format => 'atom')
-    should route(:get, "/projects/world_domination/boards/44/edit").to( :controller => 'boards',
-                                                                       :action => 'edit',
-                                                                       :project_id => 'world_domination',
-                                                                       :id => '44')
-    should route(:put, "/projects/world_domination/boards/44").to( :controller => 'boards',
-                                                                   :action => 'update',
-                                                                   :project_id => 'world_domination',
-                                                                        :id => '44')
-    should route(:delete, "/projects/world_domination/boards/44").to( :controller => 'boards',
-                                                                      :action => 'destroy',
-                                                                      :project_id => 'world_domination',
-                                                                      :id => '44')
+    should route(:get, "/projects/world_domination/boards").to( controller: 'boards',
+                                                                action: 'index',
+                                                                project_id: 'world_domination')
+    should route(:get, "/projects/world_domination/boards/new").to( controller: 'boards',
+                                                                    action: 'new',
+                                                                    project_id: 'world_domination')
+    should route(:post, "/projects/world_domination/boards").to( controller: 'boards',
+                                                                 action: 'create',
+                                                                 project_id: 'world_domination')
+    should route(:get, "/projects/world_domination/boards/44").to( controller: 'boards',
+                                                                   action: 'show',
+                                                                   project_id: 'world_domination',
+                                                                   id: '44')
+    should route(:get, "/projects/world_domination/boards/44.atom").to( controller: 'boards',
+                                                                        action: 'show',
+                                                                        project_id: 'world_domination',
+                                                                        id: '44',
+                                                                        format: 'atom')
+    should route(:get, "/projects/world_domination/boards/44/edit").to( controller: 'boards',
+                                                                       action: 'edit',
+                                                                       project_id: 'world_domination',
+                                                                       id: '44')
+    should route(:put, "/projects/world_domination/boards/44").to( controller: 'boards',
+                                                                   action: 'update',
+                                                                   project_id: 'world_domination',
+                                                                        id: '44')
+    should route(:delete, "/projects/world_domination/boards/44").to( controller: 'boards',
+                                                                      action: 'destroy',
+                                                                      project_id: 'world_domination',
+                                                                      id: '44')
 
   end
 
   context "issues" do
     # Extra actions
-    should route(:get, "/issues/changes").to( :controller => 'journals',
-                                              :action => 'index')
+    should route(:get, "/issues/changes").to( controller: 'journals',
+                                              action: 'index')
   end
 
 
   context "enumerations" do
     context "within admin" do
-      should route(:get, "admin/enumerations").to( :controller => 'enumerations',
-                                                   :action => 'index' )
+      should route(:get, "admin/enumerations").to( controller: 'enumerations',
+                                                   action: 'index' )
 
-      should route(:get, "admin/enumerations/new").to( :controller => 'enumerations',
-                                                      :action => 'new' )
+      should route(:get, "admin/enumerations/new").to( controller: 'enumerations',
+                                                      action: 'new' )
 
-      should route(:post, "admin/enumerations").to( :controller => 'enumerations',
-                                                    :action => 'create' )
+      should route(:post, "admin/enumerations").to( controller: 'enumerations',
+                                                    action: 'create' )
 
-      should route(:get, "admin/enumerations/1/edit").to( :controller => 'enumerations',
-                                                          :action => 'edit',
-                                                          :id => '1' )
+      should route(:get, "admin/enumerations/1/edit").to( controller: 'enumerations',
+                                                          action: 'edit',
+                                                          id: '1' )
 
-      should route(:put, "admin/enumerations/1").to( :controller => 'enumerations',
-                                                     :action => 'update',
-                                                     :id => '1' )
+      should route(:put, "admin/enumerations/1").to( controller: 'enumerations',
+                                                     action: 'update',
+                                                     id: '1' )
 
-      should route(:delete, "admin/enumerations/1").to( :controller => 'enumerations',
-                                                        :action => 'destroy',
-                                                        :id => '1' )
+      should route(:delete, "admin/enumerations/1").to( controller: 'enumerations',
+                                                        action: 'destroy',
+                                                        id: '1' )
     end
   end
 
   context "roles" do
     context "witin admin" do
-      should route(:get, "admin/roles").to( :controller => 'roles',
-                                            :action => 'index' )
+      should route(:get, "admin/roles").to( controller: 'roles',
+                                            action: 'index' )
 
-      should route(:get, "admin/roles/new").to( :controller => 'roles',
-                                                :action => 'new' )
+      should route(:get, "admin/roles/new").to( controller: 'roles',
+                                                action: 'new' )
 
-      should route(:post, "admin/roles").to( :controller => 'roles',
-                                             :action => 'create' )
+      should route(:post, "admin/roles").to( controller: 'roles',
+                                             action: 'create' )
 
-      should route(:get, "admin/roles/1/edit").to( :controller => 'roles',
-                                                   :action => 'edit',
-                                                   :id => '1' )
+      should route(:get, "admin/roles/1/edit").to( controller: 'roles',
+                                                   action: 'edit',
+                                                   id: '1' )
 
-      should route(:put, "admin/roles/1").to( :controller => 'roles',
-                                              :action => 'update',
-                                              :id => '1' )
+      should route(:put, "admin/roles/1").to( controller: 'roles',
+                                              action: 'update',
+                                              id: '1' )
 
-      should route(:delete, "admin/roles/1").to( :controller => 'roles',
-                                                 :action => 'destroy',
-                                                 :id => '1' )
+      should route(:delete, "admin/roles/1").to( controller: 'roles',
+                                                 action: 'destroy',
+                                                 id: '1' )
 
-      should route(:get, "admin/roles/report").to( :controller => 'roles',
-                                                   :action => 'report' )
+      should route(:get, "admin/roles/report").to( controller: 'roles',
+                                                   action: 'report' )
 
-      should route(:put, "admin/roles").to( :controller => 'roles',
-                                            :action => 'bulk_update' )
+      should route(:put, "admin/roles").to( controller: 'roles',
+                                            action: 'bulk_update' )
     end
   end
 
 
   context "journals" do
-    should route(:get, "/journals/100/diff/description").to( :controller => 'journals',
-                                                             :action => 'diff',
-                                                             :id => '100',
-                                                             :field => 'description' )
+    should route(:get, "/journals/100/diff/description").to( controller: 'journals',
+                                                             action: 'diff',
+                                                             id: '100',
+                                                             field: 'description' )
   end
 
   context "members" do
     context "project scoped" do
-      should route(:post, "/projects/5234/members").to( :controller => 'members',
-                                                        :action => 'create',
-                                                        :project_id => '5234' )
+      should route(:post, "/projects/5234/members").to( controller: 'members',
+                                                        action: 'create',
+                                                        project_id: '5234' )
 
-      should route(:get, "/projects/5234/members/autocomplete").to( :controller => 'members',
-                                                                    :action => 'autocomplete',
-                                                                    :project_id => '5234' )
+      should route(:get, "/projects/5234/members/autocomplete").to( controller: 'members',
+                                                                    action: 'autocomplete',
+                                                                    project_id: '5234' )
     end
 
-    should route(:put, "/members/5234").to( :controller => 'members',
-                                            :action => 'update',
-                                            :id => '5234' )
+    should route(:put, "/members/5234").to( controller: 'members',
+                                            action: 'update',
+                                            id: '5234' )
 
-    should route(:delete, "/members/5234").to( :controller => 'members',
-                                               :action => 'destroy',
-                                               :id => '5234' )
+    should route(:delete, "/members/5234").to( controller: 'members',
+                                               action: 'destroy',
+                                               id: '5234' )
   end
 
   context "messages" do
     context "project scoped" do
-      should route(:get, "/boards/lala/topics/new").to( :controller => 'messages',
-                                                       :action => 'new',
-                                                       :board_id => 'lala' )
+      should route(:get, "/boards/lala/topics/new").to( controller: 'messages',
+                                                       action: 'new',
+                                                       board_id: 'lala' )
 
-      should route(:post, "/boards/lala/topics").to( :controller => 'messages',
-                                                     :action => 'create',
-                                                     :board_id => 'lala' )
+      should route(:post, "/boards/lala/topics").to( controller: 'messages',
+                                                     action: 'create',
+                                                     board_id: 'lala' )
     end
 
-    should route(:get, "/topics/2").to( :controller => 'messages',
-                                        :action => 'show',
-                                        :id => '2' )
+    should route(:get, "/topics/2").to( controller: 'messages',
+                                        action: 'show',
+                                        id: '2' )
 
-    should route(:get, "/topics/22/edit").to( :controller => 'messages',
-                                              :action => 'edit',
-                                              :id => '22' )
+    should route(:get, "/topics/22/edit").to( controller: 'messages',
+                                              action: 'edit',
+                                              id: '22' )
 
-    should route(:put, "/topics/22").to( :controller => 'messages',
-                                         :action => 'update',
-                                         :id => '22' )
+    should route(:put, "/topics/22").to( controller: 'messages',
+                                         action: 'update',
+                                         id: '22' )
 
-    should route(:delete, "/topics/555").to( :controller => 'messages',
-                                             :action => 'destroy',
-                                             :id => '555' )
+    should route(:delete, "/topics/555").to( controller: 'messages',
+                                             action: 'destroy',
+                                             id: '555' )
 
-    should route(:get, "/topics/22/quote").to( :controller => 'messages',
-                                               :action => 'quote',
-                                               :id => '22' )
+    should route(:get, "/topics/22/quote").to( controller: 'messages',
+                                               action: 'quote',
+                                               id: '22' )
 
-    should route(:post, "/topics/555/reply").to( :controller => 'messages',
-                                                 :action => 'reply',
-                                                 :id => '555' )
+    should route(:post, "/topics/555/reply").to( controller: 'messages',
+                                                 action: 'reply',
+                                                 id: '555' )
   end
 
   context "news" do
     context "project scoped" do
-      should route(:get, "/projects/567/news").to( :controller => 'news',
-                                                   :action => 'index',
-                                                   :project_id => '567' )
+      should route(:get, "/projects/567/news").to( controller: 'news',
+                                                   action: 'index',
+                                                   project_id: '567' )
 
-      should route(:get, "/projects/567/news.atom").to( :controller => 'news',
-                                                        :action => 'index',
-                                                        :format => 'atom',
-                                                        :project_id => '567' )
+      should route(:get, "/projects/567/news.atom").to( controller: 'news',
+                                                        action: 'index',
+                                                        format: 'atom',
+                                                        project_id: '567' )
 
-      should route(:get, "/projects/567/news/new").to( :controller => 'news',
-                                                       :action => 'new',
-                                                       :project_id => '567' )
+      should route(:get, "/projects/567/news/new").to( controller: 'news',
+                                                       action: 'new',
+                                                       project_id: '567' )
 
-      should route(:post, "/projects/567/news").to( :controller => 'news',
-                                                    :action => 'create',
-                                                    :project_id => '567' )
+      should route(:post, "/projects/567/news").to( controller: 'news',
+                                                    action: 'create',
+                                                    project_id: '567' )
 
     end
 
-    should route(:get, "/news").to( :controller => 'news',
-                                    :action => 'index' )
+    should route(:get, "/news").to( controller: 'news',
+                                    action: 'index' )
 
-    should route(:get, "/news.atom").to( :controller => 'news',
-                                         :action => 'index',
-                                         :format => 'atom' )
+    should route(:get, "/news.atom").to( controller: 'news',
+                                         action: 'index',
+                                         format: 'atom' )
 
-    should route(:get, "/news/2").to( :controller => 'news',
-                                      :action => 'show',
-                                      :id => '2' )
+    should route(:get, "/news/2").to( controller: 'news',
+                                      action: 'show',
+                                      id: '2' )
 
-    should route(:get, "/news/234").to( :controller => 'news',
-                                        :action => 'show',
-                                        :id => '234' )
+    should route(:get, "/news/234").to( controller: 'news',
+                                        action: 'show',
+                                        id: '234' )
 
-    should route(:get, "/news/567/edit").to( :controller => 'news',
-                                             :action => 'edit',
-                                             :id => '567' )
+    should route(:get, "/news/567/edit").to( controller: 'news',
+                                             action: 'edit',
+                                             id: '567' )
 
-    should route(:put, "/news/567").to( :controller => 'news',
-                                        :action => 'update',
-                                        :id => '567' )
+    should route(:put, "/news/567").to( controller: 'news',
+                                        action: 'update',
+                                        id: '567' )
 
 
-    should route(:delete, "/news/567").to( :controller => 'news',
-                                           :action => 'destroy',
-                                           :id => '567' )
+    should route(:delete, "/news/567").to( controller: 'news',
+                                           action: 'destroy',
+                                           id: '567' )
 
   end
 
   context "news/comments" do
     context "news scoped" do
-      should route(:post, "/news/567/comments").to( :controller => 'news/comments',
-                                                    :action => 'create',
-                                                    :news_id => '567' )
+      should route(:post, "/news/567/comments").to( controller: 'news/comments',
+                                                    action: 'create',
+                                                    news_id: '567' )
 
     end
 
-    should route(:delete, "/comments/15").to( :controller => 'news/comments',
-                                              :action => 'destroy',
-                                              :id => '15' )
+    should route(:delete, "/comments/15").to( controller: 'news/comments',
+                                              action: 'destroy',
+                                              id: '15' )
   end
 
   context "project_enumerations" do
     context "project_scoped" do
-      should route(:put, "/projects/64/enumerations").to( :controller => 'project_enumerations',
-                                                          :action => 'update',
-                                                          :project_id => '64' )
+      should route(:put, "/projects/64/enumerations").to( controller: 'project_enumerations',
+                                                          action: 'update',
+                                                          project_id: '64' )
 
-      should route(:delete, "/projects/64/enumerations").to( :controller => 'project_enumerations',
-                                                             :action => 'destroy',
-                                                             :project_id => '64' )
+      should route(:delete, "/projects/64/enumerations").to( controller: 'project_enumerations',
+                                                             action: 'destroy',
+                                                             project_id: '64' )
     end
   end
 
   context "timelogs" do
-    should route(:get, "/time_entries").to( :controller => 'timelog',
-                                            :action => 'index' )
+    should route(:get, "/time_entries").to( controller: 'timelog',
+                                            action: 'index' )
 
-    should route(:get, "/time_entries.csv").to( :controller => 'timelog',
-                                                :action => 'index',
-                                                :format => 'csv' )
+    should route(:get, "/time_entries.csv").to( controller: 'timelog',
+                                                action: 'index',
+                                                format: 'csv' )
 
-    should route(:get, "/time_entries.atom").to( :controller => 'timelog',
-                                                 :action => 'index',
-                                                 :format => 'atom' )
+    should route(:get, "/time_entries.atom").to( controller: 'timelog',
+                                                 action: 'index',
+                                                 format: 'atom' )
 
-    should route(:get, "/time_entries/new").to( :controller => 'timelog',
-                                               :action => 'new' )
+    should route(:get, "/time_entries/new").to( controller: 'timelog',
+                                               action: 'new' )
 
-    should route(:get, "/time_entries/22/edit").to( :controller => 'timelog',
-                                                    :action => 'edit',
-                                                    :id => '22' )
+    should route(:get, "/time_entries/22/edit").to( controller: 'timelog',
+                                                    action: 'edit',
+                                                    id: '22' )
 
-    should route(:post, "/time_entries").to( :controller => 'timelog',
-                                             :action => 'create' )
+    should route(:post, "/time_entries").to( controller: 'timelog',
+                                             action: 'create' )
 
-    should route(:put, "/time_entries/22").to( :controller => 'timelog',
-                                               :action => 'update',
-                                               :id => '22' )
+    should route(:put, "/time_entries/22").to( controller: 'timelog',
+                                               action: 'update',
+                                               id: '22' )
 
-    should route(:delete, "/time_entries/55").to( :controller => 'timelog',
-                                                  :action => 'destroy',
-                                                  :id => '55' )
+    should route(:delete, "/time_entries/55").to( controller: 'timelog',
+                                                  action: 'destroy',
+                                                  id: '55' )
 
     context "project scoped" do
-      should route(:get, "/projects/567/time_entries").to( :controller => 'timelog',
-                                                           :action => 'index',
-                                                           :project_id => '567' )
+      should route(:get, "/projects/567/time_entries").to( controller: 'timelog',
+                                                           action: 'index',
+                                                           project_id: '567' )
 
-      should route(:get, "/projects/567/time_entries.csv").to( :controller => 'timelog',
-                                                               :action => 'index',
-                                                               :project_id => '567',
-                                                               :format => 'csv' )
+      should route(:get, "/projects/567/time_entries.csv").to( controller: 'timelog',
+                                                               action: 'index',
+                                                               project_id: '567',
+                                                               format: 'csv' )
 
-      should route(:get, "/projects/567/time_entries.atom").to( :controller => 'timelog',
-                                                                :action => 'index',
-                                                                :project_id => '567',
-                                                                :format => 'atom' )
+      should route(:get, "/projects/567/time_entries.atom").to( controller: 'timelog',
+                                                                action: 'index',
+                                                                project_id: '567',
+                                                                format: 'atom' )
 
-      should route(:get, "/projects/567/time_entries/new").to( :controller => 'timelog',
-                                                               :action => 'new',
-                                                               :project_id => '567' )
+      should route(:get, "/projects/567/time_entries/new").to( controller: 'timelog',
+                                                               action: 'new',
+                                                               project_id: '567' )
 
-      should route(:get, "/projects/567/time_entries/22/edit").to( :controller => 'timelog',
-                                                                   :action => 'edit',
-                                                                   :id => '22',
-                                                                   :project_id => '567' )
+      should route(:get, "/projects/567/time_entries/22/edit").to( controller: 'timelog',
+                                                                   action: 'edit',
+                                                                   id: '22',
+                                                                   project_id: '567' )
 
-      should route(:post, "/projects/567/time_entries").to( :controller => 'timelog',
-                                                            :action => 'create',
-                                                            :project_id => '567' )
+      should route(:post, "/projects/567/time_entries").to( controller: 'timelog',
+                                                            action: 'create',
+                                                            project_id: '567' )
 
-      should route(:put, "/projects/567/time_entries/22").to( :controller => 'timelog',
-                                                              :action => 'update',
-                                                              :id => '22',
-                                                              :project_id => '567' )
+      should route(:put, "/projects/567/time_entries/22").to( controller: 'timelog',
+                                                              action: 'update',
+                                                              id: '22',
+                                                              project_id: '567' )
 
-      should route(:delete, "/projects/567/time_entries/55").to( :controller => 'timelog',
-                                                                 :action => 'destroy',
-                                                                 :id => '55',
-                                                                 :project_id => '567' )
+      should route(:delete, "/projects/567/time_entries/55").to( controller: 'timelog',
+                                                                 action: 'destroy',
+                                                                 id: '55',
+                                                                 project_id: '567' )
     end
   end
 
 
   context "time_entries/reports" do
-    should route(:get, "/time_entries/report").to( :controller => 'time_entries/reports',
-                                                   :action => 'show' )
-    should route(:get, "/projects/567/time_entries/report").to( :controller => 'time_entries/reports',
-                                                                :action => 'show',
-                                                                :project_id => '567' )
+    should route(:get, "/time_entries/report").to( controller: 'time_entries/reports',
+                                                   action: 'show' )
+    should route(:get, "/projects/567/time_entries/report").to( controller: 'time_entries/reports',
+                                                                action: 'show',
+                                                                project_id: '567' )
 
-    should route(:get, "/projects/567/time_entries/report.csv").to( :controller => 'time_entries/reports',
-                                                                    :action => 'show',
-                                                                    :project_id => '567',
-                                                                    :format => 'csv' )
+    should route(:get, "/projects/567/time_entries/report.csv").to( controller: 'time_entries/reports',
+                                                                    action: 'show',
+                                                                    project_id: '567',
+                                                                    format: 'csv' )
   end
 
   context "users" do
-    should route(:get, "/users").to( :controller => 'users',
-                                     :action => 'index' )
+    should route(:get, "/users").to( controller: 'users',
+                                     action: 'index' )
 
-    should route(:get, "/users.xml").to( :controller => 'users',
-                                         :action => 'index',
-                                         :format => 'xml' )
+    should route(:get, "/users.xml").to( controller: 'users',
+                                         action: 'index',
+                                         format: 'xml' )
 
-    should route(:get, "/users/44").to( :controller => 'users',
-                                        :action => 'show',
-                                        :id => '44' )
+    should route(:get, "/users/44").to( controller: 'users',
+                                        action: 'show',
+                                        id: '44' )
 
-    should route(:get, "/users/44.xml").to( :controller => 'users',
-                                            :action => 'show',
-                                            :id => '44',
-                                            :format => 'xml' )
+    should route(:get, "/users/44.xml").to( controller: 'users',
+                                            action: 'show',
+                                            id: '44',
+                                            format: 'xml' )
 
-    should route(:get, "/users/current").to( :controller => 'users',
-                                             :action => 'show',
-                                             :id => 'current' )
+    should route(:get, "/users/current").to( controller: 'users',
+                                             action: 'show',
+                                             id: 'current' )
 
-    should route(:get, "/users/current.xml").to( :controller => 'users',
-                                                 :action => 'show',
-                                                 :id => 'current',
-                                                 :format => 'xml' )
+    should route(:get, "/users/current.xml").to( controller: 'users',
+                                                 action: 'show',
+                                                 id: 'current',
+                                                 format: 'xml' )
 
-    should route(:get, "/users/new").to( :controller => 'users',
-                                         :action => 'new' )
+    should route(:get, "/users/new").to( controller: 'users',
+                                         action: 'new' )
 
-    should route(:get, "/users/444/edit").to( :controller => 'users',
-                                              :action => 'edit',
-                                              :id => '444' )
+    should route(:get, "/users/444/edit").to( controller: 'users',
+                                              action: 'edit',
+                                              id: '444' )
 
-    should route(:get, "/users/222/edit/membership").to( :controller => 'users',
-                                                         :action => 'edit',
-                                                         :id => '222',
-                                                         :tab => 'membership' )
+    should route(:get, "/users/222/edit/membership").to( controller: 'users',
+                                                         action: 'edit',
+                                                         id: '222',
+                                                         tab: 'membership' )
 
-    should route(:post, "/users").to( :controller => 'users',
-                                      :action => 'create' )
+    should route(:post, "/users").to( controller: 'users',
+                                      action: 'create' )
 
-    should route(:post, "/users.xml").to( :controller => 'users',
-                                          :action => 'create',
-                                          :format => 'xml' )
+    should route(:post, "/users.xml").to( controller: 'users',
+                                          action: 'create',
+                                          format: 'xml' )
 
-    should route(:post, "/users/123/memberships").to( :controller => 'users',
-                                                      :action => 'edit_membership',
-                                                      :id => '123' )
+    should route(:post, "/users/123/memberships").to( controller: 'users',
+                                                      action: 'edit_membership',
+                                                      id: '123' )
 
-    should route(:post, "/users/123/memberships/55").to( :controller => 'users',
-                                                         :action => 'edit_membership',
-                                                         :id => '123',
-                                                         :membership_id => '55' )
+    should route(:post, "/users/123/memberships/55").to( controller: 'users',
+                                                         action: 'edit_membership',
+                                                         id: '123',
+                                                         membership_id: '55' )
 
-    should route(:post, "/users/567/memberships/12/destroy").to( :controller => 'users',
-                                                                 :action => 'destroy_membership',
-                                                                 :id => '567',
-                                                                 :membership_id => '12' )
+    should route(:post, "/users/567/memberships/12/destroy").to( controller: 'users',
+                                                                 action: 'destroy_membership',
+                                                                 id: '567',
+                                                                 membership_id: '12' )
 
-    should route(:put, "/users/444").to( :controller => 'users',
-                                         :action => 'update',
-                                         :id => '444' )
+    should route(:put, "/users/444").to( controller: 'users',
+                                         action: 'update',
+                                         id: '444' )
 
-    should route(:put, "/users/444.xml").to( :controller => 'users',
-                                             :action => 'update',
-                                             :id => '444',
-                                             :format => 'xml' )
+    should route(:put, "/users/444.xml").to( controller: 'users',
+                                             action: 'update',
+                                             id: '444',
+                                             format: 'xml' )
   end
 
   context "versions" do
-    should route(:get, "/versions/1").to( :controller => 'versions',
-                                          :action => 'show',
-                                          :id => '1' )
+    should route(:get, "/versions/1").to( controller: 'versions',
+                                          action: 'show',
+                                          id: '1' )
 
-    should route(:get, "/versions/1/edit").to( :controller => 'versions',
-                                               :action => 'edit',
-                                               :id => '1' )
+    should route(:get, "/versions/1/edit").to( controller: 'versions',
+                                               action: 'edit',
+                                               id: '1' )
 
-    should route(:put, "/versions/1").to( :controller => 'versions',
-                                          :action => 'update',
-                                          :id => '1' )
+    should route(:put, "/versions/1").to( controller: 'versions',
+                                          action: 'update',
+                                          id: '1' )
 
-    should route(:delete, "/versions/1").to( :controller => 'versions',
-                                             :action => 'destroy',
-                                             :id => '1' )
+    should route(:delete, "/versions/1").to( controller: 'versions',
+                                             action: 'destroy',
+                                             id: '1' )
 
-    should route(:get, "/versions/1/status_by").to( :controller => 'versions',
-                                                    :action => 'status_by',
-                                                    :id => '1' )
+    should route(:get, "/versions/1/status_by").to( controller: 'versions',
+                                                    action: 'status_by',
+                                                    id: '1' )
 
     context "project" do
-      should route(:get, "/projects/foo/versions/new").to( :controller => 'versions',
-                                                           :action => 'new',
-                                                           :project_id => 'foo' )
+      should route(:get, "/projects/foo/versions/new").to( controller: 'versions',
+                                                           action: 'new',
+                                                           project_id: 'foo' )
 
-      should route(:post, "/projects/foo/versions").to( :controller => 'versions',
-                                                        :action => 'create',
-                                                        :project_id => 'foo' )
+      should route(:post, "/projects/foo/versions").to( controller: 'versions',
+                                                        action: 'create',
+                                                        project_id: 'foo' )
 
-      should route(:put, "/projects/foo/versions/close_completed").to( :controller => 'versions',
-                                                                       :action => 'close_completed',
-                                                                       :project_id => 'foo' )
+      should route(:put, "/projects/foo/versions/close_completed").to( controller: 'versions',
+                                                                       action: 'close_completed',
+                                                                       project_id: 'foo' )
 
-      should route(:get, "/projects/foo/roadmap").to( :controller => 'versions',
-                                                      :action => 'index',
-                                                      :project_id => 'foo' )
+      should route(:get, "/projects/foo/roadmap").to( controller: 'versions',
+                                                      action: 'index',
+                                                      project_id: 'foo' )
     end
   end
 
   context "wiki (singular, project's pages)" do
     context "within project" do
-      should route(:get, "/projects/567/wiki").to( :controller => 'wiki',
-                                                   :action => 'show',
-                                                   :project_id => '567' )
+      should route(:get, "/projects/567/wiki").to( controller: 'wiki',
+                                                   action: 'show',
+                                                   project_id: '567' )
 
-      should route(:get, "/projects/567/wiki/lalala").to( :controller => 'wiki',
-                                                          :action => 'show',
-                                                          :project_id => '567',
-                                                          :id => 'lalala' )
+      should route(:get, "/projects/567/wiki/lalala").to( controller: 'wiki',
+                                                          action: 'show',
+                                                          project_id: '567',
+                                                          id: 'lalala' )
 
-      should route(:get, "/projects/567/wiki/my_page/edit").to( :controller => 'wiki',
-                                                                :action => 'edit',
-                                                                :project_id => '567',
-                                                                :id => 'my_page' )
+      should route(:get, "/projects/567/wiki/my_page/edit").to( controller: 'wiki',
+                                                                action: 'edit',
+                                                                project_id: '567',
+                                                                id: 'my_page' )
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/history").to( :controller => 'wiki',
-                                                                                :action => 'history',
-                                                                                :project_id => '1',
-                                                                                :id => 'CookBook_documentation' )
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff").to( :controller => 'wiki',
-                                                                             :action => 'diff',
-                                                                             :project_id => '1',
-                                                                             :id => 'CookBook_documentation' )
+      should route(:get, "/projects/1/wiki/CookBook_documentation/history").to( controller: 'wiki',
+                                                                                action: 'history',
+                                                                                project_id: '1',
+                                                                                id: 'CookBook_documentation' )
+      should route(:get, "/projects/1/wiki/CookBook_documentation/diff").to( controller: 'wiki',
+                                                                             action: 'diff',
+                                                                             project_id: '1',
+                                                                             id: 'CookBook_documentation' )
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2").to( :controller => 'wiki',
-                                                                               :action => 'diff',
-                                                                               :project_id => '1',
-                                                                               :id => 'CookBook_documentation',
-                                                                               :version => '2' )
+      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2").to( controller: 'wiki',
+                                                                               action: 'diff',
+                                                                               project_id: '1',
+                                                                               id: 'CookBook_documentation',
+                                                                               version: '2' )
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2/vs/1").to( :controller => 'wiki',
-                                                                                    :action => 'diff',
-                                                                                    :project_id => '1',
-                                                                                    :id => 'CookBook_documentation',
-                                                                                    :version => '2',
-                                                                                    :version_from => '1')
+      should route(:get, "/projects/1/wiki/CookBook_documentation/diff/2/vs/1").to( controller: 'wiki',
+                                                                                    action: 'diff',
+                                                                                    project_id: '1',
+                                                                                    id: 'CookBook_documentation',
+                                                                                    version: '2',
+                                                                                    version_from: '1')
 
-      should route(:get, "/projects/1/wiki/CookBook_documentation/annotate/2").to( :controller => 'wiki',
-                                                                                   :action => 'annotate',
-                                                                                   :project_id => '1',
-                                                                                   :id => 'CookBook_documentation',
-                                                                                   :version => '2' )
+      should route(:get, "/projects/1/wiki/CookBook_documentation/annotate/2").to( controller: 'wiki',
+                                                                                   action: 'annotate',
+                                                                                   project_id: '1',
+                                                                                   id: 'CookBook_documentation',
+                                                                                   version: '2' )
 
-      should route(:get, "/projects/22/wiki/ladida/rename").to( :controller => 'wiki',
-                                                                :action => 'rename',
-                                                                :project_id => '22',
-                                                                :id => 'ladida' )
+      should route(:get, "/projects/22/wiki/ladida/rename").to( controller: 'wiki',
+                                                                action: 'rename',
+                                                                project_id: '22',
+                                                                id: 'ladida' )
 
-      should route(:get, "/projects/567/wiki/index").to( :controller => 'wiki',
-                                                         :action => 'index',
-                                                         :project_id => '567' )
+      should route(:get, "/projects/567/wiki/index").to( controller: 'wiki',
+                                                         action: 'index',
+                                                         project_id: '567' )
 
-      should route(:get, "/projects/567/wiki/date_index").to( :controller => 'wiki',
-                                                              :action => 'date_index',
-                                                              :project_id => '567' )
+      should route(:get, "/projects/567/wiki/date_index").to( controller: 'wiki',
+                                                              action: 'date_index',
+                                                              project_id: '567' )
 
-      should route(:get, "/projects/567/wiki/export").to( :controller => 'wiki',
-                                                          :action => 'export',
-                                                          :project_id => '567' )
+      should route(:get, "/projects/567/wiki/export").to( controller: 'wiki',
+                                                          action: 'export',
+                                                          project_id: '567' )
 
-      should route(:put, "/projects/22/wiki/ladida/rename").to( :controller => 'wiki',
-                                                                 :action => 'rename',
-                                                                 :project_id => '22',
-                                                                :id => 'ladida' )
+      should route(:put, "/projects/22/wiki/ladida/rename").to( controller: 'wiki',
+                                                                 action: 'rename',
+                                                                 project_id: '22',
+                                                                id: 'ladida' )
 
-      should route(:post, "/projects/22/wiki/ladida/protect").to( :controller => 'wiki',
-                                                                  :action => 'protect',
-                                                                  :project_id => '22',
-                                                                  :id => 'ladida' )
+      should route(:post, "/projects/22/wiki/ladida/protect").to( controller: 'wiki',
+                                                                  action: 'protect',
+                                                                  project_id: '22',
+                                                                  id: 'ladida' )
 
-      should route(:post, "/projects/22/wiki/ladida/add_attachment").to( :controller => 'wiki',
-                                                                         :action => 'add_attachment',
-                                                                         :project_id => '22',
-                                                                         :id => 'ladida' )
+      should route(:post, "/projects/22/wiki/ladida/add_attachment").to( controller: 'wiki',
+                                                                         action: 'add_attachment',
+                                                                         project_id: '22',
+                                                                         id: 'ladida' )
 
-      should route(:put, "/projects/567/wiki/my_page").to( :controller => 'wiki',
-                                                           :action => 'update',
-                                                           :project_id => '567',
-                                                           :id => 'my_page' )
+      should route(:put, "/projects/567/wiki/my_page").to( controller: 'wiki',
+                                                           action: 'update',
+                                                           project_id: '567',
+                                                           id: 'my_page' )
 
-      should route(:delete, "/projects/22/wiki/ladida").to( :controller => 'wiki',
-                                                            :action => 'destroy',
-                                                            :project_id => '22',
-                                                            :id => 'ladida' )
+      should route(:delete, "/projects/22/wiki/ladida").to( controller: 'wiki',
+                                                            action: 'destroy',
+                                                            project_id: '22',
+                                                            id: 'ladida' )
     end
   end
 
   context "wikis (plural, admin setup)" do
-    should route(:get, "/projects/ladida/wiki/destroy").to( :controller => 'wikis',
-                                                            :action => 'destroy',
-                                                            :id => 'ladida')
+    should route(:get, "/projects/ladida/wiki/destroy").to( controller: 'wikis',
+                                                            action: 'destroy',
+                                                            id: 'ladida')
 
-    should route(:post, "/projects/ladida/wiki").to( :controller => 'wikis',
-                                                     :action => 'edit',
-                                                     :id => 'ladida')
-    should route(:post, "/projects/ladida/wiki/destroy").to( :controller => 'wikis',
-                                                             :action => 'destroy',
-                                                             :id => 'ladida')
+    should route(:post, "/projects/ladida/wiki").to( controller: 'wikis',
+                                                     action: 'edit',
+                                                     id: 'ladida')
+    should route(:post, "/projects/ladida/wiki/destroy").to( controller: 'wikis',
+                                                             action: 'destroy',
+                                                             id: 'ladida')
   end
 
   context "administration panel" do
-    should route(:get, "/admin/projects").to( :controller => 'admin', :action => 'projects')
+    should route(:get, "/admin/projects").to( controller: 'admin', action: 'projects')
   end
 
   context "groups" do
-    should route(:get, "/admin/groups").to( :controller => 'groups',
-                                            :action => 'index' )
+    should route(:get, "/admin/groups").to( controller: 'groups',
+                                            action: 'index' )
 
-    should route(:get, "/admin/groups/new").to( :controller => 'groups',
-                                                :action => 'new' )
+    should route(:get, "/admin/groups/new").to( controller: 'groups',
+                                                action: 'new' )
 
-    should route(:post, "/admin/groups").to( :controller => 'groups',
-                                             :action => 'create' )
+    should route(:post, "/admin/groups").to( controller: 'groups',
+                                             action: 'create' )
 
-    should route(:get, "/admin/groups/4").to( :controller => 'groups',
-                                              :action => 'show',
-                                              :id => '4' )
+    should route(:get, "/admin/groups/4").to( controller: 'groups',
+                                              action: 'show',
+                                              id: '4' )
 
-    should route(:get, "/admin/groups/4/edit").to( :controller => 'groups',
-                                                   :action => 'edit',
-                                                   :id => '4' )
+    should route(:get, "/admin/groups/4/edit").to( controller: 'groups',
+                                                   action: 'edit',
+                                                   id: '4' )
 
-    should route(:put, "/admin/groups/4").to( :controller => 'groups',
-                                              :action => 'update',
-                                              :id => '4' )
+    should route(:put, "/admin/groups/4").to( controller: 'groups',
+                                              action: 'update',
+                                              id: '4' )
 
-    should route(:delete, "/admin/groups/4").to( :controller => 'groups',
-                                                 :action => 'destroy',
-                                                 :id => '4' )
+    should route(:delete, "/admin/groups/4").to( controller: 'groups',
+                                                 action: 'destroy',
+                                                 id: '4' )
 
-    should route(:get, "/admin/groups/4/autocomplete_for_user").to( :controller => 'groups',
-                                                                    :action => 'autocomplete_for_user',
-                                                                    :id => '4' )
+    should route(:get, "/admin/groups/4/autocomplete_for_user").to( controller: 'groups',
+                                                                    action: 'autocomplete_for_user',
+                                                                    id: '4' )
 
-    should route(:post, "/admin/groups/4/members").to( :controller => 'groups',
-                                                     :action => 'add_users',
-                                                     :id => '4' )
+    should route(:post, "/admin/groups/4/members").to( controller: 'groups',
+                                                     action: 'add_users',
+                                                     id: '4' )
 
-    should route(:delete, "/admin/groups/4/members/5").to( :controller => 'groups',
-                                                           :action => 'remove_user',
-                                                           :id => '4',
-                                                           :user_id => '5' )
+    should route(:delete, "/admin/groups/4/members/5").to( controller: 'groups',
+                                                           action: 'remove_user',
+                                                           id: '4',
+                                                           user_id: '5' )
 
-    should route(:post, "/admin/groups/4/memberships").to( :controller => 'groups',
-                                                           :action => 'create_memberships',
-                                                           :id => '4' )
+    should route(:post, "/admin/groups/4/memberships").to( controller: 'groups',
+                                                           action: 'create_memberships',
+                                                           id: '4' )
 
-    should route(:put, "/admin/groups/4/memberships/5").to( :controller => 'groups',
-                                                            :action => 'edit_membership',
-                                                            :id => '4',
-                                                            :membership_id => '5' )
+    should route(:put, "/admin/groups/4/memberships/5").to( controller: 'groups',
+                                                            action: 'edit_membership',
+                                                            id: '4',
+                                                            membership_id: '5' )
 
-    should route(:delete, "/admin/groups/4/memberships/5").to( :controller => 'groups',
-                                                               :action => 'destroy_membership',
-                                                               :id => '4',
-                                                               :membership_id => '5' )
+    should route(:delete, "/admin/groups/4/memberships/5").to( controller: 'groups',
+                                                               action: 'destroy_membership',
+                                                               id: '4',
+                                                               membership_id: '5' )
   end
 end

--- a/test/object_daddy_helpers.rb
+++ b/test/object_daddy_helpers.rb
@@ -30,15 +30,15 @@
 module ObjectDaddyHelpers
   # TODO: Remove these three once everyone has ported their code to use the
   # new object_daddy version with protected attribute support
-  def User.generate_with_protected(attributes={})
+  def User.generate_with_protected(attributes = {})
     User.generate(attributes)
   end
 
-  def User.generate_with_protected!(attributes={})
+  def User.generate_with_protected!(attributes = {})
     User.generate!(attributes)
   end
 
-  def User.spawn_with_protected(attributes={})
+  def User.spawn_with_protected(attributes = {})
     User.spawn(attributes)
   end
 
@@ -53,11 +53,10 @@ module ObjectDaddyHelpers
   end
 
   # Generate the default Query
-  def Query.generate_default!(attributes={})
+  def Query.generate_default!(attributes = {})
     query = Query.spawn(attributes)
     query.name ||= '_'
     query.save!
     query
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -139,7 +139,7 @@ class ActiveSupport::TestCase
     assert_equal nil, session[:user_id]
     assert_response :success
     assert_template "account/login"
-    post "/login", :username => login, :password => password
+    post "/login", username: login, password: password
     assert_equal login, User.find(session[:user_id]).login
   end
 
@@ -185,13 +185,13 @@ class ActiveSupport::TestCase
   end
 
   def change_user_password(login, new_password)
-    user = User.first(:conditions => {:login => login})
+    user = User.first(conditions: {login: login})
     user.password, user.password_confirmation = new_password, new_password
     user.save!
   end
 
   def self.ldap_configured?
-    @test_ldap = Net::LDAP.new(:host => '127.0.0.1', :port => 389)
+    @test_ldap = Net::LDAP.new(host: '127.0.0.1', port: 389)
     return @test_ldap.bind
   rescue Exception => e
     # LDAP is not listening
@@ -216,7 +216,7 @@ class ActiveSupport::TestCase
   end
 
   def assert_error_tag(options={})
-    assert_tag({:attributes => { :id => 'errorExplanation' }}.merge(options))
+    assert_tag({attributes: { id: 'errorExplanation' }}.merge(options))
   end
 
   # Shoulda macros
@@ -275,7 +275,7 @@ class ActiveSupport::TestCase
         journal.stub(:journable).and_return(WorkPackage.last)
         journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
 
-        assert_match @new_value.class.find(@new_value.id).name, journal.render_detail(prop_key, :no_html => true)
+        assert_match @new_value.class.find(@new_value.id).name, journal.render_detail(prop_key, no_html: true)
       end
 
       should "use the old value's name" do
@@ -284,7 +284,7 @@ class ActiveSupport::TestCase
         journal.stub(:journable).and_return(WorkPackage.last)
         journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
 
-        assert_match @old_value.class.find(@old_value.id).name, journal.render_detail(prop_key, :no_html => true)
+        assert_match @old_value.class.find(@old_value.id).name, journal.render_detail(prop_key, no_html: true)
       end
     end
   end
@@ -382,7 +382,7 @@ class ActiveSupport::TestCase
     context "should allow http basic auth using a username and password for #{http_method} #{url}" do
       context "with a valid HTTP authentication" do
         setup do
-          @user = User.generate_with_protected!(:password => 'adminADMIN!', :password_confirmation => 'adminADMIN!', :admin => true) # Admin so they can access the project
+          @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!', admin: true) # Admin so they can access the project
 
           send(http_method, url, parameters, credentials(@user.login, 'adminADMIN!'))
         end
@@ -446,8 +446,8 @@ class ActiveSupport::TestCase
     context "should allow http basic auth with a key for #{http_method} #{url}" do
       context "with a valid HTTP authentication using the API token" do
         setup do
-          @user = User.generate_with_protected!(:admin => true)
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @user = User.generate_with_protected!(admin: true)
+          @token = Token.generate!(user: @user, action: 'api')
 
           send(http_method, url, parameters, credentials(@token.value, 'X'))
         end
@@ -463,7 +463,7 @@ class ActiveSupport::TestCase
       context "with an invalid HTTP authentication" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'feeds')
+          @token = Token.generate!(user: @user, action: 'feeds')
 
           send(http_method, url, parameters, credentials(@token.value, 'X'))
         end
@@ -492,8 +492,8 @@ class ActiveSupport::TestCase
     context "should allow key based auth using key=X for #{http_method} #{url}" do
       context "with a valid api token" do
         setup do
-          @user = User.generate_with_protected!(:admin => true)
-          @token = Token.generate!(:user => @user, :action => 'api')
+          @user = User.generate_with_protected!(admin: true)
+          @token = Token.generate!(user: @user, action: 'api')
           # Simple url parse to add on ?key= or &key=
           request_url = if url.match(/\?/)
                           url + "&key=#{@token.value}"
@@ -514,7 +514,7 @@ class ActiveSupport::TestCase
       context "with an invalid api token" do
         setup do
           @user = User.generate_with_protected!
-          @token = Token.generate!(:user => @user, :action => 'feeds')
+          @token = Token.generate!(user: @user, action: 'feeds')
           # Simple url parse to add on ?key= or &key=
           request_url = if url.match(/\?/)
                           url + "&key=#{@token.value}"
@@ -534,8 +534,8 @@ class ActiveSupport::TestCase
 
     context "should allow key based auth using X-OpenProject-API-Key header for #{http_method} #{url}" do
       setup do
-        @user = User.generate_with_protected!(:admin => true)
-        @token = Token.generate!(:user => @user, :action => 'api')
+        @user = User.generate_with_protected!(admin: true)
+        @token = Token.generate!(user: @user, action: 'api')
         send(http_method, url, parameters, {'X-OpenProject-API-Key' => @token.value.to_s})
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,11 +27,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 
 if ENV['CI'] == 'true'
   # we are running on a CI server, report coverage to code climate
-  require "codeclimate-test-reporter"
+  require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
 end
 
@@ -135,11 +135,11 @@ class ActiveSupport::TestCase
 
   def log_user(login, password)
     User.anonymous
-    get "/login"
+    get '/login'
     assert_equal nil, session[:user_id]
     assert_response :success
-    assert_template "account/login"
-    post "/login", username: login, password: password
+    assert_template 'account/login'
+    post '/login', username: login, password: password
     assert_equal login, User.find(session[:user_id]).login
   end
 
@@ -176,16 +176,16 @@ class ActiveSupport::TestCase
     file
   end
 
-  def with_settings(options, &block)
-    saved_settings = options.keys.inject({}) {|h, k| h[k] = Setting[k].dup; h}
-    options.each {|k, v| Setting[k] = v}
+  def with_settings(options, &_block)
+    saved_settings = options.keys.inject({}) { |h, k| h[k] = Setting[k].dup; h }
+    options.each { |k, v| Setting[k] = v }
     yield
   ensure
-    saved_settings.each {|k, v| Setting[k] = v}
+    saved_settings.each { |k, v| Setting[k] = v }
   end
 
   def change_user_password(login, new_password)
-    user = User.first(conditions: {login: login})
+    user = User.first(conditions: { login: login })
     user.password, user.password_confirmation = new_password, new_password
     user.save!
   end
@@ -215,8 +215,8 @@ class ActiveSupport::TestCase
     File.directory?(repository_path(vendor))
   end
 
-  def assert_error_tag(options={})
-    assert_tag({attributes: { id: 'errorExplanation' }}.merge(options))
+  def assert_error_tag(options = {})
+    assert_tag({ attributes: { id: 'errorExplanation' } }.merge(options))
   end
 
   # Shoulda macros
@@ -252,13 +252,13 @@ class ActiveSupport::TestCase
       expected = klass.new(:filter, expected_method.to_sym, options)
       assert_equal 1, @controller.class.filter_chain.select { |filter|
         filter.method == expected.method && filter.kind == expected.kind &&
-        filter.options == expected.options && filter.class == expected.class
+          filter.options == expected.options && filter.class == expected.class
       }.size
     end
   end
 
   def self.should_show_the_old_and_new_values_for(prop_key, model, &block)
-    context "" do
+    context '' do
       setup do
         FactoryGirl.create :issue if WorkPackage.count == 0 # some tests use WorkPackage.last
         if block_given?
@@ -273,7 +273,7 @@ class ActiveSupport::TestCase
         journal = FactoryGirl.build :work_package_journal
 
         journal.stub(:journable).and_return(WorkPackage.last)
-        journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
+        journal.stub(:details).and_return(prop_key => [@old_value.id, @new_value.id])
 
         assert_match @new_value.class.find(@new_value.id).name, journal.render_detail(prop_key, no_html: true)
       end
@@ -282,7 +282,7 @@ class ActiveSupport::TestCase
         journal = FactoryGirl.build :work_package_journal
 
         journal.stub(:journable).and_return(WorkPackage.last)
-        journal.stub(:details).and_return({prop_key => [@old_value.id, @new_value.id]})
+        journal.stub(:details).and_return(prop_key => [@old_value.id, @new_value.id])
 
         assert_match @old_value.class.find(@old_value.id).name, journal.render_detail(prop_key, no_html: true)
       end
@@ -290,7 +290,7 @@ class ActiveSupport::TestCase
   end
 
   def self.should_create_a_new_user(&block)
-    should "create a new user" do
+    should 'create a new user' do
       user = instance_eval &block
       assert user
       assert_kind_of User, user
@@ -311,7 +311,6 @@ class ActiveSupport::TestCase
     { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(login, password) }
   end
 
-
   # Test that a request allows the three types of API authentication
   #
   # * HTTP Basic with username and password
@@ -324,7 +323,7 @@ class ActiveSupport::TestCase
   # @param [optional, Hash] options additional options
   # @option options [Symbol] :success_code Successful response code (:success)
   # @option options [Symbol] :failure_code Failure response code (:unauthorized)
-  def self.should_allow_api_authentication(http_method, url, parameters={}, options={})
+  def self.should_allow_api_authentication(http_method, url, parameters = {}, options = {})
     should_allow_http_basic_auth_with_username_and_password(http_method, url, parameters, options)
     should_allow_http_basic_auth_with_key(http_method, url, parameters, options)
     should_allow_key_based_auth(http_method, url, parameters, options)
@@ -342,14 +341,14 @@ class ActiveSupport::TestCase
     failure_code = options[:failure_code] || :unauthorized
 
     context "should not send www authenticate when header accept auth is session #{http_method} #{url}" do
-      context "without credentials" do
+      context 'without credentials' do
         setup do
-          send(http_method, url, parameters, { "X-Authentication-Scheme" => "Session" })
+          send(http_method, url, parameters,  'X-Authentication-Scheme' => 'Session')
         end
 
         should respond_with failure_code
         should_respond_with_content_type_based_on_url(url)
-        should "include correct www_authenticate_header" do
+        should 'include correct www_authenticate_header' do
           # the 3.0.9 implementation of head leads to Www as the method capitalizes each
           # word split by a hyphen.
           # this is fixed in 3.1.0 http://apidock.com/rails/v3.1.0/ActionController/Head/head
@@ -364,7 +363,6 @@ class ActiveSupport::TestCase
         end
       end
     end
-
   end
 
   # Test that a request allows the username and password for HTTP BASIC
@@ -375,12 +373,12 @@ class ActiveSupport::TestCase
   # @param [optional, Hash] options additional options
   # @option options [Symbol] :success_code Successful response code (:success)
   # @option options [Symbol] :failure_code Failure response code (:unauthorized)
-  def self.should_allow_http_basic_auth_with_username_and_password(http_method, url, parameters={}, options={})
+  def self.should_allow_http_basic_auth_with_username_and_password(http_method, url, parameters = {}, options = {})
     success_code = options[:success_code] || :success
     failure_code = options[:failure_code] || :unauthorized
 
     context "should allow http basic auth using a username and password for #{http_method} #{url}" do
-      context "with a valid HTTP authentication" do
+      context 'with a valid HTTP authentication' do
         setup do
           @user = User.generate_with_protected!(password: 'adminADMIN!', password_confirmation: 'adminADMIN!', admin: true) # Admin so they can access the project
 
@@ -389,12 +387,12 @@ class ActiveSupport::TestCase
 
         should respond_with success_code
         should_respond_with_content_type_based_on_url(url)
-        should "login as the user" do
+        should 'login as the user' do
           assert_equal @user, User.current
         end
       end
 
-      context "with an invalid HTTP authentication" do
+      context 'with an invalid HTTP authentication' do
         setup do
           @user = User.generate_with_protected!
 
@@ -403,19 +401,19 @@ class ActiveSupport::TestCase
 
         should respond_with failure_code
         should_respond_with_content_type_based_on_url(url)
-        should "not login as the user" do
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
 
-      context "without credentials" do
+      context 'without credentials' do
         setup do
           send(http_method, url, parameters)
         end
 
         should respond_with failure_code
         should_respond_with_content_type_based_on_url(url)
-        should "include_www_authenticate_header" do
+        should 'include_www_authenticate_header' do
           # the 3.0.9 implementation of head leads to Www as the method capitalizes each
           # word split by a hyphen.
           # this is fixed in 3.1.0 http://apidock.com/rails/v3.1.0/ActionController/Head/head
@@ -428,7 +426,6 @@ class ActiveSupport::TestCase
         end
       end
     end
-
   end
 
   # Test that a request allows the API key with HTTP BASIC
@@ -439,12 +436,12 @@ class ActiveSupport::TestCase
   # @param [optional, Hash] options additional options
   # @option options [Symbol] :success_code Successful response code (:success)
   # @option options [Symbol] :failure_code Failure response code (:unauthorized)
-  def self.should_allow_http_basic_auth_with_key(http_method, url, parameters={}, options={})
+  def self.should_allow_http_basic_auth_with_key(http_method, url, parameters = {}, options = {})
     success_code = options[:success_code] || :success
     failure_code = options[:failure_code] || :unauthorized
 
     context "should allow http basic auth with a key for #{http_method} #{url}" do
-      context "with a valid HTTP authentication using the API token" do
+      context 'with a valid HTTP authentication using the API token' do
         setup do
           @user = User.generate_with_protected!(admin: true)
           @token = Token.generate!(user: @user, action: 'api')
@@ -455,12 +452,12 @@ class ActiveSupport::TestCase
         should respond_with success_code
         should_respond_with_content_type_based_on_url(url)
         should_be_a_valid_response_string_based_on_url(url)
-        should "login as the user" do
+        should 'login as the user' do
           assert_equal @user, User.current
         end
       end
 
-      context "with an invalid HTTP authentication" do
+      context 'with an invalid HTTP authentication' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'feeds')
@@ -470,7 +467,7 @@ class ActiveSupport::TestCase
 
         should respond_with failure_code
         should_respond_with_content_type_based_on_url(url)
-        should "not login as the user" do
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
@@ -485,12 +482,12 @@ class ActiveSupport::TestCase
   # @param [optional, Hash] options additional options
   # @option options [Symbol] :success_code Successful response code (:success)
   # @option options [Symbol] :failure_code Failure response code (:unauthorized)
-  def self.should_allow_key_based_auth(http_method, url, parameters={}, options={})
+  def self.should_allow_key_based_auth(http_method, url, parameters = {}, options = {})
     success_code = options[:success_code] || :success
     failure_code = options[:failure_code] || :unauthorized
 
     context "should allow key based auth using key=X for #{http_method} #{url}" do
-      context "with a valid api token" do
+      context 'with a valid api token' do
         setup do
           @user = User.generate_with_protected!(admin: true)
           @token = Token.generate!(user: @user, action: 'api')
@@ -506,12 +503,12 @@ class ActiveSupport::TestCase
         should respond_with success_code
         should_respond_with_content_type_based_on_url(url)
         should_be_a_valid_response_string_based_on_url(url)
-        should "login as the user" do
+        should 'login as the user' do
           assert_equal @user, User.current
         end
       end
 
-      context "with an invalid api token" do
+      context 'with an invalid api token' do
         setup do
           @user = User.generate_with_protected!
           @token = Token.generate!(user: @user, action: 'feeds')
@@ -526,7 +523,7 @@ class ActiveSupport::TestCase
 
         should respond_with failure_code
         should_respond_with_content_type_based_on_url(url)
-        should "not login as the user" do
+        should 'not login as the user' do
           assert_equal User.anonymous, User.current
         end
       end
@@ -536,13 +533,13 @@ class ActiveSupport::TestCase
       setup do
         @user = User.generate_with_protected!(admin: true)
         @token = Token.generate!(user: @user, action: 'api')
-        send(http_method, url, parameters, {'X-OpenProject-API-Key' => @token.value.to_s})
+        send(http_method, url, parameters, 'X-OpenProject-API-Key' => @token.value.to_s)
       end
 
       should respond_with success_code
       should_respond_with_content_type_based_on_url(url)
       should_be_a_valid_response_string_based_on_url(url)
-      should "login as the user" do
+      should 'login as the user' do
         assert_equal @user, User.current
       end
     end
@@ -580,19 +577,18 @@ class ActiveSupport::TestCase
     else
       raise "Unknown content type for should_be_a_valid_response_based_on_url: #{url}"
     end
-
   end
 
   # Checks that the response is a valid JSON string
   def self.should_be_a_valid_json_string
-    should "be a valid JSON string (or empty)" do
+    should 'be a valid JSON string (or empty)' do
       assert(response.body.blank? || ActiveSupport::JSON.decode(response.body))
     end
   end
 
   # Checks that the response is a valid XML string
   def self.should_be_a_valid_xml_string
-    should "be a valid XML string" do
+    should 'be a valid XML string' do
       assert REXML::Document.new(response.body)
     end
   end

--- a/test/unit/activity_test.rb
+++ b/test/unit/activity_test.rb
@@ -50,7 +50,7 @@ class ActivityTest < ActiveSupport::TestCase
   end
 
   def test_activity_without_subprojects
-    events = find_events(User.anonymous, :project => @project)
+    events = find_events(User.anonymous, project: @project)
     assert_not_nil events
 
     assert events.include?(WorkPackage.find(1))
@@ -60,7 +60,7 @@ class ActivityTest < ActiveSupport::TestCase
   end
 
   def test_activity_with_subprojects
-    events = find_events(User.anonymous, :project => @project, :with_subprojects => 1)
+    events = find_events(User.anonymous, project: @project, with_subprojects: 1)
     assert_not_nil events
 
     assert events.include?(WorkPackage.find(1))
@@ -89,7 +89,7 @@ class ActivityTest < ActiveSupport::TestCase
 
   def test_user_activity
     user = User.find(2)
-    events = Redmine::Activity::Fetcher.new(User.anonymous, :author => user).events(nil, nil, :limit => 10)
+    events = Redmine::Activity::Fetcher.new(User.anonymous, author: user).events(nil, nil, limit: 10)
 
     assert(events.size > 0)
     assert(events.size <= 10)

--- a/test/unit/activity_test.rb
+++ b/test/unit/activity_test.rb
@@ -34,14 +34,14 @@ class ActivityTest < ActiveSupport::TestCase
   def setup
     super
     @project = Project.find(1)
-    [1,4,5,6].each do |issue_id|
+    [1, 4, 5, 6].each do |issue_id|
       i = WorkPackage.find(issue_id)
-      i.add_journal(User.current, "A journal to find")
+      i.add_journal(User.current, 'A journal to find')
       i.save!
     end
 
-    WorkPackage.all.each { |i| i.recreate_initial_journal! }
-    Message.all.each { |m| m.recreate_initial_journal! }
+    WorkPackage.all.each(&:recreate_initial_journal!)
+    Message.all.each(&:recreate_initial_journal!)
   end
 
   def teardown
@@ -93,12 +93,12 @@ class ActivityTest < ActiveSupport::TestCase
 
     assert(events.size > 0)
     assert(events.size <= 10)
-    assert_nil(events.detect {|e| e.event_author != user})
+    assert_nil(events.detect { |e| e.event_author != user })
   end
 
   private
 
-  def find_events(user, options={})
+  def find_events(user, options = {})
     events = Redmine::Activity::Fetcher.new(user, options).events(Date.today - 30, Date.today + 1)
     # Because events are provided by the journals, but we want to test for
     # their targets here, transform that

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -32,9 +32,9 @@ class AttachmentTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_create
-    a = Attachment.new(:container => WorkPackage.find(1),
-                       :file => uploaded_test_file("testfile.txt", "text/plain"),
-                       :author => User.find(1))
+    a = Attachment.new(container: WorkPackage.find(1),
+                       file: uploaded_test_file("testfile.txt", "text/plain"),
+                       author: User.find(1))
     assert a.save
     assert_equal 'testfile.txt', a.filename
     assert_equal 59, a.filesize
@@ -45,27 +45,27 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   def test_create_should_auto_assign_content_type
-    a = Attachment.new(:container => WorkPackage.find(1),
-                       :file => uploaded_test_file("testfile.txt", ""),
-                       :author => User.find(1))
+    a = Attachment.new(container: WorkPackage.find(1),
+                       file: uploaded_test_file("testfile.txt", ""),
+                       author: User.find(1))
     assert a.save
     assert_equal 'text/plain', a.content_type
   end
 
   def test_identical_attachments_at_the_same_time_should_not_overwrite
-    a1 = Attachment.create!(:container => WorkPackage.find(1),
-                            :file => uploaded_test_file("testfile.txt", ""),
-                            :author => User.find(1))
-    a2 = Attachment.create!(:container => WorkPackage.find(1),
-                            :file => uploaded_test_file("testfile.txt", ""),
-                            :author => User.find(1))
+    a1 = Attachment.create!(container: WorkPackage.find(1),
+                            file: uploaded_test_file("testfile.txt", ""),
+                            author: User.find(1))
+    a2 = Attachment.create!(container: WorkPackage.find(1),
+                            file: uploaded_test_file("testfile.txt", ""),
+                            author: User.find(1))
     assert a1.diskfile.path != a2.diskfile.path
   end
 
   context "Attachmnet#attach_files" do
     should "add unsaved files to the object as unsaved attachments" do
       # Max size of 0 to force Attachment creation failures
-      with_settings(:attachment_max_size => 0) do
+      with_settings(attachment_max_size: 0) do
         @issue = WorkPackage.find(1)
         response = Attachment.attach_files(
           @issue,

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -33,7 +33,7 @@ class AttachmentTest < ActiveSupport::TestCase
 
   def test_create
     a = Attachment.new(container: WorkPackage.find(1),
-                       file: uploaded_test_file("testfile.txt", "text/plain"),
+                       file: uploaded_test_file('testfile.txt', 'text/plain'),
                        author: User.find(1))
     assert a.save
     assert_equal 'testfile.txt', a.filename
@@ -46,7 +46,7 @@ class AttachmentTest < ActiveSupport::TestCase
 
   def test_create_should_auto_assign_content_type
     a = Attachment.new(container: WorkPackage.find(1),
-                       file: uploaded_test_file("testfile.txt", ""),
+                       file: uploaded_test_file('testfile.txt', ''),
                        author: User.find(1))
     assert a.save
     assert_equal 'text/plain', a.content_type
@@ -54,16 +54,16 @@ class AttachmentTest < ActiveSupport::TestCase
 
   def test_identical_attachments_at_the_same_time_should_not_overwrite
     a1 = Attachment.create!(container: WorkPackage.find(1),
-                            file: uploaded_test_file("testfile.txt", ""),
+                            file: uploaded_test_file('testfile.txt', ''),
                             author: User.find(1))
     a2 = Attachment.create!(container: WorkPackage.find(1),
-                            file: uploaded_test_file("testfile.txt", ""),
+                            file: uploaded_test_file('testfile.txt', ''),
                             author: User.find(1))
     assert a1.diskfile.path != a2.diskfile.path
   end
 
-  context "Attachmnet#attach_files" do
-    should "add unsaved files to the object as unsaved attachments" do
+  context 'Attachmnet#attach_files' do
+    should 'add unsaved files to the object as unsaved attachments' do
       # Max size of 0 to force Attachment creation failures
       with_settings(attachment_max_size: 0) do
         @issue = WorkPackage.find(1)

--- a/test/unit/board_test.rb
+++ b/test/unit/board_test.rb
@@ -60,6 +60,6 @@ class BoardTest < ActiveSupport::TestCase
         end
       end
     end
-    assert_equal 0, Message.count(conditions: {board_id: 1})
+    assert_equal 0, Message.count(conditions: { board_id: 1 })
   end
 end

--- a/test/unit/board_test.rb
+++ b/test/unit/board_test.rb
@@ -38,7 +38,7 @@ class BoardTest < ActiveSupport::TestCase
   end
 
   def test_create
-    board = Board.new(:project => @project, :name => 'Test board', :description => 'Test board description')
+    board = Board.new(project: @project, name: 'Test board', description: 'Test board description')
     assert board.save
     board.reload
     assert_equal 'Test board', board.name
@@ -60,6 +60,6 @@ class BoardTest < ActiveSupport::TestCase
         end
       end
     end
-    assert_equal 0, Message.count(:conditions => {:board_id => 1})
+    assert_equal 0, Message.count(conditions: {board_id: 1})
   end
 end

--- a/test/unit/category_test.rb
+++ b/test/unit/category_test.rb
@@ -32,14 +32,14 @@ class CategoryTest < ActiveSupport::TestCase
   def setup
     super
     @project = FactoryGirl.create :project
-    @category = FactoryGirl.create :category, :project => @project
-    @issue = FactoryGirl.create :work_package, :category => @category
+    @category = FactoryGirl.create :category, project: @project
+    @issue = FactoryGirl.create :work_package, category: @category
     assert_equal @issue.category, @category
     assert_equal @category.work_packages, [@issue]
   end
 
   def test_create
-    (new_cat = Category.new).force_attributes = {:project_id => @project.id, :name => 'New category'}
+    (new_cat = Category.new).force_attributes = {project_id: @project.id, name: 'New category'}
     assert new_cat.valid?
     assert new_cat.save
     assert_equal 'New category', new_cat.name
@@ -49,9 +49,9 @@ class CategoryTest < ActiveSupport::TestCase
     group = FactoryGirl.create :group
     role = FactoryGirl.create :role
     (Member.new.tap do |m|
-      m.force_attributes = { :principal => group, :project => @project, :role_ids => [role.id] }
+      m.force_attributes = { principal: group, project: @project, role_ids: [role.id] }
     end).save!
-    (new_cat = Category.new).force_attributes = {:project_id => @project.id, :name => 'Group assignment', :assigned_to_id => group.id}
+    (new_cat = Category.new).force_attributes = {project_id: @project.id, name: 'Group assignment', assigned_to_id: group.id}
     assert new_cat.valid?
     assert new_cat.save
     assert_kind_of Group, new_cat.assigned_to
@@ -66,7 +66,7 @@ class CategoryTest < ActiveSupport::TestCase
 
   # both issue categories must be in the same project
   def test_destroy_with_reassign
-    reassign_to = FactoryGirl.create :category, :project => @project
+    reassign_to = FactoryGirl.create :category, project: @project
     @category.destroy(reassign_to)
     # Make sure the issue was reassigned
     assert_equal reassign_to, @issue.reload.category

--- a/test/unit/category_test.rb
+++ b/test/unit/category_test.rb
@@ -39,7 +39,7 @@ class CategoryTest < ActiveSupport::TestCase
   end
 
   def test_create
-    (new_cat = Category.new).force_attributes = {project_id: @project.id, name: 'New category'}
+    (new_cat = Category.new).force_attributes = { project_id: @project.id, name: 'New category' }
     assert new_cat.valid?
     assert new_cat.save
     assert_equal 'New category', new_cat.name
@@ -51,7 +51,7 @@ class CategoryTest < ActiveSupport::TestCase
     (Member.new.tap do |m|
       m.force_attributes = { principal: group, project: @project, role_ids: [role.id] }
     end).save!
-    (new_cat = Category.new).force_attributes = {project_id: @project.id, name: 'Group assignment', assigned_to_id: group.id}
+    (new_cat = Category.new).force_attributes = { project_id: @project.id, name: 'Group assignment', assigned_to_id: group.id }
     assert new_cat.valid?
     assert new_cat.save
     assert_kind_of Group, new_cat.assigned_to

--- a/test/unit/changeset_test.rb
+++ b/test/unit/changeset_test.rb
@@ -35,14 +35,14 @@ class ChangesetTest < ActiveSupport::TestCase
     WorkPackage.all.each { |m| m.recreate_initial_journal! }
 
     ActionMailer::Base.deliveries.clear
-    Setting.commit_fix_status_id = Status.find(:first, :conditions => ["is_closed = ?", true]).id
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
     Setting.commit_fix_done_ratio = '90'
     Setting.commit_ref_keywords = '*'
     Setting.commit_fix_keywords = 'fixes , closes'
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => 'New commit (#2). Fixes #1')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: 'New commit (#2). Fixes #1')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1, 2], c.work_package_ids.sort
@@ -56,9 +56,9 @@ class ChangesetTest < ActiveSupport::TestCase
     Setting.commit_ref_keywords = 'refs'
     Setting.commit_fix_keywords = ''
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => 'Ignores #2. Refs #1')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: 'Ignores #2. Refs #1')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1], c.work_package_ids.sort
@@ -68,9 +68,9 @@ class ChangesetTest < ActiveSupport::TestCase
     Setting.commit_ref_keywords = '*'
     Setting.commit_fix_keywords = ''
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => 'Ignores #2. Refs #1')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: 'Ignores #2. Refs #1')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1, 2], c.work_package_ids.sort
@@ -95,17 +95,17 @@ class ChangesetTest < ActiveSupport::TestCase
       '3,25' => 3.25,
       '3,25h' => 3.25,
     }.each do |syntax, expected_hours|
-      c = Changeset.new(:repository => Project.find(1).repository,
-                        :committed_on => 24.hours.ago,
-                        :comments => "Worked on this work_package #1 @#{syntax}",
-                        :revision => '520',
-                        :user => User.find(2))
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: 24.hours.ago,
+                        comments: "Worked on this work_package #1 @#{syntax}",
+                        revision: '520',
+                        user: User.find(2))
       assert_difference 'TimeEntry.count' do
         c.scan_comment_for_work_package_ids
       end
       assert_equal [1], c.work_package_ids.sort
 
-      time = TimeEntry.first(:order => 'id desc')
+      time = TimeEntry.first(order: 'id desc')
       assert_equal 1, time.work_package_id
       assert_equal 1, time.project_id
       assert_equal 2, time.user_id
@@ -117,15 +117,15 @@ class ChangesetTest < ActiveSupport::TestCase
   end
 
   def test_ref_keywords_closing_with_timelog
-    Setting.commit_fix_status_id = Status.find(:first, :conditions => ["is_closed = ?", true]).id
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
     Setting.commit_ref_keywords = '*'
     Setting.commit_fix_keywords = 'fixes , closes'
     Setting.commit_logtime_enabled = '1'
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => 'This is a comment. Fixes #1 @4.5, #2 @1',
-                      :user => User.find(2))
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: 'This is a comment. Fixes #1 @4.5, #2 @1',
+                      user: User.find(2))
     assert_difference 'TimeEntry.count', 2 do
       c.scan_comment_for_work_package_ids
     end
@@ -134,16 +134,16 @@ class ChangesetTest < ActiveSupport::TestCase
     assert WorkPackage.find(1).closed?
     assert WorkPackage.find(2).closed?
 
-    times = TimeEntry.all(:order => 'id desc', :limit => 2)
+    times = TimeEntry.all(order: 'id desc', limit: 2)
     assert_equal [1, 2], times.collect(&:work_package_id).sort
   end
 
   def test_ref_keywords_any_line_start
     Setting.commit_ref_keywords = '*'
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => '#1 is the reason of this commit')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: '#1 is the reason of this commit')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1], c.work_package_ids.sort
@@ -152,9 +152,9 @@ class ChangesetTest < ActiveSupport::TestCase
   def test_ref_keywords_allow_brackets_around_a_work_package_number
     Setting.commit_ref_keywords = '*'
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => '[#1] Worked on this work_package')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: '[#1] Worked on this work_package')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1], c.work_package_ids.sort
@@ -163,18 +163,18 @@ class ChangesetTest < ActiveSupport::TestCase
   def test_ref_keywords_allow_brackets_around_multiple_work_package_numbers
     Setting.commit_ref_keywords = '*'
 
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => '[#1 #2, #3] Worked on these')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: '[#1 #2, #3] Worked on these')
     c.scan_comment_for_work_package_ids
 
     assert_equal [1,2,3], c.work_package_ids.sort
   end
 
   def test_commit_referencing_a_subproject_work_package
-    c = Changeset.new(:repository => Project.find(1).repository,
-                      :committed_on => Time.now,
-                      :comments => 'refs #5, a subproject work_package')
+    c = Changeset.new(repository: Project.find(1).repository,
+                      committed_on: Time.now,
+                      comments: 'refs #5, a subproject work_package')
     c.scan_comment_for_work_package_ids
 
     assert_equal [5], c.work_package_ids.sort
@@ -184,12 +184,12 @@ class ChangesetTest < ActiveSupport::TestCase
   def test_commit_referencing_a_parent_project_work_package
     # repository of child project
     r = Repository::Subversion.create!(
-          :project => Project.find(3),
-          :url     => 'svn://localhost/test')
+          project: Project.find(3),
+          url:     'svn://localhost/test')
 
-    c = Changeset.new(:repository => r,
-                      :committed_on => Time.now,
-                      :comments => 'refs #2, an work_package of a parent project')
+    c = Changeset.new(repository: r,
+                      committed_on: Time.now,
+                      comments: 'refs #2, an work_package of a parent project')
     c.scan_comment_for_work_package_ids
 
     assert_equal [2], c.work_package_ids.sort
@@ -197,19 +197,19 @@ class ChangesetTest < ActiveSupport::TestCase
   end
 
   def test_text_tag_revision
-    c = Changeset.new(:revision => '520')
+    c = Changeset.new(revision: '520')
     assert_equal 'r520', c.text_tag
   end
 
   def test_text_tag_hash
     c = Changeset.new(
-          :scmid    => '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          :revision => '7234cb2750b63f47bff735edc50a1c0a433c2518')
+          scmid:    '7234cb2750b63f47bff735edc50a1c0a433c2518',
+          revision: '7234cb2750b63f47bff735edc50a1c0a433c2518')
     assert_equal 'commit:7234cb2750b63f47bff735edc50a1c0a433c2518', c.text_tag
   end
 
   def test_text_tag_hash_all_number
-    c = Changeset.new(:scmid => '0123456789', :revision => '0123456789')
+    c = Changeset.new(scmid: '0123456789', revision: '0123456789')
     assert_equal 'commit:0123456789', c.text_tag
   end
 
@@ -234,66 +234,66 @@ class ChangesetTest < ActiveSupport::TestCase
   end
 
   def test_comments_should_be_converted_to_utf8
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       proj = Project.find(3)
       str = File.read(Rails.root.join('test/fixtures/encoding/iso-8859-1.txt'))
       r = Repository::Filesystem.create!(
-            :project => proj, :url => '/tmp/test/filesystem_repository',
-            :log_encoding => 'ISO-8859-1' )
+            project: proj, url: '/tmp/test/filesystem_repository',
+            log_encoding: 'ISO-8859-1' )
       assert r
-      c = Changeset.new(:repository => r,
-                        :committed_on => Time.now,
-                        :revision => '123',
-                        :scmid => '12345',
-                        :comments => str)
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        revision: '123',
+                        scmid: '12345',
+                        comments: str)
       assert( c.save )
       assert_equal "Texte encodé en ISO-8859-1.", c.comments
     end
   end
 
   def test_invalid_utf8_sequences_in_comments_should_be_replaced_latin1
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       proj = Project.find(3)
       str = File.read(Rails.root.join('test/fixtures/encoding/iso-8859-1.txt'))
       r = Repository::Filesystem.create!(
-            :project => proj,
-            :url => '/tmp/test/filesystem_repository',
-            :log_encoding => 'UTF-8' )
+            project: proj,
+            url: '/tmp/test/filesystem_repository',
+            log_encoding: 'UTF-8' )
       assert r
-      c = Changeset.new(:repository   => r,
-                        :committed_on => Time.now,
-                        :revision     => '123',
-                        :scmid        => '12345',
-                        :comments     => str)
+      c = Changeset.new(repository:   r,
+                        committed_on: Time.now,
+                        revision:     '123',
+                        scmid:        '12345',
+                        comments:     str)
       assert( c.save )
       assert_equal "Texte encod? en ISO-8859-1.", c.comments
     end
   end
 
   def test_invalid_utf8_sequences_in_comments_should_be_replaced_ja_jis
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       proj = Project.find(3)
       str = "test\xb5\xfetest\xb5\xfe"
       if str.respond_to?(:force_encoding)
         str.force_encoding('ASCII-8BIT')
       end
       r = Repository::Filesystem.create!(
-            :project => proj,
-            :url     => '/tmp/test/filesystem_repository',
-            :log_encoding => 'ISO-2022-JP' )
+            project: proj,
+            url:     '/tmp/test/filesystem_repository',
+            log_encoding: 'ISO-2022-JP' )
       assert r
-      c = Changeset.new(:repository   => r,
-                        :committed_on => Time.now,
-                        :revision     => '123',
-                        :scmid        => '12345',
-                        :comments     => str)
+      c = Changeset.new(repository:   r,
+                        committed_on: Time.now,
+                        revision:     '123',
+                        scmid:        '12345',
+                        comments:     str)
       assert( c.save )
       assert_equal "test??test??", c.comments
     end
   end
 
   def test_comments_should_be_converted_all_latin1_to_utf8
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       s1 = "\xC2\x80"
       s2 = "\xc3\x82\xc2\x80"
       s4 = s2.dup
@@ -307,31 +307,31 @@ class ChangesetTest < ActiveSupport::TestCase
       end
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
-            :project => proj, :url => '/tmp/test/filesystem_repository',
-            :log_encoding => 'ISO-8859-1' )
+            project: proj, url: '/tmp/test/filesystem_repository',
+            log_encoding: 'ISO-8859-1' )
       assert r
-      c = Changeset.new(:repository => r,
-                        :committed_on => Time.now,
-                        :revision => '123',
-                        :scmid => '12345',
-                        :comments => s1)
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        revision: '123',
+                        scmid: '12345',
+                        comments: s1)
       assert( c.save )
       assert_equal s4, c.comments
     end
   end
 
   def test_comments_nil
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
-            :project => proj, :url => '/tmp/test/filesystem_repository',
-            :log_encoding => 'ISO-8859-1' )
+            project: proj, url: '/tmp/test/filesystem_repository',
+            log_encoding: 'ISO-8859-1' )
       assert r
-      c = Changeset.new(:repository => r,
-                        :committed_on => Time.now,
-                        :revision => '123',
-                        :scmid => '12345',
-                        :comments => nil)
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        revision: '123',
+                        scmid: '12345',
+                        comments: nil)
       assert( c.save )
       assert_equal "", c.comments
       if c.comments.respond_to?(:force_encoding)
@@ -341,17 +341,17 @@ class ChangesetTest < ActiveSupport::TestCase
   end
 
   def test_comments_empty
-    with_settings :enabled_scm => ['Filesystem'] do
+    with_settings enabled_scm: ['Filesystem'] do
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
-            :project => proj, :url => '/tmp/test/filesystem_repository',
-            :log_encoding => 'ISO-8859-1' )
+            project: proj, url: '/tmp/test/filesystem_repository',
+            log_encoding: 'ISO-8859-1' )
       assert r
-      c = Changeset.new(:repository => r,
-                        :committed_on => Time.now,
-                        :revision => '123',
-                        :scmid => '12345',
-                        :comments => "")
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        revision: '123',
+                        scmid: '12345',
+                        comments: "")
       assert( c.save )
       assert_equal "", c.comments
       if c.comments.respond_to?(:force_encoding)

--- a/test/unit/changeset_test.rb
+++ b/test/unit/changeset_test.rb
@@ -32,10 +32,10 @@ class ChangesetTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_ref_keywords_any
-    WorkPackage.all.each { |m| m.recreate_initial_journal! }
+    WorkPackage.all.each(&:recreate_initial_journal!)
 
     ActionMailer::Base.deliveries.clear
-    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ['is_closed = ?', true]).id
     Setting.commit_fix_done_ratio = '90'
     Setting.commit_ref_keywords = '*'
     Setting.commit_fix_keywords = 'fixes , closes'
@@ -117,7 +117,7 @@ class ChangesetTest < ActiveSupport::TestCase
   end
 
   def test_ref_keywords_closing_with_timelog
-    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ['is_closed = ?', true]).id
     Setting.commit_ref_keywords = '*'
     Setting.commit_fix_keywords = 'fixes , closes'
     Setting.commit_logtime_enabled = '1'
@@ -168,7 +168,7 @@ class ChangesetTest < ActiveSupport::TestCase
                       comments: '[#1 #2, #3] Worked on these')
     c.scan_comment_for_work_package_ids
 
-    assert_equal [1,2,3], c.work_package_ids.sort
+    assert_equal [1, 2, 3], c.work_package_ids.sort
   end
 
   def test_commit_referencing_a_subproject_work_package
@@ -239,15 +239,15 @@ class ChangesetTest < ActiveSupport::TestCase
       str = File.read(Rails.root.join('test/fixtures/encoding/iso-8859-1.txt'))
       r = Repository::Filesystem.create!(
             project: proj, url: '/tmp/test/filesystem_repository',
-            log_encoding: 'ISO-8859-1' )
+            log_encoding: 'ISO-8859-1')
       assert r
       c = Changeset.new(repository: r,
                         committed_on: Time.now,
                         revision: '123',
                         scmid: '12345',
                         comments: str)
-      assert( c.save )
-      assert_equal "Texte encodé en ISO-8859-1.", c.comments
+      assert(c.save)
+      assert_equal 'Texte encodé en ISO-8859-1.', c.comments
     end
   end
 
@@ -258,15 +258,15 @@ class ChangesetTest < ActiveSupport::TestCase
       r = Repository::Filesystem.create!(
             project: proj,
             url: '/tmp/test/filesystem_repository',
-            log_encoding: 'UTF-8' )
+            log_encoding: 'UTF-8')
       assert r
       c = Changeset.new(repository:   r,
                         committed_on: Time.now,
                         revision:     '123',
                         scmid:        '12345',
                         comments:     str)
-      assert( c.save )
-      assert_equal "Texte encod? en ISO-8859-1.", c.comments
+      assert(c.save)
+      assert_equal 'Texte encod? en ISO-8859-1.', c.comments
     end
   end
 
@@ -280,15 +280,15 @@ class ChangesetTest < ActiveSupport::TestCase
       r = Repository::Filesystem.create!(
             project: proj,
             url:     '/tmp/test/filesystem_repository',
-            log_encoding: 'ISO-2022-JP' )
+            log_encoding: 'ISO-2022-JP')
       assert r
       c = Changeset.new(repository:   r,
                         committed_on: Time.now,
                         revision:     '123',
                         scmid:        '12345',
                         comments:     str)
-      assert( c.save )
-      assert_equal "test??test??", c.comments
+      assert(c.save)
+      assert_equal 'test??test??', c.comments
     end
   end
 
@@ -308,14 +308,14 @@ class ChangesetTest < ActiveSupport::TestCase
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
             project: proj, url: '/tmp/test/filesystem_repository',
-            log_encoding: 'ISO-8859-1' )
+            log_encoding: 'ISO-8859-1')
       assert r
       c = Changeset.new(repository: r,
                         committed_on: Time.now,
                         revision: '123',
                         scmid: '12345',
                         comments: s1)
-      assert( c.save )
+      assert(c.save)
       assert_equal s4, c.comments
     end
   end
@@ -325,17 +325,17 @@ class ChangesetTest < ActiveSupport::TestCase
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
             project: proj, url: '/tmp/test/filesystem_repository',
-            log_encoding: 'ISO-8859-1' )
+            log_encoding: 'ISO-8859-1')
       assert r
       c = Changeset.new(repository: r,
                         committed_on: Time.now,
                         revision: '123',
                         scmid: '12345',
                         comments: nil)
-      assert( c.save )
-      assert_equal "", c.comments
+      assert(c.save)
+      assert_equal '', c.comments
       if c.comments.respond_to?(:force_encoding)
-        assert_equal "UTF-8", c.comments.encoding.to_s
+        assert_equal 'UTF-8', c.comments.encoding.to_s
       end
     end
   end
@@ -345,17 +345,17 @@ class ChangesetTest < ActiveSupport::TestCase
       proj = Project.find(3)
       r = Repository::Filesystem.create!(
             project: proj, url: '/tmp/test/filesystem_repository',
-            log_encoding: 'ISO-8859-1' )
+            log_encoding: 'ISO-8859-1')
       assert r
       c = Changeset.new(repository: r,
                         committed_on: Time.now,
                         revision: '123',
                         scmid: '12345',
-                        comments: "")
-      assert( c.save )
-      assert_equal "", c.comments
+                        comments: '')
+      assert(c.save)
+      assert_equal '', c.comments
       if c.comments.respond_to?(:force_encoding)
-        assert_equal "UTF-8", c.comments.encoding.to_s
+        assert_equal 'UTF-8', c.comments.encoding.to_s
       end
     end
   end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -36,17 +36,17 @@ class CommentTest < ActiveSupport::TestCase
     assert FactoryGirl.build(:comment).valid?
 
     # comment text required
-    refute FactoryGirl.build(:comment, :comments => '').valid?
+    refute FactoryGirl.build(:comment, comments: '').valid?
     # object that is commented required
-    refute FactoryGirl.build(:comment, :commented => nil).valid?
+    refute FactoryGirl.build(:comment, commented: nil).valid?
     # author required
-    refute FactoryGirl.build(:comment, :author => nil).valid?
+    refute FactoryGirl.build(:comment, author: nil).valid?
   end
 
   def test_create
     user = FactoryGirl.create(:user)
     news = FactoryGirl.create(:news)
-    comment = Comment.new(:commented => news, :author => user, :comments => 'some important words')
+    comment = Comment.new(commented: news, author: user, comments: 'some important words')
     assert comment.save
     assert_equal 1, news.reload.comments_count
   end
@@ -54,7 +54,7 @@ class CommentTest < ActiveSupport::TestCase
   def test_create_through_news
     user = FactoryGirl.create(:user)
     news = FactoryGirl.create(:news)
-    comment = news.new_comment(:author => user, :comments => 'some important words')
+    comment = news.new_comment(author: user, comments: 'some important words')
     assert comment.save
     assert_equal 1, news.reload.comments_count
   end
@@ -62,12 +62,12 @@ class CommentTest < ActiveSupport::TestCase
   def test_create_comment_through_news
     user = FactoryGirl.create(:user)
     news = FactoryGirl.create(:news)
-    news.post_comment!(:author => user, :comments => 'some important words')
+    news.post_comment!(author: user, comments: 'some important words')
     assert_equal 1, news.reload.comments_count
   end
 
   def test_text
-    comment = FactoryGirl.build(:comment, :comments => 'something useful')
+    comment = FactoryGirl.build(:comment, comments: 'something useful')
     assert_equal 'something useful', comment.text
   end
 
@@ -75,21 +75,21 @@ class CommentTest < ActiveSupport::TestCase
     # news needs a project in order to be notified
     # see Redmine::Acts::Journalized::Deprecated#recipients
     project = FactoryGirl.create(:project)
-    user = FactoryGirl.create(:user, :member_in_project => project)
+    user = FactoryGirl.create(:user, member_in_project: project)
     # author is automatically added as watcher
     # this makes #user to receive a notification
-    news = FactoryGirl.create(:news, :project => project, :author => user)
+    news = FactoryGirl.create(:news, project: project, author: user)
 
     # with notifications for that event turned on
     Notifier.stub(:notify?).with(:news_comment_added).and_return(true)
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
-      Comment.create!(:commented => news, :author => user, :comments => 'more useful stuff')
+      Comment.create!(commented: news, author: user, comments: 'more useful stuff')
     end
 
     # with notifications for that event turned off
     Notifier.stub(:notify?).with(:news_comment_added).and_return(false)
     assert_no_difference 'ActionMailer::Base.deliveries.size' do
-      Comment.create!(:commented => news, :author => user, :comments => 'more useful stuff')
+      Comment.create!(commented: news, author: user, comments: 'more useful stuff')
     end
   end
 

--- a/test/unit/custom_field_test.rb
+++ b/test/unit/custom_field_test.rb
@@ -30,7 +30,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class CustomFieldTest < ActiveSupport::TestCase
   def test_create
-    field = UserCustomField.new(:name => 'Money money money', :field_format => 'float')
+    field = UserCustomField.new(name: 'Money money money', field_format: 'float')
     assert field.save
   end
 

--- a/test/unit/custom_field_test.rb
+++ b/test/unit/custom_field_test.rb
@@ -36,20 +36,20 @@ class CustomFieldTest < ActiveSupport::TestCase
 
   def test_possible_values_should_accept_an_array
     field = CustomField.new
-    field.possible_values = ["One value", ""]
-    assert_equal ["One value"], field.possible_values
+    field.possible_values = ['One value', '']
+    assert_equal ['One value'], field.possible_values
   end
 
   def test_possible_values_should_accept_a_string
     field = CustomField.new
-    field.possible_values = "One value"
-    assert_equal ["One value"], field.possible_values
+    field.possible_values = 'One value'
+    assert_equal ['One value'], field.possible_values
   end
 
   def test_possible_values_should_accept_a_multiline_string
     field = CustomField.new
     field.possible_values = "One value\nAnd another one  \r\n \n"
-    assert_equal ["One value", "And another one"], field.possible_values
+    assert_equal ['One value', 'And another one'], field.possible_values
   end
 
   def test_destroy

--- a/test/unit/custom_field_user_format_test.rb
+++ b/test/unit/custom_field_user_format_test.rb
@@ -32,14 +32,14 @@ class CustomFieldUserFormatTest < ActiveSupport::TestCase
   def setup
     super
     @project = FactoryGirl.create :valid_project
-    role   = FactoryGirl.create :role, :permissions => [:view_work_packages, :edit_work_packages]
+    role   = FactoryGirl.create :role, permissions: [:view_work_packages, :edit_work_packages]
     @users = FactoryGirl.create_list(:user, 5)
     @users.each {|user| @project.add_member!(user, role) }
     @issue = FactoryGirl.create :work_package,
-        :project => @project,
-        :author => @users.first,
-        :type => @project.types.first
-    @field = WorkPackageCustomField.create!(:name => 'Tester', :field_format => 'user')
+        project: @project,
+        author: @users.first,
+        type: @project.types.first
+    @field = WorkPackageCustomField.create!(name: 'Tester', field_format: 'user')
   end
 
   def test_possible_values_with_no_arguments

--- a/test/unit/custom_field_user_format_test.rb
+++ b/test/unit/custom_field_user_format_test.rb
@@ -34,11 +34,11 @@ class CustomFieldUserFormatTest < ActiveSupport::TestCase
     @project = FactoryGirl.create :valid_project
     role   = FactoryGirl.create :role, permissions: [:view_work_packages, :edit_work_packages]
     @users = FactoryGirl.create_list(:user, 5)
-    @users.each {|user| @project.add_member!(user, role) }
+    @users.each { |user| @project.add_member!(user, role) }
     @issue = FactoryGirl.create :work_package,
-        project: @project,
-        author: @users.first,
-        type: @project.types.first
+                                project: @project,
+                                author: @users.first,
+                                type: @project.types.first
     @field = WorkPackageCustomField.create!(name: 'Tester', field_format: 'user')
   end
 
@@ -65,12 +65,12 @@ class CustomFieldUserFormatTest < ActiveSupport::TestCase
   def test_possible_values_options_with_project_resource
     possible_values_options = @field.possible_values_options(@project.work_packages.first)
     assert possible_values_options.any?
-    assert_equal @project.users.sort.map {|u| [u.name, u.id.to_s]}, possible_values_options
+    assert_equal @project.users.sort.map { |u| [u.name, u.id.to_s] }, possible_values_options
   end
 
   def test_cast_blank_value
     assert_equal nil, @field.cast_value(nil)
-    assert_equal nil, @field.cast_value("")
+    assert_equal nil, @field.cast_value('')
   end
 
   def test_cast_valid_value
@@ -81,6 +81,6 @@ class CustomFieldUserFormatTest < ActiveSupport::TestCase
 
   def test_cast_invalid_value
     User.delete_all
-    assert_equal nil, @field.cast_value("1")
+    assert_equal nil, @field.cast_value('1')
   end
 end

--- a/test/unit/custom_value_test.rb
+++ b/test/unit/custom_value_test.rb
@@ -102,12 +102,11 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_float_field_validation
-
     user = FactoryGirl.create :user
     # There are cases, where the custom-value-table is not cleared completely,
     # therefore making double sure, that we have a clean slate before we start
     CustomField.destroy_all
-    FactoryGirl.create :float_user_custom_field, name: "Money"
+    FactoryGirl.create :float_user_custom_field, name: 'Money'
     v = CustomValue.new(customized: user, custom_field: UserCustomField.find_by_name('Money'))
     v.value = '11.2'
     assert v.save
@@ -121,8 +120,8 @@ class CustomValueTest < ActiveSupport::TestCase
 
   def test_default_value
     custom_field = FactoryGirl.create :issue_custom_field,
-      field_format: 'string',
-      default_value: "Some Default String"
+                                      field_format: 'string',
+                                      default_value: 'Some Default String'
 
     field = CustomField.find_by_default_value('Some Default String')
     assert_equal field, custom_field
@@ -139,9 +138,9 @@ class CustomValueTest < ActiveSupport::TestCase
     user = FactoryGirl.create :user
     custom_field = FactoryGirl.create :user_custom_field, field_format: 'string'
     custom_value = FactoryGirl.create :principal_custom_value,
-      custom_field: custom_field,
-      customized: user,
-      value: '01 23 45 67 89'
+                                      custom_field: custom_field,
+                                      customized: user,
+                                      value: '01 23 45 67 89'
     user.reload
 
     assert !user.custom_values.empty?

--- a/test/unit/custom_value_test.rb
+++ b/test/unit/custom_value_test.rb
@@ -30,8 +30,8 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class CustomValueTest < ActiveSupport::TestCase
   def test_string_field_validation_with_blank_value
-    f = CustomField.new(:field_format => 'string')
-    v = CustomValue.new(:custom_field => f)
+    f = CustomField.new(field_format: 'string')
+    v = CustomValue.new(custom_field: f)
 
     v.value = nil
     assert v.valid?
@@ -46,8 +46,8 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_string_field_validation_with_min_and_max_lengths
-    f = CustomField.new(:field_format => 'string', :min_length => 2, :max_length => 5)
-    v = CustomValue.new(:custom_field => f, :value => '')
+    f = CustomField.new(field_format: 'string', min_length: 2, max_length: 5)
+    v = CustomValue.new(custom_field: f, value: '')
     assert v.valid?
     v.value = 'a'
     assert !v.valid?
@@ -58,8 +58,8 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_string_field_validation_with_regexp
-    f = CustomField.new(:field_format => 'string', :regexp => '^[A-Z0-9]*$')
-    v = CustomValue.new(:custom_field => f, :value => '')
+    f = CustomField.new(field_format: 'string', regexp: '^[A-Z0-9]*$')
+    v = CustomValue.new(custom_field: f, value: '')
     assert v.valid?
     v.value = 'abc'
     assert !v.valid?
@@ -68,8 +68,8 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_date_field_validation
-    f = CustomField.new(:field_format => 'date')
-    v = CustomValue.new(:custom_field => f, :value => '')
+    f = CustomField.new(field_format: 'date')
+    v = CustomValue.new(custom_field: f, value: '')
     assert v.valid?
     v.value = 'abc'
     assert !v.valid?
@@ -78,8 +78,8 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_list_field_validation
-    f = CustomField.new(:field_format => 'list', :possible_values => ['value1', 'value2'])
-    v = CustomValue.new(:custom_field => f, :value => '')
+    f = CustomField.new(field_format: 'list', possible_values: ['value1', 'value2'])
+    v = CustomValue.new(custom_field: f, value: '')
     assert v.valid?
     v.value = 'abc'
     assert !v.valid?
@@ -88,8 +88,8 @@ class CustomValueTest < ActiveSupport::TestCase
   end
 
   def test_int_field_validation
-    f = CustomField.new(:field_format => 'int')
-    v = CustomValue.new(:custom_field => f, :value => '')
+    f = CustomField.new(field_format: 'int')
+    v = CustomValue.new(custom_field: f, value: '')
     assert v.valid?
     v.value = 'abc'
     assert !v.valid?
@@ -107,8 +107,8 @@ class CustomValueTest < ActiveSupport::TestCase
     # There are cases, where the custom-value-table is not cleared completely,
     # therefore making double sure, that we have a clean slate before we start
     CustomField.destroy_all
-    FactoryGirl.create :float_user_custom_field, :name => "Money"
-    v = CustomValue.new(:customized => user, :custom_field => UserCustomField.find_by_name('Money'))
+    FactoryGirl.create :float_user_custom_field, name: "Money"
+    v = CustomValue.new(customized: user, custom_field: UserCustomField.find_by_name('Money'))
     v.value = '11.2'
     assert v.save
     v.value = ''
@@ -121,27 +121,27 @@ class CustomValueTest < ActiveSupport::TestCase
 
   def test_default_value
     custom_field = FactoryGirl.create :issue_custom_field,
-      :field_format => 'string',
-      :default_value => "Some Default String"
+      field_format: 'string',
+      default_value: "Some Default String"
 
     field = CustomField.find_by_default_value('Some Default String')
     assert_equal field, custom_field
 
-    v = CustomValue.new(:custom_field => field)
+    v = CustomValue.new(custom_field: field)
     assert_equal 'Some Default String', v.value
 
-    v = CustomValue.new(:custom_field => field, :value => 'Not empty')
+    v = CustomValue.new(custom_field: field, value: 'Not empty')
     assert_equal 'Not empty', v.value
   end
 
   def test_sti_polymorphic_association
     # Rails uses top level sti class for polymorphic association. See #3978.
     user = FactoryGirl.create :user
-    custom_field = FactoryGirl.create :user_custom_field, :field_format => 'string'
+    custom_field = FactoryGirl.create :user_custom_field, field_format: 'string'
     custom_value = FactoryGirl.create :principal_custom_value,
-      :custom_field => custom_field,
-      :customized => user,
-      :value => '01 23 45 67 89'
+      custom_field: custom_field,
+      customized: user,
+      value: '01 23 45 67 89'
     user.reload
 
     assert !user.custom_values.empty?

--- a/test/unit/default_data_test.rb
+++ b/test/unit/default_data_test.rb
@@ -58,11 +58,11 @@ class DefaultDataTest < ActiveSupport::TestCase
     end
   end
 
-private
+  private
 
   def delete_loaded_data!
-    Role.delete_all("builtin = 0")
-    Type.delete_all("is_standard = false")
+    Role.delete_all('builtin = 0')
+    Type.delete_all('is_standard = false')
     Status.delete_all
     Enumeration.delete_all
   end

--- a/test/unit/enabled_module_test.rb
+++ b/test/unit/enabled_module_test.rb
@@ -32,10 +32,10 @@ class EnabledModuleTest < ActiveSupport::TestCase
   def test_enabling_wiki_should_create_a_wiki
     CustomField.delete_all
     FactoryGirl.create(:type_standard)
-    project = Project.create!(:name => 'Project with wiki', :identifier => 'wikiproject')
+    project = Project.create!(name: 'Project with wiki', identifier: 'wikiproject')
     assert_nil project.wiki
     project.enabled_module_names = ['wiki']
-    wiki = FactoryGirl.create :wiki, :project => project
+    wiki = FactoryGirl.create :wiki, project: project
     project.reload
     assert_not_nil project.wiki
     assert_equal 'Wiki', project.wiki.start_page
@@ -43,7 +43,7 @@ class EnabledModuleTest < ActiveSupport::TestCase
 
   def test_reenabling_wiki_should_not_create_another_wiki
     project = FactoryGirl.create :project
-    wiki = FactoryGirl.create :wiki, :project => project
+    wiki = FactoryGirl.create :wiki, project: project
     project.reload
     assert_not_nil project.wiki
     project.enabled_module_names = []

--- a/test/unit/enumeration_test.rb
+++ b/test/unit/enumeration_test.rb
@@ -33,7 +33,7 @@ class EnumerationTest < ActiveSupport::TestCase
     super
     WorkPackage.delete_all
     @low_priority = FactoryGirl.create :priority_low
-    @issues = FactoryGirl.create_list :work_package, 6, :priority => @low_priority
+    @issues = FactoryGirl.create_list :work_package, 6, priority: @low_priority
     @default_enumeration = FactoryGirl.create :default_enumeration
   end
 
@@ -55,39 +55,39 @@ class EnumerationTest < ActiveSupport::TestCase
   end
 
   def test_create
-    e = Enumeration.new(:name => 'Not default', :is_default => false)
+    e = Enumeration.new(name: 'Not default', is_default: false)
     e.type = 'Enumeration'
     assert e.save
     assert_equal @default_enumeration.name, Enumeration.default.name
   end
 
   def test_create_as_default
-    e = Enumeration.new(:name => 'Very urgent', :is_default => true)
+    e = Enumeration.new(name: 'Very urgent', is_default: true)
     e.type = 'Enumeration'
     assert e.save
     assert_equal e, Enumeration.default
   end
 
   def test_update_default
-    @default_enumeration.update_attributes(:name => 'Changed', :is_default => true)
+    @default_enumeration.update_attributes(name: 'Changed', is_default: true)
     assert_equal @default_enumeration, Enumeration.default
   end
 
   def test_update_default_to_non_default
-    @default_enumeration.update_attributes(:name => 'Changed', :is_default => false)
+    @default_enumeration.update_attributes(name: 'Changed', is_default: false)
     assert_nil Enumeration.default
   end
 
   def test_change_default
     e = Enumeration.find_by_name(@default_enumeration.name)
-    e.update_attributes(:name => 'Changed Enumeration', :is_default => true)
+    e.update_attributes(name: 'Changed Enumeration', is_default: true)
     assert_equal e, Enumeration.default
   end
 
   def test_destroy_with_reassign
     new_priority = FactoryGirl.create :priority
     Enumeration.find(@low_priority).destroy(new_priority)
-    assert_nil WorkPackage.find(:first, :conditions => {:priority_id => @low_priority.id})
+    assert_nil WorkPackage.find(:first, conditions: {priority_id: @low_priority.id})
     assert_equal @issues.size, new_priority.objects_count
   end
 

--- a/test/unit/enumeration_test.rb
+++ b/test/unit/enumeration_test.rb
@@ -87,7 +87,7 @@ class EnumerationTest < ActiveSupport::TestCase
   def test_destroy_with_reassign
     new_priority = FactoryGirl.create :priority
     Enumeration.find(@low_priority).destroy(new_priority)
-    assert_nil WorkPackage.find(:first, conditions: {priority_id: @low_priority.id})
+    assert_nil WorkPackage.find(:first, conditions: { priority_id: @low_priority.id })
     assert_equal @issues.size, new_priority.objects_count
   end
 
@@ -97,7 +97,7 @@ class EnumerationTest < ActiveSupport::TestCase
 
   def test_should_belong_to_a_project
     association = Enumeration.reflect_on_association(:project)
-    assert association, "No Project association found"
+    assert association, 'No Project association found'
     assert_equal :belongs_to, association.macro
   end
 

--- a/test/unit/group_test.rb
+++ b/test/unit/group_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class GroupTest < ActiveSupport::TestCase
-
   def setup
     super
     @group = FactoryGirl.create :group
@@ -64,7 +63,7 @@ class GroupTest < ActiveSupport::TestCase
     group = FactoryGirl.create :group
     member = FactoryGirl.build :member
     roles = FactoryGirl.create_list :role, 2
-    role_ids = roles.map { |r| r.id }
+    role_ids = roles.map(&:id)
     member.force_attributes = { principal: group, role_ids: role_ids }
     member.save!
     user = FactoryGirl.create :user

--- a/test/unit/group_test.rb
+++ b/test/unit/group_test.rb
@@ -36,7 +36,7 @@ class GroupTest < ActiveSupport::TestCase
     @member = FactoryGirl.build :member
     @work_package = FactoryGirl.create :work_package
     @roles = FactoryGirl.create_list :role, 2
-    @member.force_attributes = { :principal => @group, :role_ids => @roles.map(&:id) }
+    @member.force_attributes = { principal: @group, role_ids: @roles.map(&:id) }
     @member.save!
     @project = @member.project
     @user = FactoryGirl.create :user
@@ -45,7 +45,7 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   def test_create
-    g = Group.new(:lastname => 'New group')
+    g = Group.new(lastname: 'New group')
     assert g.save
   end
 
@@ -65,7 +65,7 @@ class GroupTest < ActiveSupport::TestCase
     member = FactoryGirl.build :member
     roles = FactoryGirl.create_list :role, 2
     role_ids = roles.map { |r| r.id }
-    member.force_attributes = { :principal => group, :role_ids => role_ids }
+    member.force_attributes = { principal: group, role_ids: role_ids }
     member.save!
     user = FactoryGirl.create :user
     group.users << user

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -41,23 +41,23 @@ class ApplicationHelperTest < ActionView::TestCase
     @anonymous = FactoryGirl.create :anonymous
     @non_member = FactoryGirl.create :user
     @project_member = FactoryGirl.create :user,
-      :member_in_project => @project,
-      :member_through_role => FactoryGirl.create(:role,
-          :permissions => [:view_work_packages, :edit_work_packages,
+      member_in_project: @project,
+      member_through_role: FactoryGirl.create(:role,
+          permissions: [:view_work_packages, :edit_work_packages,
                            :browse_repository, :view_changesets, :view_wiki_pages])
 
-    @issue = FactoryGirl.create :work_package, :project => @project, :author => @project_member, :type => @project.types.first
+    @issue = FactoryGirl.create :work_package, project: @project, author: @project_member, type: @project.types.first
 
     file = create_uploaded_file name: 'logo.gif',
                                 content_type: 'image/gif',
                                 content: 'not actually a gif',
                                 binary: true
     @attachment = FactoryGirl.create :attachment,
-        :author => @project_member,
-        :file => file,
-        :content_type => 'image/gif',
-        :container => @issue,
-        :description => 'This is a logo'
+        author: @project_member,
+        file: file,
+        content_type: 'image/gif',
+        container: @issue,
+        description: 'This is a logo'
 
     User.stub(:current).and_return(@project_member)
   end
@@ -140,7 +140,7 @@ RAW
       # link image
       '!logo.gif!:http://foo.bar/' => "<a href=\"http://foo.bar/\"><img src=\"/attachments/#{@attachment.id}/download\" title=\"This is a logo\" alt=\"This is a logo\" /></a>",
     }
-    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, :attachments => [@attachment]) }
+    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, attachments: [@attachment]) }
   end
 
   def test_textile_external_links
@@ -169,7 +169,7 @@ RAW
       'This is a "link":http://foo.bar' => 'This is a <a href="http://foo.bar" class="external">link</a>',
       'This is an intern "link":/foo/bar' => 'This is an intern <a href="http://test.host/foo/bar">link</a>',
       'This is an intern "link":/foo/bar and an extern "link":http://foo.bar' => 'This is an intern <a href="http://test.host/foo/bar">link</a> and an extern <a href="http://foo.bar" class="external">link</a>',
-    }.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, :only_path => false) }
+    }.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, only_path: false) }
   end
 
   def test_textile_relative_to_full_links_in_the_mailer
@@ -187,29 +187,29 @@ RAW
       'This is a "link":http://foo.bar' => 'This is a <a href="http://foo.bar" class="external">link</a>',
       'This is an intern "link":/foo/bar' => 'This is an intern <a href="http://localhost:3000/foo/bar">link</a>',
       'This is an intern "link":/foo/bar and an extern "link":http://foo.bar' => 'This is an intern <a href="http://localhost:3000/foo/bar">link</a> and an extern <a href="http://foo.bar" class="external">link</a>',
-    }.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, :only_path => false) }
+    }.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, only_path: false) }
   end
 
   def test_cross_project_redmine_links
     version = FactoryGirl.create :version,
-                 :name => '1.0',
-                 :project => @project
+                 name: '1.0',
+                 project: @project
     Setting.enabled_scm = Setting.enabled_scm << "Filesystem" unless Setting.enabled_scm.include? "Filesystem"
     repository = FactoryGirl.create :repository,
-                 :project => @project
+                 project: @project
     changeset = FactoryGirl.create :changeset,
-                 :repository => repository,
-                 :comments => 'This commit fixes #1, #2 and references #1 & #3'
+                 repository: repository,
+                 comments: 'This commit fixes #1, #2 and references #1 & #3'
     identifier = @project.identifier
 
-    source_link = link_to("#{identifier}:source:/some/file", { :controller => 'repositories',
-                                                               :action => 'entry',
-                                                               :project_id => identifier,
-                                                               :path => 'some/file'} ,
-                                                             :class => 'source')
+    source_link = link_to("#{identifier}:source:/some/file", { controller: 'repositories',
+                                                               action: 'entry',
+                                                               project_id: identifier,
+                                                               path: 'some/file'} ,
+                                                             class: 'source')
     changeset_link = link_to("#{identifier}:r#{changeset.revision}",
-      {:controller => 'repositories', :action => 'revision', :project_id => identifier, :rev => changeset.revision},
-      :class => 'changeset', :title => 'This commit fixes #1, #2 and references #1 & #3')
+      {controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset.revision},
+      class: 'changeset', title: 'This commit fixes #1, #2 and references #1 & #3')
 
 
     # format_text "sees" the text is parses from the_other_project (and not @project)
@@ -229,40 +229,40 @@ RAW
       "#{identifier}:source:/some/file"       => source_link,
       'invalid:source:/some/file'             => 'invalid:source:/some/file',
     }
-    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, :project => the_other_project), "#{text} failed" }
+    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, project: the_other_project), "#{text} failed" }
   end
 
   def test_redmine_links_git_commit
     User.stub(:current).and_return(@admin)
     changeset_link = link_to('abcd',
                                {
-                                 :controller => 'repositories',
-                                 :action     => 'revision',
-                                 :project_id => @project.identifier,
-                                 :rev        => 'abcd',
+                                 controller: 'repositories',
+                                 action:     'revision',
+                                 project_id: @project.identifier,
+                                 rev:        'abcd',
                                 },
-                              :class => 'changeset', :title => 'test commit')
+                              class: 'changeset', title: 'test commit')
     to_test = {
       'commit:abcd' => changeset_link,
      }
-    r = Repository::Git.create!(:project => @project, :url => '/tmp/test/git')
+    r = Repository::Git.create!(project: @project, url: '/tmp/test/git')
     assert r
-    c = Changeset.new(:repository => r,
-                      :committed_on => Time.now,
-                      :revision => 'abcd',
-                      :scmid => 'abcd',
-                      :comments => 'test commit')
+    c = Changeset.new(repository: r,
+                      committed_on: Time.now,
+                      revision: 'abcd',
+                      scmid: 'abcd',
+                      comments: 'test commit')
     assert( c.save )
     @project.reload
     to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text) }
   end
 
   def test_attachment_links
-    attachment_link = link_to('logo.gif', {:controller => 'attachments', :action => 'download', :id => @attachment}, :class => 'attachment')
+    attachment_link = link_to('logo.gif', {controller: 'attachments', action: 'download', id: @attachment}, class: 'attachment')
     to_test = {
       'attachment:logo.gif' => attachment_link
     }
-    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, :attachments => [@attachment]), "#{text} failed" }
+    to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text, attachments: [@attachment]), "#{text} failed" }
   end
 
   def test_html_tags
@@ -338,8 +338,8 @@ EXPECTED
   def test_wiki_links_in_tables
     @project.wiki.start_page = "Page"
     @project.wiki.save!
-    FactoryGirl.create :wiki_page_with_content, :wiki => @project.wiki, :title => "Other page"
-    FactoryGirl.create :wiki_page_with_content, :wiki => @project.wiki, :title => "Last page"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Other page"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Last page"
 
     to_test = {"|[[Page|Link title]]|[[Other Page|Other title]]|\n|Cell 21|[[Last page]]|" =>
                  "<tr><td><a href=\"/projects/#{@project.identifier}/wiki/Page\" class=\"wiki-page new\">Link title</a></td>" +
@@ -390,8 +390,8 @@ EXPECTED
   def test_table_of_content
     @project.wiki.start_page = "Wiki"
     @project.wiki.save!
-    FactoryGirl.create :wiki_page_with_content, :wiki => @project.wiki, :title => "Wiki"
-    FactoryGirl.create :wiki_page_with_content, :wiki => @project.wiki, :title => "another Wiki"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Wiki"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "another Wiki"
 
     raw = <<-RAW
 {{toc}}
@@ -452,9 +452,9 @@ RAW
   def test_table_of_content_should_contain_included_page_headings
     @project.wiki.start_page = "Wiki"
     @project.save!
-    page  = FactoryGirl.create :wiki_page_with_content, :wiki => @project.wiki, :title => "Wiki"
-    child = FactoryGirl.create :wiki_page, :wiki => @project.wiki, :title => "Child_1", :parent => page
-    child.content = FactoryGirl.create :wiki_content, :page => child, :text => "h1. Child page 1\n\nThis is a child page"
+    page  = FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Wiki"
+    child = FactoryGirl.create :wiki_page, wiki: @project.wiki, title: "Child_1", parent: page
+    child.content = FactoryGirl.create :wiki_content, page: child, text: "h1. Child page 1\n\nThis is a child page"
     child.save!
 
     raw = <<-RAW
@@ -521,12 +521,12 @@ RAW
     assert_equal %(<a href="/projects/#{p_id}">#{p_name}</a>),
                  link_to_project(@project)
     assert_equal %(<a href="/projects/#{p_id}/settings">#{p_name}</a>),
-                 link_to_project(@project, :action => 'settings')
+                 link_to_project(@project, action: 'settings')
     assert_equal %(<a href="/projects/#{p_id}/settings/members">#{p_name}</a>),
-                 link_to_project(@project, :action => 'settings', :tab => 'members')
+                 link_to_project(@project, action: 'settings', tab: 'members')
     assert_equal %(<a href="#{root_url}projects/#{p_id}?jump=blah">#{p_name}</a>),
-                 link_to_project(@project, {:only_path => false, :jump => 'blah'})
+                 link_to_project(@project, {only_path: false, jump: 'blah'})
     assert_equal %(<a href="/projects/#{p_id}/settings" class="project">#{p_name}</a>),
-                 link_to_project(@project, {:action => 'settings'}, :class => "project")
+                 link_to_project(@project, {action: 'settings'}, class: "project")
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -41,10 +41,10 @@ class ApplicationHelperTest < ActionView::TestCase
     @anonymous = FactoryGirl.create :anonymous
     @non_member = FactoryGirl.create :user
     @project_member = FactoryGirl.create :user,
-      member_in_project: @project,
-      member_through_role: FactoryGirl.create(:role,
-          permissions: [:view_work_packages, :edit_work_packages,
-                           :browse_repository, :view_changesets, :view_wiki_pages])
+                                         member_in_project: @project,
+                                         member_through_role: FactoryGirl.create(:role,
+                                                                                 permissions: [:view_work_packages, :edit_work_packages,
+                                                                                               :browse_repository, :view_changesets, :view_wiki_pages])
 
     @issue = FactoryGirl.create :work_package, project: @project, author: @project_member, type: @project.types.first
 
@@ -53,11 +53,11 @@ class ApplicationHelperTest < ActionView::TestCase
                                 content: 'not actually a gif',
                                 binary: true
     @attachment = FactoryGirl.create :attachment,
-        author: @project_member,
-        file: file,
-        content_type: 'image/gif',
-        container: @issue,
-        description: 'This is a logo'
+                                     author: @project_member,
+                                     file: file,
+                                     content_type: 'image/gif',
+                                     container: @issue,
+                                     description: 'This is a logo'
 
     User.stub(:current).and_return(@project_member)
   end
@@ -102,7 +102,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_auto_mailto
     assert_equal '<p><a class="email" href="mailto:test@foo.bar">test@foo.bar</a></p>',
-      format_text('test@foo.bar')
+                 format_text('test@foo.bar')
   end
 
   def test_inline_images
@@ -192,25 +192,24 @@ RAW
 
   def test_cross_project_redmine_links
     version = FactoryGirl.create :version,
-                 name: '1.0',
-                 project: @project
-    Setting.enabled_scm = Setting.enabled_scm << "Filesystem" unless Setting.enabled_scm.include? "Filesystem"
+                                 name: '1.0',
+                                 project: @project
+    Setting.enabled_scm = Setting.enabled_scm << 'Filesystem' unless Setting.enabled_scm.include? 'Filesystem'
     repository = FactoryGirl.create :repository,
-                 project: @project
+                                    project: @project
     changeset = FactoryGirl.create :changeset,
-                 repository: repository,
-                 comments: 'This commit fixes #1, #2 and references #1 & #3'
+                                   repository: repository,
+                                   comments: 'This commit fixes #1, #2 and references #1 & #3'
     identifier = @project.identifier
 
     source_link = link_to("#{identifier}:source:/some/file", { controller: 'repositories',
                                                                action: 'entry',
                                                                project_id: identifier,
-                                                               path: 'some/file'} ,
-                                                             class: 'source')
+                                                               path: 'some/file' },
+                          class: 'source')
     changeset_link = link_to("#{identifier}:r#{changeset.revision}",
-      {controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset.revision},
-      class: 'changeset', title: 'This commit fixes #1, #2 and references #1 & #3')
-
+                             { controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset.revision },
+                             class: 'changeset', title: 'This commit fixes #1, #2 and references #1 & #3')
 
     # format_text "sees" the text is parses from the_other_project (and not @project)
     the_other_project = FactoryGirl.create :valid_project
@@ -235,16 +234,16 @@ RAW
   def test_redmine_links_git_commit
     User.stub(:current).and_return(@admin)
     changeset_link = link_to('abcd',
-                               {
-                                 controller: 'repositories',
-                                 action:     'revision',
-                                 project_id: @project.identifier,
-                                 rev:        'abcd',
-                                },
-                              class: 'changeset', title: 'test commit')
+                             {
+                               controller: 'repositories',
+                               action:     'revision',
+                               project_id: @project.identifier,
+                               rev:        'abcd',
+                             },
+                             class: 'changeset', title: 'test commit')
     to_test = {
       'commit:abcd' => changeset_link,
-     }
+    }
     r = Repository::Git.create!(project: @project, url: '/tmp/test/git')
     assert r
     c = Changeset.new(repository: r,
@@ -252,13 +251,13 @@ RAW
                       revision: 'abcd',
                       scmid: 'abcd',
                       comments: 'test commit')
-    assert( c.save )
+    assert(c.save)
     @project.reload
     to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text) }
   end
 
   def test_attachment_links
-    attachment_link = link_to('logo.gif', {controller: 'attachments', action: 'download', id: @attachment}, class: 'attachment')
+    attachment_link = link_to('logo.gif', { controller: 'attachments', action: 'download', id: @attachment }, class: 'attachment')
     to_test = {
       'attachment:logo.gif' => attachment_link
     }
@@ -267,21 +266,21 @@ RAW
 
   def test_html_tags
     to_test = {
-      "<div>content</div>" => "<p>&lt;div&gt;content&lt;/div&gt;</p>",
+      '<div>content</div>' => '<p>&lt;div&gt;content&lt;/div&gt;</p>',
       "<div class=\"bold\">content</div>" => "<p>&lt;div class=\"bold\"&gt;content&lt;/div&gt;</p>",
-      "<script>some script;</script>" => "<p>&lt;script&gt;some script;&lt;/script&gt;</p>",
+      '<script>some script;</script>' => '<p>&lt;script&gt;some script;&lt;/script&gt;</p>',
       # do not escape pre/code tags
       "<pre>\nline 1\nline2</pre>" => "<pre>\nline 1\nline2</pre>",
       "<pre><code>\nline 1\nline2</code></pre>" => "<pre><code>\nline 1\nline2</code></pre>",
-      "<pre><div>content</div></pre>" => "<pre>&lt;div&gt;content&lt;/div&gt;</pre>",
-      "HTML comment: <!-- no comments -->" => "<p>HTML comment: &lt;!-- no comments --&gt;</p>",
-      "<!-- opening comment" => "<p>&lt;!-- opening comment</p>",
+      '<pre><div>content</div></pre>' => '<pre>&lt;div&gt;content&lt;/div&gt;</pre>',
+      'HTML comment: <!-- no comments -->' => '<p>HTML comment: &lt;!-- no comments --&gt;</p>',
+      '<!-- opening comment' => '<p>&lt;!-- opening comment</p>',
       # remove attributes except class
       "<pre class='foo'>some text</pre>" => "<pre class='foo'>some text</pre>",
       '<pre class="foo">some text</pre>' => '<pre class="foo">some text</pre>',
       "<pre class='foo bar'>some text</pre>" => "<pre class='foo bar'>some text</pre>",
       '<pre class="foo bar">some text</pre>' => '<pre class="foo bar">some text</pre>',
-      "<pre onmouseover='alert(1)'>some text</pre>" => "<pre>some text</pre>",
+      "<pre onmouseover='alert(1)'>some text</pre>" => '<pre>some text</pre>',
       # xss
       '<pre><code class=""onmouseover="alert(1)">text</code></pre>' => '<pre><code>text</code></pre>',
       '<pre class=""onmouseover="alert(1)">text</pre>' => '<pre>text</pre>',
@@ -291,9 +290,9 @@ RAW
 
   def test_allowed_html_tags
     to_test = {
-      "<pre>preformatted text</pre>" => "<pre>preformatted text</pre>",
-      "<notextile>no *textile* formatting</notextile>" => "no *textile* formatting",
-      "<notextile>this is <tag>a tag</tag></notextile>" => "this is &lt;tag&gt;a tag&lt;/tag&gt;"
+      '<pre>preformatted text</pre>' => '<pre>preformatted text</pre>',
+      '<notextile>no *textile* formatting</notextile>' => 'no *textile* formatting',
+      '<notextile>this is <tag>a tag</tag></notextile>' => 'this is &lt;tag&gt;a tag&lt;/tag&gt;'
     }
     to_test.each { |text, result| assert_equal result, format_text(text) }
   end
@@ -336,12 +335,12 @@ EXPECTED
   end
 
   def test_wiki_links_in_tables
-    @project.wiki.start_page = "Page"
+    @project.wiki.start_page = 'Page'
     @project.wiki.save!
-    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Other page"
-    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Last page"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Other page'
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Last page'
 
-    to_test = {"|[[Page|Link title]]|[[Other Page|Other title]]|\n|Cell 21|[[Last page]]|" =>
+    to_test = { "|[[Page|Link title]]|[[Other Page|Other title]]|\n|Cell 21|[[Last page]]|" =>
                  "<tr><td><a href=\"/projects/#{@project.identifier}/wiki/Page\" class=\"wiki-page new\">Link title</a></td>" +
                  "<td><a href=\"/projects/#{@project.identifier}/wiki/Other_Page\" class=\"wiki-page\">Other title</a></td>" +
                  "</tr><tr><td>Cell 21</td><td><a href=\"/projects/#{@project.identifier}/wiki/Last_page\" class=\"wiki-page\">Last page</a></td></tr>"
@@ -351,11 +350,11 @@ EXPECTED
   end
 
   def test_text_formatting
-    to_test = {'*_+bold, italic and underline+_*' => '<strong><em><ins>bold, italic and underline</ins></em></strong>',
-               '(_text within parentheses_)' => '(<em>text within parentheses</em>)',
-               'a *Humane Web* Text Generator' => 'a <strong>Humane Web</strong> Text Generator',
-               'a H *umane* W *eb* T *ext* G *enerator*' => 'a H <strong>umane</strong> W <strong>eb</strong> T <strong>ext</strong> G <strong>enerator</strong>',
-               'a *H* umane *W* eb *T* ext *G* enerator' => 'a <strong>H</strong> umane <strong>W</strong> eb <strong>T</strong> ext <strong>G</strong> enerator',
+    to_test = { '*_+bold, italic and underline+_*' => '<strong><em><ins>bold, italic and underline</ins></em></strong>',
+                '(_text within parentheses_)' => '(<em>text within parentheses</em>)',
+                'a *Humane Web* Text Generator' => 'a <strong>Humane Web</strong> Text Generator',
+                'a H *umane* W *eb* T *ext* G *enerator*' => 'a H <strong>umane</strong> W <strong>eb</strong> T <strong>ext</strong> G <strong>enerator</strong>',
+                'a *H* umane *W* eb *T* ext *G* enerator' => 'a <strong>H</strong> umane <strong>W</strong> eb <strong>T</strong> ext <strong>G</strong> enerator',
               }
     to_test.each { |text, result| assert_equal "<p>#{result}</p>", format_text(text) }
   end
@@ -388,10 +387,10 @@ EXPECTED
   end
 
   def test_table_of_content
-    @project.wiki.start_page = "Wiki"
+    @project.wiki.start_page = 'Wiki'
     @project.wiki.save!
-    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Wiki"
-    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "another Wiki"
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Wiki'
+    FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'another Wiki'
 
     raw = <<-RAW
 {{toc}}
@@ -423,37 +422,37 @@ h2. "Project Name !/attachments/#{@attachment.id}/#{@attachment.filename}!":/pro
 RAW
 
     expected =  '<ul class="toc">' +
-                  '<li><a href="#Title">Title</a>' +
-                    '<ul>' +
-                      '<li><a href="#Subtitle-with-a-Wiki-link">Subtitle with a Wiki link</a></li>' +
-                      '<li><a href="#Subtitle-with-another-Wiki-link">Subtitle with another Wiki link</a></li>' +
-                      '<li><a href="#Subtitle-with-red-text">Subtitle with red text</a>' +
-                        '<ul>' +
-                          '<li><a href="#Subtitle-with-some-modifiers">Subtitle with some modifiers</a></li>' +
-                        '</ul>' +
-                      '</li>' +
-                    '</ul>' +
-                  '</li>' +
-                  '<li><a href="#Another-title">Another title</a>' +
-                    '<ul>' +
-                      '<li>' +
-                        '<ul>' +
-                          '<li><a href="#An-Internet-link-inside-subtitle">An Internet link inside subtitle</a></li>' +
-                        '</ul>' +
-                      '</li>' +
-                      '<li><a href="#Project-Name">Project Name</a></li>' +
-                    '</ul>' +
-                  '</li>' +
-               '</ul>'
+                '<li><a href="#Title">Title</a>' +
+                '<ul>' +
+                '<li><a href="#Subtitle-with-a-Wiki-link">Subtitle with a Wiki link</a></li>' +
+                '<li><a href="#Subtitle-with-another-Wiki-link">Subtitle with another Wiki link</a></li>' +
+                '<li><a href="#Subtitle-with-red-text">Subtitle with red text</a>' +
+                '<ul>' +
+                '<li><a href="#Subtitle-with-some-modifiers">Subtitle with some modifiers</a></li>' +
+                '</ul>' +
+                '</li>' +
+                '</ul>' +
+                '</li>' +
+                '<li><a href="#Another-title">Another title</a>' +
+                '<ul>' +
+                '<li>' +
+                '<ul>' +
+                '<li><a href="#An-Internet-link-inside-subtitle">An Internet link inside subtitle</a></li>' +
+                '</ul>' +
+                '</li>' +
+                '<li><a href="#Project-Name">Project Name</a></li>' +
+                '</ul>' +
+                '</li>' +
+                '</ul>'
 
-    assert format_text(raw).gsub("\n", "").include?(expected), format_text(raw)
+    assert format_text(raw).gsub("\n", '').include?(expected), format_text(raw)
   end
 
   def test_table_of_content_should_contain_included_page_headings
-    @project.wiki.start_page = "Wiki"
+    @project.wiki.start_page = 'Wiki'
     @project.save!
-    page  = FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: "Wiki"
-    child = FactoryGirl.create :wiki_page, wiki: @project.wiki, title: "Child_1", parent: page
+    page  = FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Wiki'
+    child = FactoryGirl.create :wiki_page, wiki: @project.wiki, title: 'Child_1', parent: page
     child.content = FactoryGirl.create :wiki_content, page: child, text: "h1. Child page 1\n\nThis is a child page"
     child.save!
 
@@ -470,7 +469,7 @@ RAW
                '<li><a href="#Child-page-1">Child page 1</a></li>' +
                '</ul>'
 
-    assert format_text(raw).gsub("\n", "").include?(expected), format_text(raw)
+    assert format_text(raw).gsub("\n", '').include?(expected), format_text(raw)
   end
 
   def test_default_formatter
@@ -525,8 +524,8 @@ RAW
     assert_equal %(<a href="/projects/#{p_id}/settings/members">#{p_name}</a>),
                  link_to_project(@project, action: 'settings', tab: 'members')
     assert_equal %(<a href="#{root_url}projects/#{p_id}?jump=blah">#{p_name}</a>),
-                 link_to_project(@project, {only_path: false, jump: 'blah'})
+                 link_to_project(@project, only_path: false, jump: 'blah')
     assert_equal %(<a href="/projects/#{p_id}/settings" class="project">#{p_name}</a>),
-                 link_to_project(@project, {action: 'settings'}, class: "project")
+                 link_to_project(@project, { action: 'settings' }, class: 'project')
   end
 end

--- a/test/unit/helpers/custom_fields_helper_test.rb
+++ b/test/unit/helpers/custom_fields_helper_test.rb
@@ -39,8 +39,8 @@ class CustomFieldsHelperTest < HelperTestCase
   end
 
   def test_unknow_field_format_should_be_edited_as_string
-    field = CustomField.new(:field_format => 'foo')
-    value = CustomValue.new(:value => 'bar', :custom_field => field)
+    field = CustomField.new(field_format: 'foo')
+    value = CustomValue.new(value: 'bar', custom_field: field)
     field.id = 52
 
     assert_match '<input id="object_custom_field_values_52" name="object[custom_field_values][52]" type="text" value="bar" />',
@@ -48,7 +48,7 @@ class CustomFieldsHelperTest < HelperTestCase
   end
 
   def test_unknow_field_format_should_be_bulk_edited_as_string
-    field = CustomField.new(:field_format => 'foo')
+    field = CustomField.new(field_format: 'foo')
     field.id = 52
 
     assert_equal '<input id="object_custom_field_values_52" name="object[custom_field_values][52]" type="text" value="" />',

--- a/test/unit/helpers/custom_fields_helper_test.rb
+++ b/test/unit/helpers/custom_fields_helper_test.rb
@@ -44,7 +44,7 @@ class CustomFieldsHelperTest < HelperTestCase
     field.id = 52
 
     assert_match '<input id="object_custom_field_values_52" name="object[custom_field_values][52]" type="text" value="bar" />',
-      custom_field_tag('object', value)
+                 custom_field_tag('object', value)
   end
 
   def test_unknow_field_format_should_be_bulk_edited_as_string
@@ -52,6 +52,6 @@ class CustomFieldsHelperTest < HelperTestCase
     field.id = 52
 
     assert_equal '<input id="object_custom_field_values_52" name="object[custom_field_values][52]" type="text" value="" />',
-      custom_field_tag_for_bulk_edit('object', field)
+                 custom_field_tag_for_bulk_edit('object', field)
   end
 end

--- a/test/unit/helpers/sort_helper_test.rb
+++ b/test/unit/helpers/sort_helper_test.rb
@@ -46,14 +46,14 @@ class SortHelperTest < HelperTestCase
 
   def test_default_sort_clause_with_hash
     sort_init 'attr1', 'desc'
-    sort_update({'attr1' => 'table1.attr1', 'attr2' => 'table2.attr2'})
+    sort_update('attr1' => 'table1.attr1', 'attr2' => 'table2.attr2')
 
     assert_equal 'table1.attr1 DESC', sort_clause
   end
 
   def test_default_sort_clause_with_multiple_columns
     sort_init 'attr1', 'desc'
-    sort_update({'attr1' => ['table1.attr1', 'table1.attr2'], 'attr2' => 'table2.attr2'})
+    sort_update('attr1' => ['table1.attr1', 'table1.attr2'], 'attr2' => 'table2.attr2')
 
     assert_equal 'table1.attr1 DESC, table1.attr2 DESC', sort_clause
   end
@@ -62,7 +62,7 @@ class SortHelperTest < HelperTestCase
     @sort_param = 'attr1,attr2:desc'
 
     sort_init 'attr1', 'desc'
-    sort_update({'attr1' => 'table1.attr1', 'attr2' => 'table2.attr2'})
+    sort_update('attr1' => 'table1.attr1', 'attr2' => 'table2.attr2')
 
     assert_equal 'table1.attr1, table2.attr2 DESC', sort_clause
     assert_equal 'attr1,attr2:desc', @session['foo_bar_sort']
@@ -72,7 +72,7 @@ class SortHelperTest < HelperTestCase
     @sort_param = 'invalid_key'
 
     sort_init 'attr1', 'desc'
-    sort_update({'attr1' => 'table1.attr1', 'attr2' => 'table2.attr2'})
+    sort_update('attr1' => 'table1.attr1', 'attr2' => 'table2.attr2')
 
     assert_equal 'table1.attr1 DESC', sort_clause
     assert_equal 'attr1:desc', @session['foo_bar_sort']
@@ -82,7 +82,7 @@ class SortHelperTest < HelperTestCase
     @sort_param = 'attr1:foo:bar,attr2'
 
     sort_init 'attr1', 'desc'
-    sort_update({'attr1' => 'table1.attr1', 'attr2' => 'table2.attr2'})
+    sort_update('attr1' => 'table1.attr1', 'attr2' => 'table2.attr2')
 
     assert_equal 'table1.attr1, table2.attr2', sort_clause
     assert_equal 'attr1,attr2', @session['foo_bar_sort']
@@ -91,7 +91,10 @@ class SortHelperTest < HelperTestCase
   private
 
   def controller_name; 'foo'; end
+
   def action_name; 'bar'; end
-  def params; {sort: @sort_param}; end
+
+  def params; { sort: @sort_param }; end
+
   def session; @session ||= {}; end
 end

--- a/test/unit/helpers/sort_helper_test.rb
+++ b/test/unit/helpers/sort_helper_test.rb
@@ -92,6 +92,6 @@ class SortHelperTest < HelperTestCase
 
   def controller_name; 'foo'; end
   def action_name; 'bar'; end
-  def params; {:sort => @sort_param}; end
+  def params; {sort: @sort_param}; end
   def session; @session ||= {}; end
 end

--- a/test/unit/helpers/timelog_helper_test.rb
+++ b/test/unit/helpers/timelog_helper_test.rb
@@ -34,23 +34,23 @@ class TimelogHelperTest < HelperTestCase
   include ActionView::Helpers::DateHelper
 
   def test_activities_collection_for_select_options_should_return_array_of_activity_names_and_ids
-    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, :name => "Design")
-    development = TimeEntryActivity.find_by_name("Development") || FactoryGirl.create(:activity, :name => "Development")
+    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, name: "Design")
+    development = TimeEntryActivity.find_by_name("Development") || FactoryGirl.create(:activity, name: "Development")
     activities = activity_collection_for_select_options
     assert activities.include?(["Design", design.id])
     assert activities.include?(["Development", development.id])
   end
 
   def test_activities_collection_for_select_options_should_not_include_inactive_activities
-    inactive = TimeEntryActivity.find_by_name("Inactive Activity") || FactoryGirl.create(:inactive_activity, :name => "Inactive Activity")
+    inactive = TimeEntryActivity.find_by_name("Inactive Activity") || FactoryGirl.create(:inactive_activity, name: "Inactive Activity")
     activities = activity_collection_for_select_options
     assert !activities.include?(["Inactive Activity", inactive.id])
   end
 
   def test_activities_collection_for_select_options_should_use_the_projects_override
     project = FactoryGirl.create :valid_project
-    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, :name => "Design")
-    override_activity = TimeEntryActivity.create!({:name => "Design override", :parent => TimeEntryActivity.find_by_name("Design"), :project => project})
+    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, name: "Design")
+    override_activity = TimeEntryActivity.create!({name: "Design override", parent: TimeEntryActivity.find_by_name("Design"), project: project})
 
     activities = activity_collection_for_select_options(nil, project)
     assert !activities.include?(["Design", design.id]), "System activity found in: " + activities.inspect

--- a/test/unit/helpers/timelog_helper_test.rb
+++ b/test/unit/helpers/timelog_helper_test.rb
@@ -34,26 +34,26 @@ class TimelogHelperTest < HelperTestCase
   include ActionView::Helpers::DateHelper
 
   def test_activities_collection_for_select_options_should_return_array_of_activity_names_and_ids
-    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, name: "Design")
-    development = TimeEntryActivity.find_by_name("Development") || FactoryGirl.create(:activity, name: "Development")
+    design = TimeEntryActivity.find_by_name('Design') || FactoryGirl.create(:activity, name: 'Design')
+    development = TimeEntryActivity.find_by_name('Development') || FactoryGirl.create(:activity, name: 'Development')
     activities = activity_collection_for_select_options
-    assert activities.include?(["Design", design.id])
-    assert activities.include?(["Development", development.id])
+    assert activities.include?(['Design', design.id])
+    assert activities.include?(['Development', development.id])
   end
 
   def test_activities_collection_for_select_options_should_not_include_inactive_activities
-    inactive = TimeEntryActivity.find_by_name("Inactive Activity") || FactoryGirl.create(:inactive_activity, name: "Inactive Activity")
+    inactive = TimeEntryActivity.find_by_name('Inactive Activity') || FactoryGirl.create(:inactive_activity, name: 'Inactive Activity')
     activities = activity_collection_for_select_options
-    assert !activities.include?(["Inactive Activity", inactive.id])
+    assert !activities.include?(['Inactive Activity', inactive.id])
   end
 
   def test_activities_collection_for_select_options_should_use_the_projects_override
     project = FactoryGirl.create :valid_project
-    design = TimeEntryActivity.find_by_name("Design") || FactoryGirl.create(:activity, name: "Design")
-    override_activity = TimeEntryActivity.create!({name: "Design override", parent: TimeEntryActivity.find_by_name("Design"), project: project})
+    design = TimeEntryActivity.find_by_name('Design') || FactoryGirl.create(:activity, name: 'Design')
+    override_activity = TimeEntryActivity.create!(name: 'Design override', parent: TimeEntryActivity.find_by_name('Design'), project: project)
 
     activities = activity_collection_for_select_options(nil, project)
-    assert !activities.include?(["Design", design.id]), "System activity found in: " + activities.inspect
-    assert activities.include?(["Design override", override_activity.id]), "Override activity not found in: " + activities.inspect
+    assert !activities.include?(['Design', design.id]), 'System activity found in: ' + activities.inspect
+    assert activities.include?(['Design override', override_activity.id]), 'Override activity not found in: ' + activities.inspect
   end
 end

--- a/test/unit/issue_nested_set_test.rb
+++ b/test/unit/issue_nested_set_test.rb
@@ -41,7 +41,7 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   end
 
   def test_creating_a_child_in_different_project_should_not_validate_unless_allowed
-    Setting.cross_project_work_package_relations = "0"
+    Setting.cross_project_work_package_relations = '0'
     issue = create_issue!
     child = WorkPackage.new.tap do |i|
       i.force_attributes = { project_id: 2,
@@ -55,7 +55,7 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   end
 
   def test_creating_a_child_in_different_project_should_validate_if_allowed
-    Setting.cross_project_work_package_relations = "1"
+    Setting.cross_project_work_package_relations = '1'
     issue = create_issue!
     child = WorkPackage.new.tap do |i|
       i.force_attributes = { project_id: 2,
@@ -218,7 +218,7 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   def test_parent_dates_should_be_lowest_start_and_highest_due_dates
     parent = create_issue!
     create_issue!(start_date: '2010-01-25', due_date: '2010-02-15', parent_id: parent.id)
-    create_issue!(                             due_date: '2010-02-13', parent_id: parent.id)
+    create_issue!(due_date: '2010-02-13', parent_id: parent.id)
     create_issue!(start_date: '2010-02-01', due_date: '2010-02-22', parent_id: parent.id)
     parent.reload
     assert_equal Date.parse('2010-01-25'), parent.start_date
@@ -292,7 +292,7 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   end
 
   # Helper that creates an issue with default attributes
-  def create_issue!(attributes={})
+  def create_issue!(attributes = {})
     (i = WorkPackage.new.tap do |i|
       attr = { project_id: 1, type_id: 1, author_id: 1, subject: 'test' }.merge(attributes)
       i.force_attributes = attr

--- a/test/unit/issue_nested_set_test.rb
+++ b/test/unit/issue_nested_set_test.rb
@@ -44,11 +44,11 @@ class IssueNestedSetTest < ActiveSupport::TestCase
     Setting.cross_project_work_package_relations = "0"
     issue = create_issue!
     child = WorkPackage.new.tap do |i|
-      i.force_attributes = { :project_id => 2,
-                             :type_id => 1,
-                             :author_id => 1,
-                             :subject => 'child',
-                             :parent_id => issue.id }
+      i.force_attributes = { project_id: 2,
+                             type_id: 1,
+                             author_id: 1,
+                             subject: 'child',
+                             parent_id: issue.id }
     end
     assert !child.save
     refute_empty child.errors[:parent_id]
@@ -58,11 +58,11 @@ class IssueNestedSetTest < ActiveSupport::TestCase
     Setting.cross_project_work_package_relations = "1"
     issue = create_issue!
     child = WorkPackage.new.tap do |i|
-      i.force_attributes = { :project_id => 2,
-                             :type_id => 1,
-                             :author_id => 1,
-                             :subject => 'child',
-                             :parent_id => issue.id }
+      i.force_attributes = { project_id: 2,
+                             type_id: 1,
+                             author_id: 1,
+                             subject: 'child',
+                             parent_id: issue.id }
     end
     assert child.save
     assert_empty child.errors[:parent_id]
@@ -70,8 +70,8 @@ class IssueNestedSetTest < ActiveSupport::TestCase
 
   def test_invalid_move_to_another_project
     parent1 = create_issue!
-    child =   create_issue!(:parent_id => parent1.id)
-    grandchild = create_issue!(:parent_id => child.id, :type_id => 2)
+    child =   create_issue!(parent_id: parent1.id)
+    grandchild = create_issue!(parent_id: child.id, type_id: 2)
     Project.find(2).type_ids = [1]
 
     parent1.reload
@@ -92,8 +92,8 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   def test_moving_an_to_a_descendant_should_not_validate
     parent1 = create_issue!
     parent2 = create_issue!
-    child =   create_issue!(:parent_id => parent1.id)
-    grandchild = create_issue!(:parent_id => child.id)
+    child =   create_issue!(parent_id: parent1.id)
+    grandchild = create_issue!(parent_id: child.id)
 
     child.reload
     child.parent_id = grandchild.id
@@ -104,22 +104,22 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   def test_moving_an_issue_should_keep_valid_relations_only
     issue1 = create_issue!
     issue2 = create_issue!
-    issue3 = create_issue!(:parent_id => issue2.id)
+    issue3 = create_issue!(parent_id: issue2.id)
     issue4 = create_issue!
     (r1 = Relation.new.tap do |i|
-      i.force_attributes = { :from => issue1,
-                             :to => issue2,
-                             :relation_type => Relation::TYPE_PRECEDES }
+      i.force_attributes = { from: issue1,
+                             to: issue2,
+                             relation_type: Relation::TYPE_PRECEDES }
     end).save!
     (r2 = Relation.new.tap do |i|
-      i.force_attributes = { :from => issue1,
-                             :to => issue3,
-                             :relation_type => Relation::TYPE_PRECEDES }
+      i.force_attributes = { from: issue1,
+                             to: issue3,
+                             relation_type: Relation::TYPE_PRECEDES }
     end).save!
     (r3 = Relation.new.tap do |i|
-      i.force_attributes = { :from => issue2,
-                             :to => issue4,
-                             :relation_type => Relation::TYPE_PRECEDES }
+      i.force_attributes = { from: issue2,
+                             to: issue4,
+                             relation_type: Relation::TYPE_PRECEDES }
     end).save!
     issue2.reload
     issue2.parent_id = issue1.id
@@ -132,8 +132,8 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   def test_destroy_should_destroy_children
     issue1 = create_issue!
     issue2 = create_issue!
-    issue3 = create_issue!(:parent_id => issue2.id)
-    issue4 = create_issue!(:parent_id => issue1.id)
+    issue3 = create_issue!(parent_id: issue2.id)
+    issue4 = create_issue!(parent_id: issue1.id)
 
     issue3.add_journal(User.find(2))
     issue3.subject = 'child with journal'
@@ -155,8 +155,8 @@ class IssueNestedSetTest < ActiveSupport::TestCase
 
   def test_destroy_parent_work_package_updated_during_children_destroy
     parent = create_issue!
-    create_issue!(:start_date => Date.today, :parent_id => parent.id)
-    create_issue!(:start_date => 2.days.from_now, :parent_id => parent.id)
+    create_issue!(start_date: Date.today, parent_id: parent.id)
+    create_issue!(start_date: 2.days.from_now, parent_id: parent.id)
 
     assert_difference 'WorkPackage.count', -3 do
       WorkPackage.find(parent.id).destroy
@@ -164,9 +164,9 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   end
 
   def test_destroy_child_issue_with_children
-    root = create_issue!(:project_id => 1, :author_id => 2, :type_id => 1, :subject => 'root').reload
-    child = create_issue!(:project_id => 1, :author_id => 2, :type_id => 1, :subject => 'child', :parent_id => root.id).reload
-    leaf = create_issue!(:project_id => 1, :author_id => 2, :type_id => 1, :subject => 'leaf', :parent_id => child.id).reload
+    root = create_issue!(project_id: 1, author_id: 2, type_id: 1, subject: 'root').reload
+    child = create_issue!(project_id: 1, author_id: 2, type_id: 1, subject: 'child', parent_id: root.id).reload
+    leaf = create_issue!(project_id: 1, author_id: 2, type_id: 1, subject: 'leaf', parent_id: child.id).reload
     leaf.add_journal(User.find(2))
     leaf.subject = 'leaf with journal'
     leaf.save!
@@ -184,10 +184,10 @@ class IssueNestedSetTest < ActiveSupport::TestCase
 
   def test_destroy_issue_with_grand_child
     parent = create_issue!
-    issue = create_issue!(:parent_id => parent.id)
-    child = create_issue!(:parent_id => issue.id)
-    grandchild1 = create_issue!(:parent_id => child.id)
-    grandchild2 = create_issue!(:parent_id => child.id)
+    issue = create_issue!(parent_id: parent.id)
+    child = create_issue!(parent_id: issue.id)
+    grandchild1 = create_issue!(parent_id: child.id)
+    grandchild2 = create_issue!(parent_id: child.id)
 
     assert_difference 'WorkPackage.count', -4 do
       WorkPackage.find(issue.id).destroy
@@ -197,14 +197,14 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   end
 
   def test_parent_priority_should_be_the_highest_child_priority
-    parent = create_issue!(:priority => IssuePriority.find_by_name('Normal'))
+    parent = create_issue!(priority: IssuePriority.find_by_name('Normal'))
     # Create children
-    child1 = create_issue!(:priority => IssuePriority.find_by_name('High'), :parent_id => parent.id)
+    child1 = create_issue!(priority: IssuePriority.find_by_name('High'), parent_id: parent.id)
     assert_equal 'High', parent.reload.priority.name
-    child2 = create_issue!(:priority => IssuePriority.find_by_name('Immediate'), :parent_id => child1.id)
+    child2 = create_issue!(priority: IssuePriority.find_by_name('Immediate'), parent_id: child1.id)
     assert_equal 'Immediate', child1.reload.priority.name
     assert_equal 'Immediate', parent.reload.priority.name
-    child3 = create_issue!(:priority => IssuePriority.find_by_name('Low'), :parent_id => parent.id)
+    child3 = create_issue!(priority: IssuePriority.find_by_name('Low'), parent_id: parent.id)
     assert_equal 'Immediate', parent.reload.priority.name
     # Destroy a child
     child1.destroy
@@ -217,9 +217,9 @@ class IssueNestedSetTest < ActiveSupport::TestCase
 
   def test_parent_dates_should_be_lowest_start_and_highest_due_dates
     parent = create_issue!
-    create_issue!(:start_date => '2010-01-25', :due_date => '2010-02-15', :parent_id => parent.id)
-    create_issue!(                             :due_date => '2010-02-13', :parent_id => parent.id)
-    create_issue!(:start_date => '2010-02-01', :due_date => '2010-02-22', :parent_id => parent.id)
+    create_issue!(start_date: '2010-01-25', due_date: '2010-02-15', parent_id: parent.id)
+    create_issue!(                             due_date: '2010-02-13', parent_id: parent.id)
+    create_issue!(start_date: '2010-02-01', due_date: '2010-02-22', parent_id: parent.id)
     parent.reload
     assert_equal Date.parse('2010-01-25'), parent.start_date
     assert_equal Date.parse('2010-02-22'), parent.due_date
@@ -227,59 +227,59 @@ class IssueNestedSetTest < ActiveSupport::TestCase
 
   def test_parent_done_ratio_should_be_average_done_ratio_of_leaves
     parent = create_issue!
-    create_issue!(:done_ratio => 20, :parent_id => parent.id)
+    create_issue!(done_ratio: 20, parent_id: parent.id)
     assert_equal 20, parent.reload.done_ratio
-    create_issue!(:done_ratio => 70, :parent_id => parent.id)
+    create_issue!(done_ratio: 70, parent_id: parent.id)
     assert_equal 45, parent.reload.done_ratio
 
-    child = create_issue!(:done_ratio => 0, :parent_id => parent.id)
+    child = create_issue!(done_ratio: 0, parent_id: parent.id)
     assert_equal 30, parent.reload.done_ratio
 
-    create_issue!(:done_ratio => 30, :parent_id => child.id)
+    create_issue!(done_ratio: 30, parent_id: child.id)
     assert_equal 30, child.reload.done_ratio
     assert_equal 40, parent.reload.done_ratio
   end
 
   def test_parent_done_ratio_should_be_weighted_by_estimated_times_if_any
     parent = create_issue!
-    create_issue!(:estimated_hours => 10, :done_ratio => 20, :parent_id => parent.id)
+    create_issue!(estimated_hours: 10, done_ratio: 20, parent_id: parent.id)
     assert_equal 20, parent.reload.done_ratio
-    create_issue!(:estimated_hours => 20, :done_ratio => 50, :parent_id => parent.id)
+    create_issue!(estimated_hours: 20, done_ratio: 50, parent_id: parent.id)
     assert_equal (50 * 20 + 20 * 10) / 30, parent.reload.done_ratio
   end
 
   def test_parent_estimate_should_be_sum_of_leaves
     parent = create_issue!
-    create_issue!(:estimated_hours => nil, :parent_id => parent.id)
+    create_issue!(estimated_hours: nil, parent_id: parent.id)
     assert_equal nil, parent.reload.estimated_hours
-    create_issue!(:estimated_hours => 5, :parent_id => parent.id)
+    create_issue!(estimated_hours: 5, parent_id: parent.id)
     assert_equal 5, parent.reload.estimated_hours
-    create_issue!(:estimated_hours => 7, :parent_id => parent.id)
+    create_issue!(estimated_hours: 7, parent_id: parent.id)
     assert_equal 12, parent.reload.estimated_hours
   end
 
   def test_move_parent_updates_old_parent_attributes
     first_parent = create_issue!
     second_parent = create_issue!
-    child = create_issue!(:estimated_hours => 5,
-                          :parent_id => first_parent.id)
+    child = create_issue!(estimated_hours: 5,
+                          parent_id: first_parent.id)
     assert_equal 5, first_parent.reload.estimated_hours
-    child.update_attributes(:estimated_hours => 7,
-                            :parent_id => second_parent.id)
+    child.update_attributes(estimated_hours: 7,
+                            parent_id: second_parent.id)
     assert_equal 7, second_parent.reload.estimated_hours
     assert_nil first_parent.reload.estimated_hours
   end
 
   def test_project_copy_should_copy_issue_tree
     Project.delete_all # make sure unqiue identifiers
-    p = Project.create!(:name => 'Tree copy', :identifier => 'tree-copy', :type_ids => [1, 2])
-    i1 = create_issue!(:project_id => p.id, :subject => 'i1')
-    i2 = create_issue!(:project_id => p.id, :subject => 'i2', :parent_id => i1.id)
-    i3 = create_issue!(:project_id => p.id, :subject => 'i3', :parent_id => i1.id)
-    i4 = create_issue!(:project_id => p.id, :subject => 'i4', :parent_id => i2.id)
-    i5 = create_issue!(:project_id => p.id, :subject => 'i5')
-    c = Project.new(:name => 'Copy', :identifier => 'copy', :type_ids => [1, 2])
-    c.copy(p, :only => 'work_packages')
+    p = Project.create!(name: 'Tree copy', identifier: 'tree-copy', type_ids: [1, 2])
+    i1 = create_issue!(project_id: p.id, subject: 'i1')
+    i2 = create_issue!(project_id: p.id, subject: 'i2', parent_id: i1.id)
+    i3 = create_issue!(project_id: p.id, subject: 'i3', parent_id: i1.id)
+    i4 = create_issue!(project_id: p.id, subject: 'i4', parent_id: i2.id)
+    i5 = create_issue!(project_id: p.id, subject: 'i5')
+    c = Project.new(name: 'Copy', identifier: 'copy', type_ids: [1, 2])
+    c.copy(p, only: 'work_packages')
     c.reload
 
     assert_equal 5, c.work_packages.count
@@ -294,7 +294,7 @@ class IssueNestedSetTest < ActiveSupport::TestCase
   # Helper that creates an issue with default attributes
   def create_issue!(attributes={})
     (i = WorkPackage.new.tap do |i|
-      attr = { :project_id => 1, :type_id => 1, :author_id => 1, :subject => 'test' }.merge(attributes)
+      attr = { project_id: 1, type_id: 1, author_id: 1, subject: 'test' }.merge(attributes)
       i.force_attributes = attr
     end).save!
     i

--- a/test/unit/journal_observer_test.rb
+++ b/test/unit/journal_observer_test.rb
@@ -33,16 +33,16 @@ class JournalObserverTest < ActiveSupport::TestCase
     super
     @type = FactoryGirl.create :type_with_workflow
     @project = FactoryGirl.create :project,
-                                  :types => [@type]
+                                  types: [@type]
     @workflow = @type.workflows.first
     @user = FactoryGirl.create :user,
-                               :mail_notification => 'all',
-                               :member_in_project => @project
+                               mail_notification: 'all',
+                               member_in_project: @project
     @issue = FactoryGirl.create :work_package,
-                                :project => @project,
-                                :author => @user,
-                                :type => @type,
-                                :status => @workflow.old_status
+                                project: @project,
+                                author: @user,
+                                type: @type,
+                                status: @workflow.old_status
 
     @user.members.first.roles << @workflow.role
     @user.reload

--- a/test/unit/journal_observer_test.rb
+++ b/test/unit/journal_observer_test.rb
@@ -53,27 +53,27 @@ class JournalObserverTest < ActiveSupport::TestCase
   end
 
   context "#after_create for 'work_package_updated'" do
-    should "should send a notification when configured as a notification" do
+    should 'should send a notification when configured as a notification' do
       Setting.notified_events = ['work_package_updated']
       assert_difference('ActionMailer::Base.deliveries.size', +1) do
         @issue.add_journal(@user)
-        @issue.subject = "A change to the issue"
+        @issue.subject = 'A change to the issue'
         assert @issue.save(validate: false)
       end
     end
 
-    should "not send a notification with not configured" do
+    should 'not send a notification with not configured' do
       Setting.notified_events = []
       assert_no_difference('ActionMailer::Base.deliveries.size') do
         @issue.add_journal(@user)
-        @issue.subject = "A change to the issue"
+        @issue.subject = 'A change to the issue'
         assert @issue.save(validate: false)
       end
     end
   end
 
   context "#after_create for 'work_package_note_added'" do
-    should "should send a notification when configured as a notification" do
+    should 'should send a notification when configured as a notification' do
       @issue.recreate_initial_journal!
 
       Setting.notified_events = ['work_package_note_added']
@@ -83,7 +83,7 @@ class JournalObserverTest < ActiveSupport::TestCase
       end
     end
 
-    should "not send a notification with not configured" do
+    should 'not send a notification with not configured' do
       Setting.notified_events = []
       assert_no_difference('ActionMailer::Base.deliveries.size') do
         @issue.add_journal(@user, 'This update has a note')
@@ -93,7 +93,7 @@ class JournalObserverTest < ActiveSupport::TestCase
   end
 
   context "#after_create for 'status_updated'" do
-    should "should send a notification when configured as a notification" do
+    should 'should send a notification when configured as a notification' do
       Setting.notified_events = ['status_updated']
       assert_difference('ActionMailer::Base.deliveries.size', +1) do
         @issue.add_journal(@user)
@@ -102,7 +102,7 @@ class JournalObserverTest < ActiveSupport::TestCase
       end
     end
 
-    should "not send a notification with not configured" do
+    should 'not send a notification with not configured' do
       Setting.notified_events = []
       assert_no_difference('ActionMailer::Base.deliveries.size') do
         @issue.add_journal(@user)
@@ -113,7 +113,7 @@ class JournalObserverTest < ActiveSupport::TestCase
   end
 
   context "#after_create for 'work_package_priority_updated'" do
-    should "should send a notification when configured as a notification" do
+    should 'should send a notification when configured as a notification' do
       Setting.notified_events = ['work_package_priority_updated']
       assert_difference('ActionMailer::Base.deliveries.size', +1) do
         @issue.add_journal(@user)
@@ -122,7 +122,7 @@ class JournalObserverTest < ActiveSupport::TestCase
       end
     end
 
-    should "not send a notification with not configured" do
+    should 'not send a notification with not configured' do
       Setting.notified_events = []
       assert_no_difference('ActionMailer::Base.deliveries.size') do
         @issue.add_journal(@user)

--- a/test/unit/journal_test.rb
+++ b/test/unit/journal_test.rb
@@ -39,13 +39,13 @@ class JournalTest < ActiveSupport::TestCase
     ActionMailer::Base.deliveries.clear
     issue = WorkPackage.find(:first)
     if issue.journals.empty?
-      issue.add_journal(User.current, "This journal represents the creationa of journal version 1")
+      issue.add_journal(User.current, 'This journal represents the creationa of journal version 1')
       issue.save
     end
     user = User.find(:first)
     assert_equal 0, ActionMailer::Base.deliveries.size
     issue.reload
-    issue.update_attribute(:subject, "New subject to trigger automatic journal entry")
+    issue.update_attribute(:subject, 'New subject to trigger automatic journal entry')
     assert_equal 2, ActionMailer::Base.deliveries.size
   end
 
@@ -53,59 +53,59 @@ class JournalTest < ActiveSupport::TestCase
     ActionMailer::Base.deliveries.clear
     issue = WorkPackage.find(:first)
     user = User.find(:first)
-    journal = issue.add_journal(user, "A note")
+    journal = issue.add_journal(user, 'A note')
     JournalObserver.instance.send_notification = false
 
-    assert_difference("Journal.count") do
+    assert_difference('Journal.count') do
       assert issue.save
     end
     assert_equal 0, ActionMailer::Base.deliveries.size
   end
 
-  test "creating the initial journal should track the changes from creation" do
+  test 'creating the initial journal should track the changes from creation' do
     Journal.delete_all
     @project = Project.generate!
     issue = WorkPackage.new do |i|
       i.project = @project
-      i.subject = "Test initial journal"
+      i.subject = 'Test initial journal'
       i.type = @project.types.first
       i.author = User.generate!
-      i.description = "Some content"
+      i.description = 'Some content'
     end
 
-    assert_difference("Journal.count") do
+    assert_difference('Journal.count') do
       assert issue.save
     end
 
     journal = issue.reload.journals.first
-    assert_equal [nil,"Test initial journal"], journal.changed_data[:subject]
+    assert_equal [nil, 'Test initial journal'], journal.changed_data[:subject]
     assert_equal [nil, @project.id], journal.changed_data[:project_id]
-    assert_equal [nil, "Some content"], journal.changed_data[:description]
+    assert_equal [nil, 'Some content'], journal.changed_data[:description]
   end
 
-  test "creating a journal should update the updated_on value of the parent record (touch)" do
+  test 'creating a journal should update the updated_on value of the parent record (touch)' do
     @user = FactoryGirl.create(:user)
     @project = FactoryGirl.create(:project)
     @issue = FactoryGirl.create(:work_package, project: @project)
     start = @issue.updated_at
     sleep(1) # TODO: massive hack to make sure the timestamps are different. switch to timecop later
 
-    assert_difference("Journal.count") do
-      @issue.add_journal(@user, "A note")
+    assert_difference('Journal.count') do
+      @issue.add_journal(@user, 'A note')
       @issue.save
     end
 
     assert_not_equal start, @issue.reload.updated_at
   end
 
-  test "accessing #journaled on a Journal should not error (parent class)" do
+  test 'accessing #journaled on a Journal should not error (parent class)' do
     journal = Journal.new
     assert_nothing_raised do
       assert_equal nil, journal.journable
     end
   end
 
-  test "setting journal fields through the journaled object for creation" do
+  test 'setting journal fields through the journaled object for creation' do
     @issue = FactoryGirl.create(:work_package)
 
     @issue.add_journal @issue.author, 'Test setting fields on Journal from Issue'
@@ -113,7 +113,7 @@ class JournalTest < ActiveSupport::TestCase
       assert @issue.save
     end
 
-    assert_equal "Test setting fields on Journal from Issue", @issue.last_journal.notes
+    assert_equal 'Test setting fields on Journal from Issue', @issue.last_journal.notes
     assert_equal @issue.author, @issue.last_journal.user
   end
 end

--- a/test/unit/ldap_auth_source_test.rb
+++ b/test/unit/ldap_auth_source_test.rb
@@ -32,13 +32,13 @@ class LdapAuthSourceTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_create
-    a = LdapAuthSource.new(:name => 'My LDAP', :host => 'ldap.example.net', :port => 389, :base_dn => 'dc=example,dc=net', :attr_login => 'sAMAccountName')
+    a = LdapAuthSource.new(name: 'My LDAP', host: 'ldap.example.net', port: 389, base_dn: 'dc=example,dc=net', attr_login: 'sAMAccountName')
     assert a.save
   end
 
   def test_should_strip_ldap_attributes
-    a = LdapAuthSource.new(:name => 'My LDAP', :host => 'ldap.example.net', :port => 389, :base_dn => 'dc=example,dc=net', :attr_login => 'sAMAccountName',
-                           :attr_firstname => 'givenName ')
+    a = LdapAuthSource.new(name: 'My LDAP', host: 'ldap.example.net', port: 389, base_dn: 'dc=example,dc=net', attr_login: 'sAMAccountName',
+                           attr_firstname: 'givenName ')
     assert a.save
     assert_equal 'givenName', a.reload.attr_firstname
   end

--- a/test/unit/ldap_auth_source_test.rb
+++ b/test/unit/ldap_auth_source_test.rb
@@ -51,8 +51,8 @@ class LdapAuthSourceTest < ActiveSupport::TestCase
 
       context 'with a valid LDAP user' do
         should 'return the user attributes' do
-          attributes =  @auth.authenticate('example1','123456')
-          assert attributes.is_a?(Hash), "An hash was not returned"
+          attributes =  @auth.authenticate('example1', '123456')
+          assert attributes.is_a?(Hash), 'An hash was not returned'
           assert_equal 'Example', attributes[:firstname]
           assert_equal 'One', attributes[:lastname]
           assert_equal 'example1@redmine.org', attributes[:mail]
@@ -65,22 +65,21 @@ class LdapAuthSourceTest < ActiveSupport::TestCase
 
       context 'with an invalid LDAP user' do
         should 'return nil' do
-          assert_equal nil, @auth.authenticate('nouser','123456')
+          assert_equal nil, @auth.authenticate('nouser', '123456')
         end
       end
 
       context 'without a login' do
         should 'return nil' do
-          assert_equal nil, @auth.authenticate('','123456')
+          assert_equal nil, @auth.authenticate('', '123456')
         end
       end
 
       context 'without a password' do
         should 'return nil' do
-          assert_equal nil, @auth.authenticate('edavis','')
+          assert_equal nil, @auth.authenticate('edavis', '')
         end
       end
-
     end
   else
     puts '(Test LDAP server not configured)'

--- a/test/unit/lib/redmine/access_control_test.rb
+++ b/test/unit/lib/redmine/access_control_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::AccessControlTest < ActiveSupport::TestCase
-
   def setup
     super
     @access_module = Redmine::AccessControl

--- a/test/unit/lib/redmine/ciphering_test.rb
+++ b/test/unit/lib/redmine/ciphering_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::CipheringTest < ActiveSupport::TestCase
-
   def test_password_should_be_encrypted
     OpenProject::Configuration.with 'database_cipher_key' => 'secret' do
       r = Repository::Subversion.generate!(password: 'foo')

--- a/test/unit/lib/redmine/ciphering_test.rb
+++ b/test/unit/lib/redmine/ciphering_test.rb
@@ -32,7 +32,7 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
 
   def test_password_should_be_encrypted
     OpenProject::Configuration.with 'database_cipher_key' => 'secret' do
-      r = Repository::Subversion.generate!(:password => 'foo')
+      r = Repository::Subversion.generate!(password: 'foo')
       assert_equal 'foo', r.password
       assert r.read_attribute(:password).match(/\Aaes-256-cbc:.+\Z/)
     end
@@ -40,7 +40,7 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
 
   def test_password_should_be_clear_with_blank_key
     OpenProject::Configuration.with 'database_cipher_key' => '' do
-      r = Repository::Subversion.generate!(:password => 'foo')
+      r = Repository::Subversion.generate!(password: 'foo')
       assert_equal 'foo', r.password
       assert_equal 'foo', r.read_attribute(:password)
     end
@@ -48,7 +48,7 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
 
   def test_password_should_be_clear_with_nil_key
     OpenProject::Configuration.with 'database_cipher_key' => nil do
-      r = Repository::Subversion.generate!(:password => 'foo')
+      r = Repository::Subversion.generate!(password: 'foo')
       assert_equal 'foo', r.password
       assert_equal 'foo', r.read_attribute(:password)
     end
@@ -56,11 +56,11 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
 
   def test_unciphered_password_should_be_readable
     OpenProject::Configuration.with 'database_cipher_key' => nil do
-      r = Repository::Subversion.generate!(:password => 'clear')
+      r = Repository::Subversion.generate!(password: 'clear')
     end
 
     OpenProject::Configuration.with 'database_cipher_key' => 'secret' do
-      r = Repository.first(:order => 'id DESC')
+      r = Repository.first(order: 'id DESC')
       assert_equal 'clear', r.password
     end
   end
@@ -68,13 +68,13 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
   def test_encrypt_all
     Repository.delete_all
     OpenProject::Configuration.with 'database_cipher_key' => nil do
-      Repository::Subversion.generate!(:password => 'foo')
-      Repository::Subversion.generate!(:password => 'bar')
+      Repository::Subversion.generate!(password: 'foo')
+      Repository::Subversion.generate!(password: 'bar')
     end
 
     OpenProject::Configuration.with 'database_cipher_key' => 'secret' do
       assert Repository.encrypt_all(:password)
-      r = Repository.first(:order => 'id DESC')
+      r = Repository.first(order: 'id DESC')
       assert_equal 'bar', r.password
       assert r.read_attribute(:password).match(/\Aaes-256-cbc:.+\Z/)
     end
@@ -83,11 +83,11 @@ class Redmine::CipheringTest < ActiveSupport::TestCase
   def test_decrypt_all
     Repository.delete_all
     OpenProject::Configuration.with 'database_cipher_key' => 'secret' do
-      Repository::Subversion.generate!(:password => 'foo')
-      Repository::Subversion.generate!(:password => 'bar')
+      Repository::Subversion.generate!(password: 'foo')
+      Repository::Subversion.generate!(password: 'bar')
 
       assert Repository.decrypt_all(:password)
-      r = Repository.first(:order => 'id DESC')
+      r = Repository.first(order: 'id DESC')
       assert_equal 'bar', r.password
       assert_equal 'bar', r.read_attribute(:password)
     end

--- a/test/unit/lib/redmine/codeset_util_test.rb
+++ b/test/unit/lib/redmine/codeset_util_test.rb
@@ -41,7 +41,7 @@ require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::CodesetUtilTest < HelperTestCase
   def test_to_utf8_by_setting_from_latin1
-    with_settings :repositories_encodings => 'UTF-8,ISO-8859-1' do
+    with_settings repositories_encodings: 'UTF-8,ISO-8859-1' do
       s1 = "Texte encod\xc3\xa9"
       s2 = "Texte encod\xe9"
       s3 = s2.dup
@@ -56,7 +56,7 @@ class Redmine::CodesetUtilTest < HelperTestCase
   end
 
   def test_to_utf8_by_setting_from_euc_jp
-    with_settings :repositories_encodings => 'UTF-8,EUC-JP' do
+    with_settings repositories_encodings: 'UTF-8,EUC-JP' do
       s1 = "\xe3\x83\xac\xe3\x83\x83\xe3\x83\x89\xe3\x83\x9e\xe3\x82\xa4\xe3\x83\xb3"
       s2 = "\xa5\xec\xa5\xc3\xa5\xc9\xa5\xde\xa5\xa4\xa5\xf3"
       s3 = s2.dup
@@ -71,7 +71,7 @@ class Redmine::CodesetUtilTest < HelperTestCase
   end
 
   def test_to_utf8_by_setting_should_be_converted_all_latin1
-    with_settings :repositories_encodings => 'ISO-8859-1' do
+    with_settings repositories_encodings: 'ISO-8859-1' do
       s1 = "\xc3\x82\xc2\x80"
       s2 = "\xC2\x80"
       s3 = s2.dup
@@ -108,7 +108,7 @@ class Redmine::CodesetUtilTest < HelperTestCase
   end
 
   def test_to_utf8_by_setting_invalid_utf8_sequences_should_be_stripped
-    with_settings :repositories_encodings => '' do
+    with_settings repositories_encodings: '' do
       s1 = "Texte encod\xe9 en ISO-8859-1."
       s1.force_encoding("ASCII-8BIT") if s1.respond_to?(:force_encoding)
       str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
@@ -121,7 +121,7 @@ class Redmine::CodesetUtilTest < HelperTestCase
   end
 
   def test_to_utf8_by_setting_invalid_utf8_sequences_should_be_stripped_ja_jis
-    with_settings :repositories_encodings => 'ISO-2022-JP' do
+    with_settings repositories_encodings: 'ISO-2022-JP' do
       s1 = "test\xb5\xfetest\xb5\xfe"
       s1.force_encoding("ASCII-8BIT") if s1.respond_to?(:force_encoding)
       str = Redmine::CodesetUtil.to_utf8_by_setting(s1)

--- a/test/unit/lib/redmine/codeset_util_test.rb
+++ b/test/unit/lib/redmine/codeset_util_test.rb
@@ -46,9 +46,9 @@ class Redmine::CodesetUtilTest < HelperTestCase
       s2 = "Texte encod\xe9"
       s3 = s2.dup
       if s1.respond_to?(:force_encoding)
-        s1.force_encoding("UTF-8")
-        s2.force_encoding("ASCII-8BIT")
-        s3.force_encoding("UTF-8")
+        s1.force_encoding('UTF-8')
+        s2.force_encoding('ASCII-8BIT')
+        s3.force_encoding('UTF-8')
       end
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
@@ -61,9 +61,9 @@ class Redmine::CodesetUtilTest < HelperTestCase
       s2 = "\xa5\xec\xa5\xc3\xa5\xc9\xa5\xde\xa5\xa4\xa5\xf3"
       s3 = s2.dup
       if s1.respond_to?(:force_encoding)
-        s1.force_encoding("UTF-8")
-        s2.force_encoding("ASCII-8BIT")
-        s3.force_encoding("UTF-8")
+        s1.force_encoding('UTF-8')
+        s2.force_encoding('ASCII-8BIT')
+        s3.force_encoding('UTF-8')
       end
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
@@ -76,9 +76,9 @@ class Redmine::CodesetUtilTest < HelperTestCase
       s2 = "\xC2\x80"
       s3 = s2.dup
       if s1.respond_to?(:force_encoding)
-        s1.force_encoding("UTF-8")
-        s2.force_encoding("ASCII-8BIT")
-        s3.force_encoding("UTF-8")
+        s1.force_encoding('UTF-8')
+        s2.force_encoding('ASCII-8BIT')
+        s3.force_encoding('UTF-8')
       end
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
       assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
@@ -86,50 +86,50 @@ class Redmine::CodesetUtilTest < HelperTestCase
   end
 
   def test_to_utf8_by_setting_blank_string
-    assert_equal "",  Redmine::CodesetUtil.to_utf8_by_setting("")
+    assert_equal '',  Redmine::CodesetUtil.to_utf8_by_setting('')
     assert_equal nil, Redmine::CodesetUtil.to_utf8_by_setting(nil)
   end
 
   def test_to_utf8_by_setting_returns_ascii_as_utf8
-    s1 = "ASCII"
+    s1 = 'ASCII'
     s2 = s1.dup
     if s1.respond_to?(:force_encoding)
-      s1.force_encoding("UTF-8")
-      s2.force_encoding("ISO-8859-1")
+      s1.force_encoding('UTF-8')
+      s2.force_encoding('ISO-8859-1')
     end
     str1 = Redmine::CodesetUtil.to_utf8_by_setting(s1)
     str2 = Redmine::CodesetUtil.to_utf8_by_setting(s2)
     assert_equal s1, str1
     assert_equal s1, str2
     if s1.respond_to?(:force_encoding)
-      assert_equal "UTF-8", str1.encoding.to_s
-      assert_equal "UTF-8", str2.encoding.to_s
+      assert_equal 'UTF-8', str1.encoding.to_s
+      assert_equal 'UTF-8', str2.encoding.to_s
     end
   end
 
   def test_to_utf8_by_setting_invalid_utf8_sequences_should_be_stripped
     with_settings repositories_encodings: '' do
       s1 = "Texte encod\xe9 en ISO-8859-1."
-      s1.force_encoding("ASCII-8BIT") if s1.respond_to?(:force_encoding)
+      s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
       str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
       if str.respond_to?(:force_encoding)
         assert str.valid_encoding?
-        assert_equal "UTF-8", str.encoding.to_s
+        assert_equal 'UTF-8', str.encoding.to_s
       end
-      assert_equal "Texte encod? en ISO-8859-1.", str
+      assert_equal 'Texte encod? en ISO-8859-1.', str
     end
   end
 
   def test_to_utf8_by_setting_invalid_utf8_sequences_should_be_stripped_ja_jis
     with_settings repositories_encodings: 'ISO-2022-JP' do
       s1 = "test\xb5\xfetest\xb5\xfe"
-      s1.force_encoding("ASCII-8BIT") if s1.respond_to?(:force_encoding)
+      s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
       str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
       if str.respond_to?(:force_encoding)
         assert str.valid_encoding?
-        assert_equal "UTF-8", str.encoding.to_s
+        assert_equal 'UTF-8', str.encoding.to_s
       end
-      assert_equal "test??test??", str
+      assert_equal 'test??test??', str
     end
   end
 end

--- a/test/unit/lib/redmine/helpers/calendar_test.rb
+++ b/test/unit/lib/redmine/helpers/calendar_test.rb
@@ -56,7 +56,7 @@ class CalendarTest < ActiveSupport::TestCase
 
   def test_monthly_start_day
     [1, 6, 7].each do |day|
-      with_settings :start_of_week => day do
+      with_settings start_of_week: day do
         c = Redmine::Helpers::Calendar.new(Date.today, :en, :month)
         assert_equal day , c.startdt.cwday
         assert_equal (day + 5) % 7 + 1, c.enddt.cwday
@@ -66,7 +66,7 @@ class CalendarTest < ActiveSupport::TestCase
 
   def test_weekly_start_day
     [1, 6, 7].each do |day|
-      with_settings :start_of_week => day do
+      with_settings start_of_week: day do
         c = Redmine::Helpers::Calendar.new(Date.today, :en, :week)
         assert_equal day, c.startdt.cwday
         assert_equal (day + 5) % 7 + 1, c.enddt.cwday

--- a/test/unit/lib/redmine/helpers/calendar_test.rb
+++ b/test/unit/lib/redmine/helpers/calendar_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../../test_helper', __FILE__)
 
 class CalendarTest < ActiveSupport::TestCase
-
   def test_monthly
     Setting.available_languages = [:de, :en]
     c = Redmine::Helpers::Calendar.new(Date.today, :de, :month)
@@ -58,7 +57,7 @@ class CalendarTest < ActiveSupport::TestCase
     [1, 6, 7].each do |day|
       with_settings start_of_week: day do
         c = Redmine::Helpers::Calendar.new(Date.today, :en, :month)
-        assert_equal day , c.startdt.cwday
+        assert_equal day, c.startdt.cwday
         assert_equal (day + 5) % 7 + 1, c.enddt.cwday
       end
     end

--- a/test/unit/lib/redmine/hook_test.rb
+++ b/test/unit/lib/redmine/hook_test.rb
@@ -54,7 +54,7 @@ class Redmine::Hook::ManagerTest < ActionView::TestCase
 
   class TestLinkToHook < TestHook
     def view_layouts_base_html_head(context)
-      link_to('Issues', :controller => 'issues')
+      link_to('Issues', controller: 'issues')
     end
   end
 
@@ -102,7 +102,7 @@ class Redmine::Hook::ManagerTest < ActionView::TestCase
   def test_call_hook_with_context
     @hook_module.add_listener(TestHook3)
     assert_equal ['Context keys: bar, controller, foo, hook_caller, project, request.'],
-                 hook_helper.call_hook(:view_layouts_base_html_head, :foo => 1, :bar => 'a')
+                 hook_helper.call_hook(:view_layouts_base_html_head, foo: 1, bar: 'a')
   end
 
   def test_call_hook_with_multiple_listeners

--- a/test/unit/lib/redmine/hook_test.rb
+++ b/test/unit/lib/redmine/hook_test.rb
@@ -35,13 +35,13 @@ class Redmine::Hook::ManagerTest < ActionView::TestCase
   class TestHook < Redmine::Hook::ViewListener; end
 
   class TestHook1 < TestHook
-    def view_layouts_base_html_head(context)
+    def view_layouts_base_html_head(_context)
       'Test hook 1 listener.'
     end
   end
 
   class TestHook2 < TestHook
-    def view_layouts_base_html_head(context)
+    def view_layouts_base_html_head(_context)
       'Test hook 2 listener.'
     end
   end
@@ -53,7 +53,7 @@ class Redmine::Hook::ManagerTest < ActionView::TestCase
   end
 
   class TestLinkToHook < TestHook
-    def view_layouts_base_html_head(context)
+    def view_layouts_base_html_head(_context)
       link_to('Issues', controller: 'issues')
     end
   end

--- a/test/unit/lib/redmine/i18n_test.rb
+++ b/test/unit/lib/redmine/i18n_test.rb
@@ -128,22 +128,22 @@ class Redmine::I18nTest < ActiveSupport::TestCase
     valid_languages.each do |lang|
       set_language_if_valid lang
       assert_nothing_raised "#{lang} failure" do
-        number_to_human_size(1024*1024*4)
+        number_to_human_size(1024 * 1024 * 4)
       end
     end
   end
 
   def test_fallback
-    ::I18n.backend.store_translations(:en, {untranslated: "Untranslated string"})
+    ::I18n.backend.store_translations(:en, untranslated: 'Untranslated string')
     ::I18n.locale = 'en'
-    assert_equal "Untranslated string", l(:untranslated)
+    assert_equal 'Untranslated string', l(:untranslated)
     ::I18n.locale = 'de'
-    assert_equal "Untranslated string", l(:untranslated)
+    assert_equal 'Untranslated string', l(:untranslated)
 
-    ::I18n.backend.store_translations(:de, {untranslated: "Keine Übersetzung"})
+    ::I18n.backend.store_translations(:de, untranslated: 'Keine Übersetzung')
     ::I18n.locale = 'en'
-    assert_equal "Untranslated string", l(:untranslated)
+    assert_equal 'Untranslated string', l(:untranslated)
     ::I18n.locale = 'de'
-    assert_equal "Keine Übersetzung", l(:untranslated)
+    assert_equal 'Keine Übersetzung', l(:untranslated)
   end
 end

--- a/test/unit/lib/redmine/i18n_test.rb
+++ b/test/unit/lib/redmine/i18n_test.rb
@@ -59,8 +59,8 @@ class Redmine::I18nTest < ActiveSupport::TestCase
         format_date(Date.today)
         format_time(Time.now)
         format_time(Time.now, false)
-        assert_not_equal 'default', ::I18n.l(Date.today, :format => :default), "date.formats.default missing in #{lang}"
-        assert_not_equal 'time',    ::I18n.l(Time.now, :format => :time),      "time.formats.time missing in #{lang}"
+        assert_not_equal 'default', ::I18n.l(Date.today, format: :default), "date.formats.default missing in #{lang}"
+        assert_not_equal 'time',    ::I18n.l(Time.now, format: :time),      "time.formats.time missing in #{lang}"
       end
       assert l('date.day_names').is_a?(Array)
       assert_equal 7, l('date.day_names').size
@@ -73,13 +73,13 @@ class Redmine::I18nTest < ActiveSupport::TestCase
   def test_time_format
     set_language_if_valid 'en'
     now = Time.parse('2011-02-20 15:45:22')
-    with_settings :time_format => '%H:%M' do
-      with_settings :date_format => '' do
+    with_settings time_format: '%H:%M' do
+      with_settings date_format: '' do
         assert_equal '02/20/2011 15:45', format_time(now)
         assert_equal '15:45', format_time(now, false)
       end
 
-      with_settings :date_format => '%Y-%m-%d' do
+      with_settings date_format: '%Y-%m-%d' do
         assert_equal '2011-02-20 15:45', format_time(now)
         assert_equal '15:45', format_time(now, false)
       end
@@ -89,13 +89,13 @@ class Redmine::I18nTest < ActiveSupport::TestCase
   def test_time_format_default
     set_language_if_valid 'en'
     now = Time.parse('2011-02-20 15:45:22')
-    with_settings :time_format => '' do
-      with_settings :date_format => '' do
+    with_settings time_format: '' do
+      with_settings date_format: '' do
         assert_equal '02/20/2011 03:45 PM', format_time(now)
         assert_equal '03:45 PM', format_time(now, false)
       end
 
-      with_settings :date_format => '%Y-%m-%d' do
+      with_settings date_format: '%Y-%m-%d' do
         assert_equal '2011-02-20 03:45 PM', format_time(now)
         assert_equal '03:45 PM', format_time(now, false)
       end
@@ -105,8 +105,8 @@ class Redmine::I18nTest < ActiveSupport::TestCase
   def test_time_format
     set_language_if_valid 'en'
     now = Time.now
-    with_settings :time_format => '%H %M' do
-      with_settings :date_format => '%d %m %Y' do
+    with_settings time_format: '%H %M' do
+      with_settings date_format: '%d %m %Y' do
         assert_equal now.strftime('%d %m %Y %H %M'), format_time(now)
         assert_equal now.strftime('%H %M'), format_time(now, false)
       end
@@ -116,8 +116,8 @@ class Redmine::I18nTest < ActiveSupport::TestCase
   def test_utc_time_format
     set_language_if_valid 'en'
     now = Time.now
-    with_settings :time_format => '%H %M' do
-      with_settings :date_format => '%d %m %Y' do
+    with_settings time_format: '%H %M' do
+      with_settings date_format: '%d %m %Y' do
         assert_equal now.localtime.strftime('%d %m %Y %H %M'), format_time(now.utc)
         assert_equal now.localtime.strftime('%H %M'), format_time(now.utc, false)
       end
@@ -134,13 +134,13 @@ class Redmine::I18nTest < ActiveSupport::TestCase
   end
 
   def test_fallback
-    ::I18n.backend.store_translations(:en, {:untranslated => "Untranslated string"})
+    ::I18n.backend.store_translations(:en, {untranslated: "Untranslated string"})
     ::I18n.locale = 'en'
     assert_equal "Untranslated string", l(:untranslated)
     ::I18n.locale = 'de'
     assert_equal "Untranslated string", l(:untranslated)
 
-    ::I18n.backend.store_translations(:de, {:untranslated => "Keine Übersetzung"})
+    ::I18n.backend.store_translations(:de, {untranslated: "Keine Übersetzung"})
     ::I18n.locale = 'en'
     assert_equal "Untranslated string", l(:untranslated)
     ::I18n.locale = 'de'

--- a/test/unit/lib/redmine/menu_manager/mapper_test.rb
+++ b/test/unit/lib/redmine/menu_manager/mapper_test.rb
@@ -29,21 +29,21 @@
 require File.expand_path('../../../../../test_helper', __FILE__)
 
 class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
-  context "Mapper#initialize" do
-    should "be tested"
+  context 'Mapper#initialize' do
+    should 'be tested'
   end
 
   def test_push_onto_root
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
 
     menu_mapper.exists?(:test_overview)
   end
 
   def test_push_onto_parent
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show' }, parent: :test_overview
 
     assert menu_mapper.exists?(:test_child)
     assert_equal :test_child, menu_mapper.find(:test_child).name
@@ -51,9 +51,9 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_onto_grandparent
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview}
-    menu_mapper.push :test_grandchild, { controller: 'projects', action: 'show'}, {parent: :test_child}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show' }, parent: :test_overview
+    menu_mapper.push :test_grandchild, { controller: 'projects', action: 'show' }, parent: :test_child
 
     assert menu_mapper.exists?(:test_grandchild)
     grandchild = menu_mapper.find(:test_grandchild)
@@ -63,100 +63,95 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_first
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {first: true}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show' }, first: true
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
-    {0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth}.each do |position, name|
+    { 0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth }.each do |position, name|
       assert_not_nil root.children[position]
       assert_equal name, root.children[position].name
     end
-
   end
 
   def test_push_before
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {before: :test_fourth}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show' }, before: :test_fourth
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
-    {0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth}.each do |position, name|
+    { 0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth }.each do |position, name|
       assert_not_nil root.children[position]
       assert_equal name, root.children[position].name
     end
-
   end
 
   def test_push_after
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {after: :test_third}
-
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show' }, after: :test_third
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
-    {0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth}.each do |position, name|
+    { 0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth }.each do |position, name|
       assert_not_nil root.children[position]
       assert_equal name, root.children[position].name
     end
-
   end
 
   def test_push_last
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {last: true}
-    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show' }, last: true
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show' }, {}
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
-    {0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth}.each do |position, name|
+    { 0 => :test_first, 1 => :test_second, 2 => :test_third, 3 => :test_fourth, 4 => :test_fifth }.each do |position, name|
       assert_not_nil root.children[position]
       assert_equal name, root.children[position].name
     end
-
   end
 
   def test_exists_for_child_node
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
-    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview }
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show' }, parent: :test_overview
 
     assert menu_mapper.exists?(:test_child)
   end
 
   def test_exists_for_invalid_node
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
 
     assert !menu_mapper.exists?(:nothing)
   end
 
   def test_find
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
 
     item = menu_mapper.find(:test_overview)
     assert_equal :test_overview, item.name
-    assert_equal({controller: 'projects', action: 'show'}, item.url)
+    assert_equal({ controller: 'projects', action: 'show' }, item.url)
   end
 
   def test_find_missing
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
 
     item = menu_mapper.find(:nothing)
     assert_equal nil, item
@@ -164,7 +159,7 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_delete
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show' }, {}
     assert_not_nil menu_mapper.delete(:test_overview)
 
     assert_nil menu_mapper.find(:test_overview)
@@ -179,7 +174,7 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
     # Exposed by deleting :last items
     Redmine::MenuManager.map :test_menu do |menu|
       menu.push :not_last, OpenProject::Info.help_url
-      menu.push :administration, { controller: 'projects', action: 'show'}, {last: true}
+      menu.push :administration, { controller: 'projects', action: 'show' }, last: true
       menu.push :help, OpenProject::Info.help_url, last: true
     end
 
@@ -187,8 +182,8 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
       Redmine::MenuManager.map :test_menu do |menu|
         menu.delete(:administration)
         menu.delete(:help)
-        menu.push :test_overview, { controller: 'projects', action: 'show'}, {}
-     end
+        menu.push :test_overview, { controller: 'projects', action: 'show' }, {}
+      end
     end
   end
 end

--- a/test/unit/lib/redmine/menu_manager/mapper_test.rb
+++ b/test/unit/lib/redmine/menu_manager/mapper_test.rb
@@ -35,15 +35,15 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_onto_root
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
 
     menu_mapper.exists?(:test_overview)
   end
 
   def test_push_onto_parent
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_child, { :controller => 'projects', :action => 'show'}, {:parent => :test_overview}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview}
 
     assert menu_mapper.exists?(:test_child)
     assert_equal :test_child, menu_mapper.find(:test_child).name
@@ -51,9 +51,9 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_onto_grandparent
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_child, { :controller => 'projects', :action => 'show'}, {:parent => :test_overview}
-    menu_mapper.push :test_grandchild, { :controller => 'projects', :action => 'show'}, {:parent => :test_child}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview}
+    menu_mapper.push :test_grandchild, { controller: 'projects', action: 'show'}, {parent: :test_child}
 
     assert menu_mapper.exists?(:test_grandchild)
     grandchild = menu_mapper.find(:test_grandchild)
@@ -63,11 +63,11 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_first
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_second, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_third, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fourth, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fifth, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_first, { :controller => 'projects', :action => 'show'}, {:first => true}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {first: true}
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
@@ -80,11 +80,11 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_before
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_second, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fourth, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fifth, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_third, { :controller => 'projects', :action => 'show'}, {:before => :test_fourth}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {before: :test_fourth}
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
@@ -97,11 +97,11 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_after
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_second, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_third, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fifth, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fourth, { :controller => 'projects', :action => 'show'}, {:after => :test_third}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {after: :test_third}
 
 
     root = menu_mapper.find(:root)
@@ -115,11 +115,11 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_push_last
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_first, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_second, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_third, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_fifth, { :controller => 'projects', :action => 'show'}, {:last => true}
-    menu_mapper.push :test_fourth, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_first, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_second, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_third, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_fifth, { controller: 'projects', action: 'show'}, {last: true}
+    menu_mapper.push :test_fourth, { controller: 'projects', action: 'show'}, {}
 
     root = menu_mapper.find(:root)
     assert_equal 5, root.children.size
@@ -132,31 +132,31 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_exists_for_child_node
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
-    menu_mapper.push :test_child, { :controller => 'projects', :action => 'show'}, {:parent => :test_overview }
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
+    menu_mapper.push :test_child, { controller: 'projects', action: 'show'}, {parent: :test_overview }
 
     assert menu_mapper.exists?(:test_child)
   end
 
   def test_exists_for_invalid_node
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
 
     assert !menu_mapper.exists?(:nothing)
   end
 
   def test_find
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
 
     item = menu_mapper.find(:test_overview)
     assert_equal :test_overview, item.name
-    assert_equal({:controller => 'projects', :action => 'show'}, item.url)
+    assert_equal({controller: 'projects', action: 'show'}, item.url)
   end
 
   def test_find_missing
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
 
     item = menu_mapper.find(:nothing)
     assert_equal nil, item
@@ -164,7 +164,7 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
 
   def test_delete
     menu_mapper = Redmine::MenuManager::Mapper.new(:test_menu, {})
-    menu_mapper.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+    menu_mapper.push :test_overview, { controller: 'projects', action: 'show'}, {}
     assert_not_nil menu_mapper.delete(:test_overview)
 
     assert_nil menu_mapper.find(:test_overview)
@@ -179,15 +179,15 @@ class Redmine::MenuManager::MapperTest < ActiveSupport::TestCase
     # Exposed by deleting :last items
     Redmine::MenuManager.map :test_menu do |menu|
       menu.push :not_last, OpenProject::Info.help_url
-      menu.push :administration, { :controller => 'projects', :action => 'show'}, {:last => true}
-      menu.push :help, OpenProject::Info.help_url, :last => true
+      menu.push :administration, { controller: 'projects', action: 'show'}, {last: true}
+      menu.push :help, OpenProject::Info.help_url, last: true
     end
 
     assert_nothing_raised do
       Redmine::MenuManager.map :test_menu do |menu|
         menu.delete(:administration)
         menu.delete(:help)
-        menu.push :test_overview, { :controller => 'projects', :action => 'show'}, {}
+        menu.push :test_overview, { controller: 'projects', action: 'show'}, {}
      end
     end
   end

--- a/test/unit/lib/redmine/menu_manager/menu_helper_test.rb
+++ b/test/unit/lib/redmine/menu_manager/menu_helper_test.rb
@@ -28,8 +28,6 @@
 #++
 require File.expand_path('../../../../../test_helper', __FILE__)
 
-
-
 class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   include Redmine::MenuManager::MenuHelper
   include ActionDispatch::Assertions::SelectorAssertions
@@ -49,97 +47,95 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
     end
   end
 
-
-  context "MenuManager#current_menu_item" do
-    should "be tested"
+  context 'MenuManager#current_menu_item' do
+    should 'be tested'
   end
 
-  context "MenuManager#render_main_menu" do
-    should "be tested"
+  context 'MenuManager#render_main_menu' do
+    should 'be tested'
   end
 
-  context "MenuManager#render_menu" do
-    should "be tested"
+  context 'MenuManager#render_menu' do
+    should 'be tested'
   end
 
-  context "MenuManager#menu_item_and_children" do
-    should "be tested"
+  context 'MenuManager#menu_item_and_children' do
+    should 'be tested'
   end
 
-  context "MenuManager#extract_node_details" do
-    should "be tested"
+  context 'MenuManager#extract_node_details' do
+    should 'be tested'
   end
 
   def test_render_single_menu_node
-    node = Redmine::MenuManager::MenuItem.new(:testing, '/test', { })
+    node = Redmine::MenuManager::MenuItem.new(:testing, '/test', {})
     @response.body = render_single_menu_node(node, 'This is a test', node.url, false)
 
     html_node = HTML::Document.new(@response.body)
-    assert_select(html_node.root, "a.testing-menu-item", "This is a test")
+    assert_select(html_node.root, 'a.testing-menu-item', 'This is a test')
   end
 
   def test_render_menu_node
-    single_node = Redmine::MenuManager::MenuItem.new(:single_node, '/test', { })
+    single_node = Redmine::MenuManager::MenuItem.new(:single_node, '/test', {})
     @response.body = render_menu_node(single_node, nil)
 
     html_node = HTML::Document.new(@response.body)
-    assert_select(html_node.root, "li") do
-      assert_select("a.single-node-menu-item", "Single node")
+    assert_select(html_node.root, 'li') do
+      assert_select('a.single-node-menu-item', 'Single node')
     end
   end
 
   def test_render_menu_node_with_nested_items
-    parent_node = Redmine::MenuManager::MenuItem.new(:parent_node, '/test', { })
-    parent_node << Redmine::MenuManager::MenuItem.new(:child_one_node, '/test', { })
-    parent_node << Redmine::MenuManager::MenuItem.new(:child_two_node, '/test', { })
+    parent_node = Redmine::MenuManager::MenuItem.new(:parent_node, '/test', {})
+    parent_node << Redmine::MenuManager::MenuItem.new(:child_one_node, '/test', {})
+    parent_node << Redmine::MenuManager::MenuItem.new(:child_two_node, '/test', {})
     parent_node <<
-      Redmine::MenuManager::MenuItem.new(:child_three_node, '/test', { }) <<
-      Redmine::MenuManager::MenuItem.new(:child_three_inner_node, '/test', { })
+      Redmine::MenuManager::MenuItem.new(:child_three_node, '/test', {}) <<
+      Redmine::MenuManager::MenuItem.new(:child_three_inner_node, '/test', {})
 
     @response.body = render_menu_node(parent_node, nil)
 
     html_node = HTML::Document.new(@response.body)
-    assert_select(html_node.root, "li") do
-      assert_select("a.parent-node-menu-item", "Parent node")
-      assert_select("ul") do
-        assert_select("li a.child-one-node-menu-item", "Child one node")
-        assert_select("li a.child-two-node-menu-item", "Child two node")
-        assert_select("li") do
-          assert_select("a.child-three-node-menu-item", "Child three node")
-          assert_select("ul") do
-            assert_select("li a.child-three-inner-node-menu-item", "Child three inner node")
+    assert_select(html_node.root, 'li') do
+      assert_select('a.parent-node-menu-item', 'Parent node')
+      assert_select('ul') do
+        assert_select('li a.child-one-node-menu-item', 'Child one node')
+        assert_select('li a.child-two-node-menu-item', 'Child two node')
+        assert_select('li') do
+          assert_select('a.child-three-node-menu-item', 'Child three node')
+          assert_select('ul') do
+            assert_select('li a.child-three-inner-node-menu-item', 'Child three inner node')
           end
         end
       end
     end
-
   end
 
   def test_render_menu_node_with_children
     User.current = User.find(1)
 
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {controller: 'issues', action: 'index'},
-                                                     {
-                                                       children: Proc.new {|p|
-                                                         children = []
-                                                         3.times do |time|
-                                                           children << Redmine::MenuManager::MenuItem.new("test_child_#{time}",
-                                                                                                             {controller: 'issues', action: 'index'},
-                                                                                                             {})
-                                                         end
-                                                         children
-                                                       }
-                                                     })
+                                                     { controller: 'issues', action: 'index' },
+
+                                                     children: Proc.new {|_p|
+                                                       children = []
+                                                       3.times do |time|
+                                                         children << Redmine::MenuManager::MenuItem.new("test_child_#{time}",
+                                                                                                        { controller: 'issues', action: 'index' },
+                                                                                                        {})
+                                                       end
+                                                       children
+                                                     }
+                                                     )
     @response.body = render_menu_node(parent_node, Project.find(1))
 
     html_node = HTML::Document.new(@response.body)
-    assert_select(html_node.root, "li") do
-      assert_select("a.parent-node-menu-item", "Parent node")
-      assert_select("ul") do
-        assert_select("li a.test-child-0-menu-item", "Test child 0")
-        assert_select("li a.test-child-1-menu-item", "Test child 1")
-        assert_select("li a.test-child-2-menu-item", "Test child 2")
+    assert_select(html_node.root, 'li') do
+      assert_select('a.parent-node-menu-item', 'Parent node')
+      assert_select('ul') do
+        assert_select('li a.test-child-0-menu-item', 'Test child 0')
+        assert_select('li a.test-child-1-menu-item', 'Test child 1')
+        assert_select('li a.test-child-2-menu-item', 'Test child 2')
       end
     end
   end
@@ -148,82 +144,81 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
     User.current = User.find(1)
 
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {controller: 'issues', action: 'index'},
-                                                     {
-                                                       children: Proc.new {|p|
-                                                         children = []
-                                                         3.times do |time|
-                                                           children << Redmine::MenuManager::MenuItem.new("test_child_#{time}", {controller: 'issues', action: 'index'}, {})
-                                                         end
-                                                         children
-                                                       }
-                                                     })
+                                                     { controller: 'issues', action: 'index' },
+
+                                                     children: Proc.new {|_p|
+                                                       children = []
+                                                       3.times do |time|
+                                                         children << Redmine::MenuManager::MenuItem.new("test_child_#{time}", { controller: 'issues', action: 'index' }, {})
+                                                       end
+                                                       children
+                                                     }
+                                                     )
 
     parent_node << Redmine::MenuManager::MenuItem.new(:child_node,
-                                                     {controller: 'issues', action: 'index'},
-                                                     {
-                                                       children: Proc.new {|p|
-                                                         children = []
-                                                         6.times do |time|
-                                                            children << Redmine::MenuManager::MenuItem.new("test_dynamic_child_#{time}", {controller: 'issues', action: 'index'}, {})
-                                                         end
-                                                         children
-                                                       }
-                                                     })
+                                                      { controller: 'issues', action: 'index' },
+
+                                                      children: Proc.new {|_p|
+                                                        children = []
+                                                        6.times do |time|
+                                                          children << Redmine::MenuManager::MenuItem.new("test_dynamic_child_#{time}", { controller: 'issues', action: 'index' }, {})
+                                                        end
+                                                        children
+                                                      }
+                                                      )
 
     @response.body = render_menu_node(parent_node, Project.find(1))
 
     html_node = HTML::Document.new(@response.body)
-    assert_select(html_node.root, "li") do
-      assert_select("a.parent-node-menu-item", "Parent node")
-      assert_select("ul") do
-        assert_select("li a.child-node-menu-item", "Child node")
-        assert_select("ul") do
-          assert_select("li a.test-dynamic-child-0-menu-item", "Test dynamic child 0")
-          assert_select("li a.test-dynamic-child-1-menu-item", "Test dynamic child 1")
-          assert_select("li a.test-dynamic-child-2-menu-item", "Test dynamic child 2")
-          assert_select("li a.test-dynamic-child-3-menu-item", "Test dynamic child 3")
-          assert_select("li a.test-dynamic-child-4-menu-item", "Test dynamic child 4")
-          assert_select("li a.test-dynamic-child-5-menu-item", "Test dynamic child 5")
+    assert_select(html_node.root, 'li') do
+      assert_select('a.parent-node-menu-item', 'Parent node')
+      assert_select('ul') do
+        assert_select('li a.child-node-menu-item', 'Child node')
+        assert_select('ul') do
+          assert_select('li a.test-dynamic-child-0-menu-item', 'Test dynamic child 0')
+          assert_select('li a.test-dynamic-child-1-menu-item', 'Test dynamic child 1')
+          assert_select('li a.test-dynamic-child-2-menu-item', 'Test dynamic child 2')
+          assert_select('li a.test-dynamic-child-3-menu-item', 'Test dynamic child 3')
+          assert_select('li a.test-dynamic-child-4-menu-item', 'Test dynamic child 4')
+          assert_select('li a.test-dynamic-child-5-menu-item', 'Test dynamic child 5')
         end
-        assert_select("li a.test-child-0-menu-item", "Test child 0")
-        assert_select("li a.test-child-1-menu-item", "Test child 1")
-        assert_select("li a.test-child-2-menu-item", "Test child 2")
+        assert_select('li a.test-child-0-menu-item', 'Test child 0')
+        assert_select('li a.test-child-1-menu-item', 'Test child 1')
+        assert_select('li a.test-child-2-menu-item', 'Test child 2')
       end
     end
   end
 
   def test_render_menu_node_with_children_without_an_array
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {controller: 'issues', action: 'index'},
-                                                     {
-                                                       children: Proc.new {|p| Redmine::MenuManager::MenuItem.new("test_child", {controller: 'issues', action: 'index'}, {})},
-                                                     })
+                                                     { controller: 'issues', action: 'index' },
 
-    assert_raises Redmine::MenuManager::MenuError, ":children must be an array of MenuItems" do
+                                                     children: Proc.new { |_p| Redmine::MenuManager::MenuItem.new('test_child', { controller: 'issues', action: 'index' }, {}) },
+                                                     )
+
+    assert_raises Redmine::MenuManager::MenuError, ':children must be an array of MenuItems' do
       @response.body = render_menu_node(parent_node, Project.find(1))
     end
   end
 
   def test_render_menu_node_with_incorrect_children
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {controller: 'issues', action: 'index'},
-                                                     {
-                                                       children: Proc.new {|p| ["a string"] }
-                                                     })
+                                                     { controller: 'issues', action: 'index' },
 
-    assert_raises Redmine::MenuManager::MenuError, ":children must be an array of MenuItems" do
+                                                     children: Proc.new { |_p| ['a string'] }
+                                                     )
+
+    assert_raises Redmine::MenuManager::MenuError, ':children must be an array of MenuItems' do
       @response.body = render_menu_node(parent_node, Project.find(1))
     end
-
   end
 
   def test_menu_items_for_should_yield_all_items_if_passed_a_block
     menu_name = :test_menu_items_for_should_yield_all_items_if_passed_a_block
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, '/', { })
-      menu.push(:a_menu_2, '/', { })
-      menu.push(:a_menu_3, '/', { })
+      menu.push(:a_menu, '/', {})
+      menu.push(:a_menu_2, '/', {})
+      menu.push(:a_menu_3, '/', {})
     end
 
     items_yielded = []
@@ -237,9 +232,9 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   def test_menu_items_for_should_return_all_items
     menu_name = :test_menu_items_for_should_return_all_items
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, '/', { })
-      menu.push(:a_menu_2, '/', { })
-      menu.push(:a_menu_3, '/', { })
+      menu.push(:a_menu, '/', {})
+      menu.push(:a_menu_2, '/', {})
+      menu.push(:a_menu_3, '/', {})
     end
 
     items = menu_items_for(menu_name)
@@ -249,9 +244,9 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   def test_menu_items_for_should_skip_unallowed_items_on_a_project
     menu_name = :test_menu_items_for_should_skip_unallowed_items_on_a_project
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, {controller: 'issues', action: 'index' }, { })
-      menu.push(:a_menu_2, {controller: 'issues', action: 'index' }, { })
-      menu.push(:unallowed, {controller: 'issues', action: 'unallowed' }, { })
+      menu.push(:a_menu, { controller: 'issues', action: 'index' }, {})
+      menu.push(:a_menu_2, { controller: 'issues', action: 'index' }, {})
+      menu.push(:unallowed, { controller: 'issues', action: 'unallowed' }, {})
     end
 
     User.current = User.find(1)
@@ -263,10 +258,10 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   def test_menu_items_for_should_skip_items_that_fail_the_conditions
     menu_name = :test_menu_items_for_should_skip_items_that_fail_the_conditions
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, { controller: 'issues', action: 'index' }, { })
+      menu.push(:a_menu, { controller: 'issues', action: 'index' }, {})
       menu.push(:unallowed,
                 { controller: 'issues', action: 'index' },
-                { if: Proc.new { false }})
+                if: Proc.new { false })
     end
 
     User.current = User.find(1)

--- a/test/unit/lib/redmine/menu_manager/menu_helper_test.rb
+++ b/test/unit/lib/redmine/menu_manager/menu_helper_test.rb
@@ -119,13 +119,13 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
     User.current = User.find(1)
 
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {:controller => 'issues', :action => 'index'},
+                                                     {controller: 'issues', action: 'index'},
                                                      {
-                                                       :children => Proc.new {|p|
+                                                       children: Proc.new {|p|
                                                          children = []
                                                          3.times do |time|
                                                            children << Redmine::MenuManager::MenuItem.new("test_child_#{time}",
-                                                                                                             {:controller => 'issues', :action => 'index'},
+                                                                                                             {controller: 'issues', action: 'index'},
                                                                                                              {})
                                                          end
                                                          children
@@ -148,24 +148,24 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
     User.current = User.find(1)
 
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {:controller => 'issues', :action => 'index'},
+                                                     {controller: 'issues', action: 'index'},
                                                      {
-                                                       :children => Proc.new {|p|
+                                                       children: Proc.new {|p|
                                                          children = []
                                                          3.times do |time|
-                                                           children << Redmine::MenuManager::MenuItem.new("test_child_#{time}", {:controller => 'issues', :action => 'index'}, {})
+                                                           children << Redmine::MenuManager::MenuItem.new("test_child_#{time}", {controller: 'issues', action: 'index'}, {})
                                                          end
                                                          children
                                                        }
                                                      })
 
     parent_node << Redmine::MenuManager::MenuItem.new(:child_node,
-                                                     {:controller => 'issues', :action => 'index'},
+                                                     {controller: 'issues', action: 'index'},
                                                      {
-                                                       :children => Proc.new {|p|
+                                                       children: Proc.new {|p|
                                                          children = []
                                                          6.times do |time|
-                                                            children << Redmine::MenuManager::MenuItem.new("test_dynamic_child_#{time}", {:controller => 'issues', :action => 'index'}, {})
+                                                            children << Redmine::MenuManager::MenuItem.new("test_dynamic_child_#{time}", {controller: 'issues', action: 'index'}, {})
                                                          end
                                                          children
                                                        }
@@ -195,9 +195,9 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
 
   def test_render_menu_node_with_children_without_an_array
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {:controller => 'issues', :action => 'index'},
+                                                     {controller: 'issues', action: 'index'},
                                                      {
-                                                       :children => Proc.new {|p| Redmine::MenuManager::MenuItem.new("test_child", {:controller => 'issues', :action => 'index'}, {})},
+                                                       children: Proc.new {|p| Redmine::MenuManager::MenuItem.new("test_child", {controller: 'issues', action: 'index'}, {})},
                                                      })
 
     assert_raises Redmine::MenuManager::MenuError, ":children must be an array of MenuItems" do
@@ -207,9 +207,9 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
 
   def test_render_menu_node_with_incorrect_children
     parent_node = Redmine::MenuManager::MenuItem.new(:parent_node,
-                                                     {:controller => 'issues', :action => 'index'},
+                                                     {controller: 'issues', action: 'index'},
                                                      {
-                                                       :children => Proc.new {|p| ["a string"] }
+                                                       children: Proc.new {|p| ["a string"] }
                                                      })
 
     assert_raises Redmine::MenuManager::MenuError, ":children must be an array of MenuItems" do
@@ -249,9 +249,9 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   def test_menu_items_for_should_skip_unallowed_items_on_a_project
     menu_name = :test_menu_items_for_should_skip_unallowed_items_on_a_project
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, {:controller => 'issues', :action => 'index' }, { })
-      menu.push(:a_menu_2, {:controller => 'issues', :action => 'index' }, { })
-      menu.push(:unallowed, {:controller => 'issues', :action => 'unallowed' }, { })
+      menu.push(:a_menu, {controller: 'issues', action: 'index' }, { })
+      menu.push(:a_menu_2, {controller: 'issues', action: 'index' }, { })
+      menu.push(:unallowed, {controller: 'issues', action: 'unallowed' }, { })
     end
 
     User.current = User.find(1)
@@ -263,10 +263,10 @@ class Redmine::MenuManager::MenuHelperTest < HelperTestCase
   def test_menu_items_for_should_skip_items_that_fail_the_conditions
     menu_name = :test_menu_items_for_should_skip_items_that_fail_the_conditions
     Redmine::MenuManager.map menu_name do |menu|
-      menu.push(:a_menu, { :controller => 'issues', :action => 'index' }, { })
+      menu.push(:a_menu, { controller: 'issues', action: 'index' }, { })
       menu.push(:unallowed,
-                { :controller => 'issues', :action => 'index' },
-                { :if => Proc.new { false }})
+                { controller: 'issues', action: 'index' },
+                { if: Proc.new { false }})
     end
 
     User.current = User.find(1)

--- a/test/unit/lib/redmine/menu_manager/menu_item_test.rb
+++ b/test/unit/lib/redmine/menu_manager/menu_item_test.rb
@@ -40,8 +40,8 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
 
   Redmine::MenuManager.map :test_menu do |menu|
     menu.push(:parent, '/test', { })
-    menu.push(:child_menu, '/test', { :parent => :parent})
-    menu.push(:child2_menu, '/test', { :parent => :parent})
+    menu.push(:child_menu, '/test', { parent: :parent})
+    menu.push(:child2_menu, '/test', { parent: :parent})
   end
 
   context "MenuItem#caption" do
@@ -79,13 +79,13 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
                                          {
-                                           :if => ['not_a_proc']
+                                           if: ['not_a_proc']
                                          })
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_if, '/test',
                                               {
-                                                :if => Proc.new{}
+                                                if: Proc.new{}
                                               })
   end
 
@@ -93,13 +93,13 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
                                          {
-                                           :html => ['not_a_hash']
+                                           html: ['not_a_hash']
                                          })
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_html, '/test',
                                               {
-                                                :html => { :onclick => 'doSomething'}
+                                                html: { onclick: 'doSomething'}
                                               })
   end
 
@@ -107,19 +107,19 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
                                          {
-                                           :children => ['not_a_proc']
+                                           children: ['not_a_proc']
                                          })
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_children, '/test',
                                               {
-                                                :children => Proc.new{}
+                                                children: Proc.new{}
                                               })
   end
 
   def test_new_should_not_allow_setting_the_parent_item_to_the_current_item
     assert_raises ArgumentError do
-      Redmine::MenuManager::MenuItem.new(:test_error, '/test', { :parent => :test_error })
+      Redmine::MenuManager::MenuItem.new(:test_error, '/test', { parent: :test_error })
     end
   end
 

--- a/test/unit/lib/redmine/menu_manager/menu_item_test.rb
+++ b/test/unit/lib/redmine/menu_manager/menu_item_test.rb
@@ -31,7 +31,7 @@ require File.expand_path('../../../../../test_helper', __FILE__)
 module RedmineMenuTestHelper
   # Helpers
   def get_menu_item(menu_name, item_name)
-    Redmine::MenuManager.items(menu_name).find {|item| item.name == item_name.to_sym}
+    Redmine::MenuManager.items(menu_name).find { |item| item.name == item_name.to_sym }
   end
 end
 
@@ -39,17 +39,17 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
   include RedmineMenuTestHelper
 
   Redmine::MenuManager.map :test_menu do |menu|
-    menu.push(:parent, '/test', { })
-    menu.push(:child_menu, '/test', { parent: :parent})
-    menu.push(:child2_menu, '/test', { parent: :parent})
+    menu.push(:parent, '/test', {})
+    menu.push(:child_menu, '/test',  parent: :parent)
+    menu.push(:child2_menu, '/test',  parent: :parent)
   end
 
-  context "MenuItem#caption" do
-    should "be tested"
+  context 'MenuItem#caption' do
+    should 'be tested'
   end
 
-  context "MenuItem#html_options" do
-    should "be tested"
+  context 'MenuItem#html_options' do
+    should 'be tested'
   end
 
   # context new menu item
@@ -78,48 +78,48 @@ class Redmine::MenuManager::MenuItemTest < ActiveSupport::TestCase
   def test_new_menu_item_should_require_a_proc_to_use_for_the_if_condition
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
-                                         {
-                                           if: ['not_a_proc']
-                                         })
+
+                                         if: ['not_a_proc']
+                                         )
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_if, '/test',
-                                              {
-                                                if: Proc.new{}
-                                              })
+
+                                              if: Proc.new {}
+                                              )
   end
 
   def test_new_menu_item_should_allow_a_hash_for_extra_html_options
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
-                                         {
-                                           html: ['not_a_hash']
-                                         })
+
+                                         html: ['not_a_hash']
+                                         )
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_html, '/test',
-                                              {
-                                                html: { onclick: 'doSomething'}
-                                              })
+
+                                              html: { onclick: 'doSomething' }
+                                              )
   end
 
   def test_new_menu_item_should_require_a_proc_to_use_the_children_option
     assert_raises ArgumentError do
       Redmine::MenuManager::MenuItem.new(:test_error, '/test',
-                                         {
-                                           children: ['not_a_proc']
-                                         })
+
+                                         children: ['not_a_proc']
+                                         )
     end
 
     assert Redmine::MenuManager::MenuItem.new(:test_good_children, '/test',
-                                              {
-                                                children: Proc.new{}
-                                              })
+
+                                              children: Proc.new {}
+                                              )
   end
 
   def test_new_should_not_allow_setting_the_parent_item_to_the_current_item
     assert_raises ArgumentError do
-      Redmine::MenuManager::MenuItem.new(:test_error, '/test', { parent: :test_error })
+      Redmine::MenuManager::MenuItem.new(:test_error, '/test',  parent: :test_error)
     end
   end
 

--- a/test/unit/lib/redmine/menu_manager_test.rb
+++ b/test/unit/lib/redmine/menu_manager_test.rb
@@ -29,11 +29,11 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::MenuManagerTest < ActiveSupport::TestCase
-  context "MenuManager#map" do
-    should "be tested"
+  context 'MenuManager#map' do
+    should 'be tested'
   end
 
-  context "MenuManager#items" do
-    should "be tested"
+  context 'MenuManager#items' do
+    should 'be tested'
   end
 end

--- a/test/unit/lib/redmine/mime_type_test.rb
+++ b/test/unit/lib/redmine/mime_type_test.rb
@@ -29,11 +29,10 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::MimeTypeTest < ActiveSupport::TestCase
-
   def test_of
-    to_test = {'test.unk' => nil,
-               'test.txt' => 'text/plain',
-               'test.c' => 'text/x-c',
+    to_test = { 'test.unk' => nil,
+                'test.txt' => 'text/plain',
+                'test.c' => 'text/x-c',
                }
     to_test.each do |name, expected|
       assert_equal expected, Redmine::MimeType.of(name)
@@ -41,9 +40,9 @@ class Redmine::MimeTypeTest < ActiveSupport::TestCase
   end
 
   def test_css_class_of
-    to_test = {'test.unk' => nil,
-               'test.txt' => 'text-plain',
-               'test.c' => 'text-x-c',
+    to_test = { 'test.unk' => nil,
+                'test.txt' => 'text-plain',
+                'test.c' => 'text-x-c',
                }
     to_test.each do |name, expected|
       assert_equal expected, Redmine::MimeType.css_class_of(name)
@@ -51,9 +50,9 @@ class Redmine::MimeTypeTest < ActiveSupport::TestCase
   end
 
   def test_main_mimetype_of
-    to_test = {'test.unk' => nil,
-               'test.txt' => 'text',
-               'test.c' => 'text',
+    to_test = { 'test.unk' => nil,
+                'test.txt' => 'text',
+                'test.c' => 'text',
                }
     to_test.each do |name, expected|
       assert_equal expected, Redmine::MimeType.main_mimetype_of(name)
@@ -61,9 +60,9 @@ class Redmine::MimeTypeTest < ActiveSupport::TestCase
   end
 
   def test_is_type
-    to_test = {['text', 'test.unk'] => false,
-               ['text', 'test.txt'] => true,
-               ['text', 'test.c'] => true,
+    to_test = { ['text', 'test.unk'] => false,
+                ['text', 'test.txt'] => true,
+                ['text', 'test.c'] => true,
                }
     to_test.each do |args, expected|
       assert_equal expected, Redmine::MimeType.is_type?(*args)

--- a/test/unit/lib/redmine/plugin_test.rb
+++ b/test/unit/lib/redmine/plugin_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::PluginTest < ActiveSupport::TestCase
-
   def setup
     super
     @klass = Redmine::Plugin
@@ -50,7 +49,7 @@ class Redmine::PluginTest < ActiveSupport::TestCase
       author_url 'http://example.net/jsmith'
       description 'This is a test plugin'
       version '0.0.1'
-      settings default: {'sample_setting' => 'value', 'foo'=>'bar'}, partial: 'foo/settings'
+      settings default: { 'sample_setting' => 'value', 'foo' => 'bar' }, partial: 'foo/settings'
     end
 
     assert_equal 1, @klass.all.size
@@ -80,9 +79,9 @@ class Redmine::PluginTest < ActiveSupport::TestCase
       test.assert_raise Redmine::PluginRequirementError do
         requires_openproject('< 0.9')
       end
-      requires_openproject('> 0.9', "<= 99.0.0")
+      requires_openproject('> 0.9', '<= 99.0.0')
       test.assert_raise Redmine::PluginRequirementError do
-        requires_openproject('< 0.9', ">= 98.0.0")
+        requires_openproject('< 0.9', '>= 98.0.0')
       end
 
       test.assert requires_openproject("~> #{Redmine::VERSION.to_semver.gsub(/\d+\z/, '0')}")
@@ -124,7 +123,6 @@ class Redmine::PluginTest < ActiveSupport::TestCase
       test.assert_raise Redmine::PluginNotFound do
         requires_redmine_plugin(:missing, version: '0.1.0')
       end
-
     end
   end
 end

--- a/test/unit/lib/redmine/plugin_test.rb
+++ b/test/unit/lib/redmine/plugin_test.rb
@@ -50,7 +50,7 @@ class Redmine::PluginTest < ActiveSupport::TestCase
       author_url 'http://example.net/jsmith'
       description 'This is a test plugin'
       version '0.0.1'
-      settings :default => {'sample_setting' => 'value', 'foo'=>'bar'}, :partial => 'foo/settings'
+      settings default: {'sample_setting' => 'value', 'foo'=>'bar'}, partial: 'foo/settings'
     end
 
     assert_equal 1, @klass.all.size
@@ -99,30 +99,30 @@ class Redmine::PluginTest < ActiveSupport::TestCase
     end
 
     @klass.register :foo do
-      test.assert requires_redmine_plugin(:other, :version_or_higher => '0.1.0')
-      test.assert requires_redmine_plugin(:other, :version_or_higher => other_version)
+      test.assert requires_redmine_plugin(:other, version_or_higher: '0.1.0')
+      test.assert requires_redmine_plugin(:other, version_or_higher: other_version)
       test.assert requires_redmine_plugin(:other, other_version)
       test.assert_raise Redmine::PluginRequirementError do
-        requires_redmine_plugin(:other, :version_or_higher => '99.0.0')
+        requires_redmine_plugin(:other, version_or_higher: '99.0.0')
       end
 
-      test.assert requires_redmine_plugin(:other, :version => other_version)
-      test.assert requires_redmine_plugin(:other, :version => [other_version, '99.0.0'])
+      test.assert requires_redmine_plugin(:other, version: other_version)
+      test.assert requires_redmine_plugin(:other, version: [other_version, '99.0.0'])
       test.assert_raise Redmine::PluginRequirementError do
-        requires_redmine_plugin(:other, :version => '99.0.0')
+        requires_redmine_plugin(:other, version: '99.0.0')
       end
       test.assert_raise Redmine::PluginRequirementError do
-        requires_redmine_plugin(:other, :version => ['98.0.0', '99.0.0'])
+        requires_redmine_plugin(:other, version: ['98.0.0', '99.0.0'])
       end
       # Missing plugin
       test.assert_raise Redmine::PluginNotFound do
-        requires_redmine_plugin(:missing, :version_or_higher => '0.1.0')
+        requires_redmine_plugin(:missing, version_or_higher: '0.1.0')
       end
       test.assert_raise Redmine::PluginNotFound do
         requires_redmine_plugin(:missing, '0.1.0')
       end
       test.assert_raise Redmine::PluginNotFound do
-        requires_redmine_plugin(:missing, :version => '0.1.0')
+        requires_redmine_plugin(:missing, version: '0.1.0')
       end
 
     end

--- a/test/unit/lib/redmine/safe_attributes_test.rb
+++ b/test/unit/lib/redmine/safe_attributes_test.rb
@@ -42,7 +42,7 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
     attr_accessor :firstname, :lastname, :login
     include Redmine::SafeAttributes
     safe_attributes :firstname, :lastname
-    safe_attributes :login, :if => lambda {|person, user| user.admin?}
+    safe_attributes :login, if: lambda {|person, user| user.admin?}
   end
 
   class Book < Base
@@ -109,7 +109,7 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
 
   def test_with_indifferent_access
     p = Person.new
-    p.safe_attributes = {'firstname' => 'Jack', :lastname => 'Miller'}
+    p.safe_attributes = {'firstname' => 'Jack', lastname: 'Miller'}
     assert_equal 'Jack', p.firstname
     assert_equal 'Miller', p.lastname
   end

--- a/test/unit/lib/redmine/safe_attributes_test.rb
+++ b/test/unit/lib/redmine/safe_attributes_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::SafeAttributesTest < ActiveSupport::TestCase
-
   class Base
     def attributes=(attrs)
       attrs.each do |key, value|
@@ -42,7 +41,7 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
     attr_accessor :firstname, :lastname, :login
     include Redmine::SafeAttributes
     safe_attributes :firstname, :lastname
-    safe_attributes :login, if: lambda {|person, user| user.admin?}
+    safe_attributes :login, if: lambda { |_person, user| user.admin? }
   end
 
   class Book < Base
@@ -51,14 +50,13 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
     safe_attributes :title
   end
 
-
   class PublishedBook < Book
     safe_attributes :isbn
   end
 
   def setup
     super
-    @admin = User.find_by_login("admin") || FactoryGirl.create(:admin)
+    @admin = User.find_by_login('admin') || FactoryGirl.create(:admin)
     @anonymous = User.anonymous || FactoryGirl.create(:anonymous)
   end
 
@@ -78,14 +76,14 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
 
   def test_set_safe_attributes
     p = Person.new
-    p.send('safe_attributes=', {'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith'}, @anonymous)
+    p.send('safe_attributes=', { 'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith' }, @anonymous)
     assert_equal 'John', p.firstname
     assert_equal 'Smith', p.lastname
     assert_nil p.login
 
     p = Person.new
     User.current = @admin
-    p.send('safe_attributes=', {'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith'}, @admin)
+    p.send('safe_attributes=', { 'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith' }, @admin)
     assert_equal 'John', p.firstname
     assert_equal 'Smith', p.lastname
     assert_equal 'jsmith', p.login
@@ -94,14 +92,14 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
   def test_set_safe_attributes_without_user
     p = Person.new
     User.current = nil
-    p.safe_attributes = {'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith'}
+    p.safe_attributes = { 'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith' }
     assert_equal 'John', p.firstname
     assert_equal 'Smith', p.lastname
     assert_nil p.login
 
     p = Person.new
     User.current = @admin
-    p.safe_attributes = {'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith'}
+    p.safe_attributes = { 'firstname' => 'John', 'lastname' => 'Smith', 'login' => 'jsmith' }
     assert_equal 'John', p.firstname
     assert_equal 'Smith', p.lastname
     assert_equal 'jsmith', p.login
@@ -109,7 +107,7 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
 
   def test_with_indifferent_access
     p = Person.new
-    p.safe_attributes = {'firstname' => 'Jack', lastname: 'Miller'}
+    p.safe_attributes = { 'firstname' => 'Jack', lastname: 'Miller' }
     assert_equal 'Jack', p.firstname
     assert_equal 'Miller', p.lastname
   end
@@ -118,8 +116,8 @@ class Redmine::SafeAttributesTest < ActiveSupport::TestCase
     b = Book.new
     p = PublishedBook.new
 
-    b.safe_attributes = {'title' => 'My awesome Ruby Book', 'isbn' => '1221132343'}
-    p.safe_attributes = {'title' => 'The Pickaxe',          'isbn' => '1934356085'}
+    b.safe_attributes = { 'title' => 'My awesome Ruby Book', 'isbn' => '1221132343' }
+    p.safe_attributes = { 'title' => 'The Pickaxe',          'isbn' => '1934356085' }
 
     assert_equal 'My awesome Ruby Book', b.title
     assert_nil b.isbn

--- a/test/unit/lib/redmine/scm/adapters/filesystem_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/filesystem_adapter_test.rb
@@ -27,11 +27,9 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-
 require File.expand_path('../../../../../../test_helper', __FILE__)
 
 class FilesystemAdapterTest < ActiveSupport::TestCase
-
   REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/filesystem_repository'
 
   if File.directory?(REPOSITORY_PATH)
@@ -42,27 +40,27 @@ class FilesystemAdapterTest < ActiveSupport::TestCase
 
     def test_entries
       assert_equal 3, @adapter.entries.size
-      assert_equal ["dir", "japanese", "test"], @adapter.entries.collect(&:name)
-      assert_equal ["dir", "japanese", "test"], @adapter.entries(nil).collect(&:name)
-      assert_equal ["dir", "japanese", "test"], @adapter.entries("/").collect(&:name)
-      ["dir", "/dir", "/dir/", "dir/"].each do |path|
-        assert_equal ["subdir", "dirfile"], @adapter.entries(path).collect(&:name)
+      assert_equal ['dir', 'japanese', 'test'], @adapter.entries.collect(&:name)
+      assert_equal ['dir', 'japanese', 'test'], @adapter.entries(nil).collect(&:name)
+      assert_equal ['dir', 'japanese', 'test'], @adapter.entries('/').collect(&:name)
+      ['dir', '/dir', '/dir/', 'dir/'].each do |path|
+        assert_equal ['subdir', 'dirfile'], @adapter.entries(path).collect(&:name)
       end
       # If y try to use "..", the path is ignored
-      ["/../","dir/../", "..", "../", "/..", "dir/.."].each do |path|
-        assert_equal ["dir", "japanese", "test"], @adapter.entries(path).collect(&:name),
-             ".. must be ignored in path argument"
+      ['/../', 'dir/../', '..', '../', '/..', 'dir/..'].each do |path|
+        assert_equal ['dir', 'japanese', 'test'], @adapter.entries(path).collect(&:name),
+                     '.. must be ignored in path argument'
       end
     end
 
     def test_cat
-      assert_equal "TEST CAT\n", @adapter.cat("test")
-      assert_equal "TEST CAT\n", @adapter.cat("/test")
+      assert_equal "TEST CAT\n", @adapter.cat('test')
+      assert_equal "TEST CAT\n", @adapter.cat('/test')
       # Revision number is ignored
-      assert_equal "TEST CAT\n", @adapter.cat("/test", 1)
+      assert_equal "TEST CAT\n", @adapter.cat('/test', 1)
     end
   else
-    puts "Filesystem test repository NOT FOUND. Skipping unit tests !!! See doc/RUNNING_TESTS."
+    puts 'Filesystem test repository NOT FOUND. Skipping unit tests !!! See doc/RUNNING_TESTS.'
     def test_fake; assert true end
   end
 end

--- a/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
@@ -88,7 +88,7 @@ class GitAdapterTest < ActiveSupport::TestCase
     end
 
     def test_getting_all_revisions
-      assert_equal 21, @adapter.revisions('',nil,nil,:all => true).length
+      assert_equal 21, @adapter.revisions('',nil,nil,all: true).length
     end
 
     def test_getting_certain_revisions
@@ -96,13 +96,13 @@ class GitAdapterTest < ActiveSupport::TestCase
     end
 
     def test_revisions_reverse
-      revs1 = @adapter.revisions('',nil,nil,{:all => true, :reverse => true })
+      revs1 = @adapter.revisions('',nil,nil,{all: true, reverse: true })
       assert_equal 21, revs1.length
       assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', revs1[0].identifier
       assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs1[20].identifier
 
       since2 = Time.gm(2010, 9, 30, 0, 0, 0)
-      revs2 = @adapter.revisions('',nil,nil,{:all => true, :since => since2, :reverse => true })
+      revs2 = @adapter.revisions('',nil,nil,{all: true, since: since2, reverse: true })
       assert_equal 6, revs2.length
       assert_equal '67e7792ce20ccae2e4bb73eed09bb397819c8834', revs2[0].identifier
       assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs2[5].identifier
@@ -110,13 +110,13 @@ class GitAdapterTest < ActiveSupport::TestCase
 
     def test_getting_revisions_with_spaces_in_filename
       assert_equal 1, @adapter.revisions("filemane with spaces.txt",
-                                         nil, nil, :all => true).length
+                                         nil, nil, all: true).length
     end
 
     def test_getting_revisions_with_leading_and_trailing_spaces_in_filename
       assert_equal " filename with a leading space.txt ",
          @adapter.revisions(" filename with a leading space.txt ",
-                             nil, nil, :all => true)[0].paths[0][:path]
+                             nil, nil, all: true)[0].paths[0][:path]
     end
 
     def test_getting_entries_with_leading_and_trailing_spaces_in_filename

--- a/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
@@ -35,7 +35,7 @@ require File.expand_path('../../../../../../test_helper', __FILE__)
 class GitAdapterTest < ActiveSupport::TestCase
   REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
 
-  FELIX_UTF8 = "Felix Schäfer"
+  FELIX_UTF8 = 'Felix Schäfer'
   FELIX_HEX  = "Felix Sch\xC3\xA4fer"
   CHAR_1_HEX = "\xc3\x9c"
 
@@ -63,77 +63,77 @@ class GitAdapterTest < ActiveSupport::TestCase
     end
 
     def test_scm_version
-      to_test = { "git version 1.7.3.4\n"             => [1,7,3,4],
-                  "1.6.1\n1.7\n1.8"                   => [1,6,1],
-                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
+      to_test = { "git version 1.7.3.4\n"             => [1, 7, 3, 4],
+                  "1.6.1\n1.7\n1.8"                   => [1, 6, 1],
+                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1, 6, 2] }
       to_test.each do |s, v|
         test_scm_version_for(s, v)
       end
     end
 
     def test_branches
-      assert_equal  [
-            'latin-1-path-encoding',
-            'master',
-            'test-latin-1',
-            'test_branch',
-          ], @adapter.branches
+      assert_equal [
+        'latin-1-path-encoding',
+        'master',
+        'test-latin-1',
+        'test_branch',
+      ], @adapter.branches
     end
 
     def test_tags
-      assert_equal  [
-            "tag00.lightweight",
-            "tag01.annotated",
-          ], @adapter.tags
+      assert_equal [
+        'tag00.lightweight',
+        'tag01.annotated',
+      ], @adapter.tags
     end
 
     def test_getting_all_revisions
-      assert_equal 21, @adapter.revisions('',nil,nil,all: true).length
+      assert_equal 21, @adapter.revisions('', nil, nil, all: true).length
     end
 
     def test_getting_certain_revisions
-      assert_equal 1, @adapter.revisions('','899a15d^','899a15d').length
+      assert_equal 1, @adapter.revisions('', '899a15d^', '899a15d').length
     end
 
     def test_revisions_reverse
-      revs1 = @adapter.revisions('',nil,nil,{all: true, reverse: true })
+      revs1 = @adapter.revisions('', nil, nil, all: true, reverse: true)
       assert_equal 21, revs1.length
       assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', revs1[0].identifier
       assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs1[20].identifier
 
       since2 = Time.gm(2010, 9, 30, 0, 0, 0)
-      revs2 = @adapter.revisions('',nil,nil,{all: true, since: since2, reverse: true })
+      revs2 = @adapter.revisions('', nil, nil, all: true, since: since2, reverse: true)
       assert_equal 6, revs2.length
       assert_equal '67e7792ce20ccae2e4bb73eed09bb397819c8834', revs2[0].identifier
       assert_equal '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127', revs2[5].identifier
     end
 
     def test_getting_revisions_with_spaces_in_filename
-      assert_equal 1, @adapter.revisions("filemane with spaces.txt",
+      assert_equal 1, @adapter.revisions('filemane with spaces.txt',
                                          nil, nil, all: true).length
     end
 
     def test_getting_revisions_with_leading_and_trailing_spaces_in_filename
-      assert_equal " filename with a leading space.txt ",
-         @adapter.revisions(" filename with a leading space.txt ",
-                             nil, nil, all: true)[0].paths[0][:path]
+      assert_equal ' filename with a leading space.txt ',
+                   @adapter.revisions(' filename with a leading space.txt ',
+                                      nil, nil, all: true)[0].paths[0][:path]
     end
 
     def test_getting_entries_with_leading_and_trailing_spaces_in_filename
-      assert_equal " filename with a leading space.txt ",
-         @adapter.entries('',
-                 '83ca5fd546063a3c7dc2e568ba3355661a9e2b2c')[3].name
+      assert_equal ' filename with a leading space.txt ',
+                   @adapter.entries('',
+                                    '83ca5fd546063a3c7dc2e568ba3355661a9e2b2c')[3].name
     end
 
     def test_annotate
       annotate = @adapter.annotate('sources/watchers_controller.rb')
       assert_kind_of Redmine::Scm::Adapters::Annotate, annotate
       assert_equal 41, annotate.lines.size
-      assert_equal "# This program is free software; you can redistribute it and/or",
+      assert_equal '# This program is free software; you can redistribute it and/or',
                    annotate.lines[4].strip
-      assert_equal "7234cb2750b63f47bff735edc50a1c0a433c2518",
-                    annotate.revisions[4].identifier
-      assert_equal "jsmith", annotate.revisions[4].author
+      assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518',
+                   annotate.revisions[4].identifier
+      assert_equal 'jsmith', annotate.revisions[4].author
     end
 
     def test_annotate_moved_file
@@ -143,34 +143,34 @@ class GitAdapterTest < ActiveSupport::TestCase
     end
 
     def test_last_rev
-      last_rev = @adapter.lastrev("README",
-                                  "4f26664364207fa8b1af9f8722647ab2d4ac5d43")
-      assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.scmid
-      assert_equal "4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8", last_rev.identifier
-      assert_equal "Adam Soltys <asoltys@gmail.com>", last_rev.author
-      assert_equal "2009-06-24 05:27:38".to_time, last_rev.time
+      last_rev = @adapter.lastrev('README',
+                                  '4f26664364207fa8b1af9f8722647ab2d4ac5d43')
+      assert_equal '4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8', last_rev.scmid
+      assert_equal '4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8', last_rev.identifier
+      assert_equal 'Adam Soltys <asoltys@gmail.com>', last_rev.author
+      assert_equal '2009-06-24 05:27:38'.to_time, last_rev.time
     end
 
     def test_last_rev_with_spaces_in_filename
-      last_rev = @adapter.lastrev("filemane with spaces.txt",
-                                  "ed5bb786bbda2dee66a2d50faf51429dbc043a7b")
+      last_rev = @adapter.lastrev('filemane with spaces.txt',
+                                  'ed5bb786bbda2dee66a2d50faf51429dbc043a7b')
       str_felix_utf8 = FELIX_UTF8.dup
       str_felix_hex  = FELIX_HEX.dup
       last_rev_author = last_rev.author
       if last_rev_author.respond_to?(:force_encoding)
         last_rev_author.force_encoding('UTF-8')
       end
-      assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.scmid
-      assert_equal "ed5bb786bbda2dee66a2d50faf51429dbc043a7b", last_rev.identifier
+      assert_equal 'ed5bb786bbda2dee66a2d50faf51429dbc043a7b', last_rev.scmid
+      assert_equal 'ed5bb786bbda2dee66a2d50faf51429dbc043a7b', last_rev.identifier
       assert_equal "#{str_felix_utf8} <felix@fachschaften.org>",
-                     last_rev.author
+                   last_rev.author
       assert_equal "#{str_felix_hex} <felix@fachschaften.org>",
-                     last_rev.author
-      assert_equal "2010-09-18 19:59:46".to_time, last_rev.time
+                   last_rev.author
+      assert_equal '2010-09-18 19:59:46'.to_time, last_rev.time
     end
 
     # TODO: need to handle edge cases of non-binary content that isn't UTF-8
-    should_eventually "test_latin_1_path" do
+    should_eventually 'test_latin_1_path' do
       if WINDOWS_PASS
         #
       else
@@ -179,7 +179,7 @@ class GitAdapterTest < ActiveSupport::TestCase
           assert @adapter.diff(p2, r1)
           assert @adapter.cat(p2, r1)
           annotation = @adapter.annotate(p2, r1)
-          assert annotation.present?, "No annotation returned"
+          assert annotation.present?, 'No annotation returned'
           assert_equal 1, annotation.lines.length
           ['64f1f3e89ad1cb57976ff0ad99a107012ba3481d', '64f1f3e89ad1cb5797'].each do |r2|
             assert @adapter.diff(p2, r1, r2)
@@ -253,7 +253,7 @@ class GitAdapterTest < ActiveSupport::TestCase
     end
 
   else
-    puts "Git test repository NOT FOUND. Skipping unit tests !!!"
+    puts 'Git test repository NOT FOUND. Skipping unit tests !!!'
     def test_fake; assert true end
   end
 end

--- a/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/subversion_adapter_test.rb
@@ -30,7 +30,6 @@
 require File.expand_path('../../../../../../test_helper', __FILE__)
 
 class SubversionAdapterTest < ActiveSupport::TestCase
-
   if repository_configured?('subversion')
     def setup
       super
@@ -43,10 +42,10 @@ class SubversionAdapterTest < ActiveSupport::TestCase
     end
 
     def test_scm_version
-      to_test = { "svn, version 1.6.13 (r1002816)\n"  => [1,6,13],
-                  "svn, versione 1.6.13 (r1002816)\n" => [1,6,13],
-                  "1.6.1\n1.7\n1.8"                   => [1,6,1],
-                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1,6,2]}
+      to_test = { "svn, version 1.6.13 (r1002816)\n"  => [1, 6, 13],
+                  "svn, versione 1.6.13 (r1002816)\n" => [1, 6, 13],
+                  "1.6.1\n1.7\n1.8"                   => [1, 6, 1],
+                  "1.6.2\r\n1.8.1\r\n1.9.1"           => [1, 6, 2] }
       to_test.each do |s, v|
         test_scm_version_for(s, v)
       end
@@ -60,7 +59,7 @@ class SubversionAdapterTest < ActiveSupport::TestCase
     end
 
   else
-    puts "Subversion test repository NOT FOUND. Skipping unit tests !!!"
+    puts 'Subversion test repository NOT FOUND. Skipping unit tests !!!'
     def test_fake; assert true end
   end
 end

--- a/test/unit/lib/redmine/unified_diff_test.rb
+++ b/test/unit/lib/redmine/unified_diff_test.rb
@@ -30,12 +30,11 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::UnifiedDiffTest < ActiveSupport::TestCase
-
   def test_subversion_diff
     diff = Redmine::UnifiedDiff.new(read_diff_fixture('subversion.diff'))
     # number of files
     assert_equal 4, diff.size
-    assert diff.detect {|file| file.file_name =~ %r{\Aconfig/settings.yml}}
+    assert diff.detect { |file| file.file_name =~ %r{\Aconfig/settings.yml} }
   end
 
   def test_truncate_diff
@@ -97,7 +96,6 @@ class Redmine::UnifiedDiffTest < ActiveSupport::TestCase
     assert_equal [24, -8], diff[6].offsets
     assert_equal [37, -1], diff[8].offsets
     assert_equal [0, -38], diff[10].offsets
-
   end
 
   def test_line_starting_with_dashes

--- a/test/unit/lib/redmine/unified_diff_test.rb
+++ b/test/unit/lib/redmine/unified_diff_test.rb
@@ -39,7 +39,7 @@ class Redmine::UnifiedDiffTest < ActiveSupport::TestCase
   end
 
   def test_truncate_diff
-    diff = Redmine::UnifiedDiff.new(read_diff_fixture('subversion.diff'), :max_lines => 20)
+    diff = Redmine::UnifiedDiff.new(read_diff_fixture('subversion.diff'), max_lines: 20)
     assert_equal 2, diff.size
   end
 
@@ -76,7 +76,7 @@ class Redmine::UnifiedDiffTest < ActiveSupport::TestCase
   end
 
   def test_side_by_side_partials
-    diff = Redmine::UnifiedDiff.new(read_diff_fixture('partials.diff'), :type => 'sbs')
+    diff = Redmine::UnifiedDiff.new(read_diff_fixture('partials.diff'), type: 'sbs')
     assert_equal 1, diff.size
     diff = diff.first
     assert_equal 32, diff.size

--- a/test/unit/lib/redmine/wiki_formatting/macros_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/macros_test.rb
@@ -77,12 +77,12 @@ class Redmine::WikiFormatting::MacrosTest < HelperTestCase
 
     @project = Project.find(1)
     # child pages of the current wiki page
-    assert_equal expected, format_text("{{child_pages}}", :object => WikiPage.find(2).content)
+    assert_equal expected, format_text("{{child_pages}}", object: WikiPage.find(2).content)
     # child pages of another page
-    assert_equal expected, format_text("{{child_pages(Another_page)}}", :object => WikiPage.find(1).content)
+    assert_equal expected, format_text("{{child_pages(Another_page)}}", object: WikiPage.find(1).content)
 
     @project = Project.find(2)
-    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page)}}", :object => WikiPage.find(1).content)
+    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page)}}", object: WikiPage.find(1).content)
   end
 
   def test_macro_child_pages_with_option
@@ -95,11 +95,11 @@ class Redmine::WikiFormatting::MacrosTest < HelperTestCase
 
     @project = Project.find(1)
     # child pages of the current wiki page
-    assert_equal expected, format_text("{{child_pages(parent=1)}}", :object => WikiPage.find(2).content)
+    assert_equal expected, format_text("{{child_pages(parent=1)}}", object: WikiPage.find(2).content)
     # child pages of another page
-    assert_equal expected, format_text("{{child_pages(Another_page, parent=1)}}", :object => WikiPage.find(1).content)
+    assert_equal expected, format_text("{{child_pages(Another_page, parent=1)}}", object: WikiPage.find(1).content)
 
     @project = Project.find(2)
-    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page, parent=1)}}", :object => WikiPage.find(1).content)
+    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page, parent=1)}}", object: WikiPage.find(1).content)
   end
 end

--- a/test/unit/lib/redmine/wiki_formatting/macros_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/macros_test.rb
@@ -44,62 +44,62 @@ class Redmine::WikiFormatting::MacrosTest < HelperTestCase
   end
 
   def test_macro_hello_world
-    text = "{{hello_world}}"
+    text = '{{hello_world}}'
     assert format_text(text).match(/Hello world!/)
     # escaping
-    text = "!{{hello_world}}"
+    text = '!{{hello_world}}'
     assert_equal '<p>{{hello_world}}</p>', format_text(text)
   end
 
   def test_macro_include
     @project = Project.find(1)
     # include a page of the current project wiki
-    text = "{{include(Another page)}}"
+    text = '{{include(Another page)}}'
     assert format_text(text).match(/This is a link to a ticket/)
 
     @project = nil
     # include a page of a specific project wiki
-    text = "{{include(ecookbook:Another page)}}"
+    text = '{{include(ecookbook:Another page)}}'
     assert format_text(text).match(/This is a link to a ticket/)
 
-    text = "{{include(ecookbook:)}}"
+    text = '{{include(ecookbook:)}}'
     assert format_text(text).match(/CookBook documentation/)
 
-    text = "{{include(unknowidentifier:somepage)}}"
+    text = '{{include(unknowidentifier:somepage)}}'
     assert format_text(text).match(/Page not found/)
   end
 
   def test_macro_child_pages
     expected =  "<p><ul class=\"pages-hierarchy\">" +
-                 "<li><a href=\"/projects/ecookbook/wiki/Child_1\">Child 1</a></li>" +
-                 "<li><a href=\"/projects/ecookbook/wiki/Child_2\">Child 2</a></li>" +
-                 "</ul></p>"
+                "<li><a href=\"/projects/ecookbook/wiki/Child_1\">Child 1</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/Child_2\">Child 2</a></li>" +
+                '</ul></p>'
 
     @project = Project.find(1)
     # child pages of the current wiki page
-    assert_equal expected, format_text("{{child_pages}}", object: WikiPage.find(2).content)
+    assert_equal expected, format_text('{{child_pages}}', object: WikiPage.find(2).content)
     # child pages of another page
-    assert_equal expected, format_text("{{child_pages(Another_page)}}", object: WikiPage.find(1).content)
+    assert_equal expected, format_text('{{child_pages(Another_page)}}', object: WikiPage.find(1).content)
 
     @project = Project.find(2)
-    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page)}}", object: WikiPage.find(1).content)
+    assert_equal expected, format_text('{{child_pages(ecookbook:Another_page)}}', object: WikiPage.find(1).content)
   end
 
   def test_macro_child_pages_with_option
     expected =  "<p><ul class=\"pages-hierarchy\">" +
-                 "<li><a href=\"/projects/ecookbook/wiki/Another_page\">Another page</a>" +
-                 "<ul class=\"pages-hierarchy\">" +
-                 "<li><a href=\"/projects/ecookbook/wiki/Child_1\">Child 1</a></li>" +
-                 "<li><a href=\"/projects/ecookbook/wiki/Child_2\">Child 2</a></li>" +
-                 "</ul></li></ul></p>"
+                "<li><a href=\"/projects/ecookbook/wiki/Another_page\">Another page</a>" +
+                "<ul class=\"pages-hierarchy\">" +
+                "<li><a href=\"/projects/ecookbook/wiki/Child_1\">Child 1</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/Child_2\">Child 2</a></li>" +
+                '</ul></li></ul></p>'
 
     @project = Project.find(1)
     # child pages of the current wiki page
-    assert_equal expected, format_text("{{child_pages(parent=1)}}", object: WikiPage.find(2).content)
+    assert_equal expected, format_text('{{child_pages(parent=1)}}', object: WikiPage.find(2).content)
     # child pages of another page
-    assert_equal expected, format_text("{{child_pages(Another_page, parent=1)}}", object: WikiPage.find(1).content)
+    assert_equal expected, format_text('{{child_pages(Another_page, parent=1)}}', object: WikiPage.find(1).content)
 
     @project = Project.find(2)
-    assert_equal expected, format_text("{{child_pages(ecookbook:Another_page, parent=1)}}", object: WikiPage.find(1).content)
+    assert_equal expected, format_text('{{child_pages(ecookbook:Another_page, parent=1)}}', object: WikiPage.find(1).content)
   end
 end

--- a/test/unit/lib/redmine/wiki_formatting/null_formatter_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/null_formatter_test.rb
@@ -30,14 +30,13 @@
 require File.expand_path('../../../../../test_helper', __FILE__)
 
 class Redmine::WikiFormatting::NullFormatterTest < HelperTestCase
-
   def setup
     super
     @formatter = Redmine::WikiFormatting::NullFormatter::Formatter
   end
 
   def test_plain_text
-    assert_html_output("This is some input" => "This is some input")
+    assert_html_output('This is some input' => 'This is some input')
   end
 
   def test_escaping
@@ -46,11 +45,11 @@ class Redmine::WikiFormatting::NullFormatterTest < HelperTestCase
     )
   end
 
-private
+  private
 
   def assert_html_output(to_test, expect_paragraph = true)
     to_test.each do |text, expected|
-      assert_equal(( expect_paragraph ? "<p>#{expected}</p>" : expected ), @formatter.new(text).to_html, "Formatting the following text failed:\n===\n#{text}\n===\n")
+      assert_equal((expect_paragraph ? "<p>#{expected}</p>" : expected), @formatter.new(text).to_html, "Formatting the following text failed:\n===\n#{text}\n===\n")
     end
   end
 

--- a/test/unit/lib/redmine/wiki_formatting/textile_formatter_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/textile_formatter_test.rb
@@ -30,19 +30,18 @@
 require File.expand_path('../../../../../test_helper', __FILE__)
 
 class Redmine::WikiFormatting::TextileFormatterTest < HelperTestCase
-
   def setup
     super
     @formatter = Redmine::WikiFormatting::Textile::Formatter
   end
 
   MODIFIERS = {
-    "*" => 'strong', # bold
-    "_" => 'em',     # italic
-    "+" => 'ins',    # underline
-    "-" => 'del',    # deleted
-    "^" => 'sup',    # superscript
-    "~" => 'sub'     # subscript
+    '*' => 'strong', # bold
+    '_' => 'em',     # italic
+    '+' => 'ins',    # underline
+    '-' => 'del',    # deleted
+    '^' => 'sup',    # superscript
+    '~' => 'sub'     # subscript
   }
 
   def test_modifiers
@@ -86,8 +85,8 @@ class Redmine::WikiFormatting::TextileFormatterTest < HelperTestCase
 
   def test_use_of_backslashes_followed_by_numbers_in_headers
     assert_html_output({
-      'h1. 2009\02\09'      => '<h1>2009\02\09</h1>'
-    }, false)
+                         'h1. 2009\02\09'      => '<h1>2009\02\09</h1>'
+                       }, false)
   end
 
   def test_double_dashes_should_not_strikethrough
@@ -107,19 +106,15 @@ class Redmine::WikiFormatting::TextileFormatterTest < HelperTestCase
 
   def test_inline_auto_link
     assert_html_output(
-        'Autolink to http://www.google.com'=>
-        'Autolink to <a class="external" href="http://www.google.com">http://www.google.com</a>'
+        'Autolink to http://www.google.com' =>         'Autolink to <a class="external" href="http://www.google.com">http://www.google.com</a>'
     )
   end
 
   def test_ignore_links_inside_macros
     assert_html_output(
-        '{{embed_youtube(http://www.google.com)}}'=>
-        '{{embed_youtube(http://www.google.com)}}'
+        '{{embed_youtube(http://www.google.com)}}' =>         '{{embed_youtube(http://www.google.com)}}'
     )
   end
-
-
 
   def test_blockquote
     # orig raw text
@@ -238,7 +233,7 @@ EXPECTED
 
   def assert_html_output(to_test, expect_paragraph = true)
     to_test.each do |text, expected|
-      assert_equal(( expect_paragraph ? "<p>#{expected}</p>" : expected ), @formatter.new(text).to_html, "Formatting the following text failed:\n===\n#{text}\n===\n")
+      assert_equal((expect_paragraph ? "<p>#{expected}</p>" : expected), @formatter.new(text).to_html, "Formatting the following text failed:\n===\n#{text}\n===\n")
     end
   end
 

--- a/test/unit/lib/redmine/wiki_formatting_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting_test.rb
@@ -29,7 +29,6 @@
 require File.expand_path('../../../../test_helper', __FILE__)
 
 class Redmine::WikiFormattingTest < ActiveSupport::TestCase
-
   def test_textile_formatter
     assert_equal Redmine::WikiFormatting::Textile::Formatter, Redmine::WikiFormatting.formatter_for('textile')
     assert_equal Redmine::WikiFormatting::Textile::Helper, Redmine::WikiFormatting.helper_for('textile')

--- a/test/unit/lib/redmine_test.rb
+++ b/test/unit/lib/redmine_test.rb
@@ -40,7 +40,7 @@ module RedmineMenuTestHelper
 
   # Helpers
   def get_menu_item(menu_name, item_name)
-    Redmine::MenuManager.items(menu_name).find {|item| item.name == item_name.to_sym}
+    Redmine::MenuManager.items(menu_name).find { |item| item.name == item_name.to_sym }
   end
 end
 

--- a/test/unit/mail_handler_test.rb
+++ b/test/unit/mail_handler_test.rb
@@ -72,7 +72,7 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   def test_add_work_package_with_default_type
     # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml', issue: {type: 'Support request'})
+    issue = submit_email('ticket_on_given_project.eml', issue: { type: 'Support request' })
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -86,7 +86,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert !issue.new_record?
     issue.reload
     assert_equal Project.find(2), issue.project
-    assert_equal Status.find_by_name("Resolved"), issue.status
+    assert_equal Status.find_by_name('Resolved'), issue.status
   end
 
   def test_add_work_package_with_attributes_override
@@ -116,7 +116,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_partial_attributes_override
-    issue = submit_email('ticket_with_attributes.eml', issue: {priority: 'High'}, allow_override: ['type'])
+    issue = submit_email('ticket_with_attributes.eml', issue: { priority: 'High' }, allow_override: ['type'])
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -143,9 +143,8 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert issue.description.include?('Lorem ipsum dolor sit amet, consectetuer adipiscing elit.')
   end
 
-
   def test_add_work_package_with_attachment_to_specific_project
-    issue = submit_email('ticket_with_attachment.eml', issue: {project: 'onlinestore'})
+    issue = submit_email('ticket_with_attachment.eml', issue: { project: 'onlinestore' })
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -161,7 +160,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_custom_fields
-    issue = submit_email('ticket_with_custom_fields.eml', issue: {project: 'onlinestore'})
+    issue = submit_email('ticket_with_custom_fields.eml', issue: { project: 'onlinestore' })
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -181,7 +180,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_cc
-    issue = submit_email('ticket_with_cc.eml', issue: {project: 'ecookbook'})
+    issue = submit_email('ticket_with_cc.eml', issue: { project: 'ecookbook' })
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -191,14 +190,14 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   def test_add_work_package_by_unknown_user
     assert_no_difference 'User.count' do
-      assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: {project: 'ecookbook'})
+      assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: { project: 'ecookbook' })
     end
   end
 
   def test_add_work_package_by_anonymous_user
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      issue = submit_email('ticket_by_unknown_user.eml', issue: {project: 'ecookbook'}, unknown_user: 'accept')
+      issue = submit_email('ticket_by_unknown_user.eml', issue: { project: 'ecookbook' }, unknown_user: 'accept')
       assert issue.is_a?(WorkPackage)
       assert issue.author.anonymous?
     end
@@ -207,7 +206,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_by_anonymous_user_with_no_from_address
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      issue = submit_email('ticket_by_empty_user.eml', issue: {project: 'ecookbook'}, unknown_user: 'accept')
+      issue = submit_email('ticket_by_empty_user.eml', issue: { project: 'ecookbook' }, unknown_user: 'accept')
       assert issue.is_a?(WorkPackage)
       assert issue.author.anonymous?
     end
@@ -217,7 +216,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
       assert_no_difference 'WorkPackage.count' do
-        assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: {project: 'onlinestore'}, unknown_user: 'accept')
+        assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: { project: 'onlinestore' }, unknown_user: 'accept')
       end
     end
   end
@@ -225,7 +224,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_by_anonymous_user_on_private_project_without_permission_check
     assert_no_difference 'User.count' do
       assert_difference 'WorkPackage.count' do
-        issue = submit_email('ticket_by_unknown_user.eml', issue: {project: 'onlinestore'}, no_permission_check: '1', unknown_user: 'accept')
+        issue = submit_email('ticket_by_unknown_user.eml', issue: { project: 'onlinestore' }, no_permission_check: '1', unknown_user: 'accept')
         assert issue.is_a?(WorkPackage)
         assert issue.author.anonymous?
         assert !issue.project.is_public?
@@ -271,7 +270,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_with_japanese_keywords
     type = Type.create!(name: '開発')
     Project.find(1).types << type
-    issue = submit_email('japanese_keywords_iso_2022_jp.eml', issue: {project: 'ecookbook'}, allow_override: 'type')
+    issue = submit_email('japanese_keywords_iso_2022_jp.eml', issue: { project: 'ecookbook' }, allow_override: 'type')
     assert_kind_of WorkPackage, issue
     assert_equal type, issue.type
   end
@@ -279,7 +278,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_from_apple_mail
     issue = submit_email(
               'apple_mail_with_attachment.eml',
-              issue: {project: 'ecookbook'}
+              issue: { project: 'ecookbook' }
             )
     assert_kind_of WorkPackage, issue
     assert_equal 1, issue.attachments.size
@@ -295,7 +294,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_with_iso_8859_1_subject
     issue = submit_email(
               'subject_as_iso-8859-1.eml',
-              issue: {project: 'ecookbook'}
+              issue: { project: 'ecookbook' }
             )
     assert_kind_of WorkPackage, issue
     assert_equal 'Testmail from Webmail: ä ö ü...', issue.subject
@@ -313,17 +312,17 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_should_ignore_emails_from_emission_address
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      assert !submit_email('ticket_from_emission_address.eml', issue: { project: 'ecookbook'}, unknown_user: 'create')
+      assert !submit_email('ticket_from_emission_address.eml', issue: { project: 'ecookbook' }, unknown_user: 'create')
     end
   end
 
   def test_should_ignore_auto_replied_emails
     MailHandler.any_instance.should_receive(:dispatch).never
     [
-      "X-Auto-Response-Suppress: OOF",
-      "Auto-Submitted: auto-replied",
-      "Auto-Submitted: Auto-Replied",
-      "Auto-Submitted: auto-generated"
+      'X-Auto-Response-Suppress: OOF',
+      'Auto-Submitted: auto-replied',
+      'Auto-Submitted: Auto-Replied',
+      'Auto-Submitted: auto-generated'
     ].each do |header|
       raw = IO.read(File.join(FIXTURES_PATH, 'ticket_on_given_project.eml'))
       raw = header + "\n" + raw
@@ -352,7 +351,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 'Feature request', journal.journable.type.name
   end
 
-  test "reply to issue update (Journal) by message_id" do
+  test 'reply to issue update (Journal) by message_id' do
     Journal.delete_all
     issue = WorkPackage.find(2)
     j = FactoryGirl.create :work_package_journal,
@@ -376,11 +375,11 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal WorkPackage.find(2), journal.journable
     assert_match /This is reply/, journal.notes
     assert_equal 'Feature request', journal.journable.type.name
-    assert_equal Status.find_by_name("Resolved"), issue.status
+    assert_equal Status.find_by_name('Resolved'), issue.status
     assert_equal '2010-01-01', issue.start_date.to_s
     assert_equal '2010-12-31', issue.due_date.to_s
     assert_equal User.find_by_login('jsmith'), issue.assigned_to
-    assert_equal "52.6", issue.custom_value_for(CustomField.find_by_name('Float field')).value
+    assert_equal '52.6', issue.custom_value_for(CustomField.find_by_name('Float field')).value
     # keywords should be removed from the email body
     assert !journal.notes.match(/^Status:/i)
     assert !journal.notes.match(/^Start Date:/i)
@@ -395,7 +394,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_note_should_not_set_defaults
-    journal = submit_email('ticket_reply.eml', issue: {type: 'Support request', priority: 'High'})
+    journal = submit_email('ticket_reply.eml', issue: { type: 'Support request', priority: 'High' })
     assert journal.is_a?(Journal)
     assert_match /This is reply/, journal.notes
     assert_equal 'Feature request', journal.journable.type.name
@@ -422,7 +421,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_should_strip_tags_of_html_only_emails
-    issue = submit_email('ticket_html_only.eml', issue: {project: 'ecookbook'})
+    issue = submit_email('ticket_html_only.eml', issue: { project: 'ecookbook' })
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -430,13 +429,13 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_equal 'This is a html-only email.', issue.description
   end
 
-  context "truncate emails based on the Setting" do
-    context "with no setting" do
+  context 'truncate emails based on the Setting' do
+    context 'with no setting' do
       setup do
         Setting.mail_handler_body_delimiters = ''
       end
 
-      should "add the entire email into the issue" do
+      should 'add the entire email into the issue' do
         issue = submit_email('ticket_on_given_project.eml')
         assert_issue_created(issue)
         assert issue.description.include?('---')
@@ -444,12 +443,12 @@ class MailHandlerTest < ActiveSupport::TestCase
       end
     end
 
-    context "with a single string" do
+    context 'with a single string' do
       setup do
         Setting.mail_handler_body_delimiters = '---'
       end
 
-      should "truncate the email at the delimiter for the issue" do
+      should 'truncate the email at the delimiter for the issue' do
         issue = submit_email('ticket_on_given_project.eml')
         assert_issue_created(issue)
         assert issue.description.include?('This paragraph is before delimiters')
@@ -459,44 +458,40 @@ class MailHandlerTest < ActiveSupport::TestCase
       end
     end
 
-    context "with a single quoted reply (e.g. reply to a Redmine email notification)" do
+    context 'with a single quoted reply (e.g. reply to a Redmine email notification)' do
       setup do
         Setting.mail_handler_body_delimiters = '--- Reply above. Do not remove this line. ---'
       end
 
-      should "truncate the email at the delimiter with the quoted reply symbols (>)" do
+      should 'truncate the email at the delimiter with the quoted reply symbols (>)' do
         journal = submit_email('issue_update_with_quoted_reply_above.eml')
         assert journal.is_a?(Journal)
         assert journal.notes.include?('An update to the issue by the sender.')
-        assert !journal.notes.match(Regexp.escape("--- Reply above. Do not remove this line. ---"))
+        assert !journal.notes.match(Regexp.escape('--- Reply above. Do not remove this line. ---'))
         assert !journal.notes.include?('Looks like the JSON api for projects was missed.')
-
       end
-
     end
 
-    context "with multiple quoted replies (e.g. reply to a reply of a Redmine email notification)" do
+    context 'with multiple quoted replies (e.g. reply to a reply of a Redmine email notification)' do
       setup do
         Setting.mail_handler_body_delimiters = '--- Reply above. Do not remove this line. ---'
       end
 
-      should "truncate the email at the delimiter with the quoted reply symbols (>)" do
+      should 'truncate the email at the delimiter with the quoted reply symbols (>)' do
         journal = submit_email('issue_update_with_multiple_quoted_reply_above.eml')
         assert journal.is_a?(Journal)
         assert journal.notes.include?('An update to the issue by the sender.')
-        assert !journal.notes.match(Regexp.escape("--- Reply above. Do not remove this line. ---"))
+        assert !journal.notes.match(Regexp.escape('--- Reply above. Do not remove this line. ---'))
         assert !journal.notes.include?('Looks like the JSON api for projects was missed.')
-
       end
-
     end
 
-    context "with multiple strings" do
+    context 'with multiple strings' do
       setup do
         Setting.mail_handler_body_delimiters = "---\nBREAK"
       end
 
-      should "truncate the email at the first delimiter found (BREAK)" do
+      should 'truncate the email at the first delimiter found (BREAK)' do
         issue = submit_email('ticket_on_given_project.eml')
         assert_issue_created(issue)
         assert issue.description.include?('This paragraph is before delimiters')
@@ -511,7 +506,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_email_with_long_subject_line
     issue = submit_email('ticket_with_long_subject.eml')
     assert issue.is_a?(WorkPackage)
-    assert_equal issue.subject, 'New ticket on a given project with a very long subject line which exceeds 255 chars and should not be ignored but chopped off. And if the subject line is still not long enough, we just add more text. And more text. Wow, this is really annoying. Especially, if you have nothing to say...'[0,255]
+    assert_equal issue.subject, 'New ticket on a given project with a very long subject line which exceeds 255 chars and should not be ignored but chopped off. And if the subject line is still not long enough, we just add more text. And more text. Wow, this is really annoying. Especially, if you have nothing to say...'[0, 255]
   end
 
   def test_new_user_from_attributes_should_return_valid_user
@@ -558,13 +553,13 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_difference 'User.count' do
       issue = submit_email(
                 'fullname_of_sender_as_utf8_encoded.eml',
-                issue: {project: 'ecookbook'},
+                issue: { project: 'ecookbook' },
                 unknown_user: 'create'
               )
     end
 
     user = User.first(order: 'id DESC')
-    assert_equal "foo@example.org", user.mail
+    assert_equal 'foo@example.org', user.mail
     str1 = "\xc3\x84\xc3\xa4"
     str2 = "\xc3\x96\xc3\xb6"
     str1.force_encoding('UTF-8') if str1.respond_to?(:force_encoding)
@@ -575,7 +570,7 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   private
 
-  def submit_email(filename, options={})
+  def submit_email(filename, options = {})
     raw = IO.read(File.join(FIXTURES_PATH, filename))
     yield raw if block_given?
     MailHandler.receive(raw, options)

--- a/test/unit/mail_handler_test.rb
+++ b/test/unit/mail_handler_test.rb
@@ -42,7 +42,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package
     ActionMailer::Base.deliveries.clear
     # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml', :allow_override => 'fixed_version')
+    issue = submit_email('ticket_on_given_project.eml', allow_override: 'fixed_version')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -72,7 +72,7 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   def test_add_work_package_with_default_type
     # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml', :issue => {:type => 'Support request'})
+    issue = submit_email('ticket_on_given_project.eml', issue: {type: 'Support request'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -90,7 +90,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_attributes_override
-    issue = submit_email('ticket_with_attributes.eml', :allow_override => 'type,category,priority')
+    issue = submit_email('ticket_with_attributes.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -104,7 +104,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_group_assignment
-    with_settings :work_package_group_assignment => '1' do
+    with_settings work_package_group_assignment: '1' do
       work_package = submit_email('ticket_on_given_project.eml') do |email|
         email.gsub!('Assigned to: John Smith', 'Assigned to: B Team')
       end
@@ -116,7 +116,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_partial_attributes_override
-    issue = submit_email('ticket_with_attributes.eml', :issue => {:priority => 'High'}, :allow_override => ['type'])
+    issue = submit_email('ticket_with_attributes.eml', issue: {priority: 'High'}, allow_override: ['type'])
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -130,7 +130,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_spaces_between_attribute_and_separator
-    issue = submit_email('ticket_with_spaces_between_attribute_and_separator.eml', :allow_override => 'type,category,priority')
+    issue = submit_email('ticket_with_spaces_between_attribute_and_separator.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -145,7 +145,7 @@ class MailHandlerTest < ActiveSupport::TestCase
 
 
   def test_add_work_package_with_attachment_to_specific_project
-    issue = submit_email('ticket_with_attachment.eml', :issue => {:project => 'onlinestore'})
+    issue = submit_email('ticket_with_attachment.eml', issue: {project: 'onlinestore'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -161,7 +161,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_custom_fields
-    issue = submit_email('ticket_with_custom_fields.eml', :issue => {:project => 'onlinestore'})
+    issue = submit_email('ticket_with_custom_fields.eml', issue: {project: 'onlinestore'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -171,8 +171,8 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_should_match_assignee_on_display_name # added from redmine  - not sure if it is ok here
-    user = User.generate!(:firstname => 'Foo', :lastname => 'Bar')
-    User.add_to_project(user, Project.find(2), Role.generate!(:name => 'Superhero'))
+    user = User.generate!(firstname: 'Foo', lastname: 'Bar')
+    User.add_to_project(user, Project.find(2), Role.generate!(name: 'Superhero'))
     issue = submit_email('ticket_on_given_project.eml') do |email|
       email.sub!(/^Assigned to.*$/, 'Assigned to: Foo Bar')
     end
@@ -181,7 +181,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_cc
-    issue = submit_email('ticket_with_cc.eml', :issue => {:project => 'ecookbook'})
+    issue = submit_email('ticket_with_cc.eml', issue: {project: 'ecookbook'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -191,14 +191,14 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   def test_add_work_package_by_unknown_user
     assert_no_difference 'User.count' do
-      assert_equal false, submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'ecookbook'})
+      assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: {project: 'ecookbook'})
     end
   end
 
   def test_add_work_package_by_anonymous_user
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      issue = submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'ecookbook'}, :unknown_user => 'accept')
+      issue = submit_email('ticket_by_unknown_user.eml', issue: {project: 'ecookbook'}, unknown_user: 'accept')
       assert issue.is_a?(WorkPackage)
       assert issue.author.anonymous?
     end
@@ -207,7 +207,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_by_anonymous_user_with_no_from_address
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      issue = submit_email('ticket_by_empty_user.eml', :issue => {:project => 'ecookbook'}, :unknown_user => 'accept')
+      issue = submit_email('ticket_by_empty_user.eml', issue: {project: 'ecookbook'}, unknown_user: 'accept')
       assert issue.is_a?(WorkPackage)
       assert issue.author.anonymous?
     end
@@ -217,7 +217,7 @@ class MailHandlerTest < ActiveSupport::TestCase
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
       assert_no_difference 'WorkPackage.count' do
-        assert_equal false, submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'onlinestore'}, :unknown_user => 'accept')
+        assert_equal false, submit_email('ticket_by_unknown_user.eml', issue: {project: 'onlinestore'}, unknown_user: 'accept')
       end
     end
   end
@@ -225,7 +225,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_by_anonymous_user_on_private_project_without_permission_check
     assert_no_difference 'User.count' do
       assert_difference 'WorkPackage.count' do
-        issue = submit_email('ticket_by_unknown_user.eml', :issue => {:project => 'onlinestore'}, :no_permission_check => '1', :unknown_user => 'accept')
+        issue = submit_email('ticket_by_unknown_user.eml', issue: {project: 'onlinestore'}, no_permission_check: '1', unknown_user: 'accept')
         assert issue.is_a?(WorkPackage)
         assert issue.author.anonymous?
         assert !issue.project.is_public?
@@ -241,7 +241,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_invalid_attributes
-    issue = submit_email('ticket_with_invalid_attributes.eml', :allow_override => 'type,category,priority')
+    issue = submit_email('ticket_with_invalid_attributes.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -255,7 +255,7 @@ class MailHandlerTest < ActiveSupport::TestCase
 
   def test_add_work_package_with_localized_attributes
     User.find_by_mail('jsmith@somenet.foo').update_attribute 'language', 'de'
-    issue = submit_email('ticket_with_localized_attributes.eml', :allow_override => 'type,category,priority')
+    issue = submit_email('ticket_with_localized_attributes.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -269,9 +269,9 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_with_japanese_keywords
-    type = Type.create!(:name => '開発')
+    type = Type.create!(name: '開発')
     Project.find(1).types << type
-    issue = submit_email('japanese_keywords_iso_2022_jp.eml', :issue => {:project => 'ecookbook'}, :allow_override => 'type')
+    issue = submit_email('japanese_keywords_iso_2022_jp.eml', issue: {project: 'ecookbook'}, allow_override: 'type')
     assert_kind_of WorkPackage, issue
     assert_equal type, issue.type
   end
@@ -279,7 +279,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_from_apple_mail
     issue = submit_email(
               'apple_mail_with_attachment.eml',
-              :issue => {:project => 'ecookbook'}
+              issue: {project: 'ecookbook'}
             )
     assert_kind_of WorkPackage, issue
     assert_equal 1, issue.attachments.size
@@ -295,7 +295,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_add_work_package_with_iso_8859_1_subject
     issue = submit_email(
               'subject_as_iso-8859-1.eml',
-              :issue => {:project => 'ecookbook'}
+              issue: {project: 'ecookbook'}
             )
     assert_kind_of WorkPackage, issue
     assert_equal 'Testmail from Webmail: ä ö ü...', issue.subject
@@ -313,7 +313,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   def test_should_ignore_emails_from_emission_address
     Role.anonymous.add_permission!(:add_work_packages)
     assert_no_difference 'User.count' do
-      assert !submit_email('ticket_from_emission_address.eml', :issue => { :project => 'ecookbook'}, :unknown_user => 'create')
+      assert !submit_email('ticket_from_emission_address.eml', issue: { project: 'ecookbook'}, unknown_user: 'create')
     end
   end
 
@@ -395,7 +395,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_add_work_package_note_should_not_set_defaults
-    journal = submit_email('ticket_reply.eml', :issue => {:type => 'Support request', :priority => 'High'})
+    journal = submit_email('ticket_reply.eml', issue: {type: 'Support request', priority: 'High'})
     assert journal.is_a?(Journal)
     assert_match /This is reply/, journal.notes
     assert_equal 'Feature request', journal.journable.type.name
@@ -422,7 +422,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_should_strip_tags_of_html_only_emails
-    issue = submit_email('ticket_html_only.eml', :issue => {:project => 'ecookbook'})
+    issue = submit_email('ticket_html_only.eml', issue: {project: 'ecookbook'})
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?
     issue.reload
@@ -540,7 +540,7 @@ class MailHandlerTest < ActiveSupport::TestCase
   end
 
   def test_new_user_from_attributes_should_respect_minimum_password_length
-    with_settings :password_min_length => 15 do
+    with_settings password_min_length: 15 do
       user = MailHandler.new_user_from_attributes('jsmith@example.net')
       assert user.valid?
       assert user.password.length >= 15
@@ -558,12 +558,12 @@ class MailHandlerTest < ActiveSupport::TestCase
     assert_difference 'User.count' do
       issue = submit_email(
                 'fullname_of_sender_as_utf8_encoded.eml',
-                :issue => {:project => 'ecookbook'},
-                :unknown_user => 'create'
+                issue: {project: 'ecookbook'},
+                unknown_user: 'create'
               )
     end
 
-    user = User.first(:order => 'id DESC')
+    user = User.first(order: 'id DESC')
     assert_equal "foo@example.org", user.mail
     str1 = "\xc3\x84\xc3\xa4"
     str2 = "\xc3\x96\xc3\xb6"

--- a/test/unit/member_test.rb
+++ b/test/unit/member_test.rb
@@ -103,10 +103,10 @@ class MemberTest < ActiveSupport::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { Member.find(@member.id) }
   end
 
-  context "removing permissions" do
+  context 'removing permissions' do
     setup do
       @private_project = FactoryGirl.create :project_with_types,
-        is_public: true # has to be public first to successfully create things. Will be set to private later
+                                            is_public: true # has to be public first to successfully create things. Will be set to private later
       @watcher_user = FactoryGirl.create(:user)
 
       # watchers for public issue
@@ -129,7 +129,7 @@ class MemberTest < ActiveSupport::TestCase
       @private_project.save
     end
 
-    context "of user" do
+    context 'of user' do
       setup do
         (@member = Member.new.tap do |m|
           m.force_attributes = { project_id: @private_project.id,
@@ -138,16 +138,16 @@ class MemberTest < ActiveSupport::TestCase
         end).save!
       end
 
-      context "by deleting membership" do
-        should "prune watchers" do
+      context 'by deleting membership' do
+        should 'prune watchers' do
           assert_difference 'Watcher.count', -4 do
             @member.destroy
           end
         end
       end
 
-      context "by updating roles" do
-        should "prune watchers" do
+      context 'by updating roles' do
+        should 'prune watchers' do
           @private_role.remove_permission! :view_wiki_pages
           assert_difference 'Watcher.count', -2 do
             @member.role_ids = [@private_role.id]
@@ -158,7 +158,7 @@ class MemberTest < ActiveSupport::TestCase
       end
     end
 
-    context "of group" do
+    context 'of group' do
       setup do
         @group = FactoryGirl.create :group
         @member = (Member.new.tap do |m|
@@ -172,16 +172,16 @@ class MemberTest < ActiveSupport::TestCase
         assert @group.save
       end
 
-      context "by deleting membership" do
-        should "prune watchers" do
+      context 'by deleting membership' do
+        should 'prune watchers' do
           assert_difference 'Watcher.count', -4 do
             @member.destroy
           end
         end
       end
 
-      context "by updating roles" do
-        should "prune watchers" do
+      context 'by updating roles' do
+        should 'prune watchers' do
           @private_role.remove_permission! :view_wiki_pages
           assert_difference 'Watcher.count', -2 do
             @member.role_ids = [@private_role.id]

--- a/test/unit/member_test.rb
+++ b/test/unit/member_test.rb
@@ -34,7 +34,7 @@ class MemberTest < ActiveSupport::TestCase
     Role.non_member.add_permission! :view_work_packages # non_member users may be watchers of work units
     Role.non_member.add_permission! :view_wiki_pages # non_member users may be watchers of wikis
     @project = FactoryGirl.create :project_with_types
-    @user = FactoryGirl.create :user, :member_in_project => @project
+    @user = FactoryGirl.create :user, member_in_project: @project
     @member = @project.members.first
     @role = @member.roles.first
     @role.add_permission! :view_wiki_pages
@@ -42,9 +42,9 @@ class MemberTest < ActiveSupport::TestCase
 
   def test_create
     member = Member.new.tap do |m|
-      m.force_attributes = { :project_id => @project.id,
-                             :user_id => FactoryGirl.create(:user).id,
-                             :role_ids => [@role.id] }
+      m.force_attributes = { project_id: @project.id,
+                             user_id: FactoryGirl.create(:user).id,
+                             role_ids: [@role.id] }
     end
     assert member.save
     member.reload
@@ -74,9 +74,9 @@ class MemberTest < ActiveSupport::TestCase
     user_id = FactoryGirl.create(:user).id
     2.times do
       members << Member.new.tap do |m|
-        m.force_attributes = { :project_id => @project.id,
-                               :user_id => user_id,
-                               :role_ids => [@role.id] }
+        m.force_attributes = { project_id: @project.id,
+                               user_id: user_id,
+                               role_ids: [@role.id] }
       end
     end
 
@@ -85,9 +85,9 @@ class MemberTest < ActiveSupport::TestCase
     assert !members.last.save
 
     member = Member.new.tap do |m|
-      m.force_attributes = { :project_id => @project,
-                             :user_id => FactoryGirl.create(:user).id,
-                             :role_ids => [] }
+      m.force_attributes = { project_id: @project,
+                             user_id: FactoryGirl.create(:user).id,
+                             role_ids: [] }
     end
     # must have one role at least
     assert !member.save
@@ -106,24 +106,24 @@ class MemberTest < ActiveSupport::TestCase
   context "removing permissions" do
     setup do
       @private_project = FactoryGirl.create :project_with_types,
-        :is_public => true # has to be public first to successfully create things. Will be set to private later
+        is_public: true # has to be public first to successfully create things. Will be set to private later
       @watcher_user = FactoryGirl.create(:user)
 
       # watchers for public issue
       public_issue = FactoryGirl.create :work_package
       public_issue.project.is_public = true
       public_issue.project.save!
-      Watcher.create!(:watchable => public_issue, :user => @watcher_user)
+      Watcher.create!(watchable: public_issue, user: @watcher_user)
 
       # watchers for private things
-      Watcher.create!(:watchable => FactoryGirl.create(:work_package, :project => @private_project), :user => @watcher_user)
-      board = FactoryGirl.create :board, :project => @private_project
-      @message = FactoryGirl.create :message, :board => board
-      Watcher.create!(:watchable => @message, :user => @watcher_user)
-      Watcher.create!(:watchable => FactoryGirl.create(:wiki, :project => @private_project), :user => @watcher_user)
+      Watcher.create!(watchable: FactoryGirl.create(:work_package, project: @private_project), user: @watcher_user)
+      board = FactoryGirl.create :board, project: @private_project
+      @message = FactoryGirl.create :message, board: board
+      Watcher.create!(watchable: @message, user: @watcher_user)
+      Watcher.create!(watchable: FactoryGirl.create(:wiki, project: @private_project), user: @watcher_user)
       @private_project.reload # to access @private_project.wiki
-      Watcher.create!(:watchable => FactoryGirl.create(:wiki_page, :wiki => @private_project.wiki), :user => @watcher_user)
-      @private_role = FactoryGirl.create :role, :permissions => [:view_wiki_pages, :view_work_packages]
+      Watcher.create!(watchable: FactoryGirl.create(:wiki_page, wiki: @private_project.wiki), user: @watcher_user)
+      @private_role = FactoryGirl.create :role, permissions: [:view_wiki_pages, :view_work_packages]
 
       @private_project.is_public = false
       @private_project.save
@@ -132,9 +132,9 @@ class MemberTest < ActiveSupport::TestCase
     context "of user" do
       setup do
         (@member = Member.new.tap do |m|
-          m.force_attributes = { :project_id => @private_project.id,
-                                 :user_id => @watcher_user.id,
-                                 :role_ids => [@private_role.id, FactoryGirl.create(:role).id] }
+          m.force_attributes = { project_id: @private_project.id,
+                                 user_id: @watcher_user.id,
+                                 role_ids: [@private_role.id, FactoryGirl.create(:role).id] }
         end).save!
       end
 
@@ -162,9 +162,9 @@ class MemberTest < ActiveSupport::TestCase
       setup do
         @group = FactoryGirl.create :group
         @member = (Member.new.tap do |m|
-          m.force_attributes = { :project_id => @private_project.id,
-                                 :user_id => @group.id,
-                                 :role_ids => [@private_role.id, FactoryGirl.create(:role).id] }
+          m.force_attributes = { project_id: @private_project.id,
+                                 user_id: @group.id,
+                                 role_ids: [@private_role.id, FactoryGirl.create(:role).id] }
         end)
 
         @group.members << @member

--- a/test/unit/message_test.rb
+++ b/test/unit/message_test.rb
@@ -42,7 +42,7 @@ class MessageTest < ActiveSupport::TestCase
     topics_count = @board.topics_count
     messages_count = @board.messages_count
 
-    message = Message.new(:board => @board, :subject => 'Test message', :content => 'Test message content', :author => @user)
+    message = Message.new(board: @board, subject: 'Test message', content: 'Test message content', author: @user)
     assert message.save
     @board.reload
     # topics count incremented
@@ -61,7 +61,7 @@ class MessageTest < ActiveSupport::TestCase
     replies_count = @message.replies_count
 
     reply_author = User.find(2)
-    reply = Message.new(:board => @board, :subject => 'Test reply', :content => 'Test reply content', :parent => @message, :author => reply_author)
+    reply = Message.new(board: @board, subject: 'Test reply', content: 'Test reply content', parent: @message, author: reply_author)
     assert reply.save
     @board.reload
     # same topics count
@@ -86,7 +86,7 @@ class MessageTest < ActiveSupport::TestCase
           # New board
           assert_difference 'Board.find(2).topics_count' do
             assert_difference 'Board.find(2).messages_count', (1 + @message.replies_count) do
-              @message.update_attributes(:board_id => 2)
+              @message.update_attributes(board_id: 2)
             end
           end
         end
@@ -159,7 +159,7 @@ class MessageTest < ActiveSupport::TestCase
 
   test "email notifications for creating a message" do
     assert_difference("ActionMailer::Base.deliveries.count", 3) do
-      message = Message.new(:board => @board, :subject => 'Test message', :content => 'Test message content', :author => @user)
+      message = Message.new(board: @board, subject: 'Test message', content: 'Test message content', author: @user)
       assert message.save
     end
 

--- a/test/unit/message_test.rb
+++ b/test/unit/message_test.rb
@@ -46,9 +46,9 @@ class MessageTest < ActiveSupport::TestCase
     assert message.save
     @board.reload
     # topics count incremented
-    assert_equal topics_count+1, @board[:topics_count]
+    assert_equal topics_count + 1, @board[:topics_count]
     # messages count incremented
-    assert_equal messages_count+1, @board[:messages_count]
+    assert_equal messages_count + 1, @board[:messages_count]
     assert_equal message, @board.last_message
     # author should be watching the message
     assert message.watched_by?(@user)
@@ -67,11 +67,11 @@ class MessageTest < ActiveSupport::TestCase
     # same topics count
     assert_equal topics_count, @board[:topics_count]
     # messages count incremented
-    assert_equal messages_count+1, @board[:messages_count]
+    assert_equal messages_count + 1, @board[:messages_count]
     assert_equal reply, @board.last_message
     @message.reload
     # replies count incremented
-    assert_equal replies_count+1, @message[:replies_count]
+    assert_equal replies_count + 1, @message[:replies_count]
     assert_equal reply, @message.last_reply
     # author should be watching the message
     assert @message.watched_by?(reply_author)
@@ -157,11 +157,10 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal 1, message.sticky
   end
 
-  test "email notifications for creating a message" do
-    assert_difference("ActionMailer::Base.deliveries.count", 3) do
+  test 'email notifications for creating a message' do
+    assert_difference('ActionMailer::Base.deliveries.count', 3) do
       message = Message.new(board: @board, subject: 'Test message', content: 'Test message content', author: @user)
       assert message.save
     end
-
   end
 end

--- a/test/unit/principal_test.rb
+++ b/test/unit/principal_test.rb
@@ -32,17 +32,17 @@ class PrincipalTest < ActiveSupport::TestCase
 
   context "#like" do
     setup do
-      Principal.generate!(:login => 'login')
-      Principal.generate!(:login => 'login2')
+      Principal.generate!(login: 'login')
+      Principal.generate!(login: 'login2')
 
-      Principal.generate!(:firstname => 'firstname')
-      Principal.generate!(:firstname => 'firstname2')
+      Principal.generate!(firstname: 'firstname')
+      Principal.generate!(firstname: 'firstname2')
 
-      Principal.generate!(:lastname => 'lastname')
-      Principal.generate!(:lastname => 'lastname2')
+      Principal.generate!(lastname: 'lastname')
+      Principal.generate!(lastname: 'lastname2')
 
-      Principal.generate!(:mail => 'mail@example.com')
-      Principal.generate!(:mail => 'mail2@example.com')
+      Principal.generate!(mail: 'mail@example.com')
+      Principal.generate!(mail: 'mail2@example.com')
     end
 
     should "search login" do

--- a/test/unit/principal_test.rb
+++ b/test/unit/principal_test.rb
@@ -29,8 +29,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class PrincipalTest < ActiveSupport::TestCase
-
-  context "#like" do
+  context '#like' do
     setup do
       Principal.generate!(login: 'login')
       Principal.generate!(login: 'login2')
@@ -45,33 +44,32 @@ class PrincipalTest < ActiveSupport::TestCase
       Principal.generate!(mail: 'mail2@example.com')
     end
 
-    should "search login" do
+    should 'search login' do
       results = Principal.like('login')
 
       assert_equal 2, results.count
-      assert results.all? {|u| u.login.match(/login/) }
+      assert results.all? { |u| u.login.match(/login/) }
     end
 
-    should "search firstname" do
+    should 'search firstname' do
       results = Principal.like('firstname')
 
       assert_equal 2, results.count
-      assert results.all? {|u| u.firstname.match(/firstname/) }
+      assert results.all? { |u| u.firstname.match(/firstname/) }
     end
 
-    should "search lastname" do
+    should 'search lastname' do
       results = Principal.like('lastname')
 
       assert_equal 2, results.count
-      assert results.all? {|u| u.lastname.match(/lastname/) }
+      assert results.all? { |u| u.lastname.match(/lastname/) }
     end
 
-    should "search mail" do
+    should 'search mail' do
       results = Principal.like('mail')
 
       assert_equal 2, results.count
-      assert results.all? {|u| u.mail.match(/mail/) }
+      assert results.all? { |u| u.mail.match(/mail/) }
     end
   end
-
 end

--- a/test/unit/project_nested_set_test.rb
+++ b/test/unit/project_nested_set_test.rb
@@ -29,8 +29,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class ProjectNestedSetTest < ActiveSupport::TestCase
-
-  context "nested set" do
+  context 'nested set' do
     setup do
       FactoryGirl.create(:type_standard)
       Project.delete_all
@@ -56,65 +55,65 @@ class ProjectNestedSetTest < ActiveSupport::TestCase
       [@a, @a1, @a2, @b, @b1, @b11, @b2, @c, @c1].each(&:reload)
     end
 
-    context "#create" do
-      should "build valid tree" do
-        assert_nested_set_values({
+    context '#create' do
+      should 'build valid tree' do
+        assert_nested_set_values(
           @a   => [nil,   1,  6],
           @a1  => [@a.id, 2,  3],
           @a2  => [@a.id, 4,  5],
           @b   => [nil,   7, 14],
           @b1  => [@b.id, 8, 11],
-          @b11 => [@b1.id,9, 10],
-          @b2  => [@b.id,12, 13],
+          @b11 => [@b1.id, 9, 10],
+          @b2  => [@b.id, 12, 13],
           @c   => [nil,  15, 18],
-          @c1  => [@c.id,16, 17]
-        })
+          @c1  => [@c.id, 16, 17]
+        )
       end
     end
 
-    context "#set_parent!" do
-      should "keep valid tree" do
+    context '#set_parent!' do
+      should 'keep valid tree' do
         assert_no_difference 'Project.count' do
           Project.find_by_name('Project B1').set_parent!(Project.find_by_name('Project A2'))
         end
-        assert_nested_set_values({
+        assert_nested_set_values(
           @a   => [nil,   1, 10],
           @a2  => [@a.id, 4,  9],
-          @b1  => [@a2.id,5,  8],
-          @b11 => [@b1.id,6,  7],
+          @b1  => [@a2.id, 5,  8],
+          @b11 => [@b1.id, 6,  7],
           @b   => [nil,  11, 14],
           @c   => [nil,  15, 18]
-        })
+        )
       end
     end
 
-    context "#destroy" do
-      context "a root with children" do
-        should "not mess up the tree" do
+    context '#destroy' do
+      context 'a root with children' do
+        should 'not mess up the tree' do
           assert_difference 'Project.count', -4 do
             Project.find_by_name('Project B').destroy
           end
-          assert_nested_set_values({
+          assert_nested_set_values(
             @a  => [nil,   1,  6],
             @a1 => [@a.id, 2,  3],
             @a2 => [@a.id, 4,  5],
             @c  => [nil,   7, 10],
             @c1 => [@c.id, 8,  9]
-          })
+          )
         end
       end
 
-      context "a child with children" do
-        should "not mess up the tree" do
+      context 'a child with children' do
+        should 'not mess up the tree' do
           assert_difference 'Project.count', -2 do
             Project.find_by_name('Project B1').destroy
           end
-          assert_nested_set_values({
+          assert_nested_set_values(
             @a  => [nil,   1,  6],
             @b  => [nil,   7, 10],
             @b2 => [@b.id, 8,  9],
             @c  => [nil,  11, 14]
-          })
+          )
         end
       end
     end

--- a/test/unit/project_nested_set_test.rb
+++ b/test/unit/project_nested_set_test.rb
@@ -35,22 +35,22 @@ class ProjectNestedSetTest < ActiveSupport::TestCase
       FactoryGirl.create(:type_standard)
       Project.delete_all
 
-      @a = Project.create!(:name => 'Project A', :identifier => 'projecta')
-      @a1 = Project.create!(:name => 'Project A1', :identifier => 'projecta1')
+      @a = Project.create!(name: 'Project A', identifier: 'projecta')
+      @a1 = Project.create!(name: 'Project A1', identifier: 'projecta1')
       @a1.set_parent!(@a)
-      @a2 = Project.create!(:name => 'Project A2', :identifier => 'projecta2')
+      @a2 = Project.create!(name: 'Project A2', identifier: 'projecta2')
       @a2.set_parent!(@a)
 
-      @b = Project.create!(:name => 'Project B', :identifier => 'projectb')
-      @b1 = Project.create!(:name => 'Project B1', :identifier => 'projectb1')
+      @b = Project.create!(name: 'Project B', identifier: 'projectb')
+      @b1 = Project.create!(name: 'Project B1', identifier: 'projectb1')
       @b1.set_parent!(@b)
-      @b11 = Project.create!(:name => 'Project B11', :identifier => 'projectb11')
+      @b11 = Project.create!(name: 'Project B11', identifier: 'projectb11')
       @b11.set_parent!(@b1)
-      @b2 = Project.create!(:name => 'Project B2', :identifier => 'projectb2')
+      @b2 = Project.create!(name: 'Project B2', identifier: 'projectb2')
       @b2.set_parent!(@b)
 
-      @c = Project.create!(:name => 'Project C', :identifier => 'projectc')
-      @c1 = Project.create!(:name => 'Project C1', :identifier => 'projectc1')
+      @c = Project.create!(name: 'Project C', identifier: 'projectc')
+      @c1 = Project.create!(name: 'Project C1', identifier: 'projectc1')
       @c1.set_parent!(@c)
 
       [@a, @a1, @a2, @b, @b1, @b11, @b2, @c, @c1].each(&:reload)

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -73,32 +73,32 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_default_attributes
-    with_settings :default_projects_public => '1' do
+    with_settings default_projects_public: '1' do
       assert_equal true, Project.new.is_public
-      assert_equal false, Project.new(:is_public => false).is_public
+      assert_equal false, Project.new(is_public: false).is_public
     end
 
-    with_settings :default_projects_public => '0' do
+    with_settings default_projects_public: '0' do
       assert_equal false, Project.new.is_public
-      assert_equal true, Project.new(:is_public => true).is_public
+      assert_equal true, Project.new(is_public: true).is_public
     end
 
-    with_settings :sequential_project_identifiers => '1' do
+    with_settings sequential_project_identifiers: '1' do
       assert !Project.new.identifier.blank?
-      assert Project.new(:identifier => '').identifier.blank?
+      assert Project.new(identifier: '').identifier.blank?
     end
 
-    with_settings :sequential_project_identifiers => '0' do
+    with_settings sequential_project_identifiers: '0' do
       assert Project.new.identifier.blank?
-      assert !Project.new(:identifier => 'test').blank?
+      assert !Project.new(identifier: 'test').blank?
     end
 
-    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
+    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
       assert_equal ['work_package_tracking', 'repository'], Project.new.enabled_module_names
     end
 
     assert_equal Type.all, Project.new.types
-    assert_equal Type.find(1, 3), Project.new(:type_ids => [1, 3]).types
+    assert_equal Type.find(1, 3), Project.new(type_ids: [1, 3]).types
   end
 
   def test_update
@@ -184,7 +184,7 @@ class ProjectTest < ActiveSupport::TestCase
     # 2 active members
     assert_equal 2, @ecookbook.members.size
     # and 1 is locked
-    assert_equal 3, Member.find(:all, :conditions => ['project_id = ?', @ecookbook.id]).size
+    assert_equal 3, Member.find(:all, conditions: ['project_id = ?', @ecookbook.id]).size
     # some boards
     assert @ecookbook.boards.any?
 
@@ -192,9 +192,9 @@ class ProjectTest < ActiveSupport::TestCase
     # make sure that the project non longer exists
     assert_raise(ActiveRecord::RecordNotFound) { Project.find(@ecookbook.id) }
     # make sure related data was removed
-    assert_nil Member.first(:conditions => {:project_id => @ecookbook.id})
-    assert_nil Board.first(:conditions => {:project_id => @ecookbook.id})
-    assert_nil WorkPackage.first(:conditions => {:project_id => @ecookbook.id})
+    assert_nil Member.first(conditions: {project_id: @ecookbook.id})
+    assert_nil Board.first(conditions: {project_id: @ecookbook.id})
+    assert_nil WorkPackage.first(conditions: {project_id: @ecookbook.id})
   end
 
   def test_destroying_root_projects_should_clear_data
@@ -216,7 +216,7 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 0, Board.count
     assert_equal 0, Message.count
     assert_equal 0, News.count
-    assert_equal 0, Query.count(:conditions => "project_id IS NOT NULL")
+    assert_equal 0, Query.count(conditions: "project_id IS NOT NULL")
     assert_equal 0, Repository.count
     assert_equal 0, Changeset.count
     assert_equal 0, Change.count
@@ -229,7 +229,7 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 0, WikiContent.count
     assert_equal 0, Project.connection.select_all("SELECT * FROM projects_types").size
     assert_equal 0, Project.connection.select_all("SELECT * FROM custom_fields_projects").size
-    assert_equal 0, CustomValue.count(:conditions => {:customized_type => ['Project', 'Issue', 'TimeEntry', 'Version']})
+    assert_equal 0, CustomValue.count(conditions: {customized_type: ['Project', 'Issue', 'TimeEntry', 'Version']})
   end
 
   def test_move_an_orphan_project_to_a_root_project
@@ -258,10 +258,10 @@ class ProjectTest < ActiveSupport::TestCase
   def test_set_parent_should_add_roots_in_alphabetical_order
     ProjectCustomField.delete_all
     Project.delete_all
-    Project.create!(:name => 'Project C', :identifier => 'project-c').set_parent!(nil)
-    Project.create!(:name => 'Project B', :identifier => 'project-b').set_parent!(nil)
-    Project.create!(:name => 'Project D', :identifier => 'project-d').set_parent!(nil)
-    Project.create!(:name => 'Project A', :identifier => 'project-a').set_parent!(nil)
+    Project.create!(name: 'Project C', identifier: 'project-c').set_parent!(nil)
+    Project.create!(name: 'Project B', identifier: 'project-b').set_parent!(nil)
+    Project.create!(name: 'Project D', identifier: 'project-d').set_parent!(nil)
+    Project.create!(name: 'Project A', identifier: 'project-a').set_parent!(nil)
 
     assert_equal 4, Project.count
     assert_equal Project.all.sort_by(&:name), Project.all.sort_by(&:lft)
@@ -269,11 +269,11 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_set_parent_should_add_children_in_alphabetical_order
     ProjectCustomField.delete_all
-    parent = Project.create!(:name => 'Parent', :identifier => 'parent')
-    Project.create!(:name => 'Project C', :identifier => 'project-c').set_parent!(parent)
-    Project.create!(:name => 'Project B', :identifier => 'project-b').set_parent!(parent)
-    Project.create!(:name => 'Project D', :identifier => 'project-d').set_parent!(parent)
-    Project.create!(:name => 'Project A', :identifier => 'project-a').set_parent!(parent)
+    parent = Project.create!(name: 'Parent', identifier: 'parent')
+    Project.create!(name: 'Project C', identifier: 'project-c').set_parent!(parent)
+    Project.create!(name: 'Project B', identifier: 'project-b').set_parent!(parent)
+    Project.create!(name: 'Project D', identifier: 'project-d').set_parent!(parent)
+    Project.create!(name: 'Project A', identifier: 'project-a').set_parent!(parent)
 
     parent.reload
     assert_equal 4, parent.children.size
@@ -282,11 +282,11 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_rebuild_should_sort_children_alphabetically
     ProjectCustomField.delete_all
-    parent = Project.create!(:name => 'Parent', :identifier => 'parent')
-    Project.create!(:name => 'Project C', :identifier => 'project-c').move_to_child_of(parent)
-    Project.create!(:name => 'Project B', :identifier => 'project-b').move_to_child_of(parent)
-    Project.create!(:name => 'Project D', :identifier => 'project-d').move_to_child_of(parent)
-    Project.create!(:name => 'Project A', :identifier => 'project-a').move_to_child_of(parent)
+    parent = Project.create!(name: 'Parent', identifier: 'parent')
+    Project.create!(name: 'Project C', identifier: 'project-c').move_to_child_of(parent)
+    Project.create!(name: 'Project B', identifier: 'project-b').move_to_child_of(parent)
+    Project.create!(name: 'Project D', identifier: 'project-d').move_to_child_of(parent)
+    Project.create!(name: 'Project A', identifier: 'project-a').move_to_child_of(parent)
 
     Project.update_all("lft = NULL, rgt = NULL")
     Project.rebuild!
@@ -467,8 +467,8 @@ class ProjectTest < ActiveSupport::TestCase
   context "#rolled_up_versions" do
     setup do
       @project = Project.generate!
-      @parent_version_1 = Version.generate!(:project => @project)
-      @parent_version_2 = Version.generate!(:project => @project)
+      @parent_version_1 = Version.generate!(project: @project)
+      @parent_version_2 = Version.generate!(project: @project)
     end
 
     should "include the versions for the current project" do
@@ -478,7 +478,7 @@ class ProjectTest < ActiveSupport::TestCase
     should "include versions for a subproject" do
       @subproject = Project.generate!
       @subproject.set_parent!(@project)
-      @subproject_version = Version.generate!(:project => @subproject)
+      @subproject_version = Version.generate!(project: @subproject)
 
       assert_same_elements [
                             @parent_version_1,
@@ -492,7 +492,7 @@ class ProjectTest < ActiveSupport::TestCase
       @subproject.set_parent!(@project)
       @sub_subproject = Project.generate!
       @sub_subproject.set_parent!(@subproject)
-      @sub_subproject_version = Version.generate!(:project => @sub_subproject)
+      @sub_subproject_version = Version.generate!(project: @sub_subproject)
 
       @project.reload
 
@@ -507,7 +507,7 @@ class ProjectTest < ActiveSupport::TestCase
     should "only check active projects" do
       @subproject = Project.generate!
       @subproject.set_parent!(@project)
-      @subproject_version = Version.generate!(:project => @subproject)
+      @subproject_version = Version.generate!(project: @subproject)
       assert @subproject.archive
 
       @project.reload
@@ -519,7 +519,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_shared_versions_none_sharing
     p = Project.find(5)
-    v = Version.create!(:name => 'none_sharing', :project => p, :sharing => 'none')
+    v = Version.create!(name: 'none_sharing', project: p, sharing: 'none')
     assert p.shared_versions.include?(v)
     assert !p.children.first.shared_versions.include?(v)
     assert !p.root.shared_versions.include?(v)
@@ -529,7 +529,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_shared_versions_descendants_sharing
     p = Project.find(5)
-    v = Version.create!(:name => 'descendants_sharing', :project => p, :sharing => 'descendants')
+    v = Version.create!(name: 'descendants_sharing', project: p, sharing: 'descendants')
     assert p.shared_versions.include?(v)
     assert p.children.first.shared_versions.include?(v)
     assert !p.root.shared_versions.include?(v)
@@ -539,7 +539,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_shared_versions_hierarchy_sharing
     p = Project.find(5)
-    v = Version.create!(:name => 'hierarchy_sharing', :project => p, :sharing => 'hierarchy')
+    v = Version.create!(name: 'hierarchy_sharing', project: p, sharing: 'hierarchy')
     assert p.shared_versions.include?(v)
     assert p.children.first.shared_versions.include?(v)
     assert p.root.shared_versions.include?(v)
@@ -549,7 +549,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_shared_versions_tree_sharing
     p = Project.find(5)
-    v = Version.create!(:name => 'tree_sharing', :project => p, :sharing => 'tree')
+    v = Version.create!(name: 'tree_sharing', project: p, sharing: 'tree')
     assert p.shared_versions.include?(v)
     assert p.children.first.shared_versions.include?(v)
     assert p.root.shared_versions.include?(v)
@@ -559,7 +559,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_shared_versions_system_sharing
     p = Project.find(5)
-    v = Version.create!(:name => 'system_sharing', :project => p, :sharing => 'system')
+    v = Version.create!(name: 'system_sharing', project: p, sharing: 'system')
     assert p.shared_versions.include?(v)
     assert p.children.first.shared_versions.include?(v)
     assert p.root.shared_versions.include?(v)
@@ -617,7 +617,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_next_identifier
     ProjectCustomField.delete_all
-    Project.create!(:name => 'last', :identifier => 'p2008040')
+    Project.create!(name: 'last', identifier: 'p2008040')
     assert_equal 'p2008041', Project.next_identifier
   end
 
@@ -627,7 +627,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_enabled_module_names
-    with_settings :default_projects_modules => ['work_package_tracking', 'repository'] do
+    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
       project = Project.new
 
       project.enabled_module_names = %w(work_package_tracking news)
@@ -669,13 +669,13 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_activities_should_use_the_system_activities
     project = Project.find(1)
-    assert_equal project.activities, TimeEntryActivity.find(:all, :conditions => {:active => true} )
+    assert_equal project.activities, TimeEntryActivity.find(:all, conditions: {active: true} )
   end
 
 
   def test_activities_should_use_the_project_specific_activities
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => project})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: project})
     assert overridden_activity.save!
 
     assert project.activities.include?(overridden_activity), "Project specific Activity not found"
@@ -683,7 +683,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_activities_should_not_include_the_inactive_project_specific_activities
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => project, :parent => TimeEntryActivity.find(:first), :active => false})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: TimeEntryActivity.find(:first), active: false})
     assert overridden_activity.save!
 
     assert !project.activities.include?(overridden_activity), "Inactive Project specific Activity found"
@@ -691,14 +691,14 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_activities_should_not_include_project_specific_activities_from_other_projects
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => Project.find(2)})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: Project.find(2)})
     assert overridden_activity.save!
 
     assert !project.activities.include?(overridden_activity), "Project specific Activity found on a different project"
   end
 
   def test_activities_should_handle_nils
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => Project.find(1), :parent => TimeEntryActivity.find(:first)})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: Project.find(1), parent: TimeEntryActivity.find(:first)})
     TimeEntryActivity.delete_all
 
     # No activities
@@ -714,7 +714,7 @@ class ProjectTest < ActiveSupport::TestCase
   def test_activities_should_override_system_activities_with_project_activities
     project = Project.find(1)
     parent_activity = TimeEntryActivity.find(:first)
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => project, :parent => parent_activity})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: parent_activity})
     assert overridden_activity.save!
 
     assert project.activities.include?(overridden_activity), "Project specific Activity not found"
@@ -723,7 +723,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_activities_should_include_inactive_activities_if_specified
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({:name => "Project", :project => project, :parent => TimeEntryActivity.find(:first), :active => false})
+    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: TimeEntryActivity.find(:first), active: false})
     assert overridden_activity.save!
 
     assert project.activities(true).include?(overridden_activity), "Inactive Project specific Activity not found"
@@ -733,7 +733,7 @@ class ProjectTest < ActiveSupport::TestCase
     project = Project.find(1)
     system_activity = TimeEntryActivity.find_by_name('Design')
     assert system_activity.active?
-    overridden_activity = TimeEntryActivity.generate!(:project => project, :parent => system_activity, :active => false)
+    overridden_activity = TimeEntryActivity.generate!(project: project, parent: system_activity, active: false)
     assert overridden_activity.save!
 
     assert !project.activities.include?(overridden_activity), "Inactive Project specific Activity not found"
@@ -759,19 +759,19 @@ class ProjectTest < ActiveSupport::TestCase
   context "Project#copy" do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      Project.destroy_all :identifier => "copy-test"
+      Project.destroy_all identifier: "copy-test"
       @source_project = Project.find(2)
-      @project = Project.new(:name => 'Copy Test', :identifier => 'copy-test')
+      @project = Project.new(name: 'Copy Test', identifier: 'copy-test')
       @project.types = @source_project.types
       @project.enabled_module_names = @source_project.enabled_modules.collect(&:name)
     end
 
     should "copy work units" do
-      @source_project.work_packages << WorkPackage.generate!(:status => Status.find_by_name('Closed'),
-                                                    :subject => "copy issue status",
-                                                    :type_id => 1,
-                                                    :assigned_to_id => 2,
-                                                    :project_id => @source_project.id)
+      @source_project.work_packages << WorkPackage.generate!(status: Status.find_by_name('Closed'),
+                                                    subject: "copy issue status",
+                                                    type_id: 1,
+                                                    assigned_to_id: 2,
+                                                    project_id: @source_project.id)
       assert @project.valid?
       assert @project.work_packages.empty?
       assert @project.copy(@source_project)
@@ -783,7 +783,7 @@ class ProjectTest < ActiveSupport::TestCase
         assert_equal @project, issue.project
       end
 
-      copied_issue = @project.work_packages.first(:conditions => {:subject => "copy issue status"})
+      copied_issue = @project.work_packages.first(conditions: {subject: "copy issue status"})
       assert copied_issue
       assert copied_issue.status
       assert_equal "Closed", copied_issue.status.name
@@ -791,18 +791,18 @@ class ProjectTest < ActiveSupport::TestCase
 
     should "change the new issues to use the copied version" do
       User.current = User.find(1)
-      assigned_version = Version.generate!(:name => "Assigned Issues", :status => 'open')
+      assigned_version = Version.generate!(name: "Assigned Issues", status: 'open')
       @source_project.versions << assigned_version
       assert_equal 3, @source_project.versions.size
       FactoryGirl.create(:work_package, project: @source_project,
-                                  :fixed_version_id => assigned_version.id,
-                                  :subject => "change the new issues to use the copied version",
-                                  :type_id => 1,
-                                  :project_id => @source_project.id)
+                                  fixed_version_id: assigned_version.id,
+                                  subject: "change the new issues to use the copied version",
+                                  type_id: 1,
+                                  project_id: @source_project.id)
 
       assert @project.copy(@source_project)
       @project.reload
-      copied_issue = @project.work_packages.first(:conditions => {:subject => "change the new issues to use the copied version"})
+      copied_issue = @project.work_packages.first(conditions: {subject: "change the new issues to use the copied version"})
 
       assert copied_issue
       assert copied_issue.fixed_version
@@ -813,17 +813,17 @@ class ProjectTest < ActiveSupport::TestCase
     should "copy issue relations" do
       Setting.cross_project_work_package_relations = '1'
 
-      second_issue = WorkPackage.generate!(:status_id => 5,
-                                     :subject => "copy issue relation",
-                                     :type_id => 1,
-                                     :assigned_to_id => 2,
-                                     :project_id => @source_project.id)
-      source_relation = Relation.generate!(:from => WorkPackage.find(4),
-                                                :to => second_issue,
-                                                :relation_type => "relates")
-      source_relation_cross_project = Relation.generate!(:from => WorkPackage.find(1),
-                                                              :to => second_issue,
-                                                              :relation_type => "duplicates")
+      second_issue = WorkPackage.generate!(status_id: 5,
+                                     subject: "copy issue relation",
+                                     type_id: 1,
+                                     assigned_to_id: 2,
+                                     project_id: @source_project.id)
+      source_relation = Relation.generate!(from: WorkPackage.find(4),
+                                                to: second_issue,
+                                                relation_type: "relates")
+      source_relation_cross_project = Relation.generate!(from: WorkPackage.find(1),
+                                                              to: second_issue,
+                                                              relation_type: "duplicates")
 
       assert @project.copy(@source_project)
       assert_equal @source_project.work_packages.count, @project.work_packages.count
@@ -858,16 +858,16 @@ class ProjectTest < ActiveSupport::TestCase
     end
 
     should "copy memberships with groups and additional roles" do
-      group = Group.create!(:lastname => "Copy group")
+      group = Group.create!(lastname: "Copy group")
       user = User.find(7)
 
       group.users << user
 
       # group role
       (Member.new.tap do |m|
-        m.force_attributes = { :project_id => @source_project.id,
-                               :principal => group,
-                               :role_ids => [2] }
+        m.force_attributes = { project_id: @source_project.id,
+                               principal: group,
+                               role_ids: [2] }
       end).save!
 
       member = Member.find_by_user_id_and_project_id(user.id, @source_project.id)
@@ -972,7 +972,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert @project.categories.empty?
       assert @source_project.work_packages.any?
 
-      assert @project.copy(@source_project, :only => ['members', 'categories'])
+      assert @project.copy(@source_project, only: ['members', 'categories'])
 
       assert @project.members.any?
       assert @project.categories.any?
@@ -984,7 +984,7 @@ class ProjectTest < ActiveSupport::TestCase
   context "#start_date" do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      @project = Project.generate!(:identifier => 'test0')
+      @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
@@ -996,8 +996,8 @@ class ProjectTest < ActiveSupport::TestCase
 
     should "be the earliest start date of it's issues" do
       early = 7.days.ago.to_date
-      FactoryGirl.create(:work_package, project: @project, :start_date => Date.today)
-      FactoryGirl.create(:work_package, project: @project, :start_date => early)
+      FactoryGirl.create(:work_package, project: @project, start_date: Date.today)
+      FactoryGirl.create(:work_package, project: @project, start_date: early)
 
       assert_equal early, @project.start_date
     end
@@ -1007,7 +1007,7 @@ class ProjectTest < ActiveSupport::TestCase
   context "#due_date" do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      @project = Project.generate!(:identifier => 'test0')
+      @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
@@ -1019,16 +1019,16 @@ class ProjectTest < ActiveSupport::TestCase
 
     should "be the latest due date of it's issues" do
       future = 7.days.from_now.to_date
-      FactoryGirl.create(:work_package, project: @project, :due_date => future)
-      FactoryGirl.create(:work_package, project: @project, :due_date => Date.today)
+      FactoryGirl.create(:work_package, project: @project, due_date: future)
+      FactoryGirl.create(:work_package, project: @project, due_date: Date.today)
 
       assert_equal future, @project.due_date
     end
 
     should "be the latest due date of it's versions" do
       future = 7.days.from_now.to_date
-      @project.versions << Version.generate!(:effective_date => future)
-      @project.versions << Version.generate!(:effective_date => Date.today)
+      @project.versions << Version.generate!(effective_date: future)
+      @project.versions << Version.generate!(effective_date: Date.today)
 
 
       assert_equal future, @project.due_date
@@ -1038,8 +1038,8 @@ class ProjectTest < ActiveSupport::TestCase
     should "pick the latest date from it's issues and versions" do
       future = 7.days.from_now.to_date
       far_future = 14.days.from_now.to_date
-      FactoryGirl.create(:work_package, project: @project, :due_date => far_future)
-      @project.versions << Version.generate!(:effective_date => future)
+      FactoryGirl.create(:work_package, project: @project, due_date: far_future)
+      @project.versions << Version.generate!(effective_date: future)
 
       assert_equal far_future, @project.due_date
     end
@@ -1049,7 +1049,7 @@ class ProjectTest < ActiveSupport::TestCase
   context "Project#completed_percent" do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      @project = Project.generate!(:identifier => 'test0')
+      @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
@@ -1061,26 +1061,26 @@ class ProjectTest < ActiveSupport::TestCase
 
     context "with versions" do
       should "return 0 if the versions have no issues" do
-        Version.generate!(:project => @project)
-        Version.generate!(:project => @project)
+        Version.generate!(project: @project)
+        Version.generate!(project: @project)
 
         assert_equal 0, @project.completed_percent
       end
 
       should "return 100 if the version has only closed issues" do
-        v1 = Version.generate!(:project => @project)
-        FactoryGirl.create(:work_package, project: @project, :status => Status.find_by_name('Closed'), :fixed_version => v1)
-        v2 = Version.generate!(:project => @project)
-        FactoryGirl.create(:work_package, project: @project, :status => Status.find_by_name('Closed'), :fixed_version => v2)
+        v1 = Version.generate!(project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v1)
+        v2 = Version.generate!(project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v2)
 
         assert_equal 100, @project.completed_percent
       end
 
       should "return the averaged completed percent of the versions (not weighted)" do
-        v1 = Version.generate!(:project => @project)
-        FactoryGirl.create(:work_package, project: @project, :status => Status.find_by_name('New'), :estimated_hours => 10, :done_ratio => 50, :fixed_version => v1)
-        v2 = Version.generate!(:project => @project)
-        FactoryGirl.create(:work_package, project: @project, :status => Status.find_by_name('New'), :estimated_hours => 10, :done_ratio => 50, :fixed_version => v2)
+        v1 = Version.generate!(project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v1)
+        v2 = Version.generate!(project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v2)
 
         assert_equal 50, @project.completed_percent
       end
@@ -1093,33 +1093,33 @@ class ProjectTest < ActiveSupport::TestCase
       @project = Project.generate!
       @role = Role.generate!
 
-      @user_with_membership_notification = User.generate!(:mail_notification => 'selected')
-      Member.create!(:project => @project, :principal => @user_with_membership_notification, :mail_notification => true) do |member|
+      @user_with_membership_notification = User.generate!(mail_notification: 'selected')
+      Member.create!(project: @project, principal: @user_with_membership_notification, mail_notification: true) do |member|
         member.role_ids = [@role.id]
       end
 
-      @all_events_user = User.generate!(:mail_notification => 'all')
-      Member.create!(:project => @project, :principal => @all_events_user) do |member|
+      @all_events_user = User.generate!(mail_notification: 'all')
+      Member.create!(project: @project, principal: @all_events_user) do |member|
         member.role_ids = [@role.id]
       end
 
-      @no_events_user = User.generate!(:mail_notification => 'none')
-      Member.create!(:project => @project, :principal => @no_events_user) do |member|
+      @no_events_user = User.generate!(mail_notification: 'none')
+      Member.create!(project: @project, principal: @no_events_user) do |member|
         member.role_ids = [@role.id]
       end
 
-      @only_my_events_user = User.generate!(:mail_notification => 'only_my_events')
-      Member.create!(:project => @project, :principal => @only_my_events_user) do |member|
+      @only_my_events_user = User.generate!(mail_notification: 'only_my_events')
+      Member.create!(project: @project, principal: @only_my_events_user) do |member|
         member.role_ids = [@role.id]
       end
 
-      @only_assigned_user = User.generate!(:mail_notification => 'only_assigned')
-      Member.create!(:project => @project, :principal => @only_assigned_user) do |member|
+      @only_assigned_user = User.generate!(mail_notification: 'only_assigned')
+      Member.create!(project: @project, principal: @only_assigned_user) do |member|
         member.role_ids = [@role.id]
       end
 
-      @only_owned_user = User.generate!(:mail_notification => 'only_owner')
-      Member.create!(:project => @project, :principal => @only_owned_user) do |member|
+      @only_owned_user = User.generate!(mail_notification: 'only_owner')
+      Member.create!(project: @project, principal: @only_owned_user) do |member|
         member.role_ids = [@role.id]
       end
     end

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -44,7 +44,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   should validate_uniqueness_of :identifier
 
-  context "associations" do
+  context 'associations' do
     should have_many :members
     should have_many(:users).through(:members)
     should have_many :member_principals
@@ -69,7 +69,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_truth
     assert_kind_of Project, @ecookbook
-    assert_equal "eCookbook", @ecookbook.name
+    assert_equal 'eCookbook', @ecookbook.name
   end
 
   def test_default_attributes
@@ -102,20 +102,20 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_update
-    assert_equal "eCookbook", @ecookbook.name
-    @ecookbook.name = "eCook"
-    assert @ecookbook.save, @ecookbook.errors.full_messages.join("; ")
+    assert_equal 'eCookbook', @ecookbook.name
+    @ecookbook.name = 'eCook'
+    assert @ecookbook.save, @ecookbook.errors.full_messages.join('; ')
     @ecookbook.reload
-    assert_equal "eCook", @ecookbook.name
+    assert_equal 'eCook', @ecookbook.name
   end
 
   def test_validate_identifier
-    to_test = {"abc" => true,
-               "ab12" => true,
-               "ab-12" => true,
-               "ab_12" => true,
-               "12" => false,
-               "new" => false}
+    to_test = { 'abc' => true,
+                'ab12' => true,
+                'ab-12' => true,
+                'ab_12' => true,
+                '12' => false,
+                'new' => false }
 
     to_test.each do |identifier, valid|
       p = Project.new
@@ -127,13 +127,13 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_members_should_be_active_users
     Project.all.each do |project|
-      assert_nil project.members.detect {|m| !(m.user.is_a?(User) && m.user.active?) }
+      assert_nil project.members.detect { |m| !(m.user.is_a?(User) && m.user.active?) }
     end
   end
 
   def test_users_should_be_active_users
     Project.all.each do |project|
-      assert_nil project.users.detect {|u| !(u.is_a?(User) && u.active?) }
+      assert_nil project.users.detect { |u| !(u.is_a?(User) && u.active?) }
     end
   end
 
@@ -192,18 +192,16 @@ class ProjectTest < ActiveSupport::TestCase
     # make sure that the project non longer exists
     assert_raise(ActiveRecord::RecordNotFound) { Project.find(@ecookbook.id) }
     # make sure related data was removed
-    assert_nil Member.first(conditions: {project_id: @ecookbook.id})
-    assert_nil Board.first(conditions: {project_id: @ecookbook.id})
-    assert_nil WorkPackage.first(conditions: {project_id: @ecookbook.id})
+    assert_nil Member.first(conditions: { project_id: @ecookbook.id })
+    assert_nil Board.first(conditions: { project_id: @ecookbook.id })
+    assert_nil WorkPackage.first(conditions: { project_id: @ecookbook.id })
   end
 
   def test_destroying_root_projects_should_clear_data
     Journal.delete_all
     WorkPackage.all.each(&:recreate_initial_journal!)
 
-    Project.roots.each do |root|
-      root.destroy
-    end
+    Project.roots.each(&:destroy)
 
     assert_equal 0, Project.count, "Projects were not deleted: #{Project.all.inspect}"
     assert_equal 0, Member.count, "Members were not deleted: #{Member.all.inspect}"
@@ -216,7 +214,7 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 0, Board.count
     assert_equal 0, Message.count
     assert_equal 0, News.count
-    assert_equal 0, Query.count(conditions: "project_id IS NOT NULL")
+    assert_equal 0, Query.count(conditions: 'project_id IS NOT NULL')
     assert_equal 0, Repository.count
     assert_equal 0, Changeset.count
     assert_equal 0, Change.count
@@ -227,9 +225,9 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 0, Wiki.count
     assert_equal 0, WikiPage.count
     assert_equal 0, WikiContent.count
-    assert_equal 0, Project.connection.select_all("SELECT * FROM projects_types").size
-    assert_equal 0, Project.connection.select_all("SELECT * FROM custom_fields_projects").size
-    assert_equal 0, CustomValue.count(conditions: {customized_type: ['Project', 'Issue', 'TimeEntry', 'Version']})
+    assert_equal 0, Project.connection.select_all('SELECT * FROM projects_types').size
+    assert_equal 0, Project.connection.select_all('SELECT * FROM custom_fields_projects').size
+    assert_equal 0, CustomValue.count(conditions: { customized_type: ['Project', 'Issue', 'TimeEntry', 'Version'] })
   end
 
   def test_move_an_orphan_project_to_a_root_project
@@ -288,14 +286,13 @@ class ProjectTest < ActiveSupport::TestCase
     Project.create!(name: 'Project D', identifier: 'project-d').move_to_child_of(parent)
     Project.create!(name: 'Project A', identifier: 'project-a').move_to_child_of(parent)
 
-    Project.update_all("lft = NULL, rgt = NULL")
+    Project.update_all('lft = NULL, rgt = NULL')
     Project.rebuild!
 
     parent.reload
     assert_equal 4, parent.children.size
     assert_equal parent.children.sort_by(&:name), parent.children
   end
-
 
   def test_set_parent_should_update_issue_fixed_version_associations_when_a_fixed_version_is_moved_out_of_the_hierarchy
     # Parent issue with a hierarchy project's fixed version
@@ -323,9 +320,9 @@ class ProjectTest < ActiveSupport::TestCase
     issue_with_local_fixed_version.reload
     issue_with_hierarchy_fixed_version.reload
 
-    assert_equal 4, issue_with_local_fixed_version.fixed_version_id, "Fixed version was not keep on an issue local to the moved project"
-    assert_equal nil, issue_with_hierarchy_fixed_version.fixed_version_id, "Fixed version is still set after moving the Project out of the hierarchy where the version is defined in"
-    assert_equal nil, parent_issue.fixed_version_id, "Fixed version is still set after moving the Version out of the hierarchy for the issue."
+    assert_equal 4, issue_with_local_fixed_version.fixed_version_id, 'Fixed version was not keep on an issue local to the moved project'
+    assert_equal nil, issue_with_hierarchy_fixed_version.fixed_version_id, 'Fixed version is still set after moving the Project out of the hierarchy where the version is defined in'
+    assert_equal nil, parent_issue.fixed_version_id, 'Fixed version is still set after moving the Version out of the hierarchy for the issue.'
   end
 
   def test_parent
@@ -420,7 +417,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_rolled_up_types
     parent = Project.find(1)
-    parent.types = Type.find([1,2])
+    parent.types = Type.find([1, 2])
     child = parent.children.find(3)
 
     assert_equal [1, 2], parent.type_ids
@@ -434,15 +431,15 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_rolled_up_types_should_ignore_archived_subprojects
     parent = Project.find(1)
-    parent.types = Type.find([1,2])
+    parent.types = Type.find([1, 2])
     child = parent.children.find(3)
-    child.types = Type.find([1,3])
+    child.types = Type.find([1, 3])
     parent.children.each(&:archive)
 
-    assert_equal [1,2], parent.rolled_up_types.collect(&:id)
+    assert_equal [1, 2], parent.rolled_up_types.collect(&:id)
   end
 
-  context "description" do
+  context 'description' do
     setup do
       # this block unfortunately isn't run
       # move first two lines of next to specs up here
@@ -451,43 +448,43 @@ class ProjectTest < ActiveSupport::TestCase
 
     def test_short_description_returns_shortened_description
       @project = Project.generate!
-      @project.description = ("Abcd " * 5 + "\n") * 11
-      @project.summary = ""
-      assert_equal (("Abcd " * 5 + "\n") * 10)[0..-2] + "...", @project.short_description
+      @project.description = ('Abcd ' * 5 + "\n") * 11
+      @project.summary = ''
+      assert_equal (('Abcd ' * 5 + "\n") * 10)[0..-2] + '...', @project.short_description
     end
 
     def test_short_description_returns_summary
       @project = Project.generate!
-      @project.description = ("Abcd " * 5 + "\n") * 11
-      @project.summary = "In short"
-      assert_equal "In short", @project.short_description
+      @project.description = ('Abcd ' * 5 + "\n") * 11
+      @project.summary = 'In short'
+      assert_equal 'In short', @project.short_description
     end
   end
 
-  context "#rolled_up_versions" do
+  context '#rolled_up_versions' do
     setup do
       @project = Project.generate!
       @parent_version_1 = Version.generate!(project: @project)
       @parent_version_2 = Version.generate!(project: @project)
     end
 
-    should "include the versions for the current project" do
+    should 'include the versions for the current project' do
       assert_same_elements [@parent_version_1, @parent_version_2], @project.rolled_up_versions
     end
 
-    should "include versions for a subproject" do
+    should 'include versions for a subproject' do
       @subproject = Project.generate!
       @subproject.set_parent!(@project)
       @subproject_version = Version.generate!(project: @subproject)
 
       assert_same_elements [
-                            @parent_version_1,
-                            @parent_version_2,
-                            @subproject_version
-                           ], @project.rolled_up_versions
+        @parent_version_1,
+        @parent_version_2,
+        @subproject_version
+      ], @project.rolled_up_versions
     end
 
-    should "include versions for a sub-subproject" do
+    should 'include versions for a sub-subproject' do
       @subproject = Project.generate!
       @subproject.set_parent!(@project)
       @sub_subproject = Project.generate!
@@ -497,14 +494,13 @@ class ProjectTest < ActiveSupport::TestCase
       @project.reload
 
       assert_same_elements [
-                            @parent_version_1,
-                            @parent_version_2,
-                            @sub_subproject_version
-                           ], @project.rolled_up_versions
+        @parent_version_1,
+        @parent_version_2,
+        @sub_subproject_version
+      ], @project.rolled_up_versions
     end
 
-
-    should "only check active projects" do
+    should 'only check active projects' do
       @subproject = Project.generate!
       @subproject.set_parent!(@project)
       @subproject_version = Version.generate!(project: @subproject)
@@ -572,7 +568,7 @@ class ProjectTest < ActiveSupport::TestCase
     child = parent.children.find(3)
     private_child = parent.children.find(5)
 
-    assert_equal [1,2,3], parent.version_ids.sort
+    assert_equal [1, 2, 3], parent.version_ids.sort
     assert_equal [4], child.version_ids
     assert_equal [6], private_child.version_ids
     assert_equal [7], Version.find_all_by_sharing('system').collect(&:id)
@@ -582,7 +578,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_kind_of Version, version
     end
 
-    assert_equal [1,2,3,4,6,7], parent.shared_versions.collect(&:id).sort
+    assert_equal [1, 2, 3, 4, 6, 7], parent.shared_versions.collect(&:id).sort
   end
 
   def test_shared_versions_should_ignore_archived_subprojects
@@ -591,7 +587,7 @@ class ProjectTest < ActiveSupport::TestCase
     child.archive
     parent.reload
 
-    assert_equal [1,2,3], parent.version_ids.sort
+    assert_equal [1, 2, 3], parent.version_ids.sort
     assert_equal [4], child.version_ids
     assert !parent.shared_versions.collect(&:id).include?(4)
   end
@@ -601,7 +597,7 @@ class ProjectTest < ActiveSupport::TestCase
     parent = Project.find(1)
     child = parent.children.find(5)
 
-    assert_equal [1,2,3], parent.version_ids.sort
+    assert_equal [1, 2, 3], parent.version_ids.sort
     assert_equal [6], child.version_ids
 
     versions = parent.shared_versions.visible(user)
@@ -613,7 +609,6 @@ class ProjectTest < ActiveSupport::TestCase
 
     assert !versions.collect(&:id).include?(6)
   end
-
 
   def test_next_identifier
     ProjectCustomField.delete_all
@@ -669,36 +664,35 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_activities_should_use_the_system_activities
     project = Project.find(1)
-    assert_equal project.activities, TimeEntryActivity.find(:all, conditions: {active: true} )
+    assert_equal project.activities, TimeEntryActivity.find(:all, conditions: { active: true })
   end
-
 
   def test_activities_should_use_the_project_specific_activities
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: project})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: project)
     assert overridden_activity.save!
 
-    assert project.activities.include?(overridden_activity), "Project specific Activity not found"
+    assert project.activities.include?(overridden_activity), 'Project specific Activity not found'
   end
 
   def test_activities_should_not_include_the_inactive_project_specific_activities
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: TimeEntryActivity.find(:first), active: false})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: project, parent: TimeEntryActivity.find(:first), active: false)
     assert overridden_activity.save!
 
-    assert !project.activities.include?(overridden_activity), "Inactive Project specific Activity found"
+    assert !project.activities.include?(overridden_activity), 'Inactive Project specific Activity found'
   end
 
   def test_activities_should_not_include_project_specific_activities_from_other_projects
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: Project.find(2)})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: Project.find(2))
     assert overridden_activity.save!
 
-    assert !project.activities.include?(overridden_activity), "Project specific Activity found on a different project"
+    assert !project.activities.include?(overridden_activity), 'Project specific Activity found on a different project'
   end
 
   def test_activities_should_handle_nils
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: Project.find(1), parent: TimeEntryActivity.find(:first)})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: Project.find(1), parent: TimeEntryActivity.find(:first))
     TimeEntryActivity.delete_all
 
     # No activities
@@ -714,19 +708,19 @@ class ProjectTest < ActiveSupport::TestCase
   def test_activities_should_override_system_activities_with_project_activities
     project = Project.find(1)
     parent_activity = TimeEntryActivity.find(:first)
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: parent_activity})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: project, parent: parent_activity)
     assert overridden_activity.save!
 
-    assert project.activities.include?(overridden_activity), "Project specific Activity not found"
-    assert !project.activities.include?(parent_activity), "System Activity found when it should have been overridden"
+    assert project.activities.include?(overridden_activity), 'Project specific Activity not found'
+    assert !project.activities.include?(parent_activity), 'System Activity found when it should have been overridden'
   end
 
   def test_activities_should_include_inactive_activities_if_specified
     project = Project.find(1)
-    overridden_activity = TimeEntryActivity.new({name: "Project", project: project, parent: TimeEntryActivity.find(:first), active: false})
+    overridden_activity = TimeEntryActivity.new(name: 'Project', project: project, parent: TimeEntryActivity.find(:first), active: false)
     assert overridden_activity.save!
 
-    assert project.activities(true).include?(overridden_activity), "Inactive Project specific Activity not found"
+    assert project.activities(true).include?(overridden_activity), 'Inactive Project specific Activity not found'
   end
 
   test 'activities should not include active System activities if the project has an override that is inactive' do
@@ -736,19 +730,19 @@ class ProjectTest < ActiveSupport::TestCase
     overridden_activity = TimeEntryActivity.generate!(project: project, parent: system_activity, active: false)
     assert overridden_activity.save!
 
-    assert !project.activities.include?(overridden_activity), "Inactive Project specific Activity not found"
-    assert !project.activities.include?(system_activity), "System activity found when the project has an inactive override"
+    assert !project.activities.include?(overridden_activity), 'Inactive Project specific Activity not found'
+    assert !project.activities.include?(system_activity), 'System activity found when the project has an inactive override'
   end
 
   def test_close_completed_versions
     Version.update_all("status = 'open'")
     project = Project.find(1)
-    assert_not_nil project.versions.detect {|v| v.completed? && v.status == 'open'}
-    assert_not_nil project.versions.detect {|v| !v.completed? && v.status == 'open'}
+    assert_not_nil project.versions.detect { |v| v.completed? && v.status == 'open' }
+    assert_not_nil project.versions.detect { |v| !v.completed? && v.status == 'open' }
     project.close_completed_versions
     project.reload
-    assert_nil project.versions.detect {|v| v.completed? && v.status != 'closed'}
-    assert_not_nil project.versions.detect {|v| !v.completed? && v.status == 'open'}
+    assert_nil project.versions.detect { |v| v.completed? && v.status != 'closed' }
+    assert_not_nil project.versions.detect { |v| !v.completed? && v.status == 'open' }
   end
 
   def test_export_work_packages_is_allowed
@@ -756,22 +750,22 @@ class ProjectTest < ActiveSupport::TestCase
     assert project.allows_to?(:export_work_packages)
   end
 
-  context "Project#copy" do
+  context 'Project#copy' do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      Project.destroy_all identifier: "copy-test"
+      Project.destroy_all identifier: 'copy-test'
       @source_project = Project.find(2)
       @project = Project.new(name: 'Copy Test', identifier: 'copy-test')
       @project.types = @source_project.types
       @project.enabled_module_names = @source_project.enabled_modules.collect(&:name)
     end
 
-    should "copy work units" do
+    should 'copy work units' do
       @source_project.work_packages << WorkPackage.generate!(status: Status.find_by_name('Closed'),
-                                                    subject: "copy issue status",
-                                                    type_id: 1,
-                                                    assigned_to_id: 2,
-                                                    project_id: @source_project.id)
+                                                             subject: 'copy issue status',
+                                                             type_id: 1,
+                                                             assigned_to_id: 2,
+                                                             project_id: @source_project.id)
       assert @project.valid?
       assert @project.work_packages.empty?
       assert @project.copy(@source_project)
@@ -779,73 +773,73 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal @source_project.work_packages.size, @project.work_packages.size
       @project.work_packages.each do |issue|
         assert issue.valid?
-        assert ! issue.assigned_to.blank?
+        assert !issue.assigned_to.blank?
         assert_equal @project, issue.project
       end
 
-      copied_issue = @project.work_packages.first(conditions: {subject: "copy issue status"})
+      copied_issue = @project.work_packages.first(conditions: { subject: 'copy issue status' })
       assert copied_issue
       assert copied_issue.status
-      assert_equal "Closed", copied_issue.status.name
+      assert_equal 'Closed', copied_issue.status.name
     end
 
-    should "change the new issues to use the copied version" do
+    should 'change the new issues to use the copied version' do
       User.current = User.find(1)
-      assigned_version = Version.generate!(name: "Assigned Issues", status: 'open')
+      assigned_version = Version.generate!(name: 'Assigned Issues', status: 'open')
       @source_project.versions << assigned_version
       assert_equal 3, @source_project.versions.size
       FactoryGirl.create(:work_package, project: @source_project,
-                                  fixed_version_id: assigned_version.id,
-                                  subject: "change the new issues to use the copied version",
-                                  type_id: 1,
-                                  project_id: @source_project.id)
+                                        fixed_version_id: assigned_version.id,
+                                        subject: 'change the new issues to use the copied version',
+                                        type_id: 1,
+                                        project_id: @source_project.id)
 
       assert @project.copy(@source_project)
       @project.reload
-      copied_issue = @project.work_packages.first(conditions: {subject: "change the new issues to use the copied version"})
+      copied_issue = @project.work_packages.first(conditions: { subject: 'change the new issues to use the copied version' })
 
       assert copied_issue
       assert copied_issue.fixed_version
-      assert_equal "Assigned Issues", copied_issue.fixed_version.name # Same name
+      assert_equal 'Assigned Issues', copied_issue.fixed_version.name # Same name
       assert_not_equal assigned_version.id, copied_issue.fixed_version.id # Different record
     end
 
-    should "copy issue relations" do
+    should 'copy issue relations' do
       Setting.cross_project_work_package_relations = '1'
 
       second_issue = WorkPackage.generate!(status_id: 5,
-                                     subject: "copy issue relation",
-                                     type_id: 1,
-                                     assigned_to_id: 2,
-                                     project_id: @source_project.id)
+                                           subject: 'copy issue relation',
+                                           type_id: 1,
+                                           assigned_to_id: 2,
+                                           project_id: @source_project.id)
       source_relation = Relation.generate!(from: WorkPackage.find(4),
-                                                to: second_issue,
-                                                relation_type: "relates")
+                                           to: second_issue,
+                                           relation_type: 'relates')
       source_relation_cross_project = Relation.generate!(from: WorkPackage.find(1),
-                                                              to: second_issue,
-                                                              relation_type: "duplicates")
+                                                         to: second_issue,
+                                                         relation_type: 'duplicates')
 
       assert @project.copy(@source_project)
       assert_equal @source_project.work_packages.count, @project.work_packages.count
-      copied_issue = @project.work_packages.find_by_subject("Issue on project 2") # Was #4
-      copied_second_issue = @project.work_packages.find_by_subject("copy issue relation")
+      copied_issue = @project.work_packages.find_by_subject('Issue on project 2') # Was #4
+      copied_second_issue = @project.work_packages.find_by_subject('copy issue relation')
 
       # First issue with a relation on project
-      assert_equal 1, copied_issue.relations.size, "Relation not copied"
+      assert_equal 1, copied_issue.relations.size, 'Relation not copied'
       copied_relation = copied_issue.relations.first
-      assert_equal "relates", copied_relation.relation_type
+      assert_equal 'relates', copied_relation.relation_type
       assert_equal copied_second_issue.id, copied_relation.to_id
       assert_not_equal source_relation.id, copied_relation.id
 
       # Second issue with a cross project relation
-      assert_equal 2, copied_second_issue.relations.size, "Relation not copied"
-      copied_relation = copied_second_issue.relations.select {|r| r.relation_type == 'duplicates'}.first
-      assert_equal "duplicates", copied_relation.relation_type
-      assert_equal 1, copied_relation.from_id, "Cross project relation not kept"
+      assert_equal 2, copied_second_issue.relations.size, 'Relation not copied'
+      copied_relation = copied_second_issue.relations.select { |r| r.relation_type == 'duplicates' }.first
+      assert_equal 'duplicates', copied_relation.relation_type
+      assert_equal 1, copied_relation.from_id, 'Cross project relation not kept'
       assert_not_equal source_relation_cross_project.id, copied_relation.id
     end
 
-    should "copy memberships" do
+    should 'copy memberships' do
       assert @project.valid?
       assert @project.members.empty?
       assert @project.copy(@source_project)
@@ -857,8 +851,8 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "copy memberships with groups and additional roles" do
-      group = Group.create!(lastname: "Copy group")
+    should 'copy memberships with groups and additional roles' do
+      group = Group.create!(lastname: 'Copy group')
       user = User.find(7)
 
       group.users << user
@@ -880,7 +874,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal [1, 2], member.role_ids.sort
     end
 
-    should "copy project specific queries" do
+    should 'copy project specific queries' do
       assert @project.valid?
       assert @project.queries.empty?
       assert @project.copy(@source_project)
@@ -892,7 +886,7 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "copy versions" do
+    should 'copy versions' do
       @source_project.versions << Version.generate!
       @source_project.versions << Version.generate!
 
@@ -906,17 +900,17 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "copy wiki" do
+    should 'copy wiki' do
       assert_difference 'Wiki.count' do
         assert @project.copy(@source_project)
       end
 
       assert @project.wiki
       assert_not_equal @source_project.wiki, @project.wiki
-      assert_equal "Start page", @project.wiki.start_page
+      assert_equal 'Start page', @project.wiki.start_page
     end
 
-    should "copy wiki pages and content with hierarchy" do
+    should 'copy wiki pages and content with hierarchy' do
       assert_difference 'WikiPage.count', @source_project.wiki.pages.size do
         assert @project.copy(@source_project)
       end
@@ -936,7 +930,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal parent, child2.parent
     end
 
-    should "copy issue categories" do
+    should 'copy issue categories' do
       assert @project.copy(@source_project)
 
       assert_equal 2, @project.categories.size
@@ -945,7 +939,7 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "copy boards" do
+    should 'copy boards' do
       assert @project.copy(@source_project)
 
       assert_equal 1, @project.boards.size
@@ -954,7 +948,7 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "change the new issues to use the copied issue categories" do
+    should 'change the new issues to use the copied issue categories' do
       issue = WorkPackage.find(4)
       issue.update_attribute(:category_id, 3)
 
@@ -962,12 +956,12 @@ class ProjectTest < ActiveSupport::TestCase
 
       @project.work_packages.each do |issue|
         assert issue.category
-        assert_equal "Stock management", issue.category.name # Same name
+        assert_equal 'Stock management', issue.category.name # Same name
         assert_not_equal Category.find(3), issue.category # Different record
       end
     end
 
-    should "limit copy with :only option" do
+    should 'limit copy with :only option' do
       assert @project.members.empty?
       assert @project.categories.empty?
       assert @source_project.work_packages.any?
@@ -978,21 +972,20 @@ class ProjectTest < ActiveSupport::TestCase
       assert @project.categories.any?
       assert @project.work_packages.empty?
     end
-
   end
 
-  context "#start_date" do
+  context '#start_date' do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
       @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
-    should "be nil if there are no issues on the project" do
+    should 'be nil if there are no issues on the project' do
       assert_nil @project.start_date
     end
 
-    should "be tested when issues have no start date"
+    should 'be tested when issues have no start date'
 
     should "be the earliest start date of it's issues" do
       early = 7.days.ago.to_date
@@ -1001,21 +994,20 @@ class ProjectTest < ActiveSupport::TestCase
 
       assert_equal early, @project.start_date
     end
-
   end
 
-  context "#due_date" do
+  context '#due_date' do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
       @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
-    should "be nil if there are no issues on the project" do
+    should 'be nil if there are no issues on the project' do
       assert_nil @project.due_date
     end
 
-    should "be tested when issues have no due date"
+    should 'be tested when issues have no due date'
 
     should "be the latest due date of it's issues" do
       future = 7.days.from_now.to_date
@@ -1030,9 +1022,7 @@ class ProjectTest < ActiveSupport::TestCase
       @project.versions << Version.generate!(effective_date: future)
       @project.versions << Version.generate!(effective_date: Date.today)
 
-
       assert_equal future, @project.due_date
-
     end
 
     should "pick the latest date from it's issues and versions" do
@@ -1043,31 +1033,30 @@ class ProjectTest < ActiveSupport::TestCase
 
       assert_equal far_future, @project.due_date
     end
-
   end
 
-  context "Project#completed_percent" do
+  context 'Project#completed_percent' do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
       @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
     end
 
-    context "no versions" do
-      should "be 100" do
+    context 'no versions' do
+      should 'be 100' do
         assert_equal 100, @project.completed_percent
       end
     end
 
-    context "with versions" do
-      should "return 0 if the versions have no issues" do
+    context 'with versions' do
+      should 'return 0 if the versions have no issues' do
         Version.generate!(project: @project)
         Version.generate!(project: @project)
 
         assert_equal 0, @project.completed_percent
       end
 
-      should "return 100 if the version has only closed issues" do
+      should 'return 100 if the version has only closed issues' do
         v1 = Version.generate!(project: @project)
         FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v1)
         v2 = Version.generate!(project: @project)
@@ -1076,7 +1065,7 @@ class ProjectTest < ActiveSupport::TestCase
         assert_equal 100, @project.completed_percent
       end
 
-      should "return the averaged completed percent of the versions (not weighted)" do
+      should 'return the averaged completed percent of the versions (not weighted)' do
         v1 = Version.generate!(project: @project)
         FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v1)
         v2 = Version.generate!(project: @project)
@@ -1084,11 +1073,10 @@ class ProjectTest < ActiveSupport::TestCase
 
         assert_equal 50, @project.completed_percent
       end
-
     end
   end
 
-  context "#notified_users" do
+  context '#notified_users' do
     setup do
       @project = Project.generate!
       @role = Role.generate!
@@ -1124,7 +1112,7 @@ class ProjectTest < ActiveSupport::TestCase
       end
     end
 
-    should "include members with a mail notification" do
+    should 'include members with a mail notification' do
       assert @project.notified_users.include?(@user_with_membership_notification)
     end
 
@@ -1148,5 +1136,4 @@ class ProjectTest < ActiveSupport::TestCase
       assert !@project.notified_users.include?(@only_owned_user)
     end
   end
-
 end

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -41,23 +41,23 @@ class QueryTest < ActiveSupport::TestCase
     Version.find(2).update_attribute :sharing, 'system'
     query = Query.new(project: nil, name: '_')
     assert query.work_package_filter_available?('fixed_version_id')
-    assert query.available_work_package_filters['fixed_version_id'][:values].detect {|v| v.last == '2'}
+    assert query.available_work_package_filters['fixed_version_id'][:values].detect { |v| v.last == '2' }
   end
 
   def test_project_filter_in_global_queries
     # User.current should be anonymous here
     query = Query.new(project: nil, name: '_')
-    project_filter = query.available_work_package_filters["project_id"]
+    project_filter = query.available_work_package_filters['project_id']
     assert_not_nil project_filter
-    project_ids = project_filter[:values].map{|p| p[1]}
-    assert project_ids.include?("1")  #public project
-    assert !project_ids.include?("2") #private project anonymous user cannot see
+    project_ids = project_filter[:values].map { |p| p[1] }
+    assert project_ids.include?('1')  # public project
+    assert !project_ids.include?('2') # private project anonymous user cannot see
   end
 
   def find_issues_with_query(query)
     WorkPackage.find :all,
-      include: [ :assigned_to, :status, :type, :project, :priority ],
-      conditions: query.statement
+                     include: [:assigned_to, :status, :type, :project, :priority],
+                     conditions: query.statement
   end
 
   def assert_find_issues_with_query_is_successful(query)
@@ -101,7 +101,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('estimated_hours', '!*', [''])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    assert issues.all? {|i| !i.estimated_hours}
+    assert issues.all? { |i| !i.estimated_hours }
   end
 
   def test_operator_all
@@ -126,7 +126,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', '>t+', ['15'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert(issue.due_date >= (Date.today + 15))}
+    issues.each { |issue| assert(issue.due_date >= (Date.today + 15)) }
   end
 
   def test_operator_in_less_than
@@ -134,7 +134,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', '<t+', ['15'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert(issue.due_date >= Date.today && issue.due_date <= (Date.today + 15))}
+    issues.each { |issue| assert(issue.due_date >= Date.today && issue.due_date <= (Date.today + 15)) }
   end
 
   def test_operator_less_than_ago
@@ -143,7 +143,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', '>t-', ['3'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert(issue.due_date >= (Date.today - 3) && issue.due_date <= Date.today)}
+    issues.each { |issue| assert(issue.due_date >= (Date.today - 3) && issue.due_date <= Date.today) }
   end
 
   def test_operator_more_than_ago
@@ -153,7 +153,7 @@ class QueryTest < ActiveSupport::TestCase
     assert query.statement.include?("#{WorkPackage.table_name}.due_date <=")
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert(issue.due_date <= (Date.today - 10))}
+    issues.each { |issue| assert(issue.due_date <= (Date.today - 10)) }
   end
 
   def test_operator_in
@@ -162,7 +162,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', 't+', ['2'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert_equal((Date.today + 2), issue.due_date)}
+    issues.each { |issue| assert_equal((Date.today + 2), issue.due_date) }
   end
 
   def test_operator_ago
@@ -171,7 +171,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', 't-', ['3'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert_equal((Date.today - 3), issue.due_date)}
+    issues.each { |issue| assert_equal((Date.today - 3), issue.due_date) }
   end
 
   def test_operator_today
@@ -179,7 +179,7 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('due_date', 't', [''])
     issues = find_issues_with_query(query)
     assert !issues.empty?
-    issues.each {|issue| assert_equal Date.today, issue.due_date}
+    issues.each { |issue| assert_equal Date.today, issue.due_date }
   end
 
   def test_operator_this_week_on_date
@@ -200,7 +200,7 @@ class QueryTest < ActiveSupport::TestCase
     assert query.statement.include?("LOWER(#{WorkPackage.table_name}.subject) LIKE '%unable%'")
     result = find_issues_with_query(query)
     assert result.empty?
-    result.each {|issue| assert issue.subject.downcase.include?('unable') }
+    result.each { |issue| assert issue.subject.downcase.include?('unable') }
   end
 
   def test_operator_does_not_contains
@@ -222,7 +222,7 @@ class QueryTest < ActiveSupport::TestCase
 
     query = Query.new(name: '_', filters: [Queries::WorkPackages::Filter.new(:assigned_to_id, operator: '=', values: ['me'])])
     result = query.results.work_packages
-    assert_equal WorkPackage.visible.all(conditions: {assigned_to_id: ([2] + user.reload.group_ids)}).sort_by(&:id), result.sort_by(&:id)
+    assert_equal WorkPackage.visible.all(conditions: { assigned_to_id: ([2] + user.reload.group_ids) }).sort_by(&:id), result.sort_by(&:id)
 
     assert result.include?(i1)
     assert result.include?(i2)
@@ -259,14 +259,14 @@ class QueryTest < ActiveSupport::TestCase
   def test_set_column_names
     q = Query.new name: '_'
     q.column_names = ['type', :subject, '', 'unknonw_column']
-    assert_equal [:type, :subject], q.columns.collect {|c| c.name}
+    assert_equal [:type, :subject], q.columns.collect(&:name)
     c = q.columns.first
     assert q.has_column?(c)
   end
 
   def test_groupable_columns_should_include_custom_fields
     q = Query.new name: '_'
-    assert q.groupable_columns.detect {|c| c.is_a? QueryCustomFieldColumn}
+    assert q.groupable_columns.detect { |c| c.is_a? QueryCustomFieldColumn }
   end
 
   def test_grouped_with_valid_column
@@ -292,7 +292,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_set_sort_criteria_with_hash
     q = Query.new name: '_'
-    q.sort_criteria = {'0' => ['priority', 'desc'], '2' => ['type']}
+    q.sort_criteria = { '0' => ['priority', 'desc'], '2' => ['type'] }
     assert_equal [['priority', 'desc'], ['type', 'asc']], q.sort_criteria
   end
 
@@ -303,7 +303,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_create_query_with_sort
-    q = Query.new({name: 'Sorted'}, initialize_with_default_filter: true)
+    q = Query.new({ name: 'Sorted' }, initialize_with_default_filter: true)
     q.sort_criteria = [['priority', 'desc'], 'type']
     assert q.save
     q.reload
@@ -312,42 +312,42 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_sort_by_string_custom_field_asc
     q = Query.new name: '_'
-    c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
+    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        include: [ :assigned_to, :status, :type, :project, :priority ],
-                        conditions: q.statement,
-                        order: "#{c.sortable} ASC"
-    values = issues.collect {|i| i.custom_value_for(c.custom_field).to_s}
+                              include: [:assigned_to, :status, :type, :project, :priority],
+                              conditions: q.statement,
+                              order: "#{c.sortable} ASC"
+    values = issues.collect { |i| i.custom_value_for(c.custom_field).to_s }
     assert !values.empty?
     assert_equal values.sort, values
   end
 
   def test_sort_by_string_custom_field_desc
     q = Query.new name: '_'
-    c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
+    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        include: [ :assigned_to, :status, :type, :project, :priority ],
-                        conditions: q.statement,
-                        order: "#{c.sortable} DESC"
-    values = issues.collect {|i| i.custom_value_for(c.custom_field).to_s}
+                              include: [:assigned_to, :status, :type, :project, :priority],
+                              conditions: q.statement,
+                              order: "#{c.sortable} DESC"
+    values = issues.collect { |i| i.custom_value_for(c.custom_field).to_s }
     assert !values.empty?
     assert_equal values.sort.reverse, values
   end
 
   def test_sort_by_float_custom_field_asc
     q = Query.new name: '_'
-    c = q.available_columns.find {|col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
+    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        include: [ :assigned_to, :status, :type, :project, :priority ],
-                        conditions: q.statement,
-                        order: "#{c.sortable} ASC"
-    values = issues.collect {|i| begin; Kernel.Float(i.custom_value_for(c.custom_field).to_s); rescue; nil; end}.compact
+                              include: [:assigned_to, :status, :type, :project, :priority],
+                              conditions: q.statement,
+                              order: "#{c.sortable} ASC"
+    values = issues.collect { |i| begin; Kernel.Float(i.custom_value_for(c.custom_field).to_s); rescue; nil; end }.compact
     assert !values.empty?
     assert_equal values.sort, values
   end
@@ -355,7 +355,7 @@ class QueryTest < ActiveSupport::TestCase
   def test_invalid_query_should_raise_query_statement_invalid_error
     q = Query.new name: '_'
     assert_raise ActiveRecord::StatementInvalid do
-      q.results(conditions: "foo = 1").work_packages.all
+      q.results(conditions: 'foo = 1').work_packages.all
     end
   end
 
@@ -363,8 +363,8 @@ class QueryTest < ActiveSupport::TestCase
     q = Query.new(name: '_', group_by: 'assigned_to')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
-    assert_equal %w(NilClass User), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
-    assert_equal %w(Fixnum), count_by_group.values.collect {|k| k.class.name}.uniq
+    assert_equal %w(NilClass User), count_by_group.keys.collect { |k| k.class.name }.uniq.sort
+    assert_equal %w(Fixnum), count_by_group.values.collect { |k| k.class.name }.uniq
     assert count_by_group.has_key?(User.find(3))
   end
 
@@ -372,8 +372,8 @@ class QueryTest < ActiveSupport::TestCase
     q = Query.new(name: '_', group_by: 'cf_1')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
-    assert_equal %w(NilClass String), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
-    assert_equal %w(Fixnum), count_by_group.values.collect {|k| k.class.name}.uniq
+    assert_equal %w(NilClass String), count_by_group.keys.collect { |k| k.class.name }.uniq.sort
+    assert_equal %w(Fixnum), count_by_group.values.collect { |k| k.class.name }.uniq
     assert count_by_group.has_key?('MySQL')
   end
 
@@ -381,13 +381,13 @@ class QueryTest < ActiveSupport::TestCase
     q = Query.new(name: '_', group_by: 'cf_8')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
-    assert_equal %w(Date NilClass), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
-    assert_equal %w(Fixnum), count_by_group.values.collect {|k| k.class.name}.uniq
+    assert_equal %w(Date NilClass), count_by_group.keys.collect { |k| k.class.name }.uniq.sort
+    assert_equal %w(Fixnum), count_by_group.values.collect { |k| k.class.name }.uniq
   end
 
   def test_label_for
     q = Query.new name: '_'
-    assert_equal WorkPackage.human_attribute_name("assigned_to_id"), q.label_for('assigned_to_id')
+    assert_equal WorkPackage.human_attribute_name('assigned_to_id'), q.label_for('assigned_to_id')
   end
 
   def test_editable_by
@@ -420,77 +420,75 @@ class QueryTest < ActiveSupport::TestCase
     assert !q.editable_by?(developer)
   end
 
-  context "#available_work_package_filters" do
+  context '#available_work_package_filters' do
     setup do
-      @query = Query.new(name: "_")
+      @query = Query.new(name: '_')
     end
 
-    should "include users of visible projects in cross-project view" do
-      users = @query.available_work_package_filters["assigned_to_id"]
+    should 'include users of visible projects in cross-project view' do
+      users = @query.available_work_package_filters['assigned_to_id']
       assert_not_nil users
-      assert users[:values].map{|u|u[1]}.include?("3")
+      assert users[:values].map { |u|u[1] }.include?('3')
     end
 
-    should "include visible projects in cross-project view" do
-      projects = @query.available_work_package_filters["project_id"]
+    should 'include visible projects in cross-project view' do
+      projects = @query.available_work_package_filters['project_id']
       assert_not_nil projects
-      assert projects[:values].map{|u|u[1]}.include?("1")
+      assert projects[:values].map { |u|u[1] }.include?('1')
     end
 
     context "'member_of_group' filter" do
-      should "be present" do
-        assert @query.available_work_package_filters.keys.include?("member_of_group")
+      should 'be present' do
+        assert @query.available_work_package_filters.keys.include?('member_of_group')
       end
 
-      should "be an optional list" do
-        assert_equal :list_optional, @query.available_work_package_filters["member_of_group"][:type]
+      should 'be an optional list' do
+        assert_equal :list_optional, @query.available_work_package_filters['member_of_group'][:type]
       end
 
-      should "have a list of the groups as values" do
+      should 'have a list of the groups as values' do
         Group.destroy_all # No fixtures
         group1 = Group.generate!.reload
         group2 = Group.generate!.reload
 
         expected_group_list = [
-                               [group1.name, group1.id.to_s],
-                               [group2.name, group2.id.to_s]
-                              ]
-        assert_equal expected_group_list.sort, @query.available_work_package_filters["member_of_group"][:values].sort
+          [group1.name, group1.id.to_s],
+          [group2.name, group2.id.to_s]
+        ]
+        assert_equal expected_group_list.sort, @query.available_work_package_filters['member_of_group'][:values].sort
       end
-
     end
 
     context "'assigned_to_role' filter" do
-      should "be present" do
-        assert @query.available_work_package_filters.keys.include?("assigned_to_role")
+      should 'be present' do
+        assert @query.available_work_package_filters.keys.include?('assigned_to_role')
       end
 
-      should "be an optional list" do
-        assert_equal :list_optional, @query.available_work_package_filters["assigned_to_role"][:type]
+      should 'be an optional list' do
+        assert_equal :list_optional, @query.available_work_package_filters['assigned_to_role'][:type]
       end
 
-      should "have a list of the Roles as values" do
-        assert @query.available_work_package_filters["assigned_to_role"][:values].include?(['Manager','1'])
-        assert @query.available_work_package_filters["assigned_to_role"][:values].include?(['Developer','2'])
-        assert @query.available_work_package_filters["assigned_to_role"][:values].include?(['Reporter','3'])
+      should 'have a list of the Roles as values' do
+        assert @query.available_work_package_filters['assigned_to_role'][:values].include?(['Manager', '1'])
+        assert @query.available_work_package_filters['assigned_to_role'][:values].include?(['Developer', '2'])
+        assert @query.available_work_package_filters['assigned_to_role'][:values].include?(['Reporter', '3'])
       end
 
-      should "not include the built in Roles as values" do
-        assert ! @query.available_work_package_filters["assigned_to_role"][:values].include?(['Non member','4'])
-        assert ! @query.available_work_package_filters["assigned_to_role"][:values].include?(['Anonymous','5'])
+      should 'not include the built in Roles as values' do
+        assert ! @query.available_work_package_filters['assigned_to_role'][:values].include?(['Non member', '4'])
+        assert ! @query.available_work_package_filters['assigned_to_role'][:values].include?(['Anonymous', '5'])
       end
-
     end
 
     context "'watcher_id' filter" do
-      context "globally" do
-        context "for an anonymous user" do
-          should "not be present" do
-            assert ! @query.available_work_package_filters.keys.include?("watcher_id")
+      context 'globally' do
+        context 'for an anonymous user' do
+          should 'not be present' do
+            assert ! @query.available_work_package_filters.keys.include?('watcher_id')
           end
         end
 
-        context "for a logged in user" do
+        context 'for a logged in user' do
           setup do
             User.current = User.find 1
           end
@@ -499,48 +497,48 @@ class QueryTest < ActiveSupport::TestCase
             User.current = nil
           end
 
-          should "be present" do
-            assert @query.available_work_package_filters.keys.include?("watcher_id")
+          should 'be present' do
+            assert @query.available_work_package_filters.keys.include?('watcher_id')
           end
 
-          should "be a list" do
-            assert_equal :list, @query.available_work_package_filters["watcher_id"][:type]
+          should 'be a list' do
+            assert_equal :list, @query.available_work_package_filters['watcher_id'][:type]
           end
 
-          should "have a list of active users as values" do
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["<< me >>", "me"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["John Smith", "2"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["Dave Lopper", "3"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["redMine Admin", "1"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["User Misc", "8"])
+          should 'have a list of active users as values' do
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['<< me >>', 'me'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['John Smith', '2'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['Dave Lopper', '3'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['redMine Admin', '1'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['User Misc', '8'])
           end
 
-          should "not include active users not member of any project" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(['Robert Hill','4'])
+          should 'not include active users not member of any project' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['Robert Hill', '4'])
           end
 
-          should "not include locked users as values" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(['Dave2 Lopper2','5'])
+          should 'not include locked users as values' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['Dave2 Lopper2', '5'])
           end
 
-          should "not include the anonymous user as values" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(['Anonymous','6'])
+          should 'not include the anonymous user as values' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['Anonymous', '6'])
           end
         end
       end
 
-      context "in a project" do
+      context 'in a project' do
         setup do
           @query.project = Project.find(1)
         end
 
-        context "for an anonymous user" do
-          should "not be present" do
-            assert ! @query.available_work_package_filters.keys.include?("watcher_id")
+        context 'for an anonymous user' do
+          should 'not be present' do
+            assert ! @query.available_work_package_filters.keys.include?('watcher_id')
           end
         end
 
-        context "for a logged in user" do
+        context 'for a logged in user' do
           setup do
             User.current = User.find 1
           end
@@ -549,37 +547,37 @@ class QueryTest < ActiveSupport::TestCase
             User.current = nil
           end
 
-          should "be present" do
-            assert @query.available_work_package_filters.keys.include?("watcher_id")
+          should 'be present' do
+            assert @query.available_work_package_filters.keys.include?('watcher_id')
           end
 
-          should "be a list" do
-            assert_equal :list, @query.available_work_package_filters["watcher_id"][:type]
+          should 'be a list' do
+            assert_equal :list, @query.available_work_package_filters['watcher_id'][:type]
           end
 
-          should "have a list of the project members as values" do
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["<< me >>", "me"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["John Smith", "2"])
-            assert @query.available_work_package_filters["watcher_id"][:values].include?(["Dave Lopper", "3"])
+          should 'have a list of the project members as values' do
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['<< me >>', 'me'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['John Smith', '2'])
+            assert @query.available_work_package_filters['watcher_id'][:values].include?(['Dave Lopper', '3'])
           end
 
-          should "not include non-project members as values" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(["redMine Admin", "1"])
+          should 'not include non-project members as values' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['redMine Admin', '1'])
           end
 
-          should "not include locked project members as values" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(['Dave2 Lopper2','5'])
+          should 'not include locked project members as values' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['Dave2 Lopper2', '5'])
           end
 
-          should "not include the anonymous user as values" do
-            assert ! @query.available_work_package_filters["watcher_id"][:values].include?(['Anonymous','6'])
+          should 'not include the anonymous user as values' do
+            assert ! @query.available_work_package_filters['watcher_id'][:values].include?(['Anonymous', '6'])
           end
         end
       end
     end
   end
 
-  context "#statement" do
+  context '#statement' do
     context "with 'member_of_group' filter" do
       setup do
         Group.destroy_all # No fixtures
@@ -598,7 +596,7 @@ class QueryTest < ActiveSupport::TestCase
         @empty_group = Group.generate!.reload
       end
 
-      should "search assigned to for users in the group" do
+      should 'search assigned to for users in the group' do
         @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '=', [@group.id.to_s])
 
@@ -606,7 +604,7 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "search not assigned to any group member (none)" do
+      should 'search not assigned to any group member (none)' do
         @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '!*', [''])
 
@@ -615,7 +613,7 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "search assigned to any group member (all)" do
+      should 'search assigned to any group member (all)' do
         @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '*', [''])
 
@@ -624,19 +622,19 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "return no results on empty set" do
+      should 'return no results on empty set' do
         @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '=', [@empty_group.id.to_s])
 
-        assert_query_statement_includes @query, "(0=1)"
+        assert_query_statement_includes @query, '(0=1)'
         assert find_issues_with_query(@query).empty?
       end
 
-      should "return results on disallowed empty set" do
+      should 'return results on disallowed empty set' do
         @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '!', [@empty_group.id.to_s])
 
-        assert_query_statement_includes @query, "(1=1)"
+        assert_query_statement_includes @query, '(1=1)'
         assert_find_issues_with_query_is_successful @query
       end
     end
@@ -661,7 +659,7 @@ class QueryTest < ActiveSupport::TestCase
         User.add_to_project(@boss, @project, [@manager_role, @developer_role])
       end
 
-      should "search assigned to for users with the Role" do
+      should 'search assigned to for users with the Role' do
         @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '=', [@manager_role.id.to_s])
 
@@ -669,7 +667,7 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "search assigned to for users not assigned to any Role (none)" do
+      should 'search assigned to for users not assigned to any Role (none)' do
         @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '!*', [''])
 
@@ -677,7 +675,7 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "search assigned to for users assigned to any Role (all)" do
+      should 'search assigned to for users assigned to any Role (all)' do
         @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '*', [''])
 
@@ -685,19 +683,19 @@ class QueryTest < ActiveSupport::TestCase
         assert_find_issues_with_query_is_successful @query
       end
 
-      should "return no results on empty set" do
+      should 'return no results on empty set' do
         @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '=', [@empty_role.id.to_s])
 
-        assert_query_statement_includes @query, "(0=1)"
+        assert_query_statement_includes @query, '(0=1)'
         assert find_issues_with_query(@query).empty?
       end
 
-      should "return results on disallowed empty set" do
+      should 'return results on disallowed empty set' do
         @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '!', [@empty_role.id.to_s])
 
-        assert_query_statement_includes @query, "(1=1)"
+        assert_query_statement_includes @query, '(1=1)'
         assert_find_issues_with_query_is_successful @query
       end
     end

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -32,21 +32,21 @@ class QueryTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_custom_fields_for_all_projects_should_be_available_in_global_queries
-    query = Query.new(:project => nil, :name => '_')
+    query = Query.new(project: nil, name: '_')
     assert query.work_package_filter_available?('cf_1')
     assert !query.work_package_filter_available?('cf_3')
   end
 
   def test_system_shared_versions_should_be_available_in_global_queries
     Version.find(2).update_attribute :sharing, 'system'
-    query = Query.new(:project => nil, :name => '_')
+    query = Query.new(project: nil, name: '_')
     assert query.work_package_filter_available?('fixed_version_id')
     assert query.available_work_package_filters['fixed_version_id'][:values].detect {|v| v.last == '2'}
   end
 
   def test_project_filter_in_global_queries
     # User.current should be anonymous here
-    query = Query.new(:project => nil, :name => '_')
+    query = Query.new(project: nil, name: '_')
     project_filter = query.available_work_package_filters["project_id"]
     assert_not_nil project_filter
     project_ids = project_filter[:values].map{|p| p[1]}
@@ -56,8 +56,8 @@ class QueryTest < ActiveSupport::TestCase
 
   def find_issues_with_query(query)
     WorkPackage.find :all,
-      :include => [ :assigned_to, :status, :type, :project, :priority ],
-      :conditions => query.statement
+      include: [ :assigned_to, :status, :type, :project, :priority ],
+      conditions: query.statement
   end
 
   def assert_find_issues_with_query_is_successful(query)
@@ -72,7 +72,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_query_should_allow_shared_versions_for_a_project_query
     subproject_version = Version.find(4)
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('fixed_version_id', '=', [subproject_version.id.to_s])
 
     assert query.statement.include?("#{WorkPackage.table_name}.fixed_version_id IN ('4')")
@@ -88,7 +88,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_none
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('fixed_version_id', '!*', [''])
     query.add_filter('cf_1', '!*', [''])
     assert query.statement.include?("#{WorkPackage.table_name}.fixed_version_id IS NULL")
@@ -97,7 +97,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_none_for_integer
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('estimated_hours', '!*', [''])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -105,7 +105,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_all
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('fixed_version_id', '*', [''])
     query.add_filter('cf_1', '*', [''])
     assert query.statement.include?("#{WorkPackage.table_name}.fixed_version_id IS NOT NULL")
@@ -114,7 +114,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_greater_than
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('done_ratio', '>=', ['40'])
     assert query.statement.include?("#{WorkPackage.table_name}.done_ratio >= 40")
     find_issues_with_query(query)
@@ -122,7 +122,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_in_more_than
     WorkPackage.find(7).update_attribute(:due_date, (Date.today + 15))
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', '>t+', ['15'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -130,7 +130,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_in_less_than
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', '<t+', ['15'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -139,7 +139,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_less_than_ago
     WorkPackage.find(7).update_attribute(:due_date, (Date.today - 3))
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', '>t-', ['3'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -148,7 +148,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_more_than_ago
     WorkPackage.find(7).update_attribute(:due_date, (Date.today - 10))
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', '<t-', ['10'])
     assert query.statement.include?("#{WorkPackage.table_name}.due_date <=")
     issues = find_issues_with_query(query)
@@ -158,7 +158,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_in
     WorkPackage.find(7).update_attribute(:due_date, (Date.today + 2))
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', 't+', ['2'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -167,7 +167,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_ago
     WorkPackage.find(7).update_attribute(:due_date, (Date.today - 3))
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', 't-', ['3'])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -175,7 +175,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_today
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', 't', [''])
     issues = find_issues_with_query(query)
     assert !issues.empty?
@@ -183,19 +183,19 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_this_week_on_date
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('due_date', 'w', [''])
     find_issues_with_query(query)
   end
 
   def test_operator_this_week_on_datetime
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('created_on', 'w', [''])
     find_issues_with_query(query)
   end
 
   def test_operator_contains
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('subject', '~', ['uNable'])
     assert query.statement.include?("LOWER(#{WorkPackage.table_name}.subject) LIKE '%unable%'")
     result = find_issues_with_query(query)
@@ -204,7 +204,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_operator_does_not_contains
-    query = Query.new(:project => Project.find(1), :name => '_')
+    query = Query.new(project: Project.find(1), name: '_')
     query.add_filter('subject', '!~', ['uNable'])
     assert query.statement.include?("LOWER(#{WorkPackage.table_name}.subject) NOT LIKE '%unable%'")
     find_issues_with_query(query)
@@ -215,14 +215,14 @@ class QueryTest < ActiveSupport::TestCase
     group = Group.find(10)
     project = Project.find(1)
     User.current = user
-    i1 = FactoryGirl.create(:work_package, :project => project, :type => project.types.first, :assigned_to => user)
-    i2 = FactoryGirl.create(:work_package, :project => project, :type => project.types.first, :assigned_to => group)
-    i3 = FactoryGirl.create(:work_package, :project => project, :type => project.types.first, :assigned_to => Group.find(11))
+    i1 = FactoryGirl.create(:work_package, project: project, type: project.types.first, assigned_to: user)
+    i2 = FactoryGirl.create(:work_package, project: project, type: project.types.first, assigned_to: group)
+    i3 = FactoryGirl.create(:work_package, project: project, type: project.types.first, assigned_to: Group.find(11))
     group.users << user
 
-    query = Query.new(:name => '_', filters: [Queries::WorkPackages::Filter.new(:assigned_to_id, operator: '=', values: ['me'])])
+    query = Query.new(name: '_', filters: [Queries::WorkPackages::Filter.new(:assigned_to_id, operator: '=', values: ['me'])])
     result = query.results.work_packages
-    assert_equal WorkPackage.visible.all(:conditions => {:assigned_to_id => ([2] + user.reload.group_ids)}).sort_by(&:id), result.sort_by(&:id)
+    assert_equal WorkPackage.visible.all(conditions: {assigned_to_id: ([2] + user.reload.group_ids)}).sort_by(&:id), result.sort_by(&:id)
 
     assert result.include?(i1)
     assert result.include?(i2)
@@ -270,7 +270,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_grouped_with_valid_column
-    q = Query.new(:group_by => 'status', :name => '_')
+    q = Query.new(group_by: 'status', name: '_')
     assert q.grouped?
     assert_not_nil q.group_by_column
     assert_equal :status, q.group_by_column.name
@@ -279,7 +279,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_grouped_with_invalid_column
-    q = Query.new(:group_by => 'foo', :name => '_')
+    q = Query.new(group_by: 'foo', name: '_')
     assert !q.grouped?
     assert_nil q.group_by_column
     assert_nil q.group_by_statement
@@ -316,9 +316,9 @@ class QueryTest < ActiveSupport::TestCase
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        :include => [ :assigned_to, :status, :type, :project, :priority ],
-                        :conditions => q.statement,
-                        :order => "#{c.sortable} ASC"
+                        include: [ :assigned_to, :status, :type, :project, :priority ],
+                        conditions: q.statement,
+                        order: "#{c.sortable} ASC"
     values = issues.collect {|i| i.custom_value_for(c.custom_field).to_s}
     assert !values.empty?
     assert_equal values.sort, values
@@ -330,9 +330,9 @@ class QueryTest < ActiveSupport::TestCase
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        :include => [ :assigned_to, :status, :type, :project, :priority ],
-                        :conditions => q.statement,
-                        :order => "#{c.sortable} DESC"
+                        include: [ :assigned_to, :status, :type, :project, :priority ],
+                        conditions: q.statement,
+                        order: "#{c.sortable} DESC"
     values = issues.collect {|i| i.custom_value_for(c.custom_field).to_s}
     assert !values.empty?
     assert_equal values.sort.reverse, values
@@ -344,9 +344,9 @@ class QueryTest < ActiveSupport::TestCase
     assert c
     assert c.sortable
     issues = WorkPackage.find :all,
-                        :include => [ :assigned_to, :status, :type, :project, :priority ],
-                        :conditions => q.statement,
-                        :order => "#{c.sortable} ASC"
+                        include: [ :assigned_to, :status, :type, :project, :priority ],
+                        conditions: q.statement,
+                        order: "#{c.sortable} ASC"
     values = issues.collect {|i| begin; Kernel.Float(i.custom_value_for(c.custom_field).to_s); rescue; nil; end}.compact
     assert !values.empty?
     assert_equal values.sort, values
@@ -355,12 +355,12 @@ class QueryTest < ActiveSupport::TestCase
   def test_invalid_query_should_raise_query_statement_invalid_error
     q = Query.new name: '_'
     assert_raise ActiveRecord::StatementInvalid do
-      q.results(:conditions => "foo = 1").work_packages.all
+      q.results(conditions: "foo = 1").work_packages.all
     end
   end
 
   def test_issue_count_by_association_group
-    q = Query.new(:name => '_', :group_by => 'assigned_to')
+    q = Query.new(name: '_', group_by: 'assigned_to')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     assert_equal %w(NilClass User), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
@@ -369,7 +369,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_issue_count_by_list_custom_field_group
-    q = Query.new(:name => '_', :group_by => 'cf_1')
+    q = Query.new(name: '_', group_by: 'cf_1')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     assert_equal %w(NilClass String), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
@@ -378,7 +378,7 @@ class QueryTest < ActiveSupport::TestCase
   end
 
   def test_issue_count_by_date_custom_field_group
-    q = Query.new(:name => '_', :group_by => 'cf_8')
+    q = Query.new(name: '_', group_by: 'cf_8')
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     assert_equal %w(Date NilClass), count_by_group.keys.collect {|k| k.class.name}.uniq.sort
@@ -422,7 +422,7 @@ class QueryTest < ActiveSupport::TestCase
 
   context "#available_work_package_filters" do
     setup do
-      @query = Query.new(:name => "_")
+      @query = Query.new(name: "_")
     end
 
     should "include users of visible projects in cross-project view" do
@@ -599,7 +599,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search assigned to for users in the group" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '=', [@group.id.to_s])
 
         assert_query_statement_includes @query, "#{WorkPackage.table_name}.assigned_to_id IN ('#{@user_in_group.id}','#{@second_user_in_group.id}')"
@@ -607,7 +607,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search not assigned to any group member (none)" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '!*', [''])
 
         # Users not in a group
@@ -616,7 +616,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search assigned to any group member (all)" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '*', [''])
 
         # Only users in a group
@@ -625,7 +625,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "return no results on empty set" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '=', [@empty_group.id.to_s])
 
         assert_query_statement_includes @query, "(0=1)"
@@ -633,7 +633,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "return results on disallowed empty set" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('member_of_group', '!', [@empty_group.id.to_s])
 
         assert_query_statement_includes @query, "(1=1)"
@@ -648,9 +648,9 @@ class QueryTest < ActiveSupport::TestCase
         Member.delete_all
         Role.delete_all
 
-        @manager_role = Role.generate!(:name => 'Manager')
-        @developer_role = Role.generate!(:name => 'Developer')
-        @empty_role = Role.generate!(:name => 'Empty')
+        @manager_role = Role.generate!(name: 'Manager')
+        @developer_role = Role.generate!(name: 'Developer')
+        @empty_role = Role.generate!(name: 'Empty')
 
         @project = Project.generate!
         @manager = User.generate!
@@ -662,7 +662,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search assigned to for users with the Role" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '=', [@manager_role.id.to_s])
 
         assert_query_statement_includes @query, "#{WorkPackage.table_name}.assigned_to_id IN ('#{@manager.id}','#{@boss.id}')"
@@ -670,7 +670,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search assigned to for users not assigned to any Role (none)" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '!*', [''])
 
         assert_query_statement_includes @query, "#{WorkPackage.table_name}.assigned_to_id IS NULL OR #{WorkPackage.table_name}.assigned_to_id NOT IN ('#{@manager.id}','#{@developer.id}','#{@boss.id}')"
@@ -678,7 +678,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "search assigned to for users assigned to any Role (all)" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '*', [''])
 
         assert_query_statement_includes @query, "#{WorkPackage.table_name}.assigned_to_id IN ('#{@manager.id}','#{@developer.id}','#{@boss.id}')"
@@ -686,7 +686,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "return no results on empty set" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '=', [@empty_role.id.to_s])
 
         assert_query_statement_includes @query, "(0=1)"
@@ -694,7 +694,7 @@ class QueryTest < ActiveSupport::TestCase
       end
 
       should "return results on disallowed empty set" do
-        @query = Query.new(:name => '_')
+        @query = Query.new(name: '_')
         @query.add_filter('assigned_to_role', '!', [@empty_role.id.to_s])
 
         assert_query_statement_includes @query, "(1=1)"

--- a/test/unit/relation_test.rb
+++ b/test/unit/relation_test.rb
@@ -37,7 +37,7 @@ class RelationTest < ActiveSupport::TestCase
     from = WorkPackage.find(1)
     to = WorkPackage.find(2)
 
-    relation = Relation.new :from => from, :to => to, :relation_type => Relation::TYPE_PRECEDES
+    relation = Relation.new from: from, to: to, relation_type: Relation::TYPE_PRECEDES
     assert relation.save
     relation.reload
     assert_equal Relation::TYPE_PRECEDES, relation.relation_type
@@ -49,7 +49,7 @@ class RelationTest < ActiveSupport::TestCase
     from = WorkPackage.find(1)
     to = WorkPackage.find(2)
 
-    relation = Relation.new :from => from, :to => to, :relation_type => Relation::TYPE_FOLLOWS
+    relation = Relation.new from: from, to: to, relation_type: Relation::TYPE_FOLLOWS
     assert relation.save
     relation.reload
     assert_equal Relation::TYPE_PRECEDES, relation.relation_type
@@ -61,7 +61,7 @@ class RelationTest < ActiveSupport::TestCase
     from = WorkPackage.find(1)
     to = WorkPackage.find(2)
 
-    relation = Relation.new :from => from, :to => to, :relation_type => Relation::TYPE_FOLLOWS, :delay => 'xx'
+    relation = Relation.new from: from, to: to, relation_type: Relation::TYPE_FOLLOWS, delay: 'xx'
     assert !relation.save
     assert_equal Relation::TYPE_FOLLOWS, relation.relation_type
     assert_equal from, relation.from
@@ -72,26 +72,26 @@ class RelationTest < ActiveSupport::TestCase
     from = WorkPackage.find(1)
     to = WorkPackage.find(2)
 
-    relation = Relation.new :from => from, :to => to, :relation_type => Relation::TYPE_PRECEDES
+    relation = Relation.new from: from, to: to, relation_type: Relation::TYPE_PRECEDES
     assert_equal Relation::TYPE_PRECEDES, relation.relation_type_for(from)
     assert_equal Relation::TYPE_FOLLOWS, relation.relation_type_for(to)
   end
 
   def test_set_dates_of_target_without_to
-    r = Relation.new(:from => WorkPackage.new(:start_date => Date.today), :relation_type => Relation::TYPE_PRECEDES, :delay => 1)
+    r = Relation.new(from: WorkPackage.new(start_date: Date.today), relation_type: Relation::TYPE_PRECEDES, delay: 1)
     assert_nil r.set_dates_of_target
   end
 
   def test_set_dates_of_target_without_issues
-    r = Relation.new(:relation_type => Relation::TYPE_PRECEDES, :delay => 1)
+    r = Relation.new(relation_type: Relation::TYPE_PRECEDES, delay: 1)
     assert_nil r.set_dates_of_target
   end
 
   def test_validates_circular_dependency
     Relation.delete_all
-    assert Relation.create!(:from => WorkPackage.find(1), :to => WorkPackage.find(2), :relation_type => Relation::TYPE_PRECEDES)
-    assert Relation.create!(:from => WorkPackage.find(2), :to => WorkPackage.find(3), :relation_type => Relation::TYPE_PRECEDES)
-    r = Relation.new(:from => WorkPackage.find(3), :to => WorkPackage.find(1), :relation_type => Relation::TYPE_PRECEDES)
+    assert Relation.create!(from: WorkPackage.find(1), to: WorkPackage.find(2), relation_type: Relation::TYPE_PRECEDES)
+    assert Relation.create!(from: WorkPackage.find(2), to: WorkPackage.find(3), relation_type: Relation::TYPE_PRECEDES)
+    r = Relation.new(from: WorkPackage.find(3), to: WorkPackage.find(1), relation_type: Relation::TYPE_PRECEDES)
     assert !r.save
     refute_empty r.errors[:base]
   end

--- a/test/unit/repository_filesystem_test.rb
+++ b/test/unit/repository_filesystem_test.rb
@@ -39,7 +39,7 @@ class RepositoryFilesystemTest < ActiveSupport::TestCase
     @project = Project.find(3)
     Setting.enabled_scm = Setting.enabled_scm.dup << 'Filesystem' unless Setting.enabled_scm.include?('Filesystem')
     assert @repository = Repository::Filesystem.create(
-                            :project => @project, :url => REPOSITORY_PATH)
+                            project: @project, url: REPOSITORY_PATH)
   end
 
   if File.directory?(REPOSITORY_PATH)

--- a/test/unit/repository_filesystem_test.rb
+++ b/test/unit/repository_filesystem_test.rb
@@ -52,16 +52,16 @@ class RepositoryFilesystemTest < ActiveSupport::TestCase
     end
 
     def test_entries
-      assert_equal 3, @repository.entries("", 2).size
-      assert_equal 2, @repository.entries("dir", 3).size
+      assert_equal 3, @repository.entries('', 2).size
+      assert_equal 2, @repository.entries('dir', 3).size
     end
 
     def test_cat
-      assert_equal "TEST CAT\n", @repository.scm.cat("test")
+      assert_equal "TEST CAT\n", @repository.scm.cat('test')
     end
 
   else
-    puts "Filesystem test repository NOT FOUND. Skipping unit tests !!! See doc/RUNNING_TESTS."
+    puts 'Filesystem test repository NOT FOUND. Skipping unit tests !!! See doc/RUNNING_TESTS.'
     def test_fake; assert true end
   end
 end

--- a/test/unit/repository_git_test.rb
+++ b/test/unit/repository_git_test.rb
@@ -48,9 +48,9 @@ class RepositoryGitTest < ActiveSupport::TestCase
     super
     @project = Project.find(3)
     @repository = Repository::Git.create(
-                      :project       => @project,
-                      :url           => REPOSITORY_PATH,
-                      :path_encoding => 'ISO-8859-1'
+                      project:       @project,
+                      url:           REPOSITORY_PATH,
+                      path_encoding: 'ISO-8859-1'
                       )
     assert @repository
     @char_1        = CHAR_1_HEX.dup
@@ -85,12 +85,12 @@ class RepositoryGitTest < ActiveSupport::TestCase
     def test_fetch_changesets_incremental
       @repository.fetch_changesets
       # Remove the 3 latest changesets
-      @repository.changesets.find(:all, :order => 'committed_on DESC', :limit => 8).each(&:destroy)
+      @repository.changesets.find(:all, order: 'committed_on DESC', limit: 8).each(&:destroy)
       @repository.reload
       cs1 = @repository.changesets
       assert_equal 13, cs1.count
 
-      rev_a_commit = @repository.changesets.find(:first, :order => 'committed_on DESC')
+      rev_a_commit = @repository.changesets.find(:first, order: 'committed_on DESC')
       assert_equal '4f26664364207fa8b1af9f8722647ab2d4ac5d43', rev_a_commit.revision
       # Mon Jul 5 22:34:26 2010 +0200
       rev_a_committed_on = Time.gm(2010, 7, 5, 20, 34, 26)
@@ -261,11 +261,11 @@ class RepositoryGitTest < ActiveSupport::TestCase
     end
 
     def test_activities
-      c = Changeset.create(:repository => @repository,
-                        :committed_on => Time.now,
-                        :revision => 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
-                        :scmid    => 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
-                        :comments => 'test')
+      c = Changeset.create(repository: @repository,
+                        committed_on: Time.now,
+                        revision: 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
+                        scmid:    'abc7234cb2750b63f47bff735edc50a1c0a433c2',
+                        comments: 'test')
 
       event = find_events(User.find(2)).first # manager
       assert event.event_title.include?('abc7234c:')

--- a/test/unit/repository_git_test.rb
+++ b/test/unit/repository_git_test.rb
@@ -33,7 +33,7 @@ class RepositoryGitTest < ActiveSupport::TestCase
 
   # No '..' in the repository path
   REPOSITORY_PATH = Rails.root.to_s.gsub(%r{config\/\.\.}, '') + '/tmp/test/git_repository'
-  REPOSITORY_PATH.gsub!(/\//, "\\") if Redmine::Platform.mswin?
+  REPOSITORY_PATH.gsub!(/\//, '\\') if Redmine::Platform.mswin?
 
   FELIX_HEX  = "Felix Sch\xC3\xA4fer"
   CHAR_1_HEX = "\xc3\x9c"
@@ -69,17 +69,17 @@ class RepositoryGitTest < ActiveSupport::TestCase
 
       commit = @repository.changesets.reorder('committed_on ASC').first
       assert_equal "Initial import.\nThe repository contains 3 files.", commit.comments
-      assert_equal "jsmith <jsmith@foo.bar>", commit.committer
+      assert_equal 'jsmith <jsmith@foo.bar>', commit.committer
       assert_equal User.find_by_login('jsmith'), commit.user
       # TODO: add a commit with commit time <> author time to the test repository
-      assert_equal "2007-12-14 09:22:52".to_time, commit.committed_on
-      assert_equal "2007-12-14".to_date, commit.commit_date
-      assert_equal "7234cb2750b63f47bff735edc50a1c0a433c2518", commit.revision
-      assert_equal "7234cb2750b63f47bff735edc50a1c0a433c2518", commit.scmid
+      assert_equal '2007-12-14 09:22:52'.to_time, commit.committed_on
+      assert_equal '2007-12-14'.to_date, commit.commit_date
+      assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', commit.revision
+      assert_equal '7234cb2750b63f47bff735edc50a1c0a433c2518', commit.scmid
       assert_equal 3, commit.changes.count
       change = commit.changes.sort_by(&:path).first
-      assert_equal "README", change.path
-      assert_equal "A", change.action
+      assert_equal 'README', change.path
+      assert_equal 'A', change.action
     end
 
     def test_fetch_changesets_incremental
@@ -113,106 +113,106 @@ class RepositoryGitTest < ActiveSupport::TestCase
       # with path
       changesets = @repository.latest_changesets('images', nil)
       assert_equal [
-              'deff712f05a90d96edbd70facc47d944be5897e3',
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        'deff712f05a90d96edbd70facc47d944be5897e3',
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', nil)
       assert_equal [
-              '32ae898b720c2f7eec2723d5bdd558b4cb2d3ddf',
-              '4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8',
-              '713f4944648826f558cf548222f813dabe7cbb04',
-              '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '32ae898b720c2f7eec2723d5bdd558b4cb2d3ddf',
+        '4a07fe31bffcf2888791f3e6cbc9c4545cefe3e8',
+        '713f4944648826f558cf548222f813dabe7cbb04',
+        '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       # with path, revision and limit
       changesets = @repository.latest_changesets('images', '899a15dba')
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('images', '899a15dba', 1)
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', '899a15dba')
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', '899a15dba', 1)
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+      ], changesets.collect(&:revision)
 
       # with path, tag and limit
       changesets = @repository.latest_changesets('images', 'tag01.annotated')
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('images', 'tag01.annotated', 1)
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', 'tag01.annotated')
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', 'tag01.annotated', 1)
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+      ], changesets.collect(&:revision)
 
       # with path, branch and limit
       changesets = @repository.latest_changesets('images', 'test_branch')
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('images', 'test_branch', 1)
       assert_equal [
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-          ], changesets.collect(&:revision)
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', 'test_branch')
       assert_equal [
-              '713f4944648826f558cf548222f813dabe7cbb04',
-              '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
-              '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
-              '7234cb2750b63f47bff735edc50a1c0a433c2518',
-          ], changesets.collect(&:revision)
+        '713f4944648826f558cf548222f813dabe7cbb04',
+        '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
+        '899a15dba03a3b350b89c3f537e4bbe02a03cdc9',
+        '7234cb2750b63f47bff735edc50a1c0a433c2518',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets('README', 'test_branch', 2)
       assert_equal [
-              '713f4944648826f558cf548222f813dabe7cbb04',
-              '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
-          ], changesets.collect(&:revision)
+        '713f4944648826f558cf548222f813dabe7cbb04',
+        '61b685fbe55ab05b5ac68402d5720c1a6ac973d1',
+      ], changesets.collect(&:revision)
 
       # latin-1 encoding path
       changesets = @repository.latest_changesets(
                     "latin-1-dir/test-#{@char_1}-2.txt", '64f1f3e89')
       assert_equal [
-              '64f1f3e89ad1cb57976ff0ad99a107012ba3481d',
-              '4fc55c43bf3d3dc2efb66145365ddc17639ce81e',
-          ], changesets.collect(&:revision)
+        '64f1f3e89ad1cb57976ff0ad99a107012ba3481d',
+        '4fc55c43bf3d3dc2efb66145365ddc17639ce81e',
+      ], changesets.collect(&:revision)
 
       changesets = @repository.latest_changesets(
                     "latin-1-dir/test-#{@char_1}-2.txt", '64f1f3e89', 1)
       assert_equal [
-              '64f1f3e89ad1cb57976ff0ad99a107012ba3481d',
-          ], changesets.collect(&:revision)
+        '64f1f3e89ad1cb57976ff0ad99a107012ba3481d',
+      ], changesets.collect(&:revision)
     end
 
     def test_latest_changesets_latin_1_dir
@@ -224,8 +224,8 @@ class RepositoryGitTest < ActiveSupport::TestCase
         changesets = @repository.latest_changesets(
                     "latin-1-dir/test-#{@char_1}-subdir", '1ca7f5ed')
         assert_equal [
-              '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127',
-          ], changesets.collect(&:revision)
+          '1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127',
+        ], changesets.collect(&:revision)
       end
     end
 
@@ -262,10 +262,10 @@ class RepositoryGitTest < ActiveSupport::TestCase
 
     def test_activities
       c = Changeset.create(repository: @repository,
-                        committed_on: Time.now,
-                        revision: 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
-                        scmid:    'abc7234cb2750b63f47bff735edc50a1c0a433c2',
-                        comments: 'test')
+                           committed_on: Time.now,
+                           revision: 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
+                           scmid:    'abc7234cb2750b63f47bff735edc50a1c0a433c2',
+                           comments: 'test')
 
       event = find_events(User.find(2)).first # manager
       assert event.event_title.include?('abc7234c:')
@@ -277,7 +277,7 @@ class RepositoryGitTest < ActiveSupport::TestCase
       @repository.reload
       str_felix_hex  = FELIX_HEX.dup
       if str_felix_hex.respond_to?(:force_encoding)
-          str_felix_hex.force_encoding('UTF-8')
+        str_felix_hex.force_encoding('UTF-8')
       end
       c = @repository.changesets.find_by_revision('ed5bb786bbda2dee66a2d50faf51429dbc043a7b')
       assert_equal "#{str_felix_hex} <felix@fachschaften.org>", c.committer
@@ -309,7 +309,7 @@ class RepositoryGitTest < ActiveSupport::TestCase
       %w|64f1f3e89ad1cb57976ff0ad99a107012ba3481d 64f1f3e89ad1|.each do |r2|
         changeset = @repository.find_changeset_by_name(r2)
         %w|1ca7f5ed374f3cb31a93ae5215c2e25cc6ec5127 1ca7f5ed|.each do |r1|
-        assert_equal @repository.find_changeset_by_name(r1), changeset.next
+          assert_equal @repository.find_changeset_by_name(r1), changeset.next
         end
       end
     end
@@ -323,13 +323,13 @@ class RepositoryGitTest < ActiveSupport::TestCase
       end
     end
   else
-    puts "Git test repository NOT FOUND. Skipping unit tests !!!"
+    puts 'Git test repository NOT FOUND. Skipping unit tests !!!'
     def test_fake; assert true end
   end
 
   private
 
-  def find_events(user, options={})
+  def find_events(user, options = {})
     fetcher = Redmine::Activity::Fetcher.new(user, options)
     fetcher.scope = ['changesets']
     fetcher.events(Date.today - 30, Date.today + 1)

--- a/test/unit/repository_subversion_test.rb
+++ b/test/unit/repository_subversion_test.rb
@@ -34,8 +34,8 @@ class RepositorySubversionTest < ActiveSupport::TestCase
   def setup
     super
     @project = Project.find(3)
-    @repository = Repository::Subversion.create(:project => @project,
-             :url => self.class.subversion_repository_url)
+    @repository = Repository::Subversion.create(project: @project,
+             url: self.class.subversion_repository_url)
     assert @repository
   end
 
@@ -90,8 +90,8 @@ class RepositorySubversionTest < ActiveSupport::TestCase
     def test_directory_listing_with_square_brackets_in_base
       @project = Project.find(3)
       @repository = Repository::Subversion.create(
-                          :project => @project,
-                          :url => "file:///#{self.class.repository_path('subversion')}/subversion_test/[folder_with_brackets]")
+                          project: @project,
+                          url: "file:///#{self.class.repository_path('subversion')}/subversion_test/[folder_with_brackets]")
 
       @repository.fetch_changesets
       @repository.reload
@@ -121,8 +121,8 @@ class RepositorySubversionTest < ActiveSupport::TestCase
     end
 
     def test_identifier_nine_digit
-      c = Changeset.new(:repository => @repository, :committed_on => Time.now,
-                        :revision => '123456789', :comments => 'test')
+      c = Changeset.new(repository: @repository, committed_on: Time.now,
+                        revision: '123456789', comments: 'test')
       assert_equal c.identifier, c.revision
     end
 
@@ -134,29 +134,29 @@ class RepositorySubversionTest < ActiveSupport::TestCase
     end
 
     def test_format_identifier_nine_digit
-      c = Changeset.new(:repository => @repository, :committed_on => Time.now,
-                        :revision => '123456789', :comments => 'test')
+      c = Changeset.new(repository: @repository, committed_on: Time.now,
+                        revision: '123456789', comments: 'test')
       assert_equal c.format_identifier, c.revision
     end
 
     def test_activities
-      c = Changeset.create(:repository => @repository, :committed_on => Time.now,
-                           :revision => '1', :comments => 'test')
+      c = Changeset.create(repository: @repository, committed_on: Time.now,
+                           revision: '1', comments: 'test')
       event = find_events(User.find(2)).first # manager
       assert event.event_title.include?('1:')
       assert event.event_path =~ /\?rev=1$/
     end
 
     def test_activities_nine_digit
-      c = Changeset.create(:repository => @repository, :committed_on => Time.now,
-                        :revision => '123456789', :comments => 'test')
+      c = Changeset.create(repository: @repository, committed_on: Time.now,
+                        revision: '123456789', comments: 'test')
       event = find_events(User.find(2)).first # manager
       assert event.event_title.include?('123456789:')
       assert event.event_path =~ /\?rev=123456789$/
     end
 
     def test_log_encoding_ignore_setting
-      with_settings :commit_logs_encoding => 'windows-1252' do
+      with_settings commit_logs_encoding: 'windows-1252' do
         s1 = "\xC2\x80"
         s2 = "\xc3\x82\xc2\x80"
         if s1.respond_to?(:force_encoding)
@@ -164,10 +164,10 @@ class RepositorySubversionTest < ActiveSupport::TestCase
           s2.force_encoding('UTF-8')
           assert_equal s1.encode('UTF-8'), s2
         end
-        c = Changeset.new(:repository => @repository,
-                          :comments   => s2,
-                          :revision   => '123',
-                          :committed_on => Time.now)
+        c = Changeset.new(repository: @repository,
+                          comments:   s2,
+                          revision:   '123',
+                          committed_on: Time.now)
         assert c.save
         assert_equal s2, c.comments
       end

--- a/test/unit/repository_subversion_test.rb
+++ b/test/unit/repository_subversion_test.rb
@@ -35,7 +35,7 @@ class RepositorySubversionTest < ActiveSupport::TestCase
     super
     @project = Project.find(3)
     @repository = Repository::Subversion.create(project: @project,
-             url: self.class.subversion_repository_url)
+                                                url: self.class.subversion_repository_url)
     assert @repository
   end
 
@@ -52,7 +52,7 @@ class RepositorySubversionTest < ActiveSupport::TestCase
     def test_fetch_changesets_incremental
       @repository.fetch_changesets
       # Remove changesets with revision > 5
-      @repository.changesets.find(:all).each {|c| c.destroy if c.revision.to_i > 5}
+      @repository.changesets.find(:all).each { |c| c.destroy if c.revision.to_i > 5 }
       @repository.reload
       assert_equal 5, @repository.changesets.count
 
@@ -66,15 +66,15 @@ class RepositorySubversionTest < ActiveSupport::TestCase
       # with limit
       changesets = @repository.latest_changesets('', nil, 2)
       assert_equal 2, changesets.size
-      assert_equal @repository.latest_changesets('', nil).slice(0,2), changesets
+      assert_equal @repository.latest_changesets('', nil).slice(0, 2), changesets
 
       # with path
       changesets = @repository.latest_changesets('subversion_test/folder', nil)
-      assert_equal ["10", "9", "7", "6", "5", "2"], changesets.collect(&:revision)
+      assert_equal ['10', '9', '7', '6', '5', '2'], changesets.collect(&:revision)
 
       # with path and revision
       changesets = @repository.latest_changesets('subversion_test/folder', 8)
-      assert_equal ["7", "6", "5", "2"], changesets.collect(&:revision)
+      assert_equal ['7', '6', '5', '2'], changesets.collect(&:revision)
     end
 
     def test_directory_listing_with_square_brackets_in_path
@@ -149,7 +149,7 @@ class RepositorySubversionTest < ActiveSupport::TestCase
 
     def test_activities_nine_digit
       c = Changeset.create(repository: @repository, committed_on: Time.now,
-                        revision: '123456789', comments: 'test')
+                           revision: '123456789', comments: 'test')
       event = find_events(User.find(2)).first # manager
       assert event.event_title.include?('123456789:')
       assert event.event_path =~ /\?rev=123456789$/
@@ -201,13 +201,13 @@ class RepositorySubversionTest < ActiveSupport::TestCase
       assert_nil changeset.next
     end
   else
-    puts "Subversion test repository NOT FOUND. Skipping unit tests !!!"
+    puts 'Subversion test repository NOT FOUND. Skipping unit tests !!!'
     def test_fake; assert true end
   end
 
   private
 
-  def find_events(user, options={})
+  def find_events(user, options = {})
     fetcher = Redmine::Activity::Fetcher.new(user, options)
     fetcher.scope = ['changesets']
     fetcher.events(Date.today - 30, Date.today + 1)

--- a/test/unit/repository_test.rb
+++ b/test/unit/repository_test.rb
@@ -37,7 +37,7 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   def test_create
-    repository = Repository::Subversion.new(:project => Project.find(3))
+    repository = Repository::Subversion.new(project: Project.find(3))
     assert !repository.save
 
     repository.url = "svn://localhost"
@@ -60,7 +60,7 @@ class RepositoryTest < ActiveSupport::TestCase
 
   def test_should_not_create_with_disabled_scm
     Setting.enabled_scm = ['Git'] # disable Subversion
-    repository = Repository::Subversion.new(:project => Project.find(3), :url => "svn://localhost")
+    repository = Repository::Subversion.new(project: Project.find(3), url: "svn://localhost")
     assert !repository.save
     assert_include repository.errors[:type], I18n.translate('activerecord.errors.messages.invalid')
     # re-enable Subversion for following tests
@@ -74,7 +74,7 @@ class RepositoryTest < ActiveSupport::TestCase
     Setting.notified_events = ['work_package_added','work_package_updated']
 
     # choosing a status to apply to fix issues
-    Setting.commit_fix_status_id = Status.find(:first, :conditions => ["is_closed = ?", true]).id
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
     Setting.commit_fix_done_ratio = "90"
     Setting.commit_ref_keywords = 'refs , references, IssueID'
     Setting.commit_fix_keywords = 'fixes , closes'
@@ -112,11 +112,11 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   def test_for_changeset_comments_strip
-    repository = Repository::Subversion.create( :project => Project.find( 4 ), :url => 'svn://:login:password@host:/path/to/the/repository' )
+    repository = Repository::Subversion.create( project: Project.find( 4 ), url: 'svn://:login:password@host:/path/to/the/repository' )
     comment = "This is a looooooooooooooong comment" + (" " * 80 + "\n") * 5
     changeset = Changeset.new(
-      :comments => comment, :commit_date => Time.now, :revision => 0, :scmid => 'f39b7922fb3c',
-      :committer => 'foo <foo@example.com>', :committed_on => Time.now, :repository => repository )
+      comments: comment, commit_date: Time.now, revision: 0, scmid: 'f39b7922fb3c',
+      committer: 'foo <foo@example.com>', committed_on: Time.now, repository: repository )
     assert( changeset.save )
     assert_not_equal( comment, changeset.comments )
     assert_equal( 'This is a looooooooooooooong comment', changeset.comments )
@@ -124,9 +124,9 @@ class RepositoryTest < ActiveSupport::TestCase
 
   def test_for_urls_strip
     repository = Repository::Subversion.create(
-        :project => Project.find(4),
-        :url => ' svn://:login:password@host:/path/to/the/repository',
-        :log_encoding => 'UTF-8')
+        project: Project.find(4),
+        url: ' svn://:login:password@host:/path/to/the/repository',
+        log_encoding: 'UTF-8')
     repository.root_url = 'foo  ' # can't mass-assign this attr
     assert repository.save
     repository.reload
@@ -136,23 +136,23 @@ class RepositoryTest < ActiveSupport::TestCase
 
   def test_manual_user_mapping
     assert_no_difference "Changeset.count(:conditions => 'user_id <> 2')" do
-      c = Changeset.create!(:repository => @repository, :committer => 'foo', :committed_on => Time.now, :revision => 100, :comments => 'Committed by foo.')
+      c = Changeset.create!(repository: @repository, committer: 'foo', committed_on: Time.now, revision: 100, comments: 'Committed by foo.')
       assert_nil c.user
       @repository.committer_ids = {'foo' => '2'}
       assert_equal User.find(2), c.reload.user
       # committer is now mapped
-      c = Changeset.create!(:repository => @repository, :committer => 'foo', :committed_on => Time.now, :revision => 101, :comments => 'Another commit by foo.')
+      c = Changeset.create!(repository: @repository, committer: 'foo', committed_on: Time.now, revision: 101, comments: 'Another commit by foo.')
       assert_equal User.find(2), c.user
     end
   end
 
   def test_auto_user_mapping_by_username
-    c = Changeset.create!(:repository => @repository, :committer => 'jsmith', :committed_on => Time.now, :revision => 100, :comments => 'Committed by john.')
+    c = Changeset.create!(repository: @repository, committer: 'jsmith', committed_on: Time.now, revision: 100, comments: 'Committed by john.')
     assert_equal User.find(2), c.user
   end
 
   def test_auto_user_mapping_by_email
-    c = Changeset.create!(:repository => @repository, :committer => 'john <jsmith@somenet.foo>', :committed_on => Time.now, :revision => 100, :comments => 'Committed by john.')
+    c = Changeset.create!(repository: @repository, committer: 'john <jsmith@somenet.foo>', committed_on: Time.now, revision: 100, comments: 'Committed by john.')
     assert_equal User.find(2), c.user
   end
 end

--- a/test/unit/repository_test.rb
+++ b/test/unit/repository_test.rb
@@ -40,7 +40,7 @@ class RepositoryTest < ActiveSupport::TestCase
     repository = Repository::Subversion.new(project: Project.find(3))
     assert !repository.save
 
-    repository.url = "svn://localhost"
+    repository.url = 'svn://localhost'
     assert repository.save
     repository.reload
 
@@ -60,7 +60,7 @@ class RepositoryTest < ActiveSupport::TestCase
 
   def test_should_not_create_with_disabled_scm
     Setting.enabled_scm = ['Git'] # disable Subversion
-    repository = Repository::Subversion.new(project: Project.find(3), url: "svn://localhost")
+    repository = Repository::Subversion.new(project: Project.find(3), url: 'svn://localhost')
     assert !repository.save
     assert_include repository.errors[:type], I18n.translate('activerecord.errors.messages.invalid')
     # re-enable Subversion for following tests
@@ -68,14 +68,14 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   def test_scan_changesets_for_work_package_ids
-    WorkPackage.all.each {|w| w.recreate_initial_journal!}
+    WorkPackage.all.each(&:recreate_initial_journal!)
 
     Setting.default_language = 'en'
-    Setting.notified_events = ['work_package_added','work_package_updated']
+    Setting.notified_events = ['work_package_added', 'work_package_updated']
 
     # choosing a status to apply to fix issues
-    Setting.commit_fix_status_id = Status.find(:first, conditions: ["is_closed = ?", true]).id
-    Setting.commit_fix_done_ratio = "90"
+    Setting.commit_fix_status_id = Status.find(:first, conditions: ['is_closed = ?', true]).id
+    Setting.commit_fix_done_ratio = '90'
     Setting.commit_ref_keywords = 'refs , references, IssueID'
     Setting.commit_fix_keywords = 'fixes , closes'
     Setting.default_language = 'en'
@@ -112,14 +112,14 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   def test_for_changeset_comments_strip
-    repository = Repository::Subversion.create( project: Project.find( 4 ), url: 'svn://:login:password@host:/path/to/the/repository' )
-    comment = "This is a looooooooooooooong comment" + (" " * 80 + "\n") * 5
+    repository = Repository::Subversion.create(project: Project.find(4), url: 'svn://:login:password@host:/path/to/the/repository')
+    comment = 'This is a looooooooooooooong comment' + (' ' * 80 + "\n") * 5
     changeset = Changeset.new(
       comments: comment, commit_date: Time.now, revision: 0, scmid: 'f39b7922fb3c',
-      committer: 'foo <foo@example.com>', committed_on: Time.now, repository: repository )
-    assert( changeset.save )
-    assert_not_equal( comment, changeset.comments )
-    assert_equal( 'This is a looooooooooooooong comment', changeset.comments )
+      committer: 'foo <foo@example.com>', committed_on: Time.now, repository: repository)
+    assert(changeset.save)
+    assert_not_equal(comment, changeset.comments)
+    assert_equal('This is a looooooooooooooong comment', changeset.comments)
   end
 
   def test_for_urls_strip
@@ -138,7 +138,7 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_no_difference "Changeset.count(:conditions => 'user_id <> 2')" do
       c = Changeset.create!(repository: @repository, committer: 'foo', committed_on: Time.now, revision: 100, comments: 'Committed by foo.')
       assert_nil c.user
-      @repository.committer_ids = {'foo' => '2'}
+      @repository.committer_ids = { 'foo' => '2' }
       assert_equal User.find(2), c.reload.user
       # committer is now mapped
       c = Changeset.create!(repository: @repository, committer: 'foo', committed_on: Time.now, revision: 101, comments: 'Another commit by foo.')

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -45,7 +45,7 @@ class RoleTest < ActiveSupport::TestCase
   def test_add_permission
     role = Role.find(1)
     size = role.permissions.size
-    role.add_permission!("apermission", "anotherpermission")
+    role.add_permission!('apermission', 'anotherpermission')
     role.reload
     assert role.permissions.include?(:anotherpermission)
     assert_equal size + 2, role.permissions.size
@@ -57,29 +57,29 @@ class RoleTest < ActiveSupport::TestCase
     perm = role.permissions[0..1]
     role.remove_permission!(*perm)
     role.reload
-    assert ! role.permissions.include?(perm[0])
+    assert !role.permissions.include?(perm[0])
     assert_equal size - 2, role.permissions.size
   end
 
-  context "#anonymous" do
-    should "return the anonymous role" do
+  context '#anonymous' do
+    should 'return the anonymous role' do
       role = Role.anonymous
       assert role.builtin?
       assert_equal Role::BUILTIN_ANONYMOUS, role.builtin
     end
 
-    context "with a missing anonymous role" do
+    context 'with a missing anonymous role' do
       setup do
         Role.delete_all("builtin = #{Role::BUILTIN_ANONYMOUS}")
       end
 
-      should "create a new anonymous role" do
+      should 'create a new anonymous role' do
         assert_difference('Role.count') do
           Role.anonymous
         end
       end
 
-      should "return the anonymous role" do
+      should 'return the anonymous role' do
         role = Role.anonymous
         assert role.builtin?
         assert_equal Role::BUILTIN_ANONYMOUS, role.builtin
@@ -87,25 +87,25 @@ class RoleTest < ActiveSupport::TestCase
     end
   end
 
-  context "#non_member" do
-    should "return the non-member role" do
+  context '#non_member' do
+    should 'return the non-member role' do
       role = Role.non_member
       assert role.builtin?
       assert_equal Role::BUILTIN_NON_MEMBER, role.builtin
     end
 
-    context "with a missing non-member role" do
+    context 'with a missing non-member role' do
       setup do
         Role.delete_all("builtin = #{Role::BUILTIN_NON_MEMBER}")
       end
 
-      should "create a new non-member role" do
+      should 'create a new non-member role' do
         assert_difference('Role.count') do
           Role.non_member
         end
       end
 
-      should "return the non-member role" do
+      should 'return the non-member role' do
         role = Role.non_member
         assert role.builtin?
         assert_equal Role::BUILTIN_NON_MEMBER, role.builtin

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -35,7 +35,7 @@ class RoleTest < ActiveSupport::TestCase
     source = Role.find(1)
     assert_equal 90, source.workflows.size
 
-    target = Role.new(:name => 'Target')
+    target = Role.new(name: 'Target')
     assert target.save
     target.workflows.copy(source)
     target.reload

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -130,9 +130,9 @@ class SearchTest < ActiveSupport::TestCase
   def test_search_issue_with_multiple_hits_in_journals
     i = WorkPackage.find(1)
     Journal.delete_all journable_id: i.id
-    i.add_journal User.current, "Journal notes"
+    i.add_journal User.current, 'Journal notes'
     i.save!
-    i.add_journal User.current, "Some notes with Redmine links: #2, r2."
+    i.add_journal User.current, 'Some notes with Redmine links: #2, r2.'
     i.save!
 
     assert_equal 2, i.journals.count(:all, conditions: "notes LIKE '%notes%'")
@@ -145,7 +145,7 @@ class SearchTest < ActiveSupport::TestCase
   private
 
   def remove_permission(role, permission)
-    role.permissions = role.permissions - [ permission ]
+    role.permissions = role.permissions - [permission]
     role.save
   end
 end

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -135,7 +135,7 @@ class SearchTest < ActiveSupport::TestCase
     i.add_journal User.current, "Some notes with Redmine links: #2, r2."
     i.save!
 
-    assert_equal 2, i.journals.count(:all, :conditions => "notes LIKE '%notes%'")
+    assert_equal 2, i.journals.count(:all, conditions: "notes LIKE '%notes%'")
 
     r = WorkPackage.search('%notes%').first
     assert_equal 1, r.size

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -32,12 +32,12 @@ class StatusTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_create
-    status = Status.new name: "Assigned"
+    status = Status.new name: 'Assigned'
     assert !status.save
     # status name uniqueness
     assert_equal 1, status.errors.count
 
-    status.name = "Test Status"
+    status.name = 'Test Status'
     assert status.save
     assert !status.is_default
   end
@@ -47,8 +47,8 @@ class StatusTest < ActiveSupport::TestCase
     assert_difference 'Status.count', -1 do
       assert status.destroy
     end
-    assert_nil Workflow.first(conditions: {old_status_id: status.id})
-    assert_nil Workflow.first(conditions: {new_status_id: status.id})
+    assert_nil Workflow.first(conditions: { old_status_id: status.id })
+    assert_nil Workflow.first(conditions: { new_status_id: status.id })
   end
 
   def test_destroy_status_in_use
@@ -80,26 +80,26 @@ class StatusTest < ActiveSupport::TestCase
     assert status.is_default?
   end
 
-  context "#update_done_ratios" do
+  context '#update_done_ratios' do
     setup do
       @issue = WorkPackage.find(1)
       @status = Status.find(1)
       @status.update_attribute(:default_done_ratio, 50)
     end
 
-    context "with Setting.work_package_done_ratio using the field" do
+    context 'with Setting.work_package_done_ratio using the field' do
       setup do
         Setting.work_package_done_ratio = 'field'
       end
 
-      should "change nothing" do
+      should 'change nothing' do
         Status.update_work_package_done_ratios
 
-        assert_equal 0, WorkPackage.count(conditions: {done_ratio: 50})
+        assert_equal 0, WorkPackage.count(conditions: { done_ratio: 50 })
       end
     end
 
-    context "with Setting.work_package_done_ratio using the status" do
+    context 'with Setting.work_package_done_ratio using the status' do
       setup do
         Setting.work_package_done_ratio = 'status'
       end
@@ -107,7 +107,7 @@ class StatusTest < ActiveSupport::TestCase
       should "update all of the issue's done_ratios to match their Issue Status" do
         Status.update_work_package_done_ratios
 
-        issues = WorkPackage.find([1,3,4,5,6,7,9,10])
+        issues = WorkPackage.find([1, 3, 4, 5, 6, 7, 9, 10])
         issues.each do |issue|
           assert_equal @status, issue.status
           assert_equal 50, issue.read_attribute(:done_ratio)

--- a/test/unit/status_test.rb
+++ b/test/unit/status_test.rb
@@ -32,7 +32,7 @@ class StatusTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_create
-    status = Status.new :name => "Assigned"
+    status = Status.new name: "Assigned"
     assert !status.save
     # status name uniqueness
     assert_equal 1, status.errors.count
@@ -47,8 +47,8 @@ class StatusTest < ActiveSupport::TestCase
     assert_difference 'Status.count', -1 do
       assert status.destroy
     end
-    assert_nil Workflow.first(:conditions => {:old_status_id => status.id})
-    assert_nil Workflow.first(:conditions => {:new_status_id => status.id})
+    assert_nil Workflow.first(conditions: {old_status_id: status.id})
+    assert_nil Workflow.first(conditions: {new_status_id: status.id})
   end
 
   def test_destroy_status_in_use
@@ -95,7 +95,7 @@ class StatusTest < ActiveSupport::TestCase
       should "change nothing" do
         Status.update_work_package_done_ratios
 
-        assert_equal 0, WorkPackage.count(:conditions => {:done_ratio => 50})
+        assert_equal 0, WorkPackage.count(conditions: {done_ratio: 50})
       end
     end
 

--- a/test/unit/testing_test.rb
+++ b/test/unit/testing_test.rb
@@ -38,20 +38,19 @@ class TestingTest < ActiveSupport::TestCase
     assert true
   end
 
-  test "Generating with object_daddy" do
-    assert_difference "Status.count" do
+  test 'Generating with object_daddy' do
+    assert_difference 'Status.count' do
       Status.generate!
     end
   end
 
-  should "work with shoulda" do
+  should 'work with shoulda' do
     assert true
   end
 
-  context "works with a context" do
-    should "work" do
+  context 'works with a context' do
+    should 'work' do
       assert true
     end
   end
-
 end

--- a/test/unit/time_entry_activity_test.rb
+++ b/test/unit/time_entry_activity_test.rb
@@ -33,14 +33,13 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
 
   fixtures :all
 
-
   def test_should_be_an_enumeration
     assert TimeEntryActivity.ancestors.include?(Enumeration)
   end
 
   def test_objects_count
-    assert_equal 3, TimeEntryActivity.find_by_name("Design").objects_count
-    assert_equal 1, TimeEntryActivity.find_by_name("Development").objects_count
+    assert_equal 3, TimeEntryActivity.find_by_name('Design').objects_count
+    assert_equal 1, TimeEntryActivity.find_by_name('Development').objects_count
   end
 
   def test_option_name
@@ -50,11 +49,11 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
   def test_create_with_custom_field
     field = TimeEntryActivityCustomField.find_by_name('Billable')
     e = TimeEntryActivity.new(name: 'Custom Data')
-    e.custom_field_values = {field.id => "1"}
+    e.custom_field_values = { field.id => '1' }
     assert e.save
 
     e.reload
-    assert_equal "1", e.custom_value_for(field).value
+    assert_equal '1', e.custom_value_for(field).value
   end
 
   def test_create_without_required_custom_field_should_fail
@@ -71,7 +70,7 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
     field.update_attribute(:is_required, true)
 
     e = TimeEntryActivity.new(name: 'Custom Data')
-    e.custom_field_values = {field.id => "1"}
+    e.custom_field_values = { field.id => '1' }
     assert e.save
   end
 
@@ -84,15 +83,14 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
     # No change to custom field, record can be saved
     assert e.save
     # Blanking custom field, save should fail
-    e.custom_field_values = {field.id => ""}
+    e.custom_field_values = { field.id => '' }
     assert !e.save
     refute_empty e.errors[:custom_values]
 
     # Update custom field to valid value, save should succeed
-    e.custom_field_values = {field.id => "0"}
+    e.custom_field_values = { field.id => '0' }
     assert e.save
     e.reload
-    assert_equal "0", e.custom_value_for(field).value
+    assert_equal '0', e.custom_value_for(field).value
   end
-
 end

--- a/test/unit/time_entry_activity_test.rb
+++ b/test/unit/time_entry_activity_test.rb
@@ -49,7 +49,7 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
 
   def test_create_with_custom_field
     field = TimeEntryActivityCustomField.find_by_name('Billable')
-    e = TimeEntryActivity.new(:name => 'Custom Data')
+    e = TimeEntryActivity.new(name: 'Custom Data')
     e.custom_field_values = {field.id => "1"}
     assert e.save
 
@@ -61,7 +61,7 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
     field = TimeEntryActivityCustomField.find_by_name('Billable')
     field.update_attribute(:is_required, true)
 
-    e = TimeEntryActivity.new(:name => 'Custom Data')
+    e = TimeEntryActivity.new(name: 'Custom Data')
     assert !e.save
     assert_include e.errors[:custom_values], I18n.translate('activerecord.errors.messages.invalid')
   end
@@ -70,7 +70,7 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
     field = TimeEntryActivityCustomField.find_by_name('Billable')
     field.update_attribute(:is_required, true)
 
-    e = TimeEntryActivity.new(:name => 'Custom Data')
+    e = TimeEntryActivity.new(name: 'Custom Data')
     e.custom_field_values = {field.id => "1"}
     assert e.save
   end

--- a/test/unit/time_entry_test.rb
+++ b/test/unit/time_entry_test.rb
@@ -32,22 +32,22 @@ class TimeEntryTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_hours_format
-    assertions = { "2"      => 2.0,
-                   "21.1"   => 21.1,
-                   "2,1"    => 2.1,
-                   "1,5h"   => 1.5,
-                   "7:12"   => 7.2,
-                   "10h"    => 10.0,
-                   "10 h"   => 10.0,
-                   "45m"    => 0.75,
-                   "45 m"   => 0.75,
-                   "3h15"   => 3.25,
-                   "3h 15"  => 3.25,
-                   "3 h 15"   => 3.25,
-                   "3 h 15m"  => 3.25,
-                   "3 h 15 m" => 3.25,
-                   "3 hours"  => 3.0,
-                   "12min"    => 0.2,
+    assertions = { '2'      => 2.0,
+                   '21.1'   => 21.1,
+                   '2,1'    => 2.1,
+                   '1,5h'   => 1.5,
+                   '7:12'   => 7.2,
+                   '10h'    => 10.0,
+                   '10 h'   => 10.0,
+                   '45m'    => 0.75,
+                   '45 m'   => 0.75,
+                   '3h15'   => 3.25,
+                   '3h 15'  => 3.25,
+                   '3 h 15'   => 3.25,
+                   '3 h 15m'  => 3.25,
+                   '3 h 15 m' => 3.25,
+                   '3 hours'  => 3.0,
+                   '12min'    => 0.2,
                   }
 
     assertions.each do |k, v|
@@ -74,13 +74,13 @@ class TimeEntryTest < ActiveSupport::TestCase
 
   def test_spent_on_with_string
     c = TimeEntry.new
-    c.spent_on = "2011-01-14"
-    assert_equal Date.parse("2011-01-14"), c.spent_on
+    c.spent_on = '2011-01-14'
+    assert_equal Date.parse('2011-01-14'), c.spent_on
   end
 
   def test_spent_on_with_invalid_string
     c = TimeEntry.new
-    c.spent_on = "foo"
+    c.spent_on = 'foo'
     assert_nil c.spent_on
   end
 
@@ -96,31 +96,7 @@ class TimeEntryTest < ActiveSupport::TestCase
     assert_equal Date.today, c.spent_on
   end
 
-  context "#earliest_date_for_project" do
-    setup do
-      User.current = nil
-      @public_project = Project.generate!(is_public: true)
-      @issue =FactoryGirl.create(:work_package, project: @public_project)
-      TimeEntry.generate!(spent_on: '2010-01-01',
-                          work_package: @issue,
-                          project: @public_project)
-    end
-
-    context "without a project" do
-      should "return the lowest spent_on value that is visible to the current user" do
-        assert_equal "2007-03-12", TimeEntry.earliest_date_for_project.to_s
-      end
-    end
-
-    context "with a project" do
-      should "return the lowest spent_on value that is visible to the current user for that project and it's subprojects only" do
-        assert_equal "2010-01-01", TimeEntry.earliest_date_for_project(@public_project).to_s
-      end
-    end
-
-  end
-
-  context "#latest_date_for_project" do
+  context '#earliest_date_for_project' do
     setup do
       User.current = nil
       @public_project = Project.generate!(is_public: true)
@@ -130,16 +106,39 @@ class TimeEntryTest < ActiveSupport::TestCase
                           project: @public_project)
     end
 
-    context "without a project" do
-      should "return the highest spent_on value that is visible to the current user" do
-        assert_equal "2010-01-01", TimeEntry.latest_date_for_project.to_s
+    context 'without a project' do
+      should 'return the lowest spent_on value that is visible to the current user' do
+        assert_equal '2007-03-12', TimeEntry.earliest_date_for_project.to_s
       end
     end
 
-    context "with a project" do
+    context 'with a project' do
+      should "return the lowest spent_on value that is visible to the current user for that project and it's subprojects only" do
+        assert_equal '2010-01-01', TimeEntry.earliest_date_for_project(@public_project).to_s
+      end
+    end
+  end
+
+  context '#latest_date_for_project' do
+    setup do
+      User.current = nil
+      @public_project = Project.generate!(is_public: true)
+      @issue = FactoryGirl.create(:work_package, project: @public_project)
+      TimeEntry.generate!(spent_on: '2010-01-01',
+                          work_package: @issue,
+                          project: @public_project)
+    end
+
+    context 'without a project' do
+      should 'return the highest spent_on value that is visible to the current user' do
+        assert_equal '2010-01-01', TimeEntry.latest_date_for_project.to_s
+      end
+    end
+
+    context 'with a project' do
       should "return the highest spent_on value that is visible to the current user for that project and it's subprojects only" do
         project = Project.find(1)
-        assert_equal "2007-04-22", TimeEntry.latest_date_for_project(project).to_s
+        assert_equal '2007-04-22', TimeEntry.latest_date_for_project(project).to_s
       end
     end
   end

--- a/test/unit/time_entry_test.rb
+++ b/test/unit/time_entry_test.rb
@@ -51,7 +51,7 @@ class TimeEntryTest < ActiveSupport::TestCase
                   }
 
     assertions.each do |k, v|
-      t = TimeEntry.new(:hours => k)
+      t = TimeEntry.new(hours: k)
       assert_equal v, t.hours, "Converting #{k} failed:"
     end
   end
@@ -99,11 +99,11 @@ class TimeEntryTest < ActiveSupport::TestCase
   context "#earliest_date_for_project" do
     setup do
       User.current = nil
-      @public_project = Project.generate!(:is_public => true)
+      @public_project = Project.generate!(is_public: true)
       @issue =FactoryGirl.create(:work_package, project: @public_project)
-      TimeEntry.generate!(:spent_on => '2010-01-01',
-                          :work_package => @issue,
-                          :project => @public_project)
+      TimeEntry.generate!(spent_on: '2010-01-01',
+                          work_package: @issue,
+                          project: @public_project)
     end
 
     context "without a project" do
@@ -123,11 +123,11 @@ class TimeEntryTest < ActiveSupport::TestCase
   context "#latest_date_for_project" do
     setup do
       User.current = nil
-      @public_project = Project.generate!(:is_public => true)
+      @public_project = Project.generate!(is_public: true)
       @issue = FactoryGirl.create(:work_package, project: @public_project)
-      TimeEntry.generate!(:spent_on => '2010-01-01',
-                          :work_package => @issue,
-                          :project => @public_project)
+      TimeEntry.generate!(spent_on: '2010-01-01',
+                          work_package: @issue,
+                          project: @public_project)
     end
 
     context "without a project" do

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -40,8 +40,8 @@ class TokenTest < ActiveSupport::TestCase
 
   def test_create_should_remove_existing_tokens
     user = User.find(1)
-    t1 = Token.create(:user => user, :action => 'autologin')
-    t2 = Token.create(:user => user, :action => 'autologin')
+    t1 = Token.create(user: user, action: 'autologin')
+    t2 = Token.create(user: user, action: 'autologin')
     assert_not_equal t1.value, t2.value
     assert !Token.exists?(t1.id)
     assert  Token.exists?(t2.id)

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -44,6 +44,6 @@ class TokenTest < ActiveSupport::TestCase
     t2 = Token.create(user: user, action: 'autologin')
     assert_not_equal t1.value, t2.value
     assert !Token.exists?(t1.id)
-    assert  Token.exists?(t2.id)
+    assert Token.exists?(t2.id)
   end
 end

--- a/test/unit/type_test.rb
+++ b/test/unit/type_test.rb
@@ -54,7 +54,7 @@ class TypeTest < ActiveSupport::TestCase
   end
 
   def test_statuses_empty
-    Workflow.delete_all("type_id = 1")
+    Workflow.delete_all('type_id = 1')
     assert_equal [], Type.find(1).statuses
   end
 end

--- a/test/unit/type_test.rb
+++ b/test/unit/type_test.rb
@@ -35,7 +35,7 @@ class TypeTest < ActiveSupport::TestCase
     source = Type.find(1)
     assert_equal 89, source.workflows.size
 
-    target = Type.new(:name => 'Target')
+    target = Type.new(name: 'Target')
     assert target.save
     target.workflows.copy(source)
     target.reload
@@ -45,8 +45,8 @@ class TypeTest < ActiveSupport::TestCase
   def test_statuses
     type = Type.find(1)
     Workflow.delete_all
-    Workflow.create!(:role_id => 1, :type_id => 1, :old_status_id => 2, :new_status_id => 3)
-    Workflow.create!(:role_id => 2, :type_id => 1, :old_status_id => 3, :new_status_id => 5)
+    Workflow.create!(role_id: 1, type_id: 1, old_status_id: 2, new_status_id: 3)
+    Workflow.create!(role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 5)
 
     assert_kind_of Array, type.statuses.all
     assert_kind_of Status, type.statuses.first

--- a/test/unit/user_preference_test.rb
+++ b/test/unit/user_preference_test.rb
@@ -36,7 +36,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
     assert FactoryGirl.build(:user_preference).valid?
 
     # user required
-    refute FactoryGirl.build(:user_preference, :user => nil).valid?
+    refute FactoryGirl.build(:user_preference, user: nil).valid?
   end
 
   def test_create
@@ -49,7 +49,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
 
   def test_update
     user = FactoryGirl.create :user
-    pref = FactoryGirl.create :user_preference, :user => user, :hide_mail => true
+    pref = FactoryGirl.create :user_preference, user: user, hide_mail: true
     assert_equal true, user.pref.hide_mail
 
     user.pref['preftest'] = 'value'

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -43,7 +43,7 @@ class UserTest < ActiveSupport::TestCase
   test 'object_daddy creation' do
     User.generate_with_protected!(firstname: 'Testing connection')
     User.generate_with_protected!(firstname: 'Testing connection')
-    assert_equal 2, User.count(:all, conditions: {firstname: 'Testing connection'})
+    assert_equal 2, User.count(:all, conditions: { firstname: 'Testing connection' })
   end
 
   def test_truth
@@ -52,31 +52,31 @@ class UserTest < ActiveSupport::TestCase
 
   def test_mail_should_be_stripped
     u = User.new
-    u.mail = " foo@bar.com  "
-    assert_equal "foo@bar.com", u.mail
+    u.mail = ' foo@bar.com  '
+    assert_equal 'foo@bar.com', u.mail
   end
 
   def test_create
-    user = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
+    user = User.new(firstname: 'new', lastname: 'user', mail: 'newuser@somenet.foo')
 
-    user.login = "jsmith"
-    user.password, user.password_confirmation = "adminADMIN!", "adminADMIN!"
+    user.login = 'jsmith'
+    user.password, user.password_confirmation = 'adminADMIN!', 'adminADMIN!'
     # login uniqueness
     assert !user.save
     assert_equal 1, user.errors.count
 
-    user.login = "newuser"
-    user.password, user.password_confirmation = "adminADMIN!", "NOTadminADMIN!"
+    user.login = 'newuser'
+    user.password, user.password_confirmation = 'adminADMIN!', 'NOTadminADMIN!'
     # password confirmation
     assert !user.save
     assert_equal 1, user.errors.count
 
-    user.password, user.password_confirmation = "adminADMIN!", "adminADMIN!"
+    user.password, user.password_confirmation = 'adminADMIN!', 'adminADMIN!'
     assert user.save
   end
 
-  context "User#before_create" do
-    should "set the mail_notification to the default Setting" do
+  context 'User#before_create' do
+    should 'set the mail_notification to the default Setting' do
       @user1 = User.generate_with_protected!
       assert_equal 'only_my_events', @user1.mail_notification
 
@@ -87,40 +87,40 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "User.login" do
-    should "be case-insensitive." do
-      u = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
+  context 'User.login' do
+    should 'be case-insensitive.' do
+      u = User.new(firstname: 'new', lastname: 'user', mail: 'newuser@somenet.foo')
       u.login = 'newuser'
-      u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
+      u.password, u.password_confirmation = 'adminADMIN!', 'adminADMIN!'
       assert u.save
 
-      u = User.new(firstname: "Similar", lastname: "User", mail: "similaruser@somenet.foo")
+      u = User.new(firstname: 'Similar', lastname: 'User', mail: 'similaruser@somenet.foo')
       u.login = 'NewUser'
-      u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
+      u.password, u.password_confirmation = 'adminADMIN!', 'adminADMIN!'
       assert !u.save
       assert_include u.errors[:login], I18n.translate('activerecord.errors.messages.taken')
     end
   end
 
   def test_mail_uniqueness_should_not_be_case_sensitive
-    u = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
+    u = User.new(firstname: 'new', lastname: 'user', mail: 'newuser@somenet.foo')
     u.login = 'newuser1'
-    u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
+    u.password, u.password_confirmation = 'adminADMIN!', 'adminADMIN!'
     assert u.save
 
-    u = User.new(firstname: "new", lastname: "user", mail: "newUser@Somenet.foo")
+    u = User.new(firstname: 'new', lastname: 'user', mail: 'newUser@Somenet.foo')
     u.login = 'newuser2'
-    u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
+    u.password, u.password_confirmation = 'adminADMIN!', 'adminADMIN!'
     assert !u.save
     assert_include u.errors[:mail], I18n.translate('activerecord.errors.messages.taken')
   end
 
   def test_update
-    assert_equal "admin", @admin.login
-    @admin.login = "john"
-    assert @admin.save, @admin.errors.full_messages.join("; ")
+    assert_equal 'admin', @admin.login
+    @admin.login = 'john'
+    assert @admin.save, @admin.errors.full_messages.join('; ')
     @admin.reload
-    assert_equal "john", @admin.login
+    assert_equal 'john', @admin.login
   end
 
   def test_destroy
@@ -130,7 +130,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_validate_login_presence
-    @admin.login = ""
+    @admin.login = ''
     assert !@admin.save
     assert_equal 1, @admin.errors.count
   end
@@ -142,35 +142,34 @@ class UserTest < ActiveSupport::TestCase
     refute_empty u.errors[:mail_notification]
   end
 
-  context "User#try_to_login" do
-    should "fall-back to case-insensitive if user login is not found as-typed." do
-      user = User.try_to_login("AdMin", "adminADMIN!")
+  context 'User#try_to_login' do
+    should 'fall-back to case-insensitive if user login is not found as-typed.' do
+      user = User.try_to_login('AdMin', 'adminADMIN!')
       assert_kind_of User, user
-      assert_equal "admin", user.login
+      assert_equal 'admin', user.login
     end
 
-    should "select the exact matching user first" do
+    should 'select the exact matching user first' do
       case_sensitive_user = User.generate_with_protected!(login: 'changed', password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
       # bypass validations to make it appear like existing data
       case_sensitive_user.update_attribute(:login, 'ADMIN')
 
-      user = User.try_to_login("ADMIN", "adminADMIN!")
+      user = User.try_to_login('ADMIN', 'adminADMIN!')
       assert_kind_of User, user
-      assert_equal "ADMIN", user.login
-
+      assert_equal 'ADMIN', user.login
     end
   end
 
   def test_password
-    user = User.try_to_login("admin", "adminADMIN!")
+    user = User.try_to_login('admin', 'adminADMIN!')
     assert_kind_of User, user
-    assert_equal "admin", user.login
-    user.password = "newpassPASS!"
+    assert_equal 'admin', user.login
+    user.password = 'newpassPASS!'
     assert user.save
 
-    user = User.try_to_login("admin", "newpassPASS!")
+    user = User.try_to_login('admin', 'newpassPASS!')
     assert_kind_of User, user
-    assert_equal "admin", user.login
+    assert_equal 'admin', user.login
   end
 
   def test_name_format
@@ -182,36 +181,36 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_lock
-    user = User.try_to_login("jsmith", "jsmith")
+    user = User.try_to_login('jsmith', 'jsmith')
     assert_equal @jsmith, user
 
     @jsmith.status = User::STATUSES[:locked]
     assert @jsmith.save
 
-    user = User.try_to_login("jsmith", "jsmith")
+    user = User.try_to_login('jsmith', 'jsmith')
     assert_equal nil, user
   end
 
-  context ".try_to_login" do
-    context "with good credentials" do
-      should "return the user" do
-        user = User.try_to_login("admin", "adminADMIN!")
+  context '.try_to_login' do
+    context 'with good credentials' do
+      should 'return the user' do
+        user = User.try_to_login('admin', 'adminADMIN!')
         assert_kind_of User, user
-        assert_equal "admin", user.login
+        assert_equal 'admin', user.login
       end
     end
 
-    context "with wrong credentials" do
-      should "return nil" do
-        assert_nil User.try_to_login("admin", "foo")
+    context 'with wrong credentials' do
+      should 'return nil' do
+        assert_nil User.try_to_login('admin', 'foo')
       end
     end
   end
 
   if ldap_configured?
-    context "#try_to_login using LDAP" do
-      context "with failed connection to the LDAP server" do
-        should "return nil" do
+    context '#try_to_login using LDAP' do
+      context 'with failed connection to the LDAP server' do
+        should 'return nil' do
           @auth_source = LdapAuthSource.find(1)
           AuthSource.any_instance.stub(:initialize_ldap_con).and_raise(Net::LDAP::LdapError, 'Cannot connect')
 
@@ -219,18 +218,18 @@ class UserTest < ActiveSupport::TestCase
         end
       end
 
-      context "with an unsuccessful authentication" do
-        should "return nil" do
+      context 'with an unsuccessful authentication' do
+        should 'return nil' do
           assert_equal nil, User.try_to_login('edavis', 'wrong')
         end
       end
 
-      context "on the fly registration" do
+      context 'on the fly registration' do
         setup do
           @auth_source = LdapAuthSource.find(1)
         end
 
-        context "with a successful authentication" do
+        context 'with a successful authentication' do
           should "create a new user account if it doesn't exist" do
             assert_difference('User.count') do
               user = User.try_to_login('edavis', '123456')
@@ -238,7 +237,7 @@ class UserTest < ActiveSupport::TestCase
             end
           end
 
-          should "retrieve existing user" do
+          should 'retrieve existing user' do
             user = User.try_to_login('edavis', '123456')
             user.admin = true
             user.save!
@@ -253,7 +252,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
   else
-    puts "Skipping LDAP tests."
+    puts 'Skipping LDAP tests.'
   end
 
   def test_create_anonymous
@@ -274,10 +273,9 @@ class UserTest < ActiveSupport::TestCase
     assert_equal key, @jsmith.rss_key
   end
 
-
   should have_one :api_token
 
-  context "User#api_key" do
+  context 'User#api_key' do
     should "generate a new one if the user doesn't have one" do
       user = User.generate_with_protected!(api_token: nil)
       assert_nil user.api_token
@@ -288,7 +286,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal key, user.api_key
     end
 
-    should "return the existing api token value" do
+    should 'return the existing api token value' do
       user = User.generate_with_protected!
       token = Token.generate!(action: 'api')
       user.api_token = token
@@ -298,12 +296,12 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "User#find_by_api_key" do
-    should "return nil if no matching key is found" do
+  context 'User#find_by_api_key' do
+    should 'return nil if no matching key is found' do
       assert_nil User.find_by_api_key('zzzzzzzzz')
     end
 
-    should "return nil if the key is found for an inactive user" do
+    should 'return nil if the key is found for an inactive user' do
       user = User.generate_with_protected!(status: User::STATUSES[:locked])
       token = Token.generate!(action: 'api')
       user.api_token = token
@@ -312,7 +310,7 @@ class UserTest < ActiveSupport::TestCase
       assert_nil User.find_by_api_key(token.value)
     end
 
-    should "return the user if the key is found for an active user" do
+    should 'return the user if the key is found for an active user' do
       user = User.generate_with_protected!(status: User::STATUSES[:active])
       token = Token.generate!(action: 'api')
       user.api_token = token
@@ -326,17 +324,17 @@ class UserTest < ActiveSupport::TestCase
     # user with a role
     roles = @jsmith.roles_for_project(Project.find(1))
     assert_kind_of Role, roles.first
-    assert_equal "Manager", roles.first.name
+    assert_equal 'Manager', roles.first.name
 
     # user with no role
-    assert_nil @dlopper.roles_for_project(Project.find(2)).detect {|role| role.member?}
+    assert_nil @dlopper.roles_for_project(Project.find(2)).detect(&:member?)
   end
 
   def test_projects_by_role_for_user_with_role
     user = User.find(2)
     assert_kind_of Hash, user.projects_by_role
     assert_equal 2, user.projects_by_role.size
-    assert_equal [1,5], user.projects_by_role[Role.find(1)].collect(&:id).sort
+    assert_equal [1, 5], user.projects_by_role[Role.find(1)].collect(&:id).sort
     assert_equal [2], user.projects_by_role[Role.find(2)].collect(&:id).sort
   end
 
@@ -400,70 +398,70 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'jsmith@somenet.foo', u.mail
   end
 
-  context "#allowed_to?" do
-    context "with a unique project" do
-      should "return false if project is archived" do
+  context '#allowed_to?' do
+    context 'with a unique project' do
+      should 'return false if project is archived' do
         project = Project.find(1)
         Project.any_instance.stub(:status).and_return(Project::STATUS_ARCHIVED)
         assert ! @admin.allowed_to?(:view_work_packages, Project.find(1))
       end
 
-      should "return false if related module is disabled" do
+      should 'return false if related module is disabled' do
         project = Project.find(1)
-        project.enabled_module_names = ["work_package_tracking"]
+        project.enabled_module_names = ['work_package_tracking']
         assert @admin.allowed_to?(:add_work_packages, project)
         assert ! @admin.allowed_to?(:view_wiki_pages, project)
       end
 
-      should "authorize nearly everything for admin users" do
+      should 'authorize nearly everything for admin users' do
         project = Project.find(1)
-        project.enabled_module_names = ["work_package_tracking", "news", "wiki", "repository"]
+        project.enabled_module_names = ['work_package_tracking', 'news', 'wiki', 'repository']
         assert ! @admin.member_of?(project)
         %w(edit_work_packages delete_work_packages manage_news manage_repository manage_wiki).each do |p|
           assert @admin.allowed_to?(p.to_sym, project)
         end
       end
 
-      should "authorize normal users depending on their roles" do
+      should 'authorize normal users depending on their roles' do
         project = Project.find(1)
-        project.enabled_module_names = ["boards"]
-        assert @jsmith.allowed_to?(:delete_messages, project)    #Manager
-        assert ! @dlopper.allowed_to?(:delete_messages, project) #Developper
+        project.enabled_module_names = ['boards']
+        assert @jsmith.allowed_to?(:delete_messages, project)    # Manager
+        assert ! @dlopper.allowed_to?(:delete_messages, project) # Developper
       end
 
-      should "only managers are allowed to export tickets" do
+      should 'only managers are allowed to export tickets' do
         project = Project.find(1)
-        project.enabled_module_names = ["work_package_tracking"]
-        assert @jsmith.allowed_to?(:export_work_packages, project)    #Manager
-        assert ! @dlopper.allowed_to?(:export_work_packages, project) #Developper
+        project.enabled_module_names = ['work_package_tracking']
+        assert @jsmith.allowed_to?(:export_work_packages, project)    # Manager
+        assert ! @dlopper.allowed_to?(:export_work_packages, project) # Developper
       end
     end
 
-    context "with multiple projects" do
-      should "return false if array is empty" do
+    context 'with multiple projects' do
+      should 'return false if array is empty' do
         assert ! @admin.allowed_to?(:view_project, [])
       end
 
-      should "return true only if user has permission on all these projects" do
+      should 'return true only if user has permission on all these projects' do
         Project.all.each do |project|
-          project.enabled_module_names = ["work_package_tracking"]
+          project.enabled_module_names = ['work_package_tracking']
           project.save!
         end
 
         assert @admin.allowed_to?(:view_project, Project.all)
-        assert ! @dlopper.allowed_to?(:view_project, Project.all) #cannot see Project(2)
-        assert @jsmith.allowed_to?(:edit_work_packages, @jsmith.projects) #Manager or Developer everywhere
-        assert ! @jsmith.allowed_to?(:delete_work_package_watchers, @jsmith.projects) #Dev cannot delete_work_package_watchers
+        assert ! @dlopper.allowed_to?(:view_project, Project.all) # cannot see Project(2)
+        assert @jsmith.allowed_to?(:edit_work_packages, @jsmith.projects) # Manager or Developer everywhere
+        assert ! @jsmith.allowed_to?(:delete_work_package_watchers, @jsmith.projects) # Dev cannot delete_work_package_watchers
       end
 
-      should "behave correctly with arrays of 1 project" do
-        assert ! User.anonymous.allowed_to?(:delete_work_packages, [Project.first])
+      should 'behave correctly with arrays of 1 project' do
+        assert !User.anonymous.allowed_to?(:delete_work_packages, [Project.first])
       end
     end
 
-    context "with options[:global]" do
-      should "authorize if user has at least one role that has this permission" do
-        @dlopper2 = User.find(5) #only Developper on a project, not Manager anywhere
+    context 'with options[:global]' do
+      should 'authorize if user has at least one role that has this permission' do
+        @dlopper2 = User.find(5) # only Developper on a project, not Manager anywhere
         @anonymous = User.find(6)
         assert @jsmith.allowed_to?(:delete_work_package_watchers, nil, global: true)
         assert ! @dlopper2.allowed_to?(:delete_work_package_watchers, nil, global: true)
@@ -474,8 +472,8 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  context "User#notify_about?" do
-    context "Issues" do
+  context 'User#notify_about?' do
+    context 'Issues' do
       setup do
         @project = Project.find(1)
         @author = User.generate_with_protected!
@@ -483,12 +481,12 @@ class UserTest < ActiveSupport::TestCase
         @issue = FactoryGirl.create(:work_package, project: @project, assigned_to: @assignee, author: @author)
       end
 
-      should "be true for a user with :all" do
+      should 'be true for a user with :all' do
         @author.update_attribute(:mail_notification, 'all')
         assert @author.notify_about?(@issue)
       end
 
-      should "be false for a user with :none" do
+      should 'be false for a user with :none' do
         @author.update_attribute(:mail_notification, 'none')
         assert ! @author.notify_about?(@issue)
       end
@@ -501,47 +499,47 @@ class UserTest < ActiveSupport::TestCase
         assert ! @user.notify_about?(@issue)
       end
 
-      should "be true for a user with :only_my_events and is the author" do
+      should 'be true for a user with :only_my_events and is the author' do
         @author.update_attribute(:mail_notification, 'only_my_events')
         assert @author.notify_about?(@issue)
       end
 
-      should "be true for a user with :only_my_events and is the assignee" do
+      should 'be true for a user with :only_my_events and is the assignee' do
         @assignee.update_attribute(:mail_notification, 'only_my_events')
         assert @assignee.notify_about?(@issue)
       end
 
-      should "be true for a user with :only_assigned and is the assignee" do
+      should 'be true for a user with :only_assigned and is the assignee' do
         @assignee.update_attribute(:mail_notification, 'only_assigned')
         assert @assignee.notify_about?(@issue)
       end
 
-      should "be false for a user with :only_assigned and is not the assignee" do
+      should 'be false for a user with :only_assigned and is not the assignee' do
         @author.update_attribute(:mail_notification, 'only_assigned')
         assert ! @author.notify_about?(@issue)
       end
 
-      should "be true for a user with :only_owner and is the author" do
+      should 'be true for a user with :only_owner and is the author' do
         @author.update_attribute(:mail_notification, 'only_owner')
         assert @author.notify_about?(@issue)
       end
 
-      should "be false for a user with :only_owner and is not the author" do
+      should 'be false for a user with :only_owner and is not the author' do
         @assignee.update_attribute(:mail_notification, 'only_owner')
         assert ! @assignee.notify_about?(@issue)
       end
 
-      should "be true for a user with :selected and is the author" do
+      should 'be true for a user with :selected and is the author' do
         @author.update_attribute(:mail_notification, 'selected')
         assert @author.notify_about?(@issue)
       end
 
-      should "be true for a user with :selected and is the assignee" do
+      should 'be true for a user with :selected and is the assignee' do
         @assignee.update_attribute(:mail_notification, 'selected')
         assert @assignee.notify_about?(@issue)
       end
 
-      should "be false for a user with :selected and is not the author or assignee" do
+      should 'be false for a user with :selected and is not the author or assignee' do
         @user = User.generate_with_protected!(mail_notification: 'selected')
         (Member.new.tap do |m|
           m.force_attributes = { user: @user, project: @project, role_ids: [1] }
@@ -550,9 +548,8 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context "other events" do
+    context 'other events' do
       should 'be added and tested'
     end
   end
-
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -41,9 +41,9 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'object_daddy creation' do
-    User.generate_with_protected!(:firstname => 'Testing connection')
-    User.generate_with_protected!(:firstname => 'Testing connection')
-    assert_equal 2, User.count(:all, :conditions => {:firstname => 'Testing connection'})
+    User.generate_with_protected!(firstname: 'Testing connection')
+    User.generate_with_protected!(firstname: 'Testing connection')
+    assert_equal 2, User.count(:all, conditions: {firstname: 'Testing connection'})
   end
 
   def test_truth
@@ -57,7 +57,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_create
-    user = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
+    user = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
 
     user.login = "jsmith"
     user.password, user.password_confirmation = "adminADMIN!", "adminADMIN!"
@@ -80,7 +80,7 @@ class UserTest < ActiveSupport::TestCase
       @user1 = User.generate_with_protected!
       assert_equal 'only_my_events', @user1.mail_notification
 
-      with_settings :default_notification_option => 'all' do
+      with_settings default_notification_option: 'all' do
         @user2 = User.generate_with_protected!
         assert_equal 'all', @user2.mail_notification
       end
@@ -89,12 +89,12 @@ class UserTest < ActiveSupport::TestCase
 
   context "User.login" do
     should "be case-insensitive." do
-      u = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
+      u = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
       u.login = 'newuser'
       u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
       assert u.save
 
-      u = User.new(:firstname => "Similar", :lastname => "User", :mail => "similaruser@somenet.foo")
+      u = User.new(firstname: "Similar", lastname: "User", mail: "similaruser@somenet.foo")
       u.login = 'NewUser'
       u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
       assert !u.save
@@ -103,12 +103,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_mail_uniqueness_should_not_be_case_sensitive
-    u = User.new(:firstname => "new", :lastname => "user", :mail => "newuser@somenet.foo")
+    u = User.new(firstname: "new", lastname: "user", mail: "newuser@somenet.foo")
     u.login = 'newuser1'
     u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
     assert u.save
 
-    u = User.new(:firstname => "new", :lastname => "user", :mail => "newUser@Somenet.foo")
+    u = User.new(firstname: "new", lastname: "user", mail: "newUser@Somenet.foo")
     u.login = 'newuser2'
     u.password, u.password_confirmation = "adminADMIN!", "adminADMIN!"
     assert !u.save
@@ -150,7 +150,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "select the exact matching user first" do
-      case_sensitive_user = User.generate_with_protected!(:login => 'changed', :password => 'adminADMIN!', :password_confirmation => 'adminADMIN!')
+      case_sensitive_user = User.generate_with_protected!(login: 'changed', password: 'adminADMIN!', password_confirmation: 'adminADMIN!')
       # bypass validations to make it appear like existing data
       case_sensitive_user.update_attribute(:login, 'ADMIN')
 
@@ -279,7 +279,7 @@ class UserTest < ActiveSupport::TestCase
 
   context "User#api_key" do
     should "generate a new one if the user doesn't have one" do
-      user = User.generate_with_protected!(:api_token => nil)
+      user = User.generate_with_protected!(api_token: nil)
       assert_nil user.api_token
 
       key = user.api_key
@@ -290,7 +290,7 @@ class UserTest < ActiveSupport::TestCase
 
     should "return the existing api token value" do
       user = User.generate_with_protected!
-      token = Token.generate!(:action => 'api')
+      token = Token.generate!(action: 'api')
       user.api_token = token
       assert user.save
 
@@ -304,8 +304,8 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return nil if the key is found for an inactive user" do
-      user = User.generate_with_protected!(:status => User::STATUSES[:locked])
-      token = Token.generate!(:action => 'api')
+      user = User.generate_with_protected!(status: User::STATUSES[:locked])
+      token = Token.generate!(action: 'api')
       user.api_token = token
       user.save
 
@@ -313,8 +313,8 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "return the user if the key is found for an active user" do
-      user = User.generate_with_protected!(:status => User::STATUSES[:active])
-      token = Token.generate!(:action => 'api')
+      user = User.generate_with_protected!(status: User::STATUSES[:active])
+      token = Token.generate!(action: 'api')
       user.api_token = token
       user.save
 
@@ -465,11 +465,11 @@ class UserTest < ActiveSupport::TestCase
       should "authorize if user has at least one role that has this permission" do
         @dlopper2 = User.find(5) #only Developper on a project, not Manager anywhere
         @anonymous = User.find(6)
-        assert @jsmith.allowed_to?(:delete_work_package_watchers, nil, :global => true)
-        assert ! @dlopper2.allowed_to?(:delete_work_package_watchers, nil, :global => true)
-        assert @dlopper2.allowed_to?(:add_work_packages, nil, :global => true)
-        assert ! @anonymous.allowed_to?(:add_work_packages, nil, :global => true)
-        assert @anonymous.allowed_to?(:view_work_packages, nil, :global => true)
+        assert @jsmith.allowed_to?(:delete_work_package_watchers, nil, global: true)
+        assert ! @dlopper2.allowed_to?(:delete_work_package_watchers, nil, global: true)
+        assert @dlopper2.allowed_to?(:add_work_packages, nil, global: true)
+        assert ! @anonymous.allowed_to?(:add_work_packages, nil, global: true)
+        assert @anonymous.allowed_to?(:view_work_packages, nil, global: true)
       end
     end
   end
@@ -480,7 +480,7 @@ class UserTest < ActiveSupport::TestCase
         @project = Project.find(1)
         @author = User.generate_with_protected!
         @assignee = User.generate_with_protected!
-        @issue = FactoryGirl.create(:work_package, project: @project, :assigned_to => @assignee, :author => @author)
+        @issue = FactoryGirl.create(:work_package, project: @project, assigned_to: @assignee, author: @author)
       end
 
       should "be true for a user with :all" do
@@ -494,9 +494,9 @@ class UserTest < ActiveSupport::TestCase
       end
 
       should "be false for a user with :only_my_events and isn't an author, creator, or assignee" do
-        @user = User.generate_with_protected!(:mail_notification => 'only_my_events')
+        @user = User.generate_with_protected!(mail_notification: 'only_my_events')
         (Member.new.tap do |m|
-          m.force_attributes = { :user => @user, :project => @project, :role_ids => [1] }
+          m.force_attributes = { user: @user, project: @project, role_ids: [1] }
         end).save!
         assert ! @user.notify_about?(@issue)
       end
@@ -542,9 +542,9 @@ class UserTest < ActiveSupport::TestCase
       end
 
       should "be false for a user with :selected and is not the author or assignee" do
-        @user = User.generate_with_protected!(:mail_notification => 'selected')
+        @user = User.generate_with_protected!(mail_notification: 'selected')
         (Member.new.tap do |m|
-          m.force_attributes = { :user => @user, :project => @project, :role_ids => [1] }
+          m.force_attributes = { user: @user, project: @project, role_ids: [1] }
         end).save!
         assert ! @user.notify_about?(@issue)
       end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -47,9 +47,9 @@ class VersionTest < ActiveSupport::TestCase
     assert_include v.errors[:effective_date], I18n.translate('activerecord.errors.messages.not_a_date')
   end
 
-  context "#start_date" do
-    context "with no value saved" do
-      should "be the date of the earlist issue" do
+  context '#start_date' do
+    context 'with no value saved' do
+      should 'be the date of the earlist issue' do
         project = Project.find(1)
         (v = Version.new.tap do |v|
           v.force_attributes = { project: project, name: 'Progress' }
@@ -61,8 +61,8 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
-    context "with a value saved" do
-      should "be the value" do
+    context 'with a value saved' do
+      should 'be the value' do
         project = Project.find(1)
         (v = Version.new.tap do |v|
           v.force_attributes = { project: project, name: 'Progress', start_date: '2010-01-05' }
@@ -73,9 +73,7 @@ class VersionTest < ActiveSupport::TestCase
         assert_equal '2010-01-05', v.start_date.to_s
       end
     end
-
   end
-
 
   def test_progress_should_be_0_with_no_assigned_issues
     project = Project.find(1)
@@ -99,7 +97,7 @@ class VersionTest < ActiveSupport::TestCase
 
   def test_progress_should_be_100_with_closed_assigned_issues
     project = Project.find(1)
-    status = Status.find(:first, conditions: {is_closed: true})
+    status = Status.find(:first, conditions: { is_closed: true })
     (v = Version.new.tap do |v|
       v.force_attributes = { project: project, name: 'Progress' }
     end).save!
@@ -119,7 +117,7 @@ class VersionTest < ActiveSupport::TestCase
     add_work_package(v)
     add_work_package(v, done_ratio: 20)
     add_work_package(v, done_ratio: 70)
-    assert_progress_equal (0.0 + 20.0 + 70.0)/3, v.completed_percent
+    assert_progress_equal (0.0 + 20.0 + 70.0) / 3, v.completed_percent
     assert_progress_equal 0, v.closed_percent
   end
 
@@ -130,9 +128,9 @@ class VersionTest < ActiveSupport::TestCase
     end).save!
     add_work_package(v)
     add_work_package(v, done_ratio: 20)
-    add_work_package(v, status: Status.find(:first, conditions: {is_closed: true}))
-    assert_progress_equal (0.0 + 20.0 + 100.0)/3, v.completed_percent
-    assert_progress_equal (100.0)/3, v.closed_percent
+    add_work_package(v, status: Status.find(:first, conditions: { is_closed: true }))
+    assert_progress_equal (0.0 + 20.0 + 100.0) / 3, v.completed_percent
+    assert_progress_equal (100.0) / 3, v.closed_percent
   end
 
   def test_progress_should_consider_estimated_hours_to_weigth_issues
@@ -143,9 +141,9 @@ class VersionTest < ActiveSupport::TestCase
     add_work_package(v, estimated_hours: 10)
     add_work_package(v, estimated_hours: 20, done_ratio: 30)
     add_work_package(v, estimated_hours: 40, done_ratio: 10)
-    add_work_package(v, estimated_hours: 25, status: Status.find(:first, conditions: {is_closed: true}))
-    assert_progress_equal (10.0*0 + 20.0*0.3 + 40*0.1 + 25.0*1)/95.0*100, v.completed_percent
-    assert_progress_equal 25.0/95.0*100, v.closed_percent
+    add_work_package(v, estimated_hours: 25, status: Status.find(:first, conditions: { is_closed: true }))
+    assert_progress_equal (10.0 * 0 + 20.0 * 0.3 + 40 * 0.1 + 25.0 * 1) / 95.0 * 100, v.completed_percent
+    assert_progress_equal 25.0 / 95.0 * 100, v.closed_percent
   end
 
   def test_progress_should_consider_average_estimated_hours_to_weigth_unestimated_issues
@@ -154,88 +152,87 @@ class VersionTest < ActiveSupport::TestCase
       v.force_attributes = { project: project, name: 'Progress' }
     end).save!
     add_work_package(v, done_ratio: 20)
-    add_work_package(v, status: Status.find(:first, conditions: {is_closed: true}))
+    add_work_package(v, status: Status.find(:first, conditions: { is_closed: true }))
     add_work_package(v, estimated_hours: 10, done_ratio: 30)
     add_work_package(v, estimated_hours: 40, done_ratio: 10)
-    assert_progress_equal (25.0*0.2 + 25.0*1 + 10.0*0.3 + 40.0*0.1)/100.0*100, v.completed_percent
-    assert_progress_equal 25.0/100.0*100, v.closed_percent
+    assert_progress_equal (25.0 * 0.2 + 25.0 * 1 + 10.0 * 0.3 + 40.0 * 0.1) / 100.0 * 100, v.completed_percent
+    assert_progress_equal 25.0 / 100.0 * 100, v.closed_percent
   end
 
-  context "#behind_schedule?" do
+  context '#behind_schedule?' do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
       @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
 
       (@version = Version.new.tap do |v|
-        v.force_attributes = { project: @project, effective_date: nil, name: "test" }
+        v.force_attributes = { project: @project, effective_date: nil, name: 'test' }
       end).save!
     end
 
-    should "be false if there are no issues assigned" do
+    should 'be false if there are no issues assigned' do
       @version.update_attribute(:effective_date, Date.yesterday)
       assert_equal false, @version.behind_schedule?
     end
 
-    should "be false if there is no effective_date" do
+    should 'be false if there is no effective_date' do
       assert_equal false, @version.behind_schedule?
     end
 
-    should "be false if all of the issues are ahead of schedule" do
+    should 'be false if all of the issues are ahead of schedule' do
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
-                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
-                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60) # 14 day span, 60% done, 50% time left
-                              ]
+        FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
+        FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60) # 14 day span, 60% done, 50% time left
+      ]
       assert_equal 60, @version.completed_percent
       assert_equal false, @version.behind_schedule?
     end
 
-    should "be true if any of the issues are behind schedule" do
+    should 'be true if any of the issues are behind schedule' do
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
-                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
-                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 20) # 14 day span, 20% done, 50% time left
-                              ]
+        FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
+        FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 20) # 14 day span, 20% done, 50% time left
+      ]
       assert_equal 40, @version.completed_percent
       assert_equal true, @version.behind_schedule?
     end
 
-    should "be false if all of the issues are complete" do
+    should 'be false if all of the issues are complete' do
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
-                               FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)), # 7 day span
-                               FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)) # 7 day span
-                              ]
+        FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)), # 7 day span
+        FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)) # 7 day span
+      ]
       assert_equal 100, @version.completed_percent
       assert_equal false, @version.behind_schedule?
-
     end
   end
 
-  context "#estimated_hours" do
+  context '#estimated_hours' do
     setup do
       (@version = Version.new.tap do |v|
         v.force_attributes = { project_id: 1, name: '#estimated_hours' }
       end).save!
     end
 
-    should "return 0 with no assigned issues" do
+    should 'return 0 with no assigned issues' do
       assert_equal 0, @version.estimated_hours
     end
 
-    should "return 0 with no estimated hours" do
+    should 'return 0 with no estimated hours' do
       add_work_package(@version)
       assert_equal 0, @version.estimated_hours
     end
 
-    should "return the sum of estimated hours" do
+    should 'return the sum of estimated hours' do
       add_work_package(@version, estimated_hours: 2.5)
       add_work_package(@version, estimated_hours: 5)
       assert_equal 7.5, @version.estimated_hours
     end
 
-    should "return the sum of leaves estimated hours" do
+    should 'return the sum of leaves estimated hours' do
       parent = add_work_package(@version)
       add_work_package(@version, estimated_hours: 2.5, parent_id: parent.id)
       add_work_package(@version, estimated_hours: 5, parent_id: parent.id)
@@ -280,7 +277,7 @@ class VersionTest < ActiveSupport::TestCase
 
   private
 
-  def add_work_package(version, attributes={})
+  def add_work_package(version, attributes = {})
     (v = WorkPackage.new.tap do |v|
       v.force_attributes = { project: version.project,
                              fixed_version: version,
@@ -292,7 +289,7 @@ class VersionTest < ActiveSupport::TestCase
     v
   end
 
-  def assert_progress_equal(expected_float, actual_float, message="")
-    assert_in_delta(expected_float, actual_float, 0.000001, message="")
+  def assert_progress_equal(expected_float, actual_float, _message = '')
+    assert_in_delta(expected_float, actual_float, 0.000001, message = '')
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -33,7 +33,7 @@ class VersionTest < ActiveSupport::TestCase
 
   def test_create
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => Project.find(1), :name => '1.1', :effective_date => '2011-03-25' }
+      v.force_attributes = { project: Project.find(1), name: '1.1', effective_date: '2011-03-25' }
     end)
     assert v.save
     assert_equal 'open', v.status
@@ -41,7 +41,7 @@ class VersionTest < ActiveSupport::TestCase
 
   def test_invalid_effective_date_validation
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => Project.find(1), :name => '1.1', :effective_date => '99999-01-01' }
+      v.force_attributes = { project: Project.find(1), name: '1.1', effective_date: '99999-01-01' }
     end)
     assert !v.save
     assert_include v.errors[:effective_date], I18n.translate('activerecord.errors.messages.not_a_date')
@@ -52,10 +52,10 @@ class VersionTest < ActiveSupport::TestCase
       should "be the date of the earlist issue" do
         project = Project.find(1)
         (v = Version.new.tap do |v|
-          v.force_attributes = { :project => project, :name => 'Progress' }
+          v.force_attributes = { project: project, name: 'Progress' }
         end).save!
-        add_work_package(v, :estimated_hours => 10, :start_date => '2010-03-01')
-        FactoryGirl.create(:work_package, project: project, :subject => 'not assigned', :start_date => '2010-01-01')
+        add_work_package(v, estimated_hours: 10, start_date: '2010-03-01')
+        FactoryGirl.create(:work_package, project: project, subject: 'not assigned', start_date: '2010-01-01')
 
         assert_equal '2010-03-01', v.start_date.to_s
       end
@@ -65,10 +65,10 @@ class VersionTest < ActiveSupport::TestCase
       should "be the value" do
         project = Project.find(1)
         (v = Version.new.tap do |v|
-          v.force_attributes = { :project => project, :name => 'Progress', :start_date => '2010-01-05' }
+          v.force_attributes = { project: project, name: 'Progress', start_date: '2010-01-05' }
         end).save!
 
-        add_work_package(v, :estimated_hours => 10, :start_date => '2010-03-01')
+        add_work_package(v, estimated_hours: 10, start_date: '2010-03-01')
 
         assert_equal '2010-01-05', v.start_date.to_s
       end
@@ -80,7 +80,7 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_be_0_with_no_assigned_issues
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
     assert_equal 0, v.completed_percent
     assert_equal 0, v.closed_percent
@@ -89,24 +89,24 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_be_0_with_unbegun_assigned_issues
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
     add_work_package(v)
-    add_work_package(v, :done_ratio => 0)
+    add_work_package(v, done_ratio: 0)
     assert_progress_equal 0, v.completed_percent
     assert_progress_equal 0, v.closed_percent
   end
 
   def test_progress_should_be_100_with_closed_assigned_issues
     project = Project.find(1)
-    status = Status.find(:first, :conditions => {:is_closed => true})
+    status = Status.find(:first, conditions: {is_closed: true})
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
-    add_work_package(v, :status => status)
-    add_work_package(v, :status => status, :done_ratio => 20)
-    add_work_package(v, :status => status, :done_ratio => 70, :estimated_hours => 25)
-    add_work_package(v, :status => status, :estimated_hours => 15)
+    add_work_package(v, status: status)
+    add_work_package(v, status: status, done_ratio: 20)
+    add_work_package(v, status: status, done_ratio: 70, estimated_hours: 25)
+    add_work_package(v, status: status, estimated_hours: 15)
     assert_progress_equal 100.0, v.completed_percent
     assert_progress_equal 100.0, v.closed_percent
   end
@@ -114,11 +114,11 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_consider_done_ratio_of_open_assigned_issues
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
     add_work_package(v)
-    add_work_package(v, :done_ratio => 20)
-    add_work_package(v, :done_ratio => 70)
+    add_work_package(v, done_ratio: 20)
+    add_work_package(v, done_ratio: 70)
     assert_progress_equal (0.0 + 20.0 + 70.0)/3, v.completed_percent
     assert_progress_equal 0, v.closed_percent
   end
@@ -126,11 +126,11 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_consider_closed_issues_as_completed
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
     add_work_package(v)
-    add_work_package(v, :done_ratio => 20)
-    add_work_package(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
+    add_work_package(v, done_ratio: 20)
+    add_work_package(v, status: Status.find(:first, conditions: {is_closed: true}))
     assert_progress_equal (0.0 + 20.0 + 100.0)/3, v.completed_percent
     assert_progress_equal (100.0)/3, v.closed_percent
   end
@@ -138,12 +138,12 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_consider_estimated_hours_to_weigth_issues
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
-    add_work_package(v, :estimated_hours => 10)
-    add_work_package(v, :estimated_hours => 20, :done_ratio => 30)
-    add_work_package(v, :estimated_hours => 40, :done_ratio => 10)
-    add_work_package(v, :estimated_hours => 25, :status => Status.find(:first, :conditions => {:is_closed => true}))
+    add_work_package(v, estimated_hours: 10)
+    add_work_package(v, estimated_hours: 20, done_ratio: 30)
+    add_work_package(v, estimated_hours: 40, done_ratio: 10)
+    add_work_package(v, estimated_hours: 25, status: Status.find(:first, conditions: {is_closed: true}))
     assert_progress_equal (10.0*0 + 20.0*0.3 + 40*0.1 + 25.0*1)/95.0*100, v.completed_percent
     assert_progress_equal 25.0/95.0*100, v.closed_percent
   end
@@ -151,12 +151,12 @@ class VersionTest < ActiveSupport::TestCase
   def test_progress_should_consider_average_estimated_hours_to_weigth_unestimated_issues
     project = Project.find(1)
     (v = Version.new.tap do |v|
-      v.force_attributes = { :project => project, :name => 'Progress' }
+      v.force_attributes = { project: project, name: 'Progress' }
     end).save!
-    add_work_package(v, :done_ratio => 20)
-    add_work_package(v, :status => Status.find(:first, :conditions => {:is_closed => true}))
-    add_work_package(v, :estimated_hours => 10, :done_ratio => 30)
-    add_work_package(v, :estimated_hours => 40, :done_ratio => 10)
+    add_work_package(v, done_ratio: 20)
+    add_work_package(v, status: Status.find(:first, conditions: {is_closed: true}))
+    add_work_package(v, estimated_hours: 10, done_ratio: 30)
+    add_work_package(v, estimated_hours: 40, done_ratio: 10)
     assert_progress_equal (25.0*0.2 + 25.0*1 + 10.0*0.3 + 40.0*0.1)/100.0*100, v.completed_percent
     assert_progress_equal 25.0/100.0*100, v.closed_percent
   end
@@ -164,11 +164,11 @@ class VersionTest < ActiveSupport::TestCase
   context "#behind_schedule?" do
     setup do
       ProjectCustomField.destroy_all # Custom values are a mess to isolate in tests
-      @project = Project.generate!(:identifier => 'test0')
+      @project = Project.generate!(identifier: 'test0')
       @project.types << Type.generate!
 
       (@version = Version.new.tap do |v|
-        v.force_attributes = { :project => @project, :effective_date => nil, :name => "test" }
+        v.force_attributes = { project: @project, effective_date: nil, name: "test" }
       end).save!
     end
 
@@ -185,7 +185,7 @@ class VersionTest < ActiveSupport::TestCase
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
                                FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
-                               FactoryGirl.create(:work_package, project: @project, :start_date => 7.days.ago, :done_ratio => 60) # 14 day span, 60% done, 50% time left
+                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60) # 14 day span, 60% done, 50% time left
                               ]
       assert_equal 60, @version.completed_percent
       assert_equal false, @version.behind_schedule?
@@ -194,8 +194,8 @@ class VersionTest < ActiveSupport::TestCase
     should "be true if any of the issues are behind schedule" do
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
-                               FactoryGirl.create(:work_package, project: @project, :start_date => 7.days.ago, :done_ratio => 60), # 14 day span, 60% done, 50% time left
-                               FactoryGirl.create(:work_package, project: @project, :start_date => 7.days.ago, :done_ratio => 20) # 14 day span, 20% done, 50% time left
+                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 60), # 14 day span, 60% done, 50% time left
+                               FactoryGirl.create(:work_package, project: @project, start_date: 7.days.ago, done_ratio: 20) # 14 day span, 20% done, 50% time left
                               ]
       assert_equal 40, @version.completed_percent
       assert_equal true, @version.behind_schedule?
@@ -204,8 +204,8 @@ class VersionTest < ActiveSupport::TestCase
     should "be false if all of the issues are complete" do
       @version.update_attribute(:effective_date, 7.days.from_now.to_date)
       @version.fixed_issues = [
-                               FactoryGirl.create(:work_package, project: @project, :start_date => 14.days.ago, :done_ratio => 100, :status => Status.find(5)), # 7 day span
-                               FactoryGirl.create(:work_package, project: @project, :start_date => 14.days.ago, :done_ratio => 100, :status => Status.find(5)) # 7 day span
+                               FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)), # 7 day span
+                               FactoryGirl.create(:work_package, project: @project, start_date: 14.days.ago, done_ratio: 100, status: Status.find(5)) # 7 day span
                               ]
       assert_equal 100, @version.completed_percent
       assert_equal false, @version.behind_schedule?
@@ -216,7 +216,7 @@ class VersionTest < ActiveSupport::TestCase
   context "#estimated_hours" do
     setup do
       (@version = Version.new.tap do |v|
-        v.force_attributes = { :project_id => 1, :name => '#estimated_hours' }
+        v.force_attributes = { project_id: 1, name: '#estimated_hours' }
       end).save!
     end
 
@@ -230,15 +230,15 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "return the sum of estimated hours" do
-      add_work_package(@version, :estimated_hours => 2.5)
-      add_work_package(@version, :estimated_hours => 5)
+      add_work_package(@version, estimated_hours: 2.5)
+      add_work_package(@version, estimated_hours: 5)
       assert_equal 7.5, @version.estimated_hours
     end
 
     should "return the sum of leaves estimated hours" do
       parent = add_work_package(@version)
-      add_work_package(@version, :estimated_hours => 2.5, :parent_id => parent.id)
-      add_work_package(@version, :estimated_hours => 5, :parent_id => parent.id)
+      add_work_package(@version, estimated_hours: 2.5, parent_id: parent.id)
+      add_work_package(@version, estimated_hours: 5, parent_id: parent.id)
       assert_equal 7.5, @version.estimated_hours
     end
   end
@@ -282,11 +282,11 @@ class VersionTest < ActiveSupport::TestCase
 
   def add_work_package(version, attributes={})
     (v = WorkPackage.new.tap do |v|
-      v.force_attributes = { :project => version.project,
-                             :fixed_version => version,
-                             :subject => 'Test',
-                             :author => User.first,
-                             :type => version.project.types.first }.merge(attributes)
+      v.force_attributes = { project: version.project,
+                             fixed_version: version,
+                             subject: 'Test',
+                             author: User.first,
+                             type: version.project.types.first }.merge(attributes)
     end).save!
 
     v

--- a/test/unit/watcher_test.rb
+++ b/test/unit/watcher_test.rb
@@ -33,7 +33,7 @@ class WatcherTest < ActiveSupport::TestCase
     super
     @user  = FactoryGirl.create :user
     @issue = FactoryGirl.create :work_package
-    @role  = FactoryGirl.create :role, :permissions => [:view_work_packages]
+    @role  = FactoryGirl.create :role, permissions: [:view_work_packages]
     @issue.project.add_member! @user, @role
   end
 
@@ -112,7 +112,7 @@ class WatcherTest < ActiveSupport::TestCase
     @issue.add_watcher(@user)
 
     assert_no_difference 'Watcher.count' do
-      Watcher.prune(:user => @user)
+      Watcher.prune(user: @user)
     end
     assert @issue.watched_by?(@user)
 
@@ -120,7 +120,7 @@ class WatcherTest < ActiveSupport::TestCase
     @user.reload
 
     assert_difference 'Watcher.count', -1 do
-      Watcher.prune(:user => @user)
+      Watcher.prune(user: @user)
     end
     refute @issue.watched_by?(@user)
   end

--- a/test/unit/wiki_content_test.rb
+++ b/test/unit/wiki_content_test.rb
@@ -38,8 +38,8 @@ class WikiContentTest < ActiveSupport::TestCase
   end
 
   def test_create
-    page = WikiPage.new(:wiki => @wiki, :title => "Page")
-    page.content = WikiContent.new(:text => "Content text", :author => User.find(1), :comments => "My comment")
+    page = WikiPage.new(wiki: @wiki, title: "Page")
+    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
     assert page.save
     page.reload
 
@@ -56,8 +56,8 @@ class WikiContentTest < ActiveSupport::TestCase
   def test_create_should_send_email_notification
     Setting.notified_events = ['wiki_content_added']
     ActionMailer::Base.deliveries.clear
-    page = WikiPage.new(:wiki => @wiki, :title => "A new page")
-    page.content = WikiContent.new(:text => "Content text", :author => User.find(1), :comments => "My comment")
+    page = WikiPage.new(wiki: @wiki, title: "A new page")
+    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
     assert page.save
 
     assert_equal 2, ActionMailer::Base.deliveries.size
@@ -97,16 +97,16 @@ class WikiContentTest < ActiveSupport::TestCase
   end
 
   def test_large_text_should_not_be_truncated_to_64k
-    page = WikiPage.new(:wiki => @wiki, :title => "Big page")
-    page.content = WikiContent.new(:text => "a" * 500.kilobyte, :author => User.find(1))
+    page = WikiPage.new(wiki: @wiki, title: "Big page")
+    page.content = WikiContent.new(text: "a" * 500.kilobyte, author: User.find(1))
     assert page.save
     page.reload
     assert_equal 500.kilobyte, page.content.text.size
   end
 
   test "new WikiContent is version 0" do
-    page = WikiPage.new(:wiki => @wiki, :title => "Page")
-    page.content = WikiContent.new(:text => "Content text", :author => User.find(1), :comments => "My comment")
+    page = WikiPage.new(wiki: @wiki, title: "Page")
+    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
 
     assert_equal 0, page.content.version
   end

--- a/test/unit/wiki_content_test.rb
+++ b/test/unit/wiki_content_test.rb
@@ -38,8 +38,8 @@ class WikiContentTest < ActiveSupport::TestCase
   end
 
   def test_create
-    page = WikiPage.new(wiki: @wiki, title: "Page")
-    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
+    page = WikiPage.new(wiki: @wiki, title: 'Page')
+    page.content = WikiContent.new(text: 'Content text', author: User.find(1), comments: 'My comment')
     assert page.save
     page.reload
 
@@ -47,8 +47,8 @@ class WikiContentTest < ActiveSupport::TestCase
     assert_kind_of WikiContent, content
     assert_equal 1, content.version
     assert_equal 1, content.versions.length
-    assert_equal "Content text", content.text
-    assert_equal "My comment", content.versions.last.notes
+    assert_equal 'Content text', content.text
+    assert_equal 'My comment', content.versions.last.notes
     assert_equal User.find(1), content.author
     assert_equal content.text, content.versions.last.data.text
   end
@@ -56,8 +56,8 @@ class WikiContentTest < ActiveSupport::TestCase
   def test_create_should_send_email_notification
     Setting.notified_events = ['wiki_content_added']
     ActionMailer::Base.deliveries.clear
-    page = WikiPage.new(wiki: @wiki, title: "A new page")
-    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
+    page = WikiPage.new(wiki: @wiki, title: 'A new page')
+    page.content = WikiContent.new(text: 'Content text', author: User.find(1), comments: 'My comment')
     assert page.save
 
     assert_equal 2, ActionMailer::Base.deliveries.size
@@ -66,18 +66,18 @@ class WikiContentTest < ActiveSupport::TestCase
   def test_update
     content = @page.content
     version_count = content.version
-    content.text = "My new content"
+    content.text = 'My new content'
     assert content.save
     content.reload
-    assert_equal version_count+1, content.version
-    assert_equal version_count+1, content.versions.length
+    assert_equal version_count + 1, content.version
+    assert_equal version_count + 1, content.versions.length
   end
 
   def test_update_should_send_email_notification
     Setting.notified_events = ['wiki_content_updated']
     ActionMailer::Base.deliveries.clear
     content = @page.content
-    content.text = "My new content"
+    content.text = 'My new content'
     assert content.save
 
     assert_equal 2, ActionMailer::Base.deliveries.size
@@ -87,7 +87,7 @@ class WikiContentTest < ActiveSupport::TestCase
     wiki_content_journal = FactoryGirl.build(:wiki_content_journal,
                                              journable_id: @page.content.id)
     wiki_content_journal.data.page_id = @page.id
-    wiki_content_journal.data.text = ""
+    wiki_content_journal.data.text = ''
 
     @page.content.journals << wiki_content_journal
     assert !@page.content.journals.empty?
@@ -97,16 +97,16 @@ class WikiContentTest < ActiveSupport::TestCase
   end
 
   def test_large_text_should_not_be_truncated_to_64k
-    page = WikiPage.new(wiki: @wiki, title: "Big page")
-    page.content = WikiContent.new(text: "a" * 500.kilobyte, author: User.find(1))
+    page = WikiPage.new(wiki: @wiki, title: 'Big page')
+    page.content = WikiContent.new(text: 'a' * 500.kilobyte, author: User.find(1))
     assert page.save
     page.reload
     assert_equal 500.kilobyte, page.content.text.size
   end
 
-  test "new WikiContent is version 0" do
-    page = WikiPage.new(wiki: @wiki, title: "Page")
-    page.content = WikiContent.new(text: "Content text", author: User.find(1), comments: "My comment")
+  test 'new WikiContent is version 0' do
+    page = WikiPage.new(wiki: @wiki, title: 'Page')
+    page.content = WikiContent.new(text: 'Content text', author: User.find(1), comments: 'My comment')
 
     assert_equal 0, page.content.version
   end

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -38,7 +38,7 @@ class WikiPageTest < ActiveSupport::TestCase
   end
 
   def test_create
-    page = WikiPage.new(:wiki => @wiki)
+    page = WikiPage.new(wiki: @wiki)
     assert !page.save
     assert_equal 1, page.errors.count
 

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -42,7 +42,7 @@ class WikiPageTest < ActiveSupport::TestCase
     assert !page.save
     assert_equal 1, page.errors.count
 
-    page.title = "Page"
+    page.title = 'Page'
     assert page.save
     page.reload
     assert !page.protected?
@@ -58,11 +58,11 @@ class WikiPageTest < ActiveSupport::TestCase
   end
 
   def test_find_or_new_page
-    page = @wiki.find_or_new_page("CookBook documentation")
+    page = @wiki.find_or_new_page('CookBook documentation')
     assert_kind_of WikiPage, page
     assert !page.new_record?
 
-    page = @wiki.find_or_new_page("Non existing page")
+    page = @wiki.find_or_new_page('Non existing page')
     assert_kind_of WikiPage, page
     assert page.new_record?
   end

--- a/test/unit/wiki_redirect_test.rb
+++ b/test/unit/wiki_redirect_test.rb
@@ -34,7 +34,7 @@ class WikiRedirectTest < ActiveSupport::TestCase
   def setup
     super
     @wiki = Wiki.find(1)
-    @original = WikiPage.create(:wiki => @wiki, :title => 'Original title')
+    @original = WikiPage.create(wiki: @wiki, title: 'Original title')
   end
 
   def test_create_redirect
@@ -50,7 +50,7 @@ class WikiRedirectTest < ActiveSupport::TestCase
 
   def test_update_redirect
     # create a redirect that point to this page
-    assert WikiRedirect.create(:wiki => @wiki, :title => 'An_old_page', :redirects_to => 'Original_title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An_old_page', redirects_to: 'Original_title')
 
     @original.title = 'New title'
     @original.save
@@ -60,7 +60,7 @@ class WikiRedirectTest < ActiveSupport::TestCase
 
   def test_reverse_rename
     # create a redirect that point to this page
-    assert WikiRedirect.create(:wiki => @wiki, :title => 'An_old_page', :redirects_to => 'Original_title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An_old_page', redirects_to: 'Original_title')
 
     @original.title = 'An old page'
     @original.save
@@ -69,7 +69,7 @@ class WikiRedirectTest < ActiveSupport::TestCase
   end
 
   def test_rename_to_already_redirected
-    assert WikiRedirect.create(:wiki => @wiki, :title => 'An_old_page', :redirects_to => 'Other_page')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An_old_page', redirects_to: 'Other_page')
 
     @original.title = 'An old page'
     @original.save
@@ -78,7 +78,7 @@ class WikiRedirectTest < ActiveSupport::TestCase
   end
 
   def test_redirects_removed_when_deleting_page
-    assert WikiRedirect.create(:wiki => @wiki, :title => 'An_old_page', :redirects_to => 'Original_title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An_old_page', redirects_to: 'Original_title')
 
     @original.destroy
     assert !@wiki.redirects.find(:first)

--- a/test/unit/wiki_test.rb
+++ b/test/unit/wiki_test.rb
@@ -36,16 +36,16 @@ class WikiTest < ActiveSupport::TestCase
     assert !wiki.save
     assert_equal 1, wiki.errors.count
 
-    wiki.start_page = "Start page"
+    wiki.start_page = 'Start page'
     assert wiki.save
   end
 
   def test_update
     @wiki = Wiki.find(1)
-    @wiki.start_page = "Another start page"
+    @wiki.start_page = 'Another start page'
     assert @wiki.save
     @wiki.reload
-    assert_equal "Another start page", @wiki.start_page
+    assert_equal 'Another start page', @wiki.start_page
   end
 
   def test_find_page
@@ -68,16 +68,16 @@ class WikiTest < ActiveSupport::TestCase
     assert_equal 'テスト', Wiki.titleize('テスト')
   end
 
-  context "#sidebar" do
+  context '#sidebar' do
     setup do
       @wiki = Wiki.find(1)
     end
 
-    should "return nil if undefined" do
+    should 'return nil if undefined' do
       assert_nil @wiki.sidebar
     end
 
-    should "return a WikiPage if defined" do
+    should 'return a WikiPage if defined' do
       page = @wiki.pages.new(title: 'Sidebar')
       page.content = WikiContent.new(text: 'Side bar content for test_show_with_sidebar')
       page.save!

--- a/test/unit/wiki_test.rb
+++ b/test/unit/wiki_test.rb
@@ -32,7 +32,7 @@ class WikiTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_create
-    wiki = Wiki.new(:project => Project.find(2))
+    wiki = Wiki.new(project: Project.find(2))
     assert !wiki.save
     assert_equal 1, wiki.errors.count
 
@@ -59,7 +59,7 @@ class WikiTest < ActiveSupport::TestCase
     page = WikiPage.find(10)
     assert_equal page, wiki.find_page('Этика_менеджмента')
 
-    page = WikiPage.generate!(:wiki => wiki, :title => '2009\\02\\09')
+    page = WikiPage.generate!(wiki: wiki, title: '2009\\02\\09')
     assert_equal page, wiki.find_page('2009\\02\\09')
   end
 
@@ -78,8 +78,8 @@ class WikiTest < ActiveSupport::TestCase
     end
 
     should "return a WikiPage if defined" do
-      page = @wiki.pages.new(:title => 'Sidebar')
-      page.content = WikiContent.new(:text => 'Side bar content for test_show_with_sidebar')
+      page = @wiki.pages.new(title: 'Sidebar')
+      page.content = WikiContent.new(text: 'Side bar content for test_show_with_sidebar')
       page.save!
 
       assert_kind_of WikiPage, @wiki.sidebar


### PR DESCRIPTION
Because #2115 was in a more mergeable condition at the time, I skipped converting test-unit test syntax in original PR #2136. 
#2115 has since diverged and it would be probably be easier to repeat the migration steps based on a fresh branch.
