### PR TITLE
Allow bypassing basic auth for repository access authorization

### DIFF
--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -37,6 +37,11 @@ See doc/COPYRIGHT.rdoc for more details.
                                         :label => :setting_mail_handler_api_key %>
       <%= link_to_function l(:label_generate_key), "if ($('settings_sys_api_key').disabled == false) { $('settings_sys_api_key').value = randomKey(20) }" %>
     </p>
+    <p><%= setting_check_box :repository_authentication_bypass %>
+      <br/><em><%= l('settings.repositories.authentication_bypass_desc') %>
+      <br/><strong><%= l(:warning) %></strong>
+      <em><%= l('settings.repositories.authentication_bypass_warning') %>
+    </p>
     <p><%= setting_multiselect(:enabled_scm, Redmine::Scm::Base.all) %></p>
     <p><%= setting_text_field :repositories_encodings, :size => 60 %>
       <em><%= l(:text_comma_separated) %></em></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1285,6 +1285,7 @@ en:
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_repositories_encodings: "Repositories encodings"
+  setting_repository_authentication_bypass: "Bypass Basic Auth authentication"
   setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_rest_api_enabled: "Enable REST web service"
@@ -1313,6 +1314,9 @@ en:
     passwords: "Passwords"
     session: "Session"
     brute_force_prevention: "Automated user blocking"
+    repositories:
+      authentication_bypass_desc: "Use this setting if you authenticate users for repository access using your web server."
+      authentication_bypass_warning: "If you enable this, make sure to restrict access to the internal /sys API to local access."
 
   show_hide_project_menu: "Hide/Show project menu"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -135,6 +135,9 @@ sys_api_key:
   default: ''
 repository_authentication_caching_enabled:
   default: 1
+repository_authentication_bypass:
+  default: 0
+commit_ref_keywords:
 commit_ref_keywords:
   default: 'refs,references,IssueID'
 commit_fix_keywords:


### PR DESCRIPTION
In our use-case, we use RADIUS to authorize users through Apache
in combination with an OmniAuth strategy.

Thus, we do not have an active authentication source to
perform basic auth against and cannot use the existing `OpenProjectAuthentication.pm` Apache wrapper.

This commit adds an optional setting to allow bypassing
basic auth in the SysController.

When authorizing the user directly in the web server,
passing the logged in user to SysController is sufficient
to retrieve the project permissions.

I suggest this as a temporary solution until the general issue of repositories and external authentication is resolved, as its discussion is still heavily ongoing.

The relevant work package:
https://community.openproject.org/work_packages/18356
