### PR TITLE
Remove cucumber-rails-training-wheels dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,6 @@ group :test do
   # connection with database cleaner here but setting it to 1.2 fixes the
   # issue.
   gem 'database_cleaner', '~> 1.2.0'
-  gem "cucumber-rails-training-wheels" # http://aslakhellesoy.com/post/11055981222/the-training-wheels-came-off
   gem 'rspec', '~> 2.99.0'
   # also add to development group, so "spec" rake task gets loaded
   gem "rspec-rails", "~> 2.99.0", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,8 +139,6 @@ GEM
       cucumber (>= 1.2.0)
       nokogiri (>= 1.5.0)
       rails (~> 3.0)
-    cucumber-rails-training-wheels (1.0.0)
-      cucumber-rails (>= 1.1.1)
     daemons (1.1.9)
     dalli (2.6.4)
     database_cleaner (1.2.0)
@@ -459,7 +457,6 @@ DEPENDENCIES
   coderay (~> 1.0.5)
   color-tools (~> 1.3.0)
   cucumber-rails
-  cucumber-rails-training-wheels
   daemons
   dalli
   database_cleaner (~> 1.2.0)


### PR DESCRIPTION
cucumber-rails-training-wheels gem provides generators. Generating
`web_steps.rb` should have been a one-off operation.
