### PR TITLE
Preselect default sorting direction when adding a new sorting criterion

### DIFF
--- a/frontend/app/work_packages/controllers/dialogs/sorting.js
+++ b/frontend/app/work_packages/controllers/dialogs/sorting.js
@@ -49,6 +49,12 @@ module.exports = function(sortingModal, $scope, $filter, QueryService, I18n) {
     }
   }
 
+  $scope.setDefaultDirection = function(criterion) {
+    if (criterion.length === 1) {
+      criterion.push($scope.defaultDirection);
+    }
+  };
+
   // functions exposing available options to select2
 
   $scope.getAvailableColumnsData = function(term, result) {
@@ -97,6 +103,7 @@ module.exports = function(sortingModal, $scope, $filter, QueryService, I18n) {
   // setup
 
   $scope.availableDirectionsData = [{ id: 'desc', label: I18n.t('js.label_descending')}, { id: 'asc', label: I18n.t('js.label_ascending')}];
+  $scope.defaultDirection = $scope.availableDirectionsData[1];
 
   var blankOption = { id: null, label: ' ', other: null };
 

--- a/frontend/public/templates/work_packages/modals/sorting.html
+++ b/frontend/public/templates/work_packages/modals/sorting.html
@@ -11,6 +11,7 @@
                  ui-select2-sortable
                  simple-query="getAvailableColumnsData"
                  ng-model="element[0]"
+                 ng-change="setDefaultDirection(element)"
                  focus="$first"></input>
           <input type="hidden"
                  ui-select2-sortable


### PR DESCRIPTION
This addresses the following issue: https://community.openproject.org/work_packages/18281

However, a search field is still displayed, since [angular-ui-select2-sortable](https://github.com/Taranys/ui-select2-sortable) does not seem to accept configuration in this respect.
