### PR TITLE
Restrict Bourbon to 4.0.x series

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'sprockets-rails',  git: 'https://github.com/finnlabs/sprockets-rails.git', 
 gem 'non-stupid-digest-assets'
 gem 'sass-rails',        git: 'https://github.com/guilleiguaran/sass-rails.git', branch: 'backport'
 gem 'sass',             '~> 3.3.6'
-gem 'bourbon',          '~> 4.0'
+gem 'bourbon',          '~> 4.0.2'
 gem 'uglifier',         '>= 1.0.3', require: false
 gem 'livingstyleguide', '~> 1.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bourbon (4.0.0)
+    bourbon (4.0.2)
       sass (~> 3.3)
       thor
     bourne (1.4.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   activerecord-tableless (~> 1.0)
   acts_as_list (~> 0.2.0)
   awesome_nested_set
-  bourbon (~> 4.0)
+  bourbon (~> 4.0.2)
   capybara (~> 2.3.0)
   capybara-screenshot
   cocaine


### PR DESCRIPTION
:warning: **This patch does not apply to dev.** Please `git merge release/4.0 -s ours` when merging back to dev.

Bourbon 4.1.0, 4.1.1 appear to need Sass 3.4 (despite not declaring
it as a dependency). See: https://github.com/thoughtbot/bourbon/issues/649

https://community.openproject.org/topics/3831
https://community.openproject.org/topics/3980
