### PR TITLE
fix a project nil call on querying visibility

### DIFF
--- a/app/controllers/reportings_controller.rb
+++ b/app/controllers/reportings_controller.rb
@@ -200,6 +200,13 @@ class ReportingsController < ApplicationController
   def create
     @reporting = @project.reportings_via_source.build
     @reporting.reporting_to_project_id = params['reporting']['reporting_to_project_id']
+
+    if @reporting.reporting_to_project.nil?
+      flash.now[:error] = l('timelines.reporting_could_not_be_saved')
+      render action: :new, status: :unprocessable_entity
+      return
+    end
+
     check_visibility
 
     if @reporting.save

--- a/spec/controllers/reportings_controller_spec.rb
+++ b/spec/controllers/reportings_controller_spec.rb
@@ -77,6 +77,15 @@ describe ReportingsController, :type => :controller do
       project_reportings_path(project)
     end
     it_should_behave_like "a controller action which needs project permissions"
+
+    it 'should not create a reporting w/o a reporting project' do
+      post :create, project_id: project.identifier,
+                    reporting: FactoryGirl.build(:reporting,
+                    project_id: project.id,
+                    reporting_to_project_id: nil).attributes
+
+      expect(response).to render_template(:new)
+    end
   end
 
   describe 'edit.html' do


### PR DESCRIPTION
This fixes an an error when creating a reporting for a project without an associated project.

This should fix the internal error reported by Nadejda Parpulova in
https://community.openproject.org/work_packages/18460
