### PR TITLE
Hotfix/16974 can see description diff without authorization

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -88,7 +88,7 @@ class JournalsController < ApplicationController
   end
 
   def diff
-    if valid_field?(params[:field])
+    if valid_diff?
       field = params[:field].parameterize.underscore.to_sym
       from = @journal.changed_data[field][0]
       to = @journal.changed_data[field][1]
@@ -131,5 +131,10 @@ class JournalsController < ApplicationController
 
   def default_breadcrumb
     I18n.t(:label_journal_diff)
+  end
+
+  def valid_diff?
+    return false unless valid_field?(params[:field])
+    @journal.journable.class == WorkPackage
   end
 end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -32,7 +32,7 @@ require 'diff'
 class JournalsController < ApplicationController
   before_filter :find_journal, :except => [:index]
   before_filter :find_optional_project, :only => [:index]
-  before_filter :authorize, :only => [:edit, :update, :preview]
+  before_filter :authorize, :only => [:edit, :update, :preview, :diff]
   accept_key_auth :index
   menu_item :issues
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -30,9 +30,9 @@
 require 'diff'
 
 class JournalsController < ApplicationController
-  before_filter :find_journal, :except => [:index]
-  before_filter :find_optional_project, :only => [:index]
-  before_filter :authorize, :only => [:edit, :update, :preview, :diff]
+  before_filter :find_journal, except: [:index]
+  before_filter :find_optional_project, only: [:index]
+  before_filter :authorize, only: [:edit, :update, :preview, :diff]
   accept_key_auth :index
   menu_item :issues
 
@@ -45,18 +45,18 @@ class JournalsController < ApplicationController
     sort_update(@query.sortable_columns)
 
     if @query.valid?
-      @journals = @query.work_package_journals(:order => "#{Journal.table_name}.created_at DESC",
-                                               :limit => 25)
+      @journals = @query.work_package_journals(order: "#{Journal.table_name}.created_at DESC",
+                                               limit: 25)
     end
 
-    title = (@project ? @project.name : Setting.app_title) + ": " + (@query.new_record? ? l(:label_changes_details) : @query.name)
+    title = (@project ? @project.name : Setting.app_title) + ': ' + (@query.new_record? ? l(:label_changes_details) : @query.name)
 
     respond_to do |format|
       format.atom do
-        render :layout => false,
-               :content_type => 'application/atom+xml',
-               :locals => { :title => title,
-                            :journals => @journals }
+        render layout: false,
+               content_type: 'application/atom+xml',
+               locals: { title: title,
+                         journals: @journals }
       end
     end
   rescue ActiveRecord::RecordNotFound
@@ -68,7 +68,7 @@ class JournalsController < ApplicationController
     respond_to do |format|
       format.html {
         # TODO: implement non-JS journal update
-        render :nothing => true
+        render nothing: true
       }
       format.js
     end
@@ -77,11 +77,13 @@ class JournalsController < ApplicationController
   def update
     @journal.update_attribute(:notes, params[:notes]) if params[:notes]
     @journal.destroy if @journal.details.empty? && @journal.notes.blank?
-    call_hook(:controller_journals_edit_post, { :journal => @journal, :params => params})
+    call_hook(:controller_journals_edit_post,  journal: @journal, params: params)
     respond_to do |format|
-      format.html { redirect_to :controller => "/#{@journal.journable.class.name.pluralize.downcase}",
-        :action => 'show', :id => @journal.journable_id }
-      format.js { render :action => 'update' }
+      format.html {
+        redirect_to controller: "/#{@journal.journable.class.name.pluralize.downcase}",
+                    action: 'show', id: @journal.journable_id
+      }
+      format.js { render action: 'update' }
     end
   end
 
@@ -94,8 +96,8 @@ class JournalsController < ApplicationController
       @diff = Redmine::Helpers::Diff.new(to, from)
       @journable = @journal.journable
       respond_to do |format|
-        format.html { }
-        format.js { render :partial => 'diff', :locals => { :diff => @diff } }
+        format.html {}
+        format.js { render partial: 'diff', locals: { diff: @diff } }
       end
     else
       render_404
@@ -106,8 +108,10 @@ class JournalsController < ApplicationController
     @journal.notes = params[:notes]
 
     respond_to do |format|
-      format.any(:html, :js) { render locals: { journal: @journal },
-                                      layout: false }
+      format.any(:html, :js) {
+        render locals: { journal: @journal },
+               layout: false
+      }
     end
   end
 
@@ -122,7 +126,7 @@ class JournalsController < ApplicationController
 
   # Is this a valid field for diff'ing?
   def valid_field?(field)
-    field.to_s.strip == "description"
+    field.to_s.strip == 'description'
   end
 
   def default_breadcrumb

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -28,30 +28,36 @@
 
 require 'spec_helper'
 
-describe JournalsController, :type => :controller do
+describe JournalsController, type: :controller do
   let(:user) { FactoryGirl.create(:user, member_in_project: project, member_through_role: role) }
   let(:project) { FactoryGirl.create(:project_with_types) }
-  let(:role) { FactoryGirl.create(:role, :permissions => permissions) }
-  let(:member) { FactoryGirl.build(:member, :project => project,
-                                            :roles => [role],
-                                            :principal => user) }
-  let(:work_package) { FactoryGirl.build(:work_package, :type => project.types.first,
-                                                        :author => user,
-                                                        :project => project,
-                                                        :description => '') }
-  let(:journal) { FactoryGirl.create(:work_package_journal,
-                  journable: work_package,
-                  user: user) }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:member) {
+    FactoryGirl.build(:member, project: project,
+                               roles: [role],
+                               principal: user)
+  }
+  let(:work_package) {
+    FactoryGirl.build(:work_package, type: project.types.first,
+                                     author: user,
+                                     project: project,
+                                     description: '')
+  }
+  let(:journal) {
+    FactoryGirl.create(:work_package_journal,
+                       journable: work_package,
+                       user: user)
+  }
   let(:permissions) { [:view_work_packages] }
 
   before do
     allow(User).to receive(:current).and_return user
   end
 
-  describe "GET diff" do
+  describe 'GET diff' do
     render_views
 
-    let(:params) { { :id => work_package.journals.last.id.to_s, :field => :description, :format => 'js' } }
+    let(:params) { { id: work_package.journals.last.id.to_s, field: :description, format: 'js' } }
 
     before do
       work_package.update_attribute :description, 'description'
@@ -59,11 +65,11 @@ describe JournalsController, :type => :controller do
     end
 
     describe 'w/ authorization' do
-      it "should be successful" do
+      it 'should be successful' do
         expect(response).to be_success
       end
 
-      it "should presetn the diff correctly" do
+      it 'should presetn the diff correctly' do
         expect(response.body.strip).to eq("<div class=\"text-diff\">\n  <ins class=\"diffmod\">description</ins>\n</div>")
       end
     end
@@ -72,7 +78,6 @@ describe JournalsController, :type => :controller do
       let(:permissions) { [] }
       it { expect(response).not_to be_success }
     end
-
   end
 
   describe :edit do

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -29,9 +29,9 @@
 require 'spec_helper'
 
 describe JournalsController, :type => :controller do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryGirl.create(:user, member_in_project: project, member_through_role: role) }
   let(:project) { FactoryGirl.create(:project_with_types) }
-  let(:role) { FactoryGirl.create(:role, :permissions => [:view_work_package]) }
+  let(:role) { FactoryGirl.create(:role, :permissions => permissions) }
   let(:member) { FactoryGirl.build(:member, :project => project,
                                             :roles => [role],
                                             :principal => user) }
@@ -42,35 +42,51 @@ describe JournalsController, :type => :controller do
   let(:journal) { FactoryGirl.create(:work_package_journal,
                   journable: work_package,
                   user: user) }
+  let(:permissions) { [:view_work_packages] }
+
+  before do
+    allow(User).to receive(:current).and_return user
+  end
 
   describe "GET diff" do
     render_views
 
+    let(:params) { { :id => work_package.journals.last.id.to_s, :field => :description, :format => 'js' } }
+
     before do
       work_package.update_attribute :description, 'description'
-      params = { :id => work_package.journals.last.id.to_s, :field => :description, :format => 'js' }
-
       get :diff, params
     end
 
-    it { expect(response).to be_success }
-    it { expect(response.body.strip).to eq("<div class=\"text-diff\">\n  <ins class=\"diffmod\">description</ins>\n</div>") }
+    describe 'w/ authorization' do
+      it "should be successful" do
+        expect(response).to be_success
+      end
+
+      it "should presetn the diff correctly" do
+        expect(response.body.strip).to eq("<div class=\"text-diff\">\n  <ins class=\"diffmod\">description</ins>\n</div>")
+      end
+    end
+
+    describe 'w/o authorization' do
+      let(:permissions) { [] }
+      it { expect(response).not_to be_success }
+    end
+
   end
 
   describe :edit do
     describe 'authorization' do
+      let(:permissions) { [:edit_work_packages, :edit_own_work_package_notes] }
+
       before do
         work_package.update_attribute :description, 'description'
-        role.add_permission! *permissions
-        member.save and user.reload
         allow(User).to receive(:current).and_return user
 
         get :edit, id: journal.id
       end
 
       context 'with permissions to edit work packages and edit own work package notes' do
-        let(:permissions) { [:edit_work_packages, :edit_own_work_package_notes] }
-
         example { assert_response :success }
       end
 


### PR DESCRIPTION
This should fix a problem where any user could view the description diff of a Work Package.

This was reported in https://community.openproject.org/work_packages/16974
