### PR TITLE
Fix auto loading of DateTimeFormatter in development mode

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -30,17 +30,12 @@
 require 'roar/decorator'
 require 'roar/json/hal'
 
-# we need to help the rails autoloader, otherwise it MIGHT fail to resolve the DateTimeFormatter
-# during development mode
-API::V3::Utilities::DateTimeFormatter
-
 module API
   module Decorators
     class Single < Roar::Decorator
       include Roar::JSON::HAL
       include Roar::Hypermedia
       include API::V3::Utilities::PathHelper
-      include API::V3::Utilities
 
       attr_reader :context
       class_attribute :as_strategy
@@ -57,6 +52,10 @@ module API
                render_nil: false
 
       private
+
+      def datetime_formatter
+        API::V3::Utilities::DateTimeFormatter
+      end
 
       def _type; end
     end

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -30,12 +30,17 @@
 require 'roar/decorator'
 require 'roar/json/hal'
 
+# we need to help the rails autoloader, otherwise it MIGHT fail to resolve the DateTimeFormatter
+# during development mode
+API::V3::Utilities::DateTimeFormatter
+
 module API
   module Decorators
     class Single < Roar::Decorator
       include Roar::JSON::HAL
       include Roar::Hypermedia
       include API::V3::Utilities::PathHelper
+      include API::V3::Utilities
 
       attr_reader :context
       class_attribute :as_strategy

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -29,7 +29,8 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
+
+API::V3::Utilities::DateTimeFormatter
 
 module API
   module V3

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -29,7 +29,6 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -29,13 +29,11 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3
     module Projects
       class ProjectRepresenter < ::API::Decorators::Single
-        include API::V3::Utilities
 
         link :self do
           {

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -59,10 +59,12 @@ module API
 
         property :created_on,
                  as: 'createdAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(created_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.created_on) }
         property :updated_on,
                  as: 'updatedAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(updated_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.updated_on) }
 
         property :type, getter: -> (*) { project_type.try(:name) }, render_nil: true
 

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -29,14 +29,12 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3
     module Users
       class UserRepresenter < ::API::Decorators::Single
         include AvatarHelper
-        include API::V3::Utilities
 
         link :self do
           {

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -87,10 +87,12 @@ module API
                           exec_context: :decorator
         property :created_on,
                  as: 'createdAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(created_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.created_on) }
         property :updated_on,
                  as: 'updatedAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(updated_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.updated_on) }
         property :status, getter: -> (*) { status_name }, render_nil: true
 
         def _type

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -69,19 +69,27 @@ module API
                  render_nil: true
 
         property :start_date,
-                 getter: -> (*) { DateTimeFormatter::format_date(start_date, allow_nil: true) },
+                 exec_context: :decorator,
+                 getter: -> (*) {
+                   datetime_formatter.format_date(represented.start_date, allow_nil: true)
+                 },
                  render_nil: true
         property :due_date,
                  as: 'endDate',
-                 getter: -> (*) { DateTimeFormatter::format_date(due_date, allow_nil: true) },
+                 exec_context: :decorator,
+                 getter: -> (*) {
+                   datetime_formatter.format_date(represented.due_date, allow_nil: true)
+                 },
                  render_nil: true
         property :status, render_nil: true
         property :created_on,
                  as: 'createdAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(created_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.created_on) }
         property :updated_on,
                  as: 'updatedAt',
-                 getter: -> (*) { DateTimeFormatter::format_datetime(updated_on) }
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.updated_on) }
 
         def _type
           'Version'

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -29,13 +29,11 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3
     module Versions
       class VersionRepresenter < ::API::Decorators::Single
-        include API::V3::Utilities
 
         link :self do
           {

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -37,7 +37,6 @@ module API
         class WorkPackagePayloadRepresenter < Roar::Decorator
           include Roar::JSON::HAL
           include Roar::Hypermedia
-          include API::V3::Utilities
 
           self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
@@ -85,10 +84,10 @@ module API
           property :start_date,
                    exec_context: :decorator,
                    getter: -> (*) {
-                     DateTimeFormatter::format_date(represented.start_date, allow_nil: true)
+                     datetime_formatter.format_date(represented.start_date, allow_nil: true)
                    },
                    setter: -> (value, *) {
-                     represented.start_date = DateTimeFormatter::parse_date(value,
+                     represented.start_date = datetime_formatter.parse_date(value,
                                                                             'startDate',
                                                                             allow_nil: true)
                    },
@@ -96,10 +95,10 @@ module API
           property :due_date,
                    exec_context: :decorator,
                    getter: -> (*) {
-                     DateTimeFormatter::format_date(represented.due_date, allow_nil: true)
+                     datetime_formatter.format_date(represented.due_date, allow_nil: true)
                    },
                    setter: -> (value, *) {
-                     represented.due_date = DateTimeFormatter::parse_date(value,
+                     represented.due_date = datetime_formatter.parse_date(value,
                                                                           'dueDate',
                                                                           allow_nil: true)
                    },
@@ -118,6 +117,10 @@ module API
           end
 
           private
+
+          def datetime_formatter
+            API::V3::Utilities::DateTimeFormatter
+          end
 
           def work_package_attribute_links_representer(represented)
             ::API::V3::WorkPackages::Form::WorkPackageAttributeLinksRepresenter.new represented

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -29,7 +29,6 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -29,13 +29,11 @@
 
 require 'roar/decorator'
 require 'roar/json/hal'
-require 'api/v3/utilities/date_time_formatter'
 
 module API
   module V3
     module WorkPackages
       class WorkPackageRepresenter < ::API::Decorators::Single
-        include API::V3::Utilities
 
         link :self do
           {

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -240,29 +240,31 @@ module API
                  render_nil: true
 
         property :start_date,
+                 exec_context: :decorator,
                  getter: -> (*) do
-                   DateTimeFormatter::format_date(start_date, allow_nil: true)
+                   datetime_formatter.format_date(represented.start_date, allow_nil: true)
                  end,
                  render_nil: true
         property :due_date,
+                 exec_context: :decorator,
                  getter: -> (*) do
-                   DateTimeFormatter::format_date(due_date, allow_nil: true)
+                   datetime_formatter.format_date(represented.due_date, allow_nil: true)
                  end,
                  render_nil: true
         property :estimated_time,
+                 exec_context: :decorator,
                  getter: -> (*) do
-                   DateTimeFormatter::format_duration_from_hours(represented.estimated_hours,
+                   datetime_formatter.format_duration_from_hours(represented.estimated_hours,
                                                                  allow_nil: true)
                  end,
-                 exec_context: :decorator,
                  render_nil: true,
                  writeable: false
         property :spent_time,
+                 exec_context: :decorator,
                  getter: -> (*) do
-                   DateTimeFormatter::format_duration_from_hours(represented.spent_hours)
+                   datetime_formatter.format_duration_from_hours(represented.spent_hours)
                  end,
                  writeable: false,
-                 exec_context: :decorator,
                  if: -> (_) { current_user_allowed_to(:view_time_entries) }
         property :percentage_done,
                  render_nil: true,
@@ -277,8 +279,12 @@ module API
         property :project_id, getter: -> (*) { project.id }
         property :project_name, getter: -> (*) { project.try(:name) }
         property :parent_id, writeable: true
-        property :created_at, getter: -> (*) { DateTimeFormatter::format_datetime(created_at) }
-        property :updated_at, getter: -> (*) { DateTimeFormatter::format_datetime(updated_at) }
+        property :created_at,
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.created_at) }
+        property :updated_at,
+                 exec_context: :decorator,
+                 getter: -> (*) { datetime_formatter.format_datetime(represented.updated_at) }
 
         collection :custom_properties, exec_context: :decorator, render_nil: true
 

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -27,7 +27,6 @@
 #++
 
 require 'spec_helper'
-require 'api/v3/utilities/date_time_formatter'
 
 describe :DateTimeFormatter do
   subject { ::API::V3::Utilities::DateTimeFormatter }


### PR DESCRIPTION
## OpenProject Work Package

This fixes part of the aftermath of: https://community.openproject.org/work_packages/17417
## Background

Apparently the rails autoloader gets confused by trying to load a class from an included module.

We can help it, by explicitly referencing (thus loading) the fully qualified class name first...
## Solution

Simply reference the class that fails to load once by its fully qualified name:

``` ruby
require 'roar/json/hal'

# ...

API::V3::Utilities::DateTimeFormatter

# ...

module API
```

This will ensure that the autoloader will not look in the wrong places and that the class is already loaded when it is needed.
To reduce the amount of duplication I moved the corresponding `include` and above workaround into the `Single` class. ~~All~~ Most of our representers
inherit from that class.
## Alternatives (that I did not chose)
### Fully qualify each access

I could as well have dropped the include at the start of each class (which I now have moved into `Single`):

``` ruby
include API::V3::Utilities
```

That would mean, that I'd have to prefix each and every call to my helper class, which would in turn make the code more unreadable.
After all I decided to `include` in the first place, to avoid mass-prefixing like this:

``` ruby
property :created_at, getter: -> (*) { API::V3::Utilities::DateTimeFormatter::format_datetime(created_at) } # note that we already hit the line length limit
property :updated_at, getter: -> (*) { API::V3::Utilities::DateTimeFormatter::format_datetime(updated_at) }
```
### Just define a helper in the `Single` class

That proposal is old and I really considered it earlier, something along the lines of:

``` ruby
def datetime_formatter
  API::V3::Utilities::DateTimeFormatter
end
```

However, this would require me to execute all properties in the context of the representer, which I did not like too much:

``` ruby
property exec_context: :decorator, :created_at, getter: -> (*) { datetime_formatter::format_datetime(created_at) } # note that we hit the line length limit again
property exec_context: :decorator, :created_at, getter: -> (*) { datetime_formatter::format_datetime(updated_at) }
```

This would also force us to multiline otherwise simple accessors... However, someone might argue that this was a good approach before
and now it has become even more viable because it avoids those nasty auto-loading issues. Tell me if that is more like your cup of tea.
