### PR TITLE
18493 fix timeline not loaded when group other is activated in filters

### DIFF
--- a/app/assets/javascripts/angular/timelines/models/mixins/ui.js
+++ b/app/assets/javascripts/angular/timelines/models/mixins/ui.js
@@ -614,8 +614,10 @@ angular.module('openproject.timelines.models')
     bustVerticalOffsetCache: function(tree) {
       tree.iterateWithChildren(function(node) {
         var currentElement = node.getDOMElement();
-        currentElement.removeAttr("data-vertical-offset");
-        currentElement.removeAttr("data-vertical-bottom-offset");
+        if (currentElement) {
+          currentElement.removeAttr("data-vertical-offset");
+          currentElement.removeAttr("data-vertical-bottom-offset");
+        }
       });
     },
     rebuildForeground: function(tree) {
@@ -661,6 +663,9 @@ angular.module('openproject.timelines.models')
 
       tree.iterateWithChildren(function(node, indent, index) {
         var currentElement = node.getDOMElement();
+        if (!currentElement) {
+          return;
+        }
         var currentOffset = timeline.getRelativeVerticalOffset(currentElement);
         var previousElement, previousEnd, groupHeight;
         var groupingChanged = false;


### PR DESCRIPTION
[`* `#18493` fix timeline not loaded when group other is activated in filters`](http://community.openproject.org/work_packages/18493)
