### PR TITLE
[API] Change representation of custom fields

### DIFF
--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -55,7 +55,9 @@ module CustomFieldsHelper
     when 'text'
       text_area_tag(field_name, custom_value.value, id: field_id, rows: 3, style: 'width:90%')
     when 'bool'
-      hidden_field_tag(field_name, '0') + check_box_tag(field_name, '1', custom_value.true?, id: field_id)
+      hidden_tag = hidden_field_tag(field_name, '0')
+      checkbox_tag = check_box_tag(field_name, '1', custom_value.typed_value, id: field_id)
+      hidden_tag + checkbox_tag
     when 'list'
       blank_option = if custom_field.is_required? && custom_field.default_value.blank?
                        "<option value=\"\">--- #{l(:actionview_instancetag_blank_option)} ---</option>"

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -248,6 +248,10 @@ class CustomField < ActiveRecord::Base
     find :all, options
   end
 
+  def accessor_name
+    "custom_field_#{id}"
+  end
+
   def type_name
     nil
   end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -160,7 +160,7 @@ class CustomField < ActiveRecord::Base
   # :locale => <locale (-> :en, :de, ...)>
   def possible_values(obj = nil)
     case field_format
-    when 'user'
+    when 'user', 'version'
       possible_values_options(obj).map(&:last)
     else
       options = obj.nil? ? {} : obj

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -155,7 +155,9 @@ class CustomField < ActiveRecord::Base
 
   ##
   # Returns possible values for this custom field.
-  # Options may be a user, or options suitable for ActiveRecord#read_attribute.
+  # Options may be a customizable, or options suitable for ActiveRecord#read_attribute.
+  # Notes: You SHOULD pass a customizable if this CF has a format of user or version.
+  #        You MUST NOT pass a customizable if this CF has any other format
   # read_attribute is localized - to get values for a specific locale pass the following options hash
   # :locale => <locale (-> :en, :de, ...)>
   def possible_values(obj = nil)

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -101,6 +101,10 @@ class CustomField < ActiveRecord::Base
 
   # validate default value in every translation available
   def validate_default_value_in_translations
+    # it is not possible to determine the validity of a value, when there is no valid format.
+    # another validation will take take of adding an error, but here we need to abort
+    return nil if field_format.blank?
+
     required_field = is_required
     self.is_required = false
     translated_locales = (translations.map(&:locale) + self.translated_locales).uniq

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -102,7 +102,7 @@ class CustomField < ActiveRecord::Base
   # validate default value in every translation available
   def validate_default_value_in_translations
     # it is not possible to determine the validity of a value, when there is no valid format.
-    # another validation will take take of adding an error, but here we need to abort
+    # another validation will take care of adding an error, but here we need to abort
     return nil if field_format.blank?
 
     required_field = is_required

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -114,6 +114,6 @@ class CustomValue < ActiveRecord::Base
   private
 
   def strategy
-    @strategy = FORMAT_STRATEGIES[custom_field.field_format].new(self)
+    @strategy ||= FORMAT_STRATEGIES[custom_field.field_format].new(self)
   end
 end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -87,8 +87,12 @@ class CustomValue < ActiveRecord::Base
         begin; Kernel.Float(value); rescue; errors.add(:value, :invalid) end
       when 'date'
         errors.add(:value, :not_a_date) unless value =~ /\A\d{4}-\d{2}-\d{2}\z/
-      when 'list', 'user', 'version'
+      when 'user', 'version'
         unless custom_field.possible_values(customized).include?(value)
+          errors.add(:value, :inclusion)
+        end
+      when 'list'
+        unless custom_field.possible_values.include?(value)
           errors.add(:value, :inclusion)
         end
       end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -97,9 +97,9 @@ class CustomValue < ActiveRecord::Base
 
   def validate_type_of_value
     if value.present?
-      result = strategy.validate_type_of_value
-      if result
-        errors.add(:value, result)
+      validation_error = strategy.validate_type_of_value
+      if validation_error
+        errors.add(:value, validation_error)
       end
     end
   end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -87,8 +87,10 @@ class CustomValue < ActiveRecord::Base
         begin; Kernel.Float(value); rescue; errors.add(:value, :invalid) end
       when 'date'
         errors.add(:value, :not_a_date) unless value =~ /\A\d{4}-\d{2}-\d{2}\z/
-      when 'list'
-        errors.add(:value, :inclusion) unless custom_field.possible_values.include?(value)
+      when 'list', 'user', 'version'
+        unless custom_field.possible_values(customized).include?(value)
+          errors.add(:value, :inclusion)
+        end
       end
     end
   end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -62,11 +62,6 @@ class CustomValue < ActiveRecord::Base
     strategy.typed_value
   end
 
-  # Returns true if the boolean custom value is true
-  def true?
-    self.value == '1'
-  end
-
   def editable?
     custom_field.editable?
   end

--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::BoolStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      value == '1'
+    end
+  end
+
+  def validate_type_of_value
+  end
+end

--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::BoolStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       value == '1'
     end
   end

--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -36,8 +36,8 @@ class CustomValue::DateStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     Date.iso8601(value)
-    return nil
+    nil
   rescue
-    return :not_a_date
+    :not_a_date
   end
 end

--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::DateStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      Date.iso8601(value)
+    end
+  end
+
+  def validate_type_of_value
+    Date.iso8601(value)
+    return nil
+  rescue
+    return :not_a_date
+  end
+end

--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::DateStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       Date.iso8601(value)
     end
   end

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -36,8 +36,8 @@ class CustomValue::FloatStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     Kernel.Float(value)
-    return nil
+    nil
   rescue
-    return :not_a_number
+    :not_a_number
   end
 end

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::FloatStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      value.to_f
+    end
+  end
+
+  def validate_type_of_value
+    Kernel.Float(value)
+    return nil
+  rescue
+    return :not_a_number
+  end
+end

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::FloatStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       value.to_f
     end
   end

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -29,17 +29,10 @@
 
 class CustomValue::FormatStrategy
   attr_reader :custom_value
+  delegate :custom_field, :value, to: :custom_value
 
   def initialize(custom_value)
     @custom_value = custom_value
-  end
-
-  def custom_field
-    custom_value.custom_field
-  end
-
-  def value
-    custom_value.value
   end
 
   # Returns the value of the CustomValue in a typed fashion (i.e. not as the string

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::FormatStrategy
+  attr_reader :custom_value
+
+  def initialize(custom_value)
+    @custom_value = custom_value
+  end
+
+  def custom_field
+    custom_value.custom_field
+  end
+
+  def value
+    custom_value.value
+  end
+
+  # Returns the value of the CustomValue in a typed fashion (i.e. not as the string
+  # that is used for representation in the database)
+  def typed_value
+    raise 'SubclassResponsibility'
+  end
+
+  # Validates the type of the custom field and returns a symbol indicating the validation error
+  # if an error occurred; returns nil if no error occurred
+  def validate_type_of_value
+    raise 'SubclassResponsibility'
+  end
+end

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::IntStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       value.to_i
     end
   end

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -36,8 +36,8 @@ class CustomValue::IntStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     Kernel.Integer(value)
-    return nil
+    nil
   rescue
-    return :not_an_integer
+    :not_an_integer
   end
 end

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::IntStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      value.to_i
+    end
+  end
+
+  def validate_type_of_value
+    Kernel.Integer(value)
+    return nil
+  rescue
+    return :not_an_integer
+  end
+end

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::ListStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       value
     end
   end

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -36,7 +36,7 @@ class CustomValue::ListStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     unless custom_field.possible_values.include?(value)
-      return :inclusion
+      :inclusion
     end
   end
 end

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -1,0 +1,42 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::ListStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      value
+    end
+  end
+
+  def validate_type_of_value
+    unless custom_field.possible_values.include?(value)
+      return :inclusion
+    end
+  end
+end

--- a/app/models/custom_value/string_strategy.rb
+++ b/app/models/custom_value/string_strategy.rb
@@ -1,0 +1,37 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::StringStrategy < CustomValue::FormatStrategy
+  def typed_value
+    return value
+  end
+
+  def validate_type_of_value
+  end
+end

--- a/app/models/custom_value/string_strategy.rb
+++ b/app/models/custom_value/string_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::StringStrategy < CustomValue::FormatStrategy
   def typed_value
-    return value
+    value
   end
 
   def validate_type_of_value

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::UserStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       User.find_by_id(value)
     end
   end

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -36,7 +36,7 @@ class CustomValue::UserStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     unless custom_field.possible_values(custom_value.customized).include?(value)
-      return :inclusion
+      :inclusion
     end
   end
 end

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -1,0 +1,42 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::UserStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      User.find_by_id(value)
+    end
+  end
+
+  def validate_type_of_value
+    unless custom_field.possible_values(custom_value.customized).include?(value)
+      return :inclusion
+    end
+  end
+end

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -36,7 +36,7 @@ class CustomValue::VersionStrategy < CustomValue::FormatStrategy
 
   def validate_type_of_value
     unless custom_field.possible_values(custom_value.customized).include?(value)
-      return :inclusion
+      :inclusion
     end
   end
 end

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -29,7 +29,7 @@
 
 class CustomValue::VersionStrategy < CustomValue::FormatStrategy
   def typed_value
-    unless value.nil? || value.blank?
+    unless value.blank?
       Version.find_by_id(value)
     end
   end

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -1,0 +1,42 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CustomValue::VersionStrategy < CustomValue::FormatStrategy
+  def typed_value
+    unless value.nil? || value.blank?
+      Version.find_by_id(value)
+    end
+  end
+
+  def validate_type_of_value
+    unless custom_field.possible_values(custom_value.customized).include?(value)
+      return :inclusion
+    end
+  end
+end

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -76,6 +76,9 @@ module ActiveModel
     def full_message(attribute, message)
       return message if attribute == :base
 
+      # if a model acts_as_customizable it will inject attributes like 'custom_field_1' into itself
+      # using attr_name_override we resolve names of such attributes.
+      # The rest of the method should reflect the original method implementation of ActiveModel
       attr_name_override = nil
       match = /\Acustom_field_(?<id>\d+)\z/.match(attribute)
       if match

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1680,8 +1680,7 @@ de:
       invalid_content_type:
         "Es wird der CONTENT-TYPE '%{content_type}' erwartet, es wurde aber der CONTENT-TYP '%{actual}' gesandt."
       invalid_user_status_transition: "Für diesen Nutzeraccount ist die angeforderte Statusänderung nicht zulässig."
-      invalid_resource:
-        "Für die Eigenschaft '%{property}' wird eine Ressource vom Typ '%{expected}' erwartet. Gesandt wurde der Typ '%{actual}'."
+      invalid_resource: "Für die Eigenschaft '%{property}' wird ein Link wie '%{expected}' erwartet. Gesandt wurde '%{actual}'."
       missing_content_type: "nicht angegeben"
       multiple_errors: "Die Integrität mehrerer Eigenschaften wurde verletzt."
       parse_error: "Die Abfrage enthielt kein valides JSON."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1669,8 +1669,7 @@ en:
       code_404: "The requested resource could not be found."
       code_409: "Couldn\'t update the resource because of conflicting modifications."
       invalid_content_type: "Expected CONTENT-TYPE to be '%{content_type}' but got '%{actual}'."
-      invalid_resource:
-        "For property '%{property}' a resource of type '%{expected}' is expected but got a resource of type '%{actual}'."
+      invalid_resource: "For property '%{property}' a link like '%{expected}' is expected, but got '%{actual}'."
       invalid_user_status_transition: "The current user account status does not allow this operation."
       missing_content_type: "not specified"
       multiple_errors: "Multiple fields violated their constraints."

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -67,7 +67,12 @@ angular.module('openproject')
         workPackage: function(WorkPackageService, $stateParams) {
           return WorkPackageService.getWorkPackage($stateParams.workPackageId).then(function(wp) {
             return WorkPackageService.loadWorkPackageForm(wp).then(function() {
-              return wp;
+              // TODO: refactor to $q.all since schema and form do not
+              // depend on each other
+              return wp.links.schema.fetch().then(function(response) {
+                wp.schema = response;
+                return wp;
+              });
             });
           });
         }

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -143,12 +143,19 @@ module.exports = function($scope,
               prop.type.toLowerCase();
     }
 
-    function getValue(workPackage, propName) {
+    function getValue(workPackage, prop, propName) {
       if (workPackage.props[propName]) {
         return workPackage.props[propName].raw;
       }
       if (workPackage.embedded[propName]) {
-        return workPackage.embedded[propName].props.id;
+        // this is here for compatibility with other code
+        // TODO: rewrite all this file when custom fields
+        // are editable
+        if (prop.type == 'User' || prop.type == 'Version') {
+          return workPackage.embedded[propName].props.id;
+        } else {
+          return workPackage.embedded[propName].props.value;
+        }
       }
       return null;
     }
@@ -161,7 +168,7 @@ module.exports = function($scope,
               return {
                 name: prop.name,
                 format: getFormat(workPackage, prop, propName),
-                value: getValue(workPackage, propName)
+                value: getValue(workPackage, prop, propName)
               };
             }
             return false;

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -154,15 +154,17 @@ module.exports = function($scope,
     }
 
     function getCustomProperties(workPackage) {
-      return _.compact(_.map(workPackage.schema.props, function(prop, propName) {
-        if (propName.match(/^customField/)) {
-          return {
-            name: prop.name,
-            format: getFormat(workPackage, prop, propName),
-            value: getValue(workPackage, propName)
-          };
-        }
-        return false;
+      return _.compact(_.map(
+          workPackage.schema.props,
+          function(prop, propName) {
+            if (propName.match(/^customField/)) {
+              return {
+                name: prop.name,
+                format: getFormat(workPackage, prop, propName),
+                value: getValue(workPackage, propName)
+              };
+            }
+            return false;
       }));
     }
 

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -137,15 +137,13 @@ module.exports = function($scope,
   (function setupWorkPackageProperties() {
     var otherAttributes = WorkPackagesOverviewService.getGroupAttributesForGroupedAttributes('other', $scope.groupedAttributes);
 
-    function getFormat(workPackage, prop, propName) {
-      return workPackage.props[propName] ?
-              workPackage.props[propName].format :
-              prop.type.toLowerCase();
-    }
 
     function getValue(workPackage, prop, propName) {
       if (workPackage.props[propName]) {
-        return workPackage.props[propName].raw;
+        if (!_.isUndefined(workPackage.props[propName].raw)) {
+          return workPackage.props[propName].raw;
+        }
+        return workPackage.props[propName];
       }
       if (workPackage.embedded[propName]) {
         // this is here for compatibility with other code
@@ -167,7 +165,7 @@ module.exports = function($scope,
             if (propName.match(/^customField/)) {
               return {
                 name: prop.name,
-                format: getFormat(workPackage, prop, propName),
+                format: prop.type.toLowerCase(),
                 value: getValue(workPackage, prop, propName)
               };
             }

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -166,9 +166,11 @@ module.exports = function($scope,
       }));
     }
 
-    angular.forEach(getCustomProperties($scope.workPackage), function(customProperty) {
-      this.push(customProperty);
-    }, otherAttributes);
+    angular.forEach(
+      getCustomProperties($scope.workPackage),
+      function(customProperty) {
+        this.push(customProperty);
+      }, otherAttributes);
 
     angular.forEach($scope.groupedAttributes, function(group) {
       var attributesWithValues = [];

--- a/frontend/tests/integration/mocks/work-packages.js
+++ b/frontend/tests/integration/mocks/work-packages.js
@@ -60,7 +60,14 @@ module.exports = function(app) {
       res.send(text);
     });
   });
-
+  workPackagesRouter.get('/schemas/:name', function(req, res) {
+    fs.readFile(
+      __dirname + '/work-packages/schemas/' +
+        req.params.name +
+      '.json', 'utf8', function(err, text) {
+      res.send(text);
+    });
+  });
 
   app.use('/api/v3/work_packages', workPackagesRouter);
 

--- a/frontend/tests/integration/mocks/work-packages/819.json
+++ b/frontend/tests/integration/mocks/work-packages/819.json
@@ -93,6 +93,9 @@
     "project": {
       "href": "/api/v3/projects/1",
       "title": "Seeded Project"
+    },
+    "schema": {
+      "href": "/api/v3/work_packages/schemas/1-7"
     }
   },
   "id": 819,

--- a/frontend/tests/integration/mocks/work-packages/820.json
+++ b/frontend/tests/integration/mocks/work-packages/820.json
@@ -84,6 +84,9 @@
     "project": {
       "href": "/api/v3/projects/1",
       "title": "Seeded Project"
+    },
+    "schema": {
+      "href": "/api/v3/work_packages/schemas/1-7"
     }
   },
   "id": 820,

--- a/frontend/tests/integration/mocks/work-packages/821.json
+++ b/frontend/tests/integration/mocks/work-packages/821.json
@@ -89,6 +89,9 @@
     "project": {
       "href": "/api/v3/projects/1",
       "title": "Seeded Project"
+    },
+    "schema": {
+      "href": "/api/v3/work_packages/schemas/1-7"
     }
   },
   "id": 821,

--- a/frontend/tests/integration/mocks/work-packages/822.json
+++ b/frontend/tests/integration/mocks/work-packages/822.json
@@ -97,6 +97,9 @@
     "project": {
       "href": "/api/v3/projects/1",
       "title": "Seeded Project"
+    },
+    "schema": {
+      "href": "/api/v3/work_packages/schemas/1-7"
     }
   },
   "id": 822,

--- a/frontend/tests/integration/mocks/work-packages/schemas/1-7.json
+++ b/frontend/tests/integration/mocks/work-packages/schemas/1-7.json
@@ -1,0 +1,211 @@
+{
+  "_type":{
+    "type":"MetaType",
+    "name":"Resource Type",
+    "required":true,
+    "writable":false
+  },
+  "lockVersion":{
+    "type":"Integer",
+    "name":"Lock Version",
+    "required":true,
+    "writable":false
+  },
+  "id":{
+    "type":"Integer",
+    "name":"ID",
+    "required":true,
+    "writable":false
+  },
+  "subject":{
+    "type":"String",
+    "name":"Subject",
+    "required":true,
+    "writable":true,
+    "minLength":1,
+    "maxLength":255
+  },
+  "description":{
+    "type":"Formattable",
+    "name":"Description",
+    "required":true,
+    "writable":true
+  },
+  "startDate":{
+    "type":"Date",
+    "name":"Start date",
+    "required":false,
+    "writable":true
+  },
+  "dueDate":{
+    "type":"Date",
+    "name":"Due date",
+    "required":false,
+    "writable":true
+  },
+  "estimatedTime":{
+    "type":"Duration",
+    "name":"Estimated time",
+    "required":false,
+    "writable":false
+  },
+  "spentTime":{
+    "type":"Duration",
+    "name":"Spent time",
+    "required":true,
+    "writable":false
+  },
+  "percentageDone":{
+    "type":"Integer",
+    "name":"% done",
+    "required":true,
+    "writable":false
+  },
+  "createdAt":{
+    "type":"DateTime",
+    "name":"Created on",
+    "required":true,
+    "writable":false
+  },
+  "updatedAt":{
+    "type":"DateTime",
+    "name":"Updated on",
+    "required":true,
+    "writable":false
+  },
+  "author":{
+    "type":"User",
+    "name":"Author",
+    "required":true,
+    "writable":false
+  },
+  "project":{
+    "type":"Project",
+    "name":"Project",
+    "required":true,
+    "writable":false
+  },
+  "type":{
+    "type":"Type",
+    "name":"Type",
+    "required":true,
+    "writable":false
+  },
+  "assignee":{
+    "type":"User",
+    "name":"Assignee",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    }
+  },
+  "responsible":{
+    "type":"User",
+    "name":"Responsible",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    }
+  },
+  "status":{
+    "type":"Status",
+    "name":"Status",
+    "required":true,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  },
+  "category":{
+    "type":"Category",
+    "name":"Category",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  },
+  "version":{
+    "type":"Version",
+    "name":"Version",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  },
+  "priority":{
+    "type":"Priority",
+    "name":"Priority",
+    "required":true,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  },
+  "customField1":{
+    "type":"Formattable",
+    "name":"dolorum quidem",
+    "required":false,
+    "writable":true
+  },
+  "customField2":{
+    "type":"Formattable",
+    "name":"aut mollitia",
+    "required":false,
+    "writable":true
+  },
+  "customField3":{
+    "type":"Formattable",
+    "name":"est exercitationem",
+    "required":false,
+    "writable":true
+  },
+  "customField5":{
+    "type":"Version",
+    "name":"version cf1",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  },
+  "customField6":{
+    "type":"User",
+    "name":"person to blame",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    }
+  },
+  "customField7":{
+    "type":"StringObject",
+    "name":"uselessness level",
+    "required":false,
+    "writable":true,
+    "_links":{
+
+    },
+    "_embedded":{
+
+    }
+  }
+}

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -57,8 +57,8 @@ describe('DetailsTabOverviewController', function() {
               writable: true
             },
             customField2: {
-              type: "Formattable",
-              name: "aut mollitia",
+              type: 'Formattable',
+              name: 'aut mollitia',
               required: false,
               writable: true
             }
@@ -121,7 +121,7 @@ describe('DetailsTabOverviewController', function() {
       scope = $rootScope.$new();
       scope.workPackage = angular.copy(workPackage);
 
-      ctrl = $controller("DetailsTabOverviewController", {
+      ctrl = $controller('DetailsTabOverviewController', {
         $scope:  scope,
         I18n: I18n,
         UserService: UserService,
@@ -696,7 +696,7 @@ describe('DetailsTabOverviewController', function() {
       var directiveName = 'my-plugin-property-directive';
 
       before(function() {
-        var workPackageOverviewAttributesStub = sinon.stub(HookService, "call");
+        var workPackageOverviewAttributesStub = sinon.stub(HookService, 'call');
 
         workPackageOverviewAttributesStub.withArgs('workPackageOverviewAttributes',
                                                    { type: propertyName,

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -48,17 +48,30 @@ describe('DetailsTabOverviewController', function() {
         formatCustomFieldValue: angular.identity
       },
       workPackage = {
+        schema: {
+          props: {
+            customField1: {
+              type: "Formattable",
+              name: "color",
+              required: false,
+              writable: true
+            },
+            customField2: {
+              type: "Formattable",
+              name: "aut mollitia",
+              required: false,
+              writable: true
+            }
+          }
+        },
         props: {
+          customField1: {format: 'plain', raw: 'red', html: '<p>red</p>'},
+          customField2: {format: 'plain', raw: '', html: '<p></p>'},
           versionName: null,
           percentageDone: 0,
           estimatedTime: 'PT0S',
           spentTime: 'PT0S',
-          id: '0815',
-          customProperties: [
-            { format: 'text', name: 'color', value: 'red' },
-            { format: 'text', name: 'Width', value: '' },
-            { format: 'text', name: 'height', value: '' },
-          ]
+          id: '0815'
         },
         embedded: {
           status: {
@@ -461,13 +474,13 @@ describe('DetailsTabOverviewController', function() {
         });
 
         it('formats values using the custom field helper', function() {
-          expect(CustomFieldHelper.formatCustomFieldValue.calledWith('red', 'text')).to.be.true;
+          expect(CustomFieldHelper.formatCustomFieldValue.calledWith('red', 'plain')).to.be.true;
         });
       });
 
       describe('when the property does not have a value', function() {
         beforeEach(function() {
-          workPackage.props.customProperties[0].value = null;
+          workPackage.props.customField1.raw = null;
           buildController();
         });
 
@@ -485,10 +498,22 @@ describe('DetailsTabOverviewController', function() {
         var getUserStub;
 
         before(function() {
-          workPackage.props.customProperties[0].value = userId;
-          workPackage.props.customProperties[0].name = userCFName;
-          workPackage.props.customProperties[0].format = 'user';
+          workPackage.schema.props.customField3 = {
+            type: 'User',
+            name: userCFName
+          };
+          workPackage.embedded = {
+            'customField3': {
+              props: {
+                id: userId,
+                name: userName
+              }
+            }
+          };
+        });
 
+        after(function() {
+          delete workPackage.schema.props.customField3;
         });
 
         describe('with an existing user', function() {
@@ -565,16 +590,32 @@ describe('DetailsTabOverviewController', function() {
         var errorMessage = 'my error message';
         var tStub;
 
+
         before(function() {
-          workPackage.props.customProperties[0].name = customVersionName;
-          workPackage.props.customProperties[0].value = versionId;
-          workPackage.props.customProperties[0].format = 'version';
+          workPackage.schema.props.customField3 = {
+            type: 'Version',
+            name: customVersionName
+          };
+          workPackage.embedded = {
+            project: {
+              props: {
+                id: '1'
+              }
+            },
+            'customField3': {
+              props: {
+                id: versionId,
+                name: versionName
+              }
+            }
+          };
 
           tStub = sinon.stub(I18n, 't');
           tStub.withArgs('js.error_could_not_resolve_version_name').returns(errorMessage);
         });
 
         after(function() {
+          delete workPackage.schema.props.customField3;
           tStub.restore();
         });
 
@@ -603,7 +644,7 @@ describe('DetailsTabOverviewController', function() {
 
           before(function() {
             getVersionsStub = sinon.stub(VersionService, 'getVersions');
-
+            getVersionsStub.withArgs('1');
             getVersionsStub.returns([{ id: versionId, name: versionName }]);
 
             buildController();
@@ -631,7 +672,7 @@ describe('DetailsTabOverviewController', function() {
             var reject = $q.reject('For test reasons!');
 
             getVersionsStub = sinon.stub(VersionService, 'getVersions');
-
+            getVersionsStub.withArgs('1');
             getVersionsStub.returns(reject);
 
             buildController();

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -488,6 +488,10 @@ describe('DetailsTabOverviewController', function() {
           buildController();
         });
 
+        afterEach(function() {
+          workPackage.props.customField1.raw = 'red';
+        });
+
         it('adds the custom property to empty properties', function() {
           expect(fetchEmptyPropertiesWithName(customPropertyName)).not.to.be.empty;
         });

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -51,8 +51,8 @@ describe('DetailsTabOverviewController', function() {
         schema: {
           props: {
             customField1: {
-              type: "Formattable",
-              name: "color",
+              type: 'Formattable',
+              name: 'color',
               required: false,
               writable: true
             },

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -29,10 +29,6 @@
 /*jshint expr: true*/
 
 describe('DetailsTabOverviewController', function() {
-  var DEFAULT_WORK_PACKAGE_PROPERTIES = ['status', 'assignee', 'responsible',
-                                         'date', 'percentageDone', 'priority',
-                                         'estimatedTime', 'version', 'spentTime'];
-
   var scope, ctrl;
   var buildController;
   var HookService;
@@ -89,14 +85,9 @@ describe('DetailsTabOverviewController', function() {
           attachments: []
         },
         links: {
-        },
+        }
       };
   var $q;
-
-  function buildWorkPackageWithId(id) {
-    angular.extend(workPackage.props, {id: id});
-    return workPackage;
-  }
 
   beforeEach(module('openproject.api',
                     'openproject.services',
@@ -110,7 +101,6 @@ describe('DetailsTabOverviewController', function() {
           _WorkPackagesOverviewService_,
           _$q_,
           _I18n_) {
-    var workPackageId = 99;
 
     HookService = _HookService_;
     WorkPackagesOverviewService = _WorkPackagesOverviewService_;
@@ -172,11 +162,6 @@ describe('DetailsTabOverviewController', function() {
       });
     };
 
-    var shouldBehaveLikePropertyWithNoValue = function(propertyName) {
-      it('adds property to present properties', function() {
-        expect(fetchEmptyPropertiesWithName(propertyName)).to.have.length(1);
-      });
-    };
 
     describe('when the property has a value', function() {
       beforeEach(function() {
@@ -473,7 +458,8 @@ describe('DetailsTabOverviewController', function() {
           expect(fetchPresentPropertiesWithName(customPropertyName)).to.have.length(1);
         });
 
-        it('formats values using the custom field helper', function() {
+        // all of this will be redone when inplace editing is added to custom fields
+        xit('formats values using the custom field helper', function() {
           expect(
             CustomFieldHelper
               .formatCustomFieldValue

--- a/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/details-tab-overview-controller-test.js
@@ -474,7 +474,11 @@ describe('DetailsTabOverviewController', function() {
         });
 
         it('formats values using the custom field helper', function() {
-          expect(CustomFieldHelper.formatCustomFieldValue.calledWith('red', 'plain')).to.be.true;
+          expect(
+            CustomFieldHelper
+              .formatCustomFieldValue
+              .calledWith('red', 'plain')
+          ).to.be.true;
         });
       });
 

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -40,11 +40,17 @@ module API
                      name:,
                      value_representer:,
                      link_factory:,
+                     required: true,
+                     writable: true,
                      current_user: nil)
         @value_representer = value_representer
         @link_factory = link_factory
 
-        super(type: type, name: name, current_user: current_user)
+        super(type: type,
+              name: name,
+              required: required,
+              writable: writable,
+              current_user: current_user)
       end
 
       links :allowedValues do

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -33,11 +33,11 @@ require 'roar/json/hal'
 module API
   module Decorators
     class PropertySchemaRepresenter < ::API::Decorators::Single
-      def initialize(type:, name:, current_user: nil)
+      def initialize(type:, name:, required: true, writable: true, current_user: nil)
         @type = type
         @name = name
-        @required = true
-        @writable = true
+        @required = required
+        @writable = writable
 
         super(nil, current_user: current_user)
       end

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -47,7 +47,8 @@ module API
                     :required,
                     :writable,
                     :min_length,
-                    :max_length
+                    :max_length,
+                    :regular_expression
 
       property :type, exec_context: :decorator
       property :name, exec_context: :decorator
@@ -55,6 +56,7 @@ module API
       property :writable, exec_context: :decorator
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator
+      property :regular_expression, exec_context: :decorator
     end
   end
 end

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -120,9 +120,6 @@ module API
           property_name.to_s.camelize
         end
       end
-
-      def current_user
-      end
     end
   end
 end

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -1,0 +1,83 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module Decorators
+    class Schema < Single
+      def self.schema(property,
+                      type:,
+                      title: represented_class.human_attribute_name(property),
+                      required: true,
+                      writable: true,
+                      min_length: nil,
+                      max_length: nil)
+        raise ArgumentError if property.nil?
+
+        schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
+                                                                  name: title)
+        schema.required = required
+        schema.writable = writable
+        schema.min_length = min_length if min_length
+        schema.max_length = max_length if max_length
+
+        property property,
+                 getter: -> (*) { schema },
+                 writeable: false
+      end
+
+      def self.schema_with_allowed_link(property,
+                                        type: property.to_s.camelize,
+                                        title: represented_class.human_attribute_name(property),
+                                        href_callback:,
+                                        required: true,
+                                        writable: true)
+        raise ArgumentError if property.nil?
+
+        property property,
+                 exec_context: :decorator,
+                 getter: -> (*) {
+                   representer = ::API::Decorators::AllowedValuesByLinkRepresenter.new(
+                     type: type,
+                     name: title)
+                   representer.required = required
+                   representer.writable = writable
+
+                   if represented.defines_assignable_values?
+                     representer.allowed_values_href = instance_eval(&href_callback)
+                   end
+
+                   representer
+                 }
+      end
+
+      def self.represented_class
+      end
+    end
+  end
+end

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -108,6 +108,9 @@ module API
 
       def self.represented_class
       end
+
+      def current_user
+      end
     end
   end
 end

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -32,12 +32,12 @@ module API
     class Schema < Single
       class << self
         def schema(property,
-                        type:,
-                        title: make_title(property),
-                        required: true,
-                        writable: true,
-                        min_length: nil,
-                        max_length: nil)
+                   type:,
+                   title: make_title(property),
+                   required: true,
+                   writable: true,
+                   min_length: nil,
+                   max_length: nil)
           raise ArgumentError if property.nil?
 
           schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
@@ -53,11 +53,11 @@ module API
         end
 
         def schema_with_allowed_link(property,
-                                          type: make_type(property),
-                                          title: make_title(property),
-                                          href_callback:,
-                                          required: true,
-                                          writable: true)
+                                     type: make_type(property),
+                                     title: make_title(property),
+                                     href_callback:,
+                                     required: true,
+                                     writable: true)
           raise ArgumentError if property.nil?
 
           property property,
@@ -78,13 +78,13 @@ module API
         end
 
         def schema_with_allowed_collection(property,
-                                                type: make_type(property),
-                                                title: make_title(property),
-                                                values_callback:,
-                                                value_representer:,
-                                                link_factory:,
-                                                required: true,
-                                                writable: true)
+                                           type: make_type(property),
+                                           title: make_title(property),
+                                           values_callback:,
+                                           value_representer:,
+                                           link_factory:,
+                                           required: true,
+                                           writable: true)
           raise ArgumentError unless property
 
           property property,

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -37,15 +37,17 @@ module API
                    required: true,
                    writable: true,
                    min_length: nil,
-                   max_length: nil)
+                   max_length: nil,
+                   regular_expression: nil)
           raise ArgumentError if property.nil?
 
           schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
                                                                     name: title,
                                                                     required: required,
                                                                     writable: writable)
-          schema.min_length = min_length if min_length
-          schema.max_length = max_length if max_length
+          schema.min_length = min_length
+          schema.max_length = max_length
+          schema.regular_expression = regular_expression
 
           property property,
                    getter: -> (*) { schema },

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -41,9 +41,9 @@ module API
           raise ArgumentError if property.nil?
 
           schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
-                                                                    name: title)
-          schema.required = required
-          schema.writable = writable
+                                                                    name: title,
+                                                                    required: required,
+                                                                    writable: writable)
           schema.min_length = min_length if min_length
           schema.max_length = max_length if max_length
 
@@ -65,9 +65,9 @@ module API
                    getter: -> (*) {
                      representer = ::API::Decorators::AllowedValuesByLinkRepresenter.new(
                        type: type,
-                       name: title)
-                     representer.required = required
-                     representer.writable = writable
+                       name: title,
+                       required: required,
+                       writable: writable)
 
                      if represented.defines_assignable_values?
                        representer.allowed_values_href = instance_eval(&href_callback)
@@ -95,9 +95,9 @@ module API
                        name: title,
                        current_user: current_user,
                        value_representer: value_representer,
-                       link_factory: -> (value) { instance_exec(value, &link_factory) })
-                     representer.required = required
-                     representer.writable = writable
+                       link_factory: -> (value) { instance_exec(value, &link_factory) },
+                       required: required,
+                       writable: writable)
 
                      if represented.defines_assignable_values?
                        representer.allowed_values = instance_exec(&values_callback)

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -77,6 +77,12 @@ module API
         end
       end
 
+      protected
+
+      def current_user
+        context[:current_user]
+      end
+
       private
 
       def datetime_formatter

--- a/lib/api/errors/form/invalid_resource_link.rb
+++ b/lib/api/errors/form/invalid_resource_link.rb
@@ -31,11 +31,11 @@ module API
   module Errors
     module Form
       class InvalidResourceLink < StandardError
-        def initialize(property_name, expected_resource, actual_resource = :unknown)
+        def initialize(property_name, expected_link, actual_link)
           message = I18n.t('api_v3.errors.invalid_resource',
                            property: property_name,
-                           expected: expected_resource,
-                           actual: actual_resource)
+                           expected: expected_link,
+                           actual: actual_link)
 
           super(message)
         end

--- a/lib/api/errors/form/invalid_resource_link.rb
+++ b/lib/api/errors/form/invalid_resource_link.rb
@@ -31,14 +31,11 @@ module API
   module Errors
     module Form
       class InvalidResourceLink < StandardError
-        def initialize(property, expected_resource, actual_resource = :unknown)
-          property_localized = I18n.t("attributes.#{property}")
-          expected_localized = I18n.t("attributes.#{expected_resource.to_s.singularize}")
-          actual_localized = I18n.t("attributes.#{actual_resource.to_s.singularize}")
+        def initialize(property_name, expected_resource, actual_resource = :unknown)
           message = I18n.t('api_v3.errors.invalid_resource',
-                           property: property_localized,
-                           expected: expected_localized,
-                           actual: actual_localized)
+                           property: property_name,
+                           expected: expected_resource,
+                           actual: actual_resource)
 
           super(message)
         end

--- a/lib/api/errors/validation.rb
+++ b/lib/api/errors/validation.rb
@@ -47,7 +47,7 @@ module API
             end
           end
 
-          hash[attribute] = ::API::Errors::Validation.new(messages)
+          hash[attribute.to_s.camelize(:lower)] = ::API::Errors::Validation.new(messages)
         end
       end
 

--- a/lib/api/errors/validation.rb
+++ b/lib/api/errors/validation.rb
@@ -33,21 +33,21 @@ module API
       def self.create(errors)
         merge_error_properties(errors)
 
-        errors.keys.each_with_object({}) do |key, hash|
-          messages = errors[key].each_with_object([]) do |m, l|
+        errors.keys.each_with_object({}) do |attribute, hash|
+          messages = errors[attribute].each_with_object([]) do |message, messages|
             # Let's assume that standard validation errors never end with a
             # punctuation mark. Then it should be fair enough to assume that we
             # don't need to prepend the error key if the error ends with a
             # punctuation mark. Let's hope that this is true for the languages
             # we'll support in OpenProject.
-            if m =~ /(\.|\?|\!)\z/
-              l << m
+            if message =~ /(\.|\?|\!)\z/
+              messages << message
             else
-              l << errors.full_message(key, m) + '.'
+              messages << errors.full_message(attribute, message) + '.'
             end
           end
 
-          hash[key] = ::API::Errors::Validation.new(messages)
+          hash[attribute] = ::API::Errors::Validation.new(messages)
         end
       end
 

--- a/lib/api/errors/validation.rb
+++ b/lib/api/errors/validation.rb
@@ -34,16 +34,16 @@ module API
         merge_error_properties(errors)
 
         errors.keys.each_with_object({}) do |attribute, hash|
-          messages = errors[attribute].each_with_object([]) do |message, messages|
+          messages = errors[attribute].each_with_object([]) do |message, message_list|
             # Let's assume that standard validation errors never end with a
             # punctuation mark. Then it should be fair enough to assume that we
             # don't need to prepend the error key if the error ends with a
             # punctuation mark. Let's hope that this is true for the languages
             # we'll support in OpenProject.
             if message =~ /(\.|\?|\!)\z/
-              messages << message
+              message_list << message
             else
-              messages << errors.full_message(attribute, message) + '.'
+              message_list << errors.full_message(attribute, message) + '.'
             end
           end
 

--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -38,10 +38,8 @@ module API
           # for a valid link (even though it does not match the compiled regex)
           match = route_options[:compiled].match(resource_link.chomp('/'))
 
-          # TODO: cleanup
-          # TODO: still does not support empty string_objects (makes them nil)
           if match
-            # we want to capture the identifying key regardless of its name
+            # we want to capture the identifying key regardless of its name (e.g. :id)
             id_key = match.names.reject { |name| ['version', 'format'].include?(name) }.first
             id = id_key ? match[id_key] : nil
 

--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -41,7 +41,7 @@ module API
 
           return nil unless match
 
-          return {
+          {
             version: match[:version],
             namespace: match[:namespace],
             id: match[:id]
@@ -57,9 +57,8 @@ module API
           resource = parse(resource_link)
 
           if resource
-            version_valid = expected_version.nil? || expected_version.to_s == resource[:version]
-            namespace_valid = expected_namespace.nil? ||
-                              expected_namespace.to_s == resource[:namespace]
+            version_valid = matches_expectation?(expected_version, resource[:version])
+            namespace_valid = matches_expectation?(expected_namespace, resource[:namespace])
           end
 
           unless resource && version_valid && namespace_valid
@@ -77,6 +76,12 @@ module API
 
         def resource_matcher
           @@matcher ||= Regexp.compile(RESOURCE_REGEX)
+        end
+
+        # returns whether expectation and actual are identical
+        # will always be true if there is no expectation (nil)
+        def matches_expectation?(expected, actual)
+          expected.nil? || expected.to_s == actual
         end
 
         def make_expected_link(version, namespace)

--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -75,7 +75,7 @@ module API
         private
 
         def resource_matcher
-          @@matcher ||= Regexp.compile(RESOURCE_REGEX)
+          @matcher ||= Regexp.compile(RESOURCE_REGEX)
         end
 
         # returns whether expectation and actual are identical

--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -33,12 +33,21 @@ module API
       def self.parse(resource_link)
         ::API::Root.routes.each do |route|
           route_options = route.instance_variable_get(:@options)
-          match = route_options[:compiled].match(resource_link)
 
+          # we are matching the resource link without trailing slashes, as they would still make
+          # for a valid link (even though it does not match the compiled regex)
+          match = route_options[:compiled].match(resource_link.chomp('/'))
+
+          # TODO: cleanup
+          # TODO: still does not support empty string_objects (makes them nil)
           if match
+            # we want to capture the identifying key regardless of its name
+            id_key = match.names.reject { |name| ['version', 'format'].include?(name) }.first
+            id = id_key ? match[id_key] : nil
+
             return {
-              ns: /\/(?<ns>\w+)\//.match(route_options[:namespace])[:ns],
-              id: match[:id]
+              ns: /\/(?<ns>\w+)/.match(route_options[:namespace])[:ns],
+              id: id
             }
           end
         end

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -81,7 +81,7 @@ module API
               if params[:context]
                 context = parse_context
 
-                case context[:ns]
+                case context[:namespace]
                 when 'work_packages'
                   WorkPackage.visible(current_user).find(context[:id])
                 end
@@ -95,7 +95,8 @@ module API
                 fail API::Errors::InvalidRenderContext.new(
                   I18n.t('api_v3.errors.render.context_not_found')
                 )
-              elsif !SUPPORTED_CONTEXT_NAMESPACES.include? context[:ns]
+              elsif !SUPPORTED_CONTEXT_NAMESPACES.include?(context[:namespace]) ||
+                    context[:version] != '3'
                 fail API::Errors::InvalidRenderContext.new(
                   I18n.t('api_v3.errors.render.unsupported_context')
                 )

--- a/lib/api/v3/string_objects/string_objects_api.rb
+++ b/lib/api/v3/string_objects/string_objects_api.rb
@@ -38,6 +38,11 @@ module API
               StringObjectRepresenter.new(params[:value])
             end
           end
+
+          # answer requests for empty strings too
+          get do
+            StringObjectRepresenter.new('')
+          end
         end
       end
     end

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -104,10 +104,6 @@ module API
 
         private
 
-        def current_user
-          context[:current_user]
-        end
-
         def work_package
           context[:work_package]
         end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -49,11 +49,29 @@ module API
 
         def inject_schema(custom_field)
           # TODO: support allowed values for list, version and user
-          @class.schema "customField#{custom_field.id}".to_sym,
-                 type: TYPE_MAP[custom_field.field_format],
-                 title: custom_field.name,
-                 required: custom_field.is_required,
-                 writable: true
+          @class.schema property_name(custom_field.id),
+                        type: TYPE_MAP[custom_field.field_format],
+                        title: custom_field.name,
+                        required: custom_field.is_required,
+                        writable: true
+        end
+
+        def inject_value(custom_field)
+          # TODO: linked properties
+          # TODO: 'text' as formattable
+          @class.property property_name(custom_field.id),
+                          getter: -> (*) {
+                            self.custom_value_for(custom_field).value
+                          },
+                          setter: -> (value, *) {
+                            self.custom_field_values = { custom_field.id => value }
+                          }
+        end
+
+        private
+
+        def property_name(id)
+          "customField#{id}".to_sym
         end
       end
     end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -1,0 +1,61 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Utilities
+      class CustomFieldInjector
+        TYPE_MAP = {
+          'string' => 'String',
+          'text' => 'Formattable',
+          'int' => 'Integer',
+          'float' => 'Float',
+          'date' => 'Date',
+          'bool' => 'Boolean',
+          'user' => 'User',
+          'version' => 'Version',
+          'list' => 'StringObject'
+        }
+
+        def initialize(representer_class)
+          @class = representer_class
+        end
+
+        def inject_schema(custom_field)
+          # TODO: support allowed values for list, version and user
+          @class.schema "customField#{custom_field.id}".to_sym,
+                 type: TYPE_MAP[custom_field.field_format],
+                 title: custom_field.name,
+                 required: custom_field.is_required,
+                 writable: true
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -221,7 +221,10 @@ module API
                         type: TYPE_MAP[custom_field.field_format],
                         title: custom_field.name,
                         required: custom_field.is_required,
-                        writable: true
+                        writable: true,
+                        min_length: (custom_field.min_length if custom_field.min_length > 0),
+                        max_length: (custom_field.max_length if custom_field.max_length > 0),
+                        regular_expression: (custom_field.regexp unless custom_field.regexp.blank?)
         end
 
         def path_method_for(custom_field)

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -193,13 +193,16 @@ module API
         def link_value_setter_for(custom_field, property, expected_namespace)
           -> (link_object, *) {
             href = link_object['href']
-            return nil unless href
 
-            value = ::API::Utilities::ResourceLinkParser.parse_id(
-              href,
-              property: property,
-              expected_version: '3',
-              expected_namespace: expected_namespace)
+            if href
+              value = ::API::Utilities::ResourceLinkParser.parse_id(
+                href,
+                property: property,
+                expected_version: '3',
+                expected_namespace: expected_namespace)
+            else
+              value = nil
+            end
 
             represented.custom_field_values = { custom_field.id => value }
           }

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -222,13 +222,13 @@ module API
               value
             end
           }
+        end
 
-          def property_value_setter_for(custom_field)
-            -> (value, *) {
-              value = value['raw'] if custom_field.field_format == 'text'
-              self.custom_field_values = { custom_field.id => value }
-            }
-          end
+        def property_value_setter_for(custom_field)
+          -> (value, *) {
+            value = value['raw'] if custom_field.field_format == 'text'
+            self.custom_field_values = { custom_field.id => value }
+          }
         end
       end
     end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -67,11 +67,13 @@ module API
           # TODO: 'text' as formattable
           @class.property property_name(custom_field.id),
                           getter: -> (*) {
-                            self.custom_value_for(custom_field).value
+                            custom_value = self.custom_value_for(custom_field)
+                            custom_value.value if custom_value
                           },
                           setter: -> (value, *) {
                             self.custom_field_values = { custom_field.id => value }
-                          }
+                          },
+                          render_nil: true
         end
 
         private

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -102,13 +102,13 @@ module API
         def inject_user_schema(custom_field, wp_schema)
           raise ArgumentError unless wp_schema
 
-          schema_with_allowed_link property_name(custom_field.id),
-                                   type: 'User',
-                                   title: custom_field.name,
-                                   required: custom_field.is_required,
-                                   href_callback: -> (*) {
-                                     api_v3_paths.available_assignees(wp_schema.project.id)
-                                   }
+          @class.schema_with_allowed_link property_name(custom_field.id),
+                                          type: 'User',
+                                          title: custom_field.name,
+                                          required: custom_field.is_required,
+                                          href_callback: -> (*) {
+                                            api_v3_paths.available_assignees(wp_schema.project.id)
+                                          }
         end
 
         def inject_list_schema(custom_field)

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -240,8 +240,7 @@ module API
 
         def link_value_getter_for(custom_field, path_method)
           -> (*) {
-            custom_value = represented.custom_value_for(custom_field)
-            value = custom_value.typed_value if custom_value
+            value = represented.send custom_field.accessor_name
             path = api_v3_paths.send(path_method, value.is_a?(String) ? value : value.id) if value
 
             { href: path }
@@ -271,8 +270,7 @@ module API
                           embedded: true,
                           exec_context: :decorator,
                           getter: -> (*) {
-                            custom_value = represented.custom_value_for(custom_field)
-                            value = custom_value.typed_value if custom_value
+                            value = represented.send custom_field.accessor_name
                             representer_class = REPRESENTER_MAP[custom_field.field_format]
 
                             representer_class.new(value, current_user: current_user) if value
@@ -288,8 +286,7 @@ module API
 
         def property_value_getter_for(custom_field)
           -> (*) {
-            custom_value = custom_value_for(custom_field)
-            value = custom_value.typed_value if custom_value
+            value = send custom_field.accessor_name
 
             if custom_field.field_format == 'text'
               ::API::Decorators::Formattable.new(value, format: 'plain')

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -51,14 +51,14 @@ module API
         # to obtain available versions and users for WP custom fields
         def inject_schema(custom_field, wp_schema: nil)
           case custom_field.field_format
-            when 'version'
-              inject_version_schema(custom_field, wp_schema)
-            when 'user'
-              inject_user_schema(custom_field, wp_schema)
-            when 'list'
-              inject_list_schema(custom_field)
-            else
-              inject_basic_schema(custom_field)
+          when 'version'
+            inject_version_schema(custom_field, wp_schema)
+          when 'user'
+            inject_user_schema(custom_field, wp_schema)
+          when 'list'
+            inject_list_schema(custom_field)
+          else
+            inject_basic_schema(custom_field)
           end
         end
 
@@ -67,7 +67,7 @@ module API
           # TODO: 'text' as formattable
           @class.property property_name(custom_field.id),
                           getter: -> (*) {
-                            custom_value = self.custom_value_for(custom_field)
+                            custom_value = custom_value_for(custom_field)
                             custom_value.value if custom_value
                           },
                           setter: -> (value, *) {

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -57,11 +57,17 @@ module API
           'list' => 'string_objects'
         }
 
+        REPRESENTER_MAP = {
+          'user' => Users::UserRepresenter,
+          'version' => Versions::VersionRepresenter,
+          'list' => StringObjects::StringObjectRepresenter
+        }
+
         class << self
           def create_value_representer(customizable, representer)
             injector = CustomFieldInjector.new(representer)
             customizable.available_custom_fields.each do |custom_field|
-              injector.inject_value(custom_field)
+              injector.inject_value(custom_field, embed_links: true)
             end
 
             injector.modified_representer_class
@@ -134,10 +140,10 @@ module API
           end
         end
 
-        def inject_value(custom_field)
+        def inject_value(custom_field, embed_links: false)
           case custom_field.field_format
           when *LINK_FORMATS
-            inject_link_value(custom_field)
+            inject_link_value(custom_field, embed: embed_links)
           else
             inject_property_value(custom_field)
           end
@@ -221,10 +227,24 @@ module API
           PATH_METHOD_MAP[custom_field.field_format]
         end
 
-        def inject_link_value(custom_field)
+        def inject_link_value(custom_field, embed:)
+          name = property_name(custom_field.id)
           getter = link_value_getter_for(custom_field, path_method_for(custom_field))
-          @class.link property_name(custom_field.id) do
+          @class.link name do
             instance_exec(&getter)
+          end
+
+          if embed
+            @class.property name,
+                            embedded: true,
+                            exec_context: :decorator,
+                            getter: -> (*) {
+                              custom_value = represented.custom_value_for(custom_field)
+                              value = custom_value.typed_value if custom_value
+                              representer_class = REPRESENTER_MAP[custom_field.field_format]
+
+                              representer_class.new(value, current_user: current_user) if value
+                            }
           end
         end
 

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -114,8 +114,9 @@ module API
 
                             resource = ::API::Utilities::ResourceLinkParser.parse href
 
-                            if resource.nil? || resource[:ns] != expected_namespace
-                              actual_namespace = resource ? resource[:ns] : nil
+                            if resource.nil? || resource[:namespace] != expected_namespace ||
+                               resource[:version] != '3'
+                              actual_namespace = resource ? resource[:namespace] : nil
 
                               fail ::API::Errors::Form::InvalidResourceLink.new(property,
                                                                                 expected_namespace,

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -122,7 +122,7 @@ module API
                                                                                 actual_namespace)
                             end
 
-                            value = resource[:id]
+                            value = resource[:id] || ''
                             represented.custom_field_values = { custom_field.id => value }
                           }
         end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -112,18 +112,12 @@ module API
                             href = link_object['href']
                             return nil unless href
 
-                            resource = ::API::Utilities::ResourceLinkParser.parse href
+                            value = ::API::Utilities::ResourceLinkParser.parse_id(
+                              href,
+                              property: property,
+                              expected_version: '3',
+                              expected_namespace: expected_namespace)
 
-                            if resource.nil? || resource[:namespace] != expected_namespace ||
-                               resource[:version] != '3'
-                              actual_namespace = resource ? resource[:namespace] : nil
-
-                              fail ::API::Errors::Form::InvalidResourceLink.new(property,
-                                                                                expected_namespace,
-                                                                                actual_namespace)
-                            end
-
-                            value = resource[:id] || ''
                             represented.custom_field_values = { custom_field.id => value }
                           }
         end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -183,9 +183,10 @@ module API
         def link_value_getter_for(custom_field, path_method)
           -> (*) {
             custom_value = represented.custom_value_for(custom_field)
-            value = custom_value.value if custom_value
+            value = custom_value.typed_value if custom_value
+            path = api_v3_paths.send(path_method, value.is_a?(String) ? value : value.id) if value
 
-            { href: (api_v3_paths.send(path_method, value) if value) }
+            { href: path }
           }
         end
 
@@ -214,7 +215,7 @@ module API
         def property_value_getter_for(custom_field)
           -> (*) {
             custom_value = custom_value_for(custom_field)
-            value = custom_value.value if custom_value
+            value = custom_value.typed_value if custom_value
 
             if custom_field.field_format == 'text'
               ::API::Decorators::Formattable.new(value, format: 'plain')

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -86,12 +86,6 @@ module API
         def _type
           'Version'
         end
-
-        private
-
-        def current_user
-          context[:current_user]
-        end
       end
     end
   end

--- a/lib/api/v3/work_packages/form/form_representer.rb
+++ b/lib/api/v3/work_packages/form/form_representer.rb
@@ -81,15 +81,17 @@ module API
 
           property :payload,
                    embedded: true,
-                   decorator: Form::WorkPackagePayloadRepresenter,
+                   decorator: -> (represented, *) {
+                     Form::WorkPackagePayloadRepresenter.create_class(represented)
+                   },
                    getter: -> (*) { self }
           property :schema,
                    embedded: true,
                    exec_context: :decorator,
                    getter: -> (*) {
                      schema = Schema::WorkPackageSchema.new(work_package: represented)
-                     Schema::WorkPackageSchemaRepresenter.new(schema,
-                                                            current_user: @current_user)
+                     Schema::WorkPackageSchemaRepresenter.create(schema,
+                                                                 current_user: @current_user)
                    }
           property :validation_errors, embedded: true, exec_context: :decorator
 

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -127,8 +127,9 @@ module API
 
             resource = ::API::Utilities::ResourceLinkParser.parse href
 
-            if resource.nil? || resource[:ns] != ns.to_s
-              actual_ns = resource ? resource[:ns] : nil
+            if resource.nil? || resource[:namespace] != ns.to_s ||
+               resource[:version] != '3'
+              actual_ns = resource ? resource[:namespace] : nil
 
               property_localized = I18n.t("attributes.#{property}")
               expected_localized = I18n.t("attributes.#{ns.to_s.singularize}")

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -40,12 +40,7 @@ module API
           include API::V3::Utilities::PathHelper
 
           class << self
-            alias_method :original_new, :new
-
-            # we can't use a factory method as we sometimes rely on ROAR instantiating representers
-            # for us. Thus we override the :new method.
-            # This allows adding instance specific properties to our representer.
-            def new(work_package)
+            def create(work_package)
               klass = Class.new(WorkPackageAttributeLinksRepresenter)
               injector_class = ::API::V3::Utilities::CustomFieldInjector
               linked_fields = work_package.available_custom_fields.select do |cf|
@@ -57,7 +52,7 @@ module API
                 injector.inject_patchable_link_value(custom_field)
               end
 
-              klass.original_new(work_package)
+              klass.new(work_package)
             end
           end
 

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -40,19 +40,14 @@ module API
           include API::V3::Utilities::PathHelper
 
           class << self
-            def create(work_package)
-              klass = Class.new(WorkPackageAttributeLinksRepresenter)
+            def create_class(work_package)
               injector_class = ::API::V3::Utilities::CustomFieldInjector
-              linked_fields = work_package.available_custom_fields.select do |cf|
-                injector_class.linked_field?(cf)
-              end
+              injector_class.create_value_representer_for_link_patching(work_package,
+                                                                        WorkPackageAttributeLinksRepresenter)
+            end
 
-              injector = injector_class.new(klass)
-              linked_fields.each do |custom_field|
-                injector.inject_patchable_link_value(custom_field)
-              end
-
-              klass.new(work_package)
+            def create(work_package)
+              create_class(work_package).new(work_package)
             end
           end
 

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -125,21 +125,10 @@ module API
           def parse_resource(property, ns, href)
             return nil unless href
 
-            resource = ::API::Utilities::ResourceLinkParser.parse href
-
-            if resource.nil? || resource[:namespace] != ns.to_s ||
-               resource[:version] != '3'
-              actual_ns = resource ? resource[:namespace] : nil
-
-              property_localized = I18n.t("attributes.#{property}")
-              expected_localized = I18n.t("attributes.#{ns.to_s.singularize}")
-              actual_localized = I18n.t("attributes.#{actual_ns.to_s.singularize}")
-              fail ::API::Errors::Form::InvalidResourceLink.new(property_localized,
-                                                                expected_localized,
-                                                                actual_localized)
-            end
-
-            resource ? resource[:id] : nil
+            ::API::Utilities::ResourceLinkParser.parse_id href,
+                                                          property: property,
+                                                          expected_version: '3',
+                                                          expected_namespace: ns
           end
         end
       end

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -141,7 +141,7 @@ module API
           end
 
           def work_package_attribute_links_representer(represented)
-            ::API::V3::WorkPackages::Form::WorkPackageAttributeLinksRepresenter.new represented
+            ::API::V3::WorkPackages::Form::WorkPackageAttributeLinksRepresenter.create represented
           end
         end
       end

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -39,12 +39,7 @@ module API
           include Roar::Hypermedia
 
           class << self
-            alias_method :original_new, :new
-
-            # we can't use a factory method as we sometimes rely on ROAR instantiating representers
-            # for us. Thus we override the :new method.
-            # This allows adding instance specific properties to our representer.
-            def new(work_package, options = {})
+            def create_class(work_package)
               klass = Class.new(WorkPackagePayloadRepresenter)
               injector_class = ::API::V3::Utilities::CustomFieldInjector
               property_fields = work_package.available_custom_fields.select do |cf|
@@ -56,7 +51,11 @@ module API
                 injector.inject_value(custom_field)
               end
 
-              klass.original_new(work_package, options)
+              klass
+            end
+
+            def create(work_package, options = {})
+              create_class(work_package).new(work_package, options)
             end
           end
 

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -38,22 +38,22 @@ module API
           include Roar::JSON::HAL
           include Roar::Hypermedia
 
-        class << self
-          alias_method :original_new, :new
+          class << self
+            alias_method :original_new, :new
 
-          # we can't use a factory method as we sometimes rely on ROAR instantiating representers
-          # for us. Thus we override the :new method.
-          # This allows adding instance specific properties to our representer.
-          def new(work_package, options = {})
-            klass = Class.new(WorkPackagePayloadRepresenter)
-            injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
-            work_package.available_custom_fields.each do |custom_field|
-              injector.inject_value(custom_field)
+            # we can't use a factory method as we sometimes rely on ROAR instantiating representers
+            # for us. Thus we override the :new method.
+            # This allows adding instance specific properties to our representer.
+            def new(work_package, options = {})
+              klass = Class.new(WorkPackagePayloadRepresenter)
+              injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
+              work_package.available_custom_fields.each do |custom_field|
+                injector.inject_value(custom_field)
+              end
+
+              klass.original_new(work_package, options)
             end
-
-            klass.original_new(work_package, options)
           end
-        end
 
           self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -40,18 +40,9 @@ module API
 
           class << self
             def create_class(work_package)
-              klass = Class.new(WorkPackagePayloadRepresenter)
               injector_class = ::API::V3::Utilities::CustomFieldInjector
-              property_fields = work_package.available_custom_fields.select do |cf|
-                injector_class.property_field?(cf)
-              end
-
-              injector = injector_class.new(klass)
-              property_fields.each do |custom_field|
-                injector.inject_value(custom_field)
-              end
-
-              klass
+              injector_class.create_value_representer_for_property_patching(work_package,
+                                                                            WorkPackagePayloadRepresenter)
             end
 
             def create(work_package, options = {})

--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -46,8 +46,13 @@ module API
             # This allows adding instance specific properties to our representer.
             def new(work_package, options = {})
               klass = Class.new(WorkPackagePayloadRepresenter)
-              injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
-              work_package.available_custom_fields.each do |custom_field|
+              injector_class = ::API::V3::Utilities::CustomFieldInjector
+              property_fields = work_package.available_custom_fields.select do |cf|
+                injector_class.property_field?(cf)
+              end
+
+              injector = injector_class.new(klass)
+              property_fields.each do |custom_field|
                 injector.inject_value(custom_field)
               end
 

--- a/lib/api/v3/work_packages/link_to_object_extractor.rb
+++ b/lib/api/v3/work_packages/link_to_object_extractor.rb
@@ -36,7 +36,7 @@ module API
             resource = ::API::Utilities::ResourceLinkParser.parse links[attribute]['href']
 
             if resource
-              case resource[:ns]
+              case resource[:namespace]
               when 'statuses'
                 h[:status_id] = resource[:id]
               end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -41,13 +41,9 @@ module API
             end
 
             def create_class(work_package_schema)
-              klass = Class.new(WorkPackageSchemaRepresenter)
-              injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
-              work_package_schema.available_custom_fields.each do |custom_field|
-                injector.inject_schema(custom_field, wp_schema: work_package_schema)
-              end
-
-              klass
+              injector_class = ::API::V3::Utilities::CustomFieldInjector
+              injector_class.create_schema_representer(work_package_schema,
+                                                       WorkPackageSchemaRepresenter)
             end
 
             def create(work_package_schema, context)

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -40,19 +40,18 @@ module API
               WorkPackage
             end
 
-            alias_method :original_new, :new
-
-            # we can't use a factory method as we sometimes rely on ROAR instantiating representers
-            # for us. Thus we override the :new method.
-            # This allows adding instance specific properties to our representer.
-            def new(work_package_schema, context)
+            def create_class(work_package_schema)
               klass = Class.new(WorkPackageSchemaRepresenter)
               injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
               work_package_schema.available_custom_fields.each do |custom_field|
                 injector.inject_schema(custom_field, wp_schema: work_package_schema)
               end
 
-              klass.original_new(work_package_schema, context)
+              klass
+            end
+
+            def create(work_package_schema, context)
+              create_class(work_package_schema).new(work_package_schema, context)
             end
           end
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -134,97 +134,59 @@ module API
                                      api_v3_paths.available_responsibles(represented.project.id)
                                    }
 
-          property :status,
-                   exec_context: :decorator,
-                   getter: -> (*) {
-                     assignable_statuses = represented.assignable_statuses_for(current_user)
-                     representer = ::API::Decorators::AllowedValuesByCollectionRepresenter.new(
-                       type: 'Status',
-                       name: WorkPackage.human_attribute_name(:status),
-                       current_user: current_user,
-                       value_representer: API::V3::Statuses::StatusRepresenter,
-                       link_factory: -> (status) {
-                         {
-                           href: api_v3_paths.status(status.id),
-                           title: status.name
-                         }
-                       })
+          schema_with_allowed_collection :status,
+                                         type: 'Status',
+                                         values_callback: -> (*) {
+                                           represented.assignable_statuses_for(current_user)
+                                         },
+                                         value_representer: Statuses::StatusRepresenter,
+                                         link_factory: -> (status) {
+                                           {
+                                             href: api_v3_paths.status(status.id),
+                                             title: status.name
+                                           }
+                                         }
 
-                     if represented.defines_assignable_values?
-                       representer.allowed_values = assignable_statuses
-                     end
+          schema_with_allowed_collection :category,
+                                         type: 'Category',
+                                         values_callback: -> (*) {
+                                           represented.assignable_categories
+                                         },
+                                         value_representer: Categories::CategoryRepresenter,
+                                         link_factory: -> (category) {
+                                           {
+                                             href: api_v3_paths.category(category.id),
+                                             title: category.name
+                                           }
+                                         },
+                                         required: false
 
-                     representer
-                   }
+          schema_with_allowed_collection :version,
+                                         type: 'Version',
+                                         values_callback: -> (*) {
+                                           represented.assignable_versions
+                                         },
+                                         value_representer: Versions::VersionRepresenter,
+                                         link_factory: -> (version) {
+                                           {
+                                             href: api_v3_paths.version(version.id),
+                                             title: version.name
+                                           }
+                                         },
+                                         required: false
 
-          property :category,
-                   exec_context: :decorator,
-                   getter: -> (*) {
-                     representer = ::API::Decorators::AllowedValuesByCollectionRepresenter.new(
-                       type: 'Category',
-                       name: WorkPackage.human_attribute_name(:category),
-                       value_representer: API::V3::Categories::CategoryRepresenter,
-                       link_factory: -> (category) {
-                         {
-                           href: api_v3_paths.category(category.id),
-                           title: category.name
-                         }
-                       })
-
-                     representer.required = false
-
-                     if represented.defines_assignable_values?
-                       representer.allowed_values = represented.assignable_categories
-                     end
-
-                     representer
-                   }
-
-          property :version,
-                   exec_context: :decorator,
-                   getter: -> (*) {
-                     representer = ::API::Decorators::AllowedValuesByCollectionRepresenter.new(
-                       type: 'Version',
-                       name: WorkPackage.human_attribute_name(:version),
-                       current_user: current_user,
-                       value_representer: API::V3::Versions::VersionRepresenter,
-                       link_factory: -> (version) {
-                         {
-                           href: api_v3_paths.version(version.id),
-                           title: version.name
-                         }
-                       })
-
-                     representer.required = false
-
-                     if represented.defines_assignable_values?
-                       representer.allowed_values = represented.assignable_versions
-                     end
-
-                     representer
-                   }
-
-          property :priority,
-                   exec_context: :decorator,
-                   getter: -> (*) {
-                     representer = ::API::Decorators::AllowedValuesByCollectionRepresenter.new(
-                       type: 'Priority',
-                       name: WorkPackage.human_attribute_name(:priority),
-                       current_user: current_user,
-                       value_representer: API::V3::Priorities::PriorityRepresenter,
-                       link_factory: -> (priority) {
-                         {
-                           href: api_v3_paths.priority(priority.id),
-                           title: priority.name
-                         }
-                       })
-
-                     if represented.defines_assignable_values?
-                       representer.allowed_values = represented.assignable_priorities
-                     end
-
-                     representer
-                   }
+          schema_with_allowed_collection :priority,
+                                         type: 'Priority',
+                                         values_callback: -> (*) {
+                                           represented.assignable_priorities
+                                         },
+                                         value_representer: Priorities::PriorityRepresenter,
+                                         link_factory: -> (priority) {
+                                           {
+                                             href: api_v3_paths.priority(priority.id),
+                                             title: priority.name
+                                           }
+                                         }
 
           def current_user
             context[:current_user]

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -35,18 +35,25 @@ module API
     module WorkPackages
       module Schema
         class WorkPackageSchemaRepresenter < ::API::Decorators::Schema
-          def self.represented_class
-            WorkPackage
-          end
-
-          def self.create(work_package_schema, context = {})
-            klass = Class.new(WorkPackageSchemaRepresenter)
-            injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
-            work_package_schema.available_custom_fields.each do |custom_field|
-              injector.inject_schema(custom_field)
+          class << self
+            def represented_class
+              WorkPackage
             end
 
-            klass.new(work_package_schema, context)
+            alias_method :original_new, :new
+
+            # we can't use a factory method as we sometimes rely on ROAR instantiating representers
+            # for us. Thus we override the :new method.
+            # This allows adding instance specific properties to our representer.
+            def new(work_package_schema, context)
+              klass = Class.new(WorkPackageSchemaRepresenter)
+              injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
+              work_package_schema.available_custom_fields.each do |custom_field|
+                injector.inject_schema(custom_field)
+              end
+
+              klass.original_new(work_package_schema, context)
+            end
           end
 
           schema :_type,

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -49,7 +49,7 @@ module API
               klass = Class.new(WorkPackageSchemaRepresenter)
               injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
               work_package_schema.available_custom_fields.each do |custom_field|
-                injector.inject_schema(custom_field)
+                injector.inject_schema(custom_field, wp_schema: work_package_schema)
               end
 
               klass.original_new(work_package_schema, context)

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -63,7 +63,7 @@ module API
                 end
 
                 schema = WorkPackageSchema.new(project: project, type: type)
-                @representer = WorkPackageSchemaRepresenter.new(schema,
+                @representer = WorkPackageSchemaRepresenter.create(schema,
                                                                 current_user: current_user)
               end
 

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -63,7 +63,7 @@ module API
                 end
 
                 schema = WorkPackageSchema.new(project: project, type: type)
-                @representer = WorkPackageSchemaRepresenter.create(schema,
+                @representer = WorkPackageSchemaRepresenter.new(schema,
                                                                 current_user: current_user)
               end
 

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -32,7 +32,6 @@ module API
       module Schema
         class WorkPackageSchemasAPI < Grape::API
           resources :schemas do
-
             params do
               requires :project, desc: 'Work package schema id'
               requires :type, desc: 'Work package schema id'

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -62,8 +62,8 @@ module API
                 end
 
                 schema = WorkPackageSchema.new(project: project, type: type)
-                @representer = WorkPackageSchemaRepresenter.new(schema,
-                                                                current_user: current_user)
+                @representer = WorkPackageSchemaRepresenter.create(schema,
+                                                                   current_user: current_user)
               end
 
               get do

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -36,13 +36,9 @@ module API
       class WorkPackageRepresenter < ::API::Decorators::Single
         class << self
           def create_class(work_package)
-            klass = Class.new(WorkPackageRepresenter)
-            injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
-            work_package.available_custom_fields.each do |custom_field|
-              injector.inject_value(custom_field)
-            end
-
-            klass
+            injector_class = ::API::V3::Utilities::CustomFieldInjector
+            injector_class.create_value_representer(work_package,
+                                                    WorkPackageRepresenter)
           end
 
           def create(work_package, context = {})

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -362,10 +362,6 @@ module API
 
         private
 
-        def current_user
-          context[:current_user]
-        end
-
         def version_policy
           @version_policy ||= ::VersionPolicy.new(current_user)
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -35,19 +35,18 @@ module API
     module WorkPackages
       class WorkPackageRepresenter < ::API::Decorators::Single
         class << self
-          alias_method :original_new, :new
-
-          # we can't use a factory method as we sometimes rely on ROAR instantiating representers
-          # for us. Thus we override the :new method.
-          # This allows adding instance specific properties to our representer.
-          def new(work_package, context = {})
+          def create_class(work_package)
             klass = Class.new(WorkPackageRepresenter)
             injector = ::API::V3::Utilities::CustomFieldInjector.new(klass)
             work_package.available_custom_fields.each do |custom_field|
               injector.inject_value(custom_field)
             end
 
-            klass.original_new(work_package, context)
+            klass
+          end
+
+          def create(work_package, context = {})
+            create_class(work_package).new(work_package, context)
           end
         end
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -40,7 +40,7 @@ module API
 
               def write_work_package_attributes
                 if request_body
-                  payload = ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter.new(
+                  payload = ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter.create(
                     @work_package,
                     enforce_lock_version_validation: true)
 
@@ -78,8 +78,8 @@ module API
 
             before do
               @work_package = WorkPackage.find(params[:id])
-              @representer = WorkPackages::WorkPackageRepresenter.new(work_package,
-                                                                      current_user: current_user)
+              @representer = WorkPackages::WorkPackageRepresenter.create(work_package,
+                                                                         current_user: current_user)
             end
 
             get do

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -47,7 +47,7 @@ module Redmine
                                    dependent: :delete_all,
                                    validate: false
           before_validation { |customized| customized.custom_field_values if customized.new_record? }
-          validate :validate_custom_values, if: -> (customized) { customized.custom_field_values_changed? }
+          validate :validate_custom_values
           send :include, Redmine::Acts::Customizable::InstanceMethods
           # Save custom values when saving the customized object
           after_save :save_custom_field_values

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -119,11 +119,9 @@ module Redmine
         end
 
         def validate_custom_values
-          custom_values.reject { |cv| cv.marked_for_destruction? }.each do |custom_value|
-            unless custom_value.valid?
-              custom_value.errors.each do |_, message|
-                errors.add(custom_value.custom_field.accessor_name.to_sym, message)
-              end
+          custom_values.reject(&:marked_for_destruction?).select(&:invalid?).each do |custom_value|
+            custom_value.errors.each do |_, message|
+              errors.add(custom_value.custom_field.accessor_name.to_sym, message)
             end
           end
         end

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -123,7 +123,7 @@ module Redmine
           custom_values.reject { |cv| cv.marked_for_destruction? }.each do |custom_value|
             unless custom_value.valid?
               custom_value.errors.each do |_, message|
-                errors.add(custom_field_accessor_name(custom_value.custom_field).to_sym, message)
+                errors.add(custom_value.custom_field.accessor_name.to_sym, message)
               end
             end
           end
@@ -131,7 +131,7 @@ module Redmine
 
         def add_custom_field_accessors
           available_custom_fields.each do |custom_field|
-            getter_name = custom_field_accessor_name(custom_field)
+            getter_name = custom_field.accessor_name
             setter_name = "#{getter_name}="
 
             define_singleton_method getter_name do
@@ -146,12 +146,6 @@ module Redmine
               self.custom_field_values = { custom_field.id => value }
             end
           end
-        end
-
-        private
-
-        def custom_field_accessor_name(custom_field)
-          "custom_field_#{custom_field.id}"
         end
 
         module ClassMethods

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -119,7 +119,7 @@ module Redmine
         end
 
         def validate_custom_values
-          custom_values.each do |custom_value|
+          custom_values.reject { |cv| cv.marked_for_destruction? }.each do |custom_value|
             unless custom_value.valid?
               custom_value.errors.each do |_, message|
                 errors.add("custom_field_#{custom_value.custom_field.id}".to_sym, message)

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -51,7 +51,6 @@ module Redmine
           send :include, Redmine::Acts::Customizable::InstanceMethods
           # Save custom values when saving the customized object
           after_save :save_custom_field_values
-          after_initialize :add_custom_field_accessors
         end
       end
 
@@ -129,22 +128,51 @@ module Redmine
           end
         end
 
-        def add_custom_field_accessors
-          available_custom_fields.each do |custom_field|
-            getter_name = custom_field.accessor_name
-            setter_name = "#{getter_name}="
+        def method_missing(method, *args)
+          for_custom_field_accessor(method) do |custom_field|
+            add_custom_field_accessors(custom_field)
+            return send method, *args
+          end
 
-            define_singleton_method getter_name do
-              custom_value = custom_value_for(custom_field)
-              custom_value ? custom_value.typed_value : nil
-            end
+          super
+        end
 
-            define_singleton_method setter_name do |value|
-              # N.B. we do no strict type checking here, it would be possible to assign a user
-              # to an integer custom field...
-              value = value.id if value.respond_to?(:id)
-              self.custom_field_values = { custom_field.id => value }
+        def respond_to?(method, include_private = false)
+          for_custom_field_accessor(method) do |custom_field|
+            # pro-actively add the accessors, the method will probably be called next
+            add_custom_field_accessors(custom_field)
+            return true
+          end
+
+          super
+        end
+
+        private
+
+        def for_custom_field_accessor(method_symbol)
+          match = /\Acustom_field_(?<id>\d+)=?\z/.match(method_symbol.to_s)
+          if match
+            custom_field = CustomField.find_by_id(match[:id])
+            if custom_field
+              yield custom_field
             end
+          end
+        end
+
+        def add_custom_field_accessors(custom_field)
+          getter_name = custom_field.accessor_name
+          setter_name = "#{getter_name}="
+
+          define_singleton_method getter_name do
+            custom_value = custom_value_for(custom_field)
+            custom_value ? custom_value.typed_value : nil
+          end
+
+          define_singleton_method setter_name do |value|
+            # N.B. we do no strict type checking here, it would be possible to assign a user
+            # to an integer custom field...
+            value = value.id if value.respond_to?(:id)
+            self.custom_field_values = { custom_field.id => value }
           end
         end
 

--- a/spec/lib/api/utilities/resource_link_parser_spec.rb
+++ b/spec/lib/api/utilities/resource_link_parser_spec.rb
@@ -142,5 +142,12 @@ describe ::API::Utilities::ResourceLinkParser do
         subject.parse_id('/api/v3/types/14', property: 'foo', expected_namespace: 'statuses')
       }.to raise_error(::API::Errors::Form::InvalidResourceLink)
     end
+
+    it 'contains the property name in exception messages' do
+      property_name = 'My Property Name'
+      expect {
+        subject.parse_id('/api/v4/statuses/14', property: property_name, expected_version: '3')
+      }.to raise_error(Regexp.compile(property_name))
+    end
   end
 end

--- a/spec/lib/api/utilities/resource_link_parser_spec.rb
+++ b/spec/lib/api/utilities/resource_link_parser_spec.rb
@@ -1,0 +1,100 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::Utilities::ResourceLinkParser do
+  subject { described_class }
+
+  describe('#parse') do
+    shared_examples_for 'accepts resource link' do
+      it 'parses the version' do
+        expect(result[:version]).to eql(version)
+      end
+
+      it 'parses the namespace' do
+        expect(result[:namespace]).to eql(namespace)
+      end
+
+      it 'parses the id' do
+        expect(result[:id]).to eql(id)
+      end
+    end
+
+    shared_examples_for 'rejects resource link' do
+      it 'is nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    describe 'accepts a simple resource' do
+      it_behaves_like 'accepts resource link' do
+        let(:result) { subject.parse '/api/v3/statuses/12' }
+        let(:version) { '3' }
+        let(:namespace) { 'statuses' }
+        let(:id) { '12' }
+      end
+    end
+
+    describe 'accepts all valid segment characters as id' do
+      it_behaves_like 'accepts resource link' do
+        let(:result) { subject.parse '/api/v3/string_object/foo-2_~!$&\'()*+.,:;=@%Fa' }
+        let(:version) { '3' }
+        let(:namespace) { 'string_object' }
+        let(:id) { 'foo-2_~!$&\'()*+.,:;=@%Fa' }
+      end
+    end
+
+    describe 'accepts resource with empty id segment' do
+      it_behaves_like 'accepts resource link' do
+        let(:result) { subject.parse '/api/v3/string_object/' }
+        let(:version) { '3' }
+        let(:namespace) { 'string_object' }
+        let(:id) { '' }
+      end
+    end
+
+    describe 'rejects resource with missing id segment' do
+      it_behaves_like 'rejects resource link' do
+        let(:result) { subject.parse '/api/v3/string_object' }
+      end
+    end
+
+    describe 'rejects the api root' do
+      it_behaves_like 'rejects resource link' do
+        let(:result) { subject.parse '/api/v3/' }
+      end
+    end
+
+    describe 'rejects nested resources' do
+      it_behaves_like 'rejects resource link' do
+        let(:result) { subject.parse '/api/v3/statuses/imaginary/' }
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -1,0 +1,95 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+shared_examples_for 'has basic schema properties' do
+  it 'exists' do
+    is_expected.to have_json_path(path)
+  end
+
+  it 'has a type' do
+    is_expected.to be_json_eql(type.to_json).at_path("#{path}/type")
+  end
+
+  it 'has a name' do
+    is_expected.to be_json_eql(name.to_json).at_path("#{path}/name")
+  end
+
+  it 'indicates if it is required' do
+    is_expected.to be_json_eql(required.to_json).at_path("#{path}/required")
+  end
+
+  it 'indicates if it is writable' do
+    is_expected.to be_json_eql(writable.to_json).at_path("#{path}/writable")
+  end
+end
+
+shared_examples_for 'links to allowed values directly' do
+  it 'has the expected number of links' do
+    is_expected.to have_json_size(hrefs.size).at_path("#{path}/_links/allowedValues")
+  end
+
+  it 'contains links to the allowed values' do
+    index = 0
+    hrefs.each do |href|
+      href_path = "#{path}/_links/allowedValues/#{index}/href"
+      is_expected.to be_json_eql(href.to_json).at_path(href_path)
+      index += 1
+    end
+  end
+
+  it 'has the expected number of embedded values' do
+    is_expected.to have_json_size(hrefs.size).at_path("#{path}/_embedded/allowedValues")
+  end
+
+  it 'embeds the allowed values' do
+    index = 0
+    hrefs.each do |href|
+      href_path = "#{path}/_embedded/allowedValues/#{index}/_links/self/href"
+      is_expected.to be_json_eql(href.to_json).at_path(href_path)
+      index += 1
+    end
+  end
+end
+
+shared_examples_for 'links to allowed values via collection link' do
+  it 'contains the link to the allowed values' do
+    is_expected.to be_json_eql(href.to_json).at_path("#{path}/_links/allowedValues/href")
+  end
+end
+
+shared_examples_for 'does not link to allowed values' do
+  it 'contains no link to the allowed values' do
+    is_expected.to_not have_json_path("#{path}/_links/allowedValues")
+  end
+
+  it 'does not embed allowed values' do
+    is_expected.to_not have_json_path("#{path}/_embedded/allowedValues")
+  end
+end

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -63,6 +63,10 @@ shared_examples_for 'links to allowed values directly' do
       index += 1
     end
   end
+end
+
+shared_examples_for 'links to and embeds allowed values directly' do
+  it_behaves_like 'links to allowed values directly'
 
   it 'has the expected number of embedded values' do
     is_expected.to have_json_size(hrefs.size).at_path("#{path}/_embedded/allowedValues")

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Utilities::CustomFieldInjector do
+  let(:custom_field) {
+    FactoryGirl.build(:custom_field,
+                      field_format: 'bool')
+  }
+
+  describe 'TYPE_MAP' do
+    it 'supports all available formats' do
+      Redmine::CustomFieldFormat.available_formats.each do |format|
+        expect(described_class::TYPE_MAP[format]).to_not be_nil
+      end
+    end
+  end
+
+  describe ':inject_schema' do
+    let(:schema_class) { Class.new(::API::Decorators::Schema) }
+    let(:rendered_json) { schema_class.new(nil).to_json }
+    let(:cf_path) { "customField#{custom_field.id}" }
+    subject { described_class.new(schema_class) }
+
+    before do
+      subject.inject_schema(custom_field)
+    end
+
+    it 'injects the schema' do
+      expect(rendered_json).to have_json_path(cf_path)
+    end
+
+    it 'sets the type' do
+      expect(rendered_json).to be_json_eql('Boolean'.to_json).at_path("#{cf_path}/type")
+    end
+
+    it 'sets the name' do
+      expect(rendered_json).to be_json_eql(custom_field.name.to_json).at_path("#{cf_path}/name")
+    end
+
+    it 'marks the field as writable' do
+      expect(rendered_json).to be_json_eql(true.to_json).at_path("#{cf_path}/writable")
+    end
+
+    context 'when the custom field is required' do
+      let(:custom_field) { FactoryGirl.build(:custom_field, is_required: true) }
+
+      it 'marks the field as required' do
+        expect(rendered_json).to be_json_eql(true.to_json).at_path("#{cf_path}/required")
+      end
+    end
+
+    context 'when the custom field is not required' do
+      let(:custom_field) { FactoryGirl.build(:custom_field, is_required: false) }
+
+      it 'marks the field as required' do
+        expect(rendered_json).to be_json_eql(false.to_json).at_path("#{cf_path}/required")
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -209,8 +209,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     let(:represented) {
       double('represented',
              available_custom_fields: [custom_field],
-             custom_value_for: double('custom_value',
-                                      typed_value: custom_value))
+             custom_field.accessor_name => custom_value)
     }
     let(:custom_value) { '' }
     let(:current_user) { FactoryGirl.build(:user) }
@@ -234,7 +233,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:represented) {
           double('represented',
                  available_custom_fields: [custom_field],
-                 custom_value_for: nil)
+                 custom_field.accessor_name => nil)
         }
 
         it_behaves_like 'has an empty link' do
@@ -261,7 +260,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:represented) {
           double('represented',
                  available_custom_fields: [custom_field],
-                 custom_value_for: nil)
+                 custom_field.accessor_name => nil)
         }
 
         it_behaves_like 'has an empty link' do
@@ -288,7 +287,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:represented) {
           double('represented',
                  available_custom_fields: [custom_field],
-                 custom_value_for: nil)
+                 custom_field.accessor_name => nil)
         }
 
         it_behaves_like 'has an empty link' do
@@ -360,12 +359,13 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
   describe '#inject_patchable_link_value' do
     let(:base_class) { Class.new(::API::Decorators::Single) }
-    let(:modified_class) { described_class.create_value_representer_for_link_patching(represented, base_class) }
+    let(:modified_class) {
+      described_class.create_value_representer_for_link_patching(represented, base_class)
+    }
     let(:represented) {
       double('represented',
              available_custom_fields: [custom_field],
-             custom_value_for: double('custom_value',
-                                      typed_value: custom_value))
+             custom_field.accessor_name => custom_value)
     }
     let(:custom_value) { '' }
     subject { "{ \"_links\": #{modified_class.new(represented).to_json} }" }
@@ -383,7 +383,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:represented) {
           double('represented',
                  available_custom_fields: [custom_field],
-                 custom_value_for: nil)
+                 custom_field.accessor_name => nil)
         }
 
         it_behaves_like 'has an empty link' do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -181,7 +181,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     let(:represented) {
       double('represented',
              custom_value_for: double('custom_value',
-                                      value: custom_value))
+                                      typed_value: custom_value))
     }
     let(:custom_value) { '' }
     let(:modified_class) { Class.new(::API::Decorators::Single) }
@@ -192,7 +192,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'link custom field' do
-      let(:custom_value) { '2' }
+      let(:custom_value) { FactoryGirl.build(:user, id: 2) }
       let(:field_format) { 'user' }
 
       it_behaves_like 'has an untitled link' do
@@ -221,7 +221,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'int custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'int' }
-        let(:custom_value) { '42' }
+        let(:custom_value) { 42 }
         let(:json_value) { 42 }
         let(:expected_setter) { json_value }
       end
@@ -230,7 +230,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'float custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'float' }
-        let(:custom_value) { '3.14' }
+        let(:custom_value) { 3.14 }
         let(:json_value) { 3.14 }
         let(:expected_setter) { json_value }
       end
@@ -239,7 +239,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'bool custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'bool' }
-        let(:custom_value) { '1' }
+        let(:custom_value) { true }
         let(:json_value) { true }
         let(:expected_setter) { json_value }
       end
@@ -248,7 +248,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'date custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'date' }
-        let(:custom_value) { Date.today.to_date.iso8601 }
+        let(:custom_value) { Date.today.to_date }
         let(:json_value) { custom_value.to_date.iso8601 }
         let(:expected_setter) { json_value }
       end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -177,15 +177,75 @@ describe ::API::V3::Utilities::CustomFieldInjector do
                                       typed_value: custom_value))
     }
     let(:custom_value) { '' }
-    subject { modified_class.new(represented).to_json }
+    let(:current_user) { FactoryGirl.build(:user) }
+    subject { modified_class.new(represented, current_user: current_user).to_json }
 
-    context 'link custom field' do
+    context 'user custom field' do
       let(:custom_value) { FactoryGirl.build(:user, id: 2) }
       let(:field_format) { 'user' }
 
       it_behaves_like 'has an untitled link' do
         let(:link) { cf_path }
         let(:href) { '/api/v3/users/2' }
+      end
+
+      it 'has the user embedded' do
+        is_expected.to be_json_eql('User'.to_json).at_path("_embedded/#{cf_path}/_type")
+        is_expected.to be_json_eql(custom_value.name.to_json).at_path("_embedded/#{cf_path}/name")
+      end
+
+      context 'value is nil' do
+        let(:represented) {
+          double('represented',
+                 available_custom_fields: [custom_field],
+                 custom_value_for: nil)
+        }
+
+        it_behaves_like 'has an empty link' do
+          let(:link) { cf_path }
+        end
+      end
+    end
+
+    context 'version custom field' do
+      let(:custom_value) { FactoryGirl.build(:version, id: 2) }
+      let(:field_format) { 'version' }
+
+      it_behaves_like 'has an untitled link' do
+        let(:link) { cf_path }
+        let(:href) { '/api/v3/versions/2' }
+      end
+
+      it 'has the version embedded' do
+        is_expected.to be_json_eql('Version'.to_json).at_path("_embedded/#{cf_path}/_type")
+        is_expected.to be_json_eql(custom_value.name.to_json).at_path("_embedded/#{cf_path}/name")
+      end
+
+      context 'value is nil' do
+        let(:represented) {
+          double('represented',
+                 available_custom_fields: [custom_field],
+                 custom_value_for: nil)
+        }
+
+        it_behaves_like 'has an empty link' do
+          let(:link) { cf_path }
+        end
+      end
+    end
+
+    context 'list custom field' do
+      let(:custom_value) { 'Foobar' }
+      let(:field_format) { 'list' }
+
+      it_behaves_like 'has an untitled link' do
+        let(:link) { cf_path }
+        let(:href) { '/api/v3/string_objects/Foobar' }
+      end
+
+      it 'has the string object embedded' do
+        is_expected.to be_json_eql('StringObject'.to_json).at_path("_embedded/#{cf_path}/_type")
+        is_expected.to be_json_eql(custom_value.to_json).at_path("_embedded/#{cf_path}/value")
       end
 
       context 'value is nil' do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -69,11 +69,47 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:writable) { true }
       end
 
-      context 'when the custom field is not required' do
+      it 'indicates no regular expression' do
+        is_expected.to_not have_json_path("#{cf_path}/regularExpression")
+      end
+
+      it 'indicates no minimum size' do
+        is_expected.to_not have_json_path("#{cf_path}/minLength")
+      end
+
+      it 'indicates no maximum size' do
+        is_expected.to_not have_json_path("#{cf_path}/maxLength")
+      end
+
+      context 'custom field is not required' do
         let(:custom_field) { FactoryGirl.build(:custom_field, is_required: false) }
 
         it 'marks the field as not required' do
           is_expected.to be_json_eql(false.to_json).at_path("#{cf_path}/required")
+        end
+      end
+
+      context 'custom field has regex' do
+        let(:custom_field) { FactoryGirl.build(:custom_field, regexp: 'Foo+bar') }
+
+        it 'renders the regular expression' do
+          is_expected.to be_json_eql('Foo+bar'.to_json).at_path("#{cf_path}/regularExpression")
+        end
+      end
+
+      context 'custom field has minimum length' do
+        let(:custom_field) { FactoryGirl.build(:custom_field, min_length: 5) }
+
+        it 'renders the minimum length' do
+          is_expected.to be_json_eql(5.to_json).at_path("#{cf_path}/minLength")
+        end
+      end
+
+      context 'custom field has maximum length' do
+        let(:custom_field) { FactoryGirl.build(:custom_field, max_length: 5) }
+
+        it 'renders the maximum length' do
+          is_expected.to be_json_eql(5.to_json).at_path("#{cf_path}/maxLength")
         end
       end
     end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -86,7 +86,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       let(:versions) { FactoryGirl.build_list(:version, 3) }
 
       before do
-        allow(::API::V3::Versions::VersionRepresenter).to receive(:new).and_return(double())
+        allow(::API::V3::Versions::VersionRepresenter).to receive(:new).and_return(double)
       end
 
       it_behaves_like 'has basic schema properties' do

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -175,16 +175,10 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
     end
 
     describe 'custom fields' do
-      let(:custom_field) { FactoryGirl.build(:custom_field) }
-      let(:injector) { double('injector') }
-
-      before do
-        allow(work_package).to receive(:available_custom_fields).and_return([custom_field])
-        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
-      end
-
-      it 'contains the custom field' do
-        expect(injector).to receive(:inject_value).with(custom_field)
+      it 'uses a CustomFieldInjector' do
+        expected_method = :create_value_representer_for_property_patching
+        expect(::API::V3::Utilities::CustomFieldInjector).to receive(expected_method)
+          .and_call_original
         representer.to_json
       end
     end

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -175,7 +175,7 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
     end
 
     describe 'custom fields' do
-      let(:custom_field) { FactoryGirl.build(:custom_field)}
+      let(:custom_field) { FactoryGirl.build(:custom_field) }
       let(:injector) { double('injector') }
 
       before do

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
                       created_at: DateTime.now,
                       updated_at: DateTime.now)
   }
-  let(:representer)  { described_class.create(work_package) }
+  let(:representer) { described_class.create(work_package) }
 
   before { allow(work_package).to receive(:lock_version).and_return(1) }
 

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
                       created_at: DateTime.now,
                       updated_at: DateTime.now)
   }
-  let(:representer)  { described_class.new(work_package) }
+  let(:representer)  { described_class.create(work_package) }
 
   before { allow(work_package).to receive(:lock_version).and_return(1) }
 

--- a/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form/work_package_payload_representer_spec.rb
@@ -173,6 +173,21 @@ describe ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter do
         end
       end
     end
+
+    describe 'custom fields' do
+      let(:custom_field) { FactoryGirl.build(:custom_field)}
+      let(:injector) { double('injector') }
+
+      before do
+        allow(work_package).to receive(:available_custom_fields).and_return([custom_field])
+        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
+      end
+
+      it 'contains the custom field' do
+        expect(injector).to receive(:inject_value).with(custom_field)
+        representer.to_json
+      end
+    end
   end
 
   describe 'parsing' do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -225,7 +225,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
     end
 
     describe 'custom fields' do
-      let(:custom_field) { FactoryGirl.build(:custom_field)}
+      let(:custom_field) { FactoryGirl.build(:custom_field) }
       let(:injector) { double('injector') }
 
       before do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -224,6 +224,21 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       end
     end
 
+    describe 'custom fields' do
+      let(:custom_field) { FactoryGirl.build(:custom_field)}
+      let(:injector) { double('injector') }
+
+      before do
+        allow(work_package).to receive(:available_custom_fields).and_return([custom_field])
+        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
+      end
+
+      it 'contains the custom field' do
+        expect(injector).to receive(:inject_value).with(custom_field)
+        representer.to_json
+      end
+    end
+
     describe '_links' do
       it { is_expected.to have_json_type(Object).at_path('_links') }
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:member) { FactoryGirl.create(:user, member_in_project: project, member_through_role: role) }
   let(:current_user) { member }
 
-  let(:representer)  { described_class.new(work_package, current_user: current_user) }
+  let(:representer)  { described_class.create(work_package, current_user: current_user) }
 
   let(:work_package) {
     FactoryGirl.build(:work_package,

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -225,16 +225,9 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
     end
 
     describe 'custom fields' do
-      let(:custom_field) { FactoryGirl.build(:custom_field) }
-      let(:injector) { double('injector') }
-
-      before do
-        allow(work_package).to receive(:available_custom_fields).and_return([custom_field])
-        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
-      end
-
-      it 'contains the custom field' do
-        expect(injector).to receive(:inject_value).with(custom_field)
+      it 'uses a CustomFieldInjector' do
+        expect(::API::V3::Utilities::CustomFieldInjector).to receive(:create_value_representer)
+          .and_call_original
         representer.to_json
       end
     end

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:member) { FactoryGirl.create(:user, member_in_project: project, member_through_role: role) }
   let(:current_user) { member }
 
-  let(:representer)  { described_class.create(work_package, current_user: current_user) }
+  let(:representer) { described_class.create(work_package, current_user: current_user) }
 
   let(:work_package) {
     FactoryGirl.build(:work_package,

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -37,7 +37,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:schema) {
     ::API::V3::WorkPackages::Schema::WorkPackageSchema.new(work_package: work_package)
   }
-  let(:representer) { described_class.create(schema, current_user: current_user) }
+  let(:representer) { described_class.new(schema, current_user: current_user) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -48,72 +48,6 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
 
-    shared_examples_for 'has basic schema properties' do
-      it 'exists' do
-        is_expected.to have_json_path(path)
-      end
-
-      it 'has a type' do
-        is_expected.to be_json_eql(type.to_json).at_path("#{path}/type")
-      end
-
-      it 'has a name' do
-        is_expected.to be_json_eql(name.to_json).at_path("#{path}/name")
-      end
-
-      it 'indicates if it is required' do
-        is_expected.to be_json_eql(required.to_json).at_path("#{path}/required")
-      end
-
-      it 'indicates if it is writable' do
-        is_expected.to be_json_eql(writable.to_json).at_path("#{path}/writable")
-      end
-    end
-
-    shared_examples_for 'links to allowed values directly' do
-      it 'has the expected number of links' do
-        is_expected.to have_json_size(hrefs.size).at_path("#{path}/_links/allowedValues")
-      end
-
-      it 'contains links to the allowed values' do
-        index = 0
-        hrefs.each do |href|
-          href_path = "#{path}/_links/allowedValues/#{index}/href"
-          is_expected.to be_json_eql(href.to_json).at_path(href_path)
-          index += 1
-        end
-      end
-
-      it 'has the expected number of embedded values' do
-        is_expected.to have_json_size(hrefs.size).at_path("#{path}/_embedded/allowedValues")
-      end
-
-      it 'embeds the allowed values' do
-        index = 0
-        hrefs.each do |href|
-          href_path = "#{path}/_embedded/allowedValues/#{index}/_links/self/href"
-          is_expected.to be_json_eql(href.to_json).at_path(href_path)
-          index += 1
-        end
-      end
-    end
-
-    shared_examples_for 'links to allowed values via collection link' do
-      it 'contains the link to the allowed values' do
-        is_expected.to be_json_eql(href.to_json).at_path("#{path}/_links/allowedValues/href")
-      end
-    end
-
-    shared_examples_for 'does not link to allowed values' do
-      it 'contains no link to the allowed values' do
-        is_expected.to_not have_json_path("#{path}/_links/allowedValues")
-      end
-
-      it 'does not embed allowed values' do
-        is_expected.to_not have_json_path("#{path}/_embedded/allowedValues")
-      end
-    end
-
     describe '_type' do
       it_behaves_like 'has basic schema properties' do
         let(:path) { '_type' }
@@ -482,8 +416,8 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
       end
 
-      it 'contains the custom field' do
-        expect(injector).to receive(:inject_schema).with(custom_field)
+      it 'uses a custom field injector' do
+        expect(injector).to receive(:inject_schema).with(custom_field, wp_schema: schema)
         representer.to_json
       end
     end

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -475,7 +475,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'custom fields' do
-      let(:injector) { double('injector')}
+      let(:injector) { double('injector') }
 
       before do
         allow(schema).to receive(:available_custom_fields).and_return([custom_field])

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -218,7 +218,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       context 'w/o allowed statuses' do
         before { allow(work_package).to receive(:new_statuses_allowed_to).and_return([]) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'status' }
           let(:hrefs) { [] }
         end
@@ -229,7 +229,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
         before { allow(work_package).to receive(:new_statuses_allowed_to).and_return(statuses) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'status' }
           let(:hrefs) { statuses.map { |status| "/api/v3/statuses/#{status.id}" } }
         end
@@ -294,7 +294,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       context 'w/o allowed versions' do
         before { allow(work_package).to receive(:assignable_versions).and_return([]) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'version' }
           let(:hrefs) { [] }
         end
@@ -305,7 +305,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
         before { allow(work_package).to receive(:assignable_versions).and_return(versions) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'version' }
           let(:hrefs) { versions.map { |version| "/api/v3/versions/#{version.id}" } }
         end
@@ -332,7 +332,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       context 'w/o allowed priorities' do
         before { allow(work_package).to receive(:assignable_priorities).and_return([]) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'priority' }
           let(:hrefs) { [] }
         end
@@ -343,7 +343,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
         before { allow(work_package).to receive(:assignable_priorities).and_return(priorities) }
 
-        it_behaves_like 'links to allowed values directly' do
+        it_behaves_like 'links to and embeds allowed values directly' do
           let(:path) { 'priority' }
           let(:hrefs) { priorities.map { |priority| "/api/v3/priorities/#{priority.id}" } }
         end

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -409,15 +409,9 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'custom fields' do
-      let(:injector) { double('injector') }
-
-      before do
-        allow(schema).to receive(:available_custom_fields).and_return([custom_field])
-        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
-      end
-
-      it 'uses a custom field injector' do
-        expect(injector).to receive(:inject_schema).with(custom_field, wp_schema: schema)
+      it 'uses a CustomFieldInjector' do
+        expect(::API::V3::Utilities::CustomFieldInjector).to receive(:create_schema_representer)
+          .and_call_original
         representer.to_json
       end
     end

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -37,7 +37,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:schema) {
     ::API::V3::WorkPackages::Schema::WorkPackageSchema.new(work_package: work_package)
   }
-  let(:representer) { described_class.new(schema, current_user: current_user) }
+  let(:representer) { described_class.create(schema, current_user: current_user) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -29,6 +29,7 @@
 require 'spec_helper'
 
 describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
+  let(:custom_field) { FactoryGirl.build(:custom_field) }
   let(:work_package) { FactoryGirl.build(:work_package) }
   let(:current_user) {
     FactoryGirl.build(:user, member_in_project: work_package.project)
@@ -36,7 +37,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:schema) {
     ::API::V3::WorkPackages::Schema::WorkPackageSchema.new(work_package: work_package)
   }
-  let(:representer) { described_class.new(schema, current_user: current_user) }
+  let(:representer) { described_class.create(schema, current_user: current_user) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }
@@ -470,6 +471,20 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
             let(:path) { 'responsible' }
           end
         end
+      end
+    end
+
+    describe 'custom fields' do
+      let(:injector) { double('injector')}
+
+      before do
+        allow(schema).to receive(:available_custom_fields).and_return([custom_field])
+        allow(::API::V3::Utilities::CustomFieldInjector).to receive(:new).and_return(injector)
+      end
+
+      it 'contains the custom field' do
+        expect(injector).to receive(:inject_schema).with(custom_field)
+        representer.to_json
       end
     end
   end

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -399,4 +399,17 @@ describe CustomField, type: :model do
       it { expect(field).not_to be_valid }
     end
   end
+
+  describe :accessor_name do
+    # create the custom field to force assignment of an id
+    let(:field)  { FactoryGirl.create :custom_field }
+
+    it 'is formatted as expected' do
+      expect(field.accessor_name).to eql("custom_field_#{field.id}")
+    end
+
+    it 'returns a string' do
+      expect(field.accessor_name).to be_a(String)
+    end
+  end
 end

--- a/spec/models/custom_value/bool_strategy_spec.rb
+++ b/spec/models/custom_value/bool_strategy_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::BoolStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value)
+  }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value corresponds to true' do
+      let(:value) { '1' }
+      it { is_expected.to eql(true) }
+    end
+
+    context 'value corresponds to false' do
+      let(:value) { '0' }
+      it { is_expected.to eql(false) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+
+    context 'value corresponds to true' do
+      let(:value) { '1' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value corresponds to false' do
+      let(:value) { '0' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/date_strategy_spec.rb
+++ b/spec/models/custom_value/date_strategy_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::DateStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value)
+  }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value is some date string' do
+      let(:value) { '2015-01-03' }
+      it { is_expected.to eql(Date.iso8601(value)) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+
+    context 'value is valid date string' do
+      let(:value) { '2015-01-03' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is invalid date string in good format' do
+      let(:value) { '2015-02-30' }
+      it 'rejects' do
+        is_expected.to eql(:not_a_date)
+      end
+    end
+
+    context 'value is date string in bad format' do
+      let(:value) { '03.01.2015' }
+      it 'rejects' do
+        is_expected.to eql(:not_a_date)
+      end
+    end
+
+    context 'value is not a date string at all' do
+      let(:value) { 'chicken' }
+      it 'rejects' do
+        is_expected.to eql(:not_a_date)
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/float_strategy_spec.rb
+++ b/spec/models/custom_value/float_strategy_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::FloatStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value)
+  }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value is some float string' do
+      let(:value) { '3.14' }
+      it { is_expected.to eql(3.14) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+
+    context 'value is float string in decimal notation' do
+      let(:value) { '3.14' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is float string in exp. notation' do
+      let(:value) { '5.0e-14' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is not a float string' do
+      let(:value) { 'banana' }
+      it 'rejects' do
+        is_expected.to eql(:not_a_number)
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/int_strategy_spec.rb
+++ b/spec/models/custom_value/int_strategy_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::IntStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value)
+  }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value is some float string' do
+      let(:value) { '10' }
+      it { is_expected.to eql(10) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+
+    context 'value is positive int string' do
+      let(:value) { '10' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is negative int string' do
+      let(:value) { '-10' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is not an int string' do
+      let(:value) { 'unicorn' }
+      it 'rejects' do
+        is_expected.to eql(:not_an_integer)
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/list_strategy_spec.rb
+++ b/spec/models/custom_value/list_strategy_spec.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::ListStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value,
+           custom_field: custom_field,
+           customized: customized)
+  }
+  let(:customized) { double('customized') }
+  let(:custom_field) { FactoryGirl.build(:custom_field) }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value is some string' do
+      let(:value) { 'foo bar' }
+      it { is_expected.to eql(value) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+    let(:allowed_values) { %w(foo bar) }
+
+    before do
+      # not passing arguments to :possible_values is important, because this method is weird
+      # see its doc for more details on its weirdness. tl; dr: do NOT pass args for list CFs
+      allow(custom_field).to receive(:possible_values).with(no_args).and_return(allowed_values)
+    end
+
+    context 'value is included' do
+      let(:value) { 'bar' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is not included' do
+      let(:value) { 'cat' }
+      it 'rejects' do
+        is_expected.to eql(:inclusion)
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/string_strategy_spec.rb
+++ b/spec/models/custom_value/string_strategy_spec.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::StringStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value)
+  }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+
+    context 'value is some string' do
+      let(:value) { 'foo bar!' }
+      it { is_expected.to eql(value) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to eql(value) }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+
+    context 'value is some string' do
+      let(:value) { 'foo bar!' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is empty string' do
+      let(:value) { '' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/user_strategy_spec.rb
+++ b/spec/models/custom_value/user_strategy_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::UserStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value,
+           custom_field: custom_field,
+           customized: customized)
+  }
+  let(:customized) { double('customized') }
+  let(:custom_field) { FactoryGirl.build(:custom_field) }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+    let(:user) { FactoryGirl.build(:user) }
+
+    before do
+      allow(User).to receive(:find_by_id).with(value).and_return(user)
+    end
+
+    context 'value is some id string' do
+      let(:value) { '10' }
+      it { is_expected.to eql(user) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+    let(:allowed_ids) { %w(12 13) }
+
+    before do
+      allow(custom_field).to receive(:possible_values).with(customized).and_return(allowed_ids)
+    end
+
+    context 'value is id of included element' do
+      let(:value) { '12' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is id of non included element' do
+      let(:value) { '10' }
+      it 'rejects' do
+        is_expected.to eql(:inclusion)
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/version_strategy_spec.rb
+++ b/spec/models/custom_value/version_strategy_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomValue::VersionStrategy do
+  let(:custom_value) {
+    double('CustomValue',
+           value: value,
+           custom_field: custom_field,
+           customized: customized)
+  }
+  let(:customized) { double('customized') }
+  let(:custom_field) { FactoryGirl.build(:custom_field) }
+
+  describe '#typed_value' do
+    subject { described_class.new(custom_value).typed_value }
+    let(:version) { FactoryGirl.build(:version) }
+
+    before do
+      allow(Version).to receive(:find_by_id).with(value).and_return(version)
+    end
+
+    context 'value is some id string' do
+      let(:value) { '10' }
+      it { is_expected.to eql(version) }
+    end
+
+    context 'value is blank' do
+      let(:value) { '' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#validate_type_of_value' do
+    subject { described_class.new(custom_value).validate_type_of_value }
+    let(:allowed_ids) { %w(12 13) }
+
+    before do
+      allow(custom_field).to receive(:possible_values).with(customized).and_return(allowed_ids)
+    end
+
+    context 'value is id of included element' do
+      let(:value) { '12' }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is id of non included element' do
+      let(:value) { '10' }
+      it 'rejects' do
+        is_expected.to eql(:inclusion)
+      end
+    end
+  end
+end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -256,13 +256,16 @@ describe WorkPackage, type: :model do
       it_behaves_like 'work package with required custom field'
 
       describe 'value' do
+        let(:relevant_journal) {
+          work_package.journals.select { |j| j.customizable_journals.size > 0 }.first
+        }
+        subject { relevant_journal.customizable_journals.first.value }
+
         before do
           change_custom_field_value(work_package, value)
         end
 
-        subject { work_package.journals.last.customizable_journals.first.value }
-
-        it { expect(subject).to eq(value) }
+        it { is_expected.to eq(value) }
       end
     end
   end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -92,7 +92,7 @@ describe WorkPackage, type: :model do
             describe 'work package attribute update' do
               subject { work_package.save }
 
-              it { is_expected.to be_false }
+              it { is_expected.to be_falsey }
             end
           end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1633,7 +1633,7 @@ describe WorkPackage, type: :model do
 
       # assert that there is only one error
       expect(work_package.errors.size).to eq 1
-      expect(work_package.errors_on(:custom_values).size).to eq 1
+      expect(work_package.errors_on("custom_field_#{cf2.id}").size).to eq 1
     end
   end
 

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -52,7 +52,9 @@ describe API::V3::Activities::ActivitiesAPI, type: :request do
   shared_examples_for 'invalid activity request' do |message|
     before { allow(User).to receive(:current).and_return(admin) }
 
-    it_behaves_like 'constraint violation', message
+    it_behaves_like 'constraint violation' do
+      let(:message) { message }
+    end
   end
 
   describe 'PATCH /api/v3/activities/:activityId' do

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -102,8 +102,14 @@ describe 'API v3 Render resource' do
                               I18n.t('api_v3.errors.render.context_not_found')
             end
 
-            describe 'unsupported context found' do
+            describe 'unsupported context resource found' do
               let(:post_path) { "#{path}?context=/api/v3/activities/2" }
+
+              it_behaves_like 'invalid render context', 'Unsupported context found.'
+            end
+
+            describe 'unsupported context version found' do
+              let(:post_path) { "#{path}?context=/api/v4/work_packages/2" }
 
               it_behaves_like 'invalid render context', 'Unsupported context found.'
             end

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -110,11 +110,10 @@ shared_examples_for 'update conflict' do
                   I18n.t('api_v3.errors.code_409')
 end
 
-shared_examples_for 'constraint violation' do |message|
+shared_examples_for 'constraint violation' do
   it_behaves_like 'error response',
                   422,
-                  'PropertyConstraintViolation',
-                  message
+                  'PropertyConstraintViolation'
 end
 
 shared_examples_for 'format error' do |message|

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -465,9 +465,9 @@ h4. things we like
           it_behaves_like 'constraint violation' do
             let(:message) {
               I18n.t('api_v3.errors.invalid_resource',
-                     property: 'Status',
-                     expected: 'Status',
-                     actual: 'User')
+                     property: 'status',
+                     expected: '/api/v3/statuses/:id',
+                     actual: status_link)
             }
           end
         end
@@ -589,9 +589,9 @@ h4. things we like
               it_behaves_like 'constraint violation' do
                 let(:message) {
                   I18n.t('api_v3.errors.invalid_resource',
-                         property: "#{property.capitalize}",
-                         expected: 'User',
-                         actual: 'Status')
+                         property: property,
+                         expected: '/api/v3/users/:id',
+                         actual: user_href)
                 }
               end
             end

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -454,7 +454,6 @@ h4. things we like
                           'work_package.attributes.status_id.status_transition_invalid')
             }
           end
-
         end
 
         context 'wrong resource' do

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -741,17 +741,6 @@ h4. things we like
         end
       end
 
-      context 'valid update' do
-        xit 'should respond with updated work package priority' do
-          expect(subject.body).to be_json_eql(params[:priority].to_json).at_path('priority')
-        end
-
-        xit 'should update the dates in iso8601 format' do
-          expect(subject.body).to be_json_eql(params[:startDate].to_json).at_path('startDate')
-          expect(subject.body).to be_json_eql(params[:dueDate].to_json).at_path('dueDate')
-        end
-      end
-
       context 'invalid update' do
         context 'single invalid attribute' do
           let(:params) { valid_params.tap { |h| h[:subject] = '' } }

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -448,9 +448,13 @@ h4. things we like
         context 'invalid status' do
           include_context 'patch request'
 
-          it_behaves_like 'constraint violation',
-                          'Status ' + I18n.t('activerecord.errors.models.' \
+          it_behaves_like 'constraint violation' do
+            let(:message) {
+              'Status ' + I18n.t('activerecord.errors.models.' \
                           'work_package.attributes.status_id.status_transition_invalid')
+            }
+          end
+
         end
 
         context 'wrong resource' do
@@ -458,11 +462,14 @@ h4. things we like
 
           include_context 'patch request'
 
-          it_behaves_like 'constraint violation',
-                          I18n.t('api_v3.errors.invalid_resource',
-                                 property: 'Status',
-                                 expected: 'Status',
-                                 actual: 'User')
+          it_behaves_like 'constraint violation' do
+            let(:message) {
+              I18n.t('api_v3.errors.invalid_resource',
+                     property: 'Status',
+                     expected: 'Status',
+                     actual: 'User')
+            }
+          end
         end
       end
 
@@ -553,20 +560,25 @@ h4. things we like
             context 'user doesn\'t exist' do
               let(:user_href) { '/api/v3/users/909090' }
 
-              it_behaves_like 'constraint violation',
-                              I18n.t('api_v3.errors.validation.' \
+              it_behaves_like 'constraint violation' do
+                let(:message) {
+                  I18n.t('api_v3.errors.validation.' \
                                      'invalid_user_assigned_to_work_package',
-                                     property: property.capitalize)
+                         property: property.capitalize)
+                }
+              end
             end
 
             context 'user is not visible' do
               let(:invalid_user) { FactoryGirl.create(:user) }
               let(:user_href) { "/api/v3/users/#{invalid_user.id}" }
 
-              it_behaves_like 'constraint violation',
-                              I18n.t('api_v3.errors.validation.' \
-                                     'invalid_user_assigned_to_work_package',
-                                     property: property.capitalize)
+              it_behaves_like 'constraint violation' do
+                let(:message) {
+                  I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
+                         property: property.capitalize)
+                }
+              end
             end
 
             context 'wrong resource' do
@@ -574,11 +586,14 @@ h4. things we like
 
               include_context 'patch request'
 
-              it_behaves_like 'constraint violation',
-                              I18n.t('api_v3.errors.invalid_resource',
-                                     property: "#{property.capitalize}",
-                                     expected: 'User',
-                                     actual: 'Status')
+              it_behaves_like 'constraint violation' do
+                let(:message) {
+                  I18n.t('api_v3.errors.invalid_resource',
+                         property: "#{property.capitalize}",
+                         expected: 'User',
+                         actual: 'Status')
+                }
+              end
             end
 
             context 'group assignement disabled' do
@@ -587,10 +602,12 @@ h4. things we like
               include_context 'setup group membership', false
               include_context 'patch request'
 
-              it_behaves_like 'constraint violation',
-                              I18n.t('api_v3.errors.validation.' \
-                                     'invalid_user_assigned_to_work_package',
-                                     property: "#{property.capitalize}")
+              it_behaves_like 'constraint violation' do
+                let(:message) {
+                  I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
+                         property: "#{property.capitalize}")
+                }
+              end
             end
           end
         end
@@ -741,7 +758,9 @@ h4. things we like
 
           include_context 'patch request'
 
-          it_behaves_like 'constraint violation', "Subject can't be blank"
+          it_behaves_like 'constraint violation' do
+            let(:message) { "Subject can't be blank" }
+          end
         end
 
         context 'multiple invalid attributes' do

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -375,11 +375,14 @@ describe 'API v3 Work package form resource', type: :request do
 
                   include_context 'post request'
 
-                  it_behaves_like 'constraint violation',
-                                  I18n.t('api_v3.errors.invalid_resource',
-                                         property: 'Status',
-                                         expected: 'Status',
-                                         actual: 'User')
+                  it_behaves_like 'constraint violation' do
+                    let(:message) {
+                      I18n.t('api_v3.errors.invalid_resource',
+                             property: 'status',
+                             expected: '/api/v3/statuses/:id',
+                             actual: status_link)
+                    }
+                  end
                 end
               end
             end
@@ -468,19 +471,21 @@ describe 'API v3 Work package form resource', type: :request do
 
                     include_context 'post request'
 
-                    it_behaves_like 'constraint violation',
-                                    I18n.t('api_v3.errors.invalid_resource',
-                                           property: "#{property.capitalize}",
-                                           expected: 'User',
-                                           actual: 'Status')
+                    it_behaves_like 'constraint violation' do
+                      let(:message) {
+                        I18n.t('api_v3.errors.invalid_resource',
+                               property: property,
+                               expected: '/api/v3/users/:id',
+                               actual: user_link)
+                      }
+                    end
                   end
 
                   context 'group assignement disabled' do
                     let(:user_link) { "/api/v3/users/#{group.id}" }
                     let(:error_message_path) { "_embedded/validationErrors/#{property}/message" }
                     let(:error_message) {
-                      I18n.t('api_v3.errors.validation.' \
-                             'invalid_user_assigned_to_work_package',
+                      I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
                              property: "#{property.capitalize}").to_json
                     }
 

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -198,7 +198,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_destroying_root_projects_should_clear_data
-    Journal.delete_all
+    Journal.destroy_all
     WorkPackage.all.each(&:recreate_initial_journal!)
 
     Project.roots.each(&:destroy)
@@ -254,7 +254,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_set_parent_should_add_roots_in_alphabetical_order
-    ProjectCustomField.delete_all
+    ProjectCustomField.destroy_all
     Project.delete_all
     Project.create!(name: 'Project C', identifier: 'project-c').set_parent!(nil)
     Project.create!(name: 'Project B', identifier: 'project-b').set_parent!(nil)
@@ -266,7 +266,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_set_parent_should_add_children_in_alphabetical_order
-    ProjectCustomField.delete_all
+    ProjectCustomField.destroy_all
     parent = Project.create!(name: 'Parent', identifier: 'parent')
     Project.create!(name: 'Project C', identifier: 'project-c').set_parent!(parent)
     Project.create!(name: 'Project B', identifier: 'project-b').set_parent!(parent)
@@ -279,7 +279,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_rebuild_should_sort_children_alphabetically
-    ProjectCustomField.delete_all
+    ProjectCustomField.destroy_all
     parent = Project.create!(name: 'Parent', identifier: 'parent')
     Project.create!(name: 'Project C', identifier: 'project-c').move_to_child_of(parent)
     Project.create!(name: 'Project B', identifier: 'project-b').move_to_child_of(parent)

--- a/test/unit/time_entry_activity_test.rb
+++ b/test/unit/time_entry_activity_test.rb
@@ -62,7 +62,8 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
 
     e = TimeEntryActivity.new(name: 'Custom Data')
     assert !e.save
-    assert_include e.errors[:custom_values], I18n.translate('activerecord.errors.messages.invalid')
+    assert_include e.errors["custom_field_#{field.id}"],
+                   I18n.translate('activerecord.errors.messages.blank')
   end
 
   def test_create_with_required_custom_field_should_succeed
@@ -85,7 +86,7 @@ class TimeEntryActivityTest < ActiveSupport::TestCase
     # Blanking custom field, save should fail
     e.custom_field_values = { field.id => '' }
     assert !e.save
-    refute_empty e.errors[:custom_values]
+    refute_empty e.errors["custom_field_#{field.id}"]
 
     # Update custom field to valid value, save should succeed
     e.custom_field_values = { field.id => '0' }


### PR DESCRIPTION
## OpenProject work packages
- https://community.openproject.org/work_packages/18296
- https://community.openproject.org/work_packages/18295
- https://community.openproject.org/work_packages/18294
- https://community.openproject.org/work_packages/18293
- https://community.openproject.org/work_packages/18292
- https://community.openproject.org/work_packages/18291
- https://community.openproject.org/work_packages/18290
- https://community.openproject.org/work_packages/18288
## Progress
- [x] schema for basic custom fields
- [x] schema for linked custom fields
- [x] schema for list custom fields
- [x] basic custom fields in WP representer
- [x] linked custom fields in WP representer
- [x] list custom fields in WP representer
- [x] patchable basic custom fields
- [x] patchable linked custom fields
- [x] patchable list custom fields
- [x] render text custom fields as formattables (forced to `plain`)
- [x] full specs for `CustomFieldInjector`
- [x] don't override `new`, but make a class creator that is usable by lambdas passed to `:decorator`
- [x] clean up messy bits and pieces >:D
- [x] validation of allowed values
## Progress during review
- [x] embed custom values of type user and version
- [x] find the root cause of unspecific custom value errors (they are more specific normally)
- [x] rename `wp_schema` of `inject_schema` (and probably adapt behaviour) to make method work for other customizables
- [x] specs for `ResourceLinkParser#parse_id`'s `property` parameter
- [x] check user deletion
- [x] avoid deep nesting in acts as custom...
- [x] fix test with journal stuff
- [x] falsey
- [x] method missing awesomeness
- [x] adapt **frontend** to missing `customProperties` dictionary on `/api/v3/work_packages/:id`
- [x] adapt StringObject
