### PR TITLE
Fix <base>-tag slash position w/ relative url root

### DIFF
--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <meta name="description" content="<%= OpenProject::Info.app_name %>" />
     <meta name="keywords" content="issue,bug,type" />
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
-    <base href="/<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
+    <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
     <meta name="current_menu_item" content="<%= current_menu_item %>" />
     <meta name="accessibility-mode" content="<%= current_user.impaired? %>" />
     <%= csrf_meta_tags %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <meta name="description" content="<%= OpenProject::Info.app_name %>" />
     <meta name="keywords" content="issue,bug,type" />
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
-    <base href="/<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
+    <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
     <meta name="current_menu_item" content="<%= current_menu_item %>" />
     <meta name="accessibility-mode" content="<%= current_user.impaired? %>" />
     <%= csrf_meta_tags %>


### PR DESCRIPTION
With a RAILS_RELATIVE_URL_ROOT set, `<base href="//path">` is emitted
rather than `<base href="/path/">`. `//path` is interpreted by the
browser as HTTP host rather than a path, breaking links and assets.

Broken since 288a8a74.
