### PR TITLE
[ON HOLD] add minitest to the list of dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,6 +161,7 @@ group :test do
   gem "json_spec"
   gem "activerecord-tableless", "~> 1.0"
   gem "codeclimate-test-reporter", :require => nil
+  gem 'minitest', '~> 5.5.1'
 end
 
 group :ldap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.6.2)
     minisyntax (0.2.3)
+    minitest (5.5.1)
     multi_json (1.10.1)
     multi_test (0.1.1)
     multi_xml (0.5.5)
@@ -488,6 +489,7 @@ DEPENDENCIES
   launchy (~> 2.3.0)
   letter_opener (~> 1.0.0)
   livingstyleguide (~> 1.2.2)
+  minitest (~> 5.5.1)
   multi_json
   mysql2 (~> 0.3.11)
   net-ldap (~> 0.8.0)


### PR DESCRIPTION
on hold: ruby 2.0.0 was used

i get the following when running `rake` inside a centos container

```
Application.initialize!... [deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
rake aborted!
LoadError: cannot load such file -- minitest/unit
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/test_case.rb:1:in `<top (required)>'
/usr/src/openproject/vendor/bundle/ruby/gems/actionpack-3.2.21/lib/action_controller/test_case.rb:355:in `<module:ActionController>'
/usr/src/openproject/vendor/bundle/ruby/gems/actionpack-3.2.21/lib/action_controller/test_case.rb:7:in `<top (required)>'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/actionpack-3.2.21/lib/action_view/test_case.rb:5:in `<top (required)>'
/usr/src/openproject/vendor/bundle/ruby/gems/prototype-rails-3.2.1/lib/prototype-rails/on_load_action_view.rb:17:in `<top (required)>'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/prototype-rails-3.2.1/lib/prototype-rails.rb:12:in `block (2 levels) in <class:Engine>'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/lazy_load_hooks.rb:36:in `instance_eval'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/lazy_load_hooks.rb:26:in `block in on_load'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/lazy_load_hooks.rb:25:in `each'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/lazy_load_hooks.rb:25:in `on_load'
/usr/src/openproject/vendor/bundle/ruby/gems/prototype-rails-3.2.1/lib/prototype-rails.rb:11:in `block in <class:Engine>'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/initializable.rb:30:in `instance_exec'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/initializable.rb:30:in `run'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/initializable.rb:55:in `block in run_initializers'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/initializable.rb:54:in `each'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/initializable.rb:54:in `run_initializers'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/application.rb:136:in `initialize!'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/railtie/configurable.rb:30:in `method_missing'
/usr/src/openproject/config/environment.rb:35:in `block in <top (required)>'
/usr/src/openproject/config/application.rb:43:in `block in bench'
/usr/src/openproject/config/application.rb:42:in `bench'
/usr/src/openproject/config/environment.rb:33:in `<top (required)>'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `block in require'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/src/openproject/vendor/bundle/ruby/gems/activesupport-3.2.21/lib/active_support/dependencies.rb:251:in `require'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/application.rb:103:in `require_environment!'
/usr/src/openproject/vendor/bundle/ruby/gems/railties-3.2.21/lib/rails/application.rb:305:in `block (2 levels) in initialize_tasks'
/usr/src/openproject/vendor/cache/sprockets-rails-e069c097056e/lib/sprockets/rails/task.rb:54:in `block (2 levels) in define'
/usr/src/openproject/lib/tasks/assets.rake:42:in `block (2 levels) in <top (required)>'
Tasks: TOP => environment
(See full trace by running task with --trace)
```

listing `minitest` as a dependency fixes the problem
