### PR TITLE
Update the contributing guidelines

### DIFF
--- a/CODE_OF_COINDUCT.md
+++ b/CODE_OF_COINDUCT.md
@@ -1,0 +1,13 @@
+### Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/). By participating in this project you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,5 +42,5 @@ We will then review your PR. Please note that you can add commits after the PR h
 
 - Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
 - Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
-- We want to keep the Pull request list as cleaned up as possible - we will close pull requests after an inactivity period of 48 hours (no comments, no further pushes)
+- We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as WIP.
 - We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,46 @@
 OpenProject is an open source project and we encourage you to help us out. We'd be happy if you do one of these things:
 
-* Create a [new work package on openproject.org](https://community.openproject.org/projects/openproject/work_packages) if you find a bug or need a feature
-* Help out other people on our [forums](https://community.openproject.org/projects/openproject/boards)
-* Help us [translate OpenProject to more languages](https://community.openproject.org/projects/openproject/wiki/Translations)
-* Contribute code via GitHub Pull Requests, see our [contribution page](https://community.openproject.org/projects/openproject/wiki/Contribution) for more information
-* See [Git Flow](https://community.openproject.org/projects/openproject/wiki/Git_Branching_Model)
+## Development flow
+For contributing source code, please follow the Git Workflow below:
+
+- Fork Openproject on GitHub
+- Clone your fork to your development machine: 
+
+```
+git clone git@github.com/<username>/openproject
+```
+
+- Optional: Add the original OpenProject repository as a remote, so you can fetch changes: 
+
+```
+git remote add upstream git@github.com:/opf/openproject
+```
+
+- Make sure you're on the right branch, right now (February 2015), the main development branch is dev: 
+
+```
+git checkout dev
+```
+
+- Create a feature branch: 
+
+```
+git checkout -b feature/<short description of your feature>
+```
+
+- Make your changes, then push the branch into your ***own*** repository:
+
+```
+git push origin <your feature branch>
+```
+
+- Create a pull request (PR) against a branch of of the <opf/openproject> repository, containing a ***clear description*** of what the pull request attempts to change and/or fix. 
+
+We will then review your PR. Please note that you can add commits after the PR has been created by pushing to the branch in your fork.
+
+## Important notices
+
+- Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
+- Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
+- We want to keep the Pull request list as cleaned up as possible - we will close pull requests after an inactivity period of 48 hours (no comments, no further pushes)
+- We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 OpenProject is an open source project and we encourage you to help us out. We'd be happy if you do one of these things:
 
+## Issue flow
+
+Ideally, there is a work package for every issue that is tackled by a contributor - the list can be found [here](https://community.openproject.org/projects/openproject/work_packages). Work packages can be created there on-demand if necessary.
+
 ## Development flow
 For contributing source code, please follow the Git Workflow below:
 
@@ -42,5 +46,5 @@ We will then review your PR. Please note that you can add commits after the PR h
 
 - Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
 - Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
-- We want to keep the Pull request list as cleaned up as possible - we aim to close pull requests after an inactivity period of ***72 hours*** (no comments, no further pushes)
+- We want to keep the Pull request list as cleaned up as possible - we will close pull requests after an inactivity period of 48 hours (no comments, no further pushes)
 - We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,12 @@
-OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please read the following guidelines:
+OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please read the following guidelines. 
+
+*Please also note that these rules should be acknowledged by everyone, but repository contributors might occasionally deviate from them for practical purposes, e.g. not fork the repo, but have a branch on the main repository.*
 
 ## Development flow
+
 For contributing source code, please follow the Git Workflow below:
 
-- Fork OpenProject on GitHub
+- **Fork** OpenProject on GitHub
 - Clone your fork to your development machine: 
 
 ```
@@ -34,13 +37,59 @@ git checkout -b feature/<short description of your feature>
 git push origin <your feature branch>
 ```
 
-- Create a pull request (PR) against a branch of of the <opf/openproject> repository, containing a ***clear description*** of what the pull request attempts to change and/or fix. 
+- Create a pull request against a branch of of the <opf/openproject> repository, containing a ***clear description*** of what the pull request attempts to change and/or fix. 
 
-We will then review your PR. Please note that you can add commits after the PR has been created by pushing to the branch in your fork.
+If your pull request **does not contain a description** for what it does and what it's intentions are, we will reject it. If you are working on a specific work package from the [list](https://community.openproject.org/projects/openproject/work_packages?query_props=%7B%22c%22:%5B%22type%22,%22status%22,%22subject%22,%22assigned_to%22%5D,%22t%22:%22parent:desc%22,%22f%22:%5B%7B%22n%22:%22status_id%22,%22o%22:%22!%22,%22t%22:%22list_status%22,%22v%22:%5B%2217%22,%2223%22,%223%22,%2214%22,%226%22%5D%7D%5D,%22pa%22:1,%22pp%22:20%7D), you may include a link to that work package in the description, so we can track your work.
+
+We will then review your pull request. Please note that you can add commits after the pull request has been created by pushing to the branch in your fork.
 
 ## Important notes
 
-- Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
-- Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
-- We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as `work in progress` by us.
-- We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.
+To ensure a smooth workflow for, please take note of the following:
+
+### Testing
+
+Please add tests to your code to verify functionality, especially if it is a new feature.
+
+Pull requests will be verified by TravisCI as well, but please run them locally as well. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
+
+### Code style guidelines
+
+We use [RuboCop](https://github.com/bbatsov/rubocop) to verify our code style for Ruby. A [RuboCop configuration](https://github.com/opf/openproject/blob/dev/.rubocop.yml) is included in the repository for your convenience. 
+
+Individual files can also be autocorrected with 
+
+```
+rubcocop -a ./path/to/file
+```
+
+JavaScript style for the frontend can be verified via a `gulp` task in the `frontend` folder:
+
+```
+gulp lint
+```
+
+Additionally, we use HoundCI to verifiy the styles for Ruby, as well as for JavaScript. We will reject pull requests which do not meet the code style requirements.
+
+The style guide applies **to lines you touch**. you do **not** have to correct a file completely if you only touch a single line for a bugfix. When in doubt, the matter will be discussed in the pull request.
+
+### Branching model
+
+The main development branch for upcoming releases is `dev`. For identifying the branch to create a pull request against, please refer to these rules:
+
+- If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
+- Hotfixes should be created against the appropiate `release/*` branch. Backports for fixes also go against their specific `release/*` branch.
+
+### Inactive pull requests
+
+We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as `work in progress` by us.
+
+### Issue tracking and coordination
+
+We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages?query_props=%7B%22c%22:%5B%22type%22,%22status%22,%22subject%22,%22assigned_to%22%5D,%22t%22:%22parent:desc%22,%22f%22:%5B%7B%22n%22:%22status_id%22,%22o%22:%22!%22,%22t%22:%22list_status%22,%22v%22:%5B%2217%22,%2223%22,%223%22,%2214%22,%226%22%5D%7D%5D,%22pa%22:1,%22pp%22:20%7D) for upcoming features and reported bugs.
+
+### Etiquette and communication
+
+Lastly, be nice and respectful to each other. We are working hard to make OpenProject the best project management software there is and we are grateful for each contribution. 
+
+If you want to get in touch with us, there is also a [Gitter channel](https://gitter.im) to talk to us directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,20 @@ We want to keep the Pull request list as cleaned up as possible - we will aim cl
 
 We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages?query_props=%7B%22c%22:%5B%22type%22,%22status%22,%22subject%22,%22assigned_to%22%5D,%22t%22:%22parent:desc%22,%22f%22:%5B%7B%22n%22:%22status_id%22,%22o%22:%22!%22,%22t%22:%22list_status%22,%22v%22:%5B%2217%22,%2223%22,%223%22,%2214%22,%226%22%5D%7D%5D,%22pa%22:1,%22pp%22:20%7D) for upcoming features and reported bugs.
 
-### Etiquette and communication
+### Contributor Code of Conduct
 
-Lastly, be nice and respectful to each other. We are working hard to make OpenProject the best project management software there is and we are grateful for each contribution. 
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+
+### Get in touch
 
 If you want to get in touch with us, there is also a [Gitter channel](https://gitter.im/opf/openproject) to talk to us directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@ OpenProject is an open source project and we encourage you to help us out. For c
 
 *Please also note that these rules should be acknowledged by everyone, but repository contributors might occasionally deviate from them for practical purposes, e.g. not fork the repo, but have a branch on the main repository.*
 
+## Contributors License Agreement
+
+External contributors have to sign a CLA before contributing to OpenProject.
+The [CLA can be found here](https://www.openproject.org/wp-content/uploads/2014/09/OPF-Contributor-License-Agreement_v.2.pdf) and has to be filled out and sent to cla@openproject.org. Additionally, a GPG signature has to be provided.
+
 ## Development flow
 
 For contributing source code, please follow the Git Workflow below:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,9 @@ To ensure a smooth workflow for everyone, please take note of the following:
 
 ### Testing
 
-Please add tests to your code to verify functionality, especially if it is a new feature.
+Please add tests to your code to verify functionality, especially if it is a new feature. 
 
-Pull requests will be verified by TravisCI as well, but please run them locally as well. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
+Pull requests will be verified by TravisCI as well, but please run them locally as well and make sure there are green before creating your pull request. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
 
 ### Branching model
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,5 +42,5 @@ We will then review your PR. Please note that you can add commits after the PR h
 
 - Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
 - Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
-- We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as WIP.
+- We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as `work in progress` by us.
 - We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ The main development branch for upcoming releases is `dev`. For identifying the 
 - If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
 - Hotfixes should be created against the appropiate `release/*` branch. Backports for fixes also go against their specific `release/*` branch.
 
+If you push to your branch in quick sucession, please consider stopping the assoicated Travis builds, as travis will run for each commit. This is especially true if you force push to the branch.
+
 ### Inactive pull requests
 
 We want to keep the Pull request list as cleaned up as possible - we will aim close pull requests after an **inactivity period of 72 hours** (no comments, no further pushes) which are not labelled as `work in progress` by us.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please do follow these steps:
+OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please read the following guidelines:
 
 ## Development flow
 For contributing source code, please follow the Git Workflow below:
@@ -13,7 +13,7 @@ git clone git@github.com/<username>/openproject
 - Optional: Add the original OpenProject repository as a remote, so you can fetch changes: 
 
 ```
-git remote add upstream git@github.com:/opf/openproject
+git remote add upstream git@github.com:opf/openproject
 ```
 
 - Make sure you're on the right branch. The main development branch is `dev`: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,4 @@
-OpenProject is an open source project and we encourage you to help us out. We'd be happy if you do one of these things:
-
-## Issue flow
-
-Ideally, there is a work package for every issue that is tackled by a contributor - the list can be found [here](https://community.openproject.org/projects/openproject/work_packages). Work packages can be created there on-demand if necessary.
+OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please do follow these steps:
 
 ## Development flow
 For contributing source code, please follow the Git Workflow below:
@@ -20,7 +16,7 @@ git clone git@github.com/<username>/openproject
 git remote add upstream git@github.com:/opf/openproject
 ```
 
-- Make sure you're on the right branch, right now (February 2015), the main development branch is dev: 
+- Make sure you're on the right branch. The main development branch is `dev`: 
 
 ```
 git checkout dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ The main development branch for upcoming releases is `dev`. For identifying the 
 - If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
 - Hotfixes should be created against the appropiate `release/*` branch. Backports for fixes also go against their specific `release/*` branch.
 
-If you push to your branch in quick sucession, please consider stopping the assoicated Travis builds, as travis will run for each commit. This is especially true if you force push to the branch.
+If you push to your branch in quick sucession, please consider stopping the assoicated Travis builds, as Travis will run for each commit. This is especially true if you force push to the branch.
 
 ### Inactive pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ git push origin <your feature branch>
 
 We will then review your PR. Please note that you can add commits after the PR has been created by pushing to the branch in your fork.
 
-## Important notices
+## Important notes
 
 - Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
 - Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 OpenProject is an open source project and we encourage you to help us out. For contributing to OpenProject, please read the following guidelines. 
 
-*Please also note that these rules should be acknowledged by everyone, but repository contributors might occasionally deviate from them for practical purposes, e.g. not fork the repo, but have a branch on the main repository.*
+*Please also note that these rules should be acknowledged by everyone, but repository contributors might occasionally deviate from them for practical purposes, e.g. not fork the repo, but have a branch on the main repository. This should however stay an exception.*
 
 ## Contributors License Agreement
 
@@ -9,7 +9,7 @@ The [CLA can be found here](https://www.openproject.org/wp-content/uploads/2014/
 
 ## Development flow
 
-For contributing source code, please follow the Git Workflow below:
+For contributing source code, please follow the git workflow below:
 
 - **Fork** OpenProject on GitHub
 - Clone your fork to your development machine: 
@@ -50,7 +50,7 @@ We will then review your pull request. Please note that you can add commits afte
 
 ## Important notes
 
-To ensure a smooth workflow for, please take note of the following:
+To ensure a smooth workflow for everyone, please take note of the following:
 
 ### Testing
 
@@ -65,7 +65,9 @@ The main development branch for upcoming releases is `dev`. For identifying the 
 - If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
 - Hotfixes should be created against the appropiate `release/*` branch. Backports for fixes also go against their specific `release/*` branch.
 
-If you push to your branch in quick sucession, please consider stopping the assoicated Travis builds, as Travis will run for each commit. This is especially true if you force push to the branch.
+If you push to your branch in quick sucession, please consider stopping the associated Travis builds, as Travis will run for each commit. This is especially true if you force push to the branch.
+
+Please also use `[ci skip]` in your commit message to suppress builds which are not necessary (e.g. after fixing a typo in the README).
 
 ### Inactive pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,5 +42,5 @@ We will then review your PR. Please note that you can add commits after the PR h
 
 - Please add tests to your code to verify functionality, especially if it is a new feature. Please also run these tests locally.
 - Please create pull requests against the current `dev` branch. Hotfixes and Bugfixes should be created against the appropiate `release/*` branch.
-- We want to keep the Pull request list as cleaned up as possible - we will close pull requests after an inactivity period of 48 hours (no comments, no further pushes)
+- We want to keep the Pull request list as cleaned up as possible - we aim to close pull requests after an inactivity period of ***72 hours*** (no comments, no further pushes)
 - We use OpenProject for development coordination - please have a look at [the work packages list](https://community.openproject.org/projects/openproject/work_packages) for upcoming features and reported bugs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,26 +58,6 @@ Please add tests to your code to verify functionality, especially if it is a new
 
 Pull requests will be verified by TravisCI as well, but please run them locally as well. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
 
-### Code style guidelines
-
-We use [RuboCop](https://github.com/bbatsov/rubocop) to verify our code style for Ruby. A [RuboCop configuration](https://github.com/opf/openproject/blob/dev/.rubocop.yml) is included in the repository for your convenience. 
-
-Individual files can also be autocorrected with 
-
-```
-rubcocop -a ./path/to/file
-```
-
-JavaScript style for the frontend can be verified via a `gulp` task in the `frontend` folder:
-
-```
-gulp lint
-```
-
-Additionally, we use HoundCI to verifiy the styles for Ruby, as well as for JavaScript. We will reject pull requests which do not meet the code style requirements.
-
-The style guide applies **to lines you touch**. you do **not** have to correct a file completely if you only touch a single line for a bugfix. When in doubt, the matter will be discussed in the pull request.
-
 ### Branching model
 
 The main development branch for upcoming releases is `dev`. For identifying the branch to create a pull request against, please refer to these rules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,18 +56,21 @@ To ensure a smooth workflow for everyone, please take note of the following:
 
 Please add tests to your code to verify functionality, especially if it is a new feature. 
 
-Pull requests will be verified by TravisCI as well, but please run them locally as well and make sure there are green before creating your pull request. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
+Pull requests will be verified by TravisCI as well, but please run them locally as well and make sure they are green before creating your pull request. We have a lot of pull requests coming in and it takes some time to run the complete suite for each one.
 
 ### Branching model
 
-The main development branch for upcoming releases is `dev`. For identifying the branch to create a pull request against, please refer to these rules:
+The main development branch for upcoming releases is `dev`. If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
 
-- If in doubt, create your pull request against `dev`. All new features, gem updates and bugfixes for the upcoming release should go into the `dev` branch.
-- Hotfixes should be created against the appropiate `release/*` branch. Backports for fixes also go against their specific `release/*` branch.
+#### Bugs and hotfixes
+
+Bugfixes for one of the actively supported versions of OpenProject should be issued against the respective branch. A fix for the current version (called "Hotfix" and the branch ideally being named `hotfix/XYZ`) should target `release/*` and a fix for the former version (called "Backport" and the branch ideally being named `backport/XYZ`) should target `backport/*`. We will try to merge hotfixes into dev branch but if that is no trivial task, we might ask you to create another PR for that.
+
+#### Travis CI
 
 If you push to your branch in quick sucession, please consider stopping the associated Travis builds, as Travis will run for each commit. This is especially true if you force push to the branch.
 
-Please also use `[ci skip]` in your commit message to suppress builds which are not necessary (e.g. after fixing a typo in the README).
+Please also use `[ci skip]` in your commit message to suppress builds which are not necessary (e.g. after fixing a typo in the `README`).
 
 ### Inactive pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,4 @@ We use OpenProject for development coordination - please have a look at [the wor
 
 Lastly, be nice and respectful to each other. We are working hard to make OpenProject the best project management software there is and we are grateful for each contribution. 
 
-If you want to get in touch with us, there is also a [Gitter channel](https://gitter.im) to talk to us directly.
+If you want to get in touch with us, there is also a [Gitter channel](https://gitter.im/opf/openproject) to talk to us directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ OpenProject is an open source project and we encourage you to help us out. For c
 ## Development flow
 For contributing source code, please follow the Git Workflow below:
 
-- Fork Openproject on GitHub
+- Fork OpenProject on GitHub
 - Clone your fork to your development machine: 
 
 ```


### PR DESCRIPTION
## Goal

In the light of some of the latest pull requests it became apparent hat we lack a single source of truth when it comes to the guidelines for contributing to OpenProject.

After some reviewing and looking into the history, I updated the guidelines for contributing to OpenProject to reflect current practices.
## Notes

Information has been pulled together from different source, mainly the [Guidelines from the OpenProject](https://community.openproject.org/projects/openproject/wiki/Git_Workflow) wiki (which is no longer available to me), comments made by @linki in #1362 and the discussion in #2594, as well as discussion with @ulferts on current practices in handling PRs.

There also was a discussion with @myabc last week on using [CLAHub](https://www.clahub.com/) for contributors to the repository, to which these guidelines have no reflection of. I'd be happy on discussing this topic, as there is some need of that in my opinion.
## Ticket

https://community.openproject.org/work_packages/18827
