### PR TITLE
Fix focusing of disabled buttons.

### DIFF
--- a/frontend/app/ui_components/focus-helper.js
+++ b/frontend/app/ui_components/focus-helper.js
@@ -40,9 +40,19 @@ module.exports = function($timeout, FOCUSABLE_SELECTOR) {
     },
 
     focus: function(element) {
-      var focusable = FocusHelper.getFocusableElement(element);
+      var focusable = angular.element(FocusHelper.getFocusableElement(element)),
+          $focusable = angular.element(focusable),
+          isDisabled = $focusable.is('[disabled]');
+
+      if(isDisabled) {
+        $focusable.removeProp('disabled');
+      }
 
       focusable.focus();
+
+      if(isDisabled) {
+        $focusable.prop('disabled');
+      }
     },
 
     focusElement: function(element) {

--- a/frontend/tests/integration/protractor.conf.js
+++ b/frontend/tests/integration/protractor.conf.js
@@ -37,7 +37,11 @@ exports.config = {
 
   directConnect: true,
 
-  specs: ['work-packages-spec.js', 'work-package-details-spec.js'],
+  specs: [
+    'work-packages-spec.js',
+    'work-package-details-spec.js',
+    'work-package-details-relations-spec.js'
+  ],
 
   allScriptsTimeout: 500000,
 

--- a/frontend/tests/integration/work-package-details-relations-spec.js
+++ b/frontend/tests/integration/work-package-details-relations-spec.js
@@ -1,0 +1,51 @@
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+
+var WorkPackageDetailsPane = require('./pages/work-package-details-pane.js');
+
+describe('OpenProject', function() {
+  function loadPane(workPackageId) {
+    var page = new WorkPackageDetailsPane(workPackageId, 'relations');
+    page.get();
+    browser.waitForAngular();
+  }
+
+  describe('details pane', function() {
+    beforeEach(function() {
+      loadPane(819);
+    });
+
+    it('opens relations tab', function() {
+      $('[ui-sref="work-packages.list.details.relations({})"]')
+      .getAttribute('class')
+      .then(function(classes) {
+        expect(classes.split(' ')).to.contain('selected');
+      });
+    });
+
+    describe('relations tab', function() {
+      var toggleAccordeon = function(titleName) {
+        getAccordeon(titleName).click();
+      },
+      getAccordeon = function(titleName) {
+        return $('.relation[title="' + titleName + '"]');
+      };
+
+      beforeEach(function(){
+        toggleAccordeon('Parent');
+      });
+
+      it('focuses on disabled button', function() {
+        $('.relation[title="Parent"] button')
+        .getAttribute('disabled')
+        .then(function(disabled){
+          expect(disabled).to.be.equal('true');
+        });
+      });
+    });
+  });
+});

--- a/frontend/tests/unit/tests/ui_components/focus-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/focus-directive-test.js
@@ -29,28 +29,25 @@
 /*jshint expr: true*/
 
 describe('focus Directive', function() {
-  var doc, compile, element, rootScope, scope;
+  var doc, compile, element, rootScope, scope, disabledButton, timeout, body;
+
+  var input = '<input type="text" name="testInput" focus id="focusTest"></input>',
+      button = '<button class="button" focus ng-disabled="true"></button>';
+  element = angular.element(input);
+  disabledButton = angular.element(button);
 
   beforeEach(angular.mock.module('openproject.uiComponents'));
   beforeEach(module('openproject.templates'));
 
   beforeEach(inject(function($compile, $rootScope, $document, $timeout) {
-    var html = '<input type="text" name="testInput" focus id="focusTest"></input>';
-
     doc = $document[0];
     rootScope = $rootScope;
     scope = $rootScope.$new();
+    body = angular.element(doc.body);
+    body.append(disabledButton).append(element);
 
-    compile = function() {
-      element = angular.element(html);
-      var body = angular.element(doc.body);
-      body.append(element);
-
-      $compile(element)(scope);
-      scope.$digest();
-
-      $timeout.flush();
-    };
+    compile = $compile;
+    timeout = $timeout;
   }));
 
   afterEach(function() {
@@ -61,10 +58,22 @@ describe('focus Directive', function() {
 
   describe('element', function() {
     it('should focus the element', function() {
-      compile();
+      compile(element)(scope);
+      scope.$digest();
+
+      timeout.flush();
 
       // NOTE: $(element).is(':focus') is broken in PhantomJS
       expect(doc.activeElement).to.equal(element[0]);
+    });
+
+    it('should focus disabled button', function(){
+      compile(disabledButton)(scope);
+      scope.$digest();
+
+      timeout.flush();
+
+      expect(doc.activeElement).to.equal(disabledButton[0]);
     });
   });
 });


### PR DESCRIPTION
[`* `#17885` Focus on relations tab jumps to beginning of tab when work package is selected as relation`](http://community.openproject.org/work_packages/17885)
