### PR TITLE
Move PrincipalAllowanceEvaluator spec into place

### DIFF
--- a/spec/lib/open_project/principal_allowance_evaluator/default_spec.rb
+++ b/spec/lib/open_project/principal_allowance_evaluator/default_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ChiliProject::PrincipalAllowanceEvaluator::Default, type: :model do
+describe OpenProject::PrincipalAllowanceEvaluator::Default, type: :model do
   let(:user) { FactoryGirl.build_stubbed(:user) }
   let(:instance) { described_class.new(user) }
 


### PR DESCRIPTION
- Replace deprecated ChiliProject constant.

See e3913ac8.

Continuation of #2476, #2610.
