### PR TITLE
18885 Fix broken autocomplete in work package relations tab

### DIFF
--- a/frontend/app/work_packages/tabs/add-work-package-relation-directive.js
+++ b/frontend/app/work_packages/tabs/add-work-package-relation-directive.js
@@ -42,7 +42,7 @@ module.exports = function($http, PathHelper) {
           scope: 'all',
           escape: false,
           id: scope.handler.workPackage.props.id,
-          'project_id': scope.handler.workPackage.props.projectId
+          'project_id': scope.handler.workPackage.embedded.project.props.id
         };
         return $http({
           method: 'GET',


### PR DESCRIPTION
[`* `#18885` WorkPackage Relations on WP display pane - Autocomplete broken`](http://community.openproject.org/work_packages/18885)
