### PR TITLE
use FactoryGirls #transient instead of #ignore

### DIFF
--- a/spec/factories/attachment_factory.rb
+++ b/spec/factories/attachment_factory.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
     container factory: :work_package
     author factory: :user
 
-    ignore do
+    transient do
       filename nil
     end
 

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -29,7 +29,7 @@
 
 FactoryGirl.define do
   factory :project do
-    ignore do
+    transient do
       no_types false
     end
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -28,7 +28,7 @@
 
 FactoryGirl.define do
   factory :user do
-    ignore do
+    transient do
       member_in_project nil
       member_in_projects nil
       member_through_role nil

--- a/spec/factories/work_package_custom_field_factory.rb
+++ b/spec/factories/work_package_custom_field_factory.rb
@@ -28,7 +28,7 @@
 
 FactoryGirl.define do
   factory :work_package_custom_field do
-    ignore do
+    transient do
       name_locales nil
       default_locales nil
     end

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -28,7 +28,7 @@
 
 FactoryGirl.define do
   factory :work_package do
-    ignore do
+    transient do
       custom_values nil
     end
 


### PR DESCRIPTION
This PR removes some deprecation warnings and is part of the usual [Housekeeping](https://community.openproject.org/work_packages/18714).

This fix should be quite harmless, because the implementation of `ignore` looks like this:

``` ruby
    def ignore(&block)
      ActiveSupport::Deprecation.warn "`#ignore` is deprecated and will be "\
        "removed in 5.0. Please use `#transient` instead."
      transient &block
    end
```
