### PR TITLE
Adjust hound configuration for new location of .jshintrc

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,4 +3,4 @@ ruby:
   config_file: .rubocop.yml
 java_script:
   enabled: true
-  config_file: .jshintrc
+  config_file: ./frontend/.jshintrc


### PR DESCRIPTION
this adjusts the hound config to use the new location of `.jshintrc` since #2617 moved it.

Signed-off-by: Florian Kraft f.kraft@finn.de
