### PR TITLE
Add a dedicated label method to the form builder

### DIFF
--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -54,6 +54,11 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     class_eval src, __FILE__, __LINE__
   end
 
+  def label(method, text = nil, options = {}, &block)
+    options[:class] = 'form--label'
+    super
+  end
+
   def select(field, choices, options = {}, html_options = {})
     html_options[:class] = Array(html_options[:class]) + %w(form--select)
 

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -55,7 +55,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def label(method, text = nil, options = {}, &block)
-    options[:class] = 'form--label'
+    options[:class] = Array(options[:class]) + %w(form--label)
     super
   end
 

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -438,4 +438,20 @@ JJ Abrams</textarea>
       expect(output).to eq %{<button name="button" type="submit">Create User</button>}
     end
   end
+
+  describe '#label' do
+    subject(:output) { builder.label :name }
+
+    it 'should output element' do
+      expect(output).to eq %{<label class="form--label" for="user_name">Name</label>}
+    end
+
+    describe 'with existing attributes' do
+      subject(:output) { builder.label :name, 'Fear', class: 'sharknado' }
+
+      it 'should keep associated classes' do
+        expect(output).to eq %{<label class="sharknado form--label" for="user_name">Fear</label>}
+      end
+    end
+  end
 end


### PR DESCRIPTION
This mainly adds the appropiate class for the fom builder, which can be useful when calling

``` erb
<%= f.label :method, "Text" %>
```
