### PR TITLE
Remove TravisCI branch restrictions according to new contribution guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,6 @@ cache:
     - frontend/node_modules
     - frontend/bower_components
 
-branches:
-  only:
-    - dev
-    - stable
-    - release/3.0
-    - release/4.0
-
 env:
   global:
     - CI=true


### PR DESCRIPTION
With the update to the contribution guidelines in #2611 we should start to clean
up the branches of the repository and remove the restriction for TravisCI to build only
certain branches.

Developers are encouraged to fork the main repository and configure their own
Travis builds. All developers should adhere to the new guidelines.

Ticket: https://community.openproject.org/work_packages/18827
