### PR TITLE
Update form specs to use #be_html_eql matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ group :test do
   gem "json_spec"
   gem "activerecord-tableless", "~> 1.0"
   gem "codeclimate-test-reporter", :require => nil
-  gem 'equivalent-xml'
+  gem 'equivalent-xml', '~> 0.5.1'
 end
 
 group :ldap do

--- a/Gemfile
+++ b/Gemfile
@@ -161,6 +161,7 @@ group :test do
   gem "json_spec"
   gem "activerecord-tableless", "~> 1.0"
   gem "codeclimate-test-reporter", :require => nil
+  gem 'equivalent-xml'
 end
 
 group :ldap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ DEPENDENCIES
   database_cleaner (~> 1.2.0)
   date_validator (~> 0.7.1)
   delayed_job_active_record (= 0.3.3)
-  equivalent-xml
+  equivalent-xml (~> 0.5.1)
   factory_girl_rails (~> 4.5)
   faker
   fog (~> 1.23.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
       representable (~> 2.0)
       uber
     equalizer (0.0.9)
+    equivalent-xml (0.5.1)
+      nokogiri (>= 1.4.3)
     erubis (2.7.0)
     eventmachine (1.0.3)
     excon (0.42.1)
@@ -474,6 +476,7 @@ DEPENDENCIES
   database_cleaner (~> 1.2.0)
   date_validator (~> 0.7.1)
   delayed_job_active_record (= 0.3.3)
+  equivalent-xml
   factory_girl_rails (~> 4.5)
   faker
   fog (~> 1.23.0)

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -119,10 +119,10 @@ describe SettingsHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field"
           id="settings_field" name="settings[field]" type="text" value="important value" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -140,10 +140,10 @@ describe SettingsHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'text-area-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <textarea class="custom-class form--text-area" id="settings_field" name="settings[field]">
 important text</textarea>
-      }.strip
+      }).at_path('textarea')
     end
   end
 

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -63,14 +63,14 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'check-box-container'
 
       it 'should output element' do
-        expect(output).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--check-box"
                  id="user#{resource.custom_field_id}"
                  lang=\"en\"
                  name="user[#{resource.custom_field_id}]"
                  type="checkbox"
                  value="1" />
-        }.squish
+        }).at_path('input:nth-of-type(2)')
       end
     end
 
@@ -86,7 +86,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--text-field"
                  id="user#{resource.custom_field_id}"
                  lang=\"en\"
@@ -94,7 +94,7 @@ describe CustomFieldFormBuilder do
                  size="30"
                  type="text"
                  value="" />
-        }.squish
+        }).at_path('input')
       end
     end
 
@@ -106,7 +106,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'text-area-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <textarea class="custom-class form--text-area"
                     cols="40"
                     id="user#{resource.custom_field_id}"
@@ -114,7 +114,7 @@ describe CustomFieldFormBuilder do
                     name="user[#{resource.custom_field_id}]"
                     rows="3">
           </textarea>
-        }.squish
+        }).at_path('textarea')
       end
     end
 
@@ -126,7 +126,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--text-field"
                  id="user#{resource.custom_field_id}"
                  lang=\"en\"
@@ -134,7 +134,7 @@ describe CustomFieldFormBuilder do
                  size="30"
                  type="text"
                  value="" />
-        }.squish
+        }).at_path('input')
       end
     end
 
@@ -146,7 +146,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--text-field"
                  id="user#{resource.custom_field_id}"
                  lang=\"en\"
@@ -154,7 +154,7 @@ describe CustomFieldFormBuilder do
                  size="30"
                  type="text"
                  value="" />
-        }.squish
+        }).at_path('input')
       end
     end
 
@@ -166,7 +166,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--text-field"
                  id="user#{resource.custom_field_id}"
                  lang=\"en\"
@@ -174,7 +174,7 @@ describe CustomFieldFormBuilder do
                  size="30"
                  type="text"
                  value="" />
-        }.squish
+        }).at_path('input')
       end
     end
 
@@ -187,7 +187,7 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'select-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <select class="custom-class form--select"
                   id="user#{resource.custom_field_id}"
                   lang=\"en\"
@@ -195,7 +195,7 @@ describe CustomFieldFormBuilder do
                   no_label="true"><option
                   value=\"\"></option>
                   <option value=\"my_option\">my_option</option></select>
-        }.squish
+        }).at_path('select')
       end
 
       context 'which is required and has no default value' do
@@ -204,7 +204,7 @@ describe CustomFieldFormBuilder do
         end
 
         it 'should output element' do
-          expect(output.squish).to include %{
+          expect(output).to be_html_eql(%{
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     lang=\"en\"
@@ -212,7 +212,7 @@ describe CustomFieldFormBuilder do
                     no_label="true"><option value=\"\">---
                     Please select ---</option>
                     <option value=\"my_option\">my_option</option></select>
-          }.squish
+          }).at_path('select')
         end
       end
 
@@ -223,14 +223,14 @@ describe CustomFieldFormBuilder do
         end
 
         it 'should output element' do
-          expect(output.squish).to include %{
+          expect(output).to be_html_eql(%{
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     lang=\"en\"
                     name="user[#{resource.custom_field_id}]"
                     no_label="true"><option
                     value=\"my_option\">my_option</option></select>
-          }.squish
+          }).at_path('select')
         end
       end
     end
@@ -243,14 +243,14 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'select-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <select class="custom-class form--select"
                   id="user#{resource.custom_field_id}"
                   lang=\"en\"
                   name="user[#{resource.custom_field_id}]"
                   no_label="true"><option value=\"\"></option>
           </select>
-        }.squish
+        }).at_path('select')
       end
 
       context 'which is required and has no default value' do
@@ -259,7 +259,7 @@ describe CustomFieldFormBuilder do
         end
 
         it 'should output element' do
-          expect(output.squish).to include %{
+          expect(output).to be_html_eql(%{
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     lang=\"en\"
@@ -267,7 +267,7 @@ describe CustomFieldFormBuilder do
                     no_label="true"><option value=\"\">---
                     Please select ---</option>
             </select>
-          }.squish
+          }).at_path('select')
         end
       end
     end
@@ -280,14 +280,14 @@ describe CustomFieldFormBuilder do
       it_behaves_like 'wrapped in container', 'select-container'
 
       it 'should output element' do
-        expect(output.squish).to include %{
+        expect(output).to be_html_eql(%{
           <select class="custom-class form--select"
                   id="user#{resource.custom_field_id}"
                   lang=\"en\"
                   name="user[#{resource.custom_field_id}]"
                   no_label="true"><option value=\"\"></option>
           </select>
-        }.squish
+        }).at_path('select')
       end
 
       context 'which is required and has no default value' do
@@ -296,7 +296,7 @@ describe CustomFieldFormBuilder do
         end
 
         it 'should output element' do
-          expect(output.squish).to include %{
+          expect(output).to be_html_eql(%{
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     lang=\"en\"
@@ -304,7 +304,7 @@ describe CustomFieldFormBuilder do
                     no_label="true"><option value=\"\">---
                     Please select ---</option>
             </select>
-          }.squish
+          }).at_path('select')
         end
       end
     end

--- a/spec/lib/open_project/form_tag_helper_spec.rb
+++ b/spec/lib/open_project/form_tag_helper_spec.rb
@@ -42,11 +42,11 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'not wrapped in container', 'form-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql(%{
         <form accept-charset="UTF-8" action="/feedback" class="form"
           method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8"
           type="hidden" value="&#x2713;" /></div><p>Form content</p></form>
-      }.squish
+      })
     end
   end
 
@@ -58,10 +58,10 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'select-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <select class="form--select"
           id="field" name="field"><option value="33">FUN</option></select>
-      }.squish
+      }).at_path('select')
     end
   end
 
@@ -75,10 +75,10 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field"
           id="field" name="field" type="text" value="Something to be seen" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -92,9 +92,9 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'not wrapped in container', 'label-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql(%{
         <label class="form--label" for="field">Label content</label>
-      }.squish
+      })
     end
   end
 
@@ -106,10 +106,10 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'file-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--file-field"
           id="file_field" name="file_field" type="file" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -121,10 +121,10 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field -password"
           id="password" name="password" type="password" value="nopE3king!" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -136,10 +136,10 @@ describe OpenProject::FormTagHelper, type: :helper do
     it_behaves_like 'wrapped in container', 'text-area-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <textarea class="form--text-area" id="field" name="field">
 Words are important</textarea>
-      }.strip
+      }).at_path('textarea')
     end
   end
 
@@ -151,10 +151,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'check-box-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--check-box"
           id="field" name="field" type="checkbox" value="1" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -168,10 +168,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'radio-button-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--radio-button"
           id="field_good_choice" name="field" type="radio" value="good choice" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -183,9 +183,9 @@ Words are important</textarea>
     it_behaves_like 'not wrapped in container', 'submit-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql %{
         <input class="button" name="commit" type="submit" value="Save it!" />
-      }.squish
+      }
     end
   end
 
@@ -199,9 +199,9 @@ Words are important</textarea>
     it_behaves_like 'not wrapped in container', 'button-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql %{
         <button class="button">Don&#x27;t save!</button>
-      }.squish
+      }
     end
   end
 
@@ -215,10 +215,11 @@ Words are important</textarea>
     it_behaves_like 'not wrapped in container', 'fieldset-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql %{
         <fieldset
-          class="form--fieldset"><legend>Fieldset Legend</legend><p>Fieldset content</p></fieldset>
-      }.squish
+          class="form--fieldset"><legend>Fieldset Legend</legend>
+            <p>Fieldset content</p></fieldset>
+      }
     end
   end
 
@@ -232,10 +233,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'search-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--search-field"
           id="field" name="field" type="search" value="Find me" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -249,10 +250,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field -telephone"
           id="field" name="field" type="tel" value="+49 555 111 999" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -266,10 +267,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field -url"
           id="field" name="field" type="url" value="https://blogger.org/" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -283,10 +284,10 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field -email"
           id="field" name="field" type="email" value="joe@blogger.com" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -300,9 +301,9 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--text-field -number" id="field" name="field" type="number" value="2" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -316,9 +317,9 @@ Words are important</textarea>
     it_behaves_like 'wrapped in container', 'range-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="form--range-field" id="field" name="field" type="range" value="2" />
-      }.squish
+      }).at_path('input')
     end
   end
 end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -123,7 +123,8 @@ describe TabularFormBuilder do
 
     it 'should output element' do
       expect(output).to be_html_eql(%{
-        <textarea class="custom-class form--text-area" cols="40" id="user_name" name="user[name]" rows="20" title="Name">
+        <textarea class="custom-class form--text-area" cols="40" id="user_name"
+          name="user[name]" rows="20" title="Name">
 JJ Abrams</textarea>
       }).at_path('textarea')
     end
@@ -452,7 +453,9 @@ JJ Abrams</textarea>
       subject(:output) { builder.label :name, 'Fear', class: 'sharknado' }
 
       it 'should keep associated classes' do
-        expect(output).to be_html_eql %{<label class="sharknado form--label" for="user_name">Fear</label>}
+        expect(output).to be_html_eql %{
+          <label class="sharknado form--label" for="user_name">Fear</label>
+        }
       end
     end
   end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -62,11 +62,11 @@ describe TabularFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output).to include %{
+        expect(output).to be_html_eql(%{
           <input class="form--text-field"
             id="user_translations_attributes_0_name"
             name="user[translations_attributes][0][name]" size="30" type="text" />
-        }.squish
+        }).at_path('input:first-child')
       end
     end
 
@@ -78,11 +78,11 @@ describe TabularFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output).to include %{
+        expect(output).to be_html_eql(%{
           <input class="form--text-field"
             id="user_translations_attributes_0_name"
             name="user[translations_attributes][0][name]" size="30" type="text" />
-        }.squish
+        }).at_path('input:first-child')
       end
 
       it 'should output select' do
@@ -90,7 +90,9 @@ describe TabularFormBuilder do
       end
 
       it 'should have a link to add a locale' do
-        expect(output).to include %{<a class="form--field-extra-actions add_locale" href="#">Add</a>}
+        expect(output).to be_html_eql(%{
+          <a class="form--field-extra-actions add_locale" href="#">Add</a>
+        }).at_path('body > a')
       end
     end
 
@@ -99,11 +101,11 @@ describe TabularFormBuilder do
       it_behaves_like 'wrapped in container', 'text-field-container'
 
       it 'should output element' do
-        expect(output).to include %{
+        expect(output).to be_html_eql(%{
           <input class="custom-class form--text-field"
             id="user_name" name="user[name]" size="30" title="Name" type="text"
             value="JJ Abrams" />
-        }.squish
+        }).at_path('input')
       end
     end
   end
@@ -120,10 +122,10 @@ describe TabularFormBuilder do
     it_behaves_like 'wrapped in container', 'text-area-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <textarea class="custom-class form--text-area" cols="40" id="user_name" name="user[name]" rows="20" title="Name">
 JJ Abrams</textarea>
-      }.strip
+      }).at_path('textarea')
     end
   end
 
@@ -140,10 +142,10 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'select-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <select class="custom-class form--select"
           id="user_name" name="user[name]"><option value="33">FUN</option></select>
-      }.squish
+      }).at_path('select')
     end
   end
 
@@ -199,11 +201,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'check-box-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--check-box"
           id="user_first_login" name="user[first_login]" title="Name" type="checkbox"
           value="1" />
-      }.squish
+      }).at_path('input:nth-of-type(2)')
     end
   end
 
@@ -223,14 +225,14 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'check-box-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input checked="checked"
                class="form--check-box"
                id="user_enabled_module_names_repositories"
                name="user[enabled_module_names][]"
                type="checkbox"
                value="repositories" />
-      }.squish
+      }).at_path('input:nth-of-type(2)')
     end
   end
 
@@ -246,9 +248,9 @@ JJ Abrams</textarea>
     it_behaves_like 'not wrapped in container', 'radio-button-container'
 
     it 'should output element' do
-      expect(output).to eq %{
+      expect(output).to be_html_eql %{
         <input id="user_name_john" name="user[name]" type="radio" value="John" />
-      }.strip
+      }
     end
   end
 
@@ -264,11 +266,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field -number"
           id="user_failed_login_count" name="user[failed_login_count]" title="Bad logins"
           type="number" value="45" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -284,11 +286,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'range-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--range-field"
           id="user_failed_login_count" name="user[failed_login_count]" title="Bad logins"
           type="range" value="45" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -304,11 +306,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'search-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--search-field" id="user_name"
           name="user[name]" size="30" title="Search name" type="search"
           value="JJ Abrams" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -324,11 +326,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field -email"
           id="user_mail" name="user[mail]" size="30" title="Email" type="email"
           value="jj@lost-mail.com" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -344,11 +346,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field -telephone"
           id="user_mail" name="user[mail]" size="30" title="Not really email"
           type="tel" value="jj@lost-mail.com" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -364,11 +366,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field -password"
           id="user_login" name="user[login]" size="30" title="Not really password"
           type="password" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -384,10 +386,10 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'file-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--file-field"
           id="user_name" name="user[name]" title="Not really file" type="file" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -403,11 +405,11 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'text-field-container'
 
     it 'should output element' do
-      expect(output).to include %{
+      expect(output).to be_html_eql(%{
         <input class="custom-class form--text-field -url"
           id="user_name" name="user[name]" size="30" title="Not really file"
           type="url" value="JJ Abrams" />
-      }.squish
+      }).at_path('input')
     end
   end
 
@@ -421,7 +423,7 @@ JJ Abrams</textarea>
     it_behaves_like 'not wrapped in container', 'submit-container'
 
     it 'should output element' do
-      expect(output).to eq %{<input name="commit" type="submit" value="Create User" />}
+      expect(output).to be_html_eql %{<input name="commit" type="submit" value="Create User" />}
     end
   end
 
@@ -435,7 +437,7 @@ JJ Abrams</textarea>
     it_behaves_like 'not wrapped in container', 'button-container'
 
     it 'should output element' do
-      expect(output).to eq %{<button name="button" type="submit">Create User</button>}
+      expect(output).to be_html_eql %{<button name="button" type="submit">Create User</button>}
     end
   end
 
@@ -443,14 +445,14 @@ JJ Abrams</textarea>
     subject(:output) { builder.label :name }
 
     it 'should output element' do
-      expect(output).to eq %{<label class="form--label" for="user_name">Name</label>}
+      expect(output).to be_html_eql %{<label class="form--label" for="user_name">Name</label>}
     end
 
     describe 'with existing attributes' do
       subject(:output) { builder.label :name, 'Fear', class: 'sharknado' }
 
       it 'should keep associated classes' do
-        expect(output).to eq %{<label class="sharknado form--label" for="user_name">Fear</label>}
+        expect(output).to be_html_eql %{<label class="sharknado form--label" for="user_name">Fear</label>}
       end
     end
   end

--- a/spec/support/matchers/be_html_eql.rb
+++ b/spec/support/matchers/be_html_eql.rb
@@ -1,0 +1,63 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+::RSpec::Matchers.define :be_html_eql do |expected|
+  def path
+    @path
+  end
+
+  def html(html)
+    Nokogiri::HTML(html)
+  end
+
+  match do |actual|
+    @actual = if path
+      html(actual).css(path)
+    else
+      actual
+    end
+
+    EquivalentXml.equivalent?(self.actual, expected, {})
+  end
+
+  chain :at_path do |path|
+    @path = path
+  end
+
+  should_message = -> (actual) do
+    ['expected:', expected.to_s, 'got:', actual.to_s].join("\n")
+  end
+
+  should_not_message = -> (actual) do
+    ['expected:', actual.to_s, 'not to be equivalent to:', expected.to_s].join("\n")
+  end
+
+  failure_message_for_should &should_message
+  failure_message_for_should_not &should_not_message
+end

--- a/spec/support/matchers/be_html_eql.rb
+++ b/spec/support/matchers/be_html_eql.rb
@@ -43,6 +43,8 @@
                 actual
               end
 
+    raise "Path specified is missing (#{path.inspect})" if path && @actual.empty?
+
     EquivalentXml.equivalent?(self.actual, expected, {})
   end
 

--- a/spec/support/matchers/be_html_eql.rb
+++ b/spec/support/matchers/be_html_eql.rb
@@ -38,10 +38,10 @@
 
   match do |actual|
     @actual = if path
-      html(actual).css(path)
-    else
-      actual
-    end
+                html(actual).css(path)
+              else
+                actual
+              end
 
     EquivalentXml.equivalent?(self.actual, expected, {})
   end


### PR DESCRIPTION
This approach should be less brittle than plain string matching.

Continuation of #2492
