### PR TITLE
update eventmachine to >=1.0.4 which works with ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       uber
     equalizer (0.0.9)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     excon (0.42.1)
     execjs (1.4.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
see https://github.com/eventmachine/eventmachine/issues/509#issuecomment-67711797

installing eventmachine 1.0.3 fails on ruby 2.2. let's update it to something above 1.0.3... turns out to be 1.0.7 at the moment.

```
root@8f9ca7f05618:/usr/src/openproject# ruby --version
ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-linux-gnu]
```

```
root@5224282495a3:/usr/src/openproject# gem install eventmachine --version 1.0.3
Fetching: eventmachine-1.0.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing eventmachine:
    ERROR: Failed to build gem native extension.

    /usr/bin/ruby2.2 -r ./siteconf20150302-204-hq45bu.rb extconf.rb
checking for main() in -lssl... yes
checking for main() in -lcrypto... yes
checking for openssl/ssl.h... yes
checking for openssl/err.h... yes
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... no
checking for inotify_init() in sys/inotify.h... yes
checking for writev() in sys/uio.h... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enable_interrupt()... no
checking for rb_time_new()... yes
checking for sys/event.h... no
checking for epoll_create() in sys/epoll.h... yes
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling kb.cpp
kb.cpp: In member function 'virtual void KeyboardDescriptor::Read()':
kb.cpp:77:27: warning: ignoring return value of 'ssize_t read(int, void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
  read (GetSocket(), &c, 1);
                           ^
compiling binder.cpp
compiling page.cpp
compiling ed.cpp
compiling em.cpp
em.cpp: In member function 'void EventMachine_t::_RunEpollOnce()':
em.cpp:574:37: error: 'rb_thread_select' was not declared in this scope
   EmSelect (0, NULL, NULL, NULL, &tv);
                                     ^
em.cpp: In member function 'int SelectData_t::_Select()':
em.cpp:827:67: error: 'rb_thread_select' was not declared in this scope
  return EmSelect (maxsocket+1, &fdreads, &fdwrites, &fderrors, &tv);
                                                                   ^
em.cpp: In member function 'void EventMachine_t::_RunSelectOnce()':
em.cpp:946:40: error: 'rb_thread_select' was not declared in this scope
      EmSelect (0, NULL, NULL, NULL, &tv);
                                        ^
em.cpp: In member function 'void EventMachine_t::SignalLoopBreaker()':
em.cpp:282:34: warning: ignoring return value of 'ssize_t write(int, const void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
  write (LoopBreakerWriter, "", 1);
                                  ^
em.cpp: In member function 'void EventMachine_t::_ReadLoopBreaker()':
em.cpp:991:50: warning: ignoring return value of 'ssize_t read(int, void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
  read (LoopBreakerReader, buffer, sizeof(buffer));
                                                  ^
make: *** [em.o] Error 1

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/2.2.0/gems/eventmachine-1.0.3 for inspection.
Results logged to /var/lib/gems/2.2.0/extensions/x86_64-linux/2.2.0/eventmachine-1.0.3/gem_make.out
```

```
root@5224282495a3:/usr/src/openproject# gem install eventmachine --version 1.0.4
Fetching: eventmachine-1.0.4.gem (100%)
Building native extensions.  This could take a while...
Successfully installed eventmachine-1.0.4
Parsing documentation for eventmachine-1.0.4
Installing ri documentation for eventmachine-1.0.4
Done installing documentation for eventmachine after 1 seconds
1 gem installed
```
