### PR TITLE
Add radio buttons to tabular form builder

### DIFF
--- a/app/assets/stylesheets/content/_forms.md
+++ b/app/assets/stylesheets/content/_forms.md
@@ -689,6 +689,30 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 </label>
 ```
 
+# Forms: Radio buttons
+
+## Within a form, multiple
+
+```
+<form class="form">
+  <div class="form--field">
+    <label class="form--label" for="radio_button_example_choice1">Foo</label>
+    <div class="form--field-container">
+      <div class="form--radio-button-container">
+        <input type="radio" class="form--radio-button" id="radio_button_example_choice1" value="foo" name="choice">
+      </div>
+    </div>
+  </div>
+  <div class="form--field">
+    <label class="form--label" for="radio_button_example_choice2">Bar</label>
+    <div class="form--field-container">
+      <div class="form--radio-button-container">
+        <input type="radio" class="form--radio-button" id="radio_button_example_choice2" value="bar" name="choice">
+      </div>
+    </div>
+  </div>
+</form>
+```
 
 # Forms: Select
 

--- a/app/views/timelines/_comparison.html.erb
+++ b/app/views/timelines/_comparison.html.erb
@@ -35,23 +35,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <div style="display:none;">
     <%= f.fields_for :options, timeline_options do |ff| %>
       <div class="form--field">
-        <%= ff.label :comparison, l('timelines.filter.comparison.none'),
-                     for: :timeline_options_comparison_none,
-                     class: "form--label" %>
-        <div class="form--field-container">
-          <div class="form--radio-button-container">
-            <%= ff.radio_button :comparison, "none", no_label: true %>
-          </div>
-        </div>
+        <%= ff.radio_button :comparison, "none", label:  l('timelines.filter.comparison.none') %>
       </div>
 
       <div class="form--field">
-        <%= ff.label :comparison, l('timelines.filter.comparison.relative'),
-                     for: :timeline_options_comparison_relative,
-                     class: "form--label" %>
-        <div class="form--field-container">
-          <%= ff.radio_button :comparison, "relative" %>
-        </div>
+          <%= ff.radio_button :comparison, "relative", label:  l('timelines.filter.comparison.relative') %>
       </div>
       <div class="form--grouping">
         <div id="timeline--form--project-filter-timeframe"
@@ -77,13 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
 
       <div class="form--field">
-        <%= ff.label :comparison,
-                     l('timelines.filter.comparison.absolute'),
-                     for: :timeline_options_comparison_absolute,
-                     class: "form--label" %>
-        <div class="form--field-container">
-          <%= ff.radio_button :comparison, "absolute" %>
-        </div>
+        <%= ff.radio_button :comparison, "absolute", label: l('timelines.filter.comparison.absolute') %>
       </div>
 
       <div class="form--grouping">

--- a/app/views/timelines/filter/_projects.html.erb
+++ b/app/views/timelines/filter/_projects.html.erb
@@ -157,14 +157,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
         <div class="form--grouping-row">
           <div class="form--field">
-            <%= ff.label :planning_element_time_absolute,
-              l('timelines.filter.comparison.absolute'),
-              class: "form--label" %>
-            <div class="form--field-container">
-              <div class="form--radio-button-container">
-                <%= ff.radio_button :planning_element_time, 'absolute' %>
-              </div>
-            </div>
+            <%= ff.radio_button :planning_element_time, 'absolute', label:  l('timelines.filter.comparison.absolute') %>
           </div>
         </div>
 
@@ -185,14 +178,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
         <div class="form--grouping-row">
           <div class="form--field">
-            <%= ff.label :planning_element_time_relative,
-                         l('timelines.filter.comparison.relative'),
-                         class: "form--label" %>
-            <div class="form--field-container">
-              <div class="form--radio-button-container">
-                <%= ff.radio_button :planning_element_time, 'relative' %>
-              </div>
-            </div>
+            <%= ff.radio_button :planning_element_time, 'relative', label: l('timelines.filter.comparison.relative') %>
           </div>
         </div>
 

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -61,7 +61,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def radio_button(field, value, options = {}, *args)
-    options[:class]     = Array(options[:class]) + %w(form--radio-button)
+    options[:class] = Array(options[:class]) + %w(form--radio-button)
 
     input_options, label_options = extract_from options
     label_options[:for] = "#{object_name}_#{field}_#{value.downcase}"

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -41,8 +41,6 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       else
         options[:class] = Array(options[:class]) + [ field_css_class('#{selector}') ]
 
-        label_options = options.dup
-        input_options = options.dup.except(:for, :label, :no_label, :prefix, :suffix)
         input_options, label_options = extract_from options
 
         label = label_for_field(field, label_options)
@@ -64,7 +62,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     options[:class] = Array(options[:class]) + %w(form--radio-button)
 
     input_options, label_options = extract_from options
-    label_options[:for] = "#{object_name}_#{field}_#{value.downcase}"
+    label_options[:for] = "#{sanitized_object_name}_#{field}_#{value.downcase}"
 
     label = label_for_field(field, label_options)
     input = super(field, value, input_options, *args)
@@ -90,7 +88,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
                            text = field.to_s + "_#{value}",
                            options = {})
 
-    label_for = "#{object_name}_#{field}_#{value}".to_sym
+    label_for = "#{sanitized_object_name}_#{field}_#{value}".to_sym
 
     input_options = options.reverse_merge(multiple: true,
                                           checked: checked,
@@ -285,8 +283,12 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
   def extract_from(options)
     label_options = options.dup
-    input_options = options.dup.except(:for, :label, :no_label)
+    input_options = options.dup.except(:for, :label, :no_label, :prefix, :suffix)
 
     [input_options, label_options]
+  end
+
+  def sanitized_object_name
+    object_name.to_s.gsub(/\]\[|[^-a-zA-Z0-9:.]/, '_').sub(/_$/, '')
   end
 end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -43,11 +43,12 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
         label_options = options.dup
         input_options = options.dup.except(:for, :label, :no_label, :prefix, :suffix)
+        input_options, label_options = extract_from options
 
         label = label_for_field(field, label_options)
         input = super(field, input_options, *args)
 
-        (label + container_wrap_field(input, '#{selector}', options)).html_safe
+        (label + container_wrap_field(input, '#{selector}', options))
       end
     end
     END_SRC
@@ -60,15 +61,15 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def radio_button(field, value, options = {}, *args)
-    options[:class] = Array(options[:class]) + %w(form--radio-button)
-    label_options = options.dup
-    input_options = options.dup.except(:for, :label, :no_label)
+    options[:class]     = Array(options[:class]) + %w(form--radio-button)
 
+    input_options, label_options = extract_from options
     label_options[:for] = "#{object_name}_#{field}_#{value.downcase}"
+
     label = label_for_field(field, label_options)
     input = super(field, value, input_options, *args)
 
-    (label + container_wrap_field(input, 'radio-button', options)).html_safe
+    (label + container_wrap_field(input, 'radio-button', options))
   end
 
   def select(field, choices, options = {}, html_options = {})
@@ -280,5 +281,12 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     User.current.language.present? ?
       User.current.language.to_sym :
       Setting.default_language.to_sym
+  end
+
+  def extract_from(options)
+    label_options = options.dup
+    input_options = options.dup.except(:for, :label, :no_label)
+
+    [input_options, label_options]
   end
 end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -59,6 +59,18 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     super
   end
 
+  def radio_button(field, value, options = {}, *args)
+    options[:class] = Array(options[:class]) + %w(form--radio-button)
+    label_options = options.dup
+    input_options = options.dup.except(:for, :label, :no_label)
+
+    label_options[:for] = "#{object_name}_#{field}_#{value.downcase}"
+    label = label_for_field(field, label_options)
+    input = super(field, value, input_options, *args)
+
+    (label + container_wrap_field(input, 'radio-button', options)).html_safe
+  end
+
   def select(field, choices, options = {}, html_options = {})
     html_options[:class] = Array(html_options[:class]) + %w(form--select)
 

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -302,7 +302,7 @@ JJ Abrams</textarea>
     it_behaves_like 'wrapped in container', 'radio-button-container'
 
     it 'should output element' do
-      expect(output).to be_html_eql %{
+      expect(output).to include %{
         <input class="custom-class form--radio-button"
                id="user_name_john"
                name="user[name]"

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -303,8 +303,13 @@ JJ Abrams</textarea>
 
     it 'should output element' do
       expect(output).to be_html_eql %{
-        <input class="custom-class form--radio-button" id="user_name_john" name="user[name]" title="Name" type="radio" value="John" />
-      }.strip
+        <input class="custom-class form--radio-button"
+               id="user_name_john"
+               name="user[name]"
+               title="Name"
+               type="radio"
+               value="John" />
+      }.squish
     end
   end
 

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -291,20 +291,20 @@ JJ Abrams</textarea>
   end
 
   describe '#radio_button' do
-    let(:options) { { title: 'Name' } }
+    let(:options) { { title: 'Name', class: 'custom-class' } }
 
     subject(:output) {
-      builder.radio_button :name, 'John'
+      builder.radio_button :name, 'John', options
     }
 
-    it_behaves_like 'not labelled'
-    it_behaves_like 'not wrapped in container'
-    it_behaves_like 'not wrapped in container', 'radio-button-container'
+    it_behaves_like 'labelled by default'
+    it_behaves_like 'wrapped in container'
+    it_behaves_like 'wrapped in container', 'radio-button-container'
 
     it 'should output element' do
       expect(output).to be_html_eql %{
-        <input id="user_name_john" name="user[name]" type="radio" value="John" />
-      }
+        <input class="custom-class form--radio-button" id="user_name_john" name="user[name]" title="Name" type="radio" value="John" />
+      }.strip
     end
   end
 


### PR DESCRIPTION
Adds a labelled version for radio buttons to the tabular form builder. They work similiar to the checkboxes which are already included in the form builder.

This will make work for tickets such as https://community.openproject.org/work_packages/18872 easier
