### PR TITLE
simplify styling of simple filters + they look nicer

### DIFF
--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -1,12 +1,13 @@
 .simple-filters--container
-  border:   1px solid $advanced-filters--border-color
-  padding:  10px
+  border: 1px solid $advanced-filters--border-color
+  padding: 1rem
   margin: 0 1.2em 1rem 0.6em
 
 .simple-filters--filters
   @extend .advanced-filters--filters
   @include grid-block
   @include grid-layout(1)
+  justify-content: space-between
 
   @include breakpoint(large)
     @include grid-layout(2)
@@ -17,10 +18,12 @@
   // 0. The elements will in sum take up more than 100% and thus the second
   // element will move to the next row.
   .simple-filters--filter,
+    padding: 0
     @include breakpoint(large)
-      flex-basis: 47%
+      flex-basis: 49%
 
 .simple-filters--filters.-columns-3
+  justify-content: space-between
   @include breakpoint(large)
     @include grid-layout(3)
 
@@ -30,18 +33,6 @@
   // 0. The elements will in sum take up more than 100% and thus the second
   // element will move to the next row.
   .simple-filters--filter,
+    padding: 0
     @include breakpoint(large)
-      flex-basis: 30%
-
-@mixin simple-filters--sizing()
-  @include grid-content
-
-.simple-filters--filter
-  @include simple-filters--sizing
-  flex-basis: 48%
-
-.simple-filters--filter-value
-  margin-right: 1rem
-
-.simple-filters--controls
-  margin: 0 1rem
+      flex-basis: 32%


### PR DESCRIPTION
I noticed that my styling of simple filters was to complicated. I could just use `justify-content: space-between` and by that get rid of a couple of styling rules. Additionally, this will distribute the forms evenly which does look nicer.
