### PR TITLE
Add form field examples for fields with errors to Living styleguide

### DIFF
--- a/app/assets/stylesheets/content/_forms.md
+++ b/app/assets/stylesheets/content/_forms.md
@@ -38,6 +38,42 @@
 </form>
 ```
 
+## Forms: Errors
+
+```
+<form action="" class="form">
+  <div class="form--field -required">
+    <label for="text-field-42" class="form--label">Name</label>
+    <div class="form--field-container">
+      <div class="form--text-field-container">
+        <input id="text-field-42" type="text" class="form--text-field -error" value="Deathstroke">
+      </div>
+    </div>
+  </div>
+  <div class="form--field -required">
+    <label for="select-field-42" class="form--label">Favorite superhero</label>
+    <div class="form--field-container">
+      <div class="form--select-field-container">
+        <select id="select-field-42" class="form--select -error">
+          <option value="catwoman">Catwoman</option>
+          <option value="superman">Superman</option>
+          <option value="auqaman" selected="selected">Aquaman</option>
+          <option value="flash">The Flash</option>
+          <option value="green_arrow">Green Arrow</option>
+        </select></div>
+    </div>
+  </div>
+  <div class="form--field">
+    <label for="poison-ivy-bio" class="form--label">Biography</label>
+    <div class="form--field-container">
+      <div class="form--text-area-container">
+        <textarea id="poison-ivy-bio" rows="10" class="form--text-area -error">Poison Ivy is an enemy of Batman. She is depicted as one of the world's most prominent eco-terrorists. She is obsessed with plants, botany, and environmentalism.</textarea>
+      </div>
+    </div>
+  </div>
+</form>
+```
+
 ## Forms: Standard layout
 
 ```

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -474,3 +474,11 @@ fieldset.form--fieldset
   %form--field-element-container + &
     margin-left:  -1rem
     border-left:  0
+
+.form--field
+  .-error
+    background: #fedada
+    border: 1px solid #ca3f3f
+    text-decoration: line-through
+    font-style: italic
+    color: #ca3f3f


### PR DESCRIPTION
This adds form fields which have errors on them to the living styleguide.

The current examples include a `textarea`, `input[type=text]` and `select` field. Other erroneous fields have yet to be provided by the visuals.

There is some basic example styling, however, i have briefly researched methods to include icons in the field with errors, however, this seems to be a little bit more complicated. The image or icon in question as designed is shown here:

![screenshot from 2015-03-04 16 39 07](https://cloud.githubusercontent.com/assets/498241/6486713/11d30850-c28d-11e4-8a3d-37719f828774.png)

Continuation of #2658.

Meets https://community.openproject.org/work_packages/19004
