### PR TITLE
Adds activity groups to styleguide

### DIFF
--- a/app/assets/stylesheets/content/_activities.md
+++ b/app/assets/stylesheets/content/_activities.md
@@ -1,0 +1,69 @@
+# Activities
+
+These componentes can used for jounral entries, activity logs, comment histories, etc.
+
+## Activity Group
+
+This element represents a single point int time with associated activities for that point in time.
+
+```
+<div class="activity-group">
+    <h1 class="activity-group--heading">May 25th, 2015</h1>
+    <div class="activity-group--entries">
+        <div class="activity-group--entry">
+            <div class="activity-group--avatar">
+                <img alt="Avatar" class="avatar" src="https://s3.amazonaws.com/uifaces/faces/twitter/teeragit/128.jpg" title="OpenProject Admin">
+            </div>
+            <div class="activity-group--entry--content">
+                <h2 class="activity-group--entry--heading">
+                    Demoproject: consequatur ea recusandae quis quaerat nostrum 
+                    <small>
+                        <span class="activity-group--entry--creator">Lautrec of Carim</span>
+                        <span class="activity-group--entry--created">5:32 pm</span>
+                        <span class="activity-group--entry--comments">
+                            <a href="#">2</a>
+                        </span>
+                    </small>
+                </h2>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima debitis eligendi soluta obcaecati quos sunt iste aspernatur, consequatur ea recusandae quis quaerat nostrum quasi sit deserunt iure quas, aut nesciunt!</p>
+            </div>
+        </div>
+        <div class="activity-group--entry">
+            <div class="activity-group--avatar">
+                <img alt="Avatar" class="avatar" src="https://s3.amazonaws.com/uifaces/faces/twitter/teeragit/128.jpg" title="OpenProject Admin">
+            </div>
+            <div class="activity-group--entry--content">
+                <h2 class="activity-group--entry--heading">
+                    Demoproject: lorem ipsum dolor sit amet
+                    <small>
+                        <span class="activity-group--entry--creator">anastasia of Astora</span>
+                        <span class="activity-group--entry--created">6:11 am</span>
+                        <span class="activity-group--entry--comments">
+                            <a href="#">3</a>
+                        </span>
+                    </small>
+                </h2>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima debitis eligendi soluta obcaecati quos sunt iste aspernatur, consequatur ea recusandae quis quaerat nostrum quasi sit deserunt iure quas, aut nesciunt!</p>
+            </div>
+        </div>
+        <div class="activity-group--entry">
+            <div class="activity-group--avatar">
+                <img alt="Avatar" class="avatar" src="https://s3.amazonaws.com/uifaces/faces/twitter/teeragit/128.jpg" title="OpenProject Admin">
+            </div>
+            <div class="activity-group--entry--content">
+                <h2 class="activity-group--entry--heading">
+                    Demoproject: lorem ipsum dolor sit amet
+                    <small>
+                        <span class="activity-group--entry--creator">Big Hat Logan</span>
+                        <span class="activity-group--entry--created">6:15 am</span>
+                        <span class="activity-group--entry--comments">
+                            <a href="#">12</a>
+                        </span>
+                    </small>
+                </h2>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima debitis eligendi soluta obcaecati quos sunt iste aspernatur, consequatur ea recusandae quis quaerat nostrum quasi sit deserunt iure quas, aut nesciunt!</p>
+            </div>
+        </div>
+    </div>
+</div>
+```

--- a/app/assets/stylesheets/content/_activities.sass
+++ b/app/assets/stylesheets/content/_activities.sass
@@ -1,0 +1,27 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -62,6 +62,7 @@
 @import content/work_packages_table
 @import content/attributes_key_value
 @import content/attributes_group
+@import content/activities
 
 @import content/work_package_details/tables
 @import content/work_package_details/activities_tab


### PR DESCRIPTION
This adds activity groups to the living styleguide which aim to be a
general solution to the comment histories, journals and the activity
view.

Meets https://community.openproject.org/work_packages/19014

We should discuss if these should already replace the existing styles in the living styleguide for the work package details pane, as these are similar in style and design goal.
