### PR TITLE
Do not use npm-shrinkwrap.json when packaging npm dependencies.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git#v58
+https://github.com/heroku/heroku-buildpack-nodejs.git#v71
 https://github.com/pkgr/heroku-buildpack-ruby.git#universal

--- a/packaging/.npmrc
+++ b/packaging/.npmrc
@@ -1,0 +1,1 @@
+registry = 'http://registry.npmjs.org/'

--- a/packaging/setup
+++ b/packaging/setup
@@ -6,5 +6,10 @@ sed -i "s|config.serve_static_assets = false|config.serve_static_assets = true|"
 
 cp -f packaging/conf/000-establish-connection.rb config/initializers/
 
+# Specific npmrc used for packaging
+cp -f packaging/.npmrc .npmrc
+# Install dependencies from package.json
+rm -f frontend/npm-shrinkwrap.json
+
 # replace every occurrence of _APP_NAME_ with the corresponding application name we're packaging
 find packaging/ -type f -print0 | xargs -0 sed -i "s|_APP_NAME_|${APP_NAME}|"


### PR DESCRIPTION
This avoids downloading a huge amount of things that are only needed in
development. It will reduce the package size, and certainly improve the
reliability of the packaging process (i.e. less ECONNREFUSED when
downloading phantomjs and such).

This commit also updates the NodeJS buildpack, and forces the use of the
HTTP npm registry for better performance and reliability when packaging.
