### PR TITLE
more consistently use route_param

### DIFF
--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -35,7 +35,7 @@ module API
           params do
             requires :id, desc: 'Activity id'
           end
-          namespace ':id' do
+          route_param :id do
 
             before do
               @activity = Journal.find(params[:id])

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -35,7 +35,7 @@ module API
           params do
             requires :id, desc: 'Attachment id'
           end
-          namespace ':id' do
+          route_param :id do
 
             before do
               @attachment = Attachment.find(params[:id])
@@ -48,7 +48,6 @@ module API
             end
 
           end
-
         end
       end
     end

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -32,7 +32,7 @@ module API
     module Categories
       class CategoriesAPI < Grape::API
         resources :categories do
-          namespace ':id' do
+          route_param :id do
             before do
               @category = Category.find(params[:id])
               authorize(:view_project, context: @category.project) do

--- a/lib/api/v3/priorities/priorities_api.rb
+++ b/lib/api/v3/priorities/priorities_api.rb
@@ -44,7 +44,7 @@ module API
                                               api_v3_paths.priorities)
           end
 
-          namespace ':id' do
+          route_param :id do
             before do
               @priority = IssuePriority.find(params[:id])
             end

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -35,7 +35,7 @@ module API
             requires :id, desc: 'Project id'
           end
 
-          namespace ':id' do
+          route_param :id do
             before do
               @project = Project.find(params[:id])
 

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -36,7 +36,7 @@ module API
           params do
             requires :id, desc: 'Query id'
           end
-          namespace ':id' do
+          route_param :id do
             before do
               @query = Query.find(params[:id])
               @representer =  ::API::V3::Queries::QueryRepresenter.new(@query)

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -26,7 +26,7 @@ module API
             end
           end
 
-          namespace ':relation_id' do
+          route_param :relation_id do
             delete do
               authorize(:manage_work_package_relations, context: @work_package.project)
               Relation.destroy(params[:relation_id])

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -44,7 +44,7 @@ module API
                                             api_v3_paths.statuses)
           end
 
-          namespace ':id' do
+          route_param :id do
             before do
               status = Status.find(params[:id])
               @representer = ::API::V3::Statuses::StatusRepresenter.new(status)

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -49,7 +49,7 @@ module API
           params do
             requires :id, desc: 'User\'s id'
           end
-          namespace ':id' do
+          route_param :id do
 
             before do
               @user  = User.find(params[:id])

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -33,7 +33,7 @@ module API
       class VersionsAPI < Grape::API
         resources :versions do
 
-          namespace ':id' do
+          route_param :id do
 
             before do
               @version = Version.find(params[:id])

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -34,7 +34,7 @@ module API
           params do
             requires :id, desc: 'Work package id'
           end
-          namespace ':id' do
+          route_param :id do
             helpers do
               attr_reader :work_package
 


### PR DESCRIPTION
This is a PR related to regular [house keeping](https://community.openproject.org/work_packages/18714).

Grape has more conveniant method for specifying parts of the URL that should be used as parameters. We now use this method consequently.

The change generically looks like:

``` ruby
namespace ':id' do
```

changes into 

``` ruby
route_param :id do
```
