### PR TITLE
Rake task for managing plugins

### DIFF
--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -1,6 +1,5 @@
 class PluginManager
   GEMFILE_PLUGINS_PATH = 'Gemfile.plugins'
-  PLUGINS_YML_PATH = 'plugins.yml'
 
   def initialize(environment)
     @environment = environment
@@ -129,6 +128,8 @@ class PluginManager
 end
 
 class Plugin
+  PLUGINS_YML_PATH = 'plugins.yml'
+
   def self._available?(name)
     available_plugins[name]
   end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -75,7 +75,7 @@ class PluginManager
   end
 
   def _migrate
-    system "RAILS_ENV='#{@environment}' rake db:migrate"
+    system "RAILS_ENV='#{@environment}' bundle exec rake db:migrate"
   end
 
   def _revert_migrations(plugin)
@@ -84,15 +84,15 @@ class PluginManager
   end
 
   def _assets_precompile
-    system "RAILS_ENV='production' rake assets:precompile"
+    system "RAILS_ENV='production' bundle exec rake assets:precompile"
   end
 
   def _assets_webpack
-    system "RAILS_ENV='production' rake assets:webpack"
+    system "RAILS_ENV='production' bundle exec rake assets:webpack"
   end
 
   def _assets_clobber
-    system "RAILS_ENV='production' rake assets:clobber"
+    system "RAILS_ENV='production' bundle exec rake assets:clobber"
   end
 
   def _remove_plugin_from_gemfile_plugins_file(plugin)

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -190,9 +190,7 @@ class Plugin
     all_other_plugin_names = Plugin.available_plugins.inject([]) do |result, (other_name, _)|
       plugin.name == other_name ? result : result << other_name
     end
-    all_other_plugins = all_other_plugin_names.inject([]) do |result, name|
-      result << Plugin.new(name)
-    end
+    all_other_plugins = _names_to_plugins(all_other_plugin_names)
     all_dependencies_from_other_plugins = all_other_plugins.inject([]) do |result, other_plugin|
       result.concat other_plugin.dependencies
     end
@@ -238,7 +236,11 @@ class Plugin
 
   def dependencies
     # We might have to solve dependencies of dependencies.
-    available_plugins_names = Plugin.available_plugins[name][:dependencies] || []
-    available_plugins_names.inject([]) { |plugins, name| plugins << Plugin.new(name) }
+    names_of_dependencies = Plugin.available_plugins[name][:dependencies] || []
+    _names_to_plugins(names_of_dependencies)
+  end
+
+  def _names_to_plugins(names)
+    names.inject([]) { |plugins, name| plugins << Plugin.new(name) }
   end
 end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -213,7 +213,6 @@ class Plugin
   end
 
   def _specs_for_gemfile_plugins_line(options)
-    # todo what about tags or commits?
     # Right now we only support gems from rubygems and from git
     # If the plugin has a key :url git will be used.
     # Else a version should be available.
@@ -222,6 +221,12 @@ class Plugin
       if options[:branch]
         branch = options[:branch]
         ref = "branch: \"#{branch}\""
+      elsif options[:tag]
+        tag = options[:tag]
+        "tag: \"#{tag}\""
+      elsif options[:commit]
+        commit = options[:commit]
+        "commit: \"#{commit}\""
       end
       "git: \"#{url}\", #{ref}"
     else

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -49,6 +49,7 @@ class PluginManager
     _sort_gemfile_plugins
     _delete_empty_lines_from_gemfile_plugins
     _remove_duplicated_lines_from_gemfile_plugins
+    _check_for_duplicated_plugins
     _write_to_gemfile_plugins_file
   end
 
@@ -78,6 +79,16 @@ class PluginManager
   def _remove_duplicated_lines_from_gemfile_plugins
     gemfile_plugins_lines = @gemfile_plugins.split("\n")
     @gemfile_plugins = gemfile_plugins_lines.uniq.join("\n")
+  end
+
+  def _check_for_duplicated_plugins
+    Plugin.available_plugins.each do |plugin_name, _|
+      occurences = @gemfile_plugins.scan(/#{plugin_name}.*/).count
+      if occurences > 1
+        puts "#{plugin_name} occurs more than once in your Gemfile.plugins, abort!"
+        exit
+      end
+    end
   end
 
   def _write_to_gemfile_plugins_file

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -1,5 +1,4 @@
 class PluginManager
-
   GEMFILE_PLUGINS_PATH = 'Gemfile.plugins'
   PLUGINS_YML_PATH = 'plugins.yml'
 
@@ -169,13 +168,13 @@ class Plugin
     all_other_plugin_names = Plugin._available_plugins.inject([]) do |result, (other_name, _)|
       plugin.name == other_name ? result : result << other_name
     end
-    all_other_plugins = all_other_plugin_names.inject([]) do
-      |result, name| result << Plugin.new(name)
+    all_other_plugins = all_other_plugin_names.inject([]) do |result, name|
+      result << Plugin.new(name)
     end
     all_dependencies_from_other_plugins = all_other_plugins.inject([]) do |result, other_plugin|
       result.concat other_plugin.dependencies
     end
-    all_dependencies_from_other_plugins.any?{|dependency| dependency.name == name}
+    all_dependencies_from_other_plugins.any? { |dependency| dependency.name == name }
   end
 
   def included_in?(str)

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -165,7 +165,7 @@ class Plugin
   end
 
   def self.available_plugins
-    @available_plugins || _load_available_plugins
+    @available_plugins ||= _load_available_plugins
   end
 
   def self._load_available_plugins

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -145,7 +145,10 @@ class PluginManager
 
   def _dependencies_only_required_by(plugin)
     dependencies = plugin.dependencies
-    dependencies.reject { |dependency| dependency._needed_by_any_other_than?(plugin) }
+    result = dependencies.reject { |dependency| dependency._needed_by_any_other_than?(plugin) }
+    # Do not remove plugins that could have been there before
+    # the installation of the plugin.
+    result.select { |dependency| dependency.dependent_from(plugin) }
   end
 
   def _line_contains_no_plugin?(line, plugins)
@@ -199,6 +202,10 @@ class Plugin
       result.concat other_plugin.dependencies
     end
     all_dependencies_from_other_plugins.any? { |dependency| dependency.name == name }
+  end
+
+  def dependent_from(plugin)
+    dependencies.any? { |dependency| dependency.name == plugin.name }
   end
 
   def included_in?(str)

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -160,7 +160,7 @@ end
 class Plugin
   PLUGINS_YML_PATH = 'plugins.yml'
 
-  def self._available?(name)
+  def self.available?(name)
     available_plugins[name]
   end
 
@@ -179,8 +179,8 @@ class Plugin
   attr_reader :name
 
   def initialize(name)
-    unless Plugin._available?(name)
       puts 'Could not find plugin, abort!'
+    unless Plugin.available?(name)
       exit
     end
     @name = name

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -75,12 +75,10 @@ class PluginManager
   end
 
   def _migrate
-    # todo should we migrate for all envs?
     system "RAILS_ENV='#{@environment}' rake db:migrate"
   end
 
   def _revert_migrations(plugin)
-    # todo should we migrate for all envs?
     migration_path = OpenProject::Application.config.paths['db/migrate'].select { |path| path.include?(plugin.name) }
     ActiveRecord::Migrator.migrate migration_path, 0
   end
@@ -113,7 +111,6 @@ class PluginManager
   end
 
   def _dependencies_only_required_by(plugin)
-    # todo this needs to be addressed
     dependencies = plugin.dependencies
     dependencies.select { |dependency| dependency._not_needed_by_any_other_than?(plugin) }
   end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -141,7 +141,7 @@ class PluginManager
 
   def _dependencies_only_required_by(plugin)
     dependencies = plugin.dependencies
-    dependencies.select { |dependency| dependency._not_needed_by_any_other_than?(plugin) }
+    dependencies.reject { |dependency| dependency._needed_by_any_other_than?(plugin) }
   end
 
   def _line_contains_no_plugin?(line, plugins)
@@ -186,7 +186,7 @@ class Plugin
     @name = name
   end
 
-  def _not_needed_by_any_other_than?(plugin)
+  def _needed_by_any_other_than?(plugin)
     all_other_plugin_names = Plugin.available_plugins.inject([]) do |result, (other_name, _)|
       plugin.name == other_name ? result : result << other_name
     end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -47,6 +47,7 @@ class PluginManager
   def _write_plugin_to_gemfile_plugins_file(plugin)
     _add_plugin_to_gemfile_plugins(plugin)
     _sort_gemfile_plugins
+    _delete_empty_lines_from_gemfile_plugins
     _write_to_gemfile_plugins_file
   end
 
@@ -56,9 +57,21 @@ class PluginManager
   end
 
   def _sort_gemfile_plugins
-    # todo we have to take of the order..
-    # e.g. global roles first and
-    # reporting engine before costs/reporting
+    # Unfortunately, the order of the calls is important.
+    # Reporting engine needs to be above openproject-reporting/costs
+    _move_plugin_on_top('reporting_engine')
+    # Global Roles needs to be on top because it changes the permission model.
+    _move_plugin_on_top('openproject-global_roles')
+  end
+
+  def _move_plugin_on_top(plugin_name)
+    @gemfile_plugins = @gemfile_plugins.split("\n").inject('') do |result, line|
+      line.include?(plugin_name) ? line + "\n" + result : result + "\n" + line
+    end
+  end
+
+  def _delete_empty_lines_from_gemfile_plugins
+    @gemfile_plugins.gsub!(/^$\n/, '')
   end
 
   def _write_to_gemfile_plugins_file

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -179,8 +179,8 @@ class Plugin
   attr_reader :name
 
   def initialize(name)
-      puts 'Could not find plugin, abort!'
     unless Plugin.available?(name)
+      puts "Could not find plugin #{name}, abort!"
       exit
     end
     @name = name

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -48,6 +48,7 @@ class PluginManager
     _add_plugin_to_gemfile_plugins(plugin)
     _sort_gemfile_plugins
     _delete_empty_lines_from_gemfile_plugins
+    _remove_duplicated_plugins
     _write_to_gemfile_plugins_file
   end
 
@@ -72,6 +73,10 @@ class PluginManager
 
   def _delete_empty_lines_from_gemfile_plugins
     @gemfile_plugins.gsub!(/^$\n/, '')
+  end
+
+  def _remove_duplicated_plugins
+    # todo
   end
 
   def _write_to_gemfile_plugins_file
@@ -206,7 +211,6 @@ class Plugin
   end
 
   def gemfile_plugins_lines_for_dependencies
-    # todo don't add dependencies twice
     result = ''
     dependencies.each do |dependency|
       result << dependency.gemfile_plugins_line

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -148,6 +148,8 @@ class Plugin
   attr_reader :name
 
   def initialize(name)
+    # This is necessary because we have some strange dependencies in openproject-pdf_export.
+    # When we delete those, we can delete this if.
     if name == 'pdf-inspector'
       @name = 'pdf-inspector'
     else
@@ -181,7 +183,7 @@ class Plugin
 
   def gemfile_plugins_line
     # todo this needs to be more general, i.e. with different ref types (commit, tag)
-    # and maybe without if 'pdf-inspector'
+    # See the comment in Plugin#initialize for the if.
     if @name == 'pdf-inspector'
       "gem \"pdf-inspector\", \"~>1.0.0\"\n"
     else

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -15,7 +15,7 @@ class PluginManager
   def add(name)
     plugin = Plugin.new(name)
     if plugin.included_in?(@gemfile_plugins)
-      puts 'Plugin already installed, abort'
+      puts 'Plugin #{name} already installed, abort'
       exit
     end
     _write_plugin_to_gemfile_plugins_file(plugin)
@@ -32,7 +32,7 @@ class PluginManager
   def remove(name)
     plugin = Plugin.new(name)
     unless plugin.included_in?(@gemfile_plugins)
-      puts 'Plugin not installed, abort!'
+      puts 'Plugin #{name} not installed, abort!'
       exit
     end
     _revert_migrations(plugin)

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -196,13 +196,12 @@ class Plugin
   end
 
   def included_in?(str)
-    # todo check for commented gems?
     str.include?(@name)
   end
 
   def gemfile_plugins_line
     # todo this needs to be more general, i.e. with different ref types (commit, tag)
-    # See the comment in Plugin#initialize for the if.
+    # See the comment in Plugin#initialize for the reason of this if.
     if @name == 'pdf-inspector'
       "gem \"pdf-inspector\", \"~>1.0.0\"\n"
     else
@@ -219,10 +218,10 @@ class Plugin
   end
 
   def dependencies
+    # We might have to solve dependencies of dependencies.
     available_plugins_names = Plugin.available_plugins[name][:dependencies] || []
     result = available_plugins_names.inject([]) { |plugins, name| plugins << Plugin.new(name) }
-    # todo we have to solve dependencies of dependencies
-    # this is just a workaround to make backlogs work for now
+    # This is just a workaround to make backlogs work for now.
     result << Plugin.new('pdf-inspector') if result.first && result.first.name == 'openproject-pdf_export'
     result
   end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -223,7 +223,7 @@ class Plugin
       end
       "git: \"#{url}\", #{ref}"
     else
-      options[:version]
+      "\"#{options[:version]}\""
     end
   end
 

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -142,7 +142,7 @@ class Plugin
       puts 'Could not find plugin list, abort!'
       exit
     end
-    @available_plugins = YAML.load_file(PLUGINS_YML_PATH)
+    YAML.load_file(PLUGINS_YML_PATH)
   end
 
   attr_reader :name

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -130,10 +130,10 @@ end
 
 class Plugin
   def self._available?(name)
-    _available_plugins[name]
+    available_plugins[name]
   end
 
-  def self._available_plugins
+  def self.available_plugins
     @available_plugins || _load_available_plugins
   end
 
@@ -158,13 +158,13 @@ class Plugin
         exit
       end
       @name = name
-      @url = Plugin._available_plugins[name][:url]
-      @branch = Plugin._available_plugins[name][:branch]
+      @url = Plugin.available_plugins[name][:url]
+      @branch = Plugin.available_plugins[name][:branch]
     end
   end
 
   def _not_needed_by_any_other_than?(plugin)
-    all_other_plugin_names = Plugin._available_plugins.inject([]) do |result, (other_name, _)|
+    all_other_plugin_names = Plugin.available_plugins.inject([]) do |result, (other_name, _)|
       plugin.name == other_name ? result : result << other_name
     end
     all_other_plugins = all_other_plugin_names.inject([]) do |result, name|
@@ -201,7 +201,7 @@ class Plugin
   end
 
   def dependencies
-    available_plugins_names = Plugin._available_plugins[name][:dependencies] || []
+    available_plugins_names = Plugin.available_plugins[name][:dependencies] || []
     result = available_plugins_names.inject([]) { |plugins, name| plugins << Plugin.new(name) }
     # todo we have to solve dependencies of dependencies
     # this is just a workaround to make backlogs work for now

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -108,7 +108,9 @@ class PluginManager
   end
 
   def _revert_migrations(plugin)
-    migration_path = OpenProject::Application.config.paths['db/migrate'].select { |path| path.include?(plugin.name) }
+    migration_path = OpenProject::Application.config.paths['db/migrate'].select {
+      |path| path.include?(plugin.name)
+    }
     ActiveRecord::Migrator.migrate migration_path, 0
   end
 
@@ -223,7 +225,6 @@ class Plugin
     else
       options[:version]
     end
-
   end
 
   def gemfile_plugins_lines_for_dependencies

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -60,6 +60,8 @@ class PluginManager
 
   def _sort_gemfile_plugins
     # Unfortunately, the order of the calls is important.
+    # OpenProject-Costs needs to be above OpenProject-Reporting.
+    _move_plugin_on_top('openproject-costs')
     # Reporting engine needs to be above openproject-reporting/costs
     _move_plugin_on_top('reporting_engine')
     # Global Roles needs to be on top because it changes the permission model.

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -54,8 +54,8 @@ class PluginManager
   end
 
   def _add_plugin_to_gemfile_plugins(plugin)
-    @gemfile_plugins << plugin.gemfile_plugins_line
-    @gemfile_plugins << plugin.gemfile_plugins_lines_for_dependencies
+    @gemfile_plugins << "\n" + plugin.gemfile_plugins_line
+    @gemfile_plugins << "\n" + plugin.gemfile_plugins_lines_for_dependencies
   end
 
   def _sort_gemfile_plugins

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -1,13 +1,15 @@
 class PluginManager
+
+  GEMFILE_PLUGINS_PATH = 'Gemfile.plugins'
+
   def initialize(environment)
     @environment = environment
     @gemfile_plugins = _gemfile_plugins || ''
   end
 
   def _gemfile_plugins
-    gemfile_plugins_path = 'Gemfile.plugins'
-    if File.exists?(gemfile_plugins_path)
-      File.read(gemfile_plugins_path)
+    if File.exists?(GEMFILE_PLUGINS_PATH)
+      File.read(GEMFILE_PLUGINS_PATH)
     end
   end
 
@@ -61,8 +63,7 @@ class PluginManager
   end
 
   def _write_to_gemfile_plugins_file
-    gemfile_plugins_path = 'Gemfile.plugins'
-    File.open(gemfile_plugins_path, 'w') do |f|
+    File.open(GEMFILE_PLUGINS_PATH, 'w') do |f|
       f.write @gemfile_plugins
     end
   end
@@ -104,14 +105,14 @@ class PluginManager
 
   def _remove_plugin_from_gemfile_plugins(plugin)
     gemfile_plugins_new = ''
-    plugins = [plugin].concat _dependencies_only_for(plugin)
+    plugins = [plugin].concat _dependencies_only_required_by(plugin)
     @gemfile_plugins.each_line do |line|
       gemfile_plugins_new << line if _line_contains_no_plugin?(line, plugins)
     end
     @gemfile_plugins = gemfile_plugins_new
   end
 
-  def _dependencies_only_for(plugin)
+  def _dependencies_only_required_by(plugin)
     # todo this needs to be addressed
     dependencies = plugin.dependencies
     dependencies.select { |dependency| true }#todo dependency._not_needed_by_any_other_than?(plugin) }
@@ -126,12 +127,7 @@ class PluginManager
   end
 
   def _remove_gemfile_plugins_if_empty
-    _remove_gemfile_plugins_file if @gemfile_plugins == ''
-  end
-
-  def _remove_gemfile_plugins_file
-    gemfile_plugins_path = 'Gemfile.plugins'
-    FileUtils.rm(gemfile_plugins_path)
+    FileUtils.rm(GEMFILE_PLUGINS_PATH) if @gemfile_plugins == ''
   end
 end
 
@@ -167,6 +163,7 @@ class Plugin
 
   def _not_needed_by_any_other_than?(plugin)
     # todo
+    require 'pry';binding.pry;exit
     true
   end
 

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -138,20 +138,20 @@ class PluginManager
     gemfile_plugins_new = ''
     plugins = [plugin].concat _dependencies_only_required_by(plugin)
     @gemfile_plugins.each_line do |line|
-      gemfile_plugins_new << line if _line_contains_no_plugin?(line, plugins)
+      gemfile_plugins_new << line if line_contains_no_plugin?(line, plugins)
     end
     @gemfile_plugins = gemfile_plugins_new
   end
 
   def _dependencies_only_required_by(plugin)
     dependencies = plugin.dependencies
-    result = dependencies.reject { |dependency| dependency._needed_by_any_other_than?(plugin) }
+    result = dependencies.reject { |dependency| dependency.needed_by_any_other_than?(plugin) }
     # Do not remove plugins that could have been there before
     # the installation of the plugin.
     result.select { |dependency| dependency.dependent_from(plugin) }
   end
 
-  def _line_contains_no_plugin?(line, plugins)
+  def line_contains_no_plugin?(line, plugins)
     result = true
     plugins.each do |plugin|
       result = false if plugin.included_in?(line)
@@ -193,7 +193,7 @@ class Plugin
     @name = name
   end
 
-  def _needed_by_any_other_than?(plugin)
+  def needed_by_any_other_than?(plugin)
     all_other_plugin_names = Plugin.available_plugins.inject([]) do |result, (other_name, _)|
       plugin.name == other_name ? result : result << other_name
     end

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -48,7 +48,7 @@ class PluginManager
     _add_plugin_to_gemfile_plugins(plugin)
     _sort_gemfile_plugins
     _delete_empty_lines_from_gemfile_plugins
-    _remove_duplicated_plugins
+    _remove_duplicated_lines_from_gemfile_plugins
     _write_to_gemfile_plugins_file
   end
 
@@ -75,8 +75,9 @@ class PluginManager
     @gemfile_plugins.gsub!(/^$\n/, '')
   end
 
-  def _remove_duplicated_plugins
-    # todo
+  def _remove_duplicated_lines_from_gemfile_plugins
+    gemfile_plugins_lines = @gemfile_plugins.split("\n")
+    @gemfile_plugins = gemfile_plugins_lines.uniq.join("\n")
   end
 
   def _write_to_gemfile_plugins_file

--- a/lib/plugin_manager.rb
+++ b/lib/plugin_manager.rb
@@ -1,0 +1,184 @@
+class PluginManager
+  def initialize(environment)
+    @environment = environment
+    @gemfile_plugins = _gemfile_plugins || ''
+  end
+
+  def _gemfile_plugins
+    gemfile_plugins_path = 'Gemfile.plugins'
+    if File.exists?(gemfile_plugins_path)
+      File.read(gemfile_plugins_path)
+    end
+  end
+
+  def add(plugin)
+    if _already_installed?(plugin)
+      puts 'Plugin already installed, abort'
+      exit
+    end
+    _write_plugin_to_gemfile_plugins_file(plugin)
+    _bundle
+    _migrate
+
+    if @environment == 'production'
+      _assets_precompile
+    else
+      _assets_webpack
+    end
+  end
+
+  def remove(plugin)
+    unless _already_installed?(plugin)
+      puts 'Plugin not installed, abort!'
+      exit
+    end
+    _revert_migrations(plugin)
+    _remove_plugin_from_gemfile_plugins_file(plugin)
+    _bundle
+    if @environment == 'production'
+      _assets_clobber
+      _assets_precompile
+    end
+  end
+
+  def _already_installed?(plugin)
+    @gemfile_plugins.include?(plugin)
+  end
+
+  def _write_plugin_to_gemfile_plugins_file(plugin)
+    _add_plugin_to_gemfile_plugins(plugin)
+    _sort_gemfile_plugins
+    _write_to_gemfile_plugins_file
+  end
+
+  def _add_plugin_to_gemfile_plugins(plugin)
+    unless _available_plugins[plugin]
+      puts 'Could not find plugin, abort!'
+      exit
+    end
+    @gemfile_plugins << _gemfile_plugins_line(plugin)
+    @gemfile_plugins << _gemfile_plugins_lines_for_dependencies(plugin)
+  end
+
+  def _available_plugins
+    @available_plugins || _load_available_plugins
+  end
+
+  def _load_available_plugins
+    @available_plugins = YAML.load_file('plugins.yml')
+  end
+
+  def _gemfile_plugins_line(plugin)
+    # todo this needs to be more general, i.e. without if 'pdf-inspector'
+    # and with different ref types (commit, tag)
+    if plugin == 'pdf-inspector'
+      "gem \"pdf-inspector\", \"~>1.0.0\"\n"
+    else
+      url = _available_plugins[plugin][:url]
+      branch = _available_plugins[plugin][:branch]
+      "gem \"#{plugin}\", git: \"#{url}\", branch: \"#{branch}\"\n"
+    end
+  end
+
+  def _gemfile_plugins_lines_for_dependencies(plugin)
+    # todo don't add dependencies twice
+    result = ''
+    _dependencies(plugin).each do |dependency|
+      result << _gemfile_plugins_line(dependency)
+    end
+    result
+  end
+
+  def _dependencies(plugin)
+    result = _available_plugins[plugin][:dependencies] || []
+    # todo we have to solve dependencies of dependencies
+    # this is just a workaround to make backlogs work for now
+    result << 'pdf-inspector' if result == ['openproject-pdf_export']
+    result
+  end
+
+  def _sort_gemfile_plugins
+    # todo we have to take of the order..
+    # e.g. global roles first and
+    # reporting engine before costs/reporting
+  end
+
+  def _write_to_gemfile_plugins_file
+    gemfile_plugins_path = 'Gemfile.plugins'
+    File.open(gemfile_plugins_path, 'w') do |f|
+      f.write @gemfile_plugins
+    end
+  end
+
+  def _bundle
+    Bundler.with_clean_env do
+      system 'bundle install --no-deployment'
+    end
+  end
+
+  def _migrate
+    # todo should we migrate for all envs?
+    system "RAILS_ENV='#{@environment}' rake db:migrate"
+  end
+
+  def _revert_migrations(plugin)
+    # todo should we migrate for all envs?
+    migration_path = OpenProject::Application.config.paths['db/migrate'].select { |path| path.include?(plugin) }
+    ActiveRecord::Migrator.migrate migration_path, 0
+  end
+
+  def _assets_precompile
+    system "RAILS_ENV='production' rake assets:precompile"
+  end
+
+  def _assets_webpack
+    system "RAILS_ENV='production' rake assets:webpack"
+  end
+
+  def _assets_clobber
+    system "RAILS_ENV='production' rake assets:clobber"
+  end
+
+  def _remove_plugin_from_gemfile_plugins_file(plugin)
+    _remove_plugin_from_gemfile_plugins(plugin)
+    _write_to_gemfile_plugins_file
+    _remove_gemfile_plugins_if_empty
+  end
+
+  def _remove_plugin_from_gemfile_plugins(plugin)
+    gemfile_plugins_new = ''
+    plugins = [plugin].concat _dependencies_only_for(plugin)
+    @gemfile_plugins.each_line do |line|
+      gemfile_plugins_new << line if _line_contains_no_plugin?(line, plugins)
+    end
+    @gemfile_plugins = gemfile_plugins_new
+  end
+
+  def _dependencies_only_for(plugin)
+    # todo this needs to be addressed
+    dependencies = _dependencies(plugin)
+    dependencies.select { |dependency| true }#todo dependency._not_needed_by_any_other_than?(plugin) }
+  end
+
+  def _not_needed_by_any_other_than?(plugin)
+    # todo
+    true
+  end
+
+  def _line_contains_no_plugin?(line, plugins)
+    result = true
+    plugins.each do |plugin|
+      result = false if line.include?(plugin)
+    end
+    result
+  end
+
+  def _remove_gemfile_plugins_if_empty
+    _remove_gemfile_plugins_file if @gemfile_plugins == ''
+  end
+
+  def _remove_gemfile_plugins_file
+    gemfile_plugins_path = 'Gemfile.plugins'
+    FileUtils.rm(gemfile_plugins_path)
+  end
+end

--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -88,3 +88,17 @@ namespace :redmine do
     end
   end
 end
+
+namespace :plugins do
+desc 'Adds Meeting plugin for now'
+  task :add, [:plugin] => :environment do |t, args|
+    plugin_manager = PluginManager.new Rails.env
+    plugin_manager.add args[:plugin]
+  end
+
+  desc 'Removes Meeting plugin for now'
+  task :remove, [:plugin] => :environment do |t, args|
+    plugin_manager = PluginManager.new Rails.env
+    plugin_manager.remove args[:plugin]
+  end
+end

--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -90,13 +90,13 @@ namespace :redmine do
 end
 
 namespace :plugins do
-desc 'Adds Meeting plugin for now'
+  desc 'Adds a plugin'
   task :add, [:plugin] => :environment do |t, args|
     plugin_manager = PluginManager.new Rails.env
     plugin_manager.add args[:plugin]
   end
 
-  desc 'Removes Meeting plugin for now'
+  desc 'Removes a plugin'
   task :remove, [:plugin] => :environment do |t, args|
     plugin_manager = PluginManager.new Rails.env
     plugin_manager.remove args[:plugin]

--- a/plugins.yml
+++ b/plugins.yml
@@ -2,23 +2,6 @@
 openproject-meeting:
   :url: https://github.com/finnlabs/openproject-meeting.git
   :branch: dev
-openproject-pdf_export:
-  :url: https://github.com/finnlabs/openproject-pdf_export.git
-  :branch: dev
-  :dependencies:
-    - openproject-backlogs
-openproject-backlogs:
-  :url: https://github.com/finnlabs/openproject-backlogs.git
-  :branch: dev
-  :dependencies:
-    - openproject-pdf_export
-    - pdf-inspector # This should actually be a dependency only of pdf_export.
-openproject-costs:
-  :url: https://github.com/finnlabs/openproject-costs.git
-  :branch: dev
-openproject-global_roles:
-  :url:  https://github.com/finnlabs/openproject-global_roles.git
-  :branch: dev
 openproject-help_link:
   :url: https://github.com/finnlabs/openproject-help_link.git
   :branch: dev
@@ -28,20 +11,9 @@ openproject-my_project_page:
 openproject-documents:
   :url: https://github.com/opf/openproject-documents.git
   :branch: dev
-reporting_engine:
-  :url: https://github.com/finnlabs/reporting_engine.git
-  :branch: dev
 openproject-translations:
   :url: https://github.com/opf/openproject-translations.git
   :branch: dev
-openproject-reporting:
-  :url: https://github.com/finnlabs/openproject-reporting.git
-  :branch: dev
-  :dependencies:
-    - openproject-costs
-    - reporting_engine
 openproject-emoji:
   :url: https://github.com/tessi/openproject-emoji.git
   :branch: dev
-pdf-inspector:
-  :version: ~>1.0.0

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,47 +1,47 @@
 ---
 openproject-meeting:
   :url: https://github.com/finnlabs/openproject-meeting.git
-  :branch: stable
+  :branch: dev
 openproject-pdf_export:
   :url: https://github.com/finnlabs/openproject-pdf_export.git
-  :branch: stable
+  :branch: dev
   :dependencies:
     - openproject-backlogs
 openproject-backlogs:
   :url: https://github.com/finnlabs/openproject-backlogs.git
-  :branch: stable
+  :branch: dev
   :dependencies:
     - openproject-pdf_export
     - pdf-inspector # This should actually be a dependency only of pdf_export.
 openproject-costs:
   :url: https://github.com/finnlabs/openproject-costs.git
-  :branch: stable
+  :branch: dev
 openproject-global_roles:
   :url:  https://github.com/finnlabs/openproject-global_roles.git
-  :branch: stable
+  :branch: dev
 openproject-help_link:
   :url: https://github.com/finnlabs/openproject-help_link.git
-  :branch: stable
+  :branch: dev
 openproject-my_project_page:
   :url: https://github.com/finnlabs/openproject-my_project_page.git
-  :branch: stable
+  :branch: dev
 openproject-documents:
   :url: https://github.com/opf/openproject-documents.git
-  :branch: stable
+  :branch: dev
 reporting_engine:
   :url: https://github.com/finnlabs/reporting_engine.git
-  :branch: stable
+  :branch: dev
 openproject-translations:
   :url: https://github.com/opf/openproject-translations.git
-  :branch: stable
+  :branch: dev
 openproject-reporting:
   :url: https://github.com/finnlabs/openproject-reporting.git
-  :branch: stable
+  :branch: dev
   :dependencies:
     - openproject-costs
     - reporting_engine
 openproject-emoji:
   :url: https://github.com/tessi/openproject-emoji.git
-  :branch: stable
+  :branch: dev
 pdf-inspector:
   :version: ~>1.0.0

--- a/plugins.yml
+++ b/plugins.yml
@@ -7,7 +7,6 @@ openproject-pdf_export:
   :branch: stable
   :dependencies:
     - openproject-backlogs
-    - pdf-inspector
 openproject-backlogs:
   :url: https://github.com/finnlabs/openproject-backlogs.git
   :branch: stable

--- a/plugins.yml
+++ b/plugins.yml
@@ -13,6 +13,7 @@ openproject-backlogs:
   :branch: stable
   :dependencies:
     - openproject-pdf_export
+    - pdf-inspector # This should actually be a dependency only of pdf_export.
 openproject-costs:
   :url: https://github.com/finnlabs/openproject-costs.git
   :branch: stable
@@ -43,3 +44,5 @@ openproject-reporting:
 openproject-emoji:
   :url: https://github.com/tessi/openproject-emoji.git
   :branch: stable
+pdf-inspector:
+  :version: ~>1.0.0

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,0 +1,41 @@
+---
+openproject-meeting:
+  :url: https://github.com/finnlabs/openproject-meeting.git
+  :branch: stable
+openproject-pdf_export:
+  :url: https://github.com/finnlabs/openproject-pdf_export.git
+  :branch: stable
+  :dependencies:
+    - openproject-backlogs
+    - pdf-inspector
+openproject-backlogs:
+  :url: https://github.com/finnlabs/openproject-backlogs.git
+  :branch: stable
+  :dependencies:
+    - openproject-pdf_export
+openproject-costs:
+  :url: https://github.com/finnlabs/openproject-costs.git
+  :branch: stable
+openproject-global_roles:
+  :url:  https://github.com/finnlabs/openproject-global_roles.git
+  :branch: stable
+openproject-help_link:
+  :url: https://github.com/finnlabs/openproject-help_link.git
+  :branch: stable
+openproject-my_project_page:
+  :url: https://github.com/finnlabs/openproject-my_project_page.git
+  :branch: stable
+openproject-documents:
+  :url: https://github.com/opf/openproject-documents.git
+  :branch: stable
+reporting_engine:
+  :url: https://github.com/finnlabs/reporting_engine.git
+  :branch: stable
+  :dependencies:
+    - openproject-costs
+openproject-translations:
+  :url: https://github.com/opf/openproject-translations.git
+  :branch: stable
+openproject-emoji:
+  :url: https://github.com/tessi/openproject-emoji.git
+  :branch: stable

--- a/plugins.yml
+++ b/plugins.yml
@@ -31,11 +31,15 @@ openproject-documents:
 reporting_engine:
   :url: https://github.com/finnlabs/reporting_engine.git
   :branch: stable
-  :dependencies:
-    - openproject-costs
 openproject-translations:
   :url: https://github.com/opf/openproject-translations.git
   :branch: stable
+openproject-reporting:
+  :url: https://github.com/finnlabs/openproject-reporting.git
+  :branch: stable
+  :dependencies:
+    - openproject-costs
+    - reporting_engine
 openproject-emoji:
   :url: https://github.com/tessi/openproject-emoji.git
   :branch: stable

--- a/spec/lib/plugin_manager_spec.rb
+++ b/spec/lib/plugin_manager_spec.rb
@@ -97,12 +97,15 @@ describe PluginManager do
       let(:dependency_to_delete) { 'dependency_to_delete' }
       let(:shared_dependency) { 'shared_dependency' }
       let(:other_plugin) { 'other_plugin' }
+      let(:independent_plugin) { 'independent_plugin' }
       let(:plugin_specs) {
         {
           plugin_to_delete => {
             url: '',
             branch: '',
-            dependencies: [dependency_to_delete, shared_dependency]
+            dependencies: [dependency_to_delete,
+                           shared_dependency,
+                           other_plugin]
           },
           dependency_to_delete => {
             url: '',
@@ -117,11 +120,17 @@ describe PluginManager do
             url: '',
             branch: '',
             dependencies: [shared_dependency]
+          },
+          independent_plugin => {
+            url: '',
+            branch: '',
+            dependencies: [shared_dependency]
           }
         }
       }
       let(:gemfile_plugins) {
-        "#{plugin_to_delete}\n#{dependency_to_delete}\n#{shared_dependency}\n#{other_plugin}"
+        "#{plugin_to_delete}\n#{dependency_to_delete}\n#{shared_dependency}\
+        \n#{other_plugin}\n#{independent_plugin}"
       }
 
       before do
@@ -140,6 +149,10 @@ describe PluginManager do
       end
 
       it 'does not remove independent plugins' do
+        expect(gemfile_plugins_new).to include(independent_plugin)
+      end
+
+      it 'does not remove plugins that could have been installed before' do
         expect(gemfile_plugins_new).to include(other_plugin)
       end
 

--- a/spec/lib/plugin_manager_spec.rb
+++ b/spec/lib/plugin_manager_spec.rb
@@ -1,0 +1,321 @@
+require 'spec_helper'
+
+describe PluginManager do
+  before do
+    allow(described_class).to receive(:system)
+  end
+
+  describe '#add' do
+    let(:plugin_manager) { described_class.new('test-environment') }
+
+    before do
+      allow(plugin_manager).to receive(:_gemfile_plugins).and_return('')
+    end
+
+    context 'with a plugin that is already installed' do
+      before do
+        plugin_manager.instance_variable_set(:@gemfile_plugins, 'test')
+      end
+
+      it 'exits' do
+        expect{plugin_manager.add('test')}.to raise_error SystemExit
+      end
+    end
+
+    context 'with a plugin that is not already installed' do
+      subject(:count_of_test) {
+        plugin_manager.instance_variable_get(:@gemfile_plugins).scan(/test.*/).count
+      }
+      let(:plugin_specs) {
+        {
+          'test' => {
+            url: 'test-url',
+            branch: 'test-branch',
+            dependencies: ['dependency']
+          },
+          'dependency' => {
+            url: 'dependency-url',
+            branch: 'dependency-branch',
+            dependencies: ['test']
+          }
+        }
+      }
+
+      before do
+        allow(Plugin).to receive(:available_plugins).and_return(plugin_specs)
+        plugin_manager.instance_variable_set(:@gemfile_plugins, '')
+        allow(plugin_manager).to receive(:_bundle)
+        allow(plugin_manager).to receive(:_migrate)
+        allow(plugin_manager).to receive(:_assets_webpack)
+        allow(plugin_manager).to receive(:_write_to_gemfile_plugins_file)
+      end
+
+      it 'does not add a plugin twice' do
+        plugin_manager.add('test')
+        expect(count_of_test).to eql(1)
+      end
+    end
+  end
+
+  describe '#remove' do
+    context 'with a plugin that is not installed' do
+      let(:plugin_manager) { described_class.new('test-environment') }
+
+      before do
+        plugin_manager.instance_variable_set(:@gemfile_plugins, '')
+      end
+
+      it 'exits' do
+        expect{plugin_manager.remove('test')}.to raise_error SystemExit
+      end
+    end
+
+    context 'with a plugin that is installed' do
+      subject(:gemfile_plugins_new) {
+        plugin_manager.instance_variable_get(:@gemfile_plugins)
+      }
+      let(:plugin_manager) { described_class.new('test-environment') }
+      let(:plugin_to_delete) { 'plugin_to_delete' }
+      let(:dependency_to_delete) { 'dependency_to_delete' }
+      let(:shared_dependency) { 'shared_dependency' }
+      let(:other_plugin) { 'other_plugin' }
+      let(:plugin_specs) {
+        {
+          plugin_to_delete => {
+            url: '',
+            branch: '',
+            dependencies: [dependency_to_delete, shared_dependency]
+          },
+          dependency_to_delete => {
+            url: '',
+            branch: '',
+            dependencies: [plugin_to_delete]
+          },
+          shared_dependency => {
+            url: '',
+            branch: '',
+          },
+          other_plugin => {
+            url: '',
+            branch: '',
+            dependencies: [shared_dependency]
+          }
+        }
+      }
+      let(:gemfile_plugins) {
+        "#{plugin_to_delete}\n#{dependency_to_delete}\n#{shared_dependency}\n#{other_plugin}"
+      }
+
+      before do
+        allow(Plugin).to receive(:available_plugins).and_return(plugin_specs)
+        plugin_manager.instance_variable_set(:@gemfile_plugins, gemfile_plugins)
+        allow(plugin_manager).to receive(:_bundle)
+        allow(plugin_manager).to receive(:_revert_migrations)
+        allow(plugin_manager).to receive(:_write_to_gemfile_plugins_file)
+        allow(plugin_manager).to receive(:_remove_gemfile_plugins_if_empty)
+
+        plugin_manager.remove(plugin_to_delete)
+      end
+
+      it 'does not remove dependencies that are required by other plugins' do
+        expect(gemfile_plugins_new).to include(shared_dependency)
+      end
+
+      it 'does not remove independent plugins' do
+        expect(gemfile_plugins_new).to include(other_plugin)
+      end
+
+      it 'removes dependencies that are only required by this plugin' do
+        expect(gemfile_plugins_new).not_to include(dependency_to_delete)
+
+      end
+
+      it 'removes the plugin' do
+        expect(gemfile_plugins_new).not_to include(plugin_to_delete)
+      end
+    end
+  end
+end
+
+describe Plugin do
+  describe '.available?' do
+    subject { described_class.available?('test') }
+
+    context 'with a non-existent plugin' do
+      it 'returns false' do
+        allow(described_class).to receive(:available_plugins).and_return({})
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'with an existent plugin' do
+      it 'returns true' do
+        allow(described_class).to receive(:available_plugins).and_return({'test' => :test})
+        is_expected.to be_truthy
+      end
+    end
+  end
+
+  describe '.available_plugins'do
+    context 'with nullified instance variable' do
+      before(:each) do
+        described_class.instance_variable_set(:@available_plugins, nil)
+      end
+
+      it 'loads the correct yml file' do
+        expect(YAML).to receive(:load_file).with(described_class::PLUGINS_YML_PATH).and_return({})
+        described_class.available_plugins
+      end
+
+      it 'sets the instance variable to the correct value' do
+        allow(YAML).to receive(:load_file).and_return('test-string')
+        described_class.available_plugins
+        expect(described_class.instance_variable_get(:@available_plugins)).to eql('test-string')
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'with an unavailable plugin' do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it 'exits' do
+        expect{described_class.new('test')}.to raise_error SystemExit
+      end
+    end
+
+    context 'with an available plugin' do
+      subject {described_class.new('test').name}
+
+      before do
+        allow(described_class).to receive(:available?).and_return(true)
+      end
+
+      it 'saves the name' do
+        is_expected.to eql('test')
+      end
+    end
+  end
+
+  describe '#included_in?' do
+    subject { plugin.included_in?(string) }
+    let(:plugin) { described_class.new('test') }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(true)
+    end
+
+    context 'with a string that does not contain the name of the plugin' do
+      let(:string) { '' }
+
+      it 'returns false' do
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'with a string that does contain the name of the plugin' do
+      let(:string) { 'test' }
+
+      it 'returns false' do
+        is_expected.to be_truthy
+      end
+    end
+  end
+
+  describe '#gemfile_plugins_line' do
+    subject { plugin.gemfile_plugins_line }
+    let(:plugin) { described_class.new('test') }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(true)
+      allow(described_class).to receive(:available_plugins).and_return(plugin_specs)
+    end
+
+    context 'with a plugin with url and branch key' do
+      let(:url) { 'test-url' }
+      let(:branch) { 'test-branch' }
+      let(:plugin_specs) {
+        {
+          'test' =>
+          {
+            url: url,
+            branch: branch
+          }
+        }
+      }
+
+      it 'contains the name of the plugin' do
+        is_expected.to include("gem \"test\"")
+      end
+
+      it 'contains the url identifier' do
+        is_expected.to include("git: \"#{url}\"")
+      end
+
+      it 'contains the branch identifier' do
+        is_expected.to include("branch: \"#{branch}\"")
+      end
+    end
+
+    context 'with a plugin with url and branch key' do
+      let(:version) { 'test-version' }
+      let(:plugin_specs) { { 'test' => { version: version } } }
+
+      it 'contains the version' do
+        is_expected.to include(version)
+      end
+    end
+  end
+
+  describe '#gemfile_plugins_lines_for_dependencies' do
+    subject {plugin.gemfile_plugins_lines_for_dependencies}
+    let(:plugin) { described_class.new('test') }
+    let(:dep1) { described_class.new('dep1') }
+    let(:dep2) { described_class.new('dep2') }
+    let(:dependencies) { [dep1, dep2] }
+    let(:version) { 'test-version' }
+    let(:plugin_specs) {
+      {
+        'test' => { version: version },
+        'dep1' => { version: version },
+        'dep2' => { version: version }
+      }
+    }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(true)
+      allow(described_class).to receive(:available_plugins).and_return(plugin_specs)
+      allow(plugin).to receive(:dependencies).and_return(dependencies)
+    end
+
+    it 'contains all dependencies'do
+      dependencies.each do |dependency|
+        is_expected.to include(dependency.name)
+      end
+    end
+
+  end
+
+  describe '#dependencies' do
+    subject { plugin.dependencies.map(&:name) }
+    let(:plugin) { described_class.new('test') }
+    let(:available_plugins) {
+      {
+        'test' => {
+          dependencies: ['dep1', 'dep2']
+        }
+      }
+    }
+
+    before do
+      allow(described_class).to receive(:available?).and_return(true)
+      allow(described_class).to receive(:available_plugins).and_return(available_plugins)
+    end
+
+    it 'contains the correct dependencies' do
+      is_expected.to eql(['dep1', 'dep2'])
+    end
+  end
+end

--- a/spec/lib/plugin_manager_spec.rb
+++ b/spec/lib/plugin_manager_spec.rb
@@ -19,7 +19,7 @@ describe PluginManager do
       end
 
       it 'exits' do
-        expect{plugin_manager.add(plugin)}.to raise_error SystemExit
+        expect { plugin_manager.add(plugin) }.to raise_error SystemExit
       end
     end
 
@@ -72,7 +72,6 @@ describe PluginManager do
       it 'contains the url of the plugin' do
         expect(gemfile_plugins).to include(branch)
       end
-
     end
   end
 
@@ -85,7 +84,7 @@ describe PluginManager do
       end
 
       it 'exits' do
-        expect{plugin_manager.remove('test')}.to raise_error SystemExit
+        expect { plugin_manager.remove('test') }.to raise_error SystemExit
       end
     end
 
@@ -146,7 +145,6 @@ describe PluginManager do
 
       it 'removes dependencies that are only required by this plugin' do
         expect(gemfile_plugins_new).not_to include(dependency_to_delete)
-
       end
 
       it 'removes the plugin' do
@@ -170,7 +168,7 @@ describe Plugin do
 
     context 'with an existent plugin' do
       it 'returns true' do
-        allow(described_class).to receive(:available_plugins).and_return({plugin => :test})
+        allow(described_class).to receive(:available_plugins).and_return(plugin => :test)
         is_expected.to be_truthy
       end
     end
@@ -204,12 +202,12 @@ describe Plugin do
       end
 
       it 'exits' do
-        expect{described_class.new('test')}.to raise_error SystemExit
+        expect { described_class.new('test') }.to raise_error SystemExit
       end
     end
 
     context 'with an available plugin' do
-      subject {described_class.new(plugin).name}
+      subject { described_class.new(plugin).name }
       let(:plugin) { 'test' }
 
       before do
@@ -294,7 +292,7 @@ describe Plugin do
   end
 
   describe '#gemfile_plugins_lines_for_dependencies' do
-    subject {plugin.gemfile_plugins_lines_for_dependencies}
+    subject { plugin.gemfile_plugins_lines_for_dependencies }
     let(:plugin) { described_class.new('test') }
     let(:dep1) { described_class.new('dep1') }
     let(:dep2) { described_class.new('dep2') }
@@ -323,7 +321,6 @@ describe Plugin do
     it 'contains the version of the plugin' do
       is_expected.to include(version)
     end
-
   end
 
   describe '#dependencies' do

--- a/spec/lib/plugin_manager_spec.rb
+++ b/spec/lib/plugin_manager_spec.rb
@@ -57,10 +57,6 @@ describe PluginManager do
         plugin_manager.add(plugin_to_add)
       end
 
-      it 'adds the dependencies of the plugin' do
-        expect(gemfile_plugins).to include(dependency)
-      end
-
       it 'does not add a plugin twice' do
         expect(count_of_plugin).to eql(1)
       end
@@ -94,8 +90,6 @@ describe PluginManager do
       }
       let(:plugin_manager) { described_class.new('test-environment') }
       let(:plugin_to_delete) { 'plugin_to_delete' }
-      let(:dependency_to_delete) { 'dependency_to_delete' }
-      let(:shared_dependency) { 'shared_dependency' }
       let(:other_plugin) { 'other_plugin' }
       let(:independent_plugin) { 'independent_plugin' }
       let(:plugin_specs) {
@@ -103,34 +97,19 @@ describe PluginManager do
           plugin_to_delete => {
             url: '',
             branch: '',
-            dependencies: [dependency_to_delete,
-                           shared_dependency,
-                           other_plugin]
-          },
-          dependency_to_delete => {
-            url: '',
-            branch: '',
-            dependencies: [plugin_to_delete]
-          },
-          shared_dependency => {
-            url: '',
-            branch: '',
           },
           other_plugin => {
             url: '',
             branch: '',
-            dependencies: [shared_dependency]
           },
           independent_plugin => {
             url: '',
             branch: '',
-            dependencies: [shared_dependency]
           }
         }
       }
       let(:gemfile_plugins) {
-        "#{plugin_to_delete}\n#{dependency_to_delete}\n#{shared_dependency}\
-        \n#{other_plugin}\n#{independent_plugin}"
+        "#{other_plugin}\n#{independent_plugin}"
       }
 
       before do
@@ -144,20 +123,12 @@ describe PluginManager do
         plugin_manager.remove(plugin_to_delete)
       end
 
-      it 'does not remove dependencies that are required by other plugins' do
-        expect(gemfile_plugins_new).to include(shared_dependency)
-      end
-
       it 'does not remove independent plugins' do
         expect(gemfile_plugins_new).to include(independent_plugin)
       end
 
       it 'does not remove plugins that could have been installed before' do
         expect(gemfile_plugins_new).to include(other_plugin)
-      end
-
-      it 'removes dependencies that are only required by this plugin' do
-        expect(gemfile_plugins_new).not_to include(dependency_to_delete)
       end
 
       it 'removes the plugin' do
@@ -303,58 +274,5 @@ describe Plugin do
       end
     end
   end
-
-  describe '#gemfile_plugins_lines_for_dependencies' do
-    subject { plugin.gemfile_plugins_lines_for_dependencies }
-    let(:plugin) { described_class.new('test') }
-    let(:dep1) { described_class.new('dep1') }
-    let(:dep2) { described_class.new('dep2') }
-    let(:dependencies) { [dep1, dep2] }
-    let(:version) { 'test-version' }
-    let(:plugin_specs) {
-      {
-        'test' => { version: version },
-        'dep1' => { version: version },
-        'dep2' => { version: version }
-      }
-    }
-
-    before do
-      allow(described_class).to receive(:available?).and_return(true)
-      allow(described_class).to receive(:available_plugins).and_return(plugin_specs)
-      allow(plugin).to receive(:dependencies).and_return(dependencies)
-    end
-
-    it 'contains all dependencies'do
-      dependencies.each do |dependency|
-        is_expected.to include(dependency.name)
-      end
-    end
-
-    it 'contains the version of the plugin' do
-      is_expected.to include(version)
-    end
-  end
-
-  describe '#dependencies' do
-    subject { plugin.dependencies.map(&:name) }
-    let(:plugin) { described_class.new('test') }
-    let(:dependencies) { ['dep1', 'dep2'] }
-    let(:available_plugins) {
-      {
-        'test' => {
-          dependencies: dependencies
-        }
-      }
-    }
-
-    before do
-      allow(described_class).to receive(:available?).and_return(true)
-      allow(described_class).to receive(:available_plugins).and_return(available_plugins)
-    end
-
-    it 'contains the correct dependencies' do
-      is_expected.to eql(dependencies)
-    end
-  end
 end
+


### PR DESCRIPTION
What we plan on doing:
- put steps into transactions
- include more sanity checks (e.g. a plugin is only listed once)
- introduce a blacklist-key for every plugin

What we might do:
- split the task up for developers
- rake plugin:add[community]

Comments welcome!

This is the relevant work package: https://community.openproject.org/work_packages/18720
