### PR TITLE
Extend API plugin capabilities

### DIFF
--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -38,7 +38,8 @@ module API
                    writable: true,
                    min_length: nil,
                    max_length: nil,
-                   regular_expression: nil)
+                   regular_expression: nil,
+                   show_if: true)
           raise ArgumentError if property.nil?
 
           property property,
@@ -55,7 +56,8 @@ module API
 
                      schema
                    },
-                   writeable: false
+                   writeable: false,
+                   if: show_if
         end
 
         def schema_with_allowed_link(property,

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -33,7 +33,7 @@ module API
       class << self
         def schema(property,
                    type:,
-                   title: make_title(property),
+                   name_source: property,
                    required: true,
                    writable: true,
                    min_length: nil,
@@ -41,22 +41,26 @@ module API
                    regular_expression: nil)
           raise ArgumentError if property.nil?
 
-          schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
-                                                                    name: title,
-                                                                    required: required,
-                                                                    writable: writable)
-          schema.min_length = min_length
-          schema.max_length = max_length
-          schema.regular_expression = regular_expression
-
           property property,
-                   getter: -> (*) { schema },
+                   exec_context: :decorator,
+                   getter: -> (*) {
+                     name = call_or_translate(name_source)
+                     schema = ::API::Decorators::PropertySchemaRepresenter.new(type: type,
+                                                                               name: name,
+                                                                               required: required,
+                                                                               writable: writable)
+                     schema.min_length = min_length
+                     schema.max_length = max_length
+                     schema.regular_expression = regular_expression
+
+                     schema
+                   },
                    writeable: false
         end
 
         def schema_with_allowed_link(property,
                                      type: make_type(property),
-                                     title: make_title(property),
+                                     name_source: property,
                                      href_callback:,
                                      required: true,
                                      writable: true)
@@ -67,7 +71,7 @@ module API
                    getter: -> (*) {
                      representer = ::API::Decorators::AllowedValuesByLinkRepresenter.new(
                        type: type,
-                       name: title,
+                       name: call_or_translate(name_source),
                        required: required,
                        writable: writable)
 
@@ -81,7 +85,7 @@ module API
 
         def schema_with_allowed_collection(property,
                                            type: make_type(property),
-                                           title: make_title(property),
+                                           name_source: property,
                                            values_callback:,
                                            value_representer:,
                                            link_factory:,
@@ -94,7 +98,7 @@ module API
                    getter: -> (*) {
                      representer = ::API::Decorators::AllowedValuesByCollectionRepresenter.new(
                        type: type,
-                       name: title,
+                       name: call_or_translate(name_source),
                        current_user: current_user,
                        value_representer: value_representer,
                        link_factory: -> (value) { instance_exec(value, &link_factory) },
@@ -114,12 +118,18 @@ module API
 
         private
 
-        def make_title(property_name)
-          represented_class.human_attribute_name(property_name)
-        end
-
         def make_type(property_name)
           property_name.to_s.camelize
+        end
+      end
+
+      private
+
+      def call_or_translate(object)
+        if object.respond_to? :call
+          object.call
+        else
+          self.class.represented_class.human_attribute_name(object)
         end
       end
     end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -170,7 +170,7 @@ module API
 
           @class.schema_with_allowed_collection property_name(custom_field.id),
                                                 type: 'Version',
-                                                title: custom_field.name,
+                                                name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
                                                   # for now we ASSUME that every customized will
                                                   # understand define that method if it has
@@ -192,7 +192,7 @@ module API
 
           @class.schema_with_allowed_link property_name(custom_field.id),
                                           type: 'User',
-                                          title: custom_field.name,
+                                          name_source: -> (*) { custom_field.name },
                                           required: custom_field.is_required,
                                           href_callback: -> (*) {
                                             # for now we ASSUME that every customized that has a
@@ -205,7 +205,7 @@ module API
           representer = StringObjects::StringObjectRepresenter
           @class.schema_with_allowed_collection property_name(custom_field.id),
                                                 type: 'StringObject',
-                                                title: custom_field.name,
+                                                name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
                                                   custom_field.possible_values
                                                 },
@@ -222,7 +222,7 @@ module API
         def inject_basic_schema(custom_field)
           @class.schema property_name(custom_field.id),
                         type: TYPE_MAP[custom_field.field_format],
-                        title: custom_field.name,
+                        name_source: -> (*) { custom_field.name },
                         required: custom_field.is_required,
                         writable: true,
                         min_length: (custom_field.min_length if custom_field.min_length > 0),

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -84,7 +84,7 @@ module API
           return nil if duration.nil? && allow_nil
 
           begin
-            iso_duration = ISO8601::Duration.new(duration)
+            iso_duration = ISO8601::Duration.new(duration.to_s)
             iso_duration.to_seconds / 3600.0
           rescue ISO8601::Errors::UnknownPattern
             raise API::Errors::PropertyFormatError.new(property_name,

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -80,6 +80,19 @@ module API
           Duration.new(hours_and_minutes(hours)).iso8601
         end
 
+        def self.parse_duration_to_hours(duration, property_name, allow_nil: false)
+          return nil if duration.nil? && allow_nil
+
+          begin
+            iso_duration = ISO8601::Duration.new(duration)
+            iso_duration.to_seconds / 3600.0
+          rescue ISO8601::Errors::UnknownPattern
+            raise API::Errors::PropertyFormatError.new(property_name,
+                                                       'ISO 8601 duration',
+                                                       duration)
+          end
+        end
+
         def self.hours_and_minutes(hours)
           hours = hours.to_f
           minutes = (hours - hours.to_i) * 60

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -53,12 +53,12 @@ module API
 
           schema :_type,
                  type: 'MetaType',
-                 title: I18n.t('api_v3.attributes._type'),
+                 name_source: -> (*) { I18n.t('api_v3.attributes._type') },
                  writable: false
 
           schema :lock_version,
                  type: 'Integer',
-                 title: I18n.t('api_v3.attributes.lock_version'),
+                 name_source: -> (*) { I18n.t('api_v3.attributes.lock_version') },
                  writable: false
 
           schema :id,
@@ -92,7 +92,7 @@ module API
 
           schema :percentage_done,
                  type: 'Integer',
-                 title: WorkPackage.human_attribute_name(:done_ratio),
+                 name_source: :done_ratio,
                  writable: false
 
           schema :created_at,

--- a/lib/api/v3/work_packages/work_package_contract.rb
+++ b/lib/api/v3/work_packages/work_package_contract.rb
@@ -35,20 +35,20 @@ module API
     module WorkPackages
       class WorkPackageContract < Reform::Contract
         def self.writable_attributes
-          @writable_attributes ||= [
-              'lock_version',
-              'subject',
-              'parent_id',
-              'description',
-              'start_date',
-              'due_date',
-              'status_id',
-              'assigned_to_id',
-              'responsible_id',
-              'priority_id',
-              'category_id',
-              'fixed_version_id'
-            ]
+          @writable_attributes ||= %w(
+            lock_version
+            subject
+            parent_id
+            description
+            start_date
+            due_date
+            status_id
+            assigned_to_id
+            responsible_id
+            priority_id
+            category_id
+            fixed_version_id
+          )
         end
 
         def initialize(object, user)

--- a/lib/api/v3/work_packages/work_package_contract.rb
+++ b/lib/api/v3/work_packages/work_package_contract.rb
@@ -34,20 +34,22 @@ module API
   module V3
     module WorkPackages
       class WorkPackageContract < Reform::Contract
-        WRITEABLE_ATTRIBUTES = [
-          'lock_version',
-          'subject',
-          'parent_id',
-          'description',
-          'start_date',
-          'due_date',
-          'status_id',
-          'assigned_to_id',
-          'responsible_id',
-          'priority_id',
-          'category_id',
-          'fixed_version_id'
-        ].freeze
+        def self.writable_attributes
+          @writable_attributes ||= [
+              'lock_version',
+              'subject',
+              'parent_id',
+              'description',
+              'start_date',
+              'due_date',
+              'status_id',
+              'assigned_to_id',
+              'responsible_id',
+              'priority_id',
+              'category_id',
+              'fixed_version_id'
+            ]
+        end
 
         def initialize(object, user)
           super(object)
@@ -94,7 +96,7 @@ module API
         end
 
         def readonly_attributes_unchanged
-          changed_attributes = model.changed - WRITEABLE_ATTRIBUTES
+          changed_attributes = model.changed - self.class.writable_attributes
 
           errors.add :error_readonly, changed_attributes unless changed_attributes.empty?
         end

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -139,6 +139,15 @@ module OpenProject::Plugins
         end
       end
 
+      base.send(:define_method, :allow_attribute_update) do |model, attribute|
+        config.to_prepare do
+          model_name = model.to_s.camelize
+          namespace = model_name.pluralize
+          contract_class = "::API::V3::#{namespace}::#{model_name}Contract".constantize
+          contract_class.writable_attributes << attribute.to_s
+        end
+      end
+
       base.class_eval do
         config.autoload_paths += Dir["#{config.root}/lib/"]
 

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -181,6 +181,12 @@ describe :DateTimeFormatter do
       }.to raise_error(API::Errors::PropertyFormatError)
     end
 
+    it 'rejects parsing pure numbers' do
+      expect {
+        subject.parse_duration_to_hours(5, 'prop')
+      }.to raise_error(API::Errors::PropertyFormatError)
+    end
+
     it_behaves_like 'can parse nil' do
       let(:method) { :parse_duration_to_hours }
       let(:input) { 'PT5H' }

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -155,4 +155,35 @@ describe :DateTimeFormatter do
       let(:input) { 5 }
     end
   end
+
+  describe 'parse_duration_to_hours' do
+    it 'parses ISO 8601 durations of full hours' do
+      expect(subject.parse_duration_to_hours('PT5H', 'prop')).to eql(5.0)
+    end
+
+    it 'parses ISO 8601 durations of fractional hours' do
+      expect(subject.parse_duration_to_hours('PT5H30M', 'prop')).to eql(5.5)
+    end
+
+    it 'parses ISO 8601 durations of days' do
+      expect(subject.parse_duration_to_hours('P1D', 'prop')).to eql(24.0)
+    end
+
+    it 'rejects parsing non sense' do
+      expect {
+        subject.parse_duration_to_hours('foo', 'prop')
+      }.to raise_error(API::Errors::PropertyFormatError)
+    end
+
+    it 'rejects parsing pure number strings' do
+      expect {
+        subject.parse_duration_to_hours('5', 'prop')
+      }.to raise_error(API::Errors::PropertyFormatError)
+    end
+
+    it_behaves_like 'can parse nil' do
+      let(:method) { :parse_duration_to_hours }
+      let(:input) { 'PT5H' }
+    end
+  end
 end

--- a/spec/lib/open_project/plugins/acts_as_op_engine_spec.rb
+++ b/spec/lib/open_project/plugins/acts_as_op_engine_spec.rb
@@ -55,7 +55,11 @@ describe OpenProject::Plugins::ActsAsOpEngine do
   end
 
   describe '#extend_api_response' do
-    it 'should lookup and extend an existing Decorator' do
+    xit 'should lookup and extend an existing Decorator' do
+      # This test does not work as intended...
+      # The actual work done by :extend_api_response is not performed unless the engine is started
+      # However, it would be green because all attributes of the represented are magically added
+      # to the representer...
       module API
         module VTest
           module WorkPackages


### PR DESCRIPTION
This PR contains some required extensions for [OpenProject #19044](https://community.openproject.org/work_packages/19044).

Notably:
- support for parsing ISO 8601 durations (also useful for #2598)
- possibility to hide specific fields from the schema
- a fix regarding the localization of schema properties
