### PR TITLE
[Zurb] Fix up custom field handling for different types

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -43,6 +43,8 @@
 //= require ./bundles/openproject-core-app
 //= require_tree ./bundles
 
+//= require custom-fields
+
 //source: http://stackoverflow.com/questions/8120065/jquery-and-prototype-dont-work-together-with-array-prototype-reverse
 if (typeof []._reverse == 'undefined') {
     jQuery.fn.reverse = Array.prototype.reverse;

--- a/app/assets/javascripts/custom-fields.js
+++ b/app/assets/javascripts/custom-fields.js
@@ -1,0 +1,134 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+(function($) {
+  /*
+   * @see /app/views/custom_fields/_form.html.erb
+   */
+  $(function() {
+    var customFieldForm = $('#custom_field_form');
+
+    if (customFieldForm.length === 0) {
+      return;
+    }
+
+    // collect the nodes involved
+    var format                = $('#custom_field_field_format'),
+        lengthField           = $('#custom_field_length'),
+        regexpField           = $('#custom_field_regexp'),
+        possibleValues        = $('#custom_field_possible_values_attributes'),
+        defaultValueFields    = $('#custom_field_default_value_attributes'),
+        spanDefaultTextMulti  = $('#default_value_text_multi'),
+        spanDefaultTextSingle = $('#default_value_text_single'),
+        spanDefaultBool       = $('#default_value_bool');
+
+    var deactivate = function(element) {
+      element.hide().find('input, textarea').not('.destroy_flag').attr('disabled', true);
+    },
+    activate = function(element) {
+      element.show().find('input, textarea').not('.destroy_flag').removeAttr('disabled');
+    },
+    toggleVisibility = function(method, args) {
+      var fields = Array.prototype.slice.call(args);
+      $.each(fields, function(idx, field) {
+        field.closest('.form--field, .form--grouping')[method]();
+      });
+    },
+    hide = function() { toggleVisibility('hide', arguments); },
+    show = function() { toggleVisibility('show', arguments); },
+    toggleFormat = function() {
+      var searchable   = $('#searchable_container'),
+          unsearchable = function() { searchable.attr('checked', false).hide(); };
+
+      // defaults (reset these fields before doing anything else)
+      $.each([spanDefaultBool, spanDefaultTextSingle], function(idx, element) {
+        deactivate(element);
+      });
+      show(defaultValueFields);
+      activate(spanDefaultTextMulti);
+
+      switch (format.val()) {
+        case 'list':
+          hide(lengthField, regexpField);
+          show(searchable);
+          activate(possibleValues);
+          break;
+        case 'bool':
+          activate(spanDefaultBool);
+          deactivate(spanDefaultTextMulti);
+          deactivate(possibleValues);
+          hide(lengthField, regexpField, searchable);
+          unsearchable();
+          break;
+        case 'date':
+          activate(spanDefaultTextSingle);
+          deactivate(spanDefaultTextMulti);
+          deactivate(possibleValues);
+          hide(lengthField, regexpField);
+          unsearchable();
+          break;
+        case 'float':
+        case 'int':
+          activate(spanDefaultTextSingle);
+          deactivate(spanDefaultTextMulti);
+          deactivate(possibleValues);
+          show(lengthField, regexpField);
+          unsearchable();
+          break;
+        case 'user':
+        case 'version':
+          deactivate(defaultValueFields);
+          deactivate(possibleValues);
+          hide(lengthField, regexpField, defaultValueFields);
+          unsearchable();
+          break;
+        default:
+          show(lengthField, regexpField, searchable);
+          deactivate(possibleValues);
+          break;
+      }
+    };
+
+    // assign the switch format function to the select field
+    format.on('change', toggleFormat).trigger('change');
+  });
+
+  $(function() {
+    var localeSelectors = $('.locale_selector');
+
+    localeSelectors.each(function (_, element) {
+      var select = $(element);
+      select.children('option:selected').each(function(_, option) {
+        var span = $(option).parents('span.translation');
+        if (typeof span.attr('lang') === 'string') {
+          span.removeAttr('lang');
+        }
+        span.attr('lang', option.value);
+      });
+    }).trigger('change');
+  });
+}(jQuery));

--- a/app/assets/javascripts/custom-fields.js
+++ b/app/assets/javascripts/custom-fields.js
@@ -120,15 +120,10 @@
   $(function() {
     var localeSelectors = $('.locale_selector');
 
-    localeSelectors.each(function (_, element) {
-      var select = $(element);
-      select.children('option:selected').each(function(_, option) {
-        var span = $(option).parents('span.translation');
-        if (typeof span.attr('lang') === 'string') {
-          span.removeAttr('lang');
-        }
-        span.attr('lang', option.value);
-      });
+    localeSelectors.change(function () {
+      var lang = $(this).val(),
+          span = $(this).closest('.translation');
+      span.attr('lang', lang);
     }).trigger('change');
   });
 }(jQuery));

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -27,112 +27,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= error_messages_for 'custom_field' %>
-<script type="text/javascript">
-  //<![CDATA[
-  function toggle_custom_field_format() {
-    var format = $("custom_field_field_format");
-    var p_length = $("custom_field_min_length");
-    var p_regexp = $("custom_field_regexp");
-    var p_values = $("custom_field_possible_values_attributes");
-    var p_searchable = $("custom_field_searchable");
-    var p_default_value = $("custom_field_default_value_attributes");
-    var span_default_text_multi = $("default_value_text_multi");
-    var span_default_text_single = $("default_value_text_single");
-    var span_default_bool = $("default_value_bool");
-    var hide_and_disable = function(element) {
-      element.hide().
-              select('input, textbox').each(function (element) {
-                                        if(!element.match('.destroy_flag')) {
-                                          element.writeAttribute('disabled', 'disabled');
-                                        }
-                                      });
-    }
-    var show_and_enable = function(element) {
-      element.show().
-              select('input, textbox').each(function (element) {
-                                        if(!element.match('.destroy_flag')) {
-                                          element.removeAttribute('disabled');
-                                        }
-                                      });
-    }
 
-    hide_and_disable(span_default_bool);
-    hide_and_disable(span_default_text_single);
-    show_and_enable(span_default_text_multi);
-    Element.show(p_default_value);
-
-    switch (format.value) {
-      case "list":
-        Element.hide(p_length.parentNode);
-        Element.hide(p_regexp.parentNode);
-        if (p_searchable) Element.show(p_searchable.parentNode);
-        show_and_enable(p_values);
-        break;
-      case "bool":
-        show_and_enable(span_default_bool);
-        hide_and_disable(span_default_text_multi);
-        Element.hide(p_length.parentNode);
-        Element.hide(p_regexp.parentNode);
-        if (p_searchable) Element.hide(p_searchable.parentNode);
-        hide_and_disable(p_values);
-        break;
-      case "date":
-        hide_and_disable(span_default_text_multi);
-        show_and_enable(span_default_text_single);
-        Element.hide(p_length.parentNode);
-        Element.hide(p_regexp.parentNode);
-        if (p_searchable) Element.hide(p_searchable.parentNode);
-        hide_and_disable(p_values);
-        break;
-      case "float":
-      case "int":
-        hide_and_disable(span_default_text_multi);
-        show_and_enable(span_default_text_single);
-        Element.show(p_length.parentNode);
-        Element.show(p_regexp.parentNode);
-        if (p_searchable) Element.hide(p_searchable.parentNode);
-        hide_and_disable(p_values);
-        break;
-      case "user":
-      case "version":
-        Element.hide(p_length.parentNode);
-        Element.hide(p_regexp.parentNode);
-        if (p_searchable) Element.hide(p_searchable.parentNode);
-        hide_and_disable(p_values);
-        Element.hide(p_default_value);
-        break;
-      default:
-        Element.show(p_length.parentNode);
-        Element.show(p_regexp.parentNode);
-        if (p_searchable) Element.show(p_searchable.parentNode);
-        hide_and_disable(p_values);
-        break;
-    }
-  }
-
-  function initLocaleChangeListener() {
-  jQuery(".locale_selector").each(function (index) {
-      var localeSelector = jQuery(this);
-
-      localeSelector.change(function () {
-        localeSelector.children("option:selected").each(function () {
-          //alert(jQuery(this).attr('value'));
-          var span = jQuery(jQuery(this).parents("span.translation")[0])
-
-          if (typeof span.attr('lang') !== 'undefined') {
-            span.removeAttr('lang');
-          }
-
-          span.attr('lang', jQuery(this).attr('value'));
-        });
-      });
-
-      localeSelector.change();
-  });
-  }
-  //]]>
-</script>
-<section class="form--section">
+<section class="form--section" id="custom_field_form">
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name,
                      :multi_locale => true %>
@@ -141,23 +37,23 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= f.select :field_format,
                  custom_field_formats_for_select(@custom_field),
                  {},
-                 :onchange => "toggle_custom_field_format();",
-                 :disabled => !@custom_field.new_record? %>
+                 disabled: !@custom_field.new_record? %>
   </div>
-  <div class="form--field">
-    <label class="form--label" for="custom_field_min_length"><%=l(:label_min_max_length)%></label>
-    <span class="form--field-container">
-      <%= f.text_field :min_length,
-                       :size => 5,
-                       :no_label => true %> -
-      <%= f.text_field :max_length,
-                       :size => 5,
-                       :no_label => true %>
-    </span>
-    <span class="form--field-instructions">
-      <%=l(:text_min_max_length_info)%>
-    </span>
+  <div class="form--grouping" id="custom_field_length">
+    <div class="form--grouping-label">
+      <%= l(:label_min_max_length) %> <br>
+      <small>(<%= l(:text_min_max_length_info ) %>)</small>
+    </div>
+    <div class="form--grouping-row">
+      <div class="form--field">
+        <%= f.text_field :min_length %>
+      </div>
+      <div class="form--field">
+        <%= f.text_field :max_length %>
+      </div>
+    </div>
   </div>
+
   <div class="form--field">
     <%= f.text_field :regexp,
                      :size => 50 %>
@@ -219,7 +115,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= f.check_box :is_required %></div>
     <div class="form--field"><%= f.check_box :is_for_all %></div>
     <div class="form--field"><%= f.check_box :is_filter %></div>
-    <div class="form--field"><%= f.check_box :searchable %></div>
+    <div class="form--field" id="searchable_container"><%= f.check_box :searchable %></div>
   <% when "UserCustomField" %>
     <div class="form--field"><%= f.check_box :is_required %></div>
     <div class="form--field"><%= f.check_box :visible %></div>
@@ -227,7 +123,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% when "ProjectCustomField" %>
     <div class="form--field"><%= f.check_box :is_required %></div>
     <div class="form--field"><%= f.check_box :visible %></div>
-    <div class="form--field"><%= f.check_box :searchable %></div>
+    <div class="form--field" id="searchable_container"><%= f.check_box :searchable %></div>
   <% when "TimeEntryCustomField" %>
     <div class="form--field"><%= f.check_box :is_required %></div>
   <% else %>
@@ -236,5 +132,3 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= call_hook(:"view_custom_fields_form_#{@custom_field.type.to_s.underscore}", :custom_field => @custom_field, :form => f) %>
 </section>
 
-<%= javascript_tag "toggle_custom_field_format();" %>
-<%= javascript_tag "initLocaleChangeListener();" %>

--- a/features/custom_fields/create_bool.feature
+++ b/features/custom_fields/create_bool.feature
@@ -45,8 +45,8 @@ Feature: Localized boolean custom fields can be created
   Scenario: Available fields
     When I select "Boolean" from "custom_field_field_format"
     Then there should be the following localizations:
-      | locale  | name    | default_value | possible_values |
-      | en      |         | 0             |                 |
+      | locale  | name    | default_value |
+      | en      |         | 0             |
     And there should be a "custom_field_type_ids_1" field visible
     And I should see "Bug"
     And there should be a "custom_field_type_ids_2" field visible


### PR DESCRIPTION
This will refactor the prototype.js based solution for type format handling in
the custom fields into a Jquery based variant, hopefully providing the same
functionality.

In addition, it repairs the error reported in https://community.openproject.org/work_packages/19094.

As an added bonus, it gets rid of https://community.openproject.org/work_packages/19096
