### PR TITLE
[Zurb] Fix styling for embedded ticket in wiki

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -190,5 +190,11 @@ h1:hover, h2:hover, h3:hover
       background: url(image-path('wiki_styles/note_small.png')) 5px 4px no-repeat #F5FFFA
       border: 1px solid #C7CFCA
 
+  .quick_info .label
+    background: none
+    color: #000
+    font-weight: bold
+    font-size: $wiki-default-font-size
+
 .wiki-content
   width: 700px


### PR DESCRIPTION
Restores the style for the embedded tickets in the wiki. This was previously
overridden by the default style for labels.

Meets https://community.openproject.org/work_packages/19102
