### PR TITLE
[Foundation] Rearrange the top of the work packages form

### DIFF
--- a/app/views/work_packages/_form.html.erb
+++ b/app/views/work_packages/_form.html.erb
@@ -29,12 +29,37 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= call_hook(:view_work_packages_form_details_top, { :issue => work_package, :form => f }) %>
 
-<% work_package_form_top_attributes(f, work_package,
-                                       :priorities => priorities,
-                                       :project => project).each do |attribute| %>
-  <%= attribute.field %>
-
+<div class="grid-block">
+  <div class="form--column">
+    <div class="form--field">
+      <%= f.select :type_id, work_package_form_type_selectable_types(project) %>
+      <%= observe_field :work_package_type_id, url: work_package_form_type_observable_url(work_package, project),
+                                                  update: :attributes,
+                                                  method: :get,
+                                                  with: "Form.serialize('work_package-form')" %>
+    </div>
+  </div>
+  <% if user_can_manage_subtasks?(project) %>
+    <div class="form--column">
+      <div class="form--field">
+        <%= f.text_field :parent_id, title: l(:description_autocomplete) %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<% if user_can_manage_subtasks?(project) %>
+  <div id="parent_issue_candidates" class="autocomplete"></div>
+  <script>
+    observeWorkPackageParentField('<%= work_package_form_parent_autocomplete_path(work_package, project) %>')
+  </script>
 <% end %>
+<div class="form--field -vertical">
+  <%= f.text_field :subject, required: true %>
+</div>
+<div class="form--field -vertical">
+  <%= f.text_area :description, accesskey: accesskey(:edit),  class: 'wiki-edit',:'ng-non-bindable' => '',
+                  :'data-wp_autocomplete_url' => work_packages_auto_complete_path(project_id: work_package.project, format: :json) %>
+</div>
 
 <div id="attributes" class="attributes">
   <%= render :partial => 'attributes', :locals => { :f => f,

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -46,8 +46,8 @@ describe 'New work package', type: :feature do
 
         work_packages_page.visit_new
 
-        input = page.find('#work_package_start_date')
-        input.click
+        # Fill in the date, a sa simple click does not seem to trigger the datepicker here
+        fill_in 'Start date', with: DateTime.now.strftime('%Y-%m-%d')
 
         expect(page).to have_selector(datepicker_selector)
       end


### PR DESCRIPTION
As requested, this rearranges the top part of the work packages form.

Meets a quick win requirement of https://community.openproject.org/work_packages/19073
