### PR TITLE
19416 Switch zoomSlider directive to use HTML5 input[type="range"]

### DIFF
--- a/frontend/app/templates/components/zoom_slider.html
+++ b/frontend/app/templates/components/zoom_slider.html
@@ -1,0 +1,5 @@
+<label for="{{ ::sliderId }}" class="hidden-for-sighted"
+  ng-bind="::labelText"></label>
+<input type="range" id="{{ ::sliderId }}"
+  min="{{ ::minValue }}" max="{{ ::maxValue }}"
+  value="{{ currentScaleIndex + 1 }}">

--- a/frontend/app/templates/components/zoom_slider.html
+++ b/frontend/app/templates/components/zoom_slider.html
@@ -1,5 +1,5 @@
-<label for="{{ ::sliderId }}" class="hidden-for-sighted"
+<label for="{{ ::ctrl.sliderId }}" class="hidden-for-sighted"
   ng-bind="::labelText"></label>
-<input type="range" id="{{ ::sliderId }}"
-  min="{{ ::minValue }}" max="{{ ::maxValue }}"
-  value="{{ selectedScaleIndex + 1 }}">
+<input type="range" id="{{ ::ctrl.sliderId }}"
+  min="{{ ::ctrl.minValue }}" max="{{ ::ctrl.maxValue }}"
+  value="{{ ctrl.selectedScaleIndex + 1 }}">

--- a/frontend/app/templates/components/zoom_slider.html
+++ b/frontend/app/templates/components/zoom_slider.html
@@ -2,4 +2,4 @@
   ng-bind="::labelText"></label>
 <input type="range" id="{{ ::sliderId }}"
   min="{{ ::minValue }}" max="{{ ::maxValue }}"
-  value="{{ currentScaleIndex + 1 }}">
+  value="{{ selectedScaleIndex + 1 }}">

--- a/frontend/app/templates/timelines/toolbar.html
+++ b/frontend/app/templates/timelines/toolbar.html
@@ -1,6 +1,6 @@
 <div class="tl-toolbar legacy-actions--inline-label" ng-show="!warning">
   <div class="tl-toolbar-container">
-    <a href="javascript://" ng-if='timeline.USE_MODALS' ng-click="timeline.addPlanningElement()" title="{{I18n.t('js.timelines.new_work_package')}}" class="icon icon-add">
+    <a href="javascript://" ng-if='ctrl.timeline.USE_MODALS' ng-click="ctrl.timeline.addPlanningElement()" title="{{I18n.t('js.timelines.new_work_package')}}" class="icon icon-add">
       <span class="hidden-for-sighted">{{ I18n.t('js.timelines.new_work_package') }}</span>
     </a>
   </div>
@@ -8,23 +8,23 @@
   <div class="tl-toolbar-container" style="width: 1px; height: 20px; background-color: rgb(0, 0, 0);"></div>
 
   <div class="tl-toolbar-container">
-    <a href="javascript://" title="{{ I18n.t('js.timelines.zoom.out') }}" class="icon icon-zoom-out" ng-click="decreaseZoom()"></a>
+    <a href="javascript://" title="{{ I18n.t('js.timelines.zoom.out') }}" class="icon icon-zoom-out" ng-click="ctrl.decreaseZoom()"></a>
   </div>
 
   <div class="tl-toolbar-container" style="width: 100px; height: 20px;">
-    <zoom-slider scales="::timeline.ZOOM_SCALES"
-      selected-scale="currentScale"></zoom-slider>
+    <zoom-slider scales="::ctrl.timeline.ZOOM_SCALES"
+      selected-scale="ctrl.currentScale"></zoom-slider>
   </div>
 
   <div class="tl-toolbar-container">
-    <a href="javascript://" title="{{ I18n.t('js.timelines.zoom.in') }}" class="icon icon-zoom-in" ng-click="increaseZoom()"></a>
+    <a href="javascript://" title="{{ I18n.t('js.timelines.zoom.in') }}" class="icon icon-zoom-in" ng-click="ctrl.increaseZoom()"></a>
   </div>
 
 
   <div class="tl-toolbar-container">
     <form>
       <label for="tl-toolbar-zooms" class="hidden-for-sighted">{{ I18n.t('js.tl_toolbar.zooms') }}</label>
-      <select id="tl-toolbar-zooms" name="zooms" ng-model="currentScale" ng-options="I18n.t('js.' + timeline.ZOOM_CONFIGURATIONS[scale].name) for scale in timeline.ZOOM_SCALES">
+      <select id="tl-toolbar-zooms" name="zooms" ng-model="ctrl.currentScale" ng-options="I18n.t('js.' + ctrl.timeline.ZOOM_CONFIGURATIONS[scale].name) for scale in ctrl.timeline.ZOOM_SCALES">
       </select>
     </form>
   </div>
@@ -32,13 +32,13 @@
   <div class="tl-toolbar-container" style="width: 1px; height: 20px; background-color: rgb(0, 0, 0);"></div>
 
   <div class="tl-toolbar-container">
-    <a href="javascript://" title="{{ I18n.t('js.timelines.outline') }}" class="icon icon-outline" ng-click="resetOutline()"></a>
+    <a href="javascript://" title="{{ I18n.t('js.timelines.outline') }}" class="icon icon-outline" ng-click="ctrl.resetOutline()"></a>
   </div>
 
   <div class="tl-toolbar-container">
     <form>
       <label for="tl-toolbar-outlines" class="hidden-for-sighted">{{ I18n.t('js.tl_toolbar.outlines') }}</label>
-      <select id="tl-toolbar-outlines" name="outlines" ng-model="currentOutlineLevel" ng-options="I18n.t('js.' + timeline.OUTLINE_CONFIGURATIONS[level].name) for level in timeline.OUTLINE_LEVELS">
+      <select id="tl-toolbar-outlines" name="outlines" ng-model="ctrl.currentOutlineLevel" ng-options="I18n.t('js.' + ctrl.timeline.OUTLINE_CONFIGURATIONS[level].name) for level in ctrl.timeline.OUTLINE_LEVELS">
       </select>
     </form>
   </div>

--- a/frontend/app/templates/timelines/toolbar.html
+++ b/frontend/app/templates/timelines/toolbar.html
@@ -12,9 +12,8 @@
   </div>
 
   <div class="tl-toolbar-container" style="width: 100px; height: 20px;">
-    <div id="zoom-slider" zoom-slider
-      scales="::timeline.ZOOM_SCALES"
-      selected-scale="currentScale"></div>
+    <zoom-slider scales="::timeline.ZOOM_SCALES"
+      selected-scale="currentScale"></zoom-slider>
   </div>
 
   <div class="tl-toolbar-container">

--- a/frontend/app/templates/timelines/toolbar.html
+++ b/frontend/app/templates/timelines/toolbar.html
@@ -12,7 +12,9 @@
   </div>
 
   <div class="tl-toolbar-container" style="width: 100px; height: 20px;">
-    <div id="zoom-slider" zoom-slider></div>
+    <div id="zoom-slider" zoom-slider
+      scales="::timeline.ZOOM_SCALES"
+      selected-scale="currentScaleName"></div>
   </div>
 
   <div class="tl-toolbar-container">

--- a/frontend/app/templates/timelines/toolbar.html
+++ b/frontend/app/templates/timelines/toolbar.html
@@ -14,7 +14,7 @@
   <div class="tl-toolbar-container" style="width: 100px; height: 20px;">
     <div id="zoom-slider" zoom-slider
       scales="::timeline.ZOOM_SCALES"
-      selected-scale="currentScaleName"></div>
+      selected-scale="currentScale"></div>
   </div>
 
   <div class="tl-toolbar-container">
@@ -25,7 +25,7 @@
   <div class="tl-toolbar-container">
     <form>
       <label for="tl-toolbar-zooms" class="hidden-for-sighted">{{ I18n.t('js.tl_toolbar.zooms') }}</label>
-      <select id="tl-toolbar-zooms" name="zooms" ng-model="currentScaleName" ng-options="I18n.t('js.' + timeline.ZOOM_CONFIGURATIONS[scale].name) for scale in timeline.ZOOM_SCALES">
+      <select id="tl-toolbar-zooms" name="zooms" ng-model="currentScale" ng-options="I18n.t('js.' + timeline.ZOOM_CONFIGURATIONS[scale].name) for scale in timeline.ZOOM_SCALES">
       </select>
     </form>
   </div>

--- a/frontend/app/timelines/directives/timeline-toolbar-directive.js
+++ b/frontend/app/timelines/directives/timeline-toolbar-directive.js
@@ -38,7 +38,6 @@ module.exports = function(I18n) {
       scope.currentScaleName = 'monthly';
 
       scope.updateToolbar = function() {
-        scope.slider.slider('value', scope.timeline.zoomIndex + 1);
         scope.currentOutlineLevel = scope.timeline.OUTLINE_LEVELS[scope.timeline.expansionIndex];
         scope.currentScaleName = scope.timeline.ZOOM_SCALES[scope.timeline.zoomIndex];
       };
@@ -61,7 +60,6 @@ module.exports = function(I18n) {
       scope.$watch('currentScaleName', function(newScaleName, oldScaleName){
         if (newScaleName !== oldScaleName) {
           scope.currentScaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScaleName);
-          scope.slider.slider('value', scope.currentScaleIndex + 1);
 
           scope.timeline.zoom(scope.currentScaleIndex); // TODO replace event-driven adaption by bindings
         }

--- a/frontend/app/timelines/directives/timeline-toolbar-directive.js
+++ b/frontend/app/timelines/directives/timeline-toolbar-directive.js
@@ -33,52 +33,60 @@ module.exports = function(I18n) {
     replace: true,
     templateUrl: '/templates/timelines/toolbar.html',
     scope: { timeline: '=' },
-    link: function(scope) {
-      scope.I18n = I18n;
-      scope.currentScale = 'monthly';
+    controller: function() {
+      var vm = this;
 
-      scope.updateToolbar = function() {
-        scope.currentOutlineLevel = scope.timeline.OUTLINE_LEVELS[scope.timeline.expansionIndex];
-        scope.currentScale = scope.timeline.ZOOM_SCALES[scope.timeline.zoomIndex];
+      vm.currentScale = 'monthly';
+
+      vm.updateToolbar = function() {
+        vm.currentOutlineLevel = vm.timeline.OUTLINE_LEVELS[vm.timeline.expansionIndex];
+        vm.currentScale = vm.timeline.ZOOM_SCALES[vm.timeline.zoomIndex];
       };
 
-      scope.increaseZoom = function() {
-        var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
+      vm.increaseZoom = function() {
+        var scaleIndex = vm.timeline.ZOOM_SCALES.indexOf(vm.currentScale);
 
-        if(scaleIndex < Object.keys(scope.timeline.ZOOM_CONFIGURATIONS).length - 1) {
+        if(scaleIndex < Object.keys(vm.timeline.ZOOM_CONFIGURATIONS).length - 1) {
           scaleIndex++;
         }
-        scope.currentScale = scope.timeline.ZOOM_SCALES[scaleIndex];
+        vm.currentScale = vm.timeline.ZOOM_SCALES[scaleIndex];
       };
-      scope.decreaseZoom = function() {
-        var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
+
+      vm.decreaseZoom = function() {
+        var scaleIndex = vm.timeline.ZOOM_SCALES.indexOf(vm.currentScale);
 
         if(scaleIndex > 0) {
           scaleIndex--;
         }
-        scope.currentScale = scope.timeline.ZOOM_SCALES[scaleIndex];
-      };
-      scope.resetOutline = function(){
-        scope.timeline.expandTo(0);
-        scope.currentOutlineLevel = scope.timeline.OUTLINE_LEVELS[scope.timeline.expansionIndex];
+        vm.currentScale = vm.timeline.ZOOM_SCALES[scaleIndex];
       };
 
-      scope.$watch('currentScale', function(newScale, oldScale){
+      vm.resetOutline = function(){
+        vm.timeline.expandTo(0);
+        vm.currentOutlineLevel = vm.timeline.OUTLINE_LEVELS[vm.timeline.expansionIndex];
+      };
+    },
+    controllerAs: 'ctrl',
+    bindToController: true,
+    link: function(scope, _element, _attributes, ctrl) {
+      scope.I18n = I18n;
+
+      scope.$watch('ctrl.currentScale', function(newScale, oldScale){
         if (newScale !== oldScale) {
-          var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
+          var scaleIndex = ctrl.timeline.ZOOM_SCALES.indexOf(ctrl.currentScale);
 
-          scope.timeline.zoom(scaleIndex);
+          ctrl.timeline.zoom(scaleIndex);
         }
       });
 
-      scope.$watch('currentOutlineLevel', function(outlineLevel, formerLevel) {
+      scope.$watch('ctrl.currentOutlineLevel', function(outlineLevel, formerLevel) {
         if (outlineLevel !== formerLevel) {
-          scope.timeline.expansionIndex = scope.timeline.OUTLINE_LEVELS.indexOf(outlineLevel);
-          scope.timeline.expandToOutlineLevel(outlineLevel); // TODO replace event-driven adaption by bindings
+          ctrl.timeline.expansionIndex = ctrl.timeline.OUTLINE_LEVELS.indexOf(outlineLevel);
+          ctrl.timeline.expandToOutlineLevel(outlineLevel); // TODO replace event-driven adaption by bindings
         }
       });
 
-      scope.updateToolbar();
+      ctrl.updateToolbar();
     }
   };
 };

--- a/frontend/app/timelines/directives/timeline-toolbar-directive.js
+++ b/frontend/app/timelines/directives/timeline-toolbar-directive.js
@@ -35,33 +35,39 @@ module.exports = function(I18n) {
     scope: { timeline: '=' },
     link: function(scope) {
       scope.I18n = I18n;
-      scope.currentScaleName = 'monthly';
+      scope.currentScale = 'monthly';
 
       scope.updateToolbar = function() {
         scope.currentOutlineLevel = scope.timeline.OUTLINE_LEVELS[scope.timeline.expansionIndex];
-        scope.currentScaleName = scope.timeline.ZOOM_SCALES[scope.timeline.zoomIndex];
+        scope.currentScale = scope.timeline.ZOOM_SCALES[scope.timeline.zoomIndex];
       };
 
       scope.increaseZoom = function() {
-        if(scope.currentScaleIndex < Object.keys(scope.timeline.ZOOM_CONFIGURATIONS).length - 1) {
-          scope.currentScaleIndex++;
+        var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
+
+        if(scaleIndex < Object.keys(scope.timeline.ZOOM_CONFIGURATIONS).length - 1) {
+          scaleIndex++;
         }
+        scope.currentScale = scope.timeline.ZOOM_SCALES[scaleIndex];
       };
       scope.decreaseZoom = function() {
-        if(scope.currentScaleIndex > 0) {
-          scope.currentScaleIndex--;
+        var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
+
+        if(scaleIndex > 0) {
+          scaleIndex--;
         }
+        scope.currentScale = scope.timeline.ZOOM_SCALES[scaleIndex];
       };
       scope.resetOutline = function(){
         scope.timeline.expandTo(0);
         scope.currentOutlineLevel = scope.timeline.OUTLINE_LEVELS[scope.timeline.expansionIndex];
       };
 
-      scope.$watch('currentScaleName', function(newScaleName, oldScaleName){
-        if (newScaleName !== oldScaleName) {
-          scope.currentScaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScaleName);
+      scope.$watch('currentScale', function(newScale, oldScale){
+        if (newScale !== oldScale) {
+          var scaleIndex = scope.timeline.ZOOM_SCALES.indexOf(scope.currentScale);
 
-          scope.timeline.zoom(scope.currentScaleIndex); // TODO replace event-driven adaption by bindings
+          scope.timeline.zoom(scaleIndex);
         }
       });
 

--- a/frontend/app/timelines/models/timeline.js
+++ b/frontend/app/timelines/models/timeline.js
@@ -264,8 +264,6 @@ module.exports = function(Constants, TreeNode, UI, Color, HistoricalPlanningElem
     checkPrerequisites: function() {
       if (jQuery === undefined) {
         throw new Error('jQuery seems to be missing (jQuery is undefined)');
-      } else if (jQuery().slider === undefined) {
-        throw new Error('jQuery UI seems to be missing (jQuery().slider is undefined)');
       } else if ((1).month === undefined) {
         throw new Error('date.js seems to be missing ((1).month is undefined)');
       }

--- a/frontend/app/ui_components/zoom-slider-directive.js
+++ b/frontend/app/ui_components/zoom-slider-directive.js
@@ -31,7 +31,7 @@ module.exports = function(I18n) {
   var latestId = 0;
 
   return {
-    restrict: 'A',
+    restrict: 'E',
     scope: {
       scales: '=',
       selectedScale: '='

--- a/frontend/app/ui_components/zoom-slider-directive.js
+++ b/frontend/app/ui_components/zoom-slider-directive.js
@@ -28,40 +28,24 @@
 
 module.exports = function(I18n) {
 
-  function makeSliderAccessible(slider) {
-    var defaultLabel = angular.element('<span class="hidden-for-sighted">');
-    var sliderLabel = defaultLabel.text(I18n.t('js.timelines.zoom.slider'));
-    var sliderHandle = slider.find('a.ui-slider-handle');
-
-    sliderHandle.append(sliderLabel);
-  }
+  var latestId = 0;
 
   // TODO pass options to directive and do not refer to timelines
   return {
     restrict: 'A',
+    templateUrl: '/templates/components/zoom_slider.html',
     link: function(scope, element, attributes) {
       scope.currentScaleIndex = Timeline.ZOOM_SCALES.indexOf(scope.currentScaleName);
-      scope.slider = element.slider({
-        min: 1,
-        max: Timeline.ZOOM_SCALES.length,
-        range: 'min',
-        value: scope.currentScaleIndex + 1,
-        slide: function(event, ui) {
-          scope.currentScaleIndex = ui.value - 1;
-          scope.$apply();
-        },
-        change: function(event, ui) {
-          scope.currentScaleIndex = ui.value - 1;
-        }
-      }).css({
-        // top right bottom left
-        'margin': '4px 6px 3px'
+      scope.minValue = 1;
+      scope.maxValue = Timeline.ZOOM_SCALES.length;
+      scope.sliderId = 'zoom-slider-' + latestId++;
+      scope.labelText = I18n.t('js.timelines.zoom.slider');
+
+      var slider = element.find('input');
+      slider.on('change', function() {
+        scope.currentScaleIndex = slider.val() - 1;
+        scope.$apply();
       });
-
-      // Slider
-      // TODO integrate angular-ui-slider
-
-      makeSliderAccessible(scope.slider);
 
       scope.$watch('currentScaleIndex', function(newIndex){
         scope.currentScaleIndex = newIndex;

--- a/frontend/app/ui_components/zoom-slider-directive.js
+++ b/frontend/app/ui_components/zoom-slider-directive.js
@@ -30,29 +30,31 @@ module.exports = function(I18n) {
 
   var latestId = 0;
 
-  // TODO pass options to directive and do not refer to timelines
   return {
     restrict: 'A',
+    scope: {
+      scales: '=',
+      selectedScale: '='
+    },
     templateUrl: '/templates/components/zoom_slider.html',
     link: function(scope, element, attributes) {
-      scope.currentScaleIndex = Timeline.ZOOM_SCALES.indexOf(scope.currentScaleName);
       scope.minValue = 1;
-      scope.maxValue = Timeline.ZOOM_SCALES.length;
+      scope.maxValue = scope.scales.length;
       scope.sliderId = 'zoom-slider-' + latestId++;
       scope.labelText = I18n.t('js.timelines.zoom.slider');
 
       var slider = element.find('input');
       slider.on('change', function() {
-        scope.currentScaleIndex = slider.val() - 1;
+        scope.selectedScaleIndex = slider.val() - 1;
+        scope.selectedScale = scope.scales[scope.selectedScaleIndex];
         scope.$apply();
       });
 
-      scope.$watch('currentScaleIndex', function(newIndex){
-        scope.currentScaleIndex = newIndex;
+      scope.$watch('selectedScale', function(newScale) {
+        var newIndex = scope.scales.indexOf(newScale);
 
-        var newScaleName = Timeline.ZOOM_SCALES[newIndex];
-        if (scope.currentScaleName !== newScaleName) {
-          scope.currentScaleName = newScaleName;
+        if (scope.selectedScaleIndex !== newIndex) {
+          scope.selectedScaleIndex = newIndex;
         }
       });
 

--- a/frontend/app/ui_components/zoom-slider-directive.js
+++ b/frontend/app/ui_components/zoom-slider-directive.js
@@ -36,25 +36,35 @@ module.exports = function(I18n) {
       scales: '=',
       selectedScale: '='
     },
+    controller: function() {
+      var vm = this;
+
+      vm.minValue = 1;
+      vm.maxValue = vm.scales.length;
+      vm.sliderId = 'zoom-slider-' + latestId++;
+
+      vm.setSelectedScaleIndex = function(index) {
+        vm.selectedScaleIndex = index;
+        vm.selectedScale = vm.scales[vm.selectedScaleIndex];
+      };
+    },
+    controllerAs: 'ctrl',
+    bindToController: true,
     templateUrl: '/templates/components/zoom_slider.html',
-    link: function(scope, element, attributes) {
-      scope.minValue = 1;
-      scope.maxValue = scope.scales.length;
-      scope.sliderId = 'zoom-slider-' + latestId++;
+    link: function(scope, element, attributes, ctrl) {
       scope.labelText = I18n.t('js.timelines.zoom.slider');
 
       var slider = element.find('input');
       slider.on('change', function() {
-        scope.selectedScaleIndex = slider.val() - 1;
-        scope.selectedScale = scope.scales[scope.selectedScaleIndex];
+        ctrl.setSelectedScaleIndex(slider.val() - 1);
         scope.$apply();
       });
 
-      scope.$watch('selectedScale', function(newScale) {
-        var newIndex = scope.scales.indexOf(newScale);
+      scope.$watch('ctrl.selectedScale', function(newScale) {
+        var newIndex = ctrl.scales.indexOf(newScale);
 
-        if (scope.selectedScaleIndex !== newIndex) {
-          scope.selectedScaleIndex = newIndex;
+        if (ctrl.selectedScaleIndex !== newIndex) {
+          ctrl.selectedScaleIndex = newIndex;
         }
       });
 

--- a/frontend/tests/unit/tests/timeline_stubs.js
+++ b/frontend/tests/unit/tests/timeline_stubs.js
@@ -34,9 +34,6 @@ var modalHelperInstance = {
   setupTimeline: nop
 };
 
-
-jQuery.fn.slider = {};
-
 var possibleData = {
   projects: [{
       "id":1,

--- a/frontend/tests/unit/tests/timelines/directives/timeline-toolbar-directive-test.js
+++ b/frontend/tests/unit/tests/timelines/directives/timeline-toolbar-directive-test.js
@@ -1,0 +1,108 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+describe('timelineToolbar Directive', function() {
+  var compile, element, scope;
+
+  beforeEach(angular.mock.module('openproject.timelines.directives'));
+  beforeEach(module('openproject.templates'));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    var html = '<timeline-toolbar timeline="timeline"></timeline-toolbar>';
+
+    element = angular.element(html);
+    scope = $rootScope.$new();
+    scope.timeline = {
+      ZOOM_SCALES:    ['monthly', 'weekly', 'daily'],
+      ZOOM_CONFIGURATIONS: { 'monthly': {}, 'weekly': {}, 'daily': {} },
+      OUTLINE_LEVELS: ['level1', 'level2', 'level3'],
+      expansionIndex: 1,
+      zoomIndex:      0,
+      zoom:           sinon.spy()
+    };
+
+    compile = function() {
+      $compile(element)(scope);
+      scope.$digest();
+    };
+  }));
+
+  describe('increase and decrease zoom buttons', function() {
+    var zoomInBtn, zoomOutBtn, zoomSelect;
+
+    beforeEach(function() {
+      compile();
+
+      zoomInBtn  = element.find('a.icon-zoom-in');
+      zoomOutBtn = element.find('a.icon-zoom-out');
+      zoomSelect = element.find('select#tl-toolbar-zooms');
+    });
+
+    it('tells the timeline to zoom in to its maximum extent', function() {
+      zoomInBtn.click();
+      zoomInBtn.click();
+      zoomInBtn.click();
+
+      expect(scope.timeline.zoom).to.have.been.calledTwice;
+      expect(scope.timeline.zoom).to.have.been.calledWith(1);
+      expect(scope.timeline.zoom).to.have.been.calledWith(2);
+    });
+
+    it('tells the timeline to zoom out to its minimum extent', function() {
+      zoomInBtn.click();
+      zoomOutBtn.click();
+      zoomOutBtn.click();
+
+      expect(scope.timeline.zoom).to.have.been.calledTwice;
+      expect(scope.timeline.zoom).to.have.been.calledWith(1);
+      expect(scope.timeline.zoom).to.have.been.calledWith(0);
+    });
+
+    it('updates the zoom select element on zooming in', function() {
+      zoomInBtn.click();
+      expect(zoomSelect.val()).to.eq('1');
+
+      zoomInBtn.click();
+      expect(zoomSelect.val()).to.eq('2');
+
+      zoomInBtn.click();
+      expect(zoomSelect.val()).to.eq('2');
+    });
+
+    it('updates the zoom select element on zooming out', function() {
+      zoomInBtn.click();
+      zoomOutBtn.click();
+      expect(zoomSelect.val()).to.eq('0');
+
+      zoomOutBtn.click();
+      expect(zoomSelect.val()).to.eq('0');
+    });
+  });
+});

--- a/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
@@ -35,7 +35,7 @@ describe('zoomSlider Directive', function() {
   beforeEach(module('openproject.templates'));
 
   beforeEach(inject(function($rootScope, $compile, _I18n_) {
-    var html = '<div zoom-slider scales="scales" selected-scale="scale"></div>';
+    var html = '<zoom-slider scales="scales" selected-scale="scale"></zoom-slider>';
 
     element = angular.element(html);
     scope = $rootScope.$new();

--- a/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
@@ -29,32 +29,61 @@
 /*jshint expr: true*/
 
 describe('zoomSlider Directive', function() {
-    var compile, element, rootScope, scope;
+  var I18n, compile, element, scope;
 
-    beforeEach(angular.mock.module('openproject.uiComponents'));
-    beforeEach(module('openproject.templates'));
+  beforeEach(angular.mock.module('openproject.uiComponents'));
+  beforeEach(module('openproject.templates'));
 
-    beforeEach(inject(function($rootScope, $compile) {
-      var html;
-      html = '<div zoom-slider></div>';
+  beforeEach(inject(function($rootScope, $compile, _I18n_) {
+    var html = '<div zoom-slider></div>';
 
-      element = angular.element(html);
-      rootScope = $rootScope;
-      scope = $rootScope.$new();
+    element = angular.element(html);
+    scope = $rootScope.$new();
 
-      compile = function() {
-        $compile(element)(scope);
-        scope.$digest();
-      };
-    }));
+    compile = function() {
+      $compile(element)(scope);
+      scope.$digest();
+    };
 
-    xdescribe('element', function() {
-      beforeEach(function() {
-        compile();
-      });
+    I18n = _I18n_;
+    sinon.stub(I18n, 't').returns('Zoom Test');
+  }));
 
-      it('should emit a div', function() {
-        expect(element.prop('tagName')).to.equal('DIV');
-      });
+  beforeEach(function() {
+    compile();
+  });
+
+  afterEach(function() {
+    I18n.t.restore();
+  });
+
+  describe('label element', function() {
+    it('provides an accessible label for the slider', function() {
+      var slider = element.find('input[type="range"]');
+      var label = element.find('label[for=' + slider.attr('id') + ']');
+
+      expect(label.text().trim()).to.equal('Zoom Test');
     });
+  });
+
+  describe('slider element', function() {
+    var slider;
+
+    beforeEach(function() {
+      slider = element.find('input[type="range"]');
+    });
+
+    it('has its value set based on currentScaleIndex', function() {
+      scope.currentScaleIndex = 4;
+      scope.$apply();
+      expect(slider.val()).to.eq('5');
+    });
+
+    it('updates currentScaleName when its value changes', function() {
+      slider.val('4');
+      slider.change();
+      expect(scope.currentScaleName).to.eq('weekly');
+      expect(scope.currentScaleIndex).to.eq(3);
+    });
+  });
 });

--- a/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/zoom-slider-directive-test.js
@@ -35,10 +35,11 @@ describe('zoomSlider Directive', function() {
   beforeEach(module('openproject.templates'));
 
   beforeEach(inject(function($rootScope, $compile, _I18n_) {
-    var html = '<div zoom-slider></div>';
+    var html = '<div zoom-slider scales="scales" selected-scale="scale"></div>';
 
     element = angular.element(html);
     scope = $rootScope.$new();
+    scope.scales = ['yearly', 'quarterly', 'monthly', 'weekly', 'daily'];
 
     compile = function() {
       $compile(element)(scope);
@@ -49,15 +50,15 @@ describe('zoomSlider Directive', function() {
     sinon.stub(I18n, 't').returns('Zoom Test');
   }));
 
-  beforeEach(function() {
-    compile();
-  });
-
   afterEach(function() {
     I18n.t.restore();
   });
 
   describe('label element', function() {
+    beforeEach(function() {
+      compile();
+    });
+
     it('provides an accessible label for the slider', function() {
       var slider = element.find('input[type="range"]');
       var label = element.find('label[for=' + slider.attr('id') + ']');
@@ -70,20 +71,26 @@ describe('zoomSlider Directive', function() {
     var slider;
 
     beforeEach(function() {
+      compile();
       slider = element.find('input[type="range"]');
     });
 
-    it('has its value set based on currentScaleIndex', function() {
-      scope.currentScaleIndex = 4;
-      scope.$apply();
-      expect(slider.val()).to.eq('5');
+    it('has an initial value set', function() {
+      expect(slider.val()).to.eq('1');
     });
 
-    it('updates currentScaleName when its value changes', function() {
-      slider.val('4');
-      slider.change();
-      expect(scope.currentScaleName).to.eq('weekly');
-      expect(scope.currentScaleIndex).to.eq(3);
+    it('has its value set based on selectedScale', function() {
+      scope.scale = 'monthly';
+      scope.$apply();
+      expect(slider.val()).to.eq('3');
+    });
+
+    it('updates selectedScale when its value changes', function() {
+      slider.val('2').change();
+      expect(scope.scale).to.eq('quarterly');
+
+      slider.val('5').change();
+      expect(scope.scale).to.eq('daily');
     });
   });
 });


### PR DESCRIPTION
https://community.openproject.org/work_packages/19416
#2702 removed the styling for the jQuery UI slider widget, breaking our zoomSlider. This PR restores functionality. `input type="range"` should be [supported on all browsers that we target](http://caniuse.com/#feat=input-range).

:information_source: Styling (particularly use of right colour) will be addressed in a subsequent WP/PR.

Also addresses:
- https://community.openproject.org/work_packages/19334
