### PR TITLE
Prohibit start/due date changes on parent WPs

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1702,5 +1702,7 @@ de:
           "Der gewählte Nutzer darf dem Arbeitspaket nicht als '%{property}' zugewiesen werden."
         estimated_hours: "Der geschätzte Aufwand kann für Eltern-Arbeitspakete nicht gesetzt werden."
         done_ratio: "Der Fortschritt kann nicht gesetzt werden falls es sich um ein Eltern-Arbeitspaket handelt, er durch den Status definiert wird oder wenn er komplett deaktiviert wurde."
+        start_date: "Das Startdatum kann für Eltern-Arbeitspakete nicht gesetzt werden."
+        due_date: "Das Enddatum kann für Eltern-Arbeitspakete nicht gesetzt werden."
     resources:
       schema: 'Schema'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1692,5 +1692,7 @@ en:
           "The chosen user is not allowed to be '%{property}' for this work package."
         estimated_hours: "Estimated hours cannot be set on parent work packages."
         done_ratio: "Done ratio cannot be set on parent work packages, when it is inferred by status or when it is disabled."
+        start_date: "Start date cannot be set on parent work packages."
+        due_date: "Due date cannot be set on parent work packages."
     resources:
       schema: 'Schema'

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2584,8 +2584,8 @@ Note that due to sharing this might be more than the versions *defined* by that 
 | type             | Name of the work package's type                        | String      | not null                                                                                               | READ                 |                                  |
 | description      | The work package description                           | Formattable |                                                                                                        | READ / WRITE         |                                  |
 | parentId         | Parent work package id                                 | Integer     | Must be an id of an existing and visible (for the current user) work package                           | READ / WRITE         |                                  |
-| startDate        |                                                        | Date        | Cannot be set for parent work packages; must be equal or greater than the earliest possible start date | READ / WRITE         |                                  |
-| dueDate          |                                                        | Date        | Cannot be set for parent work packages; must be greater than or equal to the start date                | READ / WRITE         |                                  |
+| startDate        | Scheduled beginning of a work package                  | Date        | Cannot be set for parent work packages; must be equal or greater than the earliest possible start date | READ / WRITE         |                                  |
+| dueDate          | Scheduled end of a work package                        | Date        | Cannot be set for parent work packages; must be greater than or equal to the start date                | READ / WRITE         |                                  |
 | estimatedTime    | Time a work package likely needs to be completed       | Duration    | Cannot be set for parent work packages                                                                 | READ / WRITE         |                                  |
 | spentTime        |                                                        | Duration    |                                                                                                        | READ                 | **Permission** view time entries |
 | percentageDone   | Amount of total completion for a work package          | Integer     | 0 <= x <= 100; Cannot be set for parent work packages                                                  | READ / WRITE         |                                  |
@@ -2607,6 +2607,8 @@ the human readable name of custom fields.*
 * `dueDate` is the latest due date from its children
 * `estimatedTime` is the sum of estimated times from its children
 * `percentageDone` is the weighted average of the sum of its children percentages done. The weight is given by the average of its children estimatedHours. However, if the percentage done is given by a work package's status, then only the status matters and no value is inferred.
+
+*Start date can also not be earlier than a due date of any predecessor.*
 
 ## WorkPackage [/api/v3/work_packages/{id}{?notify}]
 

--- a/lib/api/v3/work_packages/schema/work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema.rb
@@ -96,6 +96,14 @@ module API
             nil_or_leaf?(@work_package)
           end
 
+          def start_date_writable?
+            nil_or_leaf?(@work_package)
+          end
+
+          def due_date_writable?
+            nil_or_leaf?(@work_package)
+          end
+
           def nil_or_leaf?(work_package)
             work_package.nil? || work_package.leaf?
           end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -82,7 +82,7 @@ module API
                      representer = ::API::Decorators::PropertySchemaRepresenter
                                    .new(type: 'Date',
                                         name: WorkPackage.human_attribute_name(:start_date))
-                     representer.writable = represented.due_date_writable?
+                     representer.writable = represented.start_date_writable?
                      representer.required = false
                      representer
                    end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -76,13 +76,27 @@ module API
           schema :description,
                  type: 'Formattable'
 
-          schema :start_date,
-                 type: 'Date',
-                 required: false
+          property :start_date,
+                   exec_context: :decorator,
+                   getter: -> (*) do
+                     representer = ::API::Decorators::PropertySchemaRepresenter
+                                   .new(type: 'Date',
+                                        name: WorkPackage.human_attribute_name(:start_date))
+                     representer.writable = represented.due_date_writable?
+                     representer.required = false
+                     representer
+                   end
 
-          schema :due_date,
-                 type: 'Date',
-                 required: false
+          property :due_date,
+                   exec_context: :decorator,
+                   getter: -> (*) do
+                     representer = ::API::Decorators::PropertySchemaRepresenter
+                                   .new(type: 'Date',
+                                        name: WorkPackage.human_attribute_name(:due_date))
+                     representer.writable = represented.due_date_writable?
+                     representer.required = false
+                     representer
+                   end
 
           property :estimated_time,
                    exec_context: :decorator,

--- a/lib/api/v3/work_packages/work_package_contract.rb
+++ b/lib/api/v3/work_packages/work_package_contract.rb
@@ -81,6 +81,18 @@ module API
           end
         end
 
+        attribute :start_date do
+          if !model.leaf? && model.changed.include?('start_date')
+            errors.add :error_readonly, 'start_date'
+          end
+        end
+
+        attribute :due_date do
+          if !model.leaf? && model.changed.include?('due_date')
+            errors.add :error_readonly, 'due_date'
+          end
+        end
+
         def initialize(object, user)
           super(object)
 

--- a/spec/lib/api/v3/work_packages/work_package_contract_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_contract_spec.rb
@@ -58,7 +58,7 @@ describe ::API::V3::WorkPackages::WorkPackageContract do
     allow(work_package).to receive(:changed).and_return(changed_values)
   end
 
-  describe 'estimated hours' do
+  shared_examples 'a parent unwritable property' do |attribute|
     context 'is no parent' do
       before do
         contract.validate
@@ -69,7 +69,7 @@ describe ::API::V3::WorkPackages::WorkPackageContract do
       end
 
       context 'has changed' do
-        let(:changed_values) { ['estimated_hours'] }
+        let(:changed_values) { [attribute] }
 
         it('is valid') { expect(contract.errors.empty?).to be true }
       end
@@ -90,13 +90,25 @@ describe ::API::V3::WorkPackages::WorkPackageContract do
       end
 
       context 'has changed' do
-        let(:changed_values) { ['estimated_hours'] }
+        let(:changed_values) { [attribute] }
 
         it('is invalid') do
           expect(contract.errors[:error_readonly]).to match_array(changed_values)
         end
       end
     end
+  end
+
+  describe 'estimated hours' do
+    it_behaves_like 'a parent unwritable property', 'estimated_hours'
+  end
+
+  describe 'start date' do
+    it_behaves_like 'a parent unwritable property', 'start_date'
+  end
+
+  describe 'due date' do
+    it_behaves_like 'a parent unwritable property', 'due_date'
   end
 
   describe 'percentage done' do

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -141,7 +141,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:type) { 'Date' }
         let(:name) { I18n.t('attributes.start_date') }
         let(:required) { false }
-        let(:writable) { true }
+        let(:writable) { schema.start_date_writable? }
       end
     end
 
@@ -151,7 +151,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:type) { 'Date' }
         let(:name) { I18n.t('attributes.due_date') }
         let(:required) { false }
-        let(:writable) { true }
+        let(:writable) { schema.due_date_writable? }
       end
     end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/19042

Prohibits changes of start/due date on parent work packages via API, similar to percentage done and estimated time.
