### PR TITLE
Reload the autocomplete after dynamically attaching the update form

### DIFF
--- a/app/assets/javascripts/work_packages.js.erb
+++ b/app/assets/javascripts/work_packages.js.erb
@@ -35,15 +35,24 @@ var WorkPackage = WorkPackage || {};
   var init;
 
   // TODO: remove this, once the issue edit view is completely angular based
+  var bodyInjector = function() { return angular.element('body').injector(); };
+
   var manuallyCompile = function(button) {
     if (!window.angular || button.length < 1) {
       return;
     }
-    angular.element('body').injector().invoke(['$compile', function($compile) {
+    bodyInjector().invoke(['$compile', function($compile) {
       var scope = angular.element(button).scope();
       $compile(button)(scope);
     }])
   };
+
+  var initializeAtWho = function(section) {
+    var textareas = section.find('textarea');
+    bodyInjector().invoke(['AutoCompleteHelper', function(AutoCompleteHelper) {
+      AutoCompleteHelper.enableTextareaAutoCompletion(textareas);
+    }]);
+  }
 
   init = function () {
 
@@ -68,6 +77,7 @@ var WorkPackage = WorkPackage || {};
                 // TODO: see last todo
                 var previewButton = update.find(".preview.button")
                 manuallyCompile(previewButton);
+                initializeAtWho(update);
       }
     });
 

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
 <% end %>
 <div class="form--field">
-  <%= f.text_area :content, label: l(:description_message_content), data: { wp_autocomplete_url: work_packages_auto_complete_path(project_id: @project, format: :json), :'ng-non-bindable' => '' } %>
+  <%= f.text_area :content, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' }, 'data-wp_autocomplete_url' => work_packages_auto_complete_path(project_id: @project, format: :json) %>
   <%= wikitoolbar_for 'message_content' %>
 </div>
 <%= render :partial => 'attachments/form' %>


### PR DESCRIPTION
This fixes a problem where forms which are dynamically loaded will not properly load the atWho Autocompletion.

meets https://community.openproject.org/work_packages/19104
