### PR TITLE
[Foundation] Remove double required indicators

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,10 +66,6 @@ module ApplicationHelper
     end
   end
 
-  def required_field_name(name = '')
-    safe_join [name, ' ', content_tag('span', '*', class: 'required')]
-  end
-
   def li_unless_nil(link)
     content_tag(:li, link) if link
   end

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -39,13 +39,13 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <section class="form--section">
     <% if @user.auth_source_id.nil? %>
-      <div class="form--field -required">
+      <div class="form--field">
         <%= f.text_field :login, :size => 25, :required => true %>
       </div>
     <% end %>
 
     <% if @user.change_password_allowed? %>
-      <div class="form--field -required">
+      <div class="form--field">
         <%= f.password_field :password,
                              :required => true,
                              :size => 25,
@@ -54,7 +54,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <%= password_complexity_requirements %>
         </div>
       </div>
-      <div class="form--field -required">
+      <div class="form--field">
         <%= f.password_field :password_confirmation,
                              :required => true,
                              :size => 25,
@@ -62,15 +62,15 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     <% end %>
 
-    <div class="form--field -required">
+    <div class="form--field">
       <%= f.text_field :firstname, :required => true %>
     </div>
 
-    <div class="form--field -required">
+    <div class="form--field">
       <%= f.text_field :lastname,  :required => true %>
     </div>
 
-    <div class="form--field -required">
+    <div class="form--field">
       <%= f.text_field :mail,      :required => true %>
     </div>
 


### PR DESCRIPTION
This will remove duplicated required-Indicators in the standard registration form. 

I found this while working on https://community.openproject.org/work_packages/19126 but it has ultimately nothing to do with the bug itself (i just will not open a separate work package for it)
