### PR TITLE
Added missing translation strings for title of edit custom fields view

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -720,6 +720,7 @@ de:
   label_downloads_abbr: "D/L"
   label_duplicated_by: "Dupliziert durch"
   label_duplicates: "Duplikat von"
+  label_edit: "Bearbeiten von"
   label_enable_multi_select: "Mehrfachauswahl umschalten"
   label_end_to_end: "Ende - Ende"
   label_end_to_start: "Ende - Anfang"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -718,6 +718,7 @@ en:
   label_downloads_abbr: "D/L"
   label_duplicated_by: "duplicated by"
   label_duplicates: "duplicates"
+  label_edit: "Edit"
   label_enable_multi_select: "Toggle multiselect"
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"


### PR DESCRIPTION
Popped up during a test.

https://community.openproject.org/work_packages/18714

Otherwise a hint for a missing translation will be part of the title instead:

![image](https://cloud.githubusercontent.com/assets/1461183/6684330/8e5e571e-cc90-11e4-81fd-9cbf62f709ee.png)
