### PR TITLE
[Foundation] Fix several styling errors with attachment forms

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -139,8 +139,7 @@ $advanced-filters--border-color: $gray !default
   margin: 0 10px 1rem 1px
 
 fieldset.collapsible.header_collapsible > div
-  padding-top: 5px
-  padding-bottom: 5px
+  padding: 5px
 
 fieldset.collapsible.header_collapsible > *
   border-left: 1px solid #E6E6E6

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -217,15 +217,21 @@ fieldset.form--fieldset
   margin-bottom: 0.4rem
   // cancel out foundations overflow-y: auto
   overflow: visible
+  padding-right: 1rem
 
   &.-vertical,
   .form.-vertical &
     @include grid-orient(vertical)
 
-  .grid-block:nth-last-of-type(n+2) > &,
-  .form--row:nth-last-of-type(n+2) > &,
-  .form--grouping-row > &:nth-last-of-type(n+2)
-    padding-right: 1rem
+  // .grid-block:nth-last-of-type(n+2) > &,
+  // .form--row:nth-last-of-type(n+2) > &,
+  // .form--grouping-row > &:nth-last-of-type(n+2)
+  //   padding-right: 1rem
+
+  .grid-block > &:last-child,
+  .form--row > &:last-child,
+  .form--grouping-row > &:last-child
+    padding-right: 0
 
   &.-trailing-label
     .form--label

--- a/app/views/attachments/_form.html.erb
+++ b/app/views/attachments/_form.html.erb
@@ -41,11 +41,11 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
       </div>
       <div class="form--field">
-        <label class="form-label" >
+        <label class="form--label">
           <%= l(:label_optional_description) %>
         </label>
-        <div class="form--text-field-container">
-          <%= text_field_tag 'attachments[1][description]', '', :size => 38, :id => nil %>
+        <div class="form--field-container">
+          <%= styled_text_field_tag 'attachments[1][description]', '', :size => 38, :id => nil %>
         </div>
       </div>
     </div>

--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -59,7 +59,7 @@ an attachments_attributes= and not every model supports this we build a nested f
           </div>
         </div>
         <div class="form--field">
-          <label class="form-label" >
+          <label class="form--label" >
             <%= l(:label_optional_description) %>
           </label>
           <div class="form--text-field-container">


### PR DESCRIPTION
Change the way form--field padding is attached.

This also includes an updated version for the attachment partials, which should be
merged in future versions, making it into a component.

Meets the second part of https://community.openproject.org/work_packages/18927
