### PR TITLE
Core extensions for Budgets API

### DIFF
--- a/lib/api/api_patch_registry.rb
+++ b/lib/api/api_patch_registry.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -28,32 +27,25 @@
 #++
 
 module API
-  module V3
-    module Priorities
-      class PrioritiesAPI < ::API::OpenProjectAPI
-        resources :priorities do
-          before do
-            authorize(:view_work_packages, global: true)
+  class APIPatchRegistry
+    class << self
+      def add_patch(class_name, path, &block)
+        patch_maps_by_class[class_name] = {} unless patch_maps_by_class[class_name]
+        patch_map = patch_maps_by_class[class_name]
 
-            @priorities = IssuePriority.all
-          end
+        path = ":#{path}" if path.is_a?(Symbol)
+        patch_map[path] = [] unless patch_map[path]
+        patch_map[path] << block
+      end
 
-          get do
-            PriorityCollectionRepresenter.new(@priorities,
-                                              @priorities.count,
-                                              api_v3_paths.priorities)
-          end
+      def patches_for(klass)
+        patch_maps_by_class[klass.to_s] || {}
+      end
 
-          route_param :id do
-            before do
-              @priority = IssuePriority.find(params[:id])
-            end
+      private
 
-            get do
-              PriorityRepresenter.new(@priority, current_user: current_user)
-            end
-          end
-        end
+      def patch_maps_by_class
+        @patch_maps_by_class ||= {}
       end
     end
   end

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -66,7 +66,8 @@ module API
                                      name_source: property,
                                      href_callback:,
                                      required: true,
-                                     writable: true)
+                                     writable: true,
+                                     show_if: true)
           raise ArgumentError if property.nil?
 
           property property,
@@ -83,7 +84,8 @@ module API
                      end
 
                      representer
-                   }
+                   },
+                   if: show_if
         end
 
         def schema_with_allowed_collection(property,
@@ -93,7 +95,8 @@ module API
                                            value_representer:,
                                            link_factory:,
                                            required: true,
-                                           writable: true)
+                                           writable: true,
+                                           show_if: true)
           raise ArgumentError unless property
 
           property property,
@@ -113,7 +116,8 @@ module API
                      end
 
                      representer
-                   }
+                   },
+                   if: show_if
         end
 
         def represented_class

--- a/lib/api/open_project_api.rb
+++ b/lib/api/open_project_api.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -28,33 +27,7 @@
 #++
 
 module API
-  module V3
-    module Priorities
-      class PrioritiesAPI < ::API::OpenProjectAPI
-        resources :priorities do
-          before do
-            authorize(:view_work_packages, global: true)
-
-            @priorities = IssuePriority.all
-          end
-
-          get do
-            PriorityCollectionRepresenter.new(@priorities,
-                                              @priorities.count,
-                                              api_v3_paths.priorities)
-          end
-
-          route_param :id do
-            before do
-              @priority = IssuePriority.find(params[:id])
-            end
-
-            get do
-              PriorityRepresenter.new(@priority, current_user: current_user)
-            end
-          end
-        end
-      end
-    end
+  class OpenProjectAPI < Grape::API
+    include ::API::PatchableAPI
   end
 end

--- a/lib/api/patchable_api.rb
+++ b/lib/api/patchable_api.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -28,32 +27,44 @@
 #++
 
 module API
-  module V3
-    module Priorities
-      class PrioritiesAPI < ::API::OpenProjectAPI
-        resources :priorities do
-          before do
-            authorize(:view_work_packages, global: true)
+  module PatchableAPI
+    def self.included(base)
+      base.extend ClassMethods
+    end
 
-            @priorities = IssuePriority.all
-          end
+    module ClassMethods
+      def inherited(subclass)
+        super
 
-          get do
-            PriorityCollectionRepresenter.new(@priorities,
-                                              @priorities.count,
-                                              api_v3_paths.priorities)
-          end
+        # run unscoped patches (i.e. patches that are on the class root, not in a namespace)
+        subclass.send(:execute_patches_for, nil)
+      end
 
-          route_param :id do
-            before do
-              @priority = IssuePriority.find(params[:id])
-            end
+      def namespace(name, *args,  &block)
+        super(name, *args) do
+          instance_eval(&block)
+          execute_patches_for(name)
+        end
+      end
 
-            get do
-              PriorityRepresenter.new(@priority, current_user: current_user)
-            end
+      # we need to repeat all the aliases for them to work properly...
+      alias_method :group, :namespace
+      alias_method :resource, :namespace
+      alias_method :resources, :namespace
+      alias_method :segment, :namespace
+
+      private
+
+      def execute_patches_for(path)
+        if patches[path]
+          patches[path].each do |patch|
+            instance_eval(&patch)
           end
         end
+      end
+
+      def patches
+        ::API::APIPatchRegistry.patches_for(self)
       end
     end
   end

--- a/lib/api/patchable_api.rb
+++ b/lib/api/patchable_api.rb
@@ -40,7 +40,7 @@ module API
         subclass.send(:execute_patches_for, nil)
       end
 
-      def namespace(name, *args,  &block)
+      def namespace(name, *args, &block)
         super(name, *args) do
           instance_eval(&block)
           execute_patches_for(name)

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -152,6 +152,8 @@ module API
       authenticate
     end
 
-    mount API::V3::Root
+    version 'v3', using: :path do
+      mount API::V3::Root
+    end
   end
 end

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Activities
-      class ActivitiesAPI < Grape::API
+      class ActivitiesAPI < ::API::OpenProjectAPI
         resources :activities do
 
           params do

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Attachments
-      class AttachmentsAPI < Grape::API
+      class AttachmentsAPI < ::API::OpenProjectAPI
         resources :attachments do
 
           params do

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Categories
-      class CategoriesAPI < Grape::API
+      class CategoriesAPI < ::API::OpenProjectAPI
         resources :categories do
           route_param :id do
             before do

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Categories
-      class CategoriesByProjectAPI < Grape::API
+      class CategoriesByProjectAPI < ::API::OpenProjectAPI
         resources :categories do
           before do
             @categories = @project.categories

--- a/lib/api/v3/projects/available_assignees_api.rb
+++ b/lib/api/v3/projects/available_assignees_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Projects
-      class AvailableAssigneesAPI < Grape::API
+      class AvailableAssigneesAPI < ::API::OpenProjectAPI
         resource :available_assignees do
           get do
             authorize(:view_project, context: @project)

--- a/lib/api/v3/projects/available_responsibles_api.rb
+++ b/lib/api/v3/projects/available_responsibles_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Projects
-      class AvailableResponsiblesAPI < Grape::API
+      class AvailableResponsiblesAPI < ::API::OpenProjectAPI
         resource :available_responsibles do
           get do
             authorize(:view_project, context: @project)

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Projects
-      class ProjectsAPI < Grape::API
+      class ProjectsAPI < ::API::OpenProjectAPI
         resources :projects do
           params do
             requires :id, desc: 'Project id'

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -31,7 +31,7 @@ require 'securerandom'
 module API
   module V3
     module Queries
-      class QueriesAPI < Grape::API
+      class QueriesAPI < ::API::OpenProjectAPI
         resources :queries do
           params do
             requires :id, desc: 'Query id'

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -1,7 +1,7 @@
 module API
   module V3
     module Relations
-      class RelationsAPI < Grape::API
+      class RelationsAPI < ::API::OpenProjectAPI
         resources :relations do
           params do
             optional :to_id, desc: 'Id of related work package'

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Render
-      class RenderAPI < Grape::API
+      class RenderAPI < ::API::OpenProjectAPI
         format :txt
         parser :txt, ::API::V3::Formatter::TxtCharset
 

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -33,9 +33,7 @@
 
 module API
   module V3
-    class Root < Grape::API
-      version 'v3', using: :path
-
+    class Root < ::API::OpenProjectAPI
       mount ::API::V3::Activities::ActivitiesAPI
       mount ::API::V3::Attachments::AttachmentsAPI
       mount ::API::V3::Categories::CategoriesAPI

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Statuses
-      class StatusesAPI < Grape::API
+      class StatusesAPI < ::API::OpenProjectAPI
         resources :statuses do
           before do
             authorize(:view_work_packages, global: true)

--- a/lib/api/v3/string_objects/string_objects_api.rb
+++ b/lib/api/v3/string_objects/string_objects_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module StringObjects
-      class StringObjectsAPI < Grape::API
+      class StringObjectsAPI < ::API::OpenProjectAPI
         resources :string_objects do
 
           params do

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Types
-      class TypesAPI < Grape::API
+      class TypesAPI < ::API::OpenProjectAPI
         resources :types do
           before do
             authorize_any([:view_work_packages, :manage_types], global: true)

--- a/lib/api/v3/types/types_by_project_api.rb
+++ b/lib/api/v3/types/types_by_project_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Types
-      class TypesByProjectAPI < Grape::API
+      class TypesByProjectAPI < ::API::OpenProjectAPI
         resources :types do
           before do
             authorize_any [:view_work_packages, :manage_types], projects: @project

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Users
-      class UsersAPI < Grape::API
+      class UsersAPI < ::API::OpenProjectAPI
         helpers do
           def user_transition(allowed)
             if allowed

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Versions
-      class ProjectsByVersionAPI < Grape::API
+      class ProjectsByVersionAPI < ::API::OpenProjectAPI
         resources :projects do
           before do
             @projects = @version.projects.visible(current_user).all

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Versions
-      class VersionsAPI < Grape::API
+      class VersionsAPI < ::API::OpenProjectAPI
         resources :versions do
 
           route_param :id do

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -30,7 +30,7 @@
 module API
   module V3
     module Versions
-      class VersionsByProjectAPI < Grape::API
+      class VersionsByProjectAPI < ::API::OpenProjectAPI
         resources :versions do
           before do
             @versions = @project.shared_versions.all

--- a/lib/api/v3/work_packages/form/form_api.rb
+++ b/lib/api/v3/work_packages/form/form_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module WorkPackages
       module Form
-        class FormAPI < Grape::API
+        class FormAPI < ::API::OpenProjectAPI
           post '/form' do
             write_work_package_attributes
             write_request_valid?

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -56,7 +56,8 @@ module API
           def self.linked_property(property,
                                    namespace: property.to_s.pluralize,
                                    association: "#{property}_id",
-                                   path: property)
+                                   path: property,
+                                   show_if: true)
 
             property property,
                      exec_context: :decorator,
@@ -69,7 +70,8 @@ module API
                                   namespace: namespace,
                                   value: value,
                                   setter_method: :"#{association}=")
-                     }
+                     },
+                     if: show_if
           end
 
           linked_property :type

--- a/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_attribute_links_representer.rb
@@ -53,59 +53,39 @@ module API
 
           self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
-          def self.linked_property(property_name: nil,
-                                   namespace: nil,
-                                   method: nil,
-                                   path: nil)
+          def self.linked_property(property,
+                                   namespace: property.to_s.pluralize,
+                                   association: "#{property}_id",
+                                   path: property)
 
-            property property_name,
+            property property,
                      exec_context: :decorator,
                      getter: -> (*) {
-                       get_path(get_method: method,
+                       get_path(get_method: association,
                                 path: path)
                      },
                      setter: -> (value, *) {
-                       parse_link(property: property_name,
+                       parse_link(property: property,
                                   namespace: namespace,
                                   value: value,
-                                  setter_method: :"#{method}=")
+                                  setter_method: :"#{association}=")
                      }
           end
 
-          linked_property(property_name: :type,
-                          namespace: :types,
-                          method: :type_id,
-                          path: :type)
-
-          linked_property(property_name: :status,
-                          namespace: :statuses,
-                          method: :status_id,
-                          path: :status)
-
-          linked_property(property_name: :assignee,
+          linked_property :type
+          linked_property :status
+          linked_property :assignee,
                           namespace: :users,
-                          method: :assigned_to_id,
-                          path: :user)
-
-          linked_property(property_name: :responsible,
+                          association: :assigned_to_id,
+                          path: :user
+          linked_property :responsible,
                           namespace: :users,
-                          method: :responsible_id,
-                          path: :user)
-
-          linked_property(property_name: :category,
-                          namespace: :categories,
-                          method: :category_id,
-                          path: :category)
-
-          linked_property(property_name: :version,
-                          namespace: :versions,
-                          method: :fixed_version_id,
-                          path: :version)
-
-          linked_property(property_name: :priority,
-                          namespace: :priorities,
-                          method: :priority_id,
-                          path: :priority)
+                          association: :responsible_id,
+                          path: :user
+          linked_property :category
+          linked_property :version,
+                          association: :fixed_version_id
+          linked_property :priority
 
           private
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -155,7 +155,6 @@ module API
                                    }
 
           schema_with_allowed_collection :type,
-                                         type: 'Type',
                                          values_callback: -> (*) {
                                            represented.assignable_types
                                          },
@@ -168,7 +167,6 @@ module API
                                          }
 
           schema_with_allowed_collection :status,
-                                         type: 'Status',
                                          values_callback: -> (*) {
                                            represented.assignable_statuses_for(current_user)
                                          },
@@ -181,7 +179,6 @@ module API
                                          }
 
           schema_with_allowed_collection :category,
-                                         type: 'Category',
                                          values_callback: -> (*) {
                                            represented.assignable_categories
                                          },
@@ -195,7 +192,6 @@ module API
                                          required: false
 
           schema_with_allowed_collection :version,
-                                         type: 'Version',
                                          values_callback: -> (*) {
                                            represented.assignable_versions
                                          },
@@ -209,7 +205,6 @@ module API
                                          required: false
 
           schema_with_allowed_collection :priority,
-                                         type: 'Priority',
                                          values_callback: -> (*) {
                                            represented.assignable_priorities
                                          },

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -216,8 +216,8 @@ module API
                                            }
                                          }
 
-          def current_user
-            context[:current_user]
+          def current_user_allowed_to(permission)
+            current_user && current_user.allowed_to?(permission, represented.project)
           end
         end
       end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -111,7 +111,8 @@ module API
 
           schema :spent_time,
                  type: 'Duration',
-                 writable: false
+                 writable: false,
+                 show_if: -> (_) { current_user_allowed_to(:view_time_entries) }
 
           property :percentage_done,
                    exec_context: :decorator,

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module WorkPackages
       module Schema
-        class WorkPackageSchemasAPI < Grape::API
+        class WorkPackageSchemasAPI < ::API::OpenProjectAPI
           resources :schemas do
             params do
               requires :project, desc: 'Work package schema id'

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module WorkPackages
-      class WatchersAPI < Grape::API
+      class WatchersAPI < ::API::OpenProjectAPI
         get '/available_watchers' do
           authorize(:add_work_package_watchers, context: @work_package.project)
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module WorkPackages
-      class WorkPackagesAPI < Grape::API
+      class WorkPackagesAPI < ::API::OpenProjectAPI
         resources :work_packages do
           params do
             requires :id, desc: 'Work package id'

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -144,8 +144,7 @@ module OpenProject::Plugins
       base.send(:define_method, :add_api_path) do |path_name, &block|
         config.to_prepare do
           ::API::V3::Utilities::PathHelper::ApiV3Path.class_eval do
-            metaclass = class << self; self; end
-            metaclass.instance_eval do
+            singleton_class.instance_eval do
               define_method path_name, &block
             end
           end

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -141,6 +141,24 @@ module OpenProject::Plugins
         end
       end
 
+      base.send(:define_method, :add_api_path) do |path_name, &block|
+        config.to_prepare do
+          ::API::V3::Utilities::PathHelper::ApiV3Path.class_eval do
+            metaclass = class << self; self; end
+            metaclass.instance_eval do
+              define_method path_name, &block
+            end
+          end
+        end
+      end
+
+      base.send(:define_method, :add_api_endpoint) do |base_endpoint, new_endpoint|
+        config.to_prepare do
+          # FIXME: expecting strings is awful... this has to work better
+          base_endpoint.constantize.mount new_endpoint.constantize
+        end
+      end
+
       base.send(:define_method, :extend_api_response) do |*args, &block|
         config.to_prepare do
           representer_namespace = args.map { |arg| arg.to_s.camelize }.join('::')

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -152,10 +152,13 @@ module OpenProject::Plugins
         end
       end
 
-      base.send(:define_method, :add_api_endpoint) do |base_endpoint, new_endpoint|
+      base.send(:define_method, :add_api_endpoint) do |base_endpoint, path = nil, &block|
         config.to_prepare do
-          # FIXME: expecting strings is awful... this has to work better
-          base_endpoint.constantize.mount new_endpoint.constantize
+          # we are expecting the base_endpoint as string for two reasons:
+          # 1. it does not seem possible to pass it as constant (auto loader not ready yet)
+          # 2. we can't constantize it here, because that would evaluate
+          #    the API before it can be patched
+          ::API::APIPatchRegistry.add_patch base_endpoint, path, &block
         end
       end
 

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -181,7 +181,8 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
       context 'not allowed to view time entries' do
         before do
-          allow(current_user).to receive(:allowed_to?).with(:view_time_entries, work_package.project)
+          allow(current_user).to receive(:allowed_to?).with(:view_time_entries,
+                                                            work_package.project)
             .and_return false
         end
 

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -166,12 +166,28 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'spentTime' do
+      before do
+        allow(current_user).to receive(:allowed_to?).with(:view_time_entries, work_package.project)
+          .and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'spentTime' }
         let(:type) { 'Duration' }
         let(:name) { I18n.t('activerecord.attributes.work_package.spent_time') }
         let(:required) { true }
         let(:writable) { false }
+      end
+
+      context 'not allowed to view time entries' do
+        before do
+          allow(current_user).to receive(:allowed_to?).with(:view_time_entries, work_package.project)
+            .and_return false
+        end
+
+        it 'does not show spentTime' do
+          is_expected.not_to have_json_path('spentTime')
+        end
       end
     end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19141
## Description

This PR provides core side extensions to be able to make the budget in `openproject-costs` patchable.

Notably:
- allow to mount new API endpoints into existing ones
- more configurability for schema helpers
