### PR TITLE
Revert "remove required_field_name from ApplicationHelper"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,6 +66,10 @@ module ApplicationHelper
     end
   end
 
+  def required_field_name(name = '')
+    safe_join [name, ' ', content_tag('span', '*', class: 'required')]
+  end
+
   def li_unless_nil(link)
     content_tag(:li, link) if link
   end


### PR DESCRIPTION
This reverts commit a3896c6e2d7b24e64ce38667006b582c23941a8d, which removed `required_field_name` due to breaking tests on the internal CI.
