### PR TITLE
[Foundation] Use new form styles in custom fields for versions

### DIFF
--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -53,7 +53,7 @@ module CustomFieldsHelper
       styled_text_field_tag(field_name, custom_value.value, id: field_id, size: 10) +
       calendar_for(field_id)
     when 'text'
-      styled_text_area_tag(field_name, custom_value.value, id: field_id, rows: 3, style: 'width:90%')
+      styled_text_area_tag(field_name, custom_value.value, id: field_id, rows: 3)
     when 'bool'
       hidden_tag = hidden_field_tag(field_name, '0')
       checkbox_tag = styled_check_box_tag(field_name, '1', custom_value.typed_value, id: field_id)

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -50,13 +50,13 @@ module CustomFieldsHelper
 
     tag = case field_format.try(:edit_as)
     when 'date'
-      text_field_tag(field_name, custom_value.value, id: field_id, size: 10) +
+      styled_text_field_tag(field_name, custom_value.value, id: field_id, size: 10) +
       calendar_for(field_id)
     when 'text'
-      text_area_tag(field_name, custom_value.value, id: field_id, rows: 3, style: 'width:90%')
+      styled_text_area_tag(field_name, custom_value.value, id: field_id, rows: 3, style: 'width:90%')
     when 'bool'
       hidden_tag = hidden_field_tag(field_name, '0')
-      checkbox_tag = check_box_tag(field_name, '1', custom_value.typed_value, id: field_id)
+      checkbox_tag = styled_check_box_tag(field_name, '1', custom_value.typed_value, id: field_id)
       hidden_tag + checkbox_tag
     when 'list'
       blank_option = if custom_field.is_required? && custom_field.default_value.blank?
@@ -69,9 +69,9 @@ module CustomFieldsHelper
 
       options = blank_option.html_safe + options_for_select(custom_field.possible_values_options(custom_value.customized), custom_value.value)
 
-      select_tag(field_name, options, id: field_id)
+      styled_select_tag(field_name, options, id: field_id)
     else
-      text_field_tag(field_name, custom_value.value, id: field_id)
+      styled_text_field_tag(field_name, custom_value.value, id: field_id)
     end
 
     tag = content_tag :span, tag, lang: custom_field.name_locale
@@ -86,7 +86,7 @@ module CustomFieldsHelper
     content_tag 'label', h(custom_value.custom_field.name) +
       (custom_value.custom_field.is_required? ? content_tag('span', ' *', class: 'required') : ''),
                 for: "#{name}_custom_field_values_#{custom_value.custom_field.id}",
-                class: (custom_value.errors.empty? ? nil : 'error'),
+                class: "form--label #{(custom_value.errors.empty? ? nil : 'error')}",
                 lang: custom_value.custom_field.name_locale
   end
 

--- a/test/unit/helpers/custom_fields_helper_test.rb
+++ b/test/unit/helpers/custom_fields_helper_test.rb
@@ -39,12 +39,21 @@ class CustomFieldsHelperTest < HelperTestCase
     assert_equal 'No', format_value('0', 'bool')
   end
 
-  def test_unknow_field_format_should_be_edited_as_string
+  def test_unknown_field_format_should_be_edited_as_string
     field = CustomField.new(field_format: 'foo')
     value = CustomValue.new(value: 'bar', custom_field: field)
     field.id = 52
 
-    assert_match '<input id="object_custom_field_values_52" name="object[custom_field_values][52]" type="text" value="bar" />',
+    assert_equal %{<span lang="en">
+                      <span class="form--text-field-container">
+                        <input class="form--text-field"
+                               id="object_custom_field_values_52"
+                               name="object[custom_field_values][52]"
+                               type="text"
+                               value="bar" />
+                      </span>
+                    </span>
+                 }.gsub(/>\s+</, '><').squish,
                  custom_field_tag('object', value)
   end
 


### PR DESCRIPTION
This updates some custom fields helper magic to use the new form styles introduced by foundation and should solve part of the problem shown in https://community.openproject.org/work_packages/19205
