### PR TITLE
Fix preview of true custom field in WP form

### DIFF
--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -37,7 +37,7 @@ class CustomValue::BoolStrategy < CustomValue::FormatStrategy
   def typed_value
     return nil unless value_present?
 
-    value == '1'
+    value == '1' || value == true
   end
 
   def validate_type_of_value

--- a/spec/models/custom_value/bool_strategy_spec.rb
+++ b/spec/models/custom_value/bool_strategy_spec.rb
@@ -85,6 +85,16 @@ describe CustomValue::BoolStrategy do
       let(:value) { nil }
       it { is_expected.to be_nil }
     end
+
+    context 'value is true' do
+      let(:value) { true }
+      it { is_expected.to eql(true) }
+    end
+
+    context 'value is false' do
+      let(:value) { false }
+      it { is_expected.to eql(false) }
+    end
   end
 
   describe '#validate_type_of_value' do

--- a/spec/models/custom_value/bool_strategy_spec.rb
+++ b/spec/models/custom_value/bool_strategy_spec.rb
@@ -39,27 +39,27 @@ describe CustomValue::BoolStrategy do
 
     context 'value is nil' do
       let(:value) { nil }
-      it { is_expected.to eql(false) }
+      it { is_expected.to be false }
     end
 
     context 'value is empty string' do
       let(:value) { '' }
-      it { is_expected.to eql(false) }
+      it { is_expected.to be false }
     end
 
     context 'value is present string' do
       let(:value) { '1' }
-      it { is_expected.to eql(true) }
+      it { is_expected.to be true }
     end
 
     context 'value is true' do
       let(:value) { true }
-      it { is_expected.to eql(true) }
+      it { is_expected.to be true }
     end
 
     context 'value is false' do
       let(:value) { false }
-      it { is_expected.to eql(true) }
+      it { is_expected.to be true }
     end
   end
 
@@ -68,12 +68,12 @@ describe CustomValue::BoolStrategy do
 
     context 'value corresponds to true' do
       let(:value) { '1' }
-      it { is_expected.to eql(true) }
+      it { is_expected.to be true }
     end
 
     context 'value corresponds to false' do
       let(:value) { '0' }
-      it { is_expected.to eql(false) }
+      it { is_expected.to be false }
     end
 
     context 'value is blank' do
@@ -88,12 +88,12 @@ describe CustomValue::BoolStrategy do
 
     context 'value is true' do
       let(:value) { true }
-      it { is_expected.to eql(true) }
+      it { is_expected.to be true }
     end
 
     context 'value is false' do
       let(:value) { false }
-      it { is_expected.to eql(false) }
+      it { is_expected.to be false }
     end
   end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/18296
## Problem

:typed_value of `CustomValue` would not return true if the internal value was set to true (it only ever expected the internal value to be '1')
