### PR TITLE
Fix display of invalid versions/users in Form Payload

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -197,7 +197,7 @@ de:
         greater_than_or_equal_to: "muss größer oder gleich %{count} sein"
         smaller_than_or_equal_to_max_length: "muss kleiner als oder gleich der maximalen Länge sein"
         greater_than_start_date: "muss größer als Anfangsdatum sein"
-        inclusion: "ist kein gültiger Wert"
+        inclusion: "ist nicht auf einen erlaubten Wert gesetzt"
         invalid: "ist nicht gültig"
         less_than: "muss kleiner als %{count} sein"
         less_than_or_equal_to: "muss kleiner oder gleich %{count} sein"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,7 +197,7 @@ en:
         greater_than_or_equal_to: "must be greater than or equal to %{count}"
         smaller_than_or_equal_to_max_length: "must be smaller than or equal to maximum length"
         greater_than_start_date: "must be greater than start date"
-        inclusion: "is not included in the list"
+        inclusion: "is not set to one of the allowed values"
         invalid: "is invalid"
         less_than: "must be less than %{count}"
         less_than_or_equal_to: "must be less than or equal to %{count}"

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -243,8 +243,12 @@ module API
 
         def link_value_getter_for(custom_field, path_method)
           -> (*) {
-            value = represented.send custom_field.accessor_name
-            path = api_v3_paths.send(path_method, value.is_a?(String) ? value : value.id) if value
+            # we can't use the generated accessor (e.g. represented.send :custom_field_1) here,
+            # because we need to generate a link even if the id does not belong to an existing
+            # object (that behaviour is only required for form payloads)
+            custom_value = represented.custom_value_for(custom_field)
+            value = custom_value ? custom_value.value : nil
+            path = api_v3_paths.send(path_method, value) if value
 
             { href: path }
           }

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -209,14 +209,22 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     let(:represented) {
       double('represented',
              available_custom_fields: [custom_field],
-             custom_field.accessor_name => custom_value)
+             custom_field.accessor_name => value)
     }
-    let(:custom_value) { '' }
+    let(:custom_value) { double('CustomValue', value: raw_value) }
+    let(:raw_value) { nil }
+    let(:value) { '' }
     let(:current_user) { FactoryGirl.build(:user) }
     subject { modified_class.new(represented, current_user: current_user).to_json }
 
+    before do
+      # should only be called when building links
+      allow(represented).to receive(:custom_value_for).with(custom_field).and_return(custom_value)
+    end
+
     context 'user custom field' do
-      let(:custom_value) { FactoryGirl.build(:user, id: 2) }
+      let(:value) { FactoryGirl.build(:user, id: 2) }
+      let(:raw_value) { value.id.to_s }
       let(:field_format) { 'user' }
 
       it_behaves_like 'has an untitled link' do
@@ -226,15 +234,12 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       it 'has the user embedded' do
         is_expected.to be_json_eql('User'.to_json).at_path("_embedded/#{cf_path}/_type")
-        is_expected.to be_json_eql(custom_value.name.to_json).at_path("_embedded/#{cf_path}/name")
+        is_expected.to be_json_eql(value.name.to_json).at_path("_embedded/#{cf_path}/name")
       end
 
       context 'value is nil' do
-        let(:represented) {
-          double('represented',
-                 available_custom_fields: [custom_field],
-                 custom_field.accessor_name => nil)
-        }
+        let(:value) { nil }
+        let(:raw_value) { nil }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }
@@ -243,7 +248,8 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'version custom field' do
-      let(:custom_value) { FactoryGirl.build(:version, id: 2) }
+      let(:value) { FactoryGirl.build(:version, id: 2) }
+      let(:raw_value) { value.id.to_s }
       let(:field_format) { 'version' }
 
       it_behaves_like 'has an untitled link' do
@@ -253,15 +259,12 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       it 'has the version embedded' do
         is_expected.to be_json_eql('Version'.to_json).at_path("_embedded/#{cf_path}/_type")
-        is_expected.to be_json_eql(custom_value.name.to_json).at_path("_embedded/#{cf_path}/name")
+        is_expected.to be_json_eql(value.name.to_json).at_path("_embedded/#{cf_path}/name")
       end
 
       context 'value is nil' do
-        let(:represented) {
-          double('represented',
-                 available_custom_fields: [custom_field],
-                 custom_field.accessor_name => nil)
-        }
+        let(:value) { nil }
+        let(:raw_value) { nil }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }
@@ -270,7 +273,8 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'list custom field' do
-      let(:custom_value) { 'Foobar' }
+      let(:value) { 'Foobar' }
+      let(:raw_value) { value }
       let(:field_format) { 'list' }
 
       it_behaves_like 'has an untitled link' do
@@ -280,15 +284,11 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       it 'has the string object embedded' do
         is_expected.to be_json_eql('StringObject'.to_json).at_path("_embedded/#{cf_path}/_type")
-        is_expected.to be_json_eql(custom_value.to_json).at_path("_embedded/#{cf_path}/value")
+        is_expected.to be_json_eql(value.to_json).at_path("_embedded/#{cf_path}/value")
       end
 
       context 'value is nil' do
-        let(:represented) {
-          double('represented',
-                 available_custom_fields: [custom_field],
-                 custom_field.accessor_name => nil)
-        }
+        let(:value) { nil }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }
@@ -299,7 +299,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'string custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'string' }
-        let(:custom_value) { 'Foobar' }
+        let(:value) { 'Foobar' }
         let(:json_value) { 'Foobar' }
         let(:expected_setter) { json_value }
       end
@@ -308,7 +308,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'int custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'int' }
-        let(:custom_value) { 42 }
+        let(:value) { 42 }
         let(:json_value) { 42 }
         let(:expected_setter) { json_value }
       end
@@ -317,7 +317,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'float custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'float' }
-        let(:custom_value) { 3.14 }
+        let(:value) { 3.14 }
         let(:json_value) { 3.14 }
         let(:expected_setter) { json_value }
       end
@@ -326,7 +326,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'bool custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'bool' }
-        let(:custom_value) { true }
+        let(:value) { true }
         let(:json_value) { true }
         let(:expected_setter) { json_value }
       end
@@ -335,8 +335,8 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'date custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'date' }
-        let(:custom_value) { Date.today.to_date }
-        let(:json_value) { custom_value.to_date.iso8601 }
+        let(:value) { Date.today.to_date }
+        let(:json_value) { value.to_date.iso8601 }
         let(:expected_setter) { json_value }
       end
     end
@@ -344,15 +344,15 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'text custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'text' }
-        let(:custom_value) { 'Foobar' }
+        let(:value) { 'Foobar' }
         let(:json_value) do
           {
             format: 'plain',
-            raw: custom_value,
-            html: "<p>#{custom_value}</p>"
+            raw: value,
+            html: "<p>#{value}</p>"
           }
         end
-        let(:expected_setter) { custom_value }
+        let(:expected_setter) { value }
       end
     end
   end
@@ -364,14 +364,18 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     }
     let(:represented) {
       double('represented',
-             available_custom_fields: [custom_field],
-             custom_field.accessor_name => custom_value)
+             available_custom_fields: [custom_field])
     }
-    let(:custom_value) { '' }
+    let(:custom_value) { double('CustomValue', value: value) }
+    let(:value) { '' }
     subject { "{ \"_links\": #{modified_class.new(represented).to_json} }" }
 
+    before do
+      allow(represented).to receive(:custom_value_for).with(custom_field).and_return(custom_value)
+    end
+
     context 'reading' do
-      let(:custom_value) { FactoryGirl.build(:user, id: 2) }
+      let(:value) { '2' }
       let(:field_format) { 'user' }
 
       it_behaves_like 'has an untitled link' do
@@ -380,11 +384,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       end
 
       context 'value is nil' do
-        let(:represented) {
-          double('represented',
-                 available_custom_fields: [custom_field],
-                 custom_field.accessor_name => nil)
-        }
+        let(:value) { nil }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }
@@ -393,7 +393,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'writing' do
-      let(:custom_value) { nil }
+      let(:value) { nil }
       let(:field_format) { 'user' }
 
       it 'accepts a valid link' do

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -126,7 +126,7 @@ describe WorkPackage, type: :model do
 
           subject { work_package.errors.full_messages.first }
 
-          it { is_expected.to eq('Database is not included in the list') }
+          it { is_expected.to eq("Database #{I18n.t('activerecord.errors.messages.inclusion')}") }
         end
       end
 


### PR DESCRIPTION
## OpenProject work packages

Fixing errors in:
- https://community.openproject.org/work_packages/18290
- https://community.openproject.org/work_packages/18291
## Notes

I was keen enough to also change the error messages for the `:inclusion` keyword.

This message is always used in the same kind of context, but the old message never made sense to me. I hope the new one is more clear.
