### PR TITLE
Unify code in WP schema

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -76,53 +76,30 @@ module API
           schema :description,
                  type: 'Formattable'
 
-          property :start_date,
-                   exec_context: :decorator,
-                   getter: -> (*) do
-                     representer = ::API::Decorators::PropertySchemaRepresenter
-                                   .new(type: 'Date',
-                                        name: WorkPackage.human_attribute_name(:start_date))
-                     representer.writable = represented.start_date_writable?
-                     representer.required = false
-                     representer
-                   end
+          schema :start_date,
+                 type: 'Date',
+                 required: false,
+                 writable: -> { represented.start_date_writable? }
 
-          property :due_date,
-                   exec_context: :decorator,
-                   getter: -> (*) do
-                     representer = ::API::Decorators::PropertySchemaRepresenter
-                                   .new(type: 'Date',
-                                        name: WorkPackage.human_attribute_name(:due_date))
-                     representer.writable = represented.due_date_writable?
-                     representer.required = false
-                     representer
-                   end
+          schema :due_date,
+                 type: 'Date',
+                 required: false,
+                 writable: -> { represented.due_date_writable? }
 
-          property :estimated_time,
-                   exec_context: :decorator,
-                   getter: -> (*) do
-                     representer = ::API::Decorators::PropertySchemaRepresenter
-                                   .new(type: 'Duration',
-                                        name: WorkPackage.human_attribute_name(:estimated_time))
-                     representer.writable = represented.estimated_time_writable?
-                     representer.required = false
-                     representer
-                   end
+          schema :estimated_time,
+                 type: 'Duration',
+                 required: false,
+                 writable: -> { represented.estimated_time_writable? }
 
           schema :spent_time,
                  type: 'Duration',
                  writable: false
 
-          property :percentage_done,
-                   exec_context: :decorator,
-                   getter: -> (*) do
-                     representer = ::API::Decorators::PropertySchemaRepresenter
-                                   .new(type: 'Integer',
-                                        name: WorkPackage.human_attribute_name(:done_ratio))
-                     representer.writable = represented.percentage_done_writable?
-                     representer
-                   end,
-                   if: -> (*) { Setting.work_package_done_ratio != 'disabled' }
+          schema :percentage_done,
+                 type: 'Integer',
+                 name_source: :done_ratio,
+                 writable: -> { represented.percentage_done_writable? },
+                 show_if: -> (*) { Setting.work_package_done_ratio != 'disabled' }
 
           schema :created_at,
                  type: 'DateTime',

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -136,32 +136,86 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'startDate' do
+      before do
+        allow(schema).to receive(:start_date_writable?).and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'startDate' }
         let(:type) { 'Date' }
         let(:name) { I18n.t('attributes.start_date') }
         let(:required) { false }
-        let(:writable) { schema.start_date_writable? }
+        let(:writable) { true }
+      end
+
+      context 'not writable' do
+        before do
+          allow(schema).to receive(:start_date_writable?).and_return false
+        end
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'startDate' }
+          let(:type) { 'Date' }
+          let(:name) { I18n.t('attributes.start_date') }
+          let(:required) { false }
+          let(:writable) { false }
+        end
       end
     end
 
     describe 'dueDate' do
+      before do
+        allow(schema).to receive(:due_date_writable?).and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'dueDate' }
         let(:type) { 'Date' }
         let(:name) { I18n.t('attributes.due_date') }
         let(:required) { false }
-        let(:writable) { schema.due_date_writable? }
+        let(:writable) { true }
+      end
+
+      context 'not writable' do
+        before do
+          allow(schema).to receive(:due_date_writable?).and_return false
+        end
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'dueDate' }
+          let(:type) { 'Date' }
+          let(:name) { I18n.t('attributes.due_date') }
+          let(:required) { false }
+          let(:writable) { false }
+        end
       end
     end
 
     describe 'estimatedTime' do
+      before do
+        allow(schema).to receive(:estimated_time_writable?).and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'estimatedTime' }
         let(:type) { 'Duration' }
         let(:name) { I18n.t('attributes.estimated_time') }
         let(:required) { false }
-        let(:writable) { schema.estimated_time_writable? }
+        let(:writable) { true }
+      end
+
+      context 'not writable' do
+        before do
+          allow(schema).to receive(:estimated_time_writable?).and_return false
+        end
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'estimatedTime' }
+          let(:type) { 'Duration' }
+          let(:name) { I18n.t('attributes.estimated_time') }
+          let(:required) { false }
+          let(:writable) { false }
+        end
       end
     end
 
@@ -176,18 +230,40 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'percentageDone' do
+      before do
+        allow(schema).to receive(:percentage_done_writable?).and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'percentageDone' }
         let(:type) { 'Integer' }
         let(:name) { I18n.t('activerecord.attributes.work_package.done_ratio') }
         let(:required) { true }
-        let(:writable) { schema.percentage_done_writable? }
+        let(:writable) { true }
       end
 
-      it 'is hidden when disabled' do
-        allow(Setting).to receive(:work_package_done_ratio).and_return('disabled')
+      context 'not writable' do
+        before do
+          allow(schema).to receive(:percentage_done_writable?).and_return false
+        end
 
-        is_expected.to_not have_json_path('percentageDone')
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'percentageDone' }
+          let(:type) { 'Integer' }
+          let(:name) { I18n.t('activerecord.attributes.work_package.done_ratio') }
+          let(:required) { true }
+          let(:writable) { false }
+        end
+      end
+
+      context 'is disabled' do
+        before do
+          allow(Setting).to receive(:work_package_done_ratio).and_return('disabled')
+        end
+
+        it 'is hidden' do
+          is_expected.to_not have_json_path('percentageDone')
+        end
       end
     end
 


### PR DESCRIPTION
## OpenProject work package

This PR belongs to general [Housekeeping](https://community.openproject.org/work_packages/18714) tasks around OpenProject.
## Content

This PR uses the improved `schema` helper for fields that could not use it before, because it was too simple.
The specs were adapted beforehand to make sure, that the changes do not break anything.
