### PR TITLE
17057 styled inplace edit

### DIFF
--- a/app/assets/javascripts/jstoolbar/jstoolbar.js
+++ b/app/assets/javascripts/jstoolbar/jstoolbar.js
@@ -207,7 +207,7 @@ jsToolBar.prototype = {
     this.toolNodes = {}; // vide les raccourcis DOM/**/
 
     var h = document.createElement('div');
-    h.className = 'help';
+    h.className = 'jstb_help';
     h.innerHTML = this.help_link;
 
     // Draw toolbar elements

--- a/app/assets/stylesheets/_jstoolbar.sass
+++ b/app/assets/stylesheets/_jstoolbar.sass
@@ -29,6 +29,12 @@
 @import open_project_global/all
 @import fonts/openproject_icon_font
 
+$jstoolbar--icon-background: #fff
+$jstoolbar--icon-hover-border: #ccc
+$jstoolbar--icon-border: #fff
+$jstoolbar--icon-active-border: #bbb
+$jstoolbar--icon-active-background: #eee
+
 .jstEditor
   padding-left: 0
 
@@ -41,38 +47,48 @@
   cursor: s-resize
 
 .jstElements
-  padding: 3px 3px
+  @include grid-block
+  justify-content: flex-end
+  text-align: center
+  margin-bottom: 0.25rem
+  line-height: 1.6rem
 
-  button
-    margin-right: 10px
-    width: 32px
-    height: 32px
-    padding: 6px 5px 4px 5px
-    border: $content-form-input-border
-    // needs to be changed into a non background image background
-    background: url(image-path('bg_input_file.png')) repeat-x 0 0
+  button, .jstb_help
+    @include grid-content
+    padding: 0.25rem
+    margin-left: 0.25rem
+    max-width: 1.625rem
+    height: 1.625rem
+    border: 1px solid $jstoolbar--icon-border
+    background-color: $jstoolbar--icon-background
+    color: $body-font-color
     border-radius: 2px
     &:before
       @include icon-common
 
     &:hover
-      border: $content-form-input-hover-border
+      border-color: $jstoolbar--icon-hover-border
       cursor: pointer
+
+    &.-active
+      border-color: $jstoolbar--icon-hover-border
+      box-shadow: inset 0px 0px 3px $jstoolbar--icon-active-border
+      background: $jstoolbar--icon-active-background
 
     span
       display: none
 
+  .jstb_help
+    font-size: 0.8125rem
+    padding: 0.125rem
+
+    a.icon-help:before
+      color: $body-font-color
+      padding: 0
+
   span
     display: inline
 
-  .help
-    float: right
-    margin-right: 0.5em
-    padding-top: 8px
-    font-size: 0.9em
-
-    a
-      padding: 2px 0 2px 20px
 
 .jstSpacer
   width: 0

--- a/app/assets/stylesheets/_jstoolbar.sass
+++ b/app/assets/stylesheets/_jstoolbar.sass
@@ -49,6 +49,7 @@
     height: 32px
     padding: 6px 5px 4px 5px
     border: $content-form-input-border
+    // needs to be changed into a non background image background
     background: url(image-path('bg_input_file.png')) repeat-x 0 0
     border-radius: 2px
     &:before

--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -27,7 +27,7 @@
 //++
 
 .attributes-group
-  margin-bottom: 1.6875rem
+  margin-top: 1.6875rem
 
 .attributes-group--header
   @include grid-block

--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -26,6 +26,9 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+.attributes-group
+  margin-bottom: 1.6875rem
+
 .attributes-group--header
   @include grid-block
   margin:  0 0 1rem 0

--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -45,7 +45,7 @@
   @include grid-content(8)
   overflow: visible
   overflow-y: visible
-  margin-bottom: 0.4rem
+  margin-bottom: 0.1875rem
   padding: 0
 
 .attributes-key-value--value

--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -35,13 +35,11 @@
   font-size: 0.875rem
 
 .attributes-key-value--key
-  @include grid-content(4)
+  @extend .form--label
+  @include grid-size(4)
   margin-bottom: 0.1875rem
   padding: 0.375rem 0
   font-weight: bold
-  line-height: $list-line-height / 0.9
-  text-overflow: ellipsis
-  white-space: nowrap
 
 .attributes-key-value--value-container
   @include grid-content(8)

--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -32,12 +32,12 @@
   align-items: center
   overflow: visible
   overflow-y: visible
+  font-size: 0.875rem
 
 .attributes-key-value--key
   @include grid-content(4)
   margin-bottom: 0.1875rem
-  padding: 0.375rem 0 0.375rem 0.375rem
-  font-size: 0.9rem
+  padding: 0.375rem 0
   font-weight: bold
   line-height: $list-line-height / 0.9
   text-overflow: ellipsis

--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -27,14 +27,16 @@
 //++
 
 .attributes-key-value
-  @include grid-block($wrap: true)
+  @include grid-block
+  @include grid-layout(2)
+  align-items: center
   overflow: visible
   overflow-y: visible
 
 .attributes-key-value--key
   @include grid-content(4)
-  margin-bottom: 0.4rem
-  padding: 0 1rem 0 0
+  margin-bottom: 0.1875rem
+  padding: 0.375rem 0 0.375rem 0.375rem
   font-size: 0.9rem
   font-weight: bold
   line-height: $list-line-height / 0.9

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -27,11 +27,10 @@
   Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
         </span>
       </span>
-      <span class="editing-link-wrapper ng-scope">
-        <accessible-by-keyboard execute="startediting()"
-                                class="ng-isolate-scope">
+      <span class="editing-link-wrapper">
+        <accessible-by-keyboard>
           <a href="" tabindex="0">
-            <span ng-transclude="">
+            <span >
               <span class="icon-context icon-button icon-edit "
                     title="description: edit"
                     icon-name="edit"
@@ -54,10 +53,10 @@
 
 ```
 
-<div class="attributes-group ng-scope">
+<div class="attributes-group">
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
-      <h3 class="attributes-group--header-text ng-binding">
+      <h3 class="attributes-group--header-text ">
         Description
       </h3>
     </div>
@@ -65,10 +64,10 @@
   <div class="single-attribute wiki">
     <span>
       <div class="inplace-editor type-wiki_textarea attribute-description editable">
-        <div class="ined-edit ng-scope" ng-if="isEditing">
+        <div class="ined-edit" >
           <form name="editForm">
             <div class="ined-input-wrapper">
-              <div class="ined-input-wrapper-inner ng-scope" ng-include="" src="getTemplateUrl()">
+              <div class="ined-input-wrapper-inner">
                 <div class="jstElements">
                   <button type="button" class="jstb_strong" title="Strong">
                     <span>Strong</span>
@@ -150,7 +149,7 @@
                              title="Description: Save"
                              icon-name="yes"
                              icon-title="Description: Save">
-                         <span class="hidden-for-sighted ng-binding">
+                         <span class="hidden-for-sighted ">
                            Description: Save
                          </span>
                        </span>
@@ -169,11 +168,11 @@
                  </accessible-by-keyboard>
                  <accessible-by-keyboard class="ined-edit-close">
                    <a href="" tabindex="0">
-                     <span ng-transclude="">
+                     <span >
                        <span class="icon-context icon-button icon-close "
                              title="Description: Cancel"
                              icon-name="close" icon-title="Description: Cancel">
-                         <span class="hidden-for-sighted ng-binding">
+                         <span class="hidden-for-sighted ">
                            Description: Cancel
                          </span>
                        </span>
@@ -217,10 +216,10 @@
                 New
               </span>
             </span>
-            <span ng-if="isEditable" class="editing-link-wrapper">
+            <span class="editing-link-wrapper">
               <accessible-by-keyboard execute="startEditing()">
                 <a href="" tabindex="0">
-                  <span ng-transclude="">
+                  <span >
                     <span class="icon-context icon-button icon-edit "
                           title="Status: Edit"
                           icon-name="edit"
@@ -255,46 +254,46 @@
   </div>
 
   <dl class="attributes-key-value">
-    <dt class="attributes-key-value--key ng-binding ng-scope">Status</dt>
-    <dd class="attributes-key-value--value-container ng-scope" >
-      <div class="ng-scope attributes-key-value--value -status">
+    <dt class="attributes-key-value--key ">Status</dt>
+    <dd class="attributes-key-value--value-container" >
+      <div class="attributes-key-value--value -status">
         <div inplace-editor="">
           <div class="inplace-editor type-select2 attribute-status.name editable" aria-busy="false" aria-disabled="false">
             <div class="ined-edit" >
-              <form name="editForm" class="ng-valid">
+              <form name="editForm">
                 <div class="ined-input-wrapper">
                   <div class="ined-input-wrapper-inner"  >
-                    <input type="text" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false">
+                    <input type="text" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
                   </div>
                 </div>
                 <div class="ined-dashboard">
-                  <div class="ined-errors ng-binding ng-hide" role="alert" aria-live="polite" >
+                  <div class="ined-errors  " role="alert" aria-live="polite" >
                   </div>
                   <div class="ined-controls"  >
-                    <accessible-by-keyboard  class="ined-edit-save ng-isolate-scope">
+                    <accessible-by-keyboard  class="ined-edit-save ">
                       <a default-event-handling="defaultEventHandling"  href="" class="" tabindex="0">
                         <span>
                           <span class="icon-context icon-button icon-yes " title="Status: Save" icon-name="yes" icon-title="Status: Save">
-                            <span class="hidden-for-sighted ng-binding">
+                            <span class="hidden-for-sighted ">
                               Status: Save
                             </span>
                           </span>
                         </span>
                       </a>
                     </accessible-by-keyboard>
-                    <accessible-by-keyboard class="ined-edit-save-send ng-isolate-scope">
+                    <accessible-by-keyboard class="ined-edit-save-send ">
                       <a href="" class="" tabindex="0">
                         <span >
-                          <span title="Status: Save and send email" class="ng-scope">
+                          <span title="Status: Save and send email">
                             <i class="icon-yes"></i>
                             <i class="icon-mail"></i>
                           </span>
                         </span>
                       </a>
                     </accessible-by-keyboard>
-                    <accessible-by-keyboard  class="ined-edit-close ng-isolate-scope"><a  default-event-handling="defaultEventHandling"  href="" class="" tabindex="0"><span >
+                    <accessible-by-keyboard  class="ined-edit-close "><a  default-event-handling="defaultEventHandling"  href="" class="" tabindex="0"><span >
                       <span class="icon-context icon-button icon-close " title="Status: Cancel" icon-name="close" icon-title="Status: Cancel">
-            <span class="hidden-for-sighted ng-binding">Status: Cancel</span>
+            <span class="hidden-for-sighted ">Status: Cancel</span>
           </span>
                     </span></a></accessible-by-keyboard>
                   </div>

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -138,7 +138,7 @@
              <div class="ined-dashboard">
                <div class="ined-errors"
                     role="alert"
-                    ng-bind="error"
+
                     aria-live="polite"
                     aria-hidden="true">
                </div>
@@ -193,6 +193,8 @@
 
 ## In place editing: Single line of text
 
+### Read mode
+
 ```
 <div class="attributes-group">
   <div class="attributes-group--header">
@@ -211,7 +213,7 @@
         <div class="inplace-editor type-select2 attribute-status.name editable">
           <div class="ined-read-value editable" >
             <span class="read-value-wrapper">
-              <span ng-bind="readValue">
+              <span >
                 New
               </span>
             </span>
@@ -231,6 +233,74 @@
                 </a>
               </accessible-by-keyboard>
             </span>
+          </div>
+        </div>
+      </div>
+    </dd>
+  </dl>
+</div>
+```
+
+### Edit mode
+
+```
+<div class="attributes-group">
+
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text ng-binding">
+        Details
+      </h3>
+    </div>
+  </div>
+
+  <dl class="attributes-key-value">
+    <dt class="attributes-key-value--key ng-binding ng-scope">Status</dt>
+    <dd class="attributes-key-value--value-container ng-scope" >
+      <div class="ng-scope attributes-key-value--value -status">
+        <div inplace-editor="">
+          <div class="inplace-editor type-select2 attribute-status.name editable" aria-busy="false" aria-disabled="false">
+            <div class="ined-edit" >
+              <form name="editForm" class="ng-valid">
+                <div class="ined-input-wrapper">
+                  <div class="ined-input-wrapper-inner"  >
+                    <input type="text" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false">
+                  </div>
+                </div>
+                <div class="ined-dashboard">
+                  <div class="ined-errors ng-binding ng-hide" role="alert" aria-live="polite" >
+                  </div>
+                  <div class="ined-controls"  >
+                    <accessible-by-keyboard  class="ined-edit-save ng-isolate-scope">
+                      <a default-event-handling="defaultEventHandling"  href="" class="" tabindex="0">
+                        <span>
+                          <span class="icon-context icon-button icon-yes " title="Status: Save" icon-name="yes" icon-title="Status: Save">
+                            <span class="hidden-for-sighted ng-binding">
+                              Status: Save
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </accessible-by-keyboard>
+                    <accessible-by-keyboard class="ined-edit-save-send ng-isolate-scope">
+                      <a href="" class="" tabindex="0">
+                        <span >
+                          <span title="Status: Save and send email" class="ng-scope">
+                            <i class="icon-yes"></i>
+                            <i class="icon-mail"></i>
+                          </span>
+                        </span>
+                      </a>
+                    </accessible-by-keyboard>
+                    <accessible-by-keyboard  class="ined-edit-close ng-isolate-scope"><a  default-event-handling="defaultEventHandling"  href="" class="" tabindex="0"><span >
+                      <span class="icon-context icon-button icon-close " title="Status: Cancel" icon-name="close" icon-title="Status: Cancel">
+            <span class="hidden-for-sighted ng-binding">Status: Cancel</span>
+          </span>
+                    </span></a></accessible-by-keyboard>
+                  </div>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -1,39 +1,71 @@
 # In place editing
 
-# In place editing: Text areas
+# In place editing: Multiple lines of text
+
+```
+
+<div class="inplace-editor type-wiki_textarea attribute-description editable">
+  <div class="ined-read-value editable">
+    <span class="read-value-wrapper">
+      <span>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
+
+Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
+
+Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
+      </span>
+    </span>
+    <span class="editing-link-wrapper ng-scope">
+      <accessible-by-keyboard execute="startediting()"
+                              class="ng-isolate-scope">
+        <a href="" tabindex="0">
+          <span ng-transclude="">
+            <span class="icon-context icon-button icon-edit "
+                  title="description: edit"
+                  icon-name="edit"
+                  icon-title="description: edit">
+              <span class="hidden-for-sighted">
+                description: edit
+              </span>
+            </span>
+          </span>
+        </a>
+      </accessible-by-keyboard>
+    </span>
+  </div>
+</div>
 
 ```
 
 
-<div class="single-attribute wiki">
-  <span>
-    <div class="inplace-editor type-wiki_textarea attribute-description editable">
-      <div class="ined-read-value default editable">
-        <span class="read-value-wrapper">
-          <span>
-            Click to enter description...
-          </span>
-        </span>
-        <span class="editing-link-wrapper ng-scope">
-          <accessible-by-keyboard execute="startEditing()"
-                                  class="ng-isolate-scope">
-            <a tabindex="0">
-              <span ng-transclude="">
-                <span class="icon-context icon-button icon-edit "
-                      title="Description: Edit"
-                      icon-name="edit"
-                      icon-title="Description: Edit">
-                  <span class="hidden-for-sighted ng-binding">
-                    Description: Edit
-                  </span>
-                </span>
-              </span>
-            </a>
-          </accessible-by-keyboard>
-        </span>
-      </div>
-    </div>
-  </span>
-</div>
+# In place editing: Single line of text
 
+```
+<div class="inplace-editor type-select2 attribute-status.name editable">
+  <div class="ined-read-value editable" >
+    <span class="read-value-wrapper">
+      <span ng-bind="readValue">
+        New
+      </span>
+    </span>
+    <span ng-if="isEditable" class="editing-link-wrapper">
+      <accessible-by-keyboard execute="startEditing()">
+        <a href="" tabindex="0">
+          <span ng-transclude="">
+            <span class="icon-context icon-button icon-edit "
+                  title="Status: Edit"
+                  icon-name="edit"
+                  icon-title="Status: Edit">
+              <span class="hidden-for-sighted">
+                Status: Edit
+              </span>
+            </span>
+          </span>
+        </a>
+      </accessible-by-keyboard>
+    </span>
+  </div>
+</div>
 ```

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -67,68 +67,66 @@
   <div class="inplace-edit--write " >
     <form class="inplace-edit--form " name="editForm"  novalidate="">
       <div class="inplace-edit--write-value">
-        <div class="ined-input-wrapper-inner "  src="getTemplateUrl()">
-          <div class="jstElements">
-            <button type="button" class="jstb_strong" title="Strong">
-              <span>Strong</span>
-            </button>
-            <button type="button" class="jstb_em" title="Italic">
-              <span>Italic</span>
-            </button>
-            <button type="button" class="jstb_ins" title="Underline">
-              <span>Underline</span>
-            </button>
-            <button type="button" class="jstb_del" title="Deleted">
-              <span>Deleted</span></button><button type="button" class="jstb_code" title="Inline Code">
-              <span>Inline Code</span></button><span id="space1" class="jstSpacer">&nbsp;</span>
-            <button type="button" class="jstb_h1" title="Heading 1">
-              <span>Heading 1</span>
-            </button>
-            <button type="button" class="jstb_h2" title="Heading 2">
-              <span>Heading 2</span>
-            </button>
-            <button type="button" class="jstb_h3" title="Heading 3">
-              <span>Heading 3</span>
-            </button>
-            <span id="space2" class="jstSpacer">&nbsp;</span>
-            <button type="button" class="jstb_ul" title="Unordered List">
-              <span>Unordered List</span>
-            </button>
-            <button type="button" class="jstb_ol" title="Ordered List">
-              <span>Ordered List</span>
-            </button>
-            <span id="space3" class="jstSpacer">&nbsp;</span>
-            <button type="button" class="jstb_bq" title="Quote">
-              <span>Quote</span></button>
-            <button type="button" class="jstb_unbq" title="Unquote">
-              <span>Unquote</span>
-            </button>
-            <button type="button" class="jstb_pre" title="Preformatted Text">
-              <span>Preformatted Text</span></button><span id="space4" class="jstSpacer">&nbsp;</span>
-            <button type="button" class="jstb_link" title="Link to a Wiki page">
-              <span>Link to a Wiki page</span>
-            </button>
-            <button type="button" class="jstb_img" title="Image">
-              <span>Image</span>
-            </button>
-            <div class="jstb_help">
-              <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">
-                <span class="hidden-for-sighted">
-                  Text formatting
-                </span>
-              </a>
-            </div>
-            <button class="jstb_preview icon-issue-watched" type="button" title="Preview">
-            </button>
+        <div class="jstElements">
+          <button type="button" class="jstb_strong" title="Strong">
+            <span>Strong</span>
+          </button>
+          <button type="button" class="jstb_em" title="Italic">
+            <span>Italic</span>
+          </button>
+          <button type="button" class="jstb_ins" title="Underline">
+            <span>Underline</span>
+          </button>
+          <button type="button" class="jstb_del" title="Deleted">
+            <span>Deleted</span></button><button type="button" class="jstb_code" title="Inline Code">
+            <span>Inline Code</span></button><span id="space1" class="jstSpacer">&nbsp;</span>
+          <button type="button" class="jstb_h1" title="Heading 1">
+            <span>Heading 1</span>
+          </button>
+          <button type="button" class="jstb_h2" title="Heading 2">
+            <span>Heading 2</span>
+          </button>
+          <button type="button" class="jstb_h3" title="Heading 3">
+            <span>Heading 3</span>
+          </button>
+          <span id="space2" class="jstSpacer">&nbsp;</span>
+          <button type="button" class="jstb_ul" title="Unordered List">
+            <span>Unordered List</span>
+          </button>
+          <button type="button" class="jstb_ol" title="Ordered List">
+            <span>Ordered List</span>
+          </button>
+          <span id="space3" class="jstSpacer">&nbsp;</span>
+          <button type="button" class="jstb_bq" title="Quote">
+            <span>Quote</span></button>
+          <button type="button" class="jstb_unbq" title="Unquote">
+            <span>Unquote</span>
+          </button>
+          <button type="button" class="jstb_pre" title="Preformatted Text">
+            <span>Preformatted Text</span></button><span id="space4" class="jstSpacer">&nbsp;</span>
+          <button type="button" class="jstb_link" title="Link to a Wiki page">
+            <span>Link to a Wiki page</span>
+          </button>
+          <button type="button" class="jstb_img" title="Image">
+            <span>Image</span>
+          </button>
+          <div class="jstb_help">
+            <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">
+              <span class="hidden-for-sighted">
+                Text formatting
+              </span>
+            </a>
           </div>
-
-          <div class="jstEditor">
-            <textarea wiki-toolbar="" class="focus-input inplace-edit--textarea "  preview-toggle="togglePreview()" name="value"   title="Description: Edit" data-wp_autocomplete_url="/work_packages/auto_complete.json?project_id=undefined" aria-multiline="true" tabindex="0" aria-hidden="false" aria-disabled="false" aria-invalid="false" rows="5">
-            </textarea>
-          </div>
-
-          <div class="jstHandle"></div>
+          <button class="jstb_preview icon-issue-watched" type="button" title="Preview">
+          </button>
         </div>
+
+        <div class="jstEditor">
+          <textarea wiki-toolbar="" class="focus-input inplace-edit--textarea "  preview-toggle="togglePreview()" name="value"   title="Description: Edit" data-wp_autocomplete_url="/work_packages/auto_complete.json?project_id=undefined" aria-multiline="true" tabindex="0" aria-hidden="false" aria-disabled="false" aria-invalid="false" rows="5">
+          </textarea>
+        </div>
+
+        <div class="jstHandle"></div>
       </div>
       <div class="inplace-edit--dashboard">
         <div class="inplace-edit--errors "  role="alert"  aria-live="polite" aria-hidden="true">
@@ -257,9 +255,7 @@
             <div class="inplace-edit--write" >
               <form name="editForm" class="inplace-edit--form">
                 <div class="inplace-edit--write-value">
-                  <div class="ined-input-wrapper-inner"  >
-                    <input type="text" class="focus-input inplace-edit--text-field" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
-                  </div>
+                  <input type="text" class="focus-input inplace-edit--text-field" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
                 </div>
                 <div class="inplace-edit--dashboard">
                   <div class="inplace-edit--errors "  role="alert"  aria-live="polite" aria-hidden="true">

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -1,0 +1,39 @@
+# In place editing
+
+# In place editing: Text areas
+
+```
+
+
+<div class="single-attribute wiki">
+  <span>
+    <div class="inplace-editor type-wiki_textarea attribute-description editable">
+      <div class="ined-read-value default editable">
+        <span class="read-value-wrapper">
+          <span>
+            Click to enter description...
+          </span>
+        </span>
+        <span class="editing-link-wrapper ng-scope">
+          <accessible-by-keyboard execute="startEditing()"
+                                  class="ng-isolate-scope">
+            <a tabindex="0">
+              <span ng-transclude="">
+                <span class="icon-context icon-button icon-edit "
+                      title="Description: Edit"
+                      icon-name="edit"
+                      icon-title="Description: Edit">
+                  <span class="hidden-for-sighted ng-binding">
+                    Description: Edit
+                  </span>
+                </span>
+              </span>
+            </a>
+          </accessible-by-keyboard>
+        </span>
+      </div>
+    </div>
+  </span>
+</div>
+
+```

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -14,36 +14,33 @@
       </h3>
     </div>
   </div>
-  <div class="inplace-editor type-wiki_textarea attribute-description editable">
-    <div class="ined-read-value editable">
-      <span class="read-value-wrapper">
-        <span>
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
-
-  Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
-
-  Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
-
-  Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
-        </span>
-      </span>
-      <span class="editing-link-wrapper">
-        <accessible-by-keyboard>
-          <a href="" tabindex="0">
-            <span >
-              <span class="icon-context icon-button icon-edit "
-                    title="description: edit"
-                    icon-name="edit"
-                    icon-title="description: edit">
-                <span class="hidden-for-sighted">
-                  description: edit
-                </span>
+  <div class="inplace-edit type-wiki_textarea attribute-description">
+    <accessible-by-keyboard execute="startEditing()"
+                            class="inplace-editing--trigger-container">
+      <a href=""
+         tabindex="0"
+         class="inplace-editing--trigger-link">
+        <span class="inplace-editing--container">
+          <span class="inplace-edit--read-value">
+            <span class="inplace-edit--read" >
+              <span>
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
               </span>
             </span>
-          </a>
-        </accessible-by-keyboard>
-      </span>
-    </div>
+          </span>
+          <span class="inplace-edit--icon-wrapper">
+            <span class="icon-context icon-button icon-edit "
+                  title="Description: Edit"
+                  icon-name="edit"
+                  icon-title="Description: Edit">
+              <span class="hidden-for-sighted">
+                Description: Edit
+              </span>
+            </span>
+          </span>
+        </span>
+      </a>
+    </accessible-by-keyboard>
   </div>
 </div>
 
@@ -53,7 +50,8 @@
 
 ```
 
-<div class="attributes-group">
+<div class="attributes-group ">
+
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
       <h3 class="attributes-group--header-text ">
@@ -61,140 +59,124 @@
       </h3>
     </div>
   </div>
-  <div class="single-attribute wiki">
-    <span>
-      <div class="inplace-editor type-wiki_textarea attribute-description editable">
-        <div class="ined-edit" >
-          <form name="editForm">
-            <div class="ined-input-wrapper">
-              <div class="ined-input-wrapper-inner">
-                <div class="jstElements">
-                  <button type="button" class="jstb_strong" title="Strong">
-                    <span>Strong</span>
-                  </button>
-                  <button type="button" class="jstb_em" title="Italic">
-                    <span>Italic</span>
-                  </button>
-                  <button type="button" class="jstb_ins" title="Underline">
-                    <span>Underline</span>
-                  </button>
-                  <button type="button" class="jstb_del" title="Deleted">
-                    <span>Deleted</span>
-                  </button>
-                  <button type="button" class="jstb_code" title="Inline Code">
-                    <span>Inline Code</span>
-                  </button>
-                  <span id="space1" class="jstSpacer">&nbsp;</span>
-                  <button type="button" class="jstb_h1" title="Heading 1">
-                    <span>Heading 1</span>
-                  </button>
-                  <button type="button" class="jstb_h2" title="Heading 2">
-                    <span>Heading 2</span></button>
-                  <button type="button" class="jstb_h3" title="Heading 3">
-                    <span>Heading 3</span>
-                  </button>
-                  <span id="space2" class="jstSpacer">&nbsp;</span>
-                  <button type="button" class="jstb_ul" title="Unordered List">
-                    <span>Unordered List</span>
-                  </button>
-                  <button type="button" class="jstb_ol" title="Ordered List">
-                    <span>Ordered List</span>
-                  </button>
-                  <span id="space3" class="jstSpacer">&nbsp;</span>
-                  <button type="button" class="jstb_bq" title="Quote">
-                    <span>Quote</span>
-                  </button>
-                  <button type="button" class="jstb_unbq" title="Unquote">
-                    <span>Unquote</span>
-                  </button>
-                  <button type="button" class="jstb_pre" title="Preformatted Text">
-                    <span>Preformatted Text</span>
-                  </button>
-                  <span id="space4" class="jstSpacer">&nbsp;</span>
-                  <button type="button" class="jstb_link" title="Link to a Wiki page">
-                    <span>Link to a Wiki page</span>
-                  </button>
-                  <button type="button" class="jstb_img" title="Image">
-                    <span>Image</span>
-                  </button>
-                  <div class="help">
-                    <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help">
-                      Text formatting
-                    </a>
-                  </div>
-                  <button class="btn-preview" type="button">
-                    Preview
-                  </button>
-                </div>
-                <div class="jstEditor">
-                  <textarea wiki-toolbar="" class="focus-input" name="value" title="Description: Edit" tabindex="0" rows="2">
-                  </textarea>
-                </div>
-                <div class="jstHandle">
-                </div>
-              </div>
-            </div>
-             <div class="ined-dashboard">
-               <div class="ined-errors"
-                    role="alert"
 
-                    aria-live="polite"
-                    aria-hidden="true">
-               </div>
-               <div class="ined-controls inplace-edit--controls">
-                 <div class="inplace-edit--control">
-                   <accessible-by-keyboard class="ined-edit-save">
-                     <a href="" tabindex="0">
-                       <span>
-                         <span class="icon-context icon-button icon-yes "
-                               title="Description: Save"
-                               icon-name="yes"
-                               icon-title="Description: Save">
-                           <span class="hidden-for-sighted ">
-                             Description: Save
-                           </span>
-                         </span>
-                       </span>
-                     </a>
-                   </accessible-by-keyboard>
-                 </div>
-                 <div class="inplace-edit--control -icons-2">
-                   <accessible-by-keyboard class="ined-edit-save-send">
-                     <a href="" tabindex="0">
-                       <span>
-                         <span title="Description: Save and send email">
-                           <i class="icon-yes"></i>
-                           <i class="icon-mail"></i>
-                         </span>
-                       </span>
-                     </a>
-                   </accessible-by-keyboard>
-                 </div>
-                 <div class="inplace-edit--control">
-                   <accessible-by-keyboard class="ined-edit-close">
-                     <a href="" tabindex="0">
-                       <span >
-                         <span class="icon-context icon-button icon-close2"
-                               title="Description: Cancel"
-                               icon-name="close" icon-title="Description: Cancel">
-                           <span class="hidden-for-sighted ">
-                             Description: Cancel
-                           </span>
-                         </span>
-                       </span>
-                     </a>
-                   </accessible-by-keyboard>
-                  </div>
-              </div>
+  <div class="single-attribute wiki">
+    <span inplace-editor="" placeholder="Click to enter description..." autocomplete-path="/work_packages/auto_complete.json?project_id=undefined" >
+      <div class="inplace-edit type-wiki_textarea attribute-description"  aria-busy="false" >
+
+  <div class="inplace-edit--write " >
+    <form class="inplace-edit--form " name="editForm"  novalidate="">
+      <div class="ined-input-wrapper">
+        <div class="ined-input-wrapper-inner "  src="getTemplateUrl()">
+          <div class="jstElements">
+            <button type="button" class="jstb_strong" title="Strong">
+              <span>Strong</span>
+            </button>
+            <button type="button" class="jstb_em" title="Italic">
+              <span>Italic</span>
+            </button>
+            <button type="button" class="jstb_ins" title="Underline">
+              <span>Underline</span>
+            </button>
+            <button type="button" class="jstb_del" title="Deleted">
+              <span>Deleted</span></button><button type="button" class="jstb_code" title="Inline Code">
+              <span>Inline Code</span></button><span id="space1" class="jstSpacer">&nbsp;</span>
+            <button type="button" class="jstb_h1" title="Heading 1">
+              <span>Heading 1</span>
+            </button>
+            <button type="button" class="jstb_h2" title="Heading 2">
+              <span>Heading 2</span>
+            </button>
+            <button type="button" class="jstb_h3" title="Heading 3">
+              <span>Heading 3</span>
+            </button>
+            <span id="space2" class="jstSpacer">&nbsp;</span>
+            <button type="button" class="jstb_ul" title="Unordered List">
+              <span>Unordered List</span>
+            </button>
+            <button type="button" class="jstb_ol" title="Ordered List">
+              <span>Ordered List</span>
+            </button>
+            <span id="space3" class="jstSpacer">&nbsp;</span>
+            <button type="button" class="jstb_bq" title="Quote">
+              <span>Quote</span></button>
+            <button type="button" class="jstb_unbq" title="Unquote">
+              <span>Unquote</span>
+            </button>
+            <button type="button" class="jstb_pre" title="Preformatted Text">
+              <span>Preformatted Text</span></button><span id="space4" class="jstSpacer">&nbsp;</span>
+            <button type="button" class="jstb_link" title="Link to a Wiki page">
+              <span>Link to a Wiki page</span>
+            </button>
+            <button type="button" class="jstb_img" title="Image">
+              <span>Image</span>
+            </button>
+            <div class="help">
+              <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">Text formatting</a>
             </div>
-          </form>
+            <button class="btn-preview icon-issue-watched" type="button" title="Preview">
+            </button>
+          </div>
+
+          <div class="jstEditor">
+            <textarea wiki-toolbar="" class="focus-input inplace-edit--textarea "  preview-toggle="togglePreview()" name="value"   title="Description: Edit" data-wp_autocomplete_url="/work_packages/auto_complete.json?project_id=undefined" aria-multiline="true" tabindex="0" aria-hidden="false" aria-disabled="false" aria-invalid="false" rows="5">
+            </textarea>
+          </div>
+
+          <div class="jstHandle"></div>
         </div>
       </div>
-    </span>
+      <div class="inplace-edit--dashboard">
+        <div class="inplace-edit--errors "  role="alert"  aria-live="polite" aria-hidden="true">
+        </div>
+        <div class="inplace-edit--controls"  aria-hidden="false">
+          <div class="inplace-edit--control inplace-edit--control--save">
+            <accessible-by-keyboard execute="editForm.$valid &amp;&amp; submit(false)" >
+              <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                <span >
+                  <span class="icon-context icon-button icon-yes " title="Description: Save" icon-name="yes" icon-title="Description: Save">
+                    <span class="hidden-for-sighted ">Description: Save</span>
+                  </span>
+                </span>
+              </a></accessible-by-keyboard>
+          </div>
+          <div class="inplace-edit--control -icons-2 inplace-edit--control--send">
+            <accessible-by-keyboard execute="editForm.$valid &amp;&amp; submit(true)" >
+              <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                <span  >
+                  <span title="Description: Save and send email" >
+                    <i class="icon-yes"></i>
+                    <i class="icon-mail"></i>
+                  </span>
+                </span>
+              </a>
+            </accessible-by-keyboard>
+          </div>
+          <div class="inplace-edit--control inplace-edit--control--cancel">
+            <accessible-by-keyboard execute="discardEditing()" >
+              <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                <span  >
+                  <span class="icon-context icon-button icon-close2 " title="Description: Cancel" icon-name="close2" icon-title="Description: Cancel">
+                    <span class="hidden-for-sighted ">Description: Cancel</span>
+                  </span>
+                </span>
+              </a>
+            </accessible-by-keyboard>
+          </div>
+        </div>
+      </div>
+    </form>
   </div>
 </div>
 
-<div style="height: 50px;">
+
+
+</span>
+  </div>
+</div>
+
+
+<div style="height: 100px;">
 </div>
 
 ```
@@ -218,30 +200,30 @@
     </dt>
     <dd class="attributes-key-value--value-container">
       <div class="attributes-key-value--value -status">
-        <div class="inplace-editor type-select2 attribute-status.name editable">
-          <div class="ined-read-value editable" >
-            <span class="read-value-wrapper">
-              <span >
-                New
-              </span>
-            </span>
-            <span class="editing-link-wrapper">
-              <accessible-by-keyboard execute="startEditing()">
-                <a href="" tabindex="0">
-                  <span >
-                    <span class="icon-context icon-button icon-edit "
-                          title="Status: Edit"
-                          icon-name="edit"
-                          icon-title="Status: Edit">
-                      <span class="hidden-for-sighted">
-                        Status: Edit
-                      </span>
+        <div class="inplace-edit type-select2 attribute-status.name">
+          <accessible-by-keyboard execute="startEditing()"
+                                  class="inplace-editing--trigger-container">
+            <a href=""
+               tabindex="0"
+               class="inplace-editing--trigger-link">
+              <span class="inplace-editing--container">
+                <span class="inplace-edit--read-value">
+                  <span class="inplace-edit--read" >
+                    <span >
+                      New
                     </span>
                   </span>
-                </a>
-              </accessible-by-keyboard>
-            </span>
-          </div>
+                </span>
+                <span class="inplace-edit--icon-wrapper">
+                  <span class="icon-context icon-button icon-edit " title="Status: Edit" icon-name="edit" icon-title="Status: Edit">
+                    <span class="hidden-for-sighted">
+                      Status: Edit
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </a>
+          </accessible-by-keyboard>
         </div>
       </div>
     </dd>
@@ -256,7 +238,7 @@
 
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
-      <h3 class="attributes-group--header-text ng-binding">
+      <h3 class="attributes-group--header-text ">
         Details
       </h3>
     </div>
@@ -266,37 +248,34 @@
     <dt class="attributes-key-value--key ">Status</dt>
     <dd class="attributes-key-value--value-container" >
       <div class="attributes-key-value--value -status">
-        <div inplace-editor="">
-          <div class="inplace-editor type-select2 attribute-status.name editable" aria-busy="false" aria-disabled="false">
-            <div class="ined-edit" >
-              <form name="editForm">
+        <div inplace-edit="">
+          <div class="inplace-edit type-select2 attribute-status.name" aria-busy="false" aria-disabled="false">
+            <div class="inplace-edit--write" >
+              <form name="editForm" class="inplace-edit--form">
                 <div class="ined-input-wrapper">
                   <div class="ined-input-wrapper-inner"  >
-                    <input type="text" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
+                    <input type="text" class="focus-input inplace-edit--text-field" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
                   </div>
                 </div>
-                <div class="ined-dashboard">
-                  <div class="ined-errors  " role="alert" aria-live="polite" >
+                <div class="inplace-edit--dashboard">
+                  <div class="inplace-edit--errors "  role="alert"  aria-live="polite" aria-hidden="true">
                   </div>
-                  <div class="ined-controls"  >
-                    <div class="inplace-edit--control">
-                      <accessible-by-keyboard  class="ined-edit-save ">
-                        <a default-event-handling="defaultEventHandling"  href="" class="" tabindex="0">
-                          <span>
-                            <span class="icon-context icon-button icon-yes " title="Status: Save" icon-name="yes" icon-title="Status: Save">
-                              <span class="hidden-for-sighted ">
-                                Status: Save
-                              </span>
+                  <div class="inplace-edit--controls"  aria-hidden="false">
+                    <div class="inplace-edit--control inplace-edit--control--save">
+                      <accessible-by-keyboard execute="editForm.$valid &amp;&amp; submit(false)" >
+                        <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                          <span >
+                            <span class="icon-context icon-button icon-yes " title="Description: Save" icon-name="yes" icon-title="Description: Save">
+                              <span class="hidden-for-sighted ">Description: Save</span>
                             </span>
                           </span>
-                        </a>
-                      </accessible-by-keyboard>
+                        </a></accessible-by-keyboard>
                     </div>
-                    <div class="inplace-edit--control -icons-2">
-                      <accessible-by-keyboard class="ined-edit-save-send ">
-                        <a href="" class="" tabindex="0">
-                          <span >
-                            <span title="Status: Save and send email">
+                    <div class="inplace-edit--control -icons-2 inplace-edit--control--send">
+                      <accessible-by-keyboard execute="editForm.$valid &amp;&amp; submit(true)" >
+                        <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                          <span  >
+                            <span title="Description: Save and send email" >
                               <i class="icon-yes"></i>
                               <i class="icon-mail"></i>
                             </span>
@@ -304,19 +283,17 @@
                         </a>
                       </accessible-by-keyboard>
                     </div>
-                    <div class="inplace-edit--control">
-                    <accessible-by-keyboard  class="ined-edit-close ">
-                      <a href="" class="" tabindex="0">
-                        <span >
-                          <span class="icon-context icon-button icon-close2 " title="Status: Cancel" icon-name="close" icon-title="Status: Cancel">
-                            <span class="hidden-for-sighted ">
-                              Status: Cancel
+                    <div class="inplace-edit--control inplace-edit--control--cancel">
+                      <accessible-by-keyboard execute="discardEditing()" >
+                        <a execute-on-enter="execute()" default-event-handling="defaultEventHandling"  href=""  tabindex="0">
+                          <span  >
+                            <span class="icon-context icon-button icon-close2 " title="Description: Cancel" icon-name="close2" icon-title="Description: Cancel">
+                              <span class="hidden-for-sighted ">Description: Cancel</span>
                             </span>
                           </span>
-                        </span>
-                      </a>
+                        </a>
+                      </accessible-by-keyboard>
                     </div>
-                    </accessible-by-keyboard>
                   </div>
                 </div>
               </form>

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -141,44 +141,50 @@
                     aria-live="polite"
                     aria-hidden="true">
                </div>
-               <div class="ined-controls">
-                 <accessible-by-keyboard class="ined-edit-save">
-                   <a href="" tabindex="0">
-                     <span>
-                       <span class="icon-context icon-button icon-yes "
-                             title="Description: Save"
-                             icon-name="yes"
-                             icon-title="Description: Save">
-                         <span class="hidden-for-sighted ">
-                           Description: Save
+               <div class="ined-controls inplace-edit--controls">
+                 <div class="inplace-edit--control">
+                   <accessible-by-keyboard class="ined-edit-save">
+                     <a href="" tabindex="0">
+                       <span>
+                         <span class="icon-context icon-button icon-yes "
+                               title="Description: Save"
+                               icon-name="yes"
+                               icon-title="Description: Save">
+                           <span class="hidden-for-sighted ">
+                             Description: Save
+                           </span>
                          </span>
                        </span>
-                     </span>
-                   </a>
-                 </accessible-by-keyboard>
-                 <accessible-by-keyboard class="ined-edit-save-send">
-                   <a href="" tabindex="0">
-                     <span>
-                       <span title="Description: Save and send email">
-                         <i class="icon-yes"></i>
-                         <i class="icon-mail"></i>
-                       </span>
-                     </span>
-                   </a>
-                 </accessible-by-keyboard>
-                 <accessible-by-keyboard class="ined-edit-close">
-                   <a href="" tabindex="0">
-                     <span >
-                       <span class="icon-context icon-button icon-close "
-                             title="Description: Cancel"
-                             icon-name="close" icon-title="Description: Cancel">
-                         <span class="hidden-for-sighted ">
-                           Description: Cancel
+                     </a>
+                   </accessible-by-keyboard>
+                 </div>
+                 <div class="inplace-edit--control -icons-2">
+                   <accessible-by-keyboard class="ined-edit-save-send">
+                     <a href="" tabindex="0">
+                       <span>
+                         <span title="Description: Save and send email">
+                           <i class="icon-yes"></i>
+                           <i class="icon-mail"></i>
                          </span>
                        </span>
-                     </span>
-                   </a>
-                 </accessible-by-keyboard>
+                     </a>
+                   </accessible-by-keyboard>
+                 </div>
+                 <div class="inplace-edit--control">
+                   <accessible-by-keyboard class="ined-edit-close">
+                     <a href="" tabindex="0">
+                       <span >
+                         <span class="icon-context icon-button icon-close2"
+                               title="Description: Cancel"
+                               icon-name="close" icon-title="Description: Cancel">
+                           <span class="hidden-for-sighted ">
+                             Description: Cancel
+                           </span>
+                         </span>
+                       </span>
+                     </a>
+                   </accessible-by-keyboard>
+                  </div>
               </div>
             </div>
           </form>
@@ -186,6 +192,9 @@
       </div>
     </span>
   </div>
+</div>
+
+<div style="height: 50px;">
 </div>
 
 ```
@@ -270,32 +279,44 @@
                   <div class="ined-errors  " role="alert" aria-live="polite" >
                   </div>
                   <div class="ined-controls"  >
-                    <accessible-by-keyboard  class="ined-edit-save ">
-                      <a default-event-handling="defaultEventHandling"  href="" class="" tabindex="0">
-                        <span>
-                          <span class="icon-context icon-button icon-yes " title="Status: Save" icon-name="yes" icon-title="Status: Save">
+                    <div class="inplace-edit--control">
+                      <accessible-by-keyboard  class="ined-edit-save ">
+                        <a default-event-handling="defaultEventHandling"  href="" class="" tabindex="0">
+                          <span>
+                            <span class="icon-context icon-button icon-yes " title="Status: Save" icon-name="yes" icon-title="Status: Save">
+                              <span class="hidden-for-sighted ">
+                                Status: Save
+                              </span>
+                            </span>
+                          </span>
+                        </a>
+                      </accessible-by-keyboard>
+                    </div>
+                    <div class="inplace-edit--control -icons-2">
+                      <accessible-by-keyboard class="ined-edit-save-send ">
+                        <a href="" class="" tabindex="0">
+                          <span >
+                            <span title="Status: Save and send email">
+                              <i class="icon-yes"></i>
+                              <i class="icon-mail"></i>
+                            </span>
+                          </span>
+                        </a>
+                      </accessible-by-keyboard>
+                    </div>
+                    <div class="inplace-edit--control">
+                    <accessible-by-keyboard  class="ined-edit-close ">
+                      <a href="" class="" tabindex="0">
+                        <span >
+                          <span class="icon-context icon-button icon-close2 " title="Status: Cancel" icon-name="close" icon-title="Status: Cancel">
                             <span class="hidden-for-sighted ">
-                              Status: Save
+                              Status: Cancel
                             </span>
                           </span>
                         </span>
                       </a>
+                    </div>
                     </accessible-by-keyboard>
-                    <accessible-by-keyboard class="ined-edit-save-send ">
-                      <a href="" class="" tabindex="0">
-                        <span >
-                          <span title="Status: Save and send email">
-                            <i class="icon-yes"></i>
-                            <i class="icon-mail"></i>
-                          </span>
-                        </span>
-                      </a>
-                    </accessible-by-keyboard>
-                    <accessible-by-keyboard  class="ined-edit-close "><a  default-event-handling="defaultEventHandling"  href="" class="" tabindex="0"><span >
-                      <span class="icon-context icon-button icon-close " title="Status: Cancel" icon-name="close" icon-title="Status: Cancel">
-            <span class="hidden-for-sighted ">Status: Cancel</span>
-          </span>
-                    </span></a></accessible-by-keyboard>
                   </div>
                 </div>
               </form>
@@ -305,5 +326,8 @@
       </div>
     </dd>
   </dl>
+</div>
+
+<div style="height: 50px;">
 </div>
 ```

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -66,7 +66,7 @@
 
   <div class="inplace-edit--write " >
     <form class="inplace-edit--form " name="editForm"  novalidate="">
-      <div class="ined-input-wrapper">
+      <div class="inplace-edit--write-value">
         <div class="ined-input-wrapper-inner "  src="getTemplateUrl()">
           <div class="jstElements">
             <button type="button" class="jstb_strong" title="Strong">
@@ -256,7 +256,7 @@
           <div class="inplace-edit type-select2 attribute-status.name" aria-busy="false" aria-disabled="false">
             <div class="inplace-edit--write" >
               <form name="editForm" class="inplace-edit--form">
-                <div class="ined-input-wrapper">
+                <div class="inplace-edit--write-value">
                   <div class="ined-input-wrapper-inner"  >
                     <input type="text" class="focus-input inplace-edit--text-field" aria-label="Status: Edit focus" aria-haspopup="true" role="button" aria-disabled="false" value="New">
                   </div>

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -111,10 +111,14 @@
             <button type="button" class="jstb_img" title="Image">
               <span>Image</span>
             </button>
-            <div class="help">
-              <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">Text formatting</a>
+            <div class="jstb_help">
+              <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">
+                <span class="hidden-for-sighted">
+                  Text formatting
+                </span>
+              </a>
             </div>
-            <button class="btn-preview icon-issue-watched" type="button" title="Preview">
+            <button class="jstb_preview icon-issue-watched" type="button" title="Preview">
             </button>
           </div>
 

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -3,37 +3,46 @@
 # In place editing: Multiple lines of text
 
 ```
+<div class="attributes-group">
 
-<div class="inplace-editor type-wiki_textarea attribute-description editable">
-  <div class="ined-read-value editable">
-    <span class="read-value-wrapper">
-      <span>
-        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text">
+        Description
+      </h3>
+    </div>
+  </div>
+  <div class="inplace-editor type-wiki_textarea attribute-description editable">
+    <div class="ined-read-value editable">
+      <span class="read-value-wrapper">
+        <span>
+          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
+  Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
 
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
+  Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
 
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
+  Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
+        </span>
       </span>
-    </span>
-    <span class="editing-link-wrapper ng-scope">
-      <accessible-by-keyboard execute="startediting()"
-                              class="ng-isolate-scope">
-        <a href="" tabindex="0">
-          <span ng-transclude="">
-            <span class="icon-context icon-button icon-edit "
-                  title="description: edit"
-                  icon-name="edit"
-                  icon-title="description: edit">
-              <span class="hidden-for-sighted">
-                description: edit
+      <span class="editing-link-wrapper ng-scope">
+        <accessible-by-keyboard execute="startediting()"
+                                class="ng-isolate-scope">
+          <a href="" tabindex="0">
+            <span ng-transclude="">
+              <span class="icon-context icon-button icon-edit "
+                    title="description: edit"
+                    icon-name="edit"
+                    icon-title="description: edit">
+                <span class="hidden-for-sighted">
+                  description: edit
+                </span>
               </span>
             </span>
-          </span>
-        </a>
-      </accessible-by-keyboard>
-    </span>
+          </a>
+        </accessible-by-keyboard>
+      </span>
+    </div>
   </div>
 </div>
 
@@ -43,29 +52,47 @@ Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming 
 # In place editing: Single line of text
 
 ```
-<div class="inplace-editor type-select2 attribute-status.name editable">
-  <div class="ined-read-value editable" >
-    <span class="read-value-wrapper">
-      <span ng-bind="readValue">
-        New
-      </span>
-    </span>
-    <span ng-if="isEditable" class="editing-link-wrapper">
-      <accessible-by-keyboard execute="startEditing()">
-        <a href="" tabindex="0">
-          <span ng-transclude="">
-            <span class="icon-context icon-button icon-edit "
-                  title="Status: Edit"
-                  icon-name="edit"
-                  icon-title="Status: Edit">
-              <span class="hidden-for-sighted">
-                Status: Edit
+<div class="attributes-group">
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text">
+        Details
+      </h3>
+    </div>
+  </div>
+  <dl class="attributes-key-value">
+    <dt class="attributes-key-value--key">
+      Status
+    </dt>
+    <dd class="attributes-key-value--value-container">
+      <div class="attributes-key-value--value -status">
+        <div class="inplace-editor type-select2 attribute-status.name editable">
+          <div class="ined-read-value editable" >
+            <span class="read-value-wrapper">
+              <span ng-bind="readValue">
+                New
               </span>
             </span>
-          </span>
-        </a>
-      </accessible-by-keyboard>
-    </span>
-  </div>
+            <span ng-if="isEditable" class="editing-link-wrapper">
+              <accessible-by-keyboard execute="startEditing()">
+                <a href="" tabindex="0">
+                  <span ng-transclude="">
+                    <span class="icon-context icon-button icon-edit "
+                          title="Status: Edit"
+                          icon-name="edit"
+                          icon-title="Status: Edit">
+                      <span class="hidden-for-sighted">
+                        Status: Edit
+                      </span>
+                    </span>
+                  </span>
+                </a>
+              </accessible-by-keyboard>
+            </span>
+          </div>
+        </div>
+      </div>
+    </dd>
+  </dl>
 </div>
 ```

--- a/app/assets/stylesheets/content/_in_place_editing.md
+++ b/app/assets/stylesheets/content/_in_place_editing.md
@@ -1,6 +1,8 @@
 # In place editing
 
-# In place editing: Multiple lines of text
+## In place editing: Multiple lines of text
+
+### Read mode
 
 ```
 <div class="attributes-group">
@@ -48,8 +50,148 @@
 
 ```
 
+### Edit mode
 
-# In place editing: Single line of text
+```
+
+<div class="attributes-group ng-scope">
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text ng-binding">
+        Description
+      </h3>
+    </div>
+  </div>
+  <div class="single-attribute wiki">
+    <span>
+      <div class="inplace-editor type-wiki_textarea attribute-description editable">
+        <div class="ined-edit ng-scope" ng-if="isEditing">
+          <form name="editForm">
+            <div class="ined-input-wrapper">
+              <div class="ined-input-wrapper-inner ng-scope" ng-include="" src="getTemplateUrl()">
+                <div class="jstElements">
+                  <button type="button" class="jstb_strong" title="Strong">
+                    <span>Strong</span>
+                  </button>
+                  <button type="button" class="jstb_em" title="Italic">
+                    <span>Italic</span>
+                  </button>
+                  <button type="button" class="jstb_ins" title="Underline">
+                    <span>Underline</span>
+                  </button>
+                  <button type="button" class="jstb_del" title="Deleted">
+                    <span>Deleted</span>
+                  </button>
+                  <button type="button" class="jstb_code" title="Inline Code">
+                    <span>Inline Code</span>
+                  </button>
+                  <span id="space1" class="jstSpacer">&nbsp;</span>
+                  <button type="button" class="jstb_h1" title="Heading 1">
+                    <span>Heading 1</span>
+                  </button>
+                  <button type="button" class="jstb_h2" title="Heading 2">
+                    <span>Heading 2</span></button>
+                  <button type="button" class="jstb_h3" title="Heading 3">
+                    <span>Heading 3</span>
+                  </button>
+                  <span id="space2" class="jstSpacer">&nbsp;</span>
+                  <button type="button" class="jstb_ul" title="Unordered List">
+                    <span>Unordered List</span>
+                  </button>
+                  <button type="button" class="jstb_ol" title="Ordered List">
+                    <span>Ordered List</span>
+                  </button>
+                  <span id="space3" class="jstSpacer">&nbsp;</span>
+                  <button type="button" class="jstb_bq" title="Quote">
+                    <span>Quote</span>
+                  </button>
+                  <button type="button" class="jstb_unbq" title="Unquote">
+                    <span>Unquote</span>
+                  </button>
+                  <button type="button" class="jstb_pre" title="Preformatted Text">
+                    <span>Preformatted Text</span>
+                  </button>
+                  <span id="space4" class="jstSpacer">&nbsp;</span>
+                  <button type="button" class="jstb_link" title="Link to a Wiki page">
+                    <span>Link to a Wiki page</span>
+                  </button>
+                  <button type="button" class="jstb_img" title="Image">
+                    <span>Image</span>
+                  </button>
+                  <div class="help">
+                    <a href="/help/wiki_syntax" title="Text formatting" class="icon icon-help">
+                      Text formatting
+                    </a>
+                  </div>
+                  <button class="btn-preview" type="button">
+                    Preview
+                  </button>
+                </div>
+                <div class="jstEditor">
+                  <textarea wiki-toolbar="" class="focus-input" name="value" title="Description: Edit" tabindex="0" rows="2">
+                  </textarea>
+                </div>
+                <div class="jstHandle">
+                </div>
+              </div>
+            </div>
+             <div class="ined-dashboard">
+               <div class="ined-errors"
+                    role="alert"
+                    ng-bind="error"
+                    aria-live="polite"
+                    aria-hidden="true">
+               </div>
+               <div class="ined-controls">
+                 <accessible-by-keyboard class="ined-edit-save">
+                   <a href="" tabindex="0">
+                     <span>
+                       <span class="icon-context icon-button icon-yes "
+                             title="Description: Save"
+                             icon-name="yes"
+                             icon-title="Description: Save">
+                         <span class="hidden-for-sighted ng-binding">
+                           Description: Save
+                         </span>
+                       </span>
+                     </span>
+                   </a>
+                 </accessible-by-keyboard>
+                 <accessible-by-keyboard class="ined-edit-save-send">
+                   <a href="" tabindex="0">
+                     <span>
+                       <span title="Description: Save and send email">
+                         <i class="icon-yes"></i>
+                         <i class="icon-mail"></i>
+                       </span>
+                     </span>
+                   </a>
+                 </accessible-by-keyboard>
+                 <accessible-by-keyboard class="ined-edit-close">
+                   <a href="" tabindex="0">
+                     <span ng-transclude="">
+                       <span class="icon-context icon-button icon-close "
+                             title="Description: Cancel"
+                             icon-name="close" icon-title="Description: Cancel">
+                         <span class="hidden-for-sighted ng-binding">
+                           Description: Cancel
+                         </span>
+                       </span>
+                     </span>
+                   </a>
+                 </accessible-by-keyboard>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+
+```
+
+## In place editing: Single line of text
 
 ```
 <div class="attributes-group">

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -1,4 +1,6 @@
 $inplace-edit--border-color: #ddd
+$inplace-edit--dark-background: #f8f8f8
+$inplace-edit--color--very-dark: #cacaca
 
 .select2-container
   position: relative!important
@@ -66,22 +68,6 @@ $inplace-edit--border-color: #ddd
       background: white
       border: 1px solid #cacaca
       min-height: 42px
-    .ined-controls
-      float: left
-      display: inline-block
-      bottom: 17px
-      left: 29px
-      width: 120px
-      background: white
-      border: 1px solid #cacaca
-      text-align: center
-      a
-        width: 36px
-        display: inline-block
-        text-align: center
-        text-decoration: none
-        &:hover
-          background: #f0f0f0
   &.type-text
     .ined-dashboard
       width: 90%
@@ -98,7 +84,6 @@ $inplace-edit--border-color: #ddd
       padding-left: 0px
       width: 100%
       .ined-controls
-        left: 0px
         z-index: 1
     .jstHandle
       display: none
@@ -137,7 +122,21 @@ $inplace-edit--border-color: #ddd
       width: 100%
     .ined-dashboard
       padding-left: 0px
-    .ined-controls
+
+.ined-dashboard
+  position: absolute
+  width: 100%
+
+.ined-controls, .inplace-edit--controls
+  display: inline-block
+  width: 114px
+  height: 35px
+  background: #f8f8f8
+  border: 1px solid $inplace-edit--color--very-dark
+  box-shadow: 1px 1px 2px $inplace-edit--border-color
+  text-align: center
+  float: right
+  padding: 5px
 
 .inplace-editor
   @extend .form--field.-full-width
@@ -186,6 +185,27 @@ $inplace-edit--border-color: #ddd
 
     .editing-link-wrapper
       opacity: 1
+
+.inplace-edit--control
+  background: $inplace-edit--color--very-dark
+  width: 23px
+  height: 23px
+  border: 1px solid $inplace-edit--dark-background
+  display: inline-block
+  border-radius: 12px
+  font-size: 12px
+
+  &.-icons-2
+    width: 46px
+
+  a
+    color: $body-font-color
+    text-decoration: none
+    &:hover
+      //background: #f0f0f0
+
+    .icon-context::before
+      padding: 0
 
 @include breakpoint(xlarge)
   .inplace-editor .jstElements .help a

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -2,134 +2,93 @@ $inplace-edit--border-color: #ddd
 $inplace-edit--dark-background: #f8f8f8
 $inplace-edit--color--very-dark: #cacaca
 
-.select2-container
-  position: relative!important
-.inplace-editor
-  ul
-    margin-left: auto
-  display: inline
-  font-size: medium
-  .ined-input-wrapper-inner
-    display: inline
-  &.busy
-    opacity: 0.5
-    .jstElements button
-      opacity: 0.5
-    *
-      cursor: wait!important
-  &.preview
+.inplace-edit
+  @extend .form--field.-full-width
+
+  &.-preview
     button
       visibility: hidden
     .help
       display: none!important
     .btn-preview
       visibility: visible
-    &.type-wiki_textarea .ined-controls
-      bottom: -34px
-  .hidden-but-focusable
-    position: absolute
-    left: -10000px
-    top: auto
-    width: 1px
-    height: 1px
-    overflow: hidden
-  .visible-on-focus
-    left: 0
-    position: inherit
-    width: auto
-    height: auto
-    float: inherit
 
-  .ined-input-wrapper
-    display: inline
-    input
-      width: 90%
-      margin-bottom: -1px
-  .ined-read-value
-    &.default
-      span
-        font-style: italic
-    &.editable:hover
-      cursor: pointer
+  &.-busy
+    opacity: 0.5
+    .jstElements button
+      opacity: 0.5
+    *
+      cursor: wait!important
 
-  form
-    position: relative
+.inplace-edit--form
+  display: block
+  position: relative
+
+  //todo: Move to something more specific
+  .jstHandle
+    display: none
+  .jstElements
     display: inline
-    .ng-invalid
-      background: lightpink!important
-  .ined-dashboard
-    min-height: 42px
-    .ined-errors
-      line-height: 1.2em
-      width: 100%
-      padding: 5px
-      left: 251px
-      bottom: -11px
-      background: white
-      border: 1px solid #cacaca
-      min-height: 42px
-  &.type-text
-    .ined-dashboard
-      width: 90%
-  &.type-wiki_textarea
-    textarea
-      min-height: 200px
-      width: 100%
-      margin-bottom: -1px
-    .ined-input-wrapper-inner
-      display: block!important
-    form
-      display: block
-    .ined-dashboard
-      padding-left: 0px
-      width: 100%
-      .ined-controls
-        z-index: 1
-    .jstHandle
+    bottom: -31px
+    width: 307px
+    button
       display: none
-    .jstElements
+      &.btn-preview
+        float: right
+        display: inline
+        margin-right: 0
+    .help
       display: inline
-      bottom: -31px
-      width: 307px
-      button
-        display: none
-        &.btn-preview
-          float: right
-          height: 32px
-          width: auto
-          display: inline
-          margin-right: 0
-      .help
-        display: inline
-        float: none
-        position: relative
-        top: -4px
-        left: -12px
-        a
-          width: 29px
-          display: inline-block
-          height: 25px
-          overflow: hidden
-          padding-top: 7px
-          margin-bottom: -2px
-          padding-left: 0
-      .jstb_strong, .jstb_em, .jstb_ins, .jstb_del, .jstb_ul, .jstb_ol
-        display: inline
-  &.type-select2
-    .select2-display-none
-      display: none
-    input[type='text']
-      width: 100%
-    .ined-dashboard
-      padding-left: 0px
+      float: none
+      position: relative
+      top: -4px
+      left: -12px
+      a
+        width: 29px
+        display: inline-block
+        height: 25px
+        overflow: hidden
+        padding-top: 7px
+        margin-bottom: -2px
+        padding-left: 0
+    .jstb_strong, .jstb_em, .jstb_ins, .jstb_del, .jstb_ul, .jstb_ol
+      display: inline
 
-.ined-dashboard
+.inplace-edit--select
+  .select2-display-none
+    display: none
+
+.inplace-edit--textarea
+  min-height: 200px
+  width: 100%
+  margin-bottom: -1px
+
+.inplace-edit--text-field
+  margin-bottom: 0
+  padding: 0.375rem
+  font-size: inherit
+  line-height: inherit
+
+.inplace-edit--dashboard
   position: absolute
   width: 100%
+  z-index: 100
+  min-height: 42px
+  font-size: 0.875rem
 
-.ined-controls, .inplace-edit--controls
+.inplace-edit--errors
+  line-height: 1.2em
+  width: 100%
+  padding: 5px
+  left: 251px
+  bottom: -11px
+  background: white
+  border: 1px solid #cacaca
+  min-height: 42px
+
+.inplace-edit--controls
   display: inline-block
-  width: 114px
+  width: 115px
   height: 35px
   background: #f8f8f8
   border: 1px solid $inplace-edit--color--very-dark
@@ -137,18 +96,20 @@ $inplace-edit--color--very-dark: #cacaca
   text-align: center
   float: right
   padding: 5px
+  line-height: 1.6rem
+  margin-top: -1px
 
-.inplace-editor
-  @extend .form--field.-full-width
-
-.ined-read-value
+.inplace-edit--read
   @extend .form--field-container
 
-.read-value-wrapper
+.inplace-edit--read-value
   @include grid-block
   padding: 0.375rem
 
-.editing-link-wrapper
+  &.-default
+    font-style: italic
+
+.inplace-edit--icon-wrapper
   @include grid-block(shrink)
   text-align: center
   width: 33px
@@ -156,9 +117,7 @@ $inplace-edit--color--very-dark: #cacaca
   border-left: 1px solid $inplace-edit--border-color
   align-items: center
   justify-content: center
-  // hide the element until hover
-  // but keep focusability
-  opacity: 0
+  visibility: hidden
 
   .icon-edit::before
     // HACK: overriding default padding here
@@ -171,44 +130,59 @@ $inplace-edit--color--very-dark: #cacaca
     color: $body-font-color
     text-decoration: none
 
-.ined-read-value
+.inplace-editing--trigger-container
+  @include grid-block
+
+// need to specify the a explicitly as otherwise
+// the default class will win
+a.inplace-editing--trigger-link,
+.inplace-editing--trigger-link
+  @include grid-block
+  color: $body-font-color
+  font-weight: inherit
+
+  &:hover,
+  &:focus,
+    text-decoration: none
+    color: $body-font-color
+
+    .inplace-editing--container
+      border-color: $inplace-edit--border-color
+    .inplace-edit--icon-wrapper
+      visibility: visible
+
+.inplace-editing--container
+  @include grid-block
   border-color: #fff
   border-style: solid
   border-radius: 2px
   border-width: 1px
 
-  &:hover
-    border-color: $inplace-edit--border-color
-
-    .read-value-wrapper
-      border-color: $inplace-edit--border-color
-
-    .editing-link-wrapper
-      opacity: 1
+.inplace-edit--read
+  @include grid-block
 
 .inplace-edit--control
   background: $inplace-edit--color--very-dark
-  width: 23px
-  height: 23px
+  width: 1.4375rem
+  height: 1.4375rem
   border: 1px solid $inplace-edit--dark-background
   display: inline-block
-  border-radius: 12px
-  font-size: 12px
+  border-radius: 0.75rem
+  font-size: 0.75rem
 
   &.-icons-2
-    width: 46px
+    width: 2.875rem
 
   a
     color: $body-font-color
     text-decoration: none
     &:hover
-      //background: #f0f0f0
 
     .icon-context::before
       padding: 0
 
 @include breakpoint(xlarge)
-  .inplace-editor .jstElements .help a
+  .inplace-edit .jstElements .help a
     width: auto!important
     display: inline!important
     height: auto!important

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -66,7 +66,7 @@ $inplace-edit--color--very-dark: #cacaca
   left: 251px
   bottom: -11px
   background: white
-  border: 1px solid #cacaca
+  border: 1px solid $inplace-edit--color--very-dark
   min-height: 42px
 
 .inplace-edit--controls
@@ -91,6 +91,10 @@ $inplace-edit--color--very-dark: #cacaca
 
   &.-default
     font-style: italic
+
+.inplace-edit--preview
+  border: 1px solid $inplace-edit--border-color
+  padding: 0.375rem
 
 .inplace-edit--icon-wrapper
   @include grid-block(shrink)

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -1,3 +1,5 @@
+$inplace-edit--border-color: #ddd
+
 .select2-container
   position: relative!important
 .inplace-editor
@@ -35,13 +37,6 @@
     width: auto
     height: auto
     float: inherit
-  .editing-link-wrapper
-    position: absolute
-    margin-left: 4px
-    a
-      @extend .hidden-but-focusable
-      &:focus
-        @extend .visible-on-focus
 
   .ined-input-wrapper
     display: inline
@@ -49,16 +44,12 @@
       width: 90%
       margin-bottom: -1px
   .ined-read-value
-    display: inline
-    position: relative
     &.default
       span
         font-style: italic
     &.editable:hover
-      outline: 1px solid #cacaca
       cursor: pointer
-      .editing-link-wrapper a
-        @extend .visible-on-focus
+
   form
     position: relative
     display: inline
@@ -103,14 +94,6 @@
       display: block!important
     form
       display: block
-    .ined-read-value
-      display: block
-    .read-value-wrapper
-      display: inline-block
-      width: 100%
-    .editing-link-wrapper
-      top: 5px
-      right: 0px
     .ined-dashboard
       padding-left: 0px
       width: 100%
@@ -161,13 +144,55 @@
       margin: 3px
       &.editable:hover
         outline: 1px solid #cacaca
+
+.inplace-editor
+  @extend .form--field.-full-width
+
+.ined-read-value
+  @extend .form--field-container
+
+.read-value-wrapper
+  @include grid-block
+  padding: 0.375rem
+
+.editing-link-wrapper
+  @include grid-block(shrink)
+  text-align: center
+  width: 33px
+  background: $gray-light
+  border-left: 1px solid $inplace-edit--border-color
+  align-items: center
+  justify-content: center
+  // hide the element until hover
+  // but keep focusability
+  opacity: 0
+
+  .icon-edit::before
+    // HACK: overriding default padding here
+    padding-right: 0
+
+  a
+    color: $body-font-color
+
+  a:hover
+    color: $body-font-color
+    text-decoration: none
+
+.ined-read-value
+  border-color: #fff
+  border-style: solid
+  border-radius: 2px
+  border-width: 1px
+
+  &:hover
+    border-color: $inplace-edit--border-color
+
+    .read-value-wrapper
+      border-color: $inplace-edit--border-color
+
     .editing-link-wrapper
-      position: absolute
-      right: -3px
-      top: 1px
-      width: 30px
-      .icon-context:before
-        padding: 0 1px 1px 0
+      opacity: 1
+
 @include breakpoint(xlarge)
   .inplace-editor .jstElements .help a
     width: auto!important

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -6,11 +6,9 @@ $inplace-edit--color--very-dark: #cacaca
   @extend .form--field.-full-width
 
   &.-preview
-    button
+    button, .jstb_help
       visibility: hidden
-    .help
-      display: none!important
-    .btn-preview
+    .jstb_preview
       visibility: visible
 
   &.-busy
@@ -25,34 +23,19 @@ $inplace-edit--color--very-dark: #cacaca
   position: relative
 
   //todo: Move to something more specific
-  .jstHandle
+  .jstHandle, .jstSpacer
     display: none
   .jstElements
-    display: inline
-    bottom: -31px
-    width: 307px
     button
       display: none
-      &.btn-preview
-        float: right
-        display: inline
-        margin-right: 0
-    .help
-      display: inline
-      float: none
-      position: relative
-      top: -4px
-      left: -12px
-      a
-        width: 29px
-        display: inline-block
-        height: 25px
-        overflow: hidden
-        padding-top: 7px
-        margin-bottom: -2px
-        padding-left: 0
-    .jstb_strong, .jstb_em, .jstb_ins, .jstb_del, .jstb_ul, .jstb_ol
-      display: inline
+    .jstb_strong,
+    .jstb_em,
+    .jstb_ins,
+    .jstb_del,
+    .jstb_ul,
+    .jstb_ol,
+    .jstb_preview
+      display: flex
 
 .inplace-edit--select
   .select2-display-none
@@ -90,7 +73,7 @@ $inplace-edit--color--very-dark: #cacaca
   display: inline-block
   width: 115px
   height: 35px
-  background: #f8f8f8
+  background: $inplace-edit--dark-background
   border: 1px solid $inplace-edit--color--very-dark
   box-shadow: 1px 1px 2px $inplace-edit--border-color
   text-align: center
@@ -180,11 +163,3 @@ a.inplace-editing--trigger-link,
 
     .icon-context::before
       padding: 0
-
-@include breakpoint(xlarge)
-  .inplace-edit .jstElements .help a
-    width: auto!important
-    display: inline!important
-    height: auto!important
-    padding-top: auto!important
-    margin-bottom: auto!important

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -105,6 +105,7 @@ $inplace-edit--color--very-dark: #cacaca
   align-items: center
   justify-content: center
   visibility: hidden
+  font-size: rem-calc(14px)
 
   .icon-edit::before
     // HACK: overriding default padding here

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -138,12 +138,6 @@ $inplace-edit--border-color: #ddd
     .ined-dashboard
       padding-left: 0px
     .ined-controls
-    .ined-read-value
-      position: relative
-      display: block
-      margin: 3px
-      &.editable:hover
-        outline: 1px solid #cacaca
 
 .inplace-editor
   @extend .form--field.-full-width

--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -27,47 +27,45 @@
 //++
 
 .work-packages--details-content
-  font-size:  0.8125rem
+  font-size:  0.875rem
 
-  .wp-subject
-    margin:       0
-    padding:      0 0 4px 0
-    font-size:    1.25rem
-    line-height:  26px
-    font-weight:  normal
-    border:       none
-    text-transform: none
-    color:        #333
-  h3
-    margin:       0 0 10px 0
-    padding:      0
-    font-size:    0.875rem
-    font-weight:  bold
-    border:       none
+@mixin details-pane--form-field
+  overflow: visible
+  overflow-y: visible
+  padding: 0
+
+.work-packages--details--title
+  @include grid-block
+  @include details-pane--form-field
+  align-items: center
+  font-size: 1.125rem
+  font-weight: bold
+
+.work-packages--details--type
+  @include grid-content
+  @include grid-size(shrink)
+  @include details-pane--form-field
+  color: $content-link-color
+
+.work-packages--details--subject
+  @include grid-content
+  @include grid-size(expand)
+  @include details-pane--form-field
+
+  // overriding default in place editing padding
+  // because the heigt will otherwise be too much
+  // and the change from read to write will flicker
+  .inplace-edit--text-field
+    padding: 0.15625rem 0.375rem
 
 .report-category-actions
   margin-top: -28px
   width: 100%
   text-align: right
 
-// Detail Panel Content
-
-.subtitle
-  margin: 0
-  padding: 0 0 10px 0
-  display: block
-  clear: both
-
-.select-type
-  padding-top: 3px
-  line-height: 26px
-  float: left
-  color: $content-link-color
-
 .detail-panel-description
   margin: 0
   line-height: 18px
-
 
 .comments-form
   float: left

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -25,7 +25,6 @@
  *
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
-//= require jstoolbar
 //= require print
 //= require scm
 //= require top-shelf
@@ -99,3 +98,4 @@
 @import content/diff
 
 @import misc_legacy
+@import jstoolbar

--- a/app/assets/stylesheets/fonts/_openproject_icon_font.md
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.md
@@ -57,6 +57,7 @@
 <i class="icon-changeset3"></i>
 <i class="icon-clock-reminder"></i>
 <i class="icon-close"></i>
+<i class="icon-close2"></i>
 <i class="icon-code-tag"></i>
 <i class="icon-color-text"></i>
 <i class="icon-color-underline"></i>

--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -252,6 +252,9 @@ dt > .icon-changeset:before,
 .icon-close:before
   content: "\e007"
 
+.icon-close2:before
+  content: "\e0f6"
+
 .icon-copy:before
   content: "\e008"
 

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -100,7 +100,7 @@
 
 .work-packages--details-content
   position:   absolute
-  top:        65px
+  top:        45px
   bottom:     55px
   width:      100%
   +allow-vertical-scrolling

--- a/app/assets/stylesheets/styleguide.html.lsg
+++ b/app/assets/stylesheets/styleguide.html.lsg
@@ -41,6 +41,7 @@ header: |
     <div class="styleguide-banner">
       <h1 class="styleguide-banner--text">Living Style Guide</h1>
     </div>
+    <link rel="stylesheet" type="text/css" href="jstoolbar.css">
   </header>
 
   <nav class="styleguide-nav">

--- a/frontend/app/templates/components/inplace_editor.html
+++ b/frontend/app/templates/components/inplace_editor.html
@@ -16,13 +16,10 @@
 
   <div class="inplace-edit--write" ng-if="isEditing">
     <form class="inplace-edit--form" name="editForm" ng-submit="submit(false)" novalidate>
-      <div class="inplace-edit--write-value">
-        <div class="ined-input-wrapper-inner"
-             ng-include src="getTemplateUrl()">
-        </div>
-        <div class="inplace-edit--preview" ng-if="isPreview && !isBusy">
-          <span ng-bind-html="previewHtml"></span>
-        </div>
+      <div class="inplace-edit--write-value" ng-include src="getTemplateUrl()">
+      </div>
+      <div class="inplace-edit--preview" ng-if="isPreview && !isBusy">
+        <span ng-bind-html="previewHtml"></span>
       </div>
       <div class="inplace-edit--dashboard">
         <div class="inplace-edit--errors" ng-show="error" role="alert" ng-bind="error" aria-live="polite"></div>

--- a/frontend/app/templates/components/inplace_editor.html
+++ b/frontend/app/templates/components/inplace_editor.html
@@ -1,15 +1,21 @@
-<div class="inplace-editor type-{{type}} attribute-{{attribute}}" ng-class="{busy: isBusy, preview: isPreview, editable: isEditable}" aria-busy="{{ isBusy }}" ng-disabled="!isEditable">
-  <div class="ined-read-value" ng-class="{ default: placeholderSet, editable: isEditable }" ng-hide="isEditing" ng-switch="type">
-    <span class="read-value-wrapper" ng-include src="getDisplayTemplateUrl()"></span>
-    <span ng-if="isEditable" class="editing-link-wrapper">
-      <accessible-by-keyboard execute="startEditing()">
+<div class="inplace-edit type-{{type}} attribute-{{attribute}}" ng-class="{'-busy': isBusy, '-preview': isPreview}" aria-busy="{{ isBusy }}" ng-if="isEditable">
+
+  <div class="inplace-edit--read" ng-hide="isEditing" ng-switch="type">
+    <accessible-by-keyboard execute="startEditing()"
+                            link-class="inplace-editing--trigger-link"
+                            span-class="inplace-editing--container"
+                            class="inplace-editing--trigger-container">
+      <span class="inplace-edit--read-value" ng-class="{ '-default': placeholderSet }" ng-include src="getDisplayTemplateUrl()">
+      </span>
+      <span class="inplace-edit--icon-wrapper">
         <icon-wrapper icon-name="edit" icon-title="{{ editTitle }}">
         </icon-wrapper>
-      </accessible-by-keyboard>
-    </span>
+      </span>
+    </accessible-by-keyboard>
   </div>
-  <div class="ined-edit" ng-if="isEditing">
-    <form name="editForm" ng-submit="submit(false)" novalidate>
+
+  <div class="inplace-edit--write" ng-if="isEditing">
+    <form class="inplace-edit--form" name="editForm" ng-submit="submit(false)" novalidate>
       <div class="ined-input-wrapper">
         <div class="ined-input-wrapper-inner"
              ng-include src="getTemplateUrl()">
@@ -18,16 +24,16 @@
           <span ng-bind-html="previewHtml"></span>
         </div>
       </div>
-      <div class="ined-dashboard">
-        <div class="ined-errors" ng-show="error" role="alert" ng-bind="error" aria-live="polite"></div>
-        <div class="ined-controls" ng-hide="isBusy">
-          <div class="inplace-edit--control">
+      <div class="inplace-edit--dashboard">
+        <div class="inplace-edit--errors" ng-show="error" role="alert" ng-bind="error" aria-live="polite"></div>
+        <div class="inplace-edit--controls" ng-hide="isBusy">
+          <div class="inplace-edit--control inplace-edit--control--save">
             <accessible-by-keyboard execute="editForm.$valid && submit(false)">
               <icon-wrapper icon-name="yes" icon-title="{{ saveTitle }}">
               </icon-wrapper>
             </accessible-by-keyboard>
           </div>
-          <div class="inplace-edit--control -icons-2">
+          <div class="inplace-edit--control -icons-2 inplace-edit--control--send">
             <accessible-by-keyboard execute="editForm.$valid && submit(true)">
               <span title="{{ saveAndSendTitle }}">
                 <i class="icon-yes"></i>
@@ -35,9 +41,9 @@
               </span>
             </accessible-by-keyboard>
           </div>
-          <div class="inplace-edit--control">
+          <div class="inplace-edit--control inplace-edit--control--cancel">
             <accessible-by-keyboard execute="discardEditing()">
-              <icon-wrapper icon-name="close" icon-title="{{ cancelTitle }}" css-class="icon4">
+              <icon-wrapper icon-name="close2" icon-title="{{ cancelTitle }}">
               </icon-wrapper>
             </accessible-by-keyboard>
           </div>
@@ -46,3 +52,10 @@
     </form>
   </div>
 </div>
+
+<div ng-if="!isEditable" class="attribute-{{attribute}}">
+  <div class="inplace-edit--read" ng-class="{ '-default': placeholderSet }" ng-switch="type">
+    <span class="inplace-edit--read-value" ng-include src="getDisplayTemplateUrl()"></span>
+  </div>
+</div>
+

--- a/frontend/app/templates/components/inplace_editor.html
+++ b/frontend/app/templates/components/inplace_editor.html
@@ -16,11 +16,11 @@
 
   <div class="inplace-edit--write" ng-if="isEditing">
     <form class="inplace-edit--form" name="editForm" ng-submit="submit(false)" novalidate>
-      <div class="ined-input-wrapper">
+      <div class="inplace-edit--write-value">
         <div class="ined-input-wrapper-inner"
              ng-include src="getTemplateUrl()">
         </div>
-        <div class="preview-wrapper" ng-if="isPreview && !isBusy">
+        <div class="inplace-edit--preview" ng-if="isPreview && !isBusy">
           <span ng-bind-html="previewHtml"></span>
         </div>
       </div>

--- a/frontend/app/templates/components/inplace_editor.html
+++ b/frontend/app/templates/components/inplace_editor.html
@@ -21,20 +21,26 @@
       <div class="ined-dashboard">
         <div class="ined-errors" ng-show="error" role="alert" ng-bind="error" aria-live="polite"></div>
         <div class="ined-controls" ng-hide="isBusy">
-          <accessible-by-keyboard execute="editForm.$valid && submit(false)" class="ined-edit-save">
-            <icon-wrapper icon-name="yes" icon-title="{{ saveTitle }}">
-            </icon-wrapper>
-          </accessible-by-keyboard>
-          <accessible-by-keyboard execute="editForm.$valid && submit(true)" class="ined-edit-save-send">
-            <span title="{{ saveAndSendTitle }}">
-              <i class="icon-yes"></i>
-              <i class="icon-mail"></i>
-            </span>
-          </accessible-by-keyboard>
-          <accessible-by-keyboard execute="discardEditing()" class="ined-edit-close">
-            <icon-wrapper icon-name="close" icon-title="{{ cancelTitle }}">
-            </icon-wrapper>
-          </accessible-by-keyboard>
+          <div class="inplace-edit--control">
+            <accessible-by-keyboard execute="editForm.$valid && submit(false)">
+              <icon-wrapper icon-name="yes" icon-title="{{ saveTitle }}">
+              </icon-wrapper>
+            </accessible-by-keyboard>
+          </div>
+          <div class="inplace-edit--control -icons-2">
+            <accessible-by-keyboard execute="editForm.$valid && submit(true)">
+              <span title="{{ saveAndSendTitle }}">
+                <i class="icon-yes"></i>
+                <i class="icon-mail"></i>
+              </span>
+            </accessible-by-keyboard>
+          </div>
+          <div class="inplace-edit--control">
+            <accessible-by-keyboard execute="discardEditing()">
+              <icon-wrapper icon-name="close" icon-title="{{ cancelTitle }}" css-class="icon4">
+              </icon-wrapper>
+            </accessible-by-keyboard>
+          </div>
         </div>
       </div>
     </form>

--- a/frontend/app/templates/components/inplace_editor/editable/select2.html
+++ b/frontend/app/templates/components/inplace_editor/editable/select2.html
@@ -1,4 +1,5 @@
 <ui-select
+  class="inplace-edit--select"
   name="value"
   ng-disabled="isBusy"
   ng-model="dataObject.value"

--- a/frontend/app/templates/components/inplace_editor/editable/text.html
+++ b/frontend/app/templates/components/inplace_editor/editable/text.html
@@ -1,4 +1,4 @@
-<input class="focus-input"
+<input class="focus-input inplace-edit--text-field"
        name="value"
        type="text"
        ng-disabled="isBusy"

--- a/frontend/app/templates/components/inplace_editor/editable/wiki_textarea.html
+++ b/frontend/app/templates/components/inplace_editor/editable/wiki_textarea.html
@@ -1,5 +1,5 @@
 <textarea wiki-toolbar
-          class="focus-input"
+          class="focus-input inplace-edit--textarea"
           ng-show="!isPreview || isBusy"
           preview-toggle="togglePreview()"
           name="value"

--- a/frontend/app/templates/work_packages.list.details.html
+++ b/frontend/app/templates/work_packages.list.details.html
@@ -30,17 +30,18 @@
   <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="focusAnchorLabel">
   </span>
 
-  <div class="select-type">{{ type.props.name }}:&nbsp;</div>
+  <div class="work-packages--details--title">
+    <div class="work-packages--details--type">{{ type.props.name }}:</div>
 
-  <div
-    class="wp-subject"
-    inplace-editor
-    ined-type="text"
-    ined-entity="workPackage"
-    ined-attribute="subject"
-    ined-attribute-title="{{ I18n.t('js.work_packages.properties.subject') }}"
-    title="{{ workPackage.props.subject }}"
-  ></div>
+    <div class="work-packages--details--subject"
+         inplace-editor
+         ined-type="text"
+         ined-entity="workPackage"
+         ined-attribute="subject"
+         ined-attribute-title="{{ I18n.t('js.work_packages.properties.subject') }}"
+         title="{{ workPackage.props.subject }}">
+    </div>
+  </div>
 
   <span class="subtitle">
     <accessible-by-keyboard ng-if="toggleWatchLink" execute="toggleWatch()"

--- a/frontend/app/ui_components/accessible-by-keyboard-directive.js
+++ b/frontend/app/ui_components/accessible-by-keyboard-directive.js
@@ -32,11 +32,12 @@ module.exports = function() {
     transclude: true,
     scope: {
       execute: '&',
-      linkClass: '@'
+      linkClass: '@',
+      spanClass: '@',
     },
     template: "<a execute-on-enter='execute()' default-event-handling='defaultEventHandling'" +
       " ng-click='execute()' href='' class='{{ linkClass }}'>" +
-      "<span ng-transclude></span>" +
+      "<span ng-transclude class='{{ spanClass }}'></span>" +
       "</a>",
     link: function(scope, element, attrs) {
       scope.defaultEventHandling = !attrs.execute;

--- a/frontend/app/ui_components/inplace-editor-directive.js
+++ b/frontend/app/ui_components/inplace-editor-directive.js
@@ -65,7 +65,7 @@ module.exports = function(
     });
     scope.$on('startEditing', function() {
       $timeout(function() {
-        var inputElement = element.find('.ined-input-wrapper-inner .focus-input');
+        var inputElement = element.find('.inplace-edit--write-value .focus-input');
         if (inputElement.length) {
           FocusHelper.focus(inputElement);
           inputElement.triggerHandler('keyup');

--- a/frontend/app/ui_components/inplace-editor-directive.js
+++ b/frontend/app/ui_components/inplace-editor-directive.js
@@ -48,7 +48,7 @@ module.exports = function(
   };
 
   function link(scope, element, attrs) {
-    element.on('click', '.ined-read-value.editable', function(e) {
+    element.on('click', '.inplace-edit--read.editable', function(e) {
       if (angular.element(e.target).is('a')) {
         return;
       }
@@ -73,7 +73,7 @@ module.exports = function(
       });
     });
     scope.$on('finishEditing', function() {
-      FocusHelper.focusElement(element.find('.editing-link-wrapper'));
+      FocusHelper.focusElement(element.find('.inplace-editing--trigger-link'));
     });
     InplaceEditorDispatcher.dispatchHook(scope, 'link', element);
   }

--- a/frontend/app/ui_components/inplace-editor-dispatcher.js
+++ b/frontend/app/ui_components/inplace-editor-dispatcher.js
@@ -141,19 +141,6 @@ module.exports = function($sce, $http, $timeout, AutoCompleteHelper, TextileServ
     text: {
       link: function(scope, element) {
         enableAutoCompletion(element);
-        scope.$on('startEditing', function() {
-          $timeout(function() {
-            var typeWidth = element
-                .closest('.work-packages--details-content')
-                .find('.select-type:first').width();
-            element.find('.ined-dashboard').css({
-              'margin-left': typeWidth
-            });
-            element.find('input[type=text]').css({
-              'width': element.find('.ined-dashboard').width()
-            });
-          }, 0, false);
-        });
       }
     },
 

--- a/frontend/app/ui_components/inplace-editor-dispatcher.js
+++ b/frontend/app/ui_components/inplace-editor-dispatcher.js
@@ -29,7 +29,7 @@
 module.exports = function($sce, $http, $timeout, AutoCompleteHelper, TextileService) {
 
   function enableAutoCompletion(element) {
-    var textarea = element.find('.ined-input-wrapper input, .ined-input-wrapper textarea');
+    var textarea = element.find('.inplace-edit--write-value input, .inplace-edit--write-value textarea');
     AutoCompleteHelper.enableTextareaAutoCompletion(textarea);
   }
 
@@ -149,7 +149,7 @@ module.exports = function($sce, $http, $timeout, AutoCompleteHelper, TextileServ
         scope.$on('startEditing', function() {
           $timeout(function() {
             enableAutoCompletion(element);
-            var textarea = element.find('.ined-input-wrapper textarea'),
+            var textarea = element.find('.inplace-edit--write-value textarea'),
                 lines = textarea.val().split('\n');
             textarea.attr('rows', lines.length + 1);
           }, 0, false);

--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -53,14 +53,14 @@ module.exports = function() {
         var title = scope.isPreview ? PREVIEW_DISABLE_TEXT : PREVIEW_ENABLE_TEXT;
         var toggledClasses = 'icon-issue-watched icon-ticket-edit -active';
 
-        element.closest('.ined-input-wrapper')
+        element.closest('.inplace-edit--write-value')
                .find('.' + PREVIEW_BUTTON_CLASS).attr('title', title)
                                                 .toggleClass(toggledClasses);
       });
     };
 
     element
-      .closest('.ined-input-wrapper')
+      .closest('.inplace-edit--write-value')
       .find('.jstb_help')
       .after(jQuery('<button>', previewButtonAttributes));
     // changes are made by jQuery, we trigger input event so that

--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -27,11 +27,12 @@
 //++
 
 module.exports = function() {
-  var HELP_LINK_HTML = '<a href="/help/wiki_syntax" title="' + I18n.t('js.inplace.link_formatting_help') + '" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;">' + I18n.t('js.inplace.link_formatting_help') + '</a>',
+  var HELP_LINK_HTML = '<a href="/help/wiki_syntax" title="' + I18n.t('js.inplace.link_formatting_help') + '" class="icon icon-help" onclick="window.open(&quot;/help/wiki_syntax&quot;, &quot;&quot;, &quot;resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes&quot;); return false;"><span class="hidden-for-sighted">' + I18n.t('js.inplace.link_formatting_help') + '</span></a>',
       PREVIEW_ENABLE_TEXT = I18n.t('js.inplace.btn_preview_enable'),
       PREVIEW_DISABLE_TEXT = I18n.t('js.inplace.btn_preview_disable'),
+      PREVIEW_BUTTON_CLASS = 'jstb_preview',
       PREVIEW_BUTTON_ATTRIBUTES = {
-        "class": 'btn-preview icon-issue-watched',
+        "class": PREVIEW_BUTTON_CLASS + ' icon-issue-watched',
         type: 'button',
         title: PREVIEW_ENABLE_TEXT,
         text: ''
@@ -50,16 +51,17 @@ module.exports = function() {
         scope.previewToggle();
 
         var title = scope.isPreview ? PREVIEW_DISABLE_TEXT : PREVIEW_ENABLE_TEXT;
+        var toggledClasses = 'icon-issue-watched icon-ticket-edit -active';
 
         element.closest('.ined-input-wrapper')
-               .find('.btn-preview').attr('title', title)
-                                    .toggleClass('icon-issue-watched icon-ticket-edit');
+               .find('.' + PREVIEW_BUTTON_CLASS).attr('title', title)
+                                                .toggleClass(toggledClasses);
       });
     };
 
     element
       .closest('.ined-input-wrapper')
-      .find('.help')
+      .find('.jstb_help')
       .after(jQuery('<button>', previewButtonAttributes));
     // changes are made by jQuery, we trigger input event so that
     // ng-model knows that the value changed

--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -31,9 +31,10 @@ module.exports = function() {
       PREVIEW_ENABLE_TEXT = I18n.t('js.inplace.btn_preview_enable'),
       PREVIEW_DISABLE_TEXT = I18n.t('js.inplace.btn_preview_disable'),
       PREVIEW_BUTTON_ATTRIBUTES = {
-        "class": 'btn-preview',
+        "class": 'btn-preview icon-issue-watched',
         type: 'button',
-        text: PREVIEW_ENABLE_TEXT
+        title: PREVIEW_ENABLE_TEXT,
+        text: ''
       };
 
   function link(scope, element) {
@@ -47,7 +48,12 @@ module.exports = function() {
       scope.$apply(function() {
         scope.isPreview = !scope.isPreview;
         scope.previewToggle();
-        element.closest('.ined-input-wrapper').find('.btn-preview').text(scope.isPreview ? PREVIEW_DISABLE_TEXT : PREVIEW_ENABLE_TEXT);
+
+        var title = scope.isPreview ? PREVIEW_DISABLE_TEXT : PREVIEW_ENABLE_TEXT;
+
+        element.closest('.ined-input-wrapper')
+               .find('.btn-preview').attr('title', title)
+                                    .toggleClass('icon-issue-watched icon-ticket-edit');
       });
     };
 

--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
@@ -144,7 +144,7 @@ describe('OpenProject', function(){
       });
 
       describe('preview', function() {
-        var previewButton = descriptionEditor.$('.btn-preview');
+        var previewButton = descriptionEditor.$('.jstb_preview');
 
         beforeEach(function() {
           descriptionEditor.$('.inplace-editing--trigger-link').click();

--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-var expect = require('../../../spec_helper.js').expect, 
+var expect = require('../../../spec_helper.js').expect,
     detailsPaneHelper = require('./details-pane-helper.js');
 
 /*jshint expr: true*/
@@ -34,7 +34,7 @@ describe('OpenProject', function(){
   describe('editable', function() {
     function behaveLikeEmbeddedDropdown(name, correctValue) {
       context('behaviour', function() {
-        var editor = $('[ined-attribute=\'' + name + '\'] .inplace-editor');
+        var editor = $('[ined-attribute=\'' + name + '\'] .inplace-edit');
 
         beforeEach(function() {
           detailsPaneHelper.loadPane(819, 'overview');
@@ -44,7 +44,7 @@ describe('OpenProject', function(){
           it('should render a span with value', function() {
             expect(
               editor
-                .$('.read-value-wrapper')
+                .$('.inplace-edit--read-value')
                 .getText()
             ).to.eventually.equal(correctValue);
           });
@@ -52,7 +52,7 @@ describe('OpenProject', function(){
 
         describe('edit state', function() {
           beforeEach(function() {
-            editor.$('.ined-read-value').click();
+            editor.$('.inplace-editing--trigger-link').click();
           });
 
           context('dropdown', function() {
@@ -77,7 +77,7 @@ describe('OpenProject', function(){
     }
 
     describe('subject', function() {
-      var subjectEditor = $('.wp-subject .inplace-editor');
+      var subjectEditor = $('.inplace-edit.attribute-subject');
 
       context('work package with updateImmediately link', function() {
         beforeEach(function() {
@@ -85,7 +85,7 @@ describe('OpenProject', function(){
         });
 
         it('should render an editable subject', function() {
-          expect(subjectEditor.$('.editable').isPresent()).to.eventually.be.true;
+          expect(subjectEditor.$('.inplace-editing--trigger-link').isPresent()).to.eventually.be.true;
         });
       });
 
@@ -95,21 +95,21 @@ describe('OpenProject', function(){
         });
 
         it('should not render an editable subject', function() {
-          expect(subjectEditor.$('.editable').isPresent()).to.eventually.be.false;
+          expect(subjectEditor.$('.inplace-editing--trigger-link').isPresent()).to.eventually.be.false;
         });
       });
 
       context('work package with a wrong version', function() {
         beforeEach(function() {
           detailsPaneHelper.loadPane(821, 'overview');
-          subjectEditor.$('.ined-read-value').click();
-          subjectEditor.$('.ined-edit-save a').click();
+          subjectEditor.$('.inplace-editing--trigger-link').click();
+          subjectEditor.$('.inplace-edit--control--save a').click();
         });
 
         it('should render an error', function() {
           expect(
             subjectEditor
-              .$('.ined-errors')
+              .$('.inplace-edit--errors')
               .isDisplayed()
           ).to.eventually.be.true;
         });
@@ -117,7 +117,7 @@ describe('OpenProject', function(){
     });
 
     describe('description', function() {
-      var descriptionEditor = $('.inplace-editor.attribute-description');
+      var descriptionEditor = $('.inplace-edit.attribute-description');
 
       beforeEach(function() {
         detailsPaneHelper.loadPane(819, 'overview');
@@ -127,18 +127,18 @@ describe('OpenProject', function(){
         it('should render the link to another work package', function() {
           expect(
             descriptionEditor
-              .$('.ined-read-value a.work_package')
+              .$('.inplace-edit--read a.work_package')
               .isDisplayed()
           ).to.eventually.be.true;
         });
 
         it('should render the textarea', function() {
-          descriptionEditor.$('.ined-read-value').click();
+          descriptionEditor.$('.inplace-editing--trigger-link').click();
           expect(descriptionEditor.$('textarea').isDisplayed()).to.eventually.be.true;
         });
 
         xit('should not render the textarea if click is on the link', function() {
-          descriptionEditor.$('a.work_package').click();
+          descriptionEditor.$('.inplace-editing--trigger-link').click();
           expect(descriptionEditor.$('textarea').isPresent()).to.eventually.be.false;
         });
       });
@@ -147,7 +147,7 @@ describe('OpenProject', function(){
         var previewButton = descriptionEditor.$('.btn-preview');
 
         beforeEach(function() {
-          descriptionEditor.$('.ined-read-value').click();
+          descriptionEditor.$('.inplace-editing--trigger-link').click();
         });
 
         it('should render the button', function() {
@@ -172,7 +172,7 @@ describe('OpenProject', function(){
     });
     describe('version', function() {
       var name = 'version.name';
-      var editor = $('[ined-attribute=\'' + name + '\'] .inplace-editor');
+      var editor = $('[ined-attribute=\'' + name + '\'] .inplace-edit');
 
       behaveLikeEmbeddedDropdown(name, 'alpha');
 
@@ -184,13 +184,13 @@ describe('OpenProject', function(){
         it('should render a link to the version', function() {
             expect(
               editor
-              .$('span.read-value-wrapper a')
+              .$('span.inplace-edit--read-value a')
               .getText()
             ).to.eventually.equal('alpha');
 
             expect(
               editor
-              .$('span.read-value-wrapper a')
+              .$('span.inplace-edit--read-value a')
               .getAttribute('href')
             ).to.eventually.match(/\/versions\/1/);
         });
@@ -204,15 +204,15 @@ describe('OpenProject', function(){
         it('should not render an anchor', function() {
           expect(
             editor
-            .$('span.read-value-wrapper a')
+            .$('span.inplace-edit--read-value a')
             .isPresent()
           ).to.eventually.be.false;
         });
       });
     });
     context('user field', function() {
-      var assigneeEditor = $('[ined-attribute=\'assignee\'] .inplace-editor'),
-          responsibleEditor = $('[ined-attribute=\'responsible\'] .inplace-editor');
+      var assigneeEditor = $('[ined-attribute=\'assignee\'] .inplace-edit'),
+          responsibleEditor = $('[ined-attribute=\'responsible\'] .inplace-edit');
 
       beforeEach(function() {
         detailsPaneHelper.loadPane(822, 'overview');
@@ -227,7 +227,7 @@ describe('OpenProject', function(){
           it('should render a span with placeholder', function() {
             expect(
               assigneeEditor
-                .$('span.read-value-wrapper span')
+                .$('span.inplace-edit--read-value span')
                 .getText()
             ).to.eventually.equal('-');
           });
@@ -236,7 +236,7 @@ describe('OpenProject', function(){
           it('should render a link to user\'s profile', function() {
             expect(
               responsibleEditor
-              .$('span.read-value-wrapper a')
+              .$('span.inplace-edit--read-value a')
               .getText()
             ).to.eventually.equal('OpenProject Admin');
           });
@@ -245,7 +245,7 @@ describe('OpenProject', function(){
 
       describe('edit state', function() {
         beforeEach(function() {
-          responsibleEditor.$('.ined-read-value').click();
+          responsibleEditor.$('.inplace-editing--trigger-link').click();
         });
 
         context('select2', function() {

--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
@@ -158,7 +158,7 @@ describe('OpenProject', function(){
           previewButton.click();
           expect(
             descriptionEditor
-              .$('.preview-wrapper')
+              .$('.inplace-edit--preview')
               .isDisplayed()
           ).to.eventually.be.true;
         });

--- a/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
@@ -146,7 +146,7 @@ describe('inplaceEditor Directive', function() {
             scope.$digest();
           });
           it('should render a text input', function() {
-            expect(element.find('.ined-input-wrapper input[type="text"]').length).to.eq(1);
+            expect(element.find('.inplace-edit--write-value input[type="text"]').length).to.eq(1);
           });
         });
         context('wiki_textarea', function() {
@@ -192,17 +192,17 @@ describe('inplaceEditor Directive', function() {
             scope.$digest();
           });
           it('should render a textarea', function() {
-            expect(element.find('.ined-input-wrapper textarea').length).to.eq(1);
+            expect(element.find('.inplace-edit--write-value textarea').length).to.eq(1);
           });
           it('should render the js toolbar', function() {
-            expect(element.find('.ined-input-wrapper .jstElements').length).to.eq(1);
+            expect(element.find('.inplace-edit--write-value .jstElements').length).to.eq(1);
           });
           it('should render a text formatting help link', function() {
-            expect(element.find('.ined-input-wrapper .jstb_help').length).to.eq(1);
+            expect(element.find('.inplace-edit--write-value .jstb_help').length).to.eq(1);
           });
           it('should set textaria\'s row count according to the content\'s row length', function() {
             $timeout.flush();
-            expect(element.find('.ined-input-wrapper textarea').attr('rows')).to.eq('4');
+            expect(element.find('.inplace-edit--write-value textarea').attr('rows')).to.eq('4');
           });
         });
       });
@@ -237,7 +237,7 @@ describe('inplaceEditor Directive', function() {
             scope.$digest();
           });
           it('should disable the input', function() {
-            expect(element.find('.ined-input-wrapper input').prop('disabled')).to.eq(true);
+            expect(element.find('.inplace-edit--write-value input').prop('disabled')).to.eq(true);
           });
         });
       });
@@ -516,12 +516,12 @@ describe('inplaceEditor Directive', function() {
       });
       context('input', function() {
         it('should be focused', function() {
-          expect(element.find('.ined-input-wrapper input').get(0)).to.eq(document.activeElement);
+          expect(element.find('.inplace-edit--write-value input').get(0)).to.eq(document.activeElement);
         });
         it('should call submit on RETURN pressed', function() {
           submitStub = sinon.stub(elementScope, 'submit').returns(false);
           // pressing enter triggers form submit (default browser behaviour)
-          element.find('.ined-input-wrapper').closest('form').triggerHandler('submit');
+          element.find('.inplace-edit--write-value').closest('form').triggerHandler('submit');
           submitStub.should.have.been.calledWith(false);
           submitStub.restore();
         });

--- a/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
@@ -198,7 +198,7 @@ describe('inplaceEditor Directive', function() {
             expect(element.find('.ined-input-wrapper .jstElements').length).to.eq(1);
           });
           it('should render a text formatting help link', function() {
-            expect(element.find('.ined-input-wrapper .help').length).to.eq(1);
+            expect(element.find('.ined-input-wrapper .jstb_help').length).to.eq(1);
           });
           it('should set textaria\'s row count according to the content\'s row length', function() {
             $timeout.flush();

--- a/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/inplace-editor-directive-test.js
@@ -106,7 +106,7 @@ describe('inplaceEditor Directive', function() {
 
     describe('placeholder', function() {
       it('should not render the default text', function() {
-        var text = element.find('.ined-read-value .read-value-wrapper span:first').text().trim();
+        var text = element.find('.inplace-edit--read .inplace-edit--read-value span:first').text().trim();
         expect(text).to.eq('Some subject');
       });
 
@@ -209,7 +209,7 @@ describe('inplaceEditor Directive', function() {
       describe('workPackage.links.updateImmediately', function() {
         context('present', function() {
           it('should render the inplace editor', function() {
-            expect(element.find('.inplace-editor').length).to.eq(1);
+            expect(element.find('.inplace-edit').length).to.eq(1);
           });
         });
         context('not present', function() {
@@ -225,7 +225,7 @@ describe('inplaceEditor Directive', function() {
             compile();
           });
           it('should render the value without editing elements', function() {
-            expect(element.find('.editing-link-wrapper').length).to.eq(0);
+            expect(element.find('.inplace-edit--icon-wrapper').length).to.eq(0);
           });
         });
       });
@@ -248,18 +248,18 @@ describe('inplaceEditor Directive', function() {
             scope.$digest();
           });
           it('should render the edit block', function() {
-            expect(element.find('.ined-edit').length).to.eq(1);
+            expect(element.find('.inplace-edit--write').length).to.eq(1);
           });
           it('should hide the read block', function() {
-            expect(element.find('.ined-read-value').hasClass('ng-hide')).to.eq(true);
+            expect(element.find('.inplace-edit--read').hasClass('ng-hide')).to.eq(true);
           });
         });
         context('false', function() {
           it('should not render the edit block', function() {
-            expect(element.find('.ined-edit').length).to.eq(0);
+            expect(element.find('.inplace-edit--write').length).to.eq(0);
           });
           it('should not hide the read block', function() {
-            expect(element.find('.ined-read-value').hasClass('ng-hide')).to.eq(false);
+            expect(element.find('.inplace-edit--read').hasClass('ng-hide')).to.eq(false);
           });
         });
       });
@@ -433,36 +433,32 @@ describe('inplaceEditor Directive', function() {
     });
 
     it('should render the directive template', function() {
-      expect(element.find('.inplace-editor').length).to.eq(1);
+      expect(element.find('.inplace-edit').length).to.eq(1);
     });
 
     describe('read value block', function() {
       it('should be rendered', function() {
-        expect(element.find('.ined-read-value').length).to.eq(1);
+        expect(element.find('.inplace-edit--read').length).to.eq(1);
       });
       it('should have the value of the given attribute', function() {
         expect(element
-          .find('.ined-read-value .read-value-wrapper span:first')
+          .find('.inplace-edit--read .inplace-edit--read-value span:first')
           .text().trim())
           .to.eq('Some subject');
-      });
-      it('should trigger edit mode on click', function() {
-        element.find('.ined-read-value').click();
-        expect(elementScope.isEditing).to.eq(true);
       });
 
       context('edit link', function() {
         it('should not be hidden from the reader', function() {
-          expect(element.find('.editing-link-wrapper').length).to.eq(1);
+          expect(element.find('.inplace-edit--icon-wrapper').length).to.eq(1);
           //it's in the viewport and not hidden by angular
-          expect(element.find('.editing-link-wrapper').closest('.ng-hide').length).to.eq(0);
+          expect(element.find('.inplace-edit--icon-wrapper').closest('.ng-hide').length).to.eq(0);
         });
         it('should be accessible by tab', function() {
           // I suggest some manual test here as well for the screen reader
-          expect(element.find('.editing-link-wrapper a').attr('tabindex')).not.to.eq('-1');
+          expect(element.find('.inplace-edit--icon-wrapper a').attr('tabindex')).not.to.eq('-1');
         });
         it('should trigger the edit mode', function() {
-          element.find('.editing-link-wrapper a').click();
+          element.find('.inplace-editing--trigger-link').click();
           expect(elementScope.isEditing).to.eq(true);
         });
       });
@@ -497,7 +493,7 @@ describe('inplaceEditor Directive', function() {
 
         it('should render the default text', function() {
           var text = element
-            .find('.ined-read-value .read-value-wrapper span:first')
+            .find('.inplace-edit--read .inplace-edit--read-value span:first')
             .text().trim();
 
           expect(text).to.eq('The default text');
@@ -532,14 +528,14 @@ describe('inplaceEditor Directive', function() {
       });
       context('action buttons', function() {
         it('should be rendered', function() {
-          expect(element.find('.ined-edit-save').length).to.eq(1);
-          expect(element.find('.ined-edit-save-send').length).to.eq(1);
-          expect(element.find('.ined-edit-close').length).to.eq(1);
+          expect(element.find('.inplace-edit--control--save').length).to.eq(1);
+          expect(element.find('.inplace-edit--control--send').length).to.eq(1);
+          expect(element.find('.inplace-edit--control--cancel').length).to.eq(1);
         });
         describe('save', function() {
           beforeEach(function() {
             submitStub = sinon.stub(elementScope, 'submit').returns(true);
-            element.find('.ined-edit-save a').click();
+            element.find('.inplace-edit--control--save a').click();
             elementScope.submit();
           });
           afterEach(function() {
@@ -552,7 +548,7 @@ describe('inplaceEditor Directive', function() {
         describe('save and send', function() {
           beforeEach(function() {
             submitStub = sinon.stub(elementScope, 'submit').returns(false);
-            element.find('.ined-edit-save-send a').click();
+            element.find('.inplace-edit--control--send a').click();
             elementScope.submit();
           });
           afterEach(function() {
@@ -564,14 +560,14 @@ describe('inplaceEditor Directive', function() {
         });
         describe('cancel', function() {
           beforeEach(function() {
-            element.find('.ined-edit-close a').click();
+            element.find('.inplace-edit--control--cancel a').click();
           });
           it('should switch back to read mode', function() {
             expect(elementScope.isEditing).to.eq(false);
           });
           it('should focus the edit link', function() {
             $timeout.flush();
-            expect(element.find('.editing-link-wrapper a').get(0)).to.eq(document.activeElement);
+            expect(element.find('.inplace-editing--trigger-link').get(0)).to.eq(document.activeElement);
           });
         });
       });

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -34,9 +34,16 @@ module Redmine
         def wikitoolbar_for(field_id)
           heads_for_wiki_formatter
           url = url_for(controller: '/help', action: 'wiki_syntax')
-          help_link = link_to(l(:setting_text_formatting), url,
+          open_help = "window.open(\"#{ url }\", \"\", \"resizable=yes, location=no, width=600, " +
+                      "height=640, menubar=no, status=no, scrollbars=yes\"); return false;"
+          help_link = link_to(url,
                               class: 'icon icon-help',
-                              onclick: "window.open(\"#{ url }\", \"\", \"resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes\"); return false;")
+                              onclick: open_help,
+                              title: l(:setting_text_formatting)) do
+                                content_tag :span, class: 'hidden-for-sighted' do
+                                  l(:setting_text_formatting)
+                                end
+                              end
 
           javascript_tag(<<-EOF)
             var wikiToolbar = new jsToolBar($('#{field_id}'));

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -322,7 +322,7 @@ describe 'Select work package row', type: :feature do
         # ensure work package queried by double clicking the row is fully
         # loaded before starting the next spec.
         expect(page).to have_selector(
-          '.work-packages--details .wp-subject',
+          '.work-packages--details .work-packages--details--subject',
           text: work_package_3.subject,
           visible: false
         )


### PR DESCRIPTION
This styles the in-place edit functionality of the details pane as defined by the style guide. It does not:
- Style the inputs (text, select2, textarea). However it does style the toolbar above a textarea.
- Styles elements which are not yet editable. Therefore, there is a zigzag pattern in the attribute list for as long as not all elements are editable. That problem will solve itself once the element is editable.
- Styles the buttons for send, send&mail and cancel according to the style guide as it was changed after the buttons have been styled before. I will create a different package for that.
- Add functionality (I hope)

https://community.openproject.org/work_packages/17057
https://community.openproject.org/work_packages/18743
https://community.openproject.org/work_packages/18873
https://community.openproject.org/work_packages/19074
and in parts https://community.openproject.org/work_packages/19103
