### PR TITLE
fixes padding rule in form blocks and rows

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -222,8 +222,8 @@ fieldset.form--fieldset
   .form.-vertical &
     @include grid-orient(vertical)
 
-  .grid-block:nth-last-of-type(n+2) > &,
-  .form--row:nth-last-of-type(n+2) > &,
+  .grid-block > &:nth-last-of-type(n+2),
+  .form--row > &:nth-last-of-type(n+2),
   .form--grouping-row > &:nth-last-of-type(n+2)
     padding-right: 1rem
 


### PR DESCRIPTION
This should fix various padding issues which might have behaved strange because instead of each but the last form--field being selected within a grid-block or form--row, every form--field was selected in all but the last grid-block or form--row.

https://community.openproject.org/work_packages/18680
