### PR TITLE
Fix timelines form layout trailing label & fieldsets

### DIFF
--- a/app/assets/stylesheets/content/_forms.md
+++ b/app/assets/stylesheets/content/_forms.md
@@ -494,6 +494,226 @@
 </form>
 ```
 
+## Forms: Width categories
+
+The modifier classes **-middle**, **-wide**, ... can be applied to the form-[input type]-container to limit the width of the element. Please note, that this only limits the max-width of the element. The fields will become slimmer if less space is available. Also note, that the max-width is specified as an absolute value. Without a modifier, the form field will take the full width available.
+
+```
+@full-width
+
+<form class="form">
+  <section class="form--section">
+    <h3 class="form--section-title">Input type "text-field"</h3>
+    <div class="form--field -required">
+      <label class="form--label">Tiny:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -tiny">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">XSlim:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -xslim">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Slim:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -slim">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Middle:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -middle">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">Wide:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -wide">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">XWide:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -xwide">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">XXWide:</label>
+      <div class="form--field-container">
+        <div class="form--text-field-container -xxwide">
+          <input type="text" class="form--text-field">
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+  <section class="form--section">
+    <h3 class="form--section-title">Input type "text-area"</h3>
+    <div class="form--field -required">
+      <label class="form--label">Tiny:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -tiny">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">XSlim:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -xslim">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Slim:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -slim">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Middle:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -middle">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">Wide:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -wide">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">XWide:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -xwide">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+    <div class="form--field">
+      <label class="form--label">XXWide:</label>
+      <div class="form--field-container">
+        <div class="form--text-area-container -xxwide">
+          <textarea type="text-area" class="form--text-area">
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+  <section class="form--section">
+    <h3 class="form--section-title">Input type "select"</h3>
+    <div class="form--field -required">
+      <label class="form--label">Tiny:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -tiny">
+          <select class="form--select">
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">XSlim:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -xslim">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Slim:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -slim">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Middle:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -middle">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">Wide:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -wide">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">XWide:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -xwide">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="form--field -required">
+      <label class="form--label">XXWide:</label>
+      <div class="form--field-container">
+        <div class="form--select-container -xxwide">
+          <select class="form--select">
+            <option>one</option>
+            <option>two</option>
+            <option>three</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </section>
+</form>
+```
+
 
 # Forms: Lists of fields
 
@@ -605,7 +825,7 @@
 ```
 <label>Tiny:<input type="text" class="form--text-field -tiny" value="a tiny value"></label>
 
-<label>Small:<input type="text" class="form--text-field -small" value="a small value"></label>
+<label>Small:<input type="text" class="form--text-field -slim" value="a small value"></label>
 
 <label>Large:<input type="text" class="form--text-field -large" value="a large value"></label>
 ```

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -405,6 +405,15 @@ fieldset.form--fieldset
   .form &
     margin-bottom: 0.5rem
 
+.form--radio-button-container
+  //prevent radio-buttons from being cut at the border
+  padding: 0 1px
+
+.form--radio-button
+  // Be on par with Foundation's margin-bottom on labels.
+  .form &
+    margin-bottom: 0.5rem
+
 .form--grouping
   @include grid-block($wrap: true)
   align-items: center
@@ -493,6 +502,10 @@ fieldset.form--fieldset
   %form--field-element-container + &
     margin-left:  -1rem
     border-left:  0
+
+  &.-transparent
+    background: none
+    border: none
 
 .form--list
   display: flex

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -346,6 +346,40 @@ fieldset.form--fieldset
   .form--#{$field-type}-container
     @extend %form--field-element-container
 
+    &.-tiny
+      max-width: 50px
+
+    &.-xslim
+      max-width: 110px
+
+    &.-slim
+      max-width: 200px
+
+    &.-middle
+      max-width: 350px
+
+    &.-wide
+      max-width: 500px
+
+    &.-xwide
+      max-width: 800px
+
+    &.-xxwide
+      max-width: 1100px
+
+.form--select-container
+  &.-tiny,
+  &.-xslim,
+  &.-slim,
+  &.-middle,
+  &.-wide,
+  &.-xwide,
+  &.-xxwide
+    // overriding hack on select2 by another hack (select2_customizing.css)
+    // remove once the initial limit on the width is removed
+    .select2-container
+      max-width: initial
+
 .form--text-field
   @include input-style
 

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -67,7 +67,7 @@ module SettingsHelper
 
             content_tag(:label, class: 'form--label-with-check-box') do
               styled_check_box_tag("settings[#{setting}][]", value,
-                                   Setting.send(setting).include?(value)) +
+                                   Setting.send(setting).include?(value), options) +
                 text.to_s
             end
           end.join.html_safe
@@ -114,11 +114,12 @@ module SettingsHelper
   end
 
   # Renders a notification field for a Redmine::Notifiable option
-  def notification_field(notifiable)
+  def notification_field(notifiable, options = {})
     content_tag(:label, class: 'form--label-with-check-box' + (notifiable.parent.present? ? ' parent' : '')) do
       styled_check_box_tag('settings[notified_events][]',
                            notifiable.name,
-                           Setting.notified_events.include?(notifiable.name)) +
+                           Setting.notified_events.include?(notifiable.name),
+                           options) +
         l_or_humanize(notifiable.name, prefix: 'label_')
     end
   end

--- a/app/views/timelines/_comparison.html.erb
+++ b/app/views/timelines/_comparison.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="filter_comparison" class="header_collapsible collapsible collapsed">
+<fieldset id="filter_comparison" class="form--fieldset collapsible collapsed">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.filter.comparisons') %></a>
   </legend>

--- a/app/views/timelines/_comparison.html.erb
+++ b/app/views/timelines/_comparison.html.erb
@@ -50,15 +50,16 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
 
         <div class="form--grouping-row">
-          <div class="form--field">
+          <div class="form--field -wide-label">
             <%= ff.text_field :compare_to_relative, label: l('timelines.filter.comparison.compare_relative_prefix') %>
           </div>
-          <div class="form--field">
-            <div class="form--field-container inline-label">
+          <div class="form--field -full-width">
+            <div class="form--field-container">
               <%= ff.select :compare_to_relative_unit,
                             options_for_timeunits(nil),
-                            no_label: true %>
-              <span class="form-label -transparent"><%=l('timelines.filter.comparison.compare_relative_suffix')%></span>
+              <span class="form--field-affix -transparent">
+                <%=l('timelines.filter.comparison.compare_relative_suffix')%>
+              </span>
             </div>
           </div>
         </div>

--- a/app/views/timelines/_comparison.html.erb
+++ b/app/views/timelines/_comparison.html.erb
@@ -57,6 +57,8 @@ See doc/COPYRIGHT.rdoc for more details.
             <div class="form--field-container">
               <%= ff.select :compare_to_relative_unit,
                             options_for_timeunits(nil),
+                            no_label: true,
+                            container_class: '-middle' %>
               <span class="form--field-affix -transparent">
                 <%=l('timelines.filter.comparison.compare_relative_suffix')%>
               </span>

--- a/app/views/timelines/_general.html.erb
+++ b/app/views/timelines/_general.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="filter_general" class="header_collapsible collapsible">
+<fieldset id="filter_general" class="form--fieldset collapsible">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.filter.timeline') %></a>
   </legend>

--- a/app/views/timelines/_general.html.erb
+++ b/app/views/timelines/_general.html.erb
@@ -96,11 +96,13 @@ See doc/COPYRIGHT.rdoc for more details.
                        for: "timeline_options_columns_",
                        class: "form--label" %>
           <div class="form--field-container">
-            <%= ff.hidden_field :columns,
-                                name: "timeline[options][columns][]",
-                                id: "timeline_options_columns_",
-                                value: timeline.selected_columns.join(","),
-                                :"data-values" => internationalized_columns_select_object(timeline.available_columns).concat(timeline.custom_field_columns).to_json %>
+            <div class="form--select-container -wide">
+              <%= ff.hidden_field :columns,
+                                  name: "timeline[options][columns][]",
+                                  id: "timeline_options_columns_",
+                                  value: timeline.selected_columns.join(","),
+                                  :"data-values" => internationalized_columns_select_object(timeline.available_columns).concat(timeline.custom_field_columns).to_json %>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/timelines/_general.html.erb
+++ b/app/views/timelines/_general.html.erb
@@ -85,26 +85,27 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
       </div>
       <div class="form--field">
-        <% if User.current.impaired? %>
-          <%= ff.select :columns, internationalized_columns_select(timeline.available_columns),
-                   {:selected => timeline.selected_columns},
-                   {:multiple => true,
-                    :size => 12} %>
-        <% else %>
-          <%= ff.label :columns,
-                       l("timelines.filter.columns"),
-                       for: "timeline_options_columns_",
-                       class: "form--label" %>
-          <div class="form--field-container">
-            <div class="form--select-container -wide">
+        <%= ff.label :columns,
+                     l("timelines.filter.columns"),
+                     for: "timeline_options_columns_",
+                     class: "form--label" %>
+        <div class="form--field-container">
+          <div class="form--select-container -wide">
+            <% if User.current.impaired? %>
+              <%= ff.select :columns, internationalized_columns_select(timeline.available_columns),
+                            { selected: timeline.selected_columns,
+                              no_label: true },
+                            { multiple: true,
+                              size: 12 } %>
+            <% else %>
               <%= ff.hidden_field :columns,
                                   name: "timeline[options][columns][]",
                                   id: "timeline_options_columns_",
                                   value: timeline.selected_columns.join(","),
                                   :"data-values" => internationalized_columns_select_object(timeline.available_columns).concat(timeline.custom_field_columns).to_json %>
-            </div>
+            <% end %>
           </div>
-        <% end %>
+        </div>
       </div>
       <div class="form--field">
         <%= ff.select  :project_sort, [[l('timelines.filter.sort.date'), 0], [l('timelines.filter.sort.alphabet'), '1']], label: l('timelines.filter.sort.project_sortation') %>

--- a/app/views/timelines/_vertical_planning_elements.html.erb
+++ b/app/views/timelines/_vertical_planning_elements.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="filter_comparison" class="header_collapsible collapsible collapsed">
+<fieldset id="filter_comparison" class="form--fieldset collapsible collapsed">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.vertical_work_package') %></a>
   </legend>

--- a/app/views/timelines/filter/_planning_elements.html.erb
+++ b/app/views/timelines/filter/_planning_elements.html.erb
@@ -74,11 +74,13 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
       <div class="form--field">
         <% if User.current.impaired? %>
-          <%= ff.select :planning_element_responsibles, filter_select_with_none(
-                     timeline.available_planning_element_responsibles,
-                     :name, :id),
-                   { selected: timeline.selected_planning_element_responsibles.map(&:id), label: l("timelines.filter.work_package_responsible") },
-                   { multiple: true } %>
+          <%= ff.select :planning_element_responsibles,
+                        filter_select_with_none(timeline.available_responsibles,
+                                                :name,
+                                                :id),
+                        { selected: timeline.selected_planning_element_responsibles.map(&:id),
+                          label: l("timelines.filter.work_package_responsible") },
+                        { multiple: true } %>
         <% else %>
           <%= ff.select :planning_element_responsibles,
                         options_for_select([]),
@@ -92,18 +94,21 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="form--field">
         <% if User.current.impaired? %>
           <%= ff.select :planning_element_assignee, filter_select_with_none(
-                     timeline.available_planning_element_responsibles,
-                     :name, :id),
-                   { selected: timeline.selected_planning_element_assignee.map(&:id), label: l("timelines.filter.work_package_assignee") },
-                   { multiple: true } %>
-        <% else %>
-          <%= ff.select :planning_element_assignee,
-                        options_for_select([]),
-                        { label: l("timelines.filter.work_package_assignee"),
-                          container_class: '-wide' },
-                        :'data-ajaxURL' => api_v2_paginate_users_path,
-                        multiple: true,
-                        :'data-selected' => filter_select(timeline.selected_planning_element_assignee, :name, :id).to_json %>
+                         timeline.available_responsibles,
+                         :name, :id),
+                         { selected: timeline.selected_planning_element_assignee.map(&:id),
+                           label: l("timelines.filter.work_package_assignee") },
+                         { multiple: true } %>
+          <% else %>
+            <%= ff.select :planning_element_assignee,
+                          options_for_select([]),
+                          { label: l("timelines.filter.work_package_assignee"),
+                            container_class: '-wide' },
+                          :'data-ajaxURL' => api_v2_paginate_users_path,
+                          multiple: true,
+                          :'data-selected' => filter_select(timeline.selected_planning_element_assignee,
+                                                            :name,
+                                                            :id).to_json %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/timelines/filter/_planning_elements.html.erb
+++ b/app/views/timelines/filter/_planning_elements.html.erb
@@ -46,7 +46,10 @@ See doc/COPYRIGHT.rdoc for more details.
                    { selected: timeline.selected_planning_element_status.map(&:id), label: l("timelines.filter.status") },
                    { multiple: true } %>
         <% else %>
-          <%= ff.select :planning_element_status, options_for_select([]), { label: l("timelines.filter.status") },
+          <%= ff.select :planning_element_status,
+                        options_for_select([]),
+                        { label: l("timelines.filter.status"),
+                          container_class: '-wide' },
                         :'data-ajaxURL' => api_v2_paginate_statuses_path,
                         multiple: true,
                         :'data-selected' => filter_select(timeline.selected_planning_element_status, :name, :id).to_json %>
@@ -60,7 +63,10 @@ See doc/COPYRIGHT.rdoc for more details.
                    { selected: timeline.selected_planning_element_types.map(&:id), label: l("timelines.filter.types") },
                    { multiple: true } %>
         <% else %>
-          <%= ff.select :planning_element_types, options_for_select([]), { label: l("timelines.filter.types") },
+          <%= ff.select :planning_element_types,
+                        options_for_select([]),
+                        { label: l("timelines.filter.types"),
+                          container_class: '-wide' },
                         :'data-ajaxURL' => api_v2_paginate_types_path,
                         multiple: true,
                         :'data-selected' => filter_select(timeline.selected_planning_element_types, :name, :id).to_json %>
@@ -74,7 +80,10 @@ See doc/COPYRIGHT.rdoc for more details.
                    { selected: timeline.selected_planning_element_responsibles.map(&:id), label: l("timelines.filter.work_package_responsible") },
                    { multiple: true } %>
         <% else %>
-          <%= ff.select :planning_element_responsibles, options_for_select([]), { label: l("timelines.filter.work_package_responsible") },
+          <%= ff.select :planning_element_responsibles,
+                        options_for_select([]),
+                        { label: l("timelines.filter.work_package_responsible"),
+                          container_class: '-wide' },
                         :'data-ajaxURL' => api_v2_paginate_users_path,
                         multiple: true,
                         :'data-selected' => filter_select(timeline.selected_planning_element_responsibles, :name, :id).to_json %>
@@ -88,7 +97,10 @@ See doc/COPYRIGHT.rdoc for more details.
                    { selected: timeline.selected_planning_element_assignee.map(&:id), label: l("timelines.filter.work_package_assignee") },
                    { multiple: true } %>
         <% else %>
-          <%= ff.select :planning_element_assignee, options_for_select([]), { label: l("timelines.filter.work_package_assignee") },
+          <%= ff.select :planning_element_assignee,
+                        options_for_select([]),
+                        { label: l("timelines.filter.work_package_assignee"),
+                          container_class: '-wide' },
                         :'data-ajaxURL' => api_v2_paginate_users_path,
                         multiple: true,
                         :'data-selected' => filter_select(timeline.selected_planning_element_assignee, :name, :id).to_json %>

--- a/app/views/timelines/filter/_planning_elements.html.erb
+++ b/app/views/timelines/filter/_planning_elements.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="planning_element_filters" class="header_collapsible collapsible collapsed">
+<fieldset id="planning_element_filters" class="form--fieldset collapsible collapsed">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.filter.work_package_filters') %></a>
   </legend>

--- a/app/views/timelines/filter/_projects.html.erb
+++ b/app/views/timelines/filter/_projects.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="project_filters" class="header_collapsible collapsible collapsed">
+<fieldset id="project_filters" class="form--fieldset collapsible collapsed">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.filter.project_filters') %></a>
   </legend>

--- a/app/views/timelines/filter/_projects.html.erb
+++ b/app/views/timelines/filter/_projects.html.erb
@@ -53,7 +53,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
            <%= ff.select(:project_types,
                    options_for_select([]),
-                   { label: l("timelines.filter.project_types") },
+                   { label: l("timelines.filter.project_types"),
+                     container_class: '-wide' },
                    { :'data-ajaxURL' => api_v2_paginate_project_types_path,
                      :multiple => true,
                      :'data-selected' => filter_select(
@@ -74,7 +75,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select(:project_status,
                    options_for_select([]),
-                   { label:  l("timelines.filter.project_status") },
+                   { label:  l("timelines.filter.project_status"),
+                     container_class: '-wide' },
                    { :'data-ajaxURL' => api_v2_paginate_reported_project_statuses_path,
                      :multiple => true,
                      :'data-selected' => filter_select(
@@ -95,7 +97,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select(:project_responsibles,
                    options_for_select([]),
-                   { label: l("timelines.filter.project_responsible") },
+                   { label: l("timelines.filter.project_responsible"),
+                     container_class: '-wide' },
                    { :'data-ajaxURL' => api_v2_paginate_users_path,
                     :multiple => true,
                     :'data-selected' => filter_select(
@@ -116,7 +119,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select(:parents,
                    options_for_select([]),
-                   { label: l("timelines.filter.parent") },
+                   { label: l("timelines.filter.parent"),
+                     container_class: '-wide' },
                    { :'data-ajaxURL' => api_v2_paginate_projects_path,
                      :multiple => true,
                      :'data-selected' => filter_select(
@@ -138,7 +142,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select(:planning_element_time_types,
                      options_for_select([]),
-                     { label: l('timelines.filter.project_time_filter') },
+                     { label: l('timelines.filter.project_time_filter'),
+                       container_class: '-wide' },
                      { :'data-ajaxURL' => api_v2_paginate_types_path,
                        :multiple => true,
                        :'data-selected' => filter_select(

--- a/app/views/timelines/filter/_projects.html.erb
+++ b/app/views/timelines/filter/_projects.html.erb
@@ -156,7 +156,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
 
         <div class="form--grouping-row">
-          <div class="form--field">
+          <div class="form--field -trailing-label">
             <%= ff.radio_button :planning_element_time, 'absolute', label:  l('timelines.filter.comparison.absolute') %>
           </div>
         </div>
@@ -177,27 +177,33 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
 
         <div class="form--grouping-row">
-          <div class="form--field">
+          <div class="form--field -trailing-label">
             <%= ff.radio_button :planning_element_time, 'relative', label: l('timelines.filter.comparison.relative') %>
           </div>
         </div>
 
         <div class="form--grouping-row">
-          <div class="form--field">
+          <div class="form--field -wide-label">
             <%= ff.text_field :planning_element_time_relative_one, label: l('timelines.filter.project_time_filter_historical_from') %>
           </div>
           <div class="form--field">
             <%= ff.select :planning_element_time_relative_one_unit,
                           options_for_timeunits(timeline.options['planning_element_time_relative_one_unit']),
                           no_label: true %>
+            <span class="form--field-affix -transparent">
+              <%=l('timelines.filter.comparison.compare_relative_suffix')%>
+            </span>
           </div>
-          <div class="form--field">
+          <div class="form--field -wide-label">
             <%= ff.text_field :planning_element_time_relative_two, label: l('timelines.filter.project_time_filter_historical_to') %>
           </div>
           <div class="form--field">
             <%= ff.select :planning_element_time_relative_two_unit,
                           options_for_timeunits(timeline.options['planning_element_time_relative_two_unit']),
                           no_label: true %>
+            <span class="form--field-affix -transparent">
+              <%=l('timelines.filter.comparison.compare_relative_suffix')%>
+            </span>
           </div>
         </div>
       </div>

--- a/app/views/timelines/group/_grouping.html.erb
+++ b/app/views/timelines/group/_grouping.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset id="grouping" class="header_collapsible collapsible collapsed">
+<fieldset id="grouping" class="form--fieldset collapsible collapsed">
   <legend title="<%=l(:description_filter_toggle)%>", onclick="toggleFieldset(this);">
     <a href="javascript:"><%= l('timelines.filter.grouping') %></a>
   </legend>

--- a/app/views/timelines/group/_grouping.html.erb
+++ b/app/views/timelines/group/_grouping.html.erb
@@ -49,7 +49,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select :grouping_one_selection,
                    options_for_select([]),
-                   { label: l('timelines.filter.grouping_one_phrase') },
+                   { label: l('timelines.filter.grouping_one_phrase'),
+                     container_class: '-wide' },
                    { :'data-ajaxURL' => api_v2_paginate_projects_path,
                      :multiple => true,
                      :'data-selected' => filter_select(
@@ -61,9 +62,10 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
       <div class="form--field">
         <%= ff.select(:grouping_one_sort,
-           [[l('timelines.filter.sort.alphabet'), '0'], [l('timelines.filter.sort.explicit_order'), '1']],
-
-           { label: l('timelines.filter.sort.sortation') }) %>
+                      [[l('timelines.filter.sort.alphabet'), '0'],
+                       [l('timelines.filter.sort.explicit_order'), '1']],
+                      label: l('timelines.filter.sort.sortation'),
+                      container_class: '-wide') %>
       </div>
       <div class="form--field">
         <%= ff.check_box :grouping_two_enabled, { label: l('timelines.filter.grouping_two') }, 'yes', 'no' %>
@@ -80,7 +82,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% else %>
           <%= ff.select(:grouping_two_selection,
                      options_for_select([]),
-                     { label: l('timelines.filter.grouping_two_phrase') },
+                     { label: l('timelines.filter.grouping_two_phrase'),
+                       container_class: '-wide' },
                      { :'data-ajaxURL' => api_v2_paginate_project_types_path,
                        :multiple => true,
                        :'data-selected' => filter_select(
@@ -91,7 +94,12 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
       </div>
       <div class="form--field">
-        <%= ff.select(:grouping_two_sort, [[l('timelines.filter.sort.default'), '0'], [l('timelines.filter.sort.date'), '1'], [l('timelines.filter.sort.alphabet'), '2']], label: l('timelines.filter.sort.sortation') ) %>
+        <%= ff.select(:grouping_two_sort,
+                      [[l('timelines.filter.sort.default'), '0'],
+                       [l('timelines.filter.sort.date'), '1'],
+                       [l('timelines.filter.sort.alphabet'), '2']],
+                      label: l('timelines.filter.sort.sortation'),
+                      container_class: '-wide' ) %>
       </div>
       <div class="form--field">
         <%= ff.check_box :hide_other_group, { label: I18n.t('timelines.filter.grouping_hide_group', :group => l('timelines.filter.grouping_other')) }, 'yes', 'no' %>

--- a/lib/open_project/form_tag_helper.rb
+++ b/lib/open_project/form_tag_helper.rb
@@ -42,14 +42,14 @@ module OpenProject
 
     def styled_select_tag(name, styled_option_tags = nil, options = {})
       apply_css_class_to_options(options, 'form--select')
-      wrap_field 'select' do
+      wrap_field 'select', options do
         select_tag(name, styled_option_tags, options)
       end
     end
 
     def styled_text_field_tag(name, value = nil, options = {})
       apply_css_class_to_options(options, 'form--text-field')
-      wrap_field 'text-field' do
+      wrap_field 'text-field', options do
         text_field_tag(name, value, options)
       end
     end
@@ -67,28 +67,28 @@ module OpenProject
 
     def styled_file_field_tag(name, options = {})
       apply_css_class_to_options(options, 'form--file-field')
-      wrap_field 'file-field' do
+      wrap_field 'file-field', options do
         file_field_tag(name, options)
       end
     end
 
     def styled_text_area_tag(name, content = nil, options = {})
       apply_css_class_to_options(options, 'form--text-area')
-      wrap_field 'text-area' do
+      wrap_field 'text-area', options do
         text_area_tag(name, content, options)
       end
     end
 
     def styled_check_box_tag(name, value = '1', checked = false, options = {})
       apply_css_class_to_options(options, 'form--check-box')
-      wrap_field 'check-box' do
+      wrap_field 'check-box', options do
         check_box_tag(name, value, checked, options)
       end
     end
 
     def styled_radio_button_tag(name, value, checked = false, options = {})
       apply_css_class_to_options(options, 'form--radio-button')
-      wrap_field 'radio-button' do
+      wrap_field 'radio-button', options do
         radio_button_tag(name, value, checked, options)
       end
     end
@@ -113,7 +113,7 @@ module OpenProject
 
     def styled_search_field_tag(name, value = nil, options = {})
       apply_css_class_to_options(options, 'form--search-field')
-      wrap_field 'search-field' do
+      wrap_field 'search-field', options do
         search_field_tag(name, value, options)
       end
     end
@@ -121,7 +121,7 @@ module OpenProject
     TEXT_LIKE_FIELDS.each do |field|
       define_method :"styled_#{field}_tag" do |name, value = nil, options = {}|
         apply_css_class_to_options(options, "form--text-field -#{field.gsub(/_field$/, '')}")
-        wrap_field field do
+        wrap_field field, options do
           __send__(:"#{field}_tag", name, value, options)
         end
       end
@@ -129,27 +129,31 @@ module OpenProject
 
     def styled_range_field_tag(name, value = nil, options = {})
       apply_css_class_to_options(options, 'form--range-field')
-      wrap_field 'range-field' do
+      wrap_field 'range-field', options do
         range_field_tag(name, value, options)
       end
     end
 
     private
 
-    def wrap_field(name, &block)
-      content_tag(:span, class: field_container_css_class(name), &block)
+    def wrap_field(name, options, &block)
+      content_tag(:span, class: field_container_css_class(name, options), &block)
     end
 
     def apply_css_class_to_options(options, css_class)
       options[:class] = Array(options[:class]) + Array(css_class)
     end
 
-    def field_container_css_class(selector)
-      if TEXT_LIKE_FIELDS.include?(selector)
-        'form--text-field-container'
-      else
-        "form--#{selector.tr('_', '-')}-container"
-      end
+    def field_container_css_class(selector, options)
+      classes = if TEXT_LIKE_FIELDS.include?(selector)
+                  'form--text-field-container'
+                else
+                  "form--#{selector.tr('_', '-')}-container"
+                end
+
+      classes << ' ' + options.fetch(:container_class, '')
+
+      classes.strip
     end
   end
 end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -114,7 +114,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   ].freeze
 
   def container_wrap_field(field_html, selector, options = {})
-    ret = content_tag(:span, field_html, class: field_container_css_class(selector))
+    ret = content_tag(:span, field_html, class: field_container_css_class(selector, options))
 
     prefix, suffix = options.values_at(:prefix, :suffix)
 
@@ -155,12 +155,16 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     ret
   end
 
-  def field_container_css_class(selector)
-    if TEXT_LIKE_FIELDS.include?(selector)
-      'form--text-field-container'
-    else
-      "form--#{selector.tr('_', '-')}-container"
-    end
+  def field_container_css_class(selector, options)
+    classes = if TEXT_LIKE_FIELDS.include?(selector)
+                'form--text-field-container'
+              else
+                "form--#{selector.tr('_', '-')}-container"
+              end
+
+    classes << ' ' + options.fetch(:container_class, '')
+
+    classes.strip
   end
 
   def field_css_class(selector)

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -179,13 +179,24 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   def label_for_field(field, options = {}, translation_form = nil)
     options = options.dup
     return ''.html_safe if options.delete(:no_label)
-    text = options[:label].is_a?(Symbol) ? l(options[:label]) : options[:label]
-    text ||= @object.class.human_attribute_name(field.to_sym) if @object.is_a?(ActiveRecord::Base)
+
+    text = if options[:label].is_a?(Symbol)
+             l(options[:label])
+           elsif options[:label]
+             options[:label]
+           elsif @object.is_a?(ActiveRecord::Base)
+             @object.class.human_attribute_name(field.to_sym)
+           else
+             l(field)
+           end
+
+    label_options = { class: '',
+                      title: text }
+
     text += @template.content_tag('span', ' *', class: 'required') if options.delete(:required)
 
     id = element_id(translation_form) if translation_form
 
-    label_options = { class: '' }
     # FIXME: reenable the error handling
     label_options[:class] << 'error' if false && @object && @object.respond_to?(:errors) && @object.errors[field] # FIXME
     label_options[:class] << 'form--label'

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -60,10 +60,12 @@ describe SettingsHelper, type: :helper do
     end
 
     subject(:output) {
-      helper.setting_multiselect :field, [['Popsickle', '1'], ['Jello', '2'], ['Ice Cream', '3']]
+      helper.setting_multiselect :field, [['Popsickle', '1'], ['Jello', '2'], ['Ice Cream', '3']], options
     }
 
-    it_behaves_like 'wrapped in container'
+    it_behaves_like 'wrapped in container' do
+      let(:container_count) { 3 }
+    end
 
     it 'should have checkboxes wrapped in checkbox-container' do
       expect(output).to have_selector 'span.form--check-box-container', count: 3
@@ -229,7 +231,7 @@ important text</textarea>
     end
 
     subject(:output) {
-      helper.notification_field(notifiable)
+      helper.notification_field(notifiable, options)
     }
 
     context 'when setting includes option' do

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -57,10 +57,14 @@ describe CustomFieldFormBuilder do
     }
 
     it_behaves_like 'labelled by default'
-    it_behaves_like 'wrapped in field-container by default'
+    it_behaves_like 'wrapped in field-container by default' do
+      let(:container_count) { 2 }
+    end
 
     context 'for a bool custom field' do
-      it_behaves_like 'wrapped in container', 'check-box-container'
+      it_behaves_like 'wrapped in container', 'check-box-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
@@ -83,7 +87,9 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'date'
       end
 
-      it_behaves_like 'wrapped in container', 'text-field-container'
+      it_behaves_like 'wrapped in container', 'text-field-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
@@ -103,7 +109,9 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'text'
       end
 
-      it_behaves_like 'wrapped in container', 'text-area-container'
+      it_behaves_like 'wrapped in container', 'text-area-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
@@ -123,7 +131,9 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'string'
       end
 
-      it_behaves_like 'wrapped in container', 'text-field-container'
+      it_behaves_like 'wrapped in container', 'text-field-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
@@ -143,7 +153,9 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'int'
       end
 
-      it_behaves_like 'wrapped in container', 'text-field-container'
+      it_behaves_like 'wrapped in container', 'text-field-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
@@ -163,7 +175,9 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'float'
       end
 
-      it_behaves_like 'wrapped in container', 'text-field-container'
+      it_behaves_like 'wrapped in container', 'text-field-container' do
+        let(:container_count) { 2 }
+      end
 
       it 'should output element' do
         expect(output).to be_html_eql(%{

--- a/spec/support/shared/forms_html.rb
+++ b/spec/support/shared/forms_html.rb
@@ -49,6 +49,19 @@ end
 
 shared_examples_for 'wrapped in container' do |container = 'field-container'|
   it { is_expected.to have_selector "span.form--#{container}", count: 1 }
+
+  context 'with additional class provided' do
+    let(:css_class) { 'my-additional-class' }
+    let(:expected_container_count) { defined?(container_count) ? container_count : 1 }
+
+    before do
+      options[:container_class] = css_class
+    end
+
+    it 'has the class' do
+      is_expected.to have_selector "span.#{css_class}", count: expected_container_count
+    end
+  end
 end
 
 shared_examples_for 'not wrapped in container' do |container = 'field-container'|


### PR DESCRIPTION
Contains
- general form extension to allow for setting explicit max-width on form-[typo of input]-container elements. the element will get a max-width so it will still shrink if there is not enough space. There are a couple of modifier classes I added and from which one can choose the desired width. The max-width value within the modifier class is more or less arbitrary. I am willing to make amends there.
- select2 elements within such a width-limited container will have the width of the container. We should remove the explicit width for select2 but that is outside the scope of this PR.
- The modifier class is applied to timelines so that the trailing "ago" label is fixed
-  The standard form--fieldsets are used in timelines

Should finally close https://community.openproject.org/work_packages/18934
