### PR TITLE
[API] Fix class loading issues during development

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -28,18 +28,21 @@
 #++
 
 require 'roar/decorator'
+require 'roar/hypermedia'
 require 'roar/json/hal'
+
+require 'api/v3/utilities/path_helper'
 
 module API
   module Decorators
-    class Single < Roar::Decorator
-      include Roar::JSON::HAL
-      include Roar::Hypermedia
-      include API::V3::Utilities::PathHelper
+    class Single < ::Roar::Decorator
+      include ::Roar::JSON::HAL
+      include ::Roar::Hypermedia
+      include ::API::V3::Utilities::PathHelper
 
       attr_reader :context
       class_attribute :as_strategy
-      self.as_strategy = API::Utilities::CamelCasingStrategy.new
+      self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
       def initialize(model, context = {})
         @context = context
@@ -107,7 +110,7 @@ module API
       private
 
       def datetime_formatter
-        API::V3::Utilities::DateTimeFormatter
+        ::API::V3::Utilities::DateTimeFormatter
       end
 
       def _type; end

--- a/lib/api/open_project_api.rb
+++ b/lib/api/open_project_api.rb
@@ -27,7 +27,7 @@
 #++
 
 module API
-  class OpenProjectAPI < Grape::API
+  class OpenProjectAPI < ::Grape::API
     include ::API::PatchableAPI
   end
 end

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/activities/activity_representer'
+
 module API
   module V3
     module Activities
@@ -39,7 +41,7 @@ module API
 
             before do
               @activity = Journal.find(params[:id])
-              @representer = ::API::V3::Activities::ActivityRepresenter.new(@activity, current_user: current_user)
+              @representer = ActivityRepresenter.new(@activity, current_user: current_user)
             end
 
             get do
@@ -50,7 +52,7 @@ module API
             helpers do
               def save_activity(activity)
                 if activity.save
-                  representer = ::API::V3::Activities::ActivityRepresenter.new(activity)
+                  representer = ActivityRepresenter.new(activity)
 
                   representer
                 else

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -41,7 +41,7 @@ module API
 
             before do
               @attachment = Attachment.find(params[:id])
-              @representer =  AttachmentRepresenter.new(@attachment)
+              @representer = AttachmentRepresenter.new(@attachment)
             end
 
             get do

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/attachments/attachment_representer'
+
 module API
   module V3
     module Attachments
@@ -39,7 +41,7 @@ module API
 
             before do
               @attachment = Attachment.find(params[:id])
-              @representer =  ::API::V3::Attachments::AttachmentRepresenter.new(@attachment)
+              @representer =  AttachmentRepresenter.new(@attachment)
             end
 
             get do

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/categories/category_representer'
+
 module API
   module V3
     module Categories

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/categories/category_collection_representer'
+
 module API
   module V3
     module Categories

--- a/lib/api/v3/priorities/priorities_api.rb
+++ b/lib/api/v3/priorities/priorities_api.rb
@@ -27,6 +27,9 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/priorities/priority_collection_representer'
+require 'api/v3/priorities/priority_representer'
+
 module API
   module V3
     module Priorities

--- a/lib/api/v3/projects/available_assignees_api.rb
+++ b/lib/api/v3/projects/available_assignees_api.rb
@@ -39,9 +39,9 @@ module API
             available_assignees = @project.possible_assignees
             total = available_assignees.count
             self_link = api_v3_paths.available_assignees(@project.id)
-            UserCollectionRepresenter.new(available_assignees,
-                                          total,
-                                          self_link)
+            Users::UserCollectionRepresenter.new(available_assignees,
+                                                 total,
+                                                 self_link)
           end
         end
       end

--- a/lib/api/v3/projects/available_assignees_api.rb
+++ b/lib/api/v3/projects/available_assignees_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/users/user_collection_representer'
+
 module API
   module V3
     module Projects
@@ -37,9 +39,9 @@ module API
             available_assignees = @project.possible_assignees
             total = available_assignees.count
             self_link = api_v3_paths.available_assignees(@project.id)
-            ::API::V3::Users::UserCollectionRepresenter.new(available_assignees,
-                                                            total,
-                                                            self_link)
+            UserCollectionRepresenter.new(available_assignees,
+                                          total,
+                                          self_link)
           end
         end
       end

--- a/lib/api/v3/projects/available_responsibles_api.rb
+++ b/lib/api/v3/projects/available_responsibles_api.rb
@@ -39,9 +39,9 @@ module API
             available_responsibles = @project.possible_responsibles
             total = available_responsibles.count
             self_link = api_v3_paths.available_responsibles(@project.id)
-            UserCollectionRepresenter.new(available_responsibles,
-                                          total,
-                                          self_link)
+            Users::UserCollectionRepresenter.new(available_responsibles,
+                                                 total,
+                                                 self_link)
           end
         end
       end

--- a/lib/api/v3/projects/available_responsibles_api.rb
+++ b/lib/api/v3/projects/available_responsibles_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/users/user_collection_representer'
+
 module API
   module V3
     module Projects
@@ -37,9 +39,9 @@ module API
             available_responsibles = @project.possible_responsibles
             total = available_responsibles.count
             self_link = api_v3_paths.available_responsibles(@project.id)
-            ::API::V3::Users::UserCollectionRepresenter.new(available_responsibles,
-                                                            total,
-                                                            self_link)
+            UserCollectionRepresenter.new(available_responsibles,
+                                          total,
+                                          self_link)
           end
         end
       end

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/projects/project_representer'
+
 module API
   module V3
     module Projects

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'securerandom'
+require 'api/v3/queries/query_representer'
 
 module API
   module V3
@@ -39,7 +40,7 @@ module API
           route_param :id do
             before do
               @query = Query.find(params[:id])
-              @representer =  ::API::V3::Queries::QueryRepresenter.new(@query)
+              @representer =  QueryRepresenter.new(@query)
             end
 
             helpers do

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -40,7 +40,7 @@ module API
           route_param :id do
             before do
               @query = Query.find(params[:id])
-              @representer =  QueryRepresenter.new(@query)
+              @representer = QueryRepresenter.new(@query)
             end
 
             helpers do

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -32,7 +32,7 @@ require 'roar/json/hal'
 
 module API
   module V3
-    module WorkPackages
+    module Relations
       class RelationRepresenter < ::API::Decorators::Single
         link :self do
           { href: api_v3_paths.relation(represented.id) }

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -1,3 +1,33 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'api/v3/relations/relation_representer'
+
 module API
   module V3
     module Relations
@@ -19,10 +49,10 @@ module API
             end
 
             if relation.valid? && relation.save
-              representer = ::API::V3::WorkPackages::RelationRepresenter.new(relation, work_package: relation.to)
+              representer = RelationRepresenter.new(relation, work_package: relation.to)
               representer
             else
-              fail Errors::Validation.new(relation)
+              fail ::Errors::Validation.new(relation)
             end
           end
 

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -118,9 +118,9 @@ module API
               check_content_type
               setup_response
 
-              renderer = TextRenderer.new(request_body,
-                                          object: context_object,
-                                          format: @format)
+              renderer = Utilities::TextRenderer.new(request_body,
+                                                     object: context_object,
+                                                     format: @format)
               renderer.to_html
             end
           end

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/utilities/text_renderer'
+
 module API
   module V3
     module Render
@@ -48,13 +50,13 @@ module API
                                  content_type: SUPPORTED_MEDIA_TYPE,
                                  actual: bad_type)
 
-                fail API::Errors::UnsupportedMediaType, message
+                fail ::API::Errors::UnsupportedMediaType, message
               end
             end
 
             def check_format(format)
               supported_formats = ['plain']
-              supported_formats += Array(Redmine::WikiFormatting.format_names)
+              supported_formats += Array(::Redmine::WikiFormatting.format_names)
               unless supported_formats.include?(format)
                 fail ::API::Errors::NotFound, I18n.t('api_v3.errors.code_404')
               end
@@ -72,7 +74,7 @@ module API
             def context_object
               try_context_object
             rescue ::ActiveRecord::RecordNotFound
-              fail API::Errors::InvalidRenderContext.new(
+              fail ::API::Errors::InvalidRenderContext.new(
                 I18n.t('api_v3.errors.render.context_object_not_found')
               )
             end
@@ -92,12 +94,12 @@ module API
               context = ::API::Utilities::ResourceLinkParser.parse(params[:context])
 
               if context.nil?
-                fail API::Errors::InvalidRenderContext.new(
+                fail ::API::Errors::InvalidRenderContext.new(
                   I18n.t('api_v3.errors.render.context_not_parsable')
                 )
               elsif !SUPPORTED_CONTEXT_NAMESPACES.include?(context[:namespace]) ||
                     context[:version] != '3'
-                fail API::Errors::InvalidRenderContext.new(
+                fail ::API::Errors::InvalidRenderContext.new(
                   I18n.t('api_v3.errors.render.unsupported_context')
                 )
               else
@@ -116,9 +118,9 @@ module API
               check_content_type
               setup_response
 
-              renderer = ::API::Utilities::TextRenderer.new(request_body,
-                                                            object: context_object,
-                                                            format: @format)
+              renderer = TextRenderer.new(request_body,
+                                          object: context_object,
+                                          format: @format)
               renderer.to_html
             end
           end

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -27,8 +27,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'api/utilities/text_renderer'
-
 module API
   module V3
     module Render
@@ -118,9 +116,9 @@ module API
               check_content_type
               setup_response
 
-              renderer = Utilities::TextRenderer.new(request_body,
-                                                     object: context_object,
-                                                     format: @format)
+              renderer = ::API::Utilities::TextRenderer.new(request_body,
+                                                            object: context_object,
+                                                            format: @format)
               renderer.to_html
             end
           end

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -27,6 +27,9 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/statuses/status_collection_representer'
+require 'api/v3/statuses/status_representer'
+
 module API
   module V3
     module Statuses
@@ -47,7 +50,7 @@ module API
           route_param :id do
             before do
               status = Status.find(params[:id])
-              @representer = ::API::V3::Statuses::StatusRepresenter.new(status)
+              @representer = StatusRepresenter.new(status)
             end
 
             get do

--- a/lib/api/v3/string_objects/string_objects_api.rb
+++ b/lib/api/v3/string_objects/string_objects_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/string_objects/string_object_representer'
+
 module API
   module V3
     module StringObjects

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -27,6 +27,9 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/types/type_collection_representer'
+require 'api/v3/types/type_representer'
+
 module API
   module V3
     module Types
@@ -46,7 +49,7 @@ module API
           namespace ':id' do
             before do
               type = Type.find(params[:id])
-              @representer = ::API::V3::Types::TypeRepresenter.new(type)
+              @representer = TypeRepresenter.new(type)
             end
 
             get do

--- a/lib/api/v3/types/types_by_project_api.rb
+++ b/lib/api/v3/types/types_by_project_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/types/type_collection_representer'
+
 module API
   module V3
     module Types

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/users/user_representer'
+
 module API
   module V3
     module Users
@@ -37,7 +39,7 @@ module API
 
               # Show updated user
               status 200
-              Users::UserRepresenter.new(@user, current_user: current_user)
+              UserRepresenter.new(@user, current_user: current_user)
             else
               fail ::API::Errors::InvalidUserStatusTransition
             end
@@ -56,7 +58,7 @@ module API
             end
 
             get do
-              Users::UserRepresenter.new(@user, current_user: current_user)
+              UserRepresenter.new(@user, current_user: current_user)
             end
 
             delete do

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -43,9 +43,9 @@ module API
 
           get do
             path = api_v3_paths.projects_by_version @version.id
-            ProjectCollectionRepresenter.new(@projects,
-                                             @projects.count,
-                                             path)
+            Projects::ProjectCollectionRepresenter.new(@projects,
+                                                       @projects.count,
+                                                       path)
           end
         end
       end

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/projects/project_collection_representer'
+
 module API
   module V3
     module Versions
@@ -41,9 +43,9 @@ module API
 
           get do
             path = api_v3_paths.projects_by_version @version.id
-            Projects::ProjectCollectionRepresenter.new(@projects,
-                                                       @projects.count,
-                                                       path)
+            ProjectCollectionRepresenter.new(@projects,
+                                             @projects.count,
+                                             path)
           end
         end
       end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -59,7 +59,7 @@ module API
               VersionRepresenter.new(@version, context)
             end
 
-            mount API::V3::Versions::ProjectsByVersionAPI
+            mount ::API::V3::Versions::ProjectsByVersionAPI
           end
         end
       end

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/versions/version_collection_representer'
+
 module API
   module V3
     module Versions

--- a/lib/api/v3/work_packages/form/form_api.rb
+++ b/lib/api/v3/work_packages/form/form_api.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/work_packages/form/form_representer'
+
 module API
   module V3
     module WorkPackages

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -26,7 +26,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-
 require 'api/v3/work_packages/schema/work_package_schema'
 require 'api/v3/work_packages/schema/work_package_schema_representer'
 

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -26,6 +26,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+
+require 'api/v3/work_packages/schema/work_package_schema'
+require 'api/v3/work_packages/schema/work_package_schema_representer'
+
 module API
   module V3
     module WorkPackages

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -305,9 +305,9 @@ module API
           end
 
           visible_relations.map do |relation|
-            RelationRepresenter.new(relation,
-                                    work_package: represented,
-                                    current_user: current_user)
+            Relations::RelationRepresenter.new(relation,
+                                               work_package: represented,
+                                               current_user: current_user)
           end
         end
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -26,6 +26,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'api/v3/activities/activity_representer'
+require 'api/v3/work_packages/work_package_contract'
+require 'api/v3/work_packages/work_package_representer'
+require 'api/v3/work_packages/form/work_package_payload_representer'
+
 module API
   module V3
     module WorkPackages
@@ -39,8 +44,8 @@ module API
               attr_reader :work_package
 
               def work_package_representer
-                WorkPackages::WorkPackageRepresenter.create(@work_package,
-                                                            current_user: current_user)
+                WorkPackageRepresenter.create(@work_package,
+                                              current_user: current_user)
               end
 
               def write_work_package_attributes
@@ -61,7 +66,7 @@ module API
 
               # merges the given JSON representation into @work_package
               def merge_json_into_work_package!(json)
-                payload = ::API::V3::WorkPackages::Form::WorkPackagePayloadRepresenter.create(
+                payload = WorkPackagePayloadRepresenter.create(
                   @work_package,
                   enforce_lock_version_validation: true)
                 payload.from_json(json)
@@ -123,7 +128,7 @@ module API
               helpers do
                 def save_work_package(work_package)
                   if work_package.save
-                    representer = ::API::V3::Activities::ActivityRepresenter.new(
+                    representer = ActivityRepresenter.new(
                       work_package.journals.last,
                       current_user: current_user)
 
@@ -140,7 +145,7 @@ module API
               post do
                 authorize({ controller: :journals, action: :new },
                           context: @work_package.project) do
-                  raise API::Errors::NotFound.new
+                  raise ::API::Errors::NotFound.new
                 end
 
                 @work_package.journal_notes = params[:comment]

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -66,7 +66,7 @@ module API
 
               # merges the given JSON representation into @work_package
               def merge_json_into_work_package!(json)
-                payload = WorkPackagePayloadRepresenter.create(
+                payload = Form::WorkPackagePayloadRepresenter.create(
                   @work_package,
                   enforce_lock_version_validation: true)
                 payload.from_json(json)
@@ -128,11 +128,8 @@ module API
               helpers do
                 def save_work_package(work_package)
                   if work_package.save
-                    representer = ActivityRepresenter.new(
-                      work_package.journals.last,
-                      current_user: current_user)
-
-                    representer
+                    Activities::ActivityRepresenter.new(work_package.journals.last,
+                                                        current_user: current_user)
                   else
                     fail ::API::Errors::Validation.new(work_package)
                   end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19190
## Description

This is a new try for class loading in APIv3 classes, we either:
- FULLY qualify a class and trust the rails autoloader
- qualify as few as possible (see below) and require the corresponding class

That means we do not (yet) completely give up on the rails autoloader, but we circumvent a fair amount of its magic (and problems).

The hope is to eliminate the following problems in development mode:
- NameErrors because the autoloader infers the wrong prefix
- "object is not missing constant" errors occuring more rarely

What we still want to maintain is:
- The ability to automatically resolve a class' file when fully qualifying it
- The automatic reloading of changed classes during development

So far it looks as if this is still working. Lets see if that is true ^^
## What does "qualify as few as possible" mean?

Ideally, if we already require a class we do not want to qualify at all:

``` ruby
require 'api/v3/statuses/status_representer'

# in api/v3/statuses/status_api.rb
module API
  module V3
    module Statuses
      # ... [insert actual code] ...
      StatusRepresenter
    end
  end
end
```

However, when we don't share the same module we are forced to go up to the first common module, for Ruby to be able to perform the lookup successfully:

``` ruby
require 'api/v3/statuses/status_representer'

# in api/v3/whatever/another_api.rb
module API
  module V3
    module Whatever
      # this will work, our common module is API::V3, so we can refer to Statuses safely
      Statuses::StatusRepresenter

      # this will FAIL, because there is neither of the following:
      #  - ::API::V3::Whatever::StatusRepresenter
      #  - ::API::V3::StatusRepresenter
      #  - ::API::StatusRepresenter
      #  - ::StatusRepresenter
      StatusRepresenter
    end
  end
end
```

Note that Ruby will take the first match. So if you refer to `Utilities::Foo` from `A::B::C` and there are both, `A::Utilities` and `A::B::Utilities` it will take the latter, because it starts from your module going to the root. That means if `Foo` is defined in `A::Utilities` it will **not** be found.

Those are ruby basics, however I was able to not know them (I blame rails for taking too much work from me ^^)... So I thought I better repeat them here.
## Affected files

This PR only considers the actual endpoint classes, i.e. files ending in `_api.rb`. This should be a good start and to my knowledge was the source of the most errors recently.

If we choose that this is the path we want to go, **_all files**_ under `lib/api/` should follow that pattern. It should not be neccessary to touch specs, because they only run in the `test` environment.
