### PR TITLE
Allow to exclude modules with Project Factory

### DIFF
--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -31,6 +31,7 @@ FactoryGirl.define do
   factory :project do
     transient do
       no_types false
+      disable_modules []
     end
 
     sequence(:name) { |n| "My Project No. #{n}" }
@@ -38,6 +39,11 @@ FactoryGirl.define do
     created_on { Time.now }
     updated_on { Time.now }
     enabled_module_names Redmine::AccessControl.available_project_modules
+
+    callback(:after_build) do |project, evaluator|
+      disabled_modules = Array(evaluator.disable_modules)
+      project.enabled_module_names = project.enabled_module_names - disabled_modules
+    end
 
     callback(:before_create) do |project, evaluator|
       unless evaluator.no_types ||
@@ -62,12 +68,6 @@ FactoryGirl.define do
         callback(:after_build) do |project|
           project.types << FactoryGirl.build(:type_with_workflow)
         end
-      end
-    end
-
-    trait :without_wiki do
-      callback(:after_build) do |project|
-        project.enabled_module_names = project.enabled_module_names - ['wiki']
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -151,7 +151,7 @@ describe Project, type: :model do
   end
 
   context 'when the wiki module is enabled' do
-    let(:project) { FactoryGirl.create(:project, :without_wiki) }
+    let(:project) { FactoryGirl.create(:project, disable_modules: 'wiki') }
 
     before :each do
       project.enabled_module_names = project.enabled_module_names | ['wiki']

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe Wiki, type: :model do
-  let(:project) { FactoryGirl.create(:project, :without_wiki) }
+  let(:project) { FactoryGirl.create(:project, disable_modules: 'wiki') }
   let(:start_page) { 'The wiki start page' }
 
   it_behaves_like 'acts_as_watchable included' do


### PR DESCRIPTION
## OpenProject work package

required in https://community.openproject.org/work_packages/19302
## Description

By default the project factory creates projects that have all possible modules activated.
This PR allows to disable single or multiple modules at will like so:

``` ruby
p1 = FactoryGirl.build(:project, disable_modules: 'wiki')
p2 = FactoryGirl.build(:project, disable_modules: ['wiki', timelines])
```
