### PR TITLE
Do not use a relative path for the asset pipeline manifesto

### DIFF
--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -25,9 +25,8 @@
  *
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
-//= require ../javascripts/bundles/openproject-global
-//= require ../javascripts/bundles/openproject-core-app
-//= require_tree ../javascripts/bundles
+//= require bundles/openproject-global
+//= require bundles/openproject-core-app
 
 //= require print
 //= require scm


### PR DESCRIPTION
This will correct an error that occurs on our internal CI and prevents the building of artifacts.

This was introduced by #2702 by accident. The asset precompilation breaks due to not being able to read relative paths. this should leave the building of the styleguide via `gulp` with all its perks untouched and make the `rake assets:precompile` task usable again.

I am not entirely sure what `require_tree ../javascripts/bundles` did, as there are no more `sass` or `css` files in `app/assets/javascripts/bundles`. 

Summoning the powers of @myabc, @ulferts and everyone else to verify this fix.
