### PR TITLE
Fixes for UserMailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,7 +174,7 @@ group :ldap do
 end
 
 group :development do
-  gem 'letter_opener', '~> 1.0.0'
+  gem 'letter_opener', '~> 1.3.0'
   gem 'rails-dev-tweaks', '~> 0.6.1'
   gem 'thin'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,8 +245,8 @@ GEM
     kgio (2.9.2)
     launchy (2.3.0)
       addressable (~> 2.3)
-    letter_opener (1.0.0)
-      launchy (>= 2.0.4)
+    letter_opener (1.3.0)
+      launchy (~> 2.2)
     livingstyleguide (1.2.2)
       hooks (= 0.3.3)
       minisyntax
@@ -499,7 +499,7 @@ DEPENDENCIES
   jruby-openssl
   json_spec
   launchy (~> 2.3.0)
-  letter_opener (~> 1.0.0)
+  letter_opener (~> 1.3.0)
   livingstyleguide (~> 1.2.2)
   multi_json
   mysql2 (~> 0.3.11)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -171,7 +171,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def news_comment_added(user, comment)
+  def news_comment_added(user, comment, author)
     @comment = comment
     @news    = @comment.commented
 
@@ -183,11 +183,11 @@ class UserMailer < ActionMailer::Base
     with_locale_for(user) do
       subject = "#{News.model_name.human}: #{@news.title}"
       subject = "Re: [#{@news.project.name}] #{subject}" if @news.project
-      mail to: user.mail, subject: subject
+      mail_for_author author, to: user.mail, subject: subject
     end
   end
 
-  def wiki_content_added(user, wiki_content)
+  def wiki_content_added(user, wiki_content, author)
     @wiki_content = wiki_content
 
     open_project_headers 'Project'      => @wiki_content.project.identifier,
@@ -198,11 +198,11 @@ class UserMailer < ActionMailer::Base
 
     with_locale_for(user) do
       subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_content.page.pretty_title)}"
-      mail to: user.mail, subject: subject
+      mail_for_author author, to: user.mail, subject: subject
     end
   end
 
-  def wiki_content_updated(user, wiki_content)
+  def wiki_content_updated(user, wiki_content, author)
     @wiki_content  = wiki_content
     @wiki_diff_url = url_for(controller: '/wiki',
                              action:     :diff,
@@ -219,11 +219,11 @@ class UserMailer < ActionMailer::Base
 
     with_locale_for(user) do
       subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_content.page.pretty_title)}"
-      mail to: user.mail, subject: subject
+      mail_for_author author, to: user.mail, subject: subject
     end
   end
 
-  def message_posted(user, message)
+  def message_posted(user, message, author)
     @message     = message
     @message_url = topic_url(@message.root, r: @message.id, anchor: "message-#{@message.id}")
 
@@ -236,7 +236,7 @@ class UserMailer < ActionMailer::Base
 
     with_locale_for(user) do
       subject = "[#{@message.board.project.name} - #{@message.board.name} - msg#{@message.root.id}] #{@message.subject}"
-      mail to: user.mail, subject: subject
+      mail_for_author author, to: user.mail, subject: subject
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -139,7 +139,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def news_added(user, news)
+  def news_added(user, news, author)
     @news = news
 
     open_project_headers 'Type'    => 'News'
@@ -150,7 +150,7 @@ class UserMailer < ActionMailer::Base
     with_locale_for(user) do
       subject = "#{News.model_name.human}: #{@news.title}"
       subject = "[#{@news.project.name}] #{subject}" if @news.project
-      mail to: user.mail, subject: subject
+      mail_for_author author, to: user.mail, subject: subject
     end
   end
 

--- a/app/models/comment_observer.rb
+++ b/app/models/comment_observer.rb
@@ -36,7 +36,7 @@ class CommentObserver < ActiveRecord::Observer
       recipients = news.recipients + news.watcher_recipients
       users = User.find_all_by_mails(recipients)
       users.each do |user|
-        UserMailer.news_comment_added(user, comment).deliver
+        UserMailer.news_comment_added(user, comment, User.current).deliver
       end
     end
   end

--- a/app/models/message_observer.rb
+++ b/app/models/message_observer.rb
@@ -35,7 +35,7 @@ class MessageObserver < ActiveRecord::Observer
       recipients += message.board.watcher_recipients
       users = User.find_all_by_mails(recipients.uniq)
       users.each do |user|
-        UserMailer.message_posted(user, message).deliver
+        UserMailer.message_posted(user, message, User.current).deliver
       end
     end
   end

--- a/app/models/news_observer.rb
+++ b/app/models/news_observer.rb
@@ -32,7 +32,7 @@ class NewsObserver < ActiveRecord::Observer
     if Setting.notified_events.include?('news_added')
       users = User.find_all_by_mails(news.recipients)
       users.each do |user|
-        UserMailer.news_added(user, news).deliver
+        UserMailer.news_added(user, news, User.current).deliver
       end
     end
   end

--- a/app/models/wiki_content_observer.rb
+++ b/app/models/wiki_content_observer.rb
@@ -33,7 +33,7 @@ class WikiContentObserver < ActiveRecord::Observer
       recipients = wiki_content.recipients + wiki_content.page.wiki.watcher_recipients
       users = User.find_all_by_mails(recipients.uniq)
       users.each do |user|
-        UserMailer.wiki_content_added(user, wiki_content).deliver
+        UserMailer.wiki_content_added(user, wiki_content, User.current).deliver
       end
     end
   end
@@ -43,7 +43,7 @@ class WikiContentObserver < ActiveRecord::Observer
       recipients = wiki_content.recipients + wiki_content.page.wiki.watcher_recipients + wiki_content.page.watcher_recipients
       users = User.find_all_by_mails(recipients.uniq)
       users.each do |user|
-        UserMailer.wiki_content_updated(user, wiki_content).deliver
+        UserMailer.wiki_content_updated(user, wiki_content, User.current).deliver
       end
     end
   end

--- a/app/models/work_package_observer.rb
+++ b/app/models/work_package_observer.rb
@@ -45,7 +45,7 @@ class WorkPackageObserver < ActiveRecord::Observer
   ##
   # Notifies the user of the created work package.
   def notify(user, work_package)
-    job = DeliverWorkPackageCreatedJob.new(user.id, work_package.id)
+    job = DeliverWorkPackageCreatedJob.new(user.id, work_package.id, User.current.id)
 
     Delayed::Job.enqueue job
   end

--- a/app/workers/deliver_work_package_created_job.rb
+++ b/app/workers/deliver_work_package_created_job.rb
@@ -30,15 +30,16 @@
 class DeliverWorkPackageCreatedJob
   include MailNotificationJob
 
-  def initialize(user_id, work_package_id)
+  def initialize(user_id, work_package_id, current_user_id)
     @user_id         = user_id
     @work_package_id = work_package_id
+    @current_user_id = current_user_id
   end
 
   private
 
   def notification_mail
-    @notification_mail ||= UserMailer.work_package_added(user, work_package)
+    @notification_mail ||= UserMailer.work_package_added(user, work_package, current_user)
   end
 
   def user
@@ -47,5 +48,9 @@ class DeliverWorkPackageCreatedJob
 
   def work_package
     @work_package ||= WorkPackage.find(@work_package_id)
+  end
+
+  def current_user
+    @current_user ||= Principal.find(@current_user_id)
   end
 end

--- a/config/initializers/register_mail_interceptors.rb
+++ b/config/initializers/register_mail_interceptors.rb
@@ -31,6 +31,5 @@
 # Do this here, so they aren't registered multiple times due to reloading in development mode.
 
 UserMailer.register_interceptor(DefaultHeadersInterceptor)
-UserMailer.register_interceptor(RemoveSelfNotificationsInterceptor)
 # following needs to be the last interceptor
 UserMailer.register_interceptor(DoNotSendMailsWithoutReceiverInterceptor)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -52,6 +52,20 @@ describe UserMailer, type: :mailer do
     allow(Setting).to receive(:default_language).and_return('en')
   end
 
+  shared_examples_for 'mail is sent' do
+    it 'actually sends a mail' do
+      expect(ActionMailer::Base.deliveries.size).to eql(1)
+    end
+
+    it 'is sent to the recipient' do
+      expect(ActionMailer::Base.deliveries.first.to).to include(to_mail)
+    end
+
+    it 'is sent from the configured address' do
+      expect(ActionMailer::Base.deliveries.first.from).to include('john@doe.com')
+    end
+  end
+
   describe '#test_mail' do
     let(:test_email) { 'bob.bobbi@example.com' }
     let(:test_user) { User.new(firstname: 'Bob', lastname: 'Bobbi', mail: test_email) }
@@ -74,8 +88,12 @@ describe UserMailer, type: :mailer do
       UserMailer.work_package_added(recipient, work_package, user).deliver
     end
 
-    it 'actually sends a mail' do
-      expect(ActionMailer::Base.deliveries.size).to eql(1)
+    it_behaves_like 'mail is sent' do
+      let(:to_mail) { recipient.mail }
+    end
+
+    it 'contains the WP subject in the mail subject' do
+      expect(ActionMailer::Base.deliveries.first.subject).to include(work_package.subject)
     end
 
     context 'author disabled notification of own actions' do
@@ -105,8 +123,8 @@ describe UserMailer, type: :mailer do
       UserMailer.work_package_updated(recipient, journal, user).deliver
     end
 
-    it 'actually sends a mail' do
-      expect(ActionMailer::Base.deliveries.size).to eql(1)
+    it_behaves_like 'mail is sent' do
+      let(:to_mail) { recipient.mail }
     end
 
     context 'author disabled notification of own actions' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -67,7 +67,7 @@ describe UserMailer, type: :mailer do
   end
 
   shared_examples_for 'mail is not sent' do
-    it 'actually sends a mail' do
+    it 'sends no mail' do
       expect(ActionMailer::Base.deliveries.size).to eql(0)
     end
   end

--- a/spec/workers/mail_notification_jobs_spec.rb
+++ b/spec/workers/mail_notification_jobs_spec.rb
@@ -94,7 +94,7 @@ describe 'mail notification jobs', type: :model do
 
   describe DeliverWorkPackageCreatedJob do
     let(:work_package) { FactoryGirl.create :work_package, subject: mail_subject }
-    let(:job)          { DeliverWorkPackageCreatedJob.new user.id, work_package.id }
+    let(:job)          { DeliverWorkPackageCreatedJob.new user.id, work_package.id, user.id }
 
     it_behaves_like 'a mail notification job' do
       context 'with work package not found' do

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -367,18 +367,6 @@ class UserMailerTest < ActionMailer::TestCase
     assert UserMailer.message_posted(user, message, user).deliver
   end
 
-  def test_wiki_content_added
-    user         = FactoryGirl.create(:user)
-    wiki_content = FactoryGirl.create(:wiki_content)
-    assert UserMailer.wiki_content_added(user, wiki_content, user).deliver
-  end
-
-  def test_wiki_content_updated
-    user         = FactoryGirl.create(:user)
-    wiki_content = FactoryGirl.create(:wiki_content)
-    assert UserMailer.wiki_content_updated(user, wiki_content, user).deliver
-  end
-
   def test_account_information
     user = FactoryGirl.create(:user)
     assert UserMailer.account_information(user, 'pAsswORd').deliver

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -62,24 +62,6 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match /OpenProject URL/, mail.body.encoded
   end
 
-  def test_issue_add
-    user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
-    issue = FactoryGirl.create(:work_package, subject: 'some issue title')
-
-    # creating an issue actually sends an email, ohoh
-    ActionMailer::Base.deliveries.clear
-
-    mail = UserMailer.work_package_added(user, issue)
-    assert mail.deliver
-
-    assert_equal 1, ActionMailer::Base.deliveries.size
-
-    assert_match /some issue title/, mail.subject
-    assert_equal ['foo@bar.de'], mail.to
-    assert_equal ['john@doe.com'], mail.from
-    assert_match /has been reported/, mail.body.encoded
-  end
-
   def test_generated_links_in_emails
     Setting.default_language = 'en'
     Setting.host_name = 'mydomain.foo'
@@ -373,19 +355,6 @@ class UserMailerTest < ActionMailer::TestCase
         assert_equal :de, I18n.locale
       end
     end
-  end
-
-  def test_issue_add
-    user  = FactoryGirl.create(:user)
-    issue = FactoryGirl.create(:work_package)
-    assert UserMailer.work_package_added(user, issue).deliver
-  end
-
-  def test_work_package_updated
-    user    = FactoryGirl.create(:user)
-    issue   = FactoryGirl.create(:work_package)
-    journal = issue.journals.first
-    assert UserMailer.work_package_updated(user, journal).deliver
   end
 
   def test_news_added

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -284,7 +284,7 @@ class UserMailerTest < ActionMailer::TestCase
   def test_message_posted_message_id
     user    = FactoryGirl.create(:user)
     message = FactoryGirl.create(:message)
-    UserMailer.message_posted(user, message).deliver
+    UserMailer.message_posted(user, message, user).deliver
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail
     assert_equal UserMailer.generate_message_id(message, user), mail.message_id
@@ -299,7 +299,7 @@ class UserMailerTest < ActionMailer::TestCase
     user    = FactoryGirl.create(:user)
     parent  = FactoryGirl.create(:message)
     message = FactoryGirl.create(:message, parent: parent)
-    UserMailer.message_posted(user, message).deliver
+    UserMailer.message_posted(user, message, user).deliver
     mail = ActionMailer::Base.deliveries.last
     assert_not_nil mail
     assert_equal UserMailer.generate_message_id(message, user), mail.message_id
@@ -358,25 +358,25 @@ class UserMailerTest < ActionMailer::TestCase
     user    = FactoryGirl.create(:user)
     news    = FactoryGirl.create(:news)
     comment = FactoryGirl.create(:comment, commented: news)
-    assert UserMailer.news_comment_added(user, comment).deliver
+    assert UserMailer.news_comment_added(user, comment, user).deliver
   end
 
   def test_message_posted
     user    = FactoryGirl.create(:user)
     message = FactoryGirl.create(:message)
-    assert UserMailer.message_posted(user, message).deliver
+    assert UserMailer.message_posted(user, message, user).deliver
   end
 
   def test_wiki_content_added
     user         = FactoryGirl.create(:user)
     wiki_content = FactoryGirl.create(:wiki_content)
-    assert UserMailer.wiki_content_added(user, wiki_content).deliver
+    assert UserMailer.wiki_content_added(user, wiki_content, user).deliver
   end
 
   def test_wiki_content_updated
     user         = FactoryGirl.create(:user)
     wiki_content = FactoryGirl.create(:wiki_content)
-    assert UserMailer.wiki_content_updated(user, wiki_content).deliver
+    assert UserMailer.wiki_content_updated(user, wiki_content, user).deliver
   end
 
   def test_account_information

--- a/test/unit/lib/redmine/hook_test.rb
+++ b/test/unit/lib/redmine/hook_test.rb
@@ -161,14 +161,14 @@ class Redmine::Hook::ManagerTest < ActionView::TestCase
     issue = WorkPackage.find(1)
 
     ActionMailer::Base.deliveries.clear
-    UserMailer.work_package_added(user, issue).deliver
+    UserMailer.work_package_added(user, issue, user).deliver
     mail = ActionMailer::Base.deliveries.last
 
     @hook_module.add_listener(TestLinkToHook)
     hook_helper.call_hook(:view_layouts_base_html_head)
 
     ActionMailer::Base.deliveries.clear
-    UserMailer.work_package_added(user, issue).deliver
+    UserMailer.work_package_added(user, issue, user).deliver
     mail2 = ActionMailer::Base.deliveries.last
 
     assert_equal mail.text_part.body.encoded, mail2.text_part.body.encoded


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19262
## Notes

I completely replaced the usage of the corresponding Interceptor by some hand-written code. Reasons:
- no further need for the `User.current` hack
- fixes another issue prohibiting the delivery of test mails (because that is something you did "yourself")
- in most situations you do probably not want the implicit self-blocking, now it has to be explicit

In its current form the caller needs to know that there is a special `mail_for_author` method.
A more sophisticated approach could override `mail` completely and enforce the usage of the new method signature. This is something that is discussable, the `user_mailer.rb` is a file that could also easily be split up into different modules, so cleanup can be done at multiple points here.
