### PR TITLE
attempt to stabilize query menu item cuke

### DIFF
--- a/features/menu_items/query_menu_items.feature
+++ b/features/menu_items/query_menu_items.feature
@@ -56,6 +56,7 @@ Feature: Query menu items
   @javascript
   Scenario: Create a query menu item
     When I go to the applied query "Bugs" on the work packages index page of the project "Awesome Project"
+    And the work package table has finished loading
     And I click on "Settings"
     And I click on "Share ..."
     And I check "Show page in menu"
@@ -69,6 +70,7 @@ Feature: Query menu items
       | name       | title      | navigatable |
       | bugs_query | Bugs Query | Bugs        |
     When I go to the applied query "Bugs" on the work packages index page of the project "Awesome Project"
+    And the work package table has finished loading
     And I click on "Settings"
     And I click on "Share ..."
     And I uncheck "Show page in menu"

--- a/features/step_definitions/work_package_steps.rb
+++ b/features/step_definitions/work_package_steps.rb
@@ -89,6 +89,18 @@ Given(/^the user "([^\"]+)" has the following query menu items in the project "(
   end
 end
 
+When /^the work package table has finished loading$/ do
+  message <<-MESSAGE
+    This is a safeguard to ensure that the work package table is loaded before performing actions
+    on UI items that have not been fully loaded.
+
+    It currently assumes that at least one filter is set, without the necessity of the filter being
+    displayed.
+  MESSAGE
+
+  expect(page).to have_selector('.advanced-filters--filter', visible: false), message
+end
+
 When /^I fill in the id of work package "(.+?)" into "(.+?)"$/ do |wp_name, field_name|
   work_package = InstanceFinder.find(WorkPackage, wp_name)
 


### PR DESCRIPTION
The cuke used to press on the "Settings" button regardless of whether
the page was fully loaded. In cases the page was not loaded, this
resulted in a no-op as the "Settings"-menu will only open when the page
has finished loading. Therefore steps after the click that assumed the
menu to be open failed.
