### PR TITLE
[Foundation] Timetracking filter broken

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -44,6 +44,7 @@
 //= require_tree ./bundles
 
 //= require custom-fields
+//= require date-range
 
 //source: http://stackoverflow.com/questions/8120065/jquery-and-prototype-dont-work-together-with-array-prototype-reverse
 if (typeof []._reverse == 'undefined') {

--- a/app/assets/javascripts/date-range.js
+++ b/app/assets/javascripts/date-range.js
@@ -1,0 +1,53 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+(function($) {
+  $(function() {
+    /*
+     * See /app/views/timelog/_date_range.html.erb
+     */
+    if ($('#date-range').length < 1) {
+      return;
+    }
+    var intervalInputs = $('#to, #from'),
+        // select
+        period = $('#period'),
+        // radio buttons
+        periodOptionList = $('#period_type_list'),
+        periodOptionInterval = $('#period_type_interval');
+
+    var activateRadiobutton = function(radioButton) {
+      return function() {
+        radioButton.attr('checked', true);
+      };
+    };
+
+
+    intervalInputs.on('click focus', activateRadiobutton(periodOptionInterval));
+    period.on('click focus', activateRadiobutton(periodOptionList));
+  });
+}(jQuery));

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -26,40 +26,40 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<fieldset id="date-range" class="collapsible">
-  <legend onclick="toggleFieldset(this);"><a href="javascript:"><%= l(:label_date_range) %></a></legend>
-  <div>
-    <div class="form--field">
-      <%= styled_label_tag "period_type_list", l(:description_date_range_list), :class => "hidden-for-sighted" %>
+<fieldset id="date-range" class="simple-filters--container">
+  <legend><%= l(:label_date_range) %></legend>
+  <ul class="simple-filters--filters">
+    <li class="simple-filters--filter">
+      <%= styled_label_tag "period_type_list", l(:description_date_range_list), :class => "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '1',
                                   !@free_period,
                                   :onclick => 'Form.Element.disable("from");Form.Element.disable("to");Form.Element.enable("period");',
                                   :id => "period_type_list"%>
-      <%= styled_select_tag 'period',
-                            options_for_period_select(params[:period]),
-                            :onfocus => '$("period_type_1").checked = true;',
-                            :disabled => @free_period,
-                            class: "-narrow" %>
-    </div>
-    <div class="grid-block small-6">
-      <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), :class => "hidden-for-sighted" %>
+      <div class="simple-filters--filter-value">
+        <%= styled_select_tag 'period',
+                              options_for_period_select(params[:period]),
+                              :onfocus => '$("period_type_list").checked = true;',
+                              :disabled => @free_period,
+                              class: "-narrow" %>
+      </div>
+    </li>
+    <li class="simple-filters--filter">
+      <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), :class => "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '2', @free_period, :onclick => 'Form.Element.enable("from");Form.Element.enable("to");Form.Element.disable("period");', :id => "period_type_interval" %>
-
-      <span onclick="$('period_type_2').checked = true;" class="grid-block">
-      <div class="form--field">
-        <%= styled_label_tag("from", l(:label_date_from)) %>
-        <%= styled_text_field_tag('from', @from, :size => 10, :disabled => !@free_period) %>
-        <%= calendar_for('from') %>
+      <div onclick="jQuery('#period_type_interval').click()">
+        <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>
+        <div class="simple-filters--fitler-value">
+          <%= styled_text_field_tag('from', @from, :size => 10, :disabled => !@free_period) %>
+          <%= calendar_for('from') %>
+        </div>
+        <%= styled_label_tag("to", l(:label_date_to), class: 'simple-filters--filter-name') %>
+        <div class="simple-filters--filter-value">
+          <%= styled_text_field_tag('to', @to, :size => 10, :disabled => !@free_period) %>
+          <%= calendar_for('to') %>
+        </div>
       </div>
-      <div class="form--field">
-        <%= styled_label_tag("to", l(:label_date_to)) %>
-        <%= styled_text_field_tag('to', @to, :size => 10, :disabled => !@free_period) %>
-        <%= calendar_for('to') %>
-      </div>
-      </span>
-    </div>
-    <hr class="form--separator">
-    <%= link_to_function l(:button_apply), '$("query_form").submit()', :class => 'button -highlight' %>
-    <%= link_to l(:button_clear), polymorphic_time_entries_path(@issue || @project), :class => 'button ' %>
-  </div>
+    </li>
+  </ul>
+  <%= link_to_function l(:button_apply), '$("query_form").submit()', :class => 'button -highlight -small' %>
+  <%= link_to l(:button_clear), polymorphic_time_entries_path(@issue || @project), :class => 'button -small' %>
 </fieldset>

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), :class => "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '2', @free_period, :id => "period_type_interval" %>
       <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>
-      <div class="simple-filters--fitler-value">
+      <div class="simple-filters--filter-value">
         <%= styled_text_field_tag('from', @from, :size => 10) %>
         <%= calendar_for('from') %>
       </div>

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -33,33 +33,28 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_label_tag "period_type_list", l(:description_date_range_list), :class => "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '1',
                                   !@free_period,
-                                  :onclick => 'Form.Element.disable("from");Form.Element.disable("to");Form.Element.enable("period");',
                                   :id => "period_type_list"%>
       <div class="simple-filters--filter-value">
         <%= styled_select_tag 'period',
                               options_for_period_select(params[:period]),
-                              :onfocus => '$("period_type_list").checked = true;',
-                              :disabled => @free_period,
                               class: "-narrow" %>
       </div>
     </li>
     <li class="simple-filters--filter">
       <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), :class => "hidden-for-sighted simple-filters--filter-name" %>
-      <%= styled_radio_button_tag 'period_type', '2', @free_period, :onclick => 'Form.Element.enable("from");Form.Element.enable("to");Form.Element.disable("period");', :id => "period_type_interval" %>
-      <div onclick="jQuery('#period_type_interval').click()">
-        <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>
-        <div class="simple-filters--fitler-value">
-          <%= styled_text_field_tag('from', @from, :size => 10, :disabled => !@free_period) %>
-          <%= calendar_for('from') %>
-        </div>
-        <%= styled_label_tag("to", l(:label_date_to), class: 'simple-filters--filter-name') %>
-        <div class="simple-filters--filter-value">
-          <%= styled_text_field_tag('to', @to, :size => 10, :disabled => !@free_period) %>
-          <%= calendar_for('to') %>
-        </div>
+      <%= styled_radio_button_tag 'period_type', '2', @free_period, :id => "period_type_interval" %>
+      <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>
+      <div class="simple-filters--fitler-value">
+        <%= styled_text_field_tag('from', @from, :size => 10) %>
+        <%= calendar_for('from') %>
+      </div>
+      <%= styled_label_tag("to", l(:label_date_to), class: 'simple-filters--filter-name') %>
+      <div class="simple-filters--filter-value">
+        <%= styled_text_field_tag('to', @to, :size => 10) %>
+        <%= calendar_for('to') %>
       </div>
     </li>
   </ul>
-  <%= link_to_function l(:button_apply), '$("query_form").submit()', :class => 'button -highlight -small' %>
+  <%= styled_button_tag l(:button_apply), class: 'button -highlight -small' %>
   <%= link_to l(:button_clear), polymorphic_time_entries_path(@issue || @project), :class => 'button -small' %>
 </fieldset>


### PR DESCRIPTION
This meets https://community.openproject.org/work_packages/19289.

I changed the fiter set to a `simple-filters` solution which seemed like the better choice for the filter set. I also removed the prototype tumor growing in the intestines of the form and replaced it with a piece of jQuery. this should also remove problems with the activation of the datepicker in the form.

I do not think that the styling of the form is ideal yet - we have no component solution for an _either/or_ filter solution [- so far, this is the quickest solution to the problem at hand, however, we should discuss a better design for this.

Current form style:

![screenshot from 2015-03-26 13 55 48](https://cloud.githubusercontent.com/assets/498241/6846623/dfcfc0de-d3bf-11e4-882d-28b8d0f5e9f6.png)
