### PR TITLE
19435 extend .form--select class for datepicker month/year select

### DIFF
--- a/app/assets/stylesheets/content/_datepicker.sass
+++ b/app/assets/stylesheets/content/_datepicker.sass
@@ -115,6 +115,7 @@ $dp-shadow-box-opacity: 1
       .ui-datepicker-year
         width: $dp-month-year-width
       select
+        @extend .form--select
         height: $dp-header-elements-height
         font-size: $dp-font-size-rewrite
         font-weight: normal


### PR DESCRIPTION
[`* `#19435` Date picker misses arrows in dropdowns (for month, year) / not properly aligned (IE)`](https://community.openproject.org/work_packages/19435) 
