### PR TITLE
More flexibility for API-Extensions

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -58,7 +58,8 @@ module API
         link :self do
           path = _type.underscore unless path
           link_object = { href: api_v3_paths.send(path, represented.id) }
-          link_object[:title] = instance_eval(&title_getter)
+          title = instance_eval(&title_getter)
+          link_object[:title] = title if title
 
           link_object
         end

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -75,14 +75,12 @@ module API
           next unless instance_eval(&show_if)
 
           value = call_or_send_to_represented(getter)
+          link_object = { href: (api_v3_paths.send(path, value.id) if value) }
           if value
-            {
-              href: api_v3_paths.send(path, value.id),
-              title: instance_eval(&title_getter)
-            }
-          else
-            { href: nil }
+            title = instance_eval(&title_getter)
+            link_object[:title] = title if title
           end
+          link_object
         end
 
         if embed_as

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -39,7 +39,7 @@ module API
 
         linked_property :definingProject,
                         path: :project,
-                        association: :project,
+                        getter: :project,
                         show_if: -> (*) { represented.project.visible?(current_user) }
 
         link :availableInProjects do

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -109,7 +109,7 @@ module API
         linked_property :responsible, path: :user, embed_as: ::API::V3::Users::UserRepresenter
         linked_property :assignee,
                         path: :user,
-                        association: :assigned_to,
+                        getter: :assigned_to,
                         embed_as: ::API::V3::Users::UserRepresenter
 
         link :availableWatchers do
@@ -199,7 +199,7 @@ module API
         linked_property :project, embed_as: ::API::V3::Projects::ProjectRepresenter
 
         linked_property :version,
-                        association: :fixed_version,
+                        getter: :fixed_version,
                         title_getter: -> (*) {
                           represented.fixed_version.to_s_for_project(represented.project)
                         }


### PR DESCRIPTION
## OpenProject work package

Required by changes to costs for https://community.openproject.org/work_packages/19421
## Description

This PR adds further flexibility to the top-level helpers for representers in the API:
- allow to omit link titles for `self` link and for linked properties
- allow to specify a callable instead of a symbol as value getter
