### PR TITLE
Allow custom Firefox path to be set for feature specs, cukes

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -60,6 +60,13 @@ Capybara.configure do |config|
   config.visible_text_only = true
 end
 
+Capybara.register_driver :selenium do |app|
+  require 'selenium/webdriver'
+  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] ||
+    Selenium::WebDriver::Firefox::Binary.path
+  Capybara::Selenium::Driver.new(app, browser: :firefox)
+end
+
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how
 # your application behaves in the production environment, where an error page will

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,13 @@ require 'rspec/rails'
 require 'rspec/example_disabler'
 require 'capybara/rails'
 
+Capybara.register_driver :selenium do |app|
+  require 'selenium/webdriver'
+  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] ||
+    Selenium::WebDriver::Firefox::Binary.path
+  Capybara::Selenium::Driver.new(app, browser: :firefox)
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
Firefox 36 and Webdriver don't work well together:
https://code.google.com/p/selenium/issues/detail?id=8399

This PR allows for testing against multiple Firefoxen: a custom Firefox path can be set with the `FIREFOX_BINARY_PATH` environment variable.
