### PR TITLE
Fix CF links for null values

### DIFF
--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -248,7 +248,7 @@ module API
             # object (that behaviour is only required for form payloads)
             custom_value = represented.custom_value_for(custom_field)
             value = custom_value ? custom_value.value : nil
-            path = api_v3_paths.send(path_method, value) if value
+            path = api_v3_paths.send(path_method, value) if value.present?
 
             { href: path }
           }

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -241,7 +241,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       context 'value is nil' do
         let(:value) { nil }
-        let(:raw_value) { nil }
+        let(:raw_value) { '' }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }
@@ -266,7 +266,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       context 'value is nil' do
         let(:value) { nil }
-        let(:raw_value) { nil }
+        let(:raw_value) { '' }
 
         it_behaves_like 'has an empty link' do
           let(:link) { cf_path }


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19451
## Description

If you have a custom field of type user or version and don't set a value it would be rendered as `"href": "/api/v3/users/"` instead of `"href": null`.

The reason being that empty links are stored as empty string in the database and not as `nil`, like I expected.
