### PR TITLE
Gemfile: require Bundler >= 1.7.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@
 
 source 'https://rubygems.org'
 
+if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.7.11')
+ abort "We require Bundler 1.7.11 or higher (you're using #{Bundler::VERSION}).\nPlease update with 'gem update bundler'."
+end
+
 gem "rails", github: 'rails/rails', branch: '3-2-stable'
 
 gem "coderay", "~> 1.0.9"


### PR DESCRIPTION
:mri_22 was defined in Bundler 1.7.11.
https://github.com/bundler/bundler/blob/v1.7.11/CHANGELOG.md#1711-2015-01-04
- https://github.com/rails/rails/pull/19611
- https://github.com/rails/rails/commit/4ba1376c608cc797c80402a73568744b1c855f67
