### PR TITLE
Bugfix: IPv6 localhost is not working

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -132,10 +132,12 @@ gulp.task('webdriver:update', webdriverUpdate);
 gulp.task('webdriver:standalone', ['webdriver:update'], webdriverStandalone);
 
 gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express'], function(done) {
+  var address = server.address().address;
+  if ((address === '::' || address === '::1') && server.address().family === 'IPv6') address = '[0:0:0:0:0:0:0:1]';
   gulp.src('tests/integration/**/*_spec.js')
     .pipe(protractor({
       configFile: 'tests/integration/protractor.conf.js',
-      args: ['--baseUrl', 'http://' + server.address().address + ':' + server.address().port]
+      args: ['--baseUrl', 'http://' + address + ':' + server.address().port]
     }))
     .on('error', function(e) {
       throw e;

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -133,8 +133,8 @@ gulp.task('webdriver:standalone', ['webdriver:update'], webdriverStandalone);
 
 gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express'], function(done) {
   var address = server.address().address;
-  if (address === '::' || address === '::1' || address === '0.0.0.0') {
-    address = 'localhost';
+  if (server.address().family === 'IPv6') {
+    address = '[' + address + ']';
   }
   gulp.src('tests/integration/**/*_spec.js')
     .pipe(protractor({

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -135,7 +135,7 @@ gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express']
   var address = server.address().address;
   if ((address === '::' || address === '::1') && server.address().family === 'IPv6') {
     address = '[0:0:0:0:0:0:0:1]';
-  };
+  }
   gulp.src('tests/integration/**/*_spec.js')
     .pipe(protractor({
       configFile: 'tests/integration/protractor.conf.js',

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -133,8 +133,8 @@ gulp.task('webdriver:standalone', ['webdriver:update'], webdriverStandalone);
 
 gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express'], function(done) {
   var address = server.address().address;
-  if ((address === '::' || address === '::1') && server.address().family === 'IPv6') {
-    address = '[0:0:0:0:0:0:0:1]';
+  if (address === '::' || address === '::1' || address === '0.0.0.0') {
+    address = 'localhost';
   }
   gulp.src('tests/integration/**/*_spec.js')
     .pipe(protractor({

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -133,7 +133,9 @@ gulp.task('webdriver:standalone', ['webdriver:update'], webdriverStandalone);
 
 gulp.task('tests:protractor', ['webdriver:update', 'webpack', 'sass', 'express'], function(done) {
   var address = server.address().address;
-  if ((address === '::' || address === '::1') && server.address().family === 'IPv6') address = '[0:0:0:0:0:0:0:1]';
+  if ((address === '::' || address === '::1') && server.address().family === 'IPv6') {
+    address = '[0:0:0:0:0:0:0:1]';
+  };
   gulp.src('tests/integration/**/*_spec.js')
     .pipe(protractor({
       configFile: 'tests/integration/protractor.conf.js',


### PR DESCRIPTION
IPv6 localhost looks like "::" or "::1" wich is not possible to open in browser, using "[0:0:0:0:0:0:0:1]" instead.
