### PR TITLE
Replace hardcoded ID column by dynamic one

### DIFF
--- a/app/controllers/api/experimental/concerns/column_data.rb
+++ b/app/controllers/api/experimental/concerns/column_data.rb
@@ -66,6 +66,7 @@ module Api::Experimental::Concerns::ColumnData
 
   def static_link_meta
     {
+      id: { display: true, model_type: 'work_package' },
       subject: { display: true, model_type: 'work_package' },
       type: { display: false },
       status: { display: false },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -180,6 +180,7 @@ mail_handler_api_key:
 work_package_list_default_columns:
   serialized: true
   default:
+  - id
   - type
   - status
   - priority

--- a/frontend/app/templates/work_packages/work_packages_table.html
+++ b/frontend/app/templates/work_packages/work_packages_table.html
@@ -22,15 +22,6 @@
               </a>
             </div>
           </th>
-          <th sort-header
-              header-name="'id'"
-              header-title="'#'"
-              has-dropdown-menu
-              target="ColumnContextMenu"
-              locals="columns, column"
-              sortable="true"
-              query="query">
-          </th>
 
           <th sort-header ng-repeat="column in columns"
                           has-dropdown-menu
@@ -127,12 +118,6 @@
                                  checkbox-value="row.object.id"
                                  checkbox-title="{{checkboxTitle}}"
                                  model="row.checked"/>
-          </td>
-
-          <td class="id">
-            <span ng-if="workPackage.parent_id" class="hidden-for-sighted" ng-bind="parentWorkPackageHiddenText">
-            </span>
-            <a ng-href="{{ workPackagePath(row.object.id) }}">{{row.object.id}}</a>
           </td>
 
           <td ng-repeat="column in columns" class="{{column.name}}" lang="{{column.custom_field && column.custom_field.name_locale || I18n.locale}}">

--- a/frontend/app/work_packages/helpers/work-packages-helper.js
+++ b/frontend/app/work_packages/helpers/work-packages-helper.js
@@ -122,6 +122,7 @@ module.exports =function(TimezoneService, currencyFilter, CustomFieldHelper) {
           return object.parent_id;
         case 'project':
           return object.project.identifier;
+        case 'id':
         case 'subject':
           return object.id;
         default:

--- a/frontend/tests/integration/mocks/work-packages.json
+++ b/frontend/tests/integration/mocks/work-packages.json
@@ -15,6 +15,20 @@
         "columns": [
             {
                 "custom_field": false,
+                "groupable": false,
+                "meta_data": {
+                    "data_type": "integer",
+                    "link": {
+                        "display": true,
+                        "model_type": "work_package"
+                    }
+                },
+                "name": "id",
+                "sortable": true,
+                "title": "ID"
+            },
+            {
+                "custom_field": false,
                 "groupable": "type",
                 "meta_data": {
                     "data_type": "object",

--- a/frontend/tests/integration/specs/work-packages/work-packages-spec.js
+++ b/frontend/tests/integration/specs/work-packages/work-packages-spec.js
@@ -44,7 +44,7 @@ describe('OpenProject', function() {
     page.getTableHeaders().getText().then(function(text) {
       expect(text).to.include.members([
         '',
-        '#',
+        'ID',
         'TYPE',
         'STATUS',
         'SUBJECT',

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -157,7 +157,7 @@ describe 'Work package index accessibility', type: :feature do
     end
 
     describe 'id column' do
-      let(:link_caption) { '#' }
+      let(:link_caption) { 'ID' }
       let(:column_header_selector) { 'table.workpackages-table th:nth-of-type(2)' }
       let(:column_header_link_selector) { column_header_selector + ' a' }
 


### PR DESCRIPTION
## OpenProject work package
- fixes https://community.openproject.org/work_packages/19305
- apparently also implements https://community.openproject.org/work_packages/13960
## Description

The ID column of the WP list was always hardcoded, but still it is possible to add an ID column manually.

I did some very minor changes to allow the dynamic ID column to behave (nearly) exactly the same as the hard coded one and deleted the latter. The only difference I noticed is that the column title changed from `#` to `ID`.

I also included the ID column as one of the default columns according to the settings.
## Remaining Question

Should I also add a migration that adds the ID column to the setting `work_package_list_default_columns`?
The setting already existed and the ID column was already selectable, but apparently the setting itself was ignored...

I'd opt for no, because the setting is older than the work package view and thus **not hiding** the ID column was apparently a bug.
