### PR TITLE
remove travis branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,6 @@ rvm:
   - 2.1
 sudo: false
 cache: bundler
-branches:
-  only:
-    - dev
-    - stable
-    - release/3.0
-    - release/4.0
 env:
   # Frontend
   - "TEST_SUITE=karma"


### PR DESCRIPTION
with the update to the contribution guidelines we should start to clean
up the branches and remove the restriction for TravisCI to build only
certain branches.

Developers are encouraged to fork the main repo and configure their own
travis builds.

Signed-off-by: Florian Kraft f.kraft@finn.de
