### PR TITLE
[Accessibility] Modal helptexts and simple tooltips

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -520,7 +520,7 @@ fieldset.form--fieldset
 .form--tooltip-container
   flex: 0 0 auto
   display: flex
-  > [data-tooltip]
+  & > [data-tooltip], & > [class^="tooltip--"]
     padding-top: 0.6rem
 
 .form--list

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -520,7 +520,7 @@ fieldset.form--fieldset
 .form--tooltip-container
   flex: 0 0 auto
   display: flex
-  span
+  > [data-tooltip]
     padding-top: 0.6rem
 
 .form--list

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -517,6 +517,12 @@ fieldset.form--fieldset
     background: none
     border: none
 
+.form--tooltip-container
+  flex: 0 0 auto
+  display: flex
+  span
+    padding-top: 0.6rem
+
 .form--list
   display: flex
   margin: 0

--- a/app/assets/stylesheets/content/_tooltips.md
+++ b/app/assets/stylesheets/content/_tooltips.md
@@ -9,7 +9,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
 ### Right
 
 ```
-<span class="tooltip-right" data-tooltip="The content of the tooltip">
+<span class="tooltip--right" data-tooltip="The content of the tooltip">
   <i class="icon icon-help1"></i>
 </span>
 ```
@@ -17,7 +17,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
 ### Bottom
 
 ```
-<span class="tooltip-bottom" data-tooltip="The content of the tooltip">
+<span class="tooltip--bottom" data-tooltip="The content of the tooltip">
   <i class="icon icon-help1"></i>
 </span>
 ```
@@ -25,7 +25,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
 ### Left
 
 ```
-<span class="tooltip-left" data-tooltip="The content of the tooltip">
+<span class="tooltip--left" data-tooltip="The content of the tooltip">
   <i class="icon icon-help1"></i>
 </span>
 ```
@@ -33,7 +33,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
 ### Top
 
 ```
-<span class="tooltip-top" data-tooltip="The content of the tooltip">
+<span class="tooltip--top" data-tooltip="The content of the tooltip">
   <i class="icon icon-help1"></i>
 </span>
 ```
@@ -51,7 +51,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         <input type="text" placeholder="First name" class="form--text-field" id="kurosaki" >
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-right" tabindex="0" data-tooltip="First name of the son">
+        <span class="tooltip--right" tabindex="0" data-tooltip="First name of the son">
           <i class="icon icon-help"></i>
         </span>
       </div>
@@ -70,7 +70,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         </select>
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-bottom" tabindex="0" data-tooltip="Ice-type maybe?">
+        <span class="tooltip--bottom" tabindex="0" data-tooltip="Ice-type maybe?">
           <i class="icon icon-heart"></i>
         </span>
       </div>
@@ -83,7 +83,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         <input type="text" class="form--text-field" placeholder="First name" id="kuchiki">
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-right" tabindex="0" data-tooltip="First name of a captain">
+        <span class="tooltip--right" tabindex="0" data-tooltip="First name of a captain">
           <i class="icon icon-help1"></i>
         </span>
       </div>
@@ -96,7 +96,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         <input type="password" placeholder="Traitor" id="traitor">
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-right -multiline" tabindex="0" data-tooltip="Well, major spoiler, so we better hide the output, right? Then again, wouldn't this be according to Keikaku anyway?">
+        <span class="tooltip--right -multiline" tabindex="0" data-tooltip="Well, major spoiler, so we better hide the output, right? Then again, wouldn't this be according to Keikaku anyway?">
           <i class="icon icon-warning"></i>
         </span>
       </div>
@@ -111,5 +111,5 @@ Note that the tabindex has to be set manually on the `<span>` and not the contai
 
 ```
 <h2>Title</h2>
-<p>Lorem <span style="text-decoration: underline;" class="tooltip-top" data-tooltip="this is actully not a real latin text">ipsum</span> dolor sit amet, consectetur adipisicing elit. Facere quibusdam sit voluptas illo error reiciendis non nisi necessitatibus architecto beatae, ea quos <span style="text-decoration: underline;" class=" tooltip-top" data-tooltip="Sounds like an endboss in a JRPG, doesn't it?">sint</span> consectetur repellat aliquid. Ducimus provident totam pariatur.</p>
+<p>Lorem <span style="text-decoration: underline;" class="tooltip--top" data-tooltip="this is actully not a real latin text">ipsum</span> dolor sit amet, consectetur adipisicing elit. Facere quibusdam sit voluptas illo error reiciendis non nisi necessitatibus architecto beatae, ea quos <span style="text-decoration: underline;" class=" tooltip--top" data-tooltip="Sounds like an endboss in a JRPG, doesn't it?">sint</span> consectetur repellat aliquid. Ducimus provident totam pariatur.</p>
 ```

--- a/app/assets/stylesheets/content/_tooltips.md
+++ b/app/assets/stylesheets/content/_tooltips.md
@@ -51,9 +51,23 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         <input type="text" placeholder="First name" class="form--text-field" id="kurosaki" >
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-right" data-tooltip="First name of the father">
+        <span class="tooltip-right" tabindex="0" data-tooltip="First name of the son">
           <i class="icon icon-help"></i>
         </span>
+      </div>
+    </div>
+  </div>
+  <div class="form--field">
+    <label for="bankai" class="form--label">Bankai</label>
+    <div class="form--field-container">
+      <div class="form--select-container">
+        <select name="bankai" id="bankai" class="form--select">
+          <option value="hakka">Hakka no togame</option>
+          <option value="tensa">Tensa zangetsu</option>
+          <option value="zanka">Zanka no tachi</option>
+          <option value="kokujo">Kokujō Tengen Myō'ō</option>
+          <option value="tekken">Tekken tachikaze</option>
+        </select>
       </div>
     </div>
   </div>
@@ -64,7 +78,7 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
         <input type="text" class="form--text-field" placeholder="First name" id="kuchiki">
       </div>
       <div class="form--tooltip-container">
-        <span class="tooltip-right" data-tooltip="First name of a captain">
+        <span class="tooltip-right" tabindex="0" data-tooltip="First name of a captain">
           <i class="icon icon-help1"></i>
         </span>
       </div>
@@ -72,6 +86,8 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
   </div>
 </form>
 ```
+
+Note that the tabindex has to be set manually on the `<span>` and not the containing element. `tabindex="0"` makes the item tabbable at all.
 
 ### Inline text
 

--- a/app/assets/stylesheets/content/_tooltips.md
+++ b/app/assets/stylesheets/content/_tooltips.md
@@ -69,6 +69,11 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
           <option value="tekken">Tekken tachikaze</option>
         </select>
       </div>
+      <div class="form--tooltip-container">
+        <span class="tooltip-bottom" tabindex="0" data-tooltip="Ice-type maybe?">
+          <i class="icon icon-heart"></i>
+        </span>
+      </div>
     </div>
   </div>
   <div class="form--field">
@@ -80,6 +85,19 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
       <div class="form--tooltip-container">
         <span class="tooltip-right" tabindex="0" data-tooltip="First name of a captain">
           <i class="icon icon-help1"></i>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="form--field">
+    <label for="traitor" class="form--label">Traitor</label>
+    <div class="form--field-container">
+      <div class="form--text-field-container">
+        <input type="password" placeholder="Traitor" id="traitor">
+      </div>
+      <div class="form--tooltip-container">
+        <span class="tooltip-right -multiline" tabindex="0" data-tooltip="Well, major spoiler, so we better hide the output, right? Then again, wouldn't this be according to Keikaku anyway?">
+          <i class="icon icon-warning"></i>
         </span>
       </div>
     </div>

--- a/app/assets/stylesheets/content/_tooltips.md
+++ b/app/assets/stylesheets/content/_tooltips.md
@@ -1,0 +1,79 @@
+# Tooltips
+
+Adds tooltips to arbitrary elements.
+
+## Simple Tooltips
+
+These can contain simple texts but are not suitable for HTML within the Tooltip.
+
+### Right
+
+```
+<span class="tooltip-right" data-tooltip="The content of the tooltip">
+  <i class="icon icon-help1"></i>
+</span>
+```
+
+### Bottom
+
+```
+<span class="tooltip-bottom" data-tooltip="The content of the tooltip">
+  <i class="icon icon-help1"></i>
+</span>
+```
+
+### Left
+
+```
+<span class="tooltip-left" data-tooltip="The content of the tooltip">
+  <i class="icon icon-help1"></i>
+</span>
+```
+
+### Top
+
+```
+<span class="tooltip-top" data-tooltip="The content of the tooltip">
+  <i class="icon icon-help1"></i>
+</span>
+```
+
+## Examples
+
+### Form elements
+
+```
+<form class="form">
+  <div class="form--field">
+    <label for="kurosaki" class="form--label">Kurosaki</label>
+    <div class="form--field-container">
+      <div class="form--text-field-container">
+        <input type="text" placeholder="First name" class="form--text-field" id="kurosaki" >
+      </div>
+      <div class="form--tooltip-container">
+        <span class="tooltip-right" data-tooltip="First name of the father">
+          <i class="icon icon-help"></i>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="form--field">
+    <label for="kuchiki" class="form--label">Kuchiki</label>
+    <div class="form--field-container">
+      <div class="form--text-field-container">
+        <input type="text" class="form--text-field" placeholder="First name" id="kuchiki">
+      </div>
+      <span class="tooltip-right" data-tooltip="First name of a captain">
+        <i class="icon icon-help1"></i>
+      </span>
+    </div>
+  </div>
+</form>
+```
+
+### Inline text
+
+```
+<h2>Title</h2>
+<p>Lorem <span style="text-decoration: underline;" class="tooltip-top" data-tooltip="this is actully not a real latin text">ipsum</span> dolor sit amet, consectetur adipisicing elit. Facere quibusdam sit voluptas illo error reiciendis non nisi necessitatibus architecto beatae, ea quos <span style="text-decoration: underline;" class=" tooltip-top" data-tooltip="Sounds like an endboss in a JRPG, doesn't it?">sint</span> consectetur repellat aliquid. Ducimus provident totam pariatur.</p>
+```

--- a/app/assets/stylesheets/content/_tooltips.md
+++ b/app/assets/stylesheets/content/_tooltips.md
@@ -63,9 +63,11 @@ These can contain simple texts but are not suitable for HTML within the Tooltip.
       <div class="form--text-field-container">
         <input type="text" class="form--text-field" placeholder="First name" id="kuchiki">
       </div>
-      <span class="tooltip-right" data-tooltip="First name of a captain">
-        <i class="icon icon-help1"></i>
-      </span>
+      <div class="form--tooltip-container">
+        <span class="tooltip-right" data-tooltip="First name of a captain">
+          <i class="icon icon-help1"></i>
+        </span>
+      </div>
     </div>
   </div>
 </form>

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -91,7 +91,7 @@ $tooltipArrowSize: 6px
 
   &:hover, &:focus
     background-color: transparent
-    &:before, &:after
+    &::before, &::after
       opacity: 1
       visibility: visible
   +colorize

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -44,6 +44,12 @@ $tooltipArrowSize: 6px
   &:after
     width: auto
 
+  &.-multiline
+    &:before, &:after
+      transform: translateY(50%)
+      margin-bottom: 0
+      filter: blur(0px)
+
 %left-right
   &:before, &:after
     bottom: 50%
@@ -51,6 +57,12 @@ $tooltipArrowSize: 6px
     margin-bottom: $tooltipArrowSize * -1 + 1
   &:after
     margin-bottom: $tooltipHeight/-1.5
+
+  &.-multiline
+    &:before, &:after
+      transform: translateY(50%)
+      margin-bottom: 0
+      filter: blur(0px)
 
 @mixin colorize($color:$tooltipBackground, $textColor:$tooltipTextColor)
   @each $position in top, right, bottom, left
@@ -95,6 +107,16 @@ $tooltipArrowSize: 6px
       opacity: 1
       visibility: visible
   +colorize
+
+  &.-multiline
+    &:before
+    &:after
+      height: auto
+      width: 150px
+      padding: $tooltipHeight/2
+      line-height: $tooltipHeight - 3px
+      white-space: normal
+      text-align: left
 
   @each $position in left, right
     &.tooltip-#{$position}

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -107,7 +107,6 @@ $tooltip--arrow-size: 6px
       opacity: 1
       visibility: visible
 
-
   &.-multiline
     &:after
       height: auto
@@ -117,47 +116,47 @@ $tooltip--arrow-size: 6px
       white-space: normal
       text-align: left
 
-  @each $position in left, right
-    &.tooltip--#{$position}
-      @extend %tooltip--left-right
-      @if $position == 'right'
-        &:before, &:after
-          left: 100%
-        &:before
-          margin-left: -2px
-        &:after
-          margin-left: 10px
-      @else
-        &:before, &:after
-          right: 100%
-        &:before
-          margin-right: -2px
-        &:after
-          margin-right: 10px
+  &.tooltip--right
+    @extend %tooltip--left-right
+    &:before, &:after
+      left: 100%
+    &:before
+      margin-left: -2px
+    &:after
+      margin-left: 10px
 
-  @each $position in top, bottom
-    &.tooltip--#{$position}
-      @extend %tooltip--top-bottom
-      @if $position == 'top'
-        &:before, &:after
-          bottom: 100%
-        &:before
-          margin-bottom: $tooltip--arrow-size * -1 + 1
-        &:after
-          margin-bottom: 7px
-        &:hover
-          &:before, &:after
-            transform: translate(-50%, 0px)
-      @else
-        &:before, &:after
-          top: 100%
-        &:before
-          margin-top: $tooltip--arrow-size * -1 + 1
-        &:after
-          margin-top: 7px
-        &:hover
-          &:before, &:after
-            transform: translate(-50%, 0)
+  &.tooltip--left
+    @extend %tooltip--left-right
+    &:before, &:after
+      right: 100%
+    &:before
+      margin-right: -2px
+    &:after
+      margin-right: 10px
+
+  &.tooltip--top
+    @extend %tooltip--top-bottom
+    &:before, &:after
+      bottom: 100%
+    &:before
+      margin-bottom: $tooltip--arrow-size * -1 + 1
+    &:after
+      margin-bottom: 7px
+    &:hover
+      &:before, &:after
+        transform: translate(-50%, 0px)
+
+  &.tooltip--bottom
+    @extend %tooltip--top-bottom
+    &:before, &:after
+      top: 100%
+    &:before
+      margin-top: $tooltip--arrow-size * -1 + 1
+    &:after
+      margin-top: 7px
+    &:hover
+      &:before, &:after
+        transform: translate(-50%, 0)
 
 // tooltips for table content (TODO: legacy?)
 table

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -26,27 +26,139 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-/***** Tooltips *****
+//***** Tooltips *****
 
-.tooltip
+// tooltips used for arbitrary elements
+
+$tooltipBackground: #e3f5ff
+$tooltipBorder: none
+$tooltipHeight: 22px
+$tooltipTextColor: $body-font-color
+$tooltipArrowSize: 6px
+
+%top-bottom
+  &:before, &:after
+    left: 50%
+    transform: translateX(-50%)
+
+  &:after
+    width: auto
+
+%left-right
+  &:before, &:after
+    bottom: 50%
+  &:before
+    margin-bottom: $tooltipArrowSize * -1 + 1
+  &:after
+    margin-bottom: $tooltipHeight/-1.5
+
+@mixin colorize($color:$tooltipBackground, $textColor:$tooltipTextColor)
+  @each $position in top, right, bottom, left
+    &.tooltip-#{$position}
+      &:before
+        border-#{$position}-color: $color
+      &:after
+        background-color: $tooltipBackground
+        color: $tooltipTextColor
+
+[data-tooltip]
   position: relative
-  z-index: 24
-  &.hover, &:hover
-    z-index: 25
-    color: #000
-  span.tip
-    display: none
-    text-align: left
+  display: inline-block
+  box-sizing: content-box
+  // TODO: this "fixes" the spacing issue in text, we need to find a better way for that
+  padding-right: 5px
 
-div.tooltip
-  &:hover span.tip, &.hover span.tip
-    display: block
+  &:before, &:after
     position: absolute
-    top: 12px
-    left: 24px
-    width: 270px
-    border: 1px solid #555
-    background-color: #fff
-    padding: 4px
-    font-size: 0.8em
-    color: #505050
+    visibility: hidden
+    opacity: 0
+    z-index: 99999
+    box-sizing: content-box
+    transform: translate3d(0, 0, 0)
+
+  &:before
+    content: ''
+    border: $tooltipArrowSize solid transparent
+
+  &:after
+    height: $tooltipHeight
+    padding: $tooltipHeight/2 $tooltipHeight/2 0 $tooltipHeight/2
+    font-size: 13px
+    line-height: $tooltipHeight/2
+    white-space: nowrap
+    content: attr(data-tooltip)
+    border: $tooltipBorder
+
+  &:hover, &:focus
+    background-color: transparent
+    &:before, &:after
+      opacity: 1
+      visibility: visible
+  +colorize
+
+  @each $position in left, right
+    &.tooltip-#{$position}
+      @extend %left-right
+      @if $position == 'right'
+        &:before, &:after
+          left: 100%
+        &:before
+          margin-left: -2px
+        &:after
+          margin-left: 10px
+      @else
+        &:before, &:after
+          right: 100%
+        &:before
+          margin-right: -2px
+        &:after
+          margin-right: 10px
+
+  @each $position in top, bottom
+    &.tooltip-#{$position}
+      @extend %top-bottom
+      @if $position == 'top'
+        &:before, &:after
+          bottom: 100%
+        &:before
+          margin-bottom: $tooltipArrowSize * -1 + 1
+        &:after
+          margin-bottom: 7px
+        &:hover
+          &:before, &:after
+            transform: translate(-50%, 0px)
+      @else
+        &:before, &:after
+          top: 100%
+        &:before
+          margin-top: $tooltipArrowSize * -1 + 1
+        &:after
+          margin-top: 7px
+        &:hover
+          &:before, &:after
+            transform: translate(-50%, 0)
+
+// tooltips for table content (TODO: legacy?)
+table
+  .tooltip
+    position: relative
+    z-index: 24
+    &.hover, &:hover
+      z-index: 25
+      color: #000
+    span.tip
+      display: none
+      text-align: left
+
+  div.tooltip
+    &:hover span.tip, &.hover span.tip
+      display: block
+      position: absolute
+      top: 12px
+      left: 24px
+      width: 270px
+      border: 1px solid #555
+      background-color: #fff
+      padding: 4px
+      font-size: 0.8em
+      color: #505050

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -30,13 +30,13 @@
 
 // tooltips used for arbitrary elements
 
-$tooltipBackground: #e3f5ff
-$tooltipBorder: none
-$tooltipHeight: 22px
-$tooltipTextColor: $body-font-color
-$tooltipArrowSize: 6px
+$tooltip--background-color: #e3f5ff
+$tooltip--border: none
+$tooltip--height: 22px
+$tooltip--font-color: $body-font-color
+$tooltip--arrow-size: 6px
 
-%top-bottom
+%tooltip--top-bottom
   &:before, &:after
     left: 50%
     transform: translateX(-50%)
@@ -50,27 +50,27 @@ $tooltipArrowSize: 6px
       margin-bottom: 0
       filter: blur(10px)
 
-%left-right
+%tooltip--left-right
   &:before, &:after
     bottom: 50%
   &:before
-    margin-bottom: $tooltipArrowSize * -1 + 1
+    margin-bottom: $tooltip--arrow-size * -1 + 1
   &:after
-    margin-bottom: $tooltipHeight/-1.5
+    margin-bottom: $tooltip--height/-1.5
 
   &.-multiline
     &:before, &:after
       transform: translateY(50%)
       margin-bottom: 0
 
-@mixin colorize($color:$tooltipBackground, $textColor:$tooltipTextColor)
+@mixin tooltip--colorize($color: $tooltip--background-color, $textColor:$tooltip--font-color)
   @each $position in top, right, bottom, left
-    &.tooltip-#{$position}
+    &.tooltip--#{$position}
       &:before
         border-#{$position}-color: $color
       &:after
-        background-color: $tooltipBackground
-        color: $tooltipTextColor
+        background-color: $tooltip--background-color
+        color: $tooltip--font-color
 
 [data-tooltip]
   position: relative
@@ -78,6 +78,7 @@ $tooltipArrowSize: 6px
   box-sizing: content-box
   // TODO: this "fixes" the spacing issue in text, we need to find a better way for that
   padding-right: 5px
+  +tooltip--colorize
 
   &:before, &:after
     position: absolute
@@ -89,37 +90,37 @@ $tooltipArrowSize: 6px
 
   &:before
     content: ''
-    border: $tooltipArrowSize solid transparent
+    border: $tooltip--arrow-size solid transparent
 
   &:after
-    height: $tooltipHeight
-    padding: $tooltipHeight/2 $tooltipHeight/2 0 $tooltipHeight/2
+    height: $tooltip--height
+    padding: $tooltip--height/2 $tooltip--height/2 0 $tooltip--height/2
     font-size: 13px
-    line-height: $tooltipHeight/2
+    line-height: $tooltip--height/2
     white-space: nowrap
     content: attr(data-tooltip)
-    border: $tooltipBorder
+    border: $tooltip--border
 
   &:hover, &:focus
     background-color: transparent
     &::before, &::after
       opacity: 1
       visibility: visible
-  +colorize
+
 
   &.-multiline
     &:before
     &:after
       height: auto
       width: 150px
-      padding: $tooltipHeight/2
-      line-height: $tooltipHeight - 3px
+      padding: $tooltip--height/2
+      line-height: $tooltip--height - 3px
       white-space: normal
       text-align: left
 
   @each $position in left, right
-    &.tooltip-#{$position}
-      @extend %left-right
+    &.tooltip--#{$position}
+      @extend %tooltip--left-right
       @if $position == 'right'
         &:before, &:after
           left: 100%
@@ -136,13 +137,13 @@ $tooltipArrowSize: 6px
           margin-right: 10px
 
   @each $position in top, bottom
-    &.tooltip-#{$position}
-      @extend %top-bottom
+    &.tooltip--#{$position}
+      @extend %tooltip--top-bottom
       @if $position == 'top'
         &:before, &:after
           bottom: 100%
         &:before
-          margin-bottom: $tooltipArrowSize * -1 + 1
+          margin-bottom: $tooltip--arrow-size * -1 + 1
         &:after
           margin-bottom: 7px
         &:hover
@@ -152,7 +153,7 @@ $tooltipArrowSize: 6px
         &:before, &:after
           top: 100%
         &:before
-          margin-top: $tooltipArrowSize * -1 + 1
+          margin-top: $tooltip--arrow-size * -1 + 1
         &:after
           margin-top: 7px
         &:hover

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -109,7 +109,6 @@ $tooltip--arrow-size: 6px
 
 
   &.-multiline
-    &:before
     &:after
       height: auto
       width: 150px

--- a/app/assets/stylesheets/content/_tooltips.sass
+++ b/app/assets/stylesheets/content/_tooltips.sass
@@ -48,7 +48,7 @@ $tooltipArrowSize: 6px
     &:before, &:after
       transform: translateY(50%)
       margin-bottom: 0
-      filter: blur(0px)
+      filter: blur(10px)
 
 %left-right
   &:before, &:after
@@ -62,7 +62,6 @@ $tooltipArrowSize: 6px
     &:before, &:after
       transform: translateY(50%)
       margin-bottom: 0
-      filter: blur(0px)
 
 @mixin colorize($color:$tooltipBackground, $textColor:$tooltipTextColor)
   @each $position in top, right, bottom, left

--- a/app/assets/stylesheets/styleguide.html.lsg
+++ b/app/assets/stylesheets/styleguide.html.lsg
@@ -36,7 +36,6 @@ styleguide-sass: |
   .livingstyleguide--code-block
     max-height: 300px
 
-  //@todo for select2 visibility in livingStyleGuide, need another solution  it will rewrite globally
   .livingstyleguide--example
     overflow: visible
 

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -299,7 +299,8 @@ de:
       description_options_show: "Optionen einblenden"
       label_enable_multi_select: "Mehrfachauswahl aktivieren"
       label_disable_multi_select: "Mehrfachauswahl deaktivieren"
-      label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
+      label_column_multiselect: "Kombiniertes Eingabefeld: Auswahl mit Pfeiltasten, Auslösen mit Enter, Löschen mit Backspace"
+      label_column_select: "Status - Kombiniertes Eingabefeld: Auswahl mit Autovervollständigung"
       label_filter_add: "Filter hinzufügen"
       label_options: "Optionen"
       message_error_during_bulk_delete: Fehler beim Löschen der Arbeitspakete.

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -299,6 +299,7 @@ de:
       description_options_show: "Optionen einblenden"
       label_enable_multi_select: "Mehrfachauswahl aktivieren"
       label_disable_multi_select: "Mehrfachauswahl deaktivieren"
+      label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
       label_filter_add: "Filter hinzufügen"
       label_options: "Optionen"
       message_error_during_bulk_delete: Fehler beim Löschen der Arbeitspakete.

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -305,6 +305,7 @@ en:
       label_filter_add: "Add filter"
       label_options: "Options"
       label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
+      label_column_select: "Status - Combined dropdown field: Selection with auto-completion."
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       no_results:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -304,6 +304,7 @@ en:
       label_disable_multi_select: "Disable multiselect"
       label_filter_add: "Add filter"
       label_options: "Options"
+      label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       no_results:

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -14,7 +14,7 @@
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
-      <span class="tooltip-right" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
+      <span class="tooltip-right" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
         <i class="icon icon-help1"></i>
       </span>
     </div>

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -6,7 +6,7 @@
 
     <div cg-busy="vm.promise" class="columns-modal-content">
       <label for="selected_columns" class="hidden-for-sighted">{{ I18n.t('js.description_selected_columns') }}</label>
-      <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2" id="selected_columns" focus>
+      <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2" id="selected_columns" focus aria-describedby="column_multiselect_description">
         <ui-select-match>
           {{$item.title}}
         </ui-select-match>
@@ -17,6 +17,9 @@
       <span class="tooltip-right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
         <i class="icon icon-help1"></i>
       </span>
+      <div class="hidden-for-sighted" id="column_multiselect_description">
+        <p>{{ I18n.t('js.work_packages.label_column_multiselect') }}</p>
+      </div>
     </div>
 
     <div>

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -14,7 +14,7 @@
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
-      <span class="tooltip-right" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
+      <span class="tooltip-right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
         <i class="icon icon-help1"></i>
       </span>
     </div>

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -14,6 +14,8 @@
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
+      <i class="icon icon-help1" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}"></i>
+
     </div>
 
     <div>

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -14,7 +14,7 @@
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
-      <span class="tooltip-right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
+      <span class="tooltip--right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
         <i class="icon icon-help1"></i>
       </span>
       <div class="hidden-for-sighted" id="column_multiselect_description">

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -14,8 +14,9 @@
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
-      <i class="icon icon-help1" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}"></i>
-
+      <span class="tooltip-right" data-tooltip="{{ I18n.t('js.work_packages.label_column_multiselect') }}">
+        <i class="icon icon-help1"></i>
+      </span>
     </div>
 
     <div>

--- a/frontend/app/templates/work_packages/modals/columns.html
+++ b/frontend/app/templates/work_packages/modals/columns.html
@@ -5,7 +5,7 @@
     <h3>{{ I18n.t('js.label_columns') }}</h3>
 
     <div cg-busy="vm.promise" class="columns-modal-content">
-      <label for="selected_columns">{{ I18n.t('js.description_selected_columns') }}</label>
+      <label for="selected_columns" class="hidden-for-sighted">{{ I18n.t('js.description_selected_columns') }}</label>
       <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2" id="selected_columns" focus>
         <ui-select-match>
           {{$item.title}}

--- a/frontend/app/templates/work_packages/modals/group_by.html
+++ b/frontend/app/templates/work_packages/modals/group_by.html
@@ -5,12 +5,18 @@
     <h3>{{ I18n.t('js.label_group_by') }}</h3>
 
     <div>
-      <ui-select ng-model="vm.selectedColumnName" theme="select2" focus id="selected_columns_new">
+      <ui-select ng-model="vm.selectedColumnName" theme="select2" focus id="selected_columns_new" aria-describedby="column_select_description">
         <ui-select-match>{{$select.selected.title}}</ui-select-match>
         <ui-select-choices repeat="column.name as column in vm.groupableColumns | filter: { title: $select.search }">
           <div ng-bind-html="column.title | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
+      <span class="tooltip--right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_select') }}">
+        <i class="icon icon-help1"></i>
+      </span>
+      <div id="column_select_description" class="hidden-for-sighted">
+        <p>{{ I18n.t('js.work_packages.label_column_select') }}</p>
+      </div>
     </div>
     <div>
       <button class="button -highlight" ng-click="updateGroupBy()">

--- a/frontend/app/templates/work_packages/modals/sorting.html
+++ b/frontend/app/templates/work_packages/modals/sorting.html
@@ -9,12 +9,17 @@
         <div class="form--row" ng-repeat="element in sortElements">
           <div class="form--field -full-width">
             <div class="form--field-container">
-              <ui-select ng-model="element[0]" theme="select2" focus="!$index">
+              <ui-select ng-model="element[0]" theme="select2" focus="!$index" aria-describedby="sorting_select_description">
                 <ui-select-match>{{$select.selected.label}}</ui-select-match>
                 <ui-select-choices repeat="column as column in getRemainingAvailableColumnsData() | filter: { title: $select.search }">
                   <div ng-bind-html="column.label | highlight: $select.search"></div>
                 </ui-select-choices>
               </ui-select>
+              <div class="form--tooltip-container">
+                <span class="tooltip--right -multiline" tabindex="0" data-tooltip="{{ I18n.t('js.work_packages.label_column_select') }}">
+                  <i class="icon icon-help1"></i>
+                </span>
+              </div>
             </div>
           </div>
           <div class="form--field -full-width">
@@ -39,6 +44,9 @@
               </label>
             </div>
           </div>
+        </div>
+        <div id="sorting_select_description" class="hidden-for-sighted">
+          <p>{{ I18n.t('js.work_packages.label_column_select') }}</p>
         </div>
       </div>
       <button class="button -highlight"


### PR DESCRIPTION
This should meet the requirements of https://community.openproject.org/work_packages/19175.

It integrates a simple form of tooltip which is purely based on CSS and can be attached to many elements throughout the application. It is the minimum solution, but general solution to the problem stated in the work package.

There are some caveats: The tooltip does not support basic HTML yet - I plan to introduce a complex tooltip based on Foundations `Popup`, which needs some JavaScript to work properly. The tooltip is also not mobile-friendly.

It is configurable and we can style it later - for now I have chosen a basic style which should not cause eye cancer.

Examples have been added to the LSG.
