### PR TITLE
18951 Migrate from deprecated ui-select2 to ui-select in timelines view

### DIFF
--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -58,10 +58,6 @@ li.select2-result.select2-visible-selected-parent
 .tl-hidden-info
   display: none
 
-#timeline_select
-  margin-top: 2px
-  margin-bottom: 8px
-
 #content .ui-sortable .select2-search-choice
   cursor: move
 

--- a/app/helpers/timelines_helper.rb
+++ b/app/helpers/timelines_helper.rb
@@ -307,25 +307,21 @@ module TimelinesHelper
 
   include Gon::GonHelpers
 
-  def visible_timeline_paths(_visible_timelines = [])
-    @visible_timelines.inject({}) do |timeline_paths, timeline|
-      timeline_paths.merge(timeline.id => { path: project_timeline_path(@project, timeline) })
-    end
+  def push_visible_timelines(visible_timelines, target = gon)
+    target.timelines = visible_timelines.map { |timeline|
+      { id: timeline.id, name: timeline.name, path: project_timeline_path(@project, timeline) }
+    }
   end
 
-  def push_visible_timeline_paths(visible_timelines)
-    gon.timelines = visible_timeline_paths visible_timelines
+  def push_current_timeline_id(id, target = gon)
+    target.current_timeline_id = id
   end
 
-  def push_current_timeline_id(id)
-    gon.current_timeline_id = id
-  end
-
-  def push_timeline_options(timeline)
+  def push_timeline_options(timeline, target = gon)
     project_id = timeline.project.identifier
 
-    gon.timeline_options ||= {}
-    gon.timeline_options[timeline.id] = timeline.options.reverse_merge(project_id: project_id)
+    target.timeline_options ||= {}
+    target.timeline_options[timeline.id] = timeline.options.reverse_merge(project_id: project_id)
   end
 
   def timeline_options

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -62,11 +62,17 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag '', {:id => "specialForm", 'ng-controller' => 'TimelineSelectionController'} do %>
     <span class="inline-label">
       <%= label_tag 'timeline_select', l("timelines.timeline"), class: "form-label -transparent" %>
-      <%= collection_select(:timeline, :id, @visible_timelines, :id, :name, {}, {ui_select2: 'ui-select2', id: 'timeline_select', ng_model: 'currentTimelineId', ng_change: 'switchTimeline()'}) %>
+      <ui-select ng-model="vm.currentTimeline" theme="select2"
+        on-select="vm.switchTimeline()">
+        <ui-select-match>{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="timeline in vm.timelines track by timeline.id | filter: { name: $select.search }">
+          <div ng-bind-html="timeline.name | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
     </span>
   <% end %>
 
-  <% push_visible_timeline_paths @visible_timelines %>
+  <% push_visible_timelines @visible_timelines %>
   <% push_current_timeline_id @timeline.id %>
 
   <%= render :partial => "timeline", :locals => {:timeline => @timeline} %>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -65,7 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <ui-select ng-model="vm.currentTimeline" theme="select2"
         on-select="vm.switchTimeline()">
         <ui-select-match>{{$select.selected.name}}</ui-select-match>
-        <ui-select-choices repeat="timeline in vm.timelines track by timeline.id | filter: { name: $select.search }">
+        <ui-select-choices repeat="timeline in vm.timelines | filter: { name: $select.search } track by timeline.id">
           <div ng-bind-html="timeline.name | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -164,7 +164,14 @@ When /^(?:|I )select "([^"]*)" from "([^"]*)"$/ do |value, field|
     container = find(:xpath, xpath_selector)
 
     container.find('.select2-choice').click
-    find(:xpath, "//*[@id='select2-drop']/descendant::li[contains(., '#{value}')]").click
+
+    if container['class'].include?('ui-select-container')
+      # ui-select (Angular)
+      find('ul.select2-result-single li', text: value).click
+    else
+      # classic select2 (jQuery)
+      find(:xpath, "//*[@id='select2-drop']/descendant::li[contains(., '#{value}')]").click
+    end
   end
 end
 

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -46,8 +46,6 @@ if (I18n.locale === 'de') {
 }
 
 require('angular-ui-router');
-require('angular-ui-select2');
-require('angular-ui-select2-sortable');
 
 require('angular-ui-date');
 require('angular-truncate');
@@ -60,7 +58,7 @@ require('angular-context-menu');
 require('mousetrap');
 
 // global
-angular.module('openproject.uiComponents', ['ui.select2', 'ui.select', 'ngSanitize'])
+angular.module('openproject.uiComponents', ['ui.select', 'ngSanitize'])
 .run(['$rootScope', function($rootScope){
   $rootScope.I18n = I18n;
 }]);
@@ -167,8 +165,6 @@ angular.module('openproject.templates', []);
 
 // main app
 var openprojectApp = angular.module('openproject', [
-  'ui.select2',
-  'ui.select2.sortable',
   'ui.date',
   'ui.router',
   'openproject.config',

--- a/frontend/app/timelines/controllers/timeline-selection-controller.js
+++ b/frontend/app/timelines/controllers/timeline-selection-controller.js
@@ -27,10 +27,14 @@
 //++
 
 module.exports = function($scope, $window) {
-  $scope.timelines = gon.timelines;
-  $scope.currentTimelineId = gon.current_timeline_id;
+  var vm;
+  $scope.vm = vm = {};
 
-  $scope.switchTimeline = function() {
-    $window.location.href = $scope.timelines[$scope.currentTimelineId].path;
+  vm.timelines = gon.timelines;
+  vm.currentTimelineId = gon.current_timeline_id;
+  vm.currentTimeline = _.find(vm.timelines, { 'id': vm.currentTimelineId });
+
+  vm.switchTimeline = function() {
+    $window.location.href = vm.currentTimeline.path;
   };
 };

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -10,8 +10,6 @@
     "angular": "~1.3.14",
     "angular-animate": "~1.3.14",
     "angular-aria": "~1.3.14",
-    "angular-ui-select2": "0.0.5",
-    "angular-ui-select2-sortable": "0.0.1",
     "angular-ui-date": "0.0.3",
     "angular-ui-router": "0.2.13",
     "angular-i18n": "~1.3.0",

--- a/frontend/tests/unit/tests/timelines/controllers/timeline-selection-controller-test.js
+++ b/frontend/tests/unit/tests/timelines/controllers/timeline-selection-controller-test.js
@@ -38,6 +38,7 @@ describe('TimelineSelectionController', function() {
 
     win = { location: { href: '/projects/easy_project/timelines/4' } };
 
+    /*jshint camelcase: false */
     window.gon = {
       timelines: [
         { id: 1, name: 'simple',  path: '/projects/easy_project/timelines/1' },
@@ -45,6 +46,7 @@ describe('TimelineSelectionController', function() {
       ],
       current_timeline_id: 2
     };
+    /*jshint camelcase: true */
 
     ctrl = $controller('TimelineSelectionController', {
       $window: win,

--- a/frontend/tests/unit/tests/timelines/controllers/timeline-selection-controller-test.js
+++ b/frontend/tests/unit/tests/timelines/controllers/timeline-selection-controller-test.js
@@ -1,0 +1,76 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+describe('TimelineSelectionController', function() {
+  var ctrl, scope, win;
+
+  beforeEach(module('openproject.timelines.controllers'));
+
+  beforeEach(inject(function($rootScope, $controller) {
+    scope = $rootScope.$new();
+
+    win = { location: { href: '/projects/easy_project/timelines/4' } };
+
+    window.gon = {
+      timelines: [
+        { id: 1, name: 'simple',  path: '/projects/easy_project/timelines/1' },
+        { id: 2, name: 'complex', path: '/projects/easy_project/timelines/2' }
+      ],
+      current_timeline_id: 2
+    };
+
+    ctrl = $controller('TimelineSelectionController', {
+      $window: win,
+      $scope: scope
+    });
+  }));
+
+  afterEach(function() {
+    window.gon = {};
+  });
+
+  describe('initialisation', function() {
+    it('sets timelines', function() {
+      expect(scope.vm.timelines.length).to.eql(2);
+      expect(scope.vm.timelines).to.eql(window.gon.timelines);
+    });
+
+    it('sets currentTimeline', function() {
+      expect(scope.vm.currentTimeline.id).to.equal(2);
+      expect(scope.vm.currentTimeline.name).to.equal('complex');
+    });
+
+    it('forwards to the currentTimeline path', function() {
+      expect(win.location.href).to.equal('/projects/easy_project/timelines/4');
+      scope.vm.switchTimeline();
+      expect(win.location.href).to.equal('/projects/easy_project/timelines/2');
+    });
+  });
+});

--- a/spec/helpers/timelines_helper_spec.rb
+++ b/spec/helpers/timelines_helper_spec.rb
@@ -1,0 +1,50 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe TimelinesHelper, type: :helper do
+  describe '#push_visible_timelines' do
+    let(:project)   { FactoryGirl.create(:project) }
+    let(:timelines) { FactoryGirl.create_list(:timeline, 3, project: project) }
+    let(:target)    { OpenStruct.new }
+
+    before do
+      @project = project
+      push_visible_timelines(timelines, target)
+    end
+
+    it 'should push timelines' do
+      expect(target.timelines.size).to be 3
+      expect(target.timelines.first).to have_key :id
+      expect(target.timelines.first).to have_key :name
+      expect(target.timelines.first).to have_key :path
+    end
+  end
+end


### PR DESCRIPTION
:traffic_light: This PR allows us to finally get rid of ui-select2
- Add basic spec coverage.

https://community.openproject.org/work_packages/18951
