### PR TITLE
Fix journal display of boolean custom fields

### DIFF
--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -54,7 +54,7 @@ class JournalManager
 
     # we generally ignore changes from blank to blank
     predecessor.map { |k, v| current[k.to_s] != v && (v.present? || current[k.to_s].present?) }
-      .inject(false) { |r, c| r || c }
+      .any?
   end
 
   def self.association_changed?(journable, journal_association, association, id, key, value)
@@ -83,8 +83,9 @@ class JournalManager
   # treated like non-existing associations. Thus, this prevents that
   # non-existing associations (nil) are different to blank associations ("").
   # This would lead to false change information, otherwise.
+  # We need to be careful though, because we want to accept false (and false.blank? == true)
   def self.remove_empty_associations(associations, value)
-    associations.reject { |h| h.has_key?(value) && h[value].blank? }
+    associations.reject { |h| h.has_key?(value) && h[value].blank? && h[value] != false }
   end
 
   def self.merge_reference_journals_by_id(current, predecessor, key)

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -246,7 +246,10 @@ class JournalManager
     # Consider only custom values with non-blank values. Otherwise,
     # non-existing custom values are different to custom values with an empty
     # value.
-    journable.custom_values.select { |c| !c.value.blank? }.each do |cv|
+    # Mind that false.present? == false, but we don't consider false this being "blank"...
+    # This does not matter when we use stringly typed values (as in the database),
+    # but it matters when we use real types
+    journable.custom_values.select { |c| c.value.present? || c.value == false }.each do |cv|
       journal.customizable_journals.build custom_field_id: cv.custom_field_id, value: cv.value
     end
   end

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -56,7 +56,7 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
     if value.blank?
       l(:text_journal_deleted_with_diff, label: label, link: link)
     else
-      unless old_value.blank?
+      if old_value.present?
         l(:text_journal_changed_with_diff, label: label, link: link)
       else
         l(:text_journal_set_with_diff, label: label, link: link)

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -76,20 +76,14 @@ class JournalFormatter::Base
   end
 
   def render_ternary_detail_text(label, value, old_value)
-    unless value.blank?
-      unless old_value.blank?
-
-        l(:text_journal_changed, label: label, old: old_value, new: value)
-
-      else
-
-        l(:text_journal_set_to, label: label, value: value)
-
-      end
-    else
-
+    if value.blank?
       l(:text_journal_deleted, label: label, old: old_value)
-
+    else
+      if old_value.blank?
+        l(:text_journal_set_to, label: label, value: value)
+      else
+        l(:text_journal_changed, label: label, old: old_value, new: value)
+      end
     end
   end
 

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -89,13 +89,9 @@ class JournalFormatter::Base
 
   def render_binary_detail_text(label, value, old_value)
     if value.blank?
-
       l(:text_journal_deleted, label: label, old: old_value)
-
     else
-
       l(:text_journal_added, label: label, value: value)
-
     end
   end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19516
## Description:

Apparently once upon a time there were issues with missing custom value being treated differently from custom values that existed, but were blank.
Thus, at the time some checks using `blank?` and `present?` were introduced, which was fine because custom values are all stringly typed (`"1"` is `true`, `"0"` is `false``).

Fast forward until today, in the APIv3 real dynamic typing is used. Thus setting something to false does set the custom value to `false` rather than `"0"`. ActiveRecord and friends can cope with that, but journals still rely on `blank?` and `present?` which say that `false` is **not present, but blank**.

This leads to missing journal entries for `false` custom values and thus inconsistent journal data.
