### PR TITLE
Fix work package access

### DIFF
--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -72,7 +72,7 @@ module API
         end
       end
 
-      def authorize(permission, context: nil, global: false, user: current_user, &block)
+      def authorize(permission, context: nil, global: false, user: current_user)
         is_authorized = AuthorizationService.new(permission,
                                                  context: context,
                                                  global: global,
@@ -81,7 +81,7 @@ module API
         return true if is_authorized
 
         if block_given?
-          yield block
+          yield
         else
           raise API::Errors::Unauthorized
         end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -105,8 +105,6 @@ module API
             end
 
             get do
-              authorize({ controller: :work_packages_api, action: :get },
-                        context: @work_package.project)
               work_package_representer
             end
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -98,6 +98,10 @@ module API
 
             before do
               @work_package = WorkPackage.find(params[:id])
+
+              authorize(:view_work_packages, context: @work_package.project) do
+                raise API::Errors::NotFound.new
+              end
             end
 
             get do

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -186,7 +186,7 @@ h4. things we like
         get get_path
       end
 
-      it_behaves_like 'unauthorized access'
+      it_behaves_like 'not found'
     end
 
     context 'when acting as an anonymous user' do
@@ -195,7 +195,7 @@ h4. things we like
         get get_path
       end
 
-      it_behaves_like 'unauthorized access'
+      it_behaves_like 'not found'
     end
   end
 


### PR DESCRIPTION
This should no longer allow to probe for the existence of work packages via 403 responses of the API.
https://community.openproject.org/work_packages/19475
