### PR TITLE
Add simple setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+def install_dependencies
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle check || bundle install"
+  system "npm install"
+  system "bundle exec rake assets:webpack"
+end
+
+def copy_sample_configuration
+  return if File.exist?("config/database.yml")
+
+  puts "\n== Copying sample configuration files =="
+  puts " Please choose the adapter (press enter to skip):"
+  puts "  PostgreSQL adapter   : 1"
+  puts "  MySQL adapter        : 2"
+  print " (press enter to skip) : "
+
+  adapter_i = Integer(gets.chomp) rescue 0
+
+  adapter = case adapter_i
+    when 1
+      "postgres"
+    when 2
+      "mysql"
+    else
+     ""
+  end
+
+  if adapter.empty?
+    puts "\n Adapter not set! Skipping copying of database.yaml files."
+  else
+    system "cp config/database.yml.#{adapter}.example config/database.yml"
+  end
+  system "cp config/configuration.yml.example config/configuration.yml"
+end
+
+def prepare_database
+  puts "\n\n== Preparing database =="
+  # unfortunately we do not have db/schema.rb
+  # so we have to use this instead of db:setup
+  system "bundle exec rake db:create"
+  system "bundle exec rake db:migrate"
+  system "bundle exec rake db:seed"
+end
+
+def remove_logs_and_tempfiles
+  # puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+end
+
+def restart_app_server
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end
+
+Dir.chdir APP_ROOT do
+  install_dependencies
+  copy_sample_configuration
+  remove_logs_and_tempfiles
+  # restart_app_server
+end
+

--- a/config/database.yml.mysql.example
+++ b/config/database.yml.mysql.example
@@ -26,22 +26,22 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# MySQL (default setup).
+# MySQL setup
 
 production:
   adapter: mysql2
-  database: openproject
+  database: openproject_production
   host: localhost
-  username: root
-  password:
+  username: vagrant
+  password: vagrant
   encoding: utf8
 
 development:
   adapter: mysql2
   database: openproject_development
   host: localhost
-  username: root
-  password:
+  username: vagrant
+  password: vagrant
   encoding: utf8
 
 # Warning: The database defined as "test" will be erased and
@@ -51,14 +51,7 @@ test:
   adapter: mysql2
   database: openproject_test
   host: localhost
-  username: root
-  password:
+  username: vagrant
+  password: vagrant
   encoding: utf8
 
-#test_pgsql:
-  #adapter: postgresql
-  #encoding: unicode
-  #database: openproject_test
-  #pool: 5
-  #username: openproject
-  #password:

--- a/config/database.yml.postgres.example
+++ b/config/database.yml.postgres.example
@@ -39,7 +39,7 @@ production:
 development:
   adapter: postgresql
   encoding: unicode
-  database: openproject_production
+  database: openproject_development
   pool: 5
   username: vagrant
   password: vagrant

--- a/config/database.yml.postgres.example
+++ b/config/database.yml.postgres.example
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Postgresql setup
+
+production:
+  adapter: postgresql
+  encoding: unicode
+  database: openproject_production
+  pool: 5
+  username: vagrant
+  password: vagrant
+
+development:
+  adapter: postgresql
+  encoding: unicode
+  database: openproject_production
+  pool: 5
+  username: vagrant
+  password: vagrant
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: postgresql
+  encoding: unicode
+  database: openproject_test
+  pool: 5
+  username: vagrant
+  password: vagrant


### PR DESCRIPTION
This PR adds a simple setup script which can be used to "bootstrap" the dev environment. I think it is a good way to document what is necessary to get a running test environment. Especially with the whole npm and webpack stuff which I always forget to execute. 

This PR should be considered as a starting point of what we could do with this setup script. It is working but as always it can be improved. Comments are really appreciated.

@opf/developers  
