### PR TITLE
[19607] Use lodash cloneDeep instead of using angular.copy

### DIFF
--- a/frontend/app/work_packages/filters/index.js
+++ b/frontend/app/work_packages/filters/index.js
@@ -52,7 +52,7 @@ angular.module('openproject.workPackages.filters')
 .filter('remainingFilterNames', ['orderByFilter', 'FiltersHelper', function(orderByFilter, FiltersHelper) {
 
   function subtractActiveFilters(filters, filtersToSubtract) {
-    var filterDiff = angular.copy(filters);
+    var filterDiff = _.cloneDeep(filters);
 
     angular.forEach(filtersToSubtract, function(filter) {
       if(!filter.deactivated) delete filterDiff[filter.name];


### PR DESCRIPTION
This should resolve a performance issue in the WP details view in the latest
Firefox. 

Should meet the requirements of https://community.openproject.org/work_packages/19607.
