### PR TITLE
[Foundation] Fix multiselect height

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -393,6 +393,11 @@ fieldset.form--fieldset
   &[multiple]
     background-image: none
     padding-right: $form-padding
+    // TODO: this has to be fixed upstream as select are fixed
+    // in height in foundation for apps.
+    height: auto
+    // this fixes a border issue in chrome
+    border-right-width: 2px
 
 .form--text-field,
 .form--select


### PR DESCRIPTION
The upgrade to foundation 1.1 broke multiselects with were constricted to fixed height.

This PR meets the requirements of https://community.openproject.org/work_packages/19617.
