### PR TITLE
[19610] Fix watchers

### DIFF
--- a/app/assets/stylesheets/content/_choice.md
+++ b/app/assets/stylesheets/content/_choice.md
@@ -17,4 +17,5 @@ For selection from a list without having to use a form. This can be reused for s
     </button>
   </div>
 </div>
+<div class="clearfix"></div>
 ```

--- a/app/assets/stylesheets/content/_choice.sass
+++ b/app/assets/stylesheets/content/_choice.sass
@@ -51,4 +51,4 @@ $choice-parent-relation-select-width: 325px
         width: inherit
   .choice--button
     .button
-      margin: 0
+      margin: 2px

--- a/app/views/watchers/_watchers.html.erb
+++ b/app/views/watchers/_watchers.html.erb
@@ -39,20 +39,20 @@ See doc/COPYRIGHT.rdoc for more details.
   <% end %>
 </p>
 
-<%= form_for(:watcher,
+<%= labelled_tabular_form_for(:watcher,
              url: watchers_path(watched.class.name.underscore.pluralize, watched),
              method: :post,
              remote: true,
              complete: "Form.Element.focus('watcher_user_id');",
              html: { id: 'new-watcher-form', style: (@watcher ? '' : 'display:none;') }) do |f| %>
-  <div class="grid-block">
-    <div class="grid-content small-6">
+  <div class="choice">
+    <div class="choice--select">
       <%= f.select :user_id, (watched.addable_watcher_users.collect {|m| [m.name, m.id]}.sort_by{|name, id | name}),
-            { :prompt => "--- #{l(:actionview_instancetag_blank_option)} ---" },
-            class: 'form--select' %>
+            { :prompt => "--- #{l(:actionview_instancetag_blank_option)} ---", no_label: true } %>
 
-      <%= submit_tag l(:button_add), class: 'button -highlight' %>
-      <%= toggle_link l(:button_cancel), 'new-watcher-form', {}, class: 'button' %>
+    </div>
+    <div class="choice--button">
+      <%= submit_tag l(:button_add), class: 'button' %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
The component was not updated to the new form builder and used grid-block
styles which broke with the upgrade to foundation 1.1

The form now uses a choice component (see living style guide)

Also, the cancel button has been removed there is no good way to leave it in
(without extending the choice component) and it is probably not used anyway.

Meets the requirements of https://community.openproject.org/work_packages/19610

This also fixes a small styling issue with the choice component.

**:warning: May conflict with #2822.**
