### PR TITLE
Fix work package CSS rule affecting syntax highlighter

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -35,8 +35,7 @@
     float: right
     margin-right: 0
 
-// TODO: remove or rename with more specific name
-span.comment
+.user-comment
   display: block
   margin: 10px 0 0 46px
   padding: 0 100px 0 0

--- a/frontend/app/templates/work_packages/tabs/_user_activity.html
+++ b/frontend/app/templates/work_packages/tabs/_user_activity.html
@@ -23,7 +23,7 @@
   <span class="user" ng-if="userActive"><a ng-href="{{ userPath(userId) }}" name="{{ currentAnchor }}" ng-bind="userName"></a></span>
   <span class="user" ng-if="!userActive">{{ userName }}</span>
   <span class="date">{{ I18n.t('js.label_commented_on') }} <op-date-time date-time-value="activity.props.createdAt"/></op-date-time>
-  <span class="comment wiki">
+  <span class="user-comment wiki">
     <div ng-if="inEdit">
       <form name="editCommentForm">
         <div>

--- a/frontend/tests/unit/tests/work_packages/tabs/user-activity-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/tabs/user-activity-directive-test.js
@@ -149,7 +149,7 @@ describe('userActivity Directive', function() {
 
         describe('comment', function() {
           it('should render activity comment', function() {
-            var comment = element.find('span.comment > span.message').html();
+            var comment = element.find('span.user-comment > span.message').html();
 
             expect(comment).to.eq(scope.activity.props.comment.html);
           });


### PR DESCRIPTION
In the dynamic work package sidebar, user comments are addressed with a CSS
rule `span.comment` in _activities_tab.sass.
Unfortunately,  CodeRay picks up the same rule, which
causes the syntax highlighting of comments to be wrong.

![CodeRay syntax example](http://www.oliverguenther.de/stuff/coderay.png)

This commit renames the WP rule to .user-comment instead.

This PR addresses [WP 193638](https://community.openproject.org/work_packages/19638)
