### PR TITLE
Fix validations for some custom value types

### DIFF
--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -35,9 +35,13 @@ class CustomValue::DateStrategy < CustomValue::FormatStrategy
   end
 
   def validate_type_of_value
-    Date.iso8601(value)
-    nil
-  rescue
-    :not_a_date
+    return nil if value.is_a? Date
+
+    begin
+      Date.iso8601(value)
+      nil
+    rescue
+      :not_a_date
+    end
   end
 end

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -35,9 +35,13 @@ class CustomValue::IntStrategy < CustomValue::FormatStrategy
   end
 
   def validate_type_of_value
-    Kernel.Integer(value)
-    nil
-  rescue
-    :not_an_integer
+    return :not_an_integer if value.is_a? Float
+
+    begin
+      Kernel.Integer(value)
+      nil
+    rescue
+      :not_an_integer
+    end
   end
 end

--- a/spec/models/custom_value/bool_strategy_spec.rb
+++ b/spec/models/custom_value/bool_strategy_spec.rb
@@ -113,5 +113,19 @@ describe CustomValue::BoolStrategy do
         is_expected.to be_nil
       end
     end
+
+    context 'value is true' do
+      let(:value) { true }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is false' do
+      let(:value) { false }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
   end
 end

--- a/spec/models/custom_value/date_strategy_spec.rb
+++ b/spec/models/custom_value/date_strategy_spec.rb
@@ -83,5 +83,12 @@ describe CustomValue::DateStrategy do
         is_expected.to eql(:not_a_date)
       end
     end
+
+    context 'value is valid date' do
+      let(:value) { Date.iso8601('2015-01-03') }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
   end
 end

--- a/spec/models/custom_value/float_strategy_spec.rb
+++ b/spec/models/custom_value/float_strategy_spec.rb
@@ -76,5 +76,20 @@ describe CustomValue::FloatStrategy do
         is_expected.to eql(:not_a_number)
       end
     end
+
+    context 'value is float' do
+      let(:value) { 3.14 }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is int' do
+      let(:value) { 3 }
+      it 'accepts' do
+        # accepting here, as we can "losslessly" convert
+        is_expected.to be_nil
+      end
+    end
   end
 end

--- a/spec/models/custom_value/int_strategy_spec.rb
+++ b/spec/models/custom_value/int_strategy_spec.rb
@@ -76,5 +76,19 @@ describe CustomValue::IntStrategy do
         is_expected.to eql(:not_an_integer)
       end
     end
+
+    context 'value is an actual int' do
+      let(:value) { 10 }
+      it 'accepts' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'value is a float' do
+      let(:value) { 2.3 }
+      it 'rejects' do
+        is_expected.to eql(:not_an_integer)
+      end
+    end
   end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19604
## Description (ripped from commit)
- add specs for strategies to parse their typed representation as valid (instead of only their stringly typed counterpart)
- add specs to int and float strategy regarding accepting eachother
- fix int custom values accepting float inputs (which would work, but omit the fractional part)
- fix date custom values not accepting on Date
## Notes

This PR replaces https://github.com/opf/openproject/pull/2827 which was accidentially issued against `dev`.
