### PR TITLE
Fix displaying of sums in work packages overview

### DIFF
--- a/frontend/app/templates/work_packages/work_packages_table.html
+++ b/frontend/app/templates/work_packages/work_packages_table.html
@@ -144,7 +144,7 @@
               'issue',
               'work_package'
             ]">
-            <td colspan="{{2  - (!!hideWorkPackageDetails * 1)}}">
+            <td colspan="{{1  - (!!hideWorkPackageDetails * 1)}}">
               {{ I18n.t('js.label_sum_for') }}
               <span work-package-column
                     work-package="row.object"
@@ -164,7 +164,7 @@
         <tr work-package-total-sums
             ng-if="displaySums"
             class="sum group all issue work_package">
-          <td colspan="{{2  - (!!hideWorkPackageDetails * 1)}}">
+          <td colspan="{{1  - (!!hideWorkPackageDetails * 1)}}">
             <div class="work-packages-table--footer-outer">
               {{ I18n.t('js.label_sum_for') }} {{ I18n.t('js.label_all_work_packages') }}
             </div>


### PR DESCRIPTION
 [`* `#19583` Wrong display for sums in WP Overview`](http://community.openproject.org/work_packages/19583)
