### PR TITLE
Kill deprecated Redmine::MenuManager::MapDeferrer

### DIFF
--- a/lib/redmine/menu_manager/mapper.rb
+++ b/lib/redmine/menu_manager/mapper.rb
@@ -114,21 +114,3 @@ class Redmine::MenuManager::Mapper
     end
   end
 end
-
-class Redmine::MenuManager::MapDeferrer
-  def initialize(menu_builder_queue)
-    @menu_builder_queue = menu_builder_queue
-  end
-
-  def defer(method, *args)
-    ActiveSupport::Deprecation.warn "Calling #{method} and accessing the the menu object from outside of the block attached to the map method is deprecated and will be removed in ChiliProject 3.0. Please access the menu object from within the attached block instead. Please also note the differences between the APIs.", caller.drop(1)
-    menu_builder = proc { |menu_mapper| menu_mapper.send(method, *args) }
-    @menu_builder_queue.push(menu_builder)
-  end
-
-  [:push, :delete, :exists?, :find, :position_of].each do |method|
-    define_method method do |*args|
-      defer(method, *args)
-    end
-  end
-end


### PR DESCRIPTION
Scheduled for deletion in ChiliProject 3.0.

https://community.openproject.org/work_packages/18714
