### PR TITLE
[ci skip] fix typo at lib/redcloth3.rb

### DIFF
--- a/lib/redcloth3.rb
+++ b/lib/redcloth3.rb
@@ -134,7 +134,7 @@
 #
 # == Adding Tables
 #
-# In Textile, simple tables can be added by seperating each column by
+# In Textile, simple tables can be added by separating each column by
 # a pipe.
 #
 #     |a|simple|table|row|


### PR DESCRIPTION
git-svn-id: http://svn.redmine.org/redmine/trunk@13091 e93f8b46-1217-0410-a6f0-8f06a7374b81
