### PR TITLE
Fix boolean custom fields in PostgreSQL even more

### DIFF
--- a/app/decorators/api/experimental/work_package_decorator.rb
+++ b/app/decorators/api/experimental/work_package_decorator.rb
@@ -23,9 +23,9 @@ class API::Experimental::WorkPackageDecorator < SimpleDelegator
 
     custom_field = custom_value.custom_field
     value = if custom_field.field_format == 'user'
-              custom_field.cast_value(custom_value.value).as_json(methods: :name)
+              custom_value.typed_value.as_json(methods: :name)
             else
-              custom_field.cast_value(custom_value.value)
+              custom_value.typed_value
             end
 
     {

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -194,7 +194,7 @@ class CustomField < ActiveRecord::Base
       when 'date'
         casted = begin; value.to_date; rescue; nil end
       when 'bool'
-        casted = (value == '1' ? true : false)
+        casted = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value)
       when 'int'
         casted = value.to_i
       when 'float'

--- a/app/models/query_custom_field_column.rb
+++ b/app/models/query_custom_field_column.rb
@@ -48,6 +48,6 @@ class QueryCustomFieldColumn < QueryColumn
 
   def value(issue)
     cv = issue.custom_values.detect { |v| v.custom_field_id == @cf.id }
-    cv && @cf.cast_value(cv.value)
+    cv && cv.typed_value
   end
 end

--- a/lib/redmine/custom_field_format.rb
+++ b/lib/redmine/custom_field_format.rb
@@ -36,12 +36,12 @@ module Redmine
 
     attr_accessor :name, :order, :label, :edit_as, :class_names
 
-    def initialize(name, options = {})
+    def initialize(name, label:, order:, edit_as: name, only: nil)
       self.name = name
-      self.label = options[:label]
-      self.order = options[:order]
-      self.edit_as = options[:edit_as] || name
-      self.class_names = options[:only]
+      self.label = label
+      self.order = order
+      self.edit_as = edit_as
+      self.class_names = only
     end
 
     def format(value)

--- a/lib/redmine/custom_field_format.rb
+++ b/lib/redmine/custom_field_format.rb
@@ -52,7 +52,8 @@ module Redmine
       format_date(value.to_date); rescue; value     end
 
     def format_as_bool(value)
-      l(value == '1' ? :general_text_Yes : :general_text_No)
+      is_true = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value)
+      l(is_true ? :general_text_Yes : :general_text_No)
     end
 
     ['string', 'text', 'int', 'float', 'list'].each do |name|

--- a/lib/redmine/custom_field_format.rb
+++ b/lib/redmine/custom_field_format.rb
@@ -58,7 +58,7 @@ module Redmine
 
     ['string', 'text', 'int', 'float', 'list'].each do |name|
       define_method("format_as_#{name}") {|value|
-        return value
+        return value.to_s
       }
     end
 

--- a/spec/decorators/api/experimental/work_package_decorator_spec.rb
+++ b/spec/decorators/api/experimental/work_package_decorator_spec.rb
@@ -54,7 +54,7 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
   end
 
   describe '#custom_values_display_data' do
-    it 'returns a hash with a subset of information about the custom value' do
+    it 'returns a hash with a subset of information about a custom value' do
       allow(dwp1).to receive(:custom_values).and_return [custom_value]
 
       returned = dwp1.custom_values_display_data(custom_field.id)
@@ -62,18 +62,19 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
       expected = [{
         custom_field_id: custom_field.id,
         field_format: custom_field.field_format,
-        value: nil
+        value: ''
       }]
 
       expect(returned).to eql (expected)
     end
 
-    it 'returns a hash with a subset of information about the custom value' do
+    it 'returns a hash with a subset of information about a user custom value' do
       field = FactoryGirl.build_stubbed(:user_issue_custom_field)
       custom_value.custom_field = field
       user = FactoryGirl.build_stubbed(:user)
       custom_value.value = user.id.to_s
       allow(User).to receive(:find_by_id).with(user.id).and_return(user)
+      allow(User).to receive(:find_by_id).with(user.id.to_s).and_return(user)
 
       allow(dwp1).to receive(:custom_values).and_return [custom_value]
 

--- a/spec/decorators/api/experimental/work_package_decorator_spec.rb
+++ b/spec/decorators/api/experimental/work_package_decorator_spec.rb
@@ -31,12 +31,15 @@ require File.expand_path('../../../../spec_helper', __FILE__)
 describe API::Experimental::WorkPackageDecorator, type: :model do
   let(:wp1) { FactoryGirl.build_stubbed(:work_package) }
   let(:wp2) { FactoryGirl.build_stubbed(:work_package) }
-  let(:dwp1) { described_class.new(wp1) }
   let(:custom_field) { FactoryGirl.build_stubbed(:text_issue_custom_field) }
   let(:custom_value) do
     FactoryGirl.build_stubbed(:custom_value,
-                              custom_field: custom_field)
+                              custom_field: custom_field,
+                              value: value)
   end
+  let(:value) { '' }
+
+  subject { described_class.new(wp1) }
 
   describe '#decorate' do
 
@@ -54,10 +57,12 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
   end
 
   describe '#custom_values_display_data' do
-    it 'returns a hash with a subset of information about a custom value' do
-      allow(dwp1).to receive(:custom_values).and_return [custom_value]
+    before do
+      allow(wp1).to receive(:custom_values).and_return [custom_value]
+    end
 
-      returned = dwp1.custom_values_display_data(custom_field.id)
+    it 'returns a hash with a subset of information about a custom value' do
+      returned = subject.custom_values_display_data(custom_field.id)
 
       expected = [{
         custom_field_id: custom_field.id,
@@ -65,28 +70,30 @@ describe API::Experimental::WorkPackageDecorator, type: :model do
         value: ''
       }]
 
-      expect(returned).to eql (expected)
+      expect(returned).to eql expected
     end
 
-    it 'returns a hash with a subset of information about a user custom value' do
-      field = FactoryGirl.build_stubbed(:user_issue_custom_field)
-      custom_value.custom_field = field
-      user = FactoryGirl.build_stubbed(:user)
-      custom_value.value = user.id.to_s
-      allow(User).to receive(:find_by_id).with(user.id).and_return(user)
-      allow(User).to receive(:find_by_id).with(user.id.to_s).and_return(user)
+    context 'user custom value' do
+      let(:custom_field) { FactoryGirl.build_stubbed(:user_issue_custom_field) }
+      let(:user) { FactoryGirl.build_stubbed(:user) }
+      let(:value) { user.id.to_s }
 
-      allow(dwp1).to receive(:custom_values).and_return [custom_value]
+      before do
+        allow(User).to receive(:find_by_id).with(user.id).and_return(user)
+        allow(User).to receive(:find_by_id).with(user.id.to_s).and_return(user)
+      end
 
-      returned = dwp1.custom_values_display_data(field.id)
+      it 'returns a hash with a subset of information about a custom value' do
+        returned = subject.custom_values_display_data(custom_field.id)
 
-      expected = [{
-        custom_field_id: field.id,
-        field_format: field.field_format,
-        value: user.as_json(methods: :name)
-      }]
+        expected = [{
+          custom_field_id: custom_field.id,
+          field_format: custom_field.field_format,
+          value: user.as_json(methods: :name)
+        }]
 
-      expect(returned).to eql (expected)
+        expect(returned).to eql expected
+      end
     end
   end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19601
## Description

Turns out that even more code assumed that `true == "1"`...
For some occurences I replaced legacy methods by calls to `CustomValue.typed_value`, for others I just fixed the offending code immediately, keeping the duplication in place.

This is sad, but true...
