### PR TITLE
[Protractor] Fix the protractor tests

### DIFF
--- a/frontend/tests/integration/specs/work-packages/details-pane/relations/parent-relations-handler-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/relations/parent-relations-handler-spec.js
@@ -56,7 +56,7 @@ describe('Details pane', function() {
         browser.waitForAngular();
       });
 
-      iit('shows "No realtion exists"', function() {
+      it('shows "No relation exists"', function() {
         element.all(by.repeater('relation in handler.relations')).count().then(function(count) {
           expect(count).to.eq(0);
         });


### PR DESCRIPTION
This will unfocus the protractor test that lead to a very focused test suite for quite some time. Travis should execute all of the tests again.
