### PR TITLE
[API] always show the parent id in the WP form payload

### DIFF
--- a/lib/api/v3/work_packages/form/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/form/work_package_payload_representer.rb
@@ -101,7 +101,10 @@ module API
                    },
                    setter: -> (value, *) { represented.description = value['raw'] },
                    render_nil: true
-          property :parent_id, writeable: true
+
+          property :parent_id,
+                   writeable: true,
+                   render_nil: true
 
           property :project_id,
                    getter: -> (*) { nil },


### PR DESCRIPTION
## OpenProject work package

Found while investigating https://community.openproject.org/work_packages/19737

This is IMHO not related to the issue mentioned there, so I would not update the status of that WP, when merging this PR.
