### PR TITLE
[19708] Select background color

### DIFF
--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -120,7 +120,7 @@
 $se2-theme-selectable-color: #f8f8f8;
 //todo change to global theme color var
 //{bgThemeHighlight}
-$se2-theme-selectable-color-highlighted: #24b3e7;
+$se2-theme-selectable-color-highlighted: $drop-down-selected-bg-color;
 
 $se2-element-height: 33px;
 $se2-line-height: 30px;
@@ -190,7 +190,7 @@ $se2-width: 100%;
       //possible background tweaks
     }
   }
-  
+
   .select2-results {
     max-height: $se2-results-max-height;
     overflow: auto;


### PR DESCRIPTION
This will meet the requirements for https://community.openproject.org/work_packages/19708 indirectly, as it forces the `select2` background highlight to use the global variable from `_variables.sass`.

@vcostin @myabc IMHO we should move the `select2` related variables to `_variables.sass`, but I am not sure whether this would clutter the file. Then again, this would definitely stuff for a separate PR.

This PR also saves us from changing anything in the `openproject-theme` plugin for MyProject.
