### PR TITLE
[19707] Fix 'My Account' layout

### DIFF
--- a/app/assets/stylesheets/content/_accounts.sass
+++ b/app/assets/stylesheets/content/_accounts.sass
@@ -115,9 +115,3 @@
 
 #top-menu #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
-
-// TODO: this temporarily fixes an issue with zurb 1.1
-// @see https://github.com/zurb/foundation-apps/issues/575
-#my_account_form
-  .grid-block
-    @extend .medium-up-2

--- a/app/assets/stylesheets/content/_accounts.sass
+++ b/app/assets/stylesheets/content/_accounts.sass
@@ -115,3 +115,9 @@
 
 #top-menu #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
+
+// TODO: this temporarily fixes an issue with zurb 1.1
+// @see https://github.com/zurb/foundation-apps/issues/575
+#my_account_form
+  .grid-content
+    @extend .medium-6

--- a/app/assets/stylesheets/content/_accounts.sass
+++ b/app/assets/stylesheets/content/_accounts.sass
@@ -119,5 +119,5 @@
 // TODO: this temporarily fixes an issue with zurb 1.1
 // @see https://github.com/zurb/foundation-apps/issues/575
 #my_account_form
-  .grid-content
-    @extend .medium-6
+  .grid-block
+    @extend .medium-up-2

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -40,7 +40,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for @user, :as => :user, :url => { :action => "account" },
                           :lang => current_language,
                           :html => { :id => 'my_account_form', class: 'form -wide-labels' } do |f| %>
-  <div class="grid-block">
+  <%# @see https://github.com/zurb/foundation-apps/issues/575 -%>
+  <div class="grid-block medium-up-2">
     <div class="grid-content">
       <h3 class="form--section-title"><%=l(:label_information_plural)%></h3>
       <section class="form--section">


### PR DESCRIPTION
This uses a hack hack (an otherwise unnecessary `@extend`) to hack around the my
account layout, which breaks if certain plugins are used (myProject).

This relates to https://github.com/zurb/foundation-apps/issues/575, which
currently breaks layouts.

should also fix the issue documented in https://community.openproject.org/work_packages/19707.

I consider this a bandaid, not a satisfying solution, please treat it as such.
