### PR TITLE
Correct class applied on attachments description label

### DIFF
--- a/app/views/attachments/_form.html.erb
+++ b/app/views/attachments/_form.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
       </div>
       <div class="form--field">
-        <label class="form-label" >
+        <label class="form--label">
           <%= l(:label_optional_description) %>
         </label>
         <div class="form--text-field-container">

--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -59,7 +59,7 @@ an attachments_attributes= and not every model supports this we build a nested f
           </div>
         </div>
         <div class="form--field">
-          <label class="form-label" >
+          <label class="form--label">
             <%= l(:label_optional_description) %>
           </label>
           <div class="form--text-field-container">


### PR DESCRIPTION
This should improve alignment.

/ HT @vcostin

TODO: better naming for `inline-label` (?)
