### PR TITLE
Re-Enable Category filtering in WP list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 /log/*.log
 /tmp
 
+# Ignore RubyMine files
+/.idea
+
 /backup
 /.project
 /.loadpath

--- a/Gemfile
+++ b/Gemfile
@@ -179,9 +179,8 @@ end
 
 # API gems
 gem 'grape', '~> 0.7.0'
-gem 'representable', git: 'https://github.com/finnlabs/representable'
-gem 'roar',   '~> 0.12.6'
-gem 'reform', '~> 1.0.4', require: false
+gem 'roar',   '~> 1.0.0'
+gem 'reform', '~> 1.2.6', require: false
 
 # Use the commented pure ruby gems, if you have not the needed prerequisites on
 # board to compile the native ones.  Note, that their use is discouraged, since

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,6 @@ GIT
       rack
 
 GIT
-  remote: https://github.com/finnlabs/representable
-  revision: 5f8fbcb1e61720699135c39be3f36a725ca870ad
-  specs:
-    representable (1.8.1)
-      multi_json
-      nokogiri
-      uber
-
-GIT
   remote: https://github.com/finnlabs/rspec-example_disabler.git
   revision: deb9c38e3f4e3688724583ac1ff58e1ae8aba409
   specs:
@@ -162,8 +153,8 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    disposable (0.0.4)
-      representable (~> 1.8.1)
+    disposable (0.0.9)
+      representable (~> 2.0)
       uber
     equalizer (0.0.9)
     erubis (2.7.0)
@@ -310,14 +301,18 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.0.0)
-    reform (1.0.4)
+    reform (1.2.6)
       activemodel
-      disposable (~> 0.0.4)
-      representable (~> 1.8.1)
-      uber (~> 0.0.4)
+      disposable (~> 0.0.5)
+      representable (~> 2.1.0)
+      uber (~> 0.0.11)
+    representable (2.1.5)
+      multi_json
+      nokogiri
+      uber (~> 0.0.7)
     request_store (1.1.0)
-    roar (0.12.7)
-      representable (>= 1.6.0)
+    roar (1.0.0)
+      representable (>= 2.0.1, <= 3.0.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -388,7 +383,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.43)
-    uber (0.0.10)
+    uber (0.0.13)
     uglifier (2.1.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
@@ -471,10 +466,9 @@ DEPENDENCIES
   rails_autolink (~> 1.1.6)
   rb-readline (~> 0.5.1)
   rdoc (>= 2.4.2)
-  reform (~> 1.0.4)
-  representable!
+  reform (~> 1.2.6)
   request_store (~> 1.1.0)
-  roar (~> 0.12.6)
+  roar (~> 1.0.0)
   rspec (~> 2.99.0)
   rspec-activemodel-mocks
   rspec-example_disabler!

--- a/app/assets/javascripts/angular/helpers/path-helper.js
+++ b/app/assets/javascripts/angular/helpers/path-helper.js
@@ -240,6 +240,12 @@ angular.module('openproject.helpers')
     },
 
     // API V3
+    apiV3ProjectPath: function(projectIdentifier) {
+      return PathHelper.apiV3 + "/projects/" + projectIdentifier;
+    },
+    apiProjectCategoriesPath: function(projectIdentifier) {
+      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/categories';
+    },
     apiQueryStarPath: function(queryId) {
       return PathHelper.apiV3QueryPath(queryId) + '/star';
     },

--- a/app/assets/javascripts/angular/services/category-service.js
+++ b/app/assets/javascripts/angular/services/category-service.js
@@ -43,9 +43,9 @@ angular.module('openproject.services')
 
       doQuery: function(url, params) {
         return $http.get(url, { params: params })
-          .then(function(response){
-            // TODO: parse the real response (the code below is c&p from version-service)
-            return _.sortBy(response.data.categories, 'name');
+          .then(function(response) {
+            var elements =  response.data._embedded.elements;
+            return _.sortBy(elements, 'name');
           });
       }
     };

--- a/app/assets/javascripts/angular/services/category-service.js
+++ b/app/assets/javascripts/angular/services/category-service.js
@@ -1,0 +1,54 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+angular.module('openproject.services')
+
+  .service('CategoryService', ['$http', 'PathHelper', function($http, PathHelper) {
+
+    var CategoryService = {
+      getCategories: function(projectIdentifier) {
+        if(!projectIdentifier) {
+          return [];
+        }
+
+        var url = PathHelper.apiProjectCategoriesPath(projectIdentifier);
+
+        return CategoryService.doQuery(url);
+      },
+
+      doQuery: function(url, params) {
+        return $http.get(url, { params: params })
+          .then(function(response){
+            // TODO: parse the real response (the code below is c&p from version-service)
+            return _.sortBy(response.data.categories, 'name');
+          });
+      }
+    };
+
+    return CategoryService;
+  }]);

--- a/app/assets/javascripts/angular/services/query-service.js
+++ b/app/assets/javascripts/angular/services/query-service.js
@@ -40,6 +40,7 @@ angular.module('openproject.services')
   'PriorityService',
   'UserService',
   'VersionService',
+  'CategoryService',
   'RoleService',
   'GroupService',
   'ProjectService',
@@ -48,7 +49,7 @@ angular.module('openproject.services')
   'queryMenuItemFactory',
   '$rootScope',
   'QUERY_MENU_ITEM_TYPE',
-  function(Query, Sortation, $http, PathHelper, $q, AVAILABLE_WORK_PACKAGE_FILTERS, StatusService, TypeService, PriorityService, UserService, VersionService, RoleService, GroupService, ProjectService, WorkPackagesTableHelper, I18n, queryMenuItemFactory, $rootScope, QUERY_MENU_ITEM_TYPE) {
+  function(Query, Sortation, $http, PathHelper, $q, AVAILABLE_WORK_PACKAGE_FILTERS, StatusService, TypeService, PriorityService, UserService, VersionService, CategoryService, RoleService, GroupService, ProjectService, WorkPackagesTableHelper, I18n, queryMenuItemFactory, $rootScope, QUERY_MENU_ITEM_TYPE) {
 
   var query;
 
@@ -300,6 +301,9 @@ angular.module('openproject.services')
                 break;
               case 'version':
                 retrieveAvailableValues = VersionService.getVersions(projectIdentifier);
+                break;
+              case 'category':
+                retrieveAvailableValues = CategoryService.getCategories(projectIdentifier);
                 break;
               case 'role':
                 retrieveAvailableValues = RoleService.getRoles();

--- a/app/assets/javascripts/angular/work_packages/config/work-packages-config.js
+++ b/app/assets/javascripts/angular/work_packages/config/work-packages-config.js
@@ -52,6 +52,7 @@ angular.module('openproject.workPackages.config')
   watcher_id: {type: 'list_model', modelName: 'user', order: 6, locale_name: 'watcher'},
   responsible_id: {type: 'list_optional', modelName: 'user', order: 6, locale_name: 'responsible'},
   fixed_version_id: {type: 'list_optional', modelName: 'version', order: 7, locale_name: 'fixed_version'},
+  category_id: {type: 'list_optional', modelName: 'category', order: 7, locale_name: 'category'},
   member_of_group: {type: 'list_optional', modelName: 'group', order: 8, locale_name: 'member_of_group'},
   assigned_to_role: {type: 'list_optional', modelName: 'role', order: 9, locale_name: 'assigned_to_role'},
   subject: { type: 'text', order: 10, locale_name: 'subject' },

--- a/config/initializers/grape.rb
+++ b/config/initializers/grape.rb
@@ -1,7 +1,6 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,27 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Categories
-      class CategoriesAPI < Grape::API
-
-        resources :categories do
-
-          namespace ':id' do
-
-            before do
-              @category = Category.find(params[:id])
-              authorize(:view_project, context: @category.project)
-            end
-
-            get do
-              CategoryRepresenter.new(@category)
-            end
-          end
-        end
-
-      end
-    end
+module Grape
+  class Endpoint
+    include ::API::V3::Utilities::PathHelper
   end
 end

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -161,6 +161,7 @@ de:
       assigned_to: "Zugewiesen an"
       assigned_to_role: "Zuständigkeitsrolle"
       author: "Autor"
+      category: "Kategorie"
       created_at: "Angelegt"
       done_ratio: "% erledigt"
       due_date: "Abgabedatum"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -160,6 +160,7 @@ en:
       assigned_to: "Assignee"
       assigned_to_role: "Assignee's role"
       author: "Author"
+      category: "Category"
       created_at: "Created on"
       done_ratio: "% done"
       due_date: "Due date"

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -989,6 +989,10 @@ Updates an activity's comment and, on success, returns the updated activity.
                         "href": "/api/v3/work_packages/1298",
                         "title": "nisi eligendi officiis eos delectus quis voluptas dolores"
                     },
+                    "category": {
+                        "href": "/api/v3/categories/1298",
+                        "title": "eligend isi"
+                    },
                     "children": [
                         {
                             "href": "/api/v3/work_packages/1529",

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -1,0 +1,126 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'roar/decorator'
+require 'roar/hypermedia'
+require 'roar/json/hal'
+
+require 'api/v3/utilities/path_helper'
+
+module API
+  module Decorators
+    class Single < ::Roar::Decorator
+      include ::Roar::JSON::HAL
+      include ::Roar::Hypermedia
+      include ::API::V3::Utilities::PathHelper
+
+      attr_reader :context
+      class_attribute :as_strategy
+      self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
+
+      def initialize(model, context = {})
+        @context = context
+
+        super(model)
+      end
+
+      property :_type,
+               exec_context: :decorator,
+               render_nil: false
+
+      def self.self_link(path: nil, title_getter: -> (*) { represented.name })
+        link :self do
+          path = _type.underscore unless path
+          link_object = { href: api_v3_paths.send(path, represented.id) }
+          title = instance_eval(&title_getter)
+          link_object[:title] = title if title
+
+          link_object
+        end
+      end
+
+      def self.linked_property(property,
+          path: property,
+          getter: property,
+          title_getter: -> (*) { call_or_send_to_represented(getter).name },
+          show_if: -> (*) { true },
+          embed_as: nil)
+        link property.to_s.camelize(:lower) do
+          next unless instance_eval(&show_if)
+
+          value = call_or_send_to_represented(getter)
+          link_object = { href: (api_v3_paths.send(path, value.id) if value) }
+          if value
+            title = instance_eval(&title_getter)
+            link_object[:title] = title if title
+          end
+          link_object
+        end
+
+        if embed_as
+          embed_property property,
+                         getter: getter,
+                         decorator: embed_as,
+                         show_if: show_if
+        end
+      end
+
+      def self.embed_property(property, getter: property, decorator:, show_if: true)
+        property property,
+                 exec_context: :decorator,
+                 getter: -> (*) { call_or_send_to_represented(getter) },
+                 embedded: true,
+                 decorator: decorator,
+                 if: show_if
+      end
+
+      protected
+
+      def current_user
+        context[:current_user]
+      end
+
+      private
+
+      def call_or_send_to_represented(callable_or_name)
+        if callable_or_name.respond_to? :call
+          instance_exec(&callable_or_name)
+        else
+          represented.send(callable_or_name)
+        end
+      end
+
+      def datetime_formatter
+        ::API::V3::Utilities::DateTimeFormatter
+      end
+
+      def _type; end
+    end
+  end
+end

--- a/lib/api/utilities/url_helper.rb
+++ b/lib/api/utilities/url_helper.rb
@@ -1,6 +1,7 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,12 +27,13 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
+module API
+  module Utilities
+    module UrlHelper
+      include OpenProject::StaticRouting::UrlHelpers
+      include ActionView::Helpers::UrlHelper
 
-describe ::API::V3::Categories::CategoryModel do
-  subject(:model) { ::API::V3::Categories::CategoryModel.new(category) }
-  let(:category) { FactoryGirl.build(:category, attributes) }
-  let(:attributes) { { name: 'Specific Category' } }
-
-  its(:name) { should eq 'Specific Category' }
+      def controller; end # The URL helpers need a controller, even if it's nil
+    end
+  end
 end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -28,14 +28,15 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/hypermedia'
+require 'roar/json/hal'
 
 module API
   module V3
     module Activities
       class ActivityRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Attachments
       class AttachmentRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -1,7 +1,7 @@
 #-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -30,23 +30,20 @@
 module API
   module V3
     module Categories
-      class CategoriesAPI < Grape::API
-
+      class CategoriesByProjectAPI < Grape::API
         resources :categories do
+          before do
+            @categories = @project.categories
+          end
 
-          namespace ':id' do
+          get do
+            self_link = api_v3_paths.categories(@project.identifier)
 
-            before do
-              @category = Category.find(params[:id])
-              authorize(:view_project, context: @category.project)
-            end
-
-            get do
-              CategoryRepresenter.new(@category)
-            end
+            CategoryCollectionRepresenter.new(@categories,
+                                              @categories.count,
+                                              self_link)
           end
         end
-
       end
     end
   end

--- a/lib/api/v3/categories/category_collection_representer.rb
+++ b/lib/api/v3/categories/category_collection_representer.rb
@@ -1,7 +1,7 @@
 #-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,37 +27,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'representable/json/collection'
-require 'roar/representer/json/hal'
-
 module API
   module V3
     module Categories
-      class CategoryCollectionRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include OpenProject::StaticRouting::UrlHelpers
-
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
-
-        attr_reader :project
-
-        def initialize(model, project)
-          @project = project
-          super(model)
-        end
-
-        link :self do
-          "#{root_path}api/v3/projects/#{project.id}/categories"
-        end
-
-        property :_type, exec_context: :decorator
-
-        collection :categories, embedded: true, extend: CategoryRepresenter, getter: ->(_) { self }
-
-        def _type
-          'Categories'
-        end
+      class CategoryCollectionRepresenter < ::API::Decorators::CollectionFourDotOne
+        element_decorator ::API::V3::Categories::CategoryRepresenter
       end
     end
   end

--- a/lib/api/v3/categories/category_representer.rb
+++ b/lib/api/v3/categories/category_representer.rb
@@ -27,22 +27,32 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/representer/json/hal'
-
 module API
   module V3
     module Categories
-      class CategoryRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
-        include OpenProject::StaticRouting::UrlHelpers
+      class CategoryRepresenter < ::API::Decorators::Single
+        link :self do
+          {
+            href: api_v3_paths.category(represented.id),
+            title: "#{represented.name}"
+          }
+        end
 
-        self.as_strategy = API::Utilities::CamelCasingStrategy.new
+        link :project do
+          {
+            href: api_v3_paths.project(represented.project.id),
+            title: represented.project.name
+          }
+        end
 
-        property :_type, exec_context: :decorator
+        link :user do
+          {
+            href: api_v3_paths.user(represented.assigned_to.id),
+            title: represented.assigned_to.name
+          } if represented.assigned_to
+        end
 
-        property :id, getter: -> (*) { model.id }, render_nil: true
+        property :id, render_nil: true
         property :name, render_nil: true
 
         def _type

--- a/lib/api/v3/priorities/priority_collection_representer.rb
+++ b/lib/api/v3/priorities/priority_collection_representer.rb
@@ -29,13 +29,13 @@
 
 require 'roar/decorator'
 require 'representable/json/collection'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Priorities
       class PriorityCollectionRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
+        include Roar::JSON::HAL
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/priorities/priority_representer.rb
+++ b/lib/api/v3/priorities/priority_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Priorities
       class PriorityRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Projects
       class ProjectRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -40,14 +40,14 @@ module API
             before do
               @project = Project.find(params[:id])
               @model   = ProjectModel.new(@project)
+              authorize(:view_project, context: @project)
             end
 
             get do
-              authorize(:view_project, context: @project)
               ProjectRepresenter.new(@model)
             end
 
-            mount API::V3::Categories::CategoriesAPI
+            mount API::V3::Categories::CategoriesByProjectAPI
             mount API::V3::Versions::VersionsAPI
           end
 

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Queries
       class QueryRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -38,6 +38,7 @@ module API
 
       mount ::API::V3::Activities::ActivitiesAPI
       mount ::API::V3::Attachments::AttachmentsAPI
+      mount ::API::V3::Categories::CategoriesAPI
       mount ::API::V3::Priorities::PrioritiesAPI
       mount ::API::V3::Projects::ProjectsAPI
       mount ::API::V3::Queries::QueriesAPI

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -28,13 +28,13 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     class RootRepresenter < Roar::Decorator
-      include Roar::Representer::JSON::HAL
-      include Roar::Representer::Feature::Hypermedia
+      include Roar::JSON::HAL
+      include Roar::Hypermedia
       include OpenProject::StaticRouting::UrlHelpers
 
       self.as_strategy = ::API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/statuses/status_collection_representer.rb
+++ b/lib/api/v3/statuses/status_collection_representer.rb
@@ -29,13 +29,13 @@
 
 require 'roar/decorator'
 require 'representable/json/collection'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Statuses
       class StatusCollectionRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
+        include Roar::JSON::HAL
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/statuses/status_representer.rb
+++ b/lib/api/v3/statuses/status_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Statuses
       class StatusRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Users
       class UserRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
         include AvatarHelper
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -1,0 +1,178 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Utilities
+      module PathHelper
+        include API::Utilities::UrlHelper
+
+        class ApiV3Path
+          def self.root
+            "#{root_path}api/v3"
+          end
+
+          def self.activity(id)
+            "#{root}/activities/#{id}"
+          end
+
+          def self.attachment(id)
+            "#{root}/attachments/#{id}"
+          end
+
+          def self.available_assignees(project_id)
+            "#{project(project_id)}/available_assignees"
+          end
+
+          def self.available_responsibles(project_id)
+            "#{project(project_id)}/available_responsibles"
+          end
+
+          def self.available_watchers(work_package_id)
+            "#{work_package(work_package_id)}/available_watchers"
+          end
+
+          def self.categories(project_id)
+            "#{project(project_id)}/categories"
+          end
+
+          def self.category(id)
+            "#{root}/categories/#{id}"
+          end
+
+          def self.preview_textile(link)
+            preview_markup(:textile, link)
+          end
+
+          def self.priorities
+            "#{root}/priorities"
+          end
+
+          def self.projects
+            "#{root}/projects"
+          end
+
+          def self.project(id)
+            "#{projects}/#{id}"
+          end
+
+          def self.query(id)
+            "#{root}/queries/#{id}"
+          end
+
+          def self.relation(id)
+            "#{root}/relations/#{id}"
+          end
+
+          def self.statuses
+            "#{root}/statuses"
+          end
+
+          def self.status(id)
+            "#{statuses}/#{id}"
+          end
+
+          def self.users
+            "#{root}/users"
+          end
+
+          def self.user(id)
+            "#{users}/#{id}"
+          end
+
+          def self.user_lock(id)
+            "#{user(id)}/lock"
+          end
+
+          def self.version(version_id)
+            "#{root}/versions/#{version_id}"
+          end
+
+          def self.versions(project_id)
+            "#{project(project_id)}/versions"
+          end
+
+          def self.versions_projects(version_id)
+            "#{version(version_id)}/projects"
+          end
+
+          def self.watcher(id, work_package_id)
+            "#{work_package(work_package_id)}/watchers/#{id}"
+          end
+
+          def self.work_packages
+            "#{root}/work_packages"
+          end
+
+          def self.work_package(id)
+            "#{work_packages}/#{id}"
+          end
+
+          def self.work_package_activities(id)
+            "#{work_package(id)}/activities"
+          end
+
+          def self.work_package_relations(id)
+            "#{work_package(id)}/relations"
+          end
+
+          def self.work_package_relation(id, work_package_id)
+            "#{work_package_relations(work_package_id)}/#{id}"
+          end
+
+          def self.work_package_form(id)
+            "#{work_package(id)}/form"
+          end
+
+          def self.work_package_watchers(id)
+            "#{work_package(id)}/watchers"
+          end
+
+          def self.root_path
+            @@root_path ||= Class.new.tap do |c|
+              c.extend(::API::V3::Utilities::PathHelper)
+            end.root_path
+          end
+
+          def self.preview_markup(method, link)
+            path = "#{root}/render/#{method}"
+
+            path += "?#{link}" unless link.nil?
+
+            path
+          end
+        end
+
+        def api_v3_paths
+          ApiV3Path
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/versions/version_collection_representer.rb
+++ b/lib/api/v3/versions/version_collection_representer.rb
@@ -29,13 +29,13 @@
 
 require 'roar/decorator'
 require 'representable/json/collection'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Versions
       class VersionCollectionRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
+        include Roar::JSON::HAL
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module Versions
       class VersionRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/work_packages/relation_representer.rb
+++ b/lib/api/v3/work_packages/relation_representer.rb
@@ -28,14 +28,14 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
 
 module API
   module V3
     module WorkPackages
       class RelationRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
 
         self.as_strategy = API::Utilities::CamelCasingStrategy.new

--- a/lib/api/v3/work_packages/work_package_model.rb
+++ b/lib/api/v3/work_packages/work_package_model.rb
@@ -118,7 +118,7 @@ module API
         end
 
         def category
-          ::API::V3::Categories::CategoryModel.new(model.category)  unless model.category.nil?
+          model.category
         end
 
         def activities

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -28,15 +28,18 @@
 #++
 
 require 'roar/decorator'
-require 'roar/representer/json/hal'
+require 'roar/json/hal'
+
+require 'api/v3/utilities/path_helper'
 
 module API
   module V3
     module WorkPackages
       class WorkPackageRepresenter < Roar::Decorator
-        include Roar::Representer::JSON::HAL
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON::HAL
+        include Roar::Hypermedia
         include OpenProject::StaticRouting::UrlHelpers
+        include ::API::V3::Utilities::PathHelper
 
         self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
@@ -199,6 +202,13 @@ module API
           } unless represented.model.parent.nil? || !represented.model.parent.visible?
         end
 
+        link :category do
+          {
+            href: api_v3_paths.category(represented.category.id),
+            title: represented.category.name
+          } unless represented.category.nil?
+        end
+
         link :version do
           {
             href: version_path(represented.model.fixed_version),
@@ -254,7 +264,7 @@ module API
         property :author, embedded: true, class: ::API::V3::Users::UserModel, decorator: ::API::V3::Users::UserRepresenter, if: -> (*) { !author.nil? }, writeable: false
         property :responsible, embedded: true, class: ::API::V3::Users::UserModel, decorator: ::API::V3::Users::UserRepresenter, if: -> (*) { !responsible.nil? }, writeable: false
         property :assignee, embedded: true, class: ::API::V3::Users::UserModel, decorator: ::API::V3::Users::UserRepresenter, if: -> (*) { !assignee.nil? }, writeable: false
-        property :category, embedded: true, class: ::API::V3::Categories::CategoryModel, decorator: ::API::V3::Categories::CategoryRepresenter, if: -> (*) { !category.nil? }, writeable: false
+        property :category, embedded: true, decorator: ::API::V3::Categories::CategoryRepresenter, if: -> (*) { !category.nil? }, writeable: false
 
         property :activities, embedded: true, exec_context: :decorator, writeable: false
         property :watchers, embedded: true, exec_context: :decorator, if: -> (*) { current_user_allowed_to(:view_work_package_watchers, represented.model) }, writeable: false

--- a/spec/lib/api/v3/categories/category_collection_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_collection_representer_spec.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -29,36 +29,12 @@
 require 'spec_helper'
 
 describe ::API::V3::Categories::CategoryCollectionRepresenter do
-  let(:project)    { FactoryGirl.build(:project, id: 888) }
   let(:categories) { FactoryGirl.build_list(:category, 3) }
-  let(:models)     { categories.map { |category|
-    ::API::V3::Categories::CategoryModel.new(category)
-  } }
-  let(:representer) { described_class.new(models, project) }
-
-  describe '#initialize' do
-    context 'with incorrect parameters' do
-      it 'should raise without a project' do
-        expect { described_class.new(models) }.to raise_error(ArgumentError)
-      end
-    end
-  end
+  let(:representer) { described_class.new(categories, 42, '/api/v3/projects/1/categories') }
 
   context 'generation' do
-    subject(:generated) { representer.to_json }
+    subject(:collection) { representer.to_json }
 
-    it { should include_json('Categories'.to_json).at_path('_type') }
-
-    it { should have_json_type(Object).at_path('_links') }
-    it 'should link to self' do
-      expect(generated).to have_json_path('_links/self/href')
-      expect(parse_json(generated, '_links/self/href')).to match %r{/api/v3/projects/888/categories$}
-    end
-
-    describe 'categories' do
-      it { should have_json_path('_embedded/categories') }
-      it { should have_json_size(3).at_path('_embedded/categories') }
-      it { should have_json_path('_embedded/categories/2/name') }
-    end
+    it_behaves_like 'API V3 collection decorated', 42, 3, 'projects/1/categories', 'Category'
   end
 end

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -53,6 +53,9 @@ describe ::API::V3::Projects::ProjectRepresenter do
       it 'should link to self' do
         expect(subject).to have_json_path('_links/self/href')
       end
+      it 'should have a title for link to self' do
+        expect(subject).to have_json_path('_links/self/title')
+      end
 
       describe 'categories' do
         it { should have_json_path('_links/categories')      }

--- a/spec/lib/api/v3/support/api_v3_collection.rb
+++ b/spec/lib/api/v3/support/api_v3_collection.rb
@@ -1,7 +1,6 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,27 +26,26 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Categories
-      class CategoriesAPI < Grape::API
+require 'spec_helper'
 
-        resources :categories do
+shared_examples_for 'API V3 collection decorated' do |total, count, self_link, type|
+  it { expect(collection).to be_json_eql('Collection'.to_json).at_path('_type') }
 
-          namespace ':id' do
+  describe 'elements' do
+    it { expect(collection).to be_json_eql(type.to_json).at_path('_embedded/elements/0/_type') }
+  end
 
-            before do
-              @category = Category.find(params[:id])
-              authorize(:view_project, context: @category.project)
-            end
+  describe 'quantities' do
+    it { expect(collection).to be_json_eql(total.to_json).at_path('total') }
 
-            get do
-              CategoryRepresenter.new(@category)
-            end
-          end
-        end
+    it { expect(collection).to be_json_eql(count.to_json).at_path('count') }
 
-      end
-    end
+    it { expect(collection).to have_json_size(count).at_path('_embedded/elements') }
+  end
+
+  describe '_links' do
+    let(:href) { "/api/v3/#{self_link}".to_json }
+
+    it { expect(collection).to be_json_eql(href).at_path('_links/self/href') }
   end
 end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -1,0 +1,279 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Utilities::PathHelper do
+  let(:helper) { Class.new.tap { |c| c.extend(::API::V3::Utilities::PathHelper) }.api_v3_paths }
+
+  shared_examples_for 'api v3 path' do
+    it { is_expected.to match(/^\/api\/v3/) }
+  end
+
+  describe '#root' do
+    subject { helper.root }
+
+    it_behaves_like 'api v3 path'
+  end
+
+  describe '#activity' do
+    subject { helper.activity 1 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/activities\/1/) }
+  end
+
+  describe '#attachment' do
+    subject { helper.attachment 1 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/attachments\/1/) }
+  end
+
+  describe '#available_assignees' do
+    subject { helper.available_assignees 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/projects\/42\/available_assignees/) }
+  end
+
+  describe '#available_responsibles' do
+    subject { helper.available_responsibles 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/projects\/42\/available_responsibles/) }
+  end
+
+  describe '#available_watchers' do
+    subject { helper.available_watchers 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/available_watchers/) }
+  end
+
+  describe '#categories' do
+    subject { helper.categories 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/projects\/42\/categories/) }
+  end
+
+  describe '#category' do
+    subject { helper.category 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/categories\/42/) }
+  end
+
+  describe '#preview_textile' do
+    subject { helper.preview_textile '/api/v3/work_packages/42' }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/render\/textile/) }
+
+    it { is_expected.to match(/\?\/api\/v3\/work_packages\/42$/) }
+  end
+
+  describe '#priorities' do
+    subject { helper.priorities }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/priorities/) }
+  end
+
+  describe 'projects paths' do
+    describe '#projects' do
+      subject { helper.projects }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/projects/) }
+    end
+
+    describe '#project' do
+      subject { helper.project 1 }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/projects\/1/) }
+    end
+  end
+
+  describe '#query' do
+    subject { helper.query 1 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/queries\/1/) }
+  end
+
+  describe 'relations paths' do
+    describe '#relation' do
+      subject { helper.relation 1 }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/relations/) }
+    end
+
+    describe '#relation' do
+      subject { helper.relation 1 }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/relations\/1/) }
+    end
+  end
+
+  describe 'statuses paths' do
+    describe '#statuses' do
+      subject { helper.statuses }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/statuses/) }
+    end
+
+    describe '#status' do
+      subject { helper.status 1 }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to match(/^\/api\/v3\/statuses\/1/) }
+    end
+  end
+
+  describe '#user' do
+    subject { helper.user 1 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/users\/1/) }
+  end
+
+  describe '#version' do
+    subject { helper.version 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/versions\/42/) }
+  end
+
+  describe '#versions' do
+    subject { helper.versions 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/projects\/42\/versions/) }
+  end
+
+  describe '#versions_projects' do
+    subject { helper.versions_projects 42 }
+
+    it_behaves_like 'api v3 path'
+
+    it { is_expected.to match(/^\/api\/v3\/versions\/42\/projects/) }
+  end
+
+  describe 'work packages paths' do
+    shared_examples_for 'api v3 work packages path' do
+      it { is_expected.to match(/^\/api\/v3\/work_packages/) }
+    end
+
+    describe '#work_packages' do
+      subject { helper.work_packages }
+
+      it_behaves_like 'api v3 work packages path'
+    end
+
+    describe '#work_package' do
+      subject { helper.work_package 1 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/1/) }
+    end
+
+    describe '#work_package_activities' do
+      subject { helper.work_package_activities 42 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/activities/) }
+    end
+
+    describe '#work_package_relations' do
+      subject { helper.work_package_relations 42 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/relations/) }
+    end
+
+    describe '#work_package_relation' do
+      subject { helper.work_package_relation 1, 42 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/relations\/1/) }
+    end
+
+    describe '#work_package_form' do
+      subject { helper.work_package_form 1 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/1\/form/) }
+    end
+
+    describe '#work_package_watchers' do
+      subject { helper.work_package_watchers 1 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/1\/watchers/) }
+    end
+
+    describe '#watcher' do
+      subject { helper.watcher 1, 42 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/watchers\/1/) }
+    end
+  end
+end

--- a/spec/requests/api/v3/category_resource_spec.rb
+++ b/spec/requests/api/v3/category_resource_spec.rb
@@ -32,36 +32,55 @@ require 'rack/test'
 describe 'API v3 Category resource' do
   include Rack::Test::Methods
 
-  let(:current_user) { FactoryGirl.create(:user) }
-  let(:role) { FactoryGirl.create(:role, permissions: []) }
-  let(:project) { FactoryGirl.create(:project, is_public: false) }
-  let(:categories) { FactoryGirl.create_list(:category, 3, project: project) }
-  let(:other_categories) { FactoryGirl.create_list(:category, 2) }
+  let(:role) { FactoryGirl.create(:role, permissions: [:view_project]) }
+  let(:private_project) { FactoryGirl.create(:project, is_public: false) }
+  let(:public_project) { FactoryGirl.create(:project, is_public: true) }
+  let(:anonymous_user) { FactoryGirl.create(:user) }
+  let(:privileged_user) do
+    FactoryGirl.create(:user,
+                       member_in_project: private_project,
+                       member_through_role: role)
+  end
 
-  describe '#get' do
+  let!(:categories) { FactoryGirl.create_list(:category, 3, project: private_project) }
+  let!(:other_categories) { FactoryGirl.create_list(:category, 2, project: public_project) }
+  let!(:user_categories) do
+    FactoryGirl.create_list(:category,
+                            2,
+                            project: private_project,
+                            assigned_to: privileged_user)
+  end
+
+  describe 'categories by project' do
     subject(:response) { last_response }
 
     context 'logged in user' do
-      let(:get_path) { "/api/v3/projects/#{project.id}/categories" }
+      let(:get_path) { "/api/v3/projects/#{private_project.id}/categories" }
       before do
-        allow(User).to receive(:current).and_return current_user
-        member = FactoryGirl.build(:member, user: current_user, project: project)
-        member.role_ids = [role.id]
-        member.save!
-
-        categories
-        other_categories
+        allow(User).to receive(:current).and_return privileged_user
 
         get get_path
       end
 
-      it 'should respond with 200' do
-        expect(subject.status).to eq(200)
+      it_behaves_like 'API V3 collection response', 5, 5, 'Category'
+    end
+  end
+
+  describe 'categories/:id' do
+    subject(:response) { last_response }
+
+    context 'logged in user' do
+      let(:get_path) { "/api/v3/categories/#{other_categories.first.id}" }
+      before do
+        allow(User).to receive(:current).and_return privileged_user
+
+        get get_path
       end
 
-      it 'should respond with categories' do
-        expect(subject.body).to include_json('Categories'.to_json).at_path('_type')
-        expect(subject.body).to have_json_size(3).at_path('_embedded/categories')
+      context 'valid priority id' do
+        it 'should return HTTP 200' do
+          expect(response.status).to eql(200)
+        end
       end
     end
   end

--- a/spec/requests/api/v3/support/api_v3_collection_response.rb
+++ b/spec/requests/api/v3/support/api_v3_collection_response.rb
@@ -1,7 +1,6 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -27,27 +26,24 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Categories
-      class CategoriesAPI < Grape::API
+require 'spec_helper'
 
-        resources :categories do
+shared_examples_for 'API V3 collection response' do |total, count, type|
+  subject { response.body }
 
-          namespace ':id' do
+  it { expect(response.status).to eql(200) }
 
-            before do
-              @category = Category.find(params[:id])
-              authorize(:view_project, context: @category.project)
-            end
+  it { is_expected.to be_json_eql('Collection'.to_json).at_path('_type') }
 
-            get do
-              CategoryRepresenter.new(@category)
-            end
-          end
-        end
+  it { is_expected.to be_json_eql(count.to_json).at_path('count') }
 
-      end
+  it { is_expected.to be_json_eql(total.to_json).at_path('total') }
+
+  it { is_expected.to have_json_size(count) .at_path('_embedded/elements') }
+
+  it 'has element of specified type if elements exist' do
+    if count > 0
+      is_expected.to be_json_eql(type.to_json).at_path('_embedded/elements/0/_type')
     end
   end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19759
public WP: https://community.openproject.org/work_packages/19809
## Description

This PR adds category filters to the WP list. Those filters were available before and simply forgotten to implement.

For better forwards compatibility I did not invent an experimental API endpoint for categories, but used the one introduced in release 4.1. That involved some backporting, see the notes below.
## :warning: :warning: :warning:  Important notes :warning: :warning: :warning:

Commit https://github.com/opf/openproject/commit/23e7b113c4af39f76d1cd733aeb808521c0a1806 contains lots of code that was backported from `release/4.1`.

You should merge that **commit** (read: not the PR, but the sole commit) into the `release/4.1` branch using the `ours` strategy:

```
git checkout release/4.1
git merge -s ours 23e7b113c4af39f76d1cd733aeb808521c0a1806 -m "Resolving forward-merge of backport commit"
```

The afforementioned commit contains things like ridicuously simplified specs (to have basic specs, but to not let them fail or backport them in a 4.0 compatible manner; e.g. error cases).
It should be considered poisonous for everything else, but the `release/4.0` branch.

The rest of this PR can be merged safely and should not contain unhealthy ingredients.
