### PR TITLE
Don't fail WP schema spec for unexpected method call

### DIFF
--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -221,6 +221,9 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
     describe 'spentTime' do
       before do
+        # don't fail the test for other allowed_to calls than the expected ones
+        allow(current_user).to receive(:allowed_to?).and_return false
+
         allow(current_user).to receive(:allowed_to?).with(:view_time_entries, work_package.project)
           .and_return true
       end


### PR DESCRIPTION
This is part routine house keeping (https://community.openproject.org/work_packages/18714), but also caused some trouble while running specs with the costs plugin enabled.
## Description

The spec was too strict in that any call to `user.allowed_to?` with a parameter different from `:view_time_entries` would fail the test.

However, it is allowed to call this method as often and with all the parameters you like. What the test _meant_ to say was: If the method is called with _specific params_, then please mock me _specific behaviour_ so that I can verify my assertions.

The test did not intend to change the _general behaviour_.
