### PR TITLE
Allow whitespace in username (for LDAP)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < Principal
   validates_uniqueness_of :login, :if => Proc.new { |user| !user.login.blank? }, :case_sensitive => false
   validates_uniqueness_of :mail, :allow_blank => true, :case_sensitive => false
   # Login must contain letters, numbers, underscores only
-  validates_format_of :login, :with => /\A[a-z0-9_\-@\.]*\z/i
+  validates_format_of :login, :with => /\A[a-z0-9_\-@\.\s]*\z/i
   validates_length_of :login, :maximum => 256
   validates_length_of :firstname, :lastname, :maximum => 30
   validates_format_of :mail, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :allow_blank => true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,7 +144,6 @@ class User < Principal
 
   validates_uniqueness_of :login, :if => Proc.new { |user| !user.login.blank? }, :case_sensitive => false
   validates_uniqueness_of :mail, :allow_blank => true, :case_sensitive => false
-  # Login must contain letters, numbers, underscores only
   validates_format_of :login, :with => /\A[a-z0-9_\-@\. ]*\z/i
   validates_length_of :login, :maximum => 256
   validates_length_of :firstname, :lastname, :maximum => 30

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < Principal
   validates_uniqueness_of :login, :if => Proc.new { |user| !user.login.blank? }, :case_sensitive => false
   validates_uniqueness_of :mail, :allow_blank => true, :case_sensitive => false
   # Login must contain letters, numbers, underscores only
-  validates_format_of :login, :with => /\A[a-z0-9_\-@\.\s]*\z/i
+  validates_format_of :login, :with => /\A[a-z0-9_\-@\. ]*\z/i
   validates_length_of :login, :maximum => 256
   validates_length_of :firstname, :lastname, :maximum => 30
   validates_format_of :mail, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :allow_blank => true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,7 +72,48 @@ describe User, :type => :model do
       user.login = 'a' * 257
       expect(user.save).to be_falsey
     end
+  end
 
+  describe 'login whitespace' do
+    before do
+      user.login = login
+    end
+
+    context 'simple spaces' do
+      let(:login) { 'a b  c' }
+
+      it 'is valid' do
+        expect(user).to be_valid
+      end
+
+      it 'may be stored in the database' do
+        expect(user.save).to be_truthy
+      end
+    end
+
+    context 'line breaks' do
+      let(:login) { 'ab\nc' }
+
+      it 'is invalid' do
+        expect(user).not_to be_valid
+      end
+
+      it 'may not be stored in the database' do
+        expect(user.save).to be_falsey
+      end
+    end
+
+    context 'tabs' do
+      let(:login) { 'ab\tc' }
+
+      it 'is invalid' do
+        expect(user).not_to be_valid
+      end
+
+      it 'may not be stored in the database' do
+        expect(user.save).to be_falsey
+      end
+    end
   end
 
 


### PR DESCRIPTION
## OpenProject Work package

https://community.openproject.org/work_packages/17835
## Description

This is a follow-up PR on https://github.com/opf/openproject/pull/2475 and intends to fix LDAP issues with usernames that contain whitespace.
