### PR TITLE
Enforce eqeqeq option in jshint

### DIFF
--- a/frontend/.jshintrc
+++ b/frontend/.jshintrc
@@ -52,5 +52,6 @@
   "quotmark": true,
   "sub": true,
   "undef": true,
-  "unused": true
+  "unused": true,
+  "eqeqeq": true
 }


### PR DESCRIPTION
This will enforce the use of `===` and `!==` in favour of `==` and `!=`.

From the[ options](http://jshint.com/docs/options/) of `jshint`:

> This options prohibits the use of == and != in favor of === and !==. The former try to coerce values before comparing them which can lead to some unexpected results. The latter don't do any coercion so they are generally safer. If you would like to learn more about type coercion in JavaScript, we recommend Truth, Equality and JavaScript by Angus Croll.

This can be considered [Housekeeping](https://community.openproject.org/work_packages/18714)
