### PR TITLE
Revert "Temp. silence deprecation warnings in test env"

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -69,7 +69,7 @@ OpenProject::Application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :silence
+  config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
This reverts commit d4444cfe5ed82dd921d134696703cf1ad633e43a.

Duplication warning says behavior change.
You should remove deprecation warnings at first.
