### PR TITLE
[19866] Fix project overview

### DIFF
--- a/app/assets/stylesheets/content/_my_page.sass
+++ b/app/assets/stylesheets/content/_my_page.sass
@@ -46,6 +46,15 @@ div.box-actions
   margin-bottom: 20px
   padding: 15px 0 15px 0
 
+  #visible-grid &
+    @extend .grid-content
+    min-height: 32px
+    // TODO: this fixes an issue which currently breaks the layout
+    // It has to be removed once it is fixed upstream
+    // @see https://github.com/zurb/foundation-apps/issues/575
+    &.left, &.right
+      @extend .medium-6
+
   div.mypage-box
     margin-top: 8px
     padding-bottom: 8px


### PR DESCRIPTION
:warning: **This will only work in conjunction with https://github.com/finnlabs/openproject-my_project_page/pull/38**

This moves some dependent classes for the my project page plugin into core. This should resolve some issues on the project overview page which have been caused by wrongly re-importing foundation. 
