### PR TITLE
Allow bypassing basic auth for repository access authorization

### DIFF
--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -101,15 +101,19 @@ class SysController < ActionController::Base
   private
 
   def require_basic_auth
-    @authenticated_user =
+    @authenticated_user = get_authenticated_user
+    render_authorization_required unless @authenticated_user.present?
+  end
+
+  ##
+  # Returns the authenticated user from the auth dialog.
+  def get_authenticated_user
     if Setting.repository_authentication_bypass?
       find_user_from_basic_auth
     else
       # Authenticate the user internally
       perform_basic_auth
     end
-
-    render_authorization_required unless @authenticated_user.present?
   end
 
   ##

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -37,6 +37,11 @@ See doc/COPYRIGHT.rdoc for more details.
                                         :label => :setting_mail_handler_api_key %>
       <span class="form--field-extra-actions">
         <%= link_to_function l(:label_generate_key), "if ($('settings_sys_api_key').disabled == false) { $('settings_sys_api_key').value = randomKey(20) }" %>
+        <p><%= setting_check_box :repository_authentication_bypass %>
+          <br/><em><%= l('settings.repositories.authentication_bypass_desc') %>
+          <br/><strong><%= l(:warning) %></strong>
+          <em><%= l('settings.repositories.authentication_bypass_warning') %>
+        </p>
       </span>
     </div>
     <div class="form--field"><%= setting_multiselect(:enabled_scm, Redmine::Scm::Base.configured) %></div>

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -37,12 +37,15 @@ See doc/COPYRIGHT.rdoc for more details.
                                         :label => :setting_mail_handler_api_key %>
       <span class="form--field-extra-actions">
         <%= link_to_function l(:label_generate_key), "if ($('settings_sys_api_key').disabled == false) { $('settings_sys_api_key').value = randomKey(20) }" %>
-        <p><%= setting_check_box :repository_authentication_bypass %>
-          <br/><em><%= l('settings.repositories.authentication_bypass_desc') %>
-          <br/><strong><%= l(:warning) %></strong>
-          <em><%= l('settings.repositories.authentication_bypass_warning') %>
-        </p>
       </span>
+    </div>
+    <div class="form--field">
+        <%= setting_check_box :repository_authentication_bypass %>
+        <span class="form--field-extra-actions">
+          <em><%= l('settings.repositories.authentication_bypass_desc') %>
+          <br/><strong><%= l(:warning) %>:</strong>
+          <em><%= l('settings.repositories.authentication_bypass_warning') %>
+        </span>
     </div>
     <div class="form--field"><%= setting_multiselect(:enabled_scm, Redmine::Scm::Base.configured) %></div>
     <div class="form--field">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1300,6 +1300,7 @@ en:
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_repositories_encodings: "Repositories encodings"
+  setting_repository_authentication_bypass: "Bypass Basic Auth authentication"
   setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_rest_api_enabled: "Enable REST web service"
@@ -1328,6 +1329,9 @@ en:
     passwords: "Passwords"
     session: "Session"
     brute_force_prevention: "Automated user blocking"
+    repositories:
+      authentication_bypass_desc: "Use this setting if you authenticate users for repository access using your web server."
+      authentication_bypass_warning: "If you enable this, make sure to restrict access to the internal /sys API to local access."
 
   show_hide_project_menu: "Hide/Show project menu"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1300,7 +1300,7 @@ en:
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_repositories_encodings: "Repositories encodings"
-  setting_repository_authentication_bypass: "Bypass Basic Auth authentication"
+  setting_repository_authentication_bypass: "Bypass API Basic Auth"
   setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_rest_api_enabled: "Enable REST web service"
@@ -1330,7 +1330,7 @@ en:
     session: "Session"
     brute_force_prevention: "Automated user blocking"
     repositories:
-      authentication_bypass_desc: "Use this setting if you authenticate users for repository access using your web server."
+      authentication_bypass_desc: "Bypass Basic Auth authentication on the repository API. Use this setting if you authenticate users for repository access using your web server."
       authentication_bypass_warning: "If you enable this, make sure to restrict access to the internal /sys API to local access."
 
   show_hide_project_menu: "Hide/Show project menu"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -135,6 +135,9 @@ sys_api_key:
   default: ''
 repository_authentication_caching_enabled:
   default: 1
+repository_authentication_bypass:
+  default: 0
+commit_ref_keywords:
 commit_ref_keywords:
   default: 'refs,references,IssueID'
 commit_fix_keywords:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,7 +138,6 @@ repository_authentication_caching_enabled:
 repository_authentication_bypass:
   default: 0
 commit_ref_keywords:
-commit_ref_keywords:
   default: 'refs,references,IssueID'
 commit_fix_keywords:
   default: 'fixes,closes'

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -42,6 +42,7 @@ module OpenProjectRepositoryAuthenticationSpecs
                                 password: valid_user_password,
                                 password_confirmation: valid_user_password)
     }
+    let(:auth_bypass) { false }
 
     before(:each) do
       FactoryGirl.create(:non_member, permissions: [:browse_repository])
@@ -53,6 +54,7 @@ module OpenProjectRepositoryAuthenticationSpecs
                                             project: random_project)
       allow(Setting).to receive(:sys_api_key).and_return('12345678')
       allow(Setting).to receive(:sys_api_enabled?).and_return(true)
+      allow(Setting).to receive(:repository_authentication_bypass?).and_return(auth_bypass)
       allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(true)
     end
 
@@ -126,13 +128,37 @@ module OpenProjectRepositoryAuthenticationSpecs
       it 'should respond 401 auth required' do
         expect(response.code).to eq('401')
       end
+
+      context 'with authentication bypass' do
+        let(:auth_bypass) { true }
+        it 'should respond 200 okay dokay for POST' do
+          expect(response.code).to eq('200')
+        end
+      end
+    end
+
+    describe :repo_auth, 'for missing username' do
+      before(:each) do
+        @key = Setting.sys_api_key
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('invalid_user', 'an invalid password')
+        post 'repo_auth',  key: @key, repository: 'any-repo', method: 'GET'
+      end
+
+      context 'with authentication bypass' do
+        let(:auth_bypass) { true }
+        it 'should respond with 401' do
+          expect(response.code).to eq('401')
+          expect(response.body).to eq('Authorization required')
+        end
+      end
     end
 
     describe '#repo_auth', 'for valid login and user is not member for project' do
       before(:each) do
         @key = Setting.sys_api_key
         @project = FactoryGirl.create(:project, is_public: false)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic
+          .encode_credentials(valid_user.login, valid_user_password)
         post 'repo_auth',  key: @key, repository: @project.identifier, method: 'GET'
       end
 
@@ -169,6 +195,14 @@ module OpenProjectRepositoryAuthenticationSpecs
       it 'should respond 401 auth required' do
         expect(response.code).to eq('401')
         expect(response.body).to eq('Authorization required')
+      end
+
+      context 'with authentication bypass' do
+        let(:auth_bypass) { true }
+        it 'should still respond with 401' do
+          expect(response.code).to eq('401')
+          expect(response.body).to eq('Authorization required')
+        end
       end
     end
 

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -140,8 +140,11 @@ module OpenProjectRepositoryAuthenticationSpecs
     describe :repo_auth, 'for missing username' do
       before(:each) do
         @key = Setting.sys_api_key
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('invalid_user', 'an invalid password')
-        post 'repo_auth',  key: @key, repository: 'any-repo', method: 'GET'
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials('invalid_user', 'an invalid password')
+
+        post 'repo_auth', key: @key, repository: 'any-repo', method: 'GET'
       end
 
       context 'with authentication bypass' do
@@ -157,8 +160,10 @@ module OpenProjectRepositoryAuthenticationSpecs
       before(:each) do
         @key = Setting.sys_api_key
         @project = FactoryGirl.create(:project, is_public: false)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic
           .encode_credentials(valid_user.login, valid_user_password)
+
         post 'repo_auth',  key: @key, repository: @project.identifier, method: 'GET'
       end
 


### PR DESCRIPTION
This is a follow-up of https://github.com/opf/openproject/pull/2449, as GitHub decided to mark my (very much existing) fork as `unknown repository` which I can no longer push to. Oh well.

---

In our use-case, we use RADIUS to authorize users through Apache
in combination with an OmniAuth strategy.

Thus, we do not have an active authentication source to
perform basic auth against and cannot use the existing `OpenProjectAuthentication.pm` Apache wrapper.

This commit adds an optional setting to allow bypassing
basic auth in the SysController.
The setting is placed right beside the API key (cf. screenshot below).

![op_bypass](https://cloud.githubusercontent.com/assets/459462/7410198/f1a1812a-ef2c-11e4-872f-18f61169ebe9.png)

If the checkbox is checked, the surrounding web server is responsible for authentication. The sys API endpoint will still initiate a Basic Auth, however any password input is disregarded.

I agree that this workaround feels rather hacky. An alternative solution that we might discuss is to remove basic auth completely for the bypass, and instead use a GET parameter alongside repository and key to set the user for which access rights are determined.

However, putting any more efforts regarding authentication wrappers are questionable with the ongoing discussion and dire need to refactor the entire repository handling in OpenProject.

When authorizing the user directly in the web server,
passing the logged in user to SysController is sufficient
to retrieve the project permissions.

I suggest this as a temporary solution until the general issue of repositories and external authentication is resolved, as its discussion is still heavily ongoing.

The relevant work package:
https://community.openproject.org/work_packages/18356
