### PR TITLE
[19759] Remove the max height for advanced filters

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -29,7 +29,6 @@
 .advanced-filters--container
   @extend %filters--container
   padding: rem-calc(10px)
-  max-height: 250px
   overflow-y: auto
 
 @mixin advanced-filters--sizing()


### PR DESCRIPTION
This removes the maximum height for advanced filters as requested in https://community.openproject.org/work_packages/19579.

Altough personally disliking it very much, this will allow for behavior similar to `release/4.0` where unrestricted growth of the filter section is allowed.

New view:

![screenshot from 2015-04-30 14 17 01](https://cloud.githubusercontent.com/assets/498241/7412516/fa96c4a4-ef43-11e4-87a1-41a32c6b2944.png)
