### PR TITLE
[19768] Flipped arrow

### DIFF
--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -45,7 +45,7 @@ an attachments_attributes= and not every model supports this we build a nested f
   <legend class="form--fieldset-legend" title="<%=l(:description_attachment_toggle)%>" onclick="toggleFieldset(this);">
     <a href="javascript:"><%=l(:label_attachment_plural)%></a>
   </legend>
-  <div <%= 'style="display: none;"' unless open %>>
+  <div <%= "style=\"display: none;\"".html_safe unless open %>>
     <div id="attachments_fields">
       <div class="grid-block" id="attachment_template">
         <div class="form--field">


### PR DESCRIPTION
This PR inverts the arrow for the Files tab in the legacy work package form to achieve a more consistent experience with the rest of the sections (e.g. "Log time")

This should meet the requirements of https://community.openproject.org/work_packages/19768
