### PR TITLE
[19577] Remove red box shadow in Firefox required fields

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -61,6 +61,8 @@
 
 .advanced-filters--text-field
   @extend .form--text-field, .form--text-field.-small
+  &:required
+    box-shadow: none
 
 .advanced-filters--select
   @extend .form--select, .form--select.-small, .form--select.-narrow


### PR DESCRIPTION
This PR removes the red box shadow that is the default for HTML5 required fields

It corrects an issue that only occurs in Firefox:

![image](https://cloud.githubusercontent.com/assets/498241/7414051/6849af32-ef50-11e4-987b-6af1809d9973.png)

Meets the requirements of https://community.openproject.org/work_packages/19577.
