### PR TITLE
[16769] Truncate the assignee name in Work package list

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -92,9 +92,6 @@ tr
       &.category
         white-space: normal
 
-td.assigned_to
-  white-space: normal
-
 tr.issue
   td
     &.subject
@@ -135,9 +132,6 @@ tr
       white-space: normal
   &.issue td.category
     white-space: normal
-
-td.assigned_to
-  white-space: normal
 
 tr.work-package
   td


### PR DESCRIPTION
Restores the default behaviour for the whitespace property in the "assigned to"
column.

New view:

![screenshot from 2015-04-30 16 25 17](https://cloud.githubusercontent.com/assets/498241/7414850/8e390dd2-ef55-11e4-819a-baa779419dd0.png)

Meets the requirements of https://community.openproject.org/work_packages/16769
