### PR TITLE
[19759] Use viewport height to restrict filters in WP List

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -29,7 +29,7 @@
 .advanced-filters--container
   @extend %filters--container
   padding: rem-calc(10px)
-  max-height: 250px
+  max-height: 50vh
   overflow-y: auto
 
 @mixin advanced-filters--sizing()


### PR DESCRIPTION
This PR also addresses the requirements of https://community.openproject.org/work_packages/19579.

These issues have already been addressed in #2943, but this could provide a better solution to the problem.
