### PR TITLE
[19799] Realign subject in work package details pane

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -259,6 +259,6 @@ a.inplace-editing--trigger-link,
       margin-top: auto
 
 // this aligns the title for the WP
-.work-packages--details-content > .work-packages--details--title
+.work-packages--details--title
   margin-left: -0.375rem
 

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -257,3 +257,8 @@ a.inplace-editing--trigger-link,
     // which in textile is shown due to edit buttons on the right side
     &.edit-strategy-textarea
       margin-top: auto
+
+// this aligns the title for the WP
+.work-packages--details-content > .work-packages--details--title
+  margin-left: -0.375rem
+


### PR DESCRIPTION
This PR should meet the requirements of https://community.openproject.org/work_packages/19799 andd realign the subject of the details pane with the rest of the headings:

![image](https://cloud.githubusercontent.com/assets/498241/7416140/8d55918a-ef5d-11e4-87d3-62f0c682f4f8.png)

I'll be honest, this is the easy way out - as @NobodysNightmare pointed out to me correctly, we should probably expand the boxes more when an `inplace-edit` enabled field is focused. 

However, this would mean a lot more changes to the styling which could lead to potential issues later on*, so this is only a fix for the special case of the subject in the details pane.

If this quick fix is not enough we should discuss other options.

---
- We will probably reuse these styles later on
