### PR TITLE
fix factoryGirl screws up rake db:migrate process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,7 +128,7 @@ group :test do
   gem 'shoulda'
   gem 'object-daddy', '~> 1.1.0'
   gem "launchy", "~> 2.3.0"
-  gem "factory_girl_rails", "~> 4.5"
+  gem "factory_girl_rails", "~> 4.5", :require => false
   gem 'cucumber-rails', "~> 1.4.2", :require => false
   gem 'rack_session_access'
   # restrict because in version 1.3 a lot of tests using acts as journalized

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'rspec/example_disabler'
 require 'capybara/rails'
+require 'factory_girl_rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'fileutils'
 require 'rspec/mocks'
+require 'factory_girl_rails'
 
 require File.expand_path(File.dirname(__FILE__) + '/helper_testcase')
 


### PR DESCRIPTION
$ rake db:migrate RAILS_ENV=test

rake aborted!
ActiveRecord::StatementInvalid: Could not find table 'work_package_journals'

http://stackoverflow.com/questions/12423273/factorygirl-screws-up-rake-dbmigrate-process
