### PR TITLE
Fix setting large durations via details pane

### DIFF
--- a/frontend/app/global.js
+++ b/frontend/app/global.js
@@ -47,9 +47,9 @@ require('jquery-ui/themes/base/jquery.ui.datepicker.css');
 // TODO: move require to backlogs plugin
 require('jquery-ui/themes/base/jquery.ui.dialog.css');
 
-require('momentjs');
-require('momentjs/lang/en-gb.js');
-require('momentjs/lang/de.js');
+require('moment');
+require('moment/locale/en-gb.js');
+require('moment/locale/de.js');
 
 require('moment-timezone/moment-timezone.js');
 require('moment-timezone/moment-timezone-data.js');

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -18,8 +18,8 @@
     "angular-truncate": "sparkalow/angular-truncate#fdf60fda265042d12e9414b5354b2cc52f1419de",
     "angular-feature-flags": "mjt01/angular-feature-flags",
     "jquery-migrate": "~1.2.1",
-    "momentjs": "~2.7.0",
-    "moment-timezone": "~0.2.0",
+    "moment": "finnlabs/moment#9bc879e7b146c484b499b3135b8d84e8425f8ec4",
+    "moment-timezone": "~0.3.1",
     "angular-context-menu": "nickmessing/angular-context-menu#a908eccaec323cd66973d58af4965694bdff16a1",
     "angular-busy": "~4.1.1",
     "hyperagent": "manwithtwowatches/hyperagent#v0.4.2",
@@ -39,6 +39,7 @@
     "select2": "3.3.2",
     "jquery": "1.11.0",
     "angular": "1.3.14",
-    "angular-animate": "1.3.14"
+    "angular-animate": "1.3.14",
+    "moment": "9bc879e7b146c484b499b3135b8d84e8425f8ec4"
   }
 }


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19876
## Description

This PR fixes issues when trying to set durations greater 720 hours via details pane.
The reason for that is on the one hand that moment.js converts _720 hours_ to _one month_ in its ISO representation. Our backend library to parse ISO durations on the other hand parses _one month_ as _730 hours_, which happens to be 30 days and 10 hours.

I am not sure if the behaviour of the backend library is correct here, however, I am quite certain that the initial conversion of _720 hours_ to _one month_ is in itself invalid:
1. By definition of ISO durations you can't simply convert from hours to days, because when there is a clock change in the meantime `PT24H` is different from `P1D` (also: leap seconds)
2. It is not possible to convert between days and months without context (e.g. without know a start date). Simply dividing the days by 30 gives an approximation, but no exact results
## How is the problem solved?

On the OpenProject side this PR uses a custom built version of moment.js. This custom build is moment.js version 2.10.2 with the following PR already applied: https://github.com/moment/moment/pull/2357

The afforementioned PR fixes the "bubbling" of units (e.g. 60 seconds becoming one minute) by stopping the bubbling at the level of hours and at the level of days when generating ISO representations.

I hope that the PR will be merged upstream, so that we can later go back to the official build of moment.js and don't need to maintain our own build of it.
