### PR TITLE
[19871] Fix mypage rendering

### DIFF
--- a/app/assets/stylesheets/content/_my_page.sass
+++ b/app/assets/stylesheets/content/_my_page.sass
@@ -41,6 +41,15 @@ div.box-actions
   margin-right: 16px
   z-index: 500
 
+#invisible-grid
+
+  #list-top
+    padding: 0 4px
+  #list-right
+    padding: 0 4px 0 10px
+  #list-left
+    padding: 0 10px 0px
+
 .block-receiver
   border: 1px dashed $my-page-edit-box-border-color
   margin-bottom: 20px

--- a/app/views/my/page.html.erb
+++ b/app/views/my/page.html.erb
@@ -27,37 +27,43 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% breadcrumb_paths(l(:label_my_page)) %>
-<% content_for :action_menu_specific do %>
-  <%= link_to l(:label_personalize_page), { action: 'page_layout' }, accesskey: accesskey(:edit) %>
+<% content_for :toolbar do %>
+  <li class="toolbar-item">
+    <%= link_to({ action: 'page_layout' }, accesskey: accesskey(:edit), class: 'button') do %>
+      <i class="icon-edit"></i> <%= l(:label_personalize_page) %>
+    <% end %>
+  </li>
 <% end %>
 <h2><%=l(:label_my_page)%></h2>
-<%= render :partial => 'layouts/action_menu_specific' %>
-<div class="grid-block">
-  <div id="list-top" class="grid-content">
-    <% @blocks['top'].each do |b|
-       next unless MyController.available_blocks.keys.include? b  %>
-      <div class="mypage-box">
-        <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
-      </div>
-    <% end if @blocks['top'] %>
+<%= render :partial => 'layouts/toolbar' %>
+<div id="invisible-grid">
+  <div class="grid-block">
+    <div id="list-top" class="grid-content">
+      <% @blocks['top'].each do |b|
+         next unless MyController.available_blocks.keys.include? b  %>
+        <div class="mypage-box">
+          <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
+        </div>
+      <% end if @blocks['top'] %>
+    </div>
   </div>
-</div>
-<div class="grid-block">
-  <div id="list-left" class="grid-content">
-    <% @blocks['left'].each do |b|
-       next unless MyController.available_blocks.keys.include? b %>
-      <div class="mypage-box">
-        <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
-      </div>
-    <% end if @blocks['left'] %>
-  </div>
-  <div id="list-right" class="grid-content">
-    <% @blocks['right'].each do |b|
-       next unless MyController.available_blocks.keys.include? b %>
-      <div class="mypage-box">
-        <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
-      </div>
-    <% end if @blocks['right'] %>
+  <div class="grid-block">
+    <div id="list-left" class="grid-content">
+      <% @blocks['left'].each do |b|
+         next unless MyController.available_blocks.keys.include? b %>
+        <div class="mypage-box">
+          <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
+        </div>
+      <% end if @blocks['left'] %>
+    </div>
+    <div id="list-right" class="grid-content">
+      <% @blocks['right'].each do |b|
+         next unless MyController.available_blocks.keys.include? b %>
+        <div class="mypage-box">
+          <%= render :partial => "my/blocks/#{b}", :locals => { :user => @user } %>
+        </div>
+      <% end if @blocks['right'] %>
+    </div>
   </div>
 </div>
 <% html_title(l(:label_my_page)) -%>

--- a/app/views/my/page_layout.html.erb
+++ b/app/views/my/page_layout.html.erb
@@ -88,30 +88,57 @@ See doc/COPYRIGHT.rdoc for more details.
   <li><%= link_to l(:button_back), {:action => 'page'}, :class => 'icon icon-cancel' %></li>
 <% end %>
 
+<% content_for :toolbar do %>
+    <li class="toolbar-item">
+      <%= styled_form_tag({:action => "add_block"}, :id => "block-form") do %>
+        <%= styled_select_tag 'block', "<option>--#{t(:button_add)}--</option>".html_safe + options_for_select(@block_options),
+              :id => "block-select",
+              class: '-small' %>
+      <% end %>
+    </li>
+    <li class="toolbar-item">
+      <%= link_to_remote l(:button_add),
+                       {:url => { :action => "add_block" },
+                        :with => "Form.serialize('block-form')",
+                        :update => "list-top",
+                        :position => :top,
+                        :complete => "afterAddBlock();"
+                       }, :class => 'button'
+                         %>
+    </li>
+  <li class="toolbar-item">
+    <%= link_to({action: 'page'}, class: 'button') do %>
+      <i class="icon-cancel"></i> <%= l(:button_back) %>
+    <% end %>
+  </li>
+<% end %>
+
 <h2><%=l(:label_my_page)%></h2>
 
-<%= render :partial => 'layouts/action_menu_specific' %>
+<%= render :partial => 'layouts/toolbar' %>
 
-<div class="grid-block">
-  <div id="list-top" class="grid-content block-receiver">
-    <% @blocks['top'].each do |b|
-       next unless MyController.available_blocks.keys.include? b %>
-      <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
-    <% end if @blocks['top'] %>
+<div id="visible-grid">
+  <div class="grid-block">
+    <div id="list-top" class="grid-content block-receiver">
+      <% @blocks['top'].each do |b|
+         next unless MyController.available_blocks.keys.include? b %>
+        <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
+      <% end if @blocks['top'] %>
+    </div>
   </div>
-</div>
-<div class="grid-block">
-  <div id="list-left" class="grid-content block-receiver">
-    <% @blocks['left'].each do |b|
-       next unless MyController.available_blocks.keys.include? b %>
-      <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
-    <% end if @blocks['left'] %>
-  </div>
-  <div id="list-right" class="grid-content block-receiver">
-    <% @blocks['right'].each do |b|
-       next unless MyController.available_blocks.keys.include? b %>
-      <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
-    <% end if @blocks['right'] %>
+  <div class="grid-block">
+    <div id="list-left" class="grid-content block-receiver">
+      <% @blocks['left'].each do |b|
+         next unless MyController.available_blocks.keys.include? b %>
+        <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
+      <% end if @blocks['left'] %>
+    </div>
+    <div id="list-right" class="grid-content block-receiver">
+      <% @blocks['right'].each do |b|
+         next unless MyController.available_blocks.keys.include? b %>
+        <%= render :partial => 'block', :locals => {:user => @user, :block_name => b} %>
+      <% end if @blocks['right'] %>
+    </div>
   </div>
 </div>
 <%= sortable_element 'list-top',

--- a/app/views/my/page_layout.html.erb
+++ b/app/views/my/page_layout.html.erb
@@ -64,29 +64,6 @@ See doc/COPYRIGHT.rdoc for more details.
   }
   //]]>
 </script>
-<% content_for :action_menu_specific do %>
-  <li>
-    <%= form_tag({:action => "add_block"}, :id => "block-form") do %>
-      <span class="legacy-actions--inline-label">
-        <%= label_tag('block-select', "#{l(:label_my_page_block)}:", class: 'form-label -transparent') %>
-        <%= select_tag 'block', "<option></option>".html_safe + options_for_select(@block_options),
-              :id => "block-select",
-              class: 'form--select -small' %>
-        <span>
-          <%= link_to_remote l(:button_add),
-                     {:url => { :action => "add_block" },
-                      :with => "Form.serialize('block-form')",
-                      :update => "list-top",
-                      :position => :top,
-                      :complete => "afterAddBlock();"
-                     }, :class => 'icon icon-add'
-                       %>
-        </span>
-      </span>
-    <% end %>
-  </li>
-  <li><%= link_to l(:button_back), {:action => 'page'}, :class => 'icon icon-cancel' %></li>
-<% end %>
 
 <% content_for :toolbar do %>
     <li class="toolbar-item">


### PR DESCRIPTION
This should realign the "personalized my page" styles with the project overview. It also will provide core styles for the `my_project_page` plugin.

The `toolbar` component is now used on `my page` - in _the near future_ we should move the `my_project_page` plugin into core, as there is still a lot of duplication in there (e.g. the plugin implements the grid functionality via `prototype.Sortable` again)
