### PR TITLE
Prevent the jumping of selects when focusing

### DIFF
--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
              :html => {:id => "members_add_form"}) do |f| %>
   <div class="form--section">
     <h3 class="form--section-title"><%= l(:label_member_new) %></h3>
-    <div class="grid-block">
+    <div class="grid-block medium-up-2">
       <div class="form--column">
         <div class="form--field">
           <%= styled_label_tag :principal_search, l(:label_principal_search) %>

--- a/app/views/members/_member_form_non_impaired.html.erb
+++ b/app/views/members/_member_form_non_impaired.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
                      :html => {:id => "members_add_form"}) do |f| %>
   <div class="form--section">
     <h3 class="form--section-title"><%= l(:label_member_new) %></h3>
-    <div class="grid-block">
+    <div class="grid-block medium-up-2">
       <div class="form--column">
         <div class="form--field -vertical">
           <%= styled_label_tag :member_user_ids, l(:label_principal_search) %>


### PR DESCRIPTION
This will prevent the "jumping" (changing the width of the outer column) of the members tab in Project Settings when focusing either select box.

The issue here again is a bug in foundation.
