### PR TITLE
fix positions of timelines icons

### DIFF
--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -114,56 +114,51 @@ li.select2-result.select2-visible-selected-parent
 .tl-toolbar-container *
   vertical-align: bottom
 
-.tl-icon-postponed, .tl-icon-preponed, .tl-icon-added, .tl-icon-deleted, .tl-icon-changed, .tl-icon-calendar, .tl-icon-zoomin, .tl-icon-zoomout, .tl-icon-outline
-  background-position: 0% 50%
+.tl-icon-postponed,
+.tl-icon-preponed,
+.tl-icon-added,
+.tl-icon-deleted,
+.tl-icon-changed,
+.tl-icon-calendar,
+.tl-icon-zoomin,
+.tl-icon-zoomout,
+.tl-icon-outline
+  background-position: left center
   background-repeat: no-repeat
   padding-left: 19px
-  padding-top: 2px
-  padding-bottom: 3px
 
 .tl-icon-postponed
   cursor: default
-  background: image-url("bullet_red.png") no-repeat center
+  background-image: image-url("bullet_red.png")
 
 .tl-icon-preponed
   cursor: default
-  background: image-url("bullet_green.png") no-repeat center
+  background-image: image-url("bullet_green.png")
 
 .tl-icon-added
   cursor: default
-  background: image-url("added.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("added.png")
 
 .tl-icon-deleted
   cursor: default
-  background: image-url("webalys/deleted.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("webalys/deleted.png")
 
 .tl-icon-changed
   cursor: default
-  background: image-url("webalys/arrow_left_right.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("webalys/arrow_left_right.png")
 
 .tl-icon-calendar
   cursor: default
-  background: image-url("webalys/calendar.png") no-repeat center
-  display: inline
-  width: 16px
+  background-image: image-url("webalys/calendar.png")
 
 .tl-icon-zoomin
-  background: image-url("webalys/zoom_in.png") no-repeat center
+  background-image: image-url("webalys/zoom_in.png")
 
 .tl-icon-zoomout
-  background: image-url("webalys/zoom_out.png") no-repeat center
+  background-image: image-url("webalys/zoom_out.png")
 
 .tl-icon-outline
-  background: image-url("webalys/outline.png") no-repeat center
+  background-image: image-url("webalys/outline.png")
 
 /* ╭───────────────────────────────────────────────────────────────────╮ *
  * │ Timeline tree                                                     │ *

--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -123,42 +123,28 @@ li.select2-result.select2-visible-selected-parent
 .tl-icon-zoomin,
 .tl-icon-zoomout,
 .tl-icon-outline
+  cursor: default
   background-position: left center
   background-repeat: no-repeat
   padding-left: 19px
 
 .tl-icon-postponed
-  cursor: default
   background-image: image-url("bullet_red.png")
 
 .tl-icon-preponed
-  cursor: default
   background-image: image-url("bullet_green.png")
 
 .tl-icon-added
-  cursor: default
   background-image: image-url("added.png")
 
 .tl-icon-deleted
-  cursor: default
   background-image: image-url("webalys/deleted.png")
 
 .tl-icon-changed
-  cursor: default
   background-image: image-url("webalys/arrow_left_right.png")
 
 .tl-icon-calendar
-  cursor: default
   background-image: image-url("webalys/calendar.png")
-
-.tl-icon-zoomin
-  background-image: image-url("webalys/zoom_in.png")
-
-.tl-icon-zoomout
-  background-image: image-url("webalys/zoom_out.png")
-
-.tl-icon-outline
-  background-image: image-url("webalys/outline.png")
 
 /* ╭───────────────────────────────────────────────────────────────────╮ *
  * │ Timeline tree                                                     │ *


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19090
## Description

This should fix the alignment of icons for the planning comparison in the timeline view:

![icons-aligned](https://cloud.githubusercontent.com/assets/453584/7492827/1b72e7ae-f3fc-11e4-97ed-44f7cd07a27d.PNG)
