### PR TITLE
[19866] Breadcrumb font issues

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-%default-font
+%breadcrumb--default-font
   @include default-font($breadcrumb-font-color, $breadcrumb-font-size, bold)
 
 #breadcrumb
@@ -52,10 +52,10 @@
     margin-left: 13px
 
   a
-    @extend %default-font
+    @extend %breadcrumb--default-font
     text-decoration: underline
   li
-    @extend %default-font
+    @extend %breadcrumb--default-font
     color: lighten($breadcrumb-font-color, 20)
     list-style-type: none
     white-space: nowrap

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -26,6 +26,9 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+%default-font
+  @include default-font($breadcrumb-font-color, $breadcrumb-font-size, bold)
+
 #breadcrumb
   @include default-transition
   height: $breadcrumb-height
@@ -47,14 +50,13 @@
   h1
     margin-bottom: 0
     margin-left: 13px
-    @include default-font($breadcrumb-font-color, $breadcrumb-font-size)
 
   a
-    @include default-font($breadcrumb-font-color, $breadcrumb-font-size, bold)
-    text-decoration: none
-    &:hover
-      text-decoration: underline
+    @extend %default-font
+    text-decoration: underline
   li
+    @extend %default-font
+    color: lighten($breadcrumb-font-color, 20)
     list-style-type: none
     white-space: nowrap
     &.cutme
@@ -77,6 +79,7 @@ ul.breadcrumb
     text-decoration: none
     display: block
     width: 25px
+    font-size: 12px
 
 #breadcrumb ul.breadcrumb li
   float: left
@@ -84,5 +87,3 @@ ul.breadcrumb
   padding: 0 25px 0 0
   background: image-url('breadcrumb-list.png') no-repeat right center
 
-#breadcrumb a.breadcrumb-project-title
-  font-size: $breadcrumb-highlighted-font-size

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -53,7 +53,7 @@
 
   a
     @extend %breadcrumb--default-font
-    text-decoration: underline
+
   li
     @extend %breadcrumb--default-font
     color: lighten($breadcrumb-font-color, 20)


### PR DESCRIPTION
This PR attempts to harmonize the breadrcumbs issue correctly noted by @NobodysNightmare in https://community.openproject.org/work_packages/19866.

This PR is a **suggestion**, it removes special cases and makes a better distinction between clickable breadcrumbs and non-clickable breadcrumbs. Also, the font size should be the same throughout the breadcrumb bar.
## Pictures

Overview: 

![screenshot from 2015-05-06 14 38 40](https://cloud.githubusercontent.com/assets/498241/7493114/3f001f6e-f3fe-11e4-885c-bbad52f7b880.png)

Single WP:

![screenshot from 2015-05-06 14 38 49](https://cloud.githubusercontent.com/assets/498241/7493123/50b0baa2-f3fe-11e4-8533-549d070918db.png)
