### PR TITLE
Improve work package list performance (esp. in Firefox)

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -5,6 +5,8 @@ targets:
     build_dependencies:
       - libmagickwand-dev
       - libsqlite3-dev
+  debian-8:
+    <<: *debian
   ubuntu-14.04:
     <<: *debian
   fedora-20: &redhat
@@ -21,13 +23,13 @@ crons:
   - packaging/cron/openproject-create-svn-repositories
 services:
   - postgres
-installer: https://github.com/pkgr/installer.git#suse
+installer: https://github.com/pkgr/installer.git
 wizards:
   - https://github.com/pkgr/addon-legacy-installer.git
-  - https://github.com/pkgr/addon-mysql.git#suse
-  - https://github.com/pkgr/addon-apache2.git#suse
-  - https://github.com/pkgr/addon-svn-dav.git#suse
-  - https://github.com/pkgr/addon-smtp.git#suse
-  - https://github.com/pkgr/addon-memcached.git#suse
-  - https://github.com/pkgr/addon-openproject.git#suse
+  - https://github.com/pkgr/addon-mysql.git
+  - https://github.com/pkgr/addon-apache2.git
+  - https://github.com/pkgr/addon-svn-dav.git
+  - https://github.com/pkgr/addon-smtp.git
+  - https://github.com/pkgr/addon-memcached.git
+  - https://github.com/pkgr/addon-openproject.git
 buildpack: https://github.com/ddollar/heroku-buildpack-multi.git

--- a/app/assets/stylesheets/content/_buttons.sass
+++ b/app/assets/stylesheets/content/_buttons.sass
@@ -45,10 +45,6 @@ $button--success-background-hover-color:    darken($success-color, 18%) !default
 
 $button--text-icon-spacing:                 0.65em !default
 
-%button--icon
-  display: inline-block
-  transition: scale 0.25s ease-out
-
 .button,
 a.button
   @extend %button
@@ -67,16 +63,9 @@ a.button
   &:hover
     text-decoration: none
 
-    .button--icon
-      transform: scale(1.15)
-
   &.-with-icon
     &::before
-      @extend %button--icon
       padding: 0 $button--text-icon-spacing 0 0
-
-    &:hover::before
-      transform: scale(1.15)
 
   &.-highlight
     @include button-style($button--highlight-background-color, $button--highlight-background-hover-color, $button--highlight-font-color, $button-style)
@@ -129,7 +118,7 @@ a.button
     border-radius: 2em
 
 .button--icon
-  @extend %button--icon
+  @include icon-common
 
 .button--icon + .button--text,
 .button--text + .button--icon

--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -114,56 +114,51 @@ li.select2-result.select2-visible-selected-parent
 .tl-toolbar-container *
   vertical-align: bottom
 
-.tl-icon-postponed, .tl-icon-preponed, .tl-icon-added, .tl-icon-deleted, .tl-icon-changed, .tl-icon-calendar, .tl-icon-zoomin, .tl-icon-zoomout, .tl-icon-outline
-  background-position: 0% 50%
+.tl-icon-postponed,
+.tl-icon-preponed,
+.tl-icon-added,
+.tl-icon-deleted,
+.tl-icon-changed,
+.tl-icon-calendar,
+.tl-icon-zoomin,
+.tl-icon-zoomout,
+.tl-icon-outline
+  background-position: left center
   background-repeat: no-repeat
   padding-left: 19px
-  padding-top: 2px
-  padding-bottom: 3px
 
 .tl-icon-postponed
   cursor: default
-  background: image-url("bullet_red.png") no-repeat center
+  background-image: image-url("bullet_red.png")
 
 .tl-icon-preponed
   cursor: default
-  background: image-url("bullet_green.png") no-repeat center
+  background-image: image-url("bullet_green.png")
 
 .tl-icon-added
   cursor: default
-  background: image-url("added.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("added.png")
 
 .tl-icon-deleted
   cursor: default
-  background: image-url("webalys/deleted.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("webalys/deleted.png")
 
 .tl-icon-changed
   cursor: default
-  background: image-url("webalys/arrow_left_right.png") no-repeat center
-  display: inline
-  width: 16px
-  background-position: 2px 2px
+  background-image: image-url("webalys/arrow_left_right.png")
 
 .tl-icon-calendar
   cursor: default
-  background: image-url("webalys/calendar.png") no-repeat center
-  display: inline
-  width: 16px
+  background-image: image-url("webalys/calendar.png")
 
 .tl-icon-zoomin
-  background: image-url("webalys/zoom_in.png") no-repeat center
+  background-image: image-url("webalys/zoom_in.png")
 
 .tl-icon-zoomout
-  background: image-url("webalys/zoom_out.png") no-repeat center
+  background-image: image-url("webalys/zoom_out.png")
 
 .tl-icon-outline
-  background: image-url("webalys/outline.png") no-repeat center
+  background-image: image-url("webalys/outline.png")
 
 /* ╭───────────────────────────────────────────────────────────────────╮ *
  * │ Timeline tree                                                     │ *

--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -123,42 +123,28 @@ li.select2-result.select2-visible-selected-parent
 .tl-icon-zoomin,
 .tl-icon-zoomout,
 .tl-icon-outline
+  cursor: default
   background-position: left center
   background-repeat: no-repeat
   padding-left: 19px
 
 .tl-icon-postponed
-  cursor: default
   background-image: image-url("bullet_red.png")
 
 .tl-icon-preponed
-  cursor: default
   background-image: image-url("bullet_green.png")
 
 .tl-icon-added
-  cursor: default
   background-image: image-url("added.png")
 
 .tl-icon-deleted
-  cursor: default
   background-image: image-url("webalys/deleted.png")
 
 .tl-icon-changed
-  cursor: default
   background-image: image-url("webalys/arrow_left_right.png")
 
 .tl-icon-calendar
-  cursor: default
   background-image: image-url("webalys/calendar.png")
-
-.tl-icon-zoomin
-  background-image: image-url("webalys/zoom_in.png")
-
-.tl-icon-zoomout
-  background-image: image-url("webalys/zoom_out.png")
-
-.tl-icon-outline
-  background-image: image-url("webalys/outline.png")
 
 /* ╭───────────────────────────────────────────────────────────────────╮ *
  * │ Timeline tree                                                     │ *

--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
              :html => {:id => "members_add_form"}) do |f| %>
   <div class="form--section">
     <h3 class="form--section-title"><%= l(:label_member_new) %></h3>
-    <div class="grid-block">
+    <div class="grid-block medium-up-2">
       <div class="form--column">
         <div class="form--field">
           <%= styled_label_tag :principal_search, l(:label_principal_search) %>

--- a/app/views/members/_member_form_non_impaired.html.erb
+++ b/app/views/members/_member_form_non_impaired.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
                      :html => {:id => "members_add_form"}) do |f| %>
   <div class="form--section">
     <h3 class="form--section-title"><%= l(:label_member_new) %></h3>
-    <div class="grid-block">
+    <div class="grid-block medium-up-2">
       <div class="form--column">
         <div class="form--field -vertical">
           <%= styled_label_tag :member_user_ids, l(:label_principal_search) %>

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -111,8 +111,6 @@ de:
     label_menu_collapse: "ausblenden"
     label_menu_expand: "einblenden"
     label_more_than_ago: "vor mehr als"
-    label_move_column_left: "Spalte nach links verschieben"
-    label_move_column_right: "Spalte nach rechts verschieben"
     label_next: "Weiter"
     label_no_data: "Nichts anzuzeigen"
     label_no_due_date: "kein Abgabedatum"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -111,8 +111,6 @@ en:
     label_menu_collapse: "collapse"
     label_menu_expand: "expand"
     label_more_than_ago: "more than days ago"
-    label_move_column_left: "Move column left"
-    label_move_column_right: "Move column right"
     label_next: "Next"
     label_no_data: "No data to display"
     label_no_due_date: "no end date"

--- a/frontend/app/work_packages/controllers/menus/column-context-menu-controller.js
+++ b/frontend/app/work_packages/controllers/menus/column-context-menu-controller.js
@@ -78,7 +78,7 @@ module.exports = function($scope, ColumnContextMenu, I18n, QueryService, WorkPac
     };
 
     function isValidColumn(column) {
-      return column && column.name !== 'id';
+      return column;
     }
 
     $scope.canMoveLeft = function() {

--- a/frontend/app/work_packages/filters/index.js
+++ b/frontend/app/work_packages/filters/index.js
@@ -52,7 +52,7 @@ angular.module('openproject.workPackages.filters')
 .filter('remainingFilterNames', ['orderByFilter', 'FiltersHelper', function(orderByFilter, FiltersHelper) {
 
   function subtractActiveFilters(filters, filtersToSubtract) {
-    var filterDiff = _.cloneDeep(filters);
+    var filterDiff = _.clone(filters);
 
     angular.forEach(filtersToSubtract, function(filter) {
       if(!filter.deactivated) delete filterDiff[filter.name];


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19607
## Description

This is another attempt to improve the performance for the WP list.
There is still quite a big deal of JS time spent in [setHeaderFooterWidths](https://github.com/opf/openproject/blob/eb0109a83c8db257f9cd3370aacad7873eef55f0/frontend/app/work_packages/directives/work-packages-table-directive.js#L109-114) (~20%), but after talking to @myabc it would require a significant amount of refactoring to do this without JS.

Thus keeping this PR simple and lean.
