### PR TITLE
Improve performance of work package list (esp. in Firefox)

### DIFF
--- a/frontend/app/work_packages/filters/index.js
+++ b/frontend/app/work_packages/filters/index.js
@@ -52,7 +52,7 @@ angular.module('openproject.workPackages.filters')
 .filter('remainingFilterNames', ['orderByFilter', 'FiltersHelper', function(orderByFilter, FiltersHelper) {
 
   function subtractActiveFilters(filters, filtersToSubtract) {
-    var filterDiff = _.cloneDeep(filters);
+    var filterDiff = _.clone(filters);
 
     angular.forEach(filtersToSubtract, function(filter) {
       if(!filter.deactivated) delete filterDiff[filter.name];


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/19607
## Description

This is another attempt to improve the performance for the WP list.
There is still quite a big deal of JS time spent in [setHeaderFooterWidths](https://github.com/opf/openproject/blob/eb0109a83c8db257f9cd3370aacad7873eef55f0/frontend/app/work_packages/directives/work-packages-table-directive.js#L109-114) (~20%), but after talking to @myabc it would require a significant amount of refactoring to do this without JS.

Thus keeping this PR simple and lean.
