### PR TITLE
Load all js locales

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -28,9 +28,12 @@
 
 var I18n = require('./vendor/i18n');
 
-// standard locales
-I18n.translations.en = require("locales/js-en.yml").en;
-I18n.translations.de = require("locales/js-de.yml").de;
+// load all js locales
+var requireExtraLocale = require.context('../../config/locales', false, /js-[\w|-]{2,5}\.yml$/);
+requireExtraLocale.keys().forEach(function(localeFile) {
+  var locale = localeFile.match(/js-([\w|-]{2,5})\.yml/)[1];
+  I18n.translations[locale] = requireExtraLocale(localeFile)[locale];
+});
 
 I18n.addTranslations = function(locale, translations) {
   I18n.translations[locale] = _.merge(I18n.translations[locale], translations);

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -29,10 +29,10 @@
 var I18n = require('./vendor/i18n');
 
 // load all js locales
-var requireExtraLocale = require.context('../../config/locales', false, /js-[\w|-]{2,5}\.yml$/);
-requireExtraLocale.keys().forEach(function(localeFile) {
+var localeFiles = require.context('../../config/locales', false, /js-[\w|-]{2,5}\.yml$/);
+localeFiles.keys().forEach(function(localeFile) {
   var locale = localeFile.match(/js-([\w|-]{2,5})\.yml/)[1];
-  I18n.translations[locale] = requireExtraLocale(localeFile)[locale];
+  I18n.translations[locale] = localeFiles(localeFile)[locale];
 });
 
 I18n.addTranslations = function(locale, translations) {


### PR DESCRIPTION
This autoloads all js locales, just like the rails part does it with the rails locales. I have to admit: I just copied the snippet from openproject-translations. 

If we do this here we should do it to every plugin that has js locales (e.g. openproject-backlogs). 

Work package: https://community.openproject.org/work_packages/19980
