### PR TITLE
19455 fix arrow in select element in IE10-11

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -383,6 +383,9 @@ fieldset.form--fieldset
   @extend %input-style
   line-height: normal
   padding: rem-concat-list($select-element-padding)
+  // TODO: Temporary fix, for sure it will be fixed with next foundation-app release v1.1.1
+  // remove background image after/if upgrade
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20version%3D%221.1%22%20width%3D%2232%22%20height%3D%2224%22%20viewBox%3D%220%200%2032%2024%22%3E%3Cpolygon%20points%3D%220%2C0%2032%2C0%2016%2C24%22%20style%3D%22fill%3A%20black%22%3E%3C/polygon%3E%3C/svg%3E")
 
   &[multiple]
     background-image: none


### PR DESCRIPTION
[`* `#19455` [Design][Accessibility][IE 11] Select fields missing arrows`](https://community.openproject.org/work_packages/19455)
