### PR TITLE
Configure select2 to use separate container class

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -573,6 +573,10 @@ jQuery(document).ready(function($) {
     },
     formatSearching: function () {
       return I18n.t("js.select2.searching");
+    },
+    containerCssClass: 'form--select2',
+    adaptContainerCssClass: function(clazz) {
+      return null;
     }
   });
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -394,6 +394,10 @@ fieldset.form--fieldset
     // in height in foundation for apps.
     height: auto
 
+.form--select2
+  border: none
+  padding-right: 0
+
 .form--text-field,
 .form--select
   &.-tiny

--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -90,11 +90,6 @@ li.select2-result.select2-visible-selected-parent
   input
     margin-left: 1em
 
-/* Hack for as long as select2 is in there.
-.select2-container.form--select
-  border: none
-  padding-right: 0
-
 /* ╭───────────────────────────────────────────────────────────────────╮ *
  * │ Timeline toolbar & icons.                                         │ *
  * ╰───────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Alernative to #2989

Apply `form--select2` rather than `form--select` (possibly copied from the select element).

https://community.openproject.org/work_packages/19455
