### PR TITLE
19960 Multiselect does not use the whole width

### DIFF
--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -199,3 +199,10 @@ $se2-width: 100%;
 input[type="text"].select2-input {
   height: $se2-input-height;
 }
+
+.columns-modal-content {
+  .select2-container {
+    max-width: calc(100% - 45px);
+  }
+}
+


### PR DESCRIPTION
[`* `#19960`[Design][WP List][Modal] Multiselect does not use the whole width`](https://community.openproject.org/work_packages/19960) 
