### PR TITLE
[19392] Harmonize wiki headings

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -28,9 +28,24 @@
 
 div.wiki
   font-size: $wiki-default-font-size
+  $wiki-max-heading-font-size: 24px
   line-height: 1.6em
 
-  h1, h2, h3
+  // this should be the same as a normal heading (see toolbar)
+  h1
+    padding: 12px 0 0 0
+    border: 0
+    font-size: $wiki-max-heading-font-size
+    line-height: 1.4
+    height: 45px
+  h2
+    font-size: $wiki-max-heading-font-size * 0.8
+  h3
+    font-size: $wiki-max-heading-font-size * 0.6
+  h4
+    font-size: $wiki-max-heading-font-size * 0.5
+
+  h2, h3
     margin: 1em 0 1em 0
     font-weight: bold
     color: #555555


### PR DESCRIPTION
This PR will "fix" the wiki headings by letting them behave like the toolbar component which is introduced in #3000.

This should meet the requirements of https://community.openproject.org/work_packages/19392.

I am probably going to hell for this, as this is no real fix for the underlying problem, just more fighting the symptoms.

![93q9ogb](https://cloud.githubusercontent.com/assets/498241/7703109/9fe9e95e-fe35-11e4-8325-2228c1b8aa7c.png)
