### PR TITLE
avoid XSS through gravatars

### DIFF
--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -82,7 +82,7 @@ module AvatarHelper
 
   def merge_image_options(user, options)
     default_options = { class: 'avatar' }
-    default_options[:title] = user.name if user.respond_to?(:name)
+    default_options[:title] = h(user.name) if user.respond_to?(:name)
 
     options.reverse_merge(default_options)
   end


### PR DESCRIPTION
## OpenProject work package

There is no associated work package. I found and fixed this while reviewing https://community.openproject.org/work_packages/18330
## Description

This PR fixes a XSS vulnerability in the `AvatarHelper` that allowed to inject ~30-60 characters of markup through the title attribute of an avatars `img` tag.
## Note

:warning: Dear reviewer, after merging this PR please immediately merge this through `release/4.1` into `dev`.
