### PR TITLE
[Flash Messages] Small style improvement

### DIFF
--- a/app/assets/stylesheets/content/_flash_messages.sass
+++ b/app/assets/stylesheets/content/_flash_messages.sass
@@ -28,6 +28,7 @@
 
 #errorExplanation, .flash, .nodata, .warning
   padding: 4px
+  line-height: 1.25rem
   margin: 0 0 10px 0
   color: $content-flash-msg-font-color
 


### PR DESCRIPTION
The fix is subtle but makes old flash messages have their text aligned a tiny
bit better.

Before:
![screenshot from 2015-05-19 20 09 14](https://cloud.githubusercontent.com/assets/498241/7710268/f2a6ef70-fe62-11e4-94d4-5de4e26481de.png)

After:
![screenshot from 2015-05-19 20 08 40](https://cloud.githubusercontent.com/assets/498241/7710261/e4ecccb0-fe62-11e4-996b-286122a74911.png)
