### PR TITLE
Fix alignment for "Remember me" login checkbox

### DIFF
--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -40,7 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
         <div class="form--field-extra-actions">
           <% if Setting.autologin? %>
-            <label for="autologin"><%= styled_check_box_tag 'autologin', 1, false %> <%= l(:label_stay_logged_in) %></label>
+            <label class="form--label-with-check-box" for="autologin"><%= styled_check_box_tag 'autologin', 1, false %> <%= l(:label_stay_logged_in) %></label>
           <% elsif Setting.self_registration? %>
             <%# show here if autologin is disabled, otherwise below lost_password link %>
             <%= link_to l(:label_register), { :controller => '/account', :action => 'register' } %>


### PR DESCRIPTION
This will realign the checkbox for remember me (if activated).

Found by @robinwagner
