### PR TITLE
[18330] Use toolbar for harmonizing the headings [FIXUP]

### DIFF
--- a/app/views/admin/projects.html.erb
+++ b/app/views/admin/projects.html.erb
@@ -35,7 +35,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_project_plural) do %>
   <li class="toolbar-item">
     <%= link_to new_project_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_project_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_project_new) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_auth_source_plural) do %>
   <li class="toolbar-item">
     <%= link_to new_auth_source_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_auth_source_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_auth_source_new) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -54,7 +54,8 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= link_to({ controller: '/messages', action: 'new', board_id: @board},
                     class: 'button -alt-highlight',
                     onclick: 'Element.show("add-message"); Form.Element.focus("message_subject"); return false;') do %>
-        <i class="button--icon icon-add"></i> <%= l(:label_message_new) %>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l(:label_message_new) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_group_plural) do %>
   <li class="toolbar-item">
     <%= link_to new_group_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_group_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_group_new) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/my/page.html.erb
+++ b/app/views/my/page.html.erb
@@ -30,7 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_my_page) do %>
   <li class="toolbar-item">
     <%= link_to({ action: 'page_layout' }, accesskey: accesskey(:edit), class: 'button') do %>
-      <i class="icon-edit"></i> <%= l(:label_personalize_page) %>
+      <i class="button--icon icon-edit"></i>
+      <span class="button--text"><%= l(:label_personalize_page) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/my/page_layout.html.erb
+++ b/app/views/my/page_layout.html.erb
@@ -85,7 +85,8 @@ See doc/COPYRIGHT.rdoc for more details.
     </li>
   <li class="toolbar-item">
     <%= link_to({action: 'page'}, class: 'button') do %>
-      <i class="icon-cancel"></i> <%= l(:button_back) %>
+      <i class="button--icon icon-cancel"></i>
+      <span class="button--text"><%= l(:button_back) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?(:manage_news, @project) %>
     <li class="toolbar-item">
       <%= link_to new_project_news_path(@project), title: l(:label_news_new), id: 'new_news_link', class: 'button -alt-highlight' do %>
-        <i class="button--icon icon-add"></i> <%= l(:label_news_new) %>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l(:label_news_new) %></span>
       <% end %>
     </li>
   <% end %>
@@ -57,4 +58,3 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom, params.merge({:format => 'atom', :page => nil, :key => User.current.rss_key})) %>
 <% end %>
-

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -33,7 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
       :accesskey => accesskey(:edit),
       class: 'button',
       :onclick => 'Element.show("edit-news"); return false;') do %>
-      <i class="button--icon icon-edit"></i> <%= l(:button_edit) %>
+      <i class="button--icon icon-edit"></i>
+      <span class="button--text"><%= l(:button_edit) %></span>
     <% end %>
   <% end %>
   <li class="toolbar-item">
@@ -47,7 +48,8 @@ See doc/COPYRIGHT.rdoc for more details.
           :confirm => l(:text_are_you_sure),
           :method => :delete,
           :class => 'button') do %>
-      <i class="button--icon icon-delete"></i> <%= l(:button_delete) %>
+      <i class="button--icon icon-delete"></i>
+      <span class="button--text"><%= l(:button_delete) %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/planning_element_type_colors/index.html.erb
+++ b/app/views/planning_element_type_colors/index.html.erb
@@ -32,7 +32,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l('timelines.admin_menu.colors') do %>
   <li class="toolbar-item">
     <%= link_to new_color_path, class: 'button -alt-highlight', title: l('timelines.new_color') do %>
-      <i class="button--icon icon-add"></i> <%= l('timelines.new_color') %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l('timelines.new_color') %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/project_types/index.html.erb
+++ b/app/views/project_types/index.html.erb
@@ -32,7 +32,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l("timelines.admin_menu.project_types") do %>
   <li class="toolbar-item">
     <%= link_to new_project_type_path, class: 'button -alt-highlight', title: l('timelines.new_project_type') do %>
-      <i class="button--icon icon-add"></i> <%= l('timelines.new_project_type') %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l('timelines.new_project_type') %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -36,7 +36,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?(:add_project, nil, global: true) %>
     <li class="toolbar-item">
       <%= link_to new_project_path, class: 'button -alt-highlight' do %>
-        <i class="button--icon icon-add"></i> <%= l(:label_project_new) %>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l(:label_project_new) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/projects/settings.html.erb
+++ b/app/views/projects/settings.html.erb
@@ -32,11 +32,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @project.copy_allowed? %>
     <li class="toolbar-item">
       <%= link_to copy_from_project_path(@project, coming_from: :settings), class: 'button copy', accesskey: accesskey(:copy) do %>
-        <i class="button--icon icon-copy"></i> <%= l(:button_copy) %>
+        <i class="button--icon icon-copy"></i>
+        <span class="button--text"><%= l(:button_copy) %></span>
       <% end %>
     </li>
   <% end %>
 <% end %>
 
 <%= render_tabs project_settings_tabs %>
-

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?(:add_subprojects, @project) %>
     <li class="toolbar-item">
       <%= link_to({:controller => '/projects', :action => 'new', :parent_id => @project}, :class => 'button -alt-highlight') do %>
-        <span class="button--text"><i class="button--icon icon-add"></i> <%= l(:label_subproject_new) %></span>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l(:label_subproject_new) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/reportings/_toolbar.html.erb
+++ b/app/views/reportings/_toolbar.html.erb
@@ -4,13 +4,15 @@
       <% if authorize_for :reportings, :edit %>
         <li class="toolbar-item">
           <%= link_to edit_project_reporting_path(@project, @reporting), class: 'button' do %>
-            <i class="button--icon icon-edit"></i> <%= l(:button_edit) %>
+            <i class="button--icon icon-edit"></i>
+            <span class="button--text"><%= l(:button_edit) %></span>
           <% end %>
         </li>
       <% end %>
       <% if authorize_for :reportings, :destroy %>
         <%= link_to confirm_destroy_project_reporting_path(@project, @reporting), class: 'button' do %>
-            <i class="button--icon icon-delete"></i> <%= l(:button_delete) %>
+            <i class="button--icon icon-delete"></i>
+            <span class="button--text"><%= l(:button_delete) %></span>
           <% end %>
       <% end %>
     <% end %>

--- a/app/views/reportings/index.html.erb
+++ b/app/views/reportings/index.html.erb
@@ -33,7 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title:  l("timelines.project_menu.reportings") do %>
   <% if authorize_for(:reportings, :new) %>
     <%= link_to new_project_reporting_path(@project), title: l("timelines.new_reporting"), class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l("timelines.new_reporting") %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l("timelines.new_reporting") %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/repositories/_navigation.html.erb
+++ b/app/views/repositories/_navigation.html.erb
@@ -35,7 +35,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: crumbs  do %>
   <li class="toolbar-item">
     <%= link_to stats_project_repository_path(@project), class: 'button' do %>
-      <i class="icon icon-stats1"></i> <%= l(:label_statistics) %>
+      <i class="button--icon icon-stats1"></i>
+      <span class="button--text"><%= l(:label_statistics) %></span>
     <% end %>
   </li>
   <%# rev => nil prevents overwriting the rev parameter queried for in the form with the parameter from the request %>
@@ -65,4 +66,3 @@ See doc/COPYRIGHT.rdoc for more details.
     <% end %>
   <% end -%>
 <% end %>
-

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -33,7 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_role_plural)  do %>
   <li class="toolbar-item">
     <%= link_to new_role_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_role_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_role_new) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -31,13 +31,15 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_work_package_status_plural) do %>
   <li class="toolbar-item">
     <%= link_to new_status_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_work_package_status_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_work_package_status_new) %></span>
     <% end %>
   </li>
   <% if WorkPackage.use_status_for_done_ratio? %>
     <li class="toolbar-item">
       <%= link_to update_work_package_done_ratio_statuses_path, class: 'button', remote: true, method: :post, data: { confirm: l(:text_are_you_sure) } do %>
-        <i class="button--icon icon-reload2"></i> <%= l(:label_update_work_package_done_ratios) %>
+        <i class="button--icon icon-reload2"></i>
+        <span class="button--text"><%= l(:label_update_work_package_done_ratios) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/time_entries/reports/show.html.erb
+++ b/app/views/time_entries/reports/show.html.erb
@@ -33,7 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?({controller: 'timelog', action: :new}, @project) %>
       <li class="toolbar-item">
         <%= link_to polymorphic_new_time_entry_path(@issue || @project), class: 'button' do %>
-          <span class="button--text"><i class="button--icon icon-time"></i> <%= l(:button_log_time) %></span>
+          <i class="button--icon icon-time"></i>
+          <span class="button--text"><%= l(:button_log_time) %></span>
         <% end %>
       </li>
   <% end %>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -32,7 +32,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if timeline_action_authorized?(:new) %>
     <li class="toolbar-item">
       <%= new_timeline_link @project do %>
-        <i class="button--icon icon-add"></i> <%= l('timelines.new_timeline') %><span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l('timelines.new_timeline') %></span>
+        <span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
       <% end %>
     </li>
   <% end %>
@@ -40,7 +42,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if timeline_action_authorized?(:edit) %>
     <li class="toolbar-item">
       <%= edit_timeline_link @project, @timeline do %>
-        <i class="button--icon icon-edit"></i> <%= l(:button_edit) %><span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
+        <i class="button--icon icon-edit"></i>
+        <span class="button--text"><%= l(:button_edit) %></span>
+        <span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
       <% end %>
     </li>
   <% end %>
@@ -48,7 +52,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if timeline_action_authorized?(:destroy) %>
     <li class="toolbar-item">
       <%= destroy_timeline_link @project, @timeline do %>
-        <i class="button--icon icon-delete"></i> <%= l(:button_delete) %><span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
+        <i class="button--icon icon-delete"></i>
+        <span class="button--text"><%= l(:button_delete) %></span>
+        <span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/timelog/index.html.erb
+++ b/app/views/timelog/index.html.erb
@@ -35,7 +35,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?({controller: :timelog, action: :new}, @project) %>
       <li class="toolbar-item">
         <%= link_to polymorphic_new_time_entry_path(@issue || @project), class: 'button' do %>
-          <span class="button--text"><i class="button--icon icon-time"></i> <%= l(:button_log_time) %></span>
+          <i class="button--icon icon-time"></i>
+          <span class="button--text"><%= l(:button_log_time) %></span>
         <% end %>
       </li>
   <% end %>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_type_plural) do %>
   <li class="toolbar-item">
     <%= link_to new_type_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_type_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_type_new) %></button>
     <% end %>
   </li>
 <% end %>

--- a/app/views/users/_toolbar.html
+++ b/app/views/users/_toolbar.html
@@ -30,7 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% unless @user.new_record? %>
     <li class="toolbar-item">
       <%= link_to user_path(@user), class: 'button' do %>
-        <i class="button--icon icon-user1"></i> <%= l(:label_profile) %>
+        <i class="button--icon icon-user1"></i>
+        <span class="button--text"><%= l(:label_profile) %></span>
       <% end %>
     </li>
     <% unless current_user.id == @user.id %>
@@ -44,7 +45,8 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if Setting.users_deletable_by_admins? %>
       <li class="toolbar-items">
         <%= link_to deletion_info_user_path(@user), class: 'button' do %>
-          <i class="button--icon icon-delete"></i> <%= l(:button_delete) %>
+          <i class="button--icon icon-delete"></i>
+          <span class="button--text"><%= l(:button_delete) %></span>
         <% end %>
       </li>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_user_plural) do %>
   <% unless OpenProject::Configuration.disable_password_login? %>
     <%= link_to new_user_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_user_new) %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_user_new) %></span>
     <% end %>
   <% end %>
   <%= call_hook(:user_admin_action_menu) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if User.current.admin? %>
     <li class="toolbar-item">
       <%= link_to edit_user_path(@user), class: 'button', accesskey: accesskey(:edit) do %>
-        <i class="button--icon icon-edit"></i> <%= l(:button_edit) %>
+        <i class="button--icon icon-edit"></i>
+        <span class="button--text"><%= l(:button_edit) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -31,9 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
  <% if authorize_for(:versions, :edit) %>
     <li class="toolbar-item">
       <%= link_to(edit_version_path(@project, @version), class: 'button') do %>
-        <span class="button--text">
-          <i class="button--icon icon-edit"></i> <%= l(:button_edit) %>
-        </span>
+        <i class="button--icon icon-edit"></i>
+        <span class="button--text"><%= l(:button_edit) %></span>
       <% end %>
     </li>
   <% end %>
@@ -43,9 +42,8 @@ See doc/COPYRIGHT.rdoc for more details.
                    :project_id => @version.project,
                    :id => Wiki.titleize(@version.wiki_page_title)},
                    class: 'button') do %>
-        <span class="button--text">
-          <i class="button--icon icon-edit"></i> <%= l(:button_edit_associated_wikipage, :page_title => truncate(@version.wiki_page_title, :length => 50, :separator => ' ')) %>
-        </span>
+        <i class="button--icon icon-edit"></i>
+        <span class="button--text"><%= l(:button_edit_associated_wikipage, :page_title => truncate(@version.wiki_page_title, :length => 50, :separator => ' ')) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/workflows/_action_menu.html.erb
+++ b/app/views/workflows/_action_menu.html.erb
@@ -30,12 +30,14 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: title do %>
   <li class="toolbar-item">
     <%= link_to({ action: 'copy' }, class: 'button') do %>
-      <i class="button--icon icon-copy"></i> <%= l(:button_copy) %>
+      <i class="button--icon icon-copy"></i>
+      <span class="button--text"><%= l(:button_copy) %></span>
     <% end %>
   </li>
   <li class="toolbar-item">
     <%= link_to({ action: 'index' }, class: 'button') do %>
-      <i class="button--icon icon-info"></i> <%= l(:label_workflow_summary) %>
+      <i class="button--icon icon-info"></i>
+      <span class="button--text"><%= l(:label_workflow_summary) %></span>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
Contination of #3000: Correct toolbar composite buttons markup structure: this ensures buttons are rendered as intended, with correct/consistent

Before:
![team_2_-_openproject_-_timelines__timeline_-_openproject_and_seeded_project_-_timelines__sample_timeline_-_openproject](https://cloud.githubusercontent.com/assets/755/7748406/90017b16-ffc4-11e4-8f99-07b2762fe20d.png)
 spacing between button icon and text.

After:
![pasted_image_21_05_15_14_18](https://cloud.githubusercontent.com/assets/755/7748423/9e3b79b6-ffc4-11e4-97c9-7a7098465a15.png)

https://community.openproject.org/work_packages/18330
