### PR TITLE
Version edit page broken

### DIFF
--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: h(@version.name) do %>
  <% if authorize_for(:versions, :edit) %>
     <li class="toolbar-item">
-      <%= link_to(edit_version_path(@project, @version), class: 'button') do %>
+      <%= link_to(edit_version_path(@version), class: 'button') do %>
         <i class="button--icon icon-edit"></i>
         <span class="button--text"><%= l(:button_edit) %></span>
       <% end %>

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -373,6 +373,14 @@ module NavigationHelpers
       message = Message.find_by_subject($1)
       topic_path(message)
 
+    when /^the show page (for|of) version ('|")(.+)('|")$/
+      version = Version.find_by_name($3)
+      version_path(version)
+
+    when /^the edit page (for|of) version ('|")(.+)('|")$/
+      version = Version.find_by_name($3)
+      edit_version_path(version)
+
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #

--- a/features/versions/edit.feature
+++ b/features/versions/edit.feature
@@ -28,7 +28,7 @@
 
 Feature: Editing a version
 
-  Scenario: a version can bed edited from it's show page
+  Scenario: a version can be edited from its show page
     Given there is 1 project with the following:
       | identifier | omicronpersei8 |
       | name       | omicronpersei8 |

--- a/features/versions/edit.feature
+++ b/features/versions/edit.feature
@@ -1,0 +1,40 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+Feature: Editing a version
+
+  Scenario: a version can bed edited from it's show page
+    Given there is 1 project with the following:
+      | identifier | omicronpersei8 |
+      | name       | omicronpersei8 |
+    Given the project "omicronpersei8" has 1 version with the following:
+      | name       | Milestone |
+    And I am already admin
+    And I am on the show page for version 'Milestone'
+    And I click on "Edit" within "#toolbar"
+    Then I should be on the edit page of version 'Milestone'


### PR DESCRIPTION
When coming from a version show page, one currently receives a 500 error, as the path helper was fed the wrong parameters.

This PR corrects that and add a test for verification.
