### PR TITLE
fix sprockets revision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :production do
   gem 'dalli', '~> 2.7.2'
 end
 
-gem 'sprockets',        git: 'https://github.com/tessi/sprockets.git', branch: '2_2_2_backport2'
+gem 'sprockets',        git: 'https://github.com/tessi/sprockets.git', ref: '1e56fd0a92a9fda9'
 gem 'sprockets-rails',  git: 'https://github.com/finnlabs/sprockets-rails.git', branch: 'backport'
 gem 'non-stupid-digest-assets'
 gem 'sass-rails',        git: 'https://github.com/guilleiguaran/sass-rails.git', branch: 'backport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 GIT
   remote: https://github.com/tessi/sprockets.git
   revision: 1e56fd0a92a9fda93dab4550ab3cf82138d097ac
-  branch: 2_2_2_backport2
+  ref: 1e56fd0a92a9fda9
   specs:
     sprockets (2.2.2.backport2)
       hike (~> 1.2)


### PR DESCRIPTION
Ref: #2883

```
$ bundle update gon
Updating https://github.com/tessi/sprockets.git
Fetching gem metadata from https://rubygems.org/..........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "sprockets":
  In Gemfile:
    sprockets-rails (>= 0) ruby depends on
      sprockets (= 2.2.2.backport2) ruby

    sprockets (2.2.3.backport2)
```
