### PR TITLE
Fix non-links in quick start guide

### DIFF
--- a/doc/QUICK_START.md
+++ b/doc/QUICK_START.md
@@ -43,8 +43,8 @@ These are generic (and condensed) installation instructions for the **current de
 * Git
 * Database (MySQL 5.x/PostgreSQL 8.x)
 * Ruby 2.1.x
-* [Node.js] (version v0.10.x)
-* [Bundler] (version 1.5.1 or higher required)
+* Node.js (version v0.10.x)
+* Bundler (version 1.5.1 or higher required)
 
 ### Install Dependencies
 


### PR DESCRIPTION
I think those two thingies were never intended to be links...

Created PR via web-UI, sorry for the local branch.
