### PR TITLE
Add wiki syntax for using acronyms

### DIFF
--- a/app/views/help/wiki_syntax_detailed.html.erb
+++ b/app/views/help/wiki_syntax_detailed.html.erb
@@ -236,6 +236,16 @@ To go live, all you need to add is a database and a web server.
 {{toc}} => left aligned toc
 {{>toc}} => right aligned toc
 </pre>
+<h3><a name="11" class="wiki-page"></a>Acronyms</h3>
+<p>Display tooltip for acronym by entering tooltip in parantheses after upper case
+acronym.</p>
+<pre>
+WHO(World Health Organisation) => Displays "World Health Organisation" as
+tooltip of "WHO"
+</pre>
+<p>
+  <acronym title="World Health Organisation">WHO</acronym>
+</p>
 <h2><a name="12" class="wiki-page"></a>Macros</h2>
 <p>OpenProject has the following builtin macros:</p>
 <p>


### PR DESCRIPTION
Textile supports the use of acronyms. However, the wiki syntax details page currently does not include a description of this feature.
Requested by a user in the forum:
https://community.openproject.org/topics/4642
