### PR TITLE
Adds a fix for syntax problem when generating json by hand

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -502,7 +502,10 @@ module ApplicationHelper
         when 6
           '6' # Saturday
         else
-          '' # use language
+          # use language (pass a blank string into the JSON object,
+          # as the datepicker implementation checks for numbers in
+          # /frontend/app/misc/datepicker-defaults.js:34)
+          '""'
         end
         # FIXME: Get rid of this abomination
         js = "var CS = { lang: '#{current_language.to_s.downcase}', firstDay: #{start_of_week} };"


### PR DESCRIPTION
This is a small fix for a issue that can pop up when the default case is used
for the first day of the week set in the datepicker via admin settings.

It would have generated the wrong JSON structure breaking _everything_.

Credit goes to @NobodysNightmare for finding this.
