### PR TITLE
suppress browser prompt on authenticate failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,7 +466,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.3)
       rack (>= 1.0)
-    warden-basic_auth (0.2.0)
+    warden-basic_auth (0.2.1)
       warden (~> 1.2)
     websocket (1.2.2)
     will_paginate (3.0.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -259,7 +259,7 @@ class ApplicationController < ActionController::Base
         authentication_scheme = if request.headers['X-Authentication-Scheme'] == 'Session'
                                   'Session'
                                 else
-                                  'Basic'
+                                  'BasicAuth' # not 'Basic' on purpose to suppress prompt
                                 end
         format.any(:xml, :js, :json)  do
           head :unauthorized,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -256,15 +256,13 @@ class ApplicationController < ActionController::Base
       respond_to do |format|
         format.any(:html, :atom) { redirect_to signin_path(back_url: url) }
 
-        authentication_scheme = if request.headers['X-Authentication-Scheme'] == 'Session'
-                                  'Session'
-                                else
-                                  'BasicAuth' # not 'Basic' on purpose to suppress prompt
-                                end
+        auth_header = OpenProject::Authentication::WWWAuthenticate.response_header(
+          request_headers: request.headers)
+
         format.any(:xml, :js, :json)  do
           head :unauthorized,
                'X-Reason' => 'login needed',
-               'WWW-Authenticate' => authentication_scheme + ' realm="OpenProject API"'
+               'WWW-Authenticate' => auth_header
         end
       end
       return false

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -22,7 +22,6 @@ end
 include OpenProject::Authentication::Scope
 
 api_v3_options = {
-  realm: 'OpenProject API',
   store: false
 }
 OpenProject::Authentication.update_strategies(API_V3, api_v3_options) do |_strategies|

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -6,11 +6,13 @@ require 'open_project/authentication/strategies/warden/global_basic_auth'
 require 'open_project/authentication/strategies/warden/user_basic_auth'
 require 'open_project/authentication/strategies/warden/session'
 
+WS = OpenProject::Authentication::Strategies::Warden
+
 strategies = [
-  [:basic_auth_failure, OpenProject::Authentication::Strategies::Warden::BasicAuthFailure, 'Basic'],
-  [:global_basic_auth,  OpenProject::Authentication::Strategies::Warden::GlobalBasicAuth,  'Basic'],
-  [:user_basic_auth,    OpenProject::Authentication::Strategies::Warden::UserBasicAuth,    'Basic'],
-  [:session,            OpenProject::Authentication::Strategies::Warden::Session,          'Session']
+  [:basic_auth_failure, WS::BasicAuthFailure, 'Basic'],
+  [:global_basic_auth,  WS::GlobalBasicAuth,  'Basic'],
+  [:user_basic_auth,    WS::UserBasicAuth,    'Basic'],
+  [:session,            WS::Session,          'Session']
 ]
 
 strategies.each do |name, clazz, auth_scheme|

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -6,19 +6,22 @@ require 'open_project/authentication/strategies/warden/global_basic_auth'
 require 'open_project/authentication/strategies/warden/user_basic_auth'
 require 'open_project/authentication/strategies/warden/session'
 
-strategies = {
-  basic_auth_failure: OpenProject::Authentication::Strategies::Warden::BasicAuthFailure,
-  global_basic_auth:  OpenProject::Authentication::Strategies::Warden::GlobalBasicAuth,
-  user_basic_auth:    OpenProject::Authentication::Strategies::Warden::UserBasicAuth,
-  session:            OpenProject::Authentication::Strategies::Warden::Session
-}
+strategies = [
+  [:basic_auth_failure, OpenProject::Authentication::Strategies::Warden::BasicAuthFailure, 'Basic'],
+  [:global_basic_auth,  OpenProject::Authentication::Strategies::Warden::GlobalBasicAuth,  'Basic'],
+  [:user_basic_auth,    OpenProject::Authentication::Strategies::Warden::UserBasicAuth,    'Basic'],
+  [:session,            OpenProject::Authentication::Strategies::Warden::Session,          'Session']
+]
 
-strategies.each do |name, clazz|
-  Warden::Strategies.add name, clazz
+strategies.each do |name, clazz, auth_scheme|
+  OpenProject::Authentication.add_strategy name, clazz, auth_scheme
 end
 
 include OpenProject::Authentication::Scope
 
-OpenProject::Authentication.update_strategies(API_V3) do |_strategies|
+api_v3_options = {
+  realm: 'OpenProject API'
+}
+OpenProject::Authentication.update_strategies(API_V3, api_v3_options) do |_strategies|
   [:global_basic_auth, :user_basic_auth, :basic_auth_failure, :session]
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -22,7 +22,8 @@ end
 include OpenProject::Authentication::Scope
 
 api_v3_options = {
-  realm: 'OpenProject API'
+  realm: 'OpenProject API',
+  store: false
 }
 OpenProject::Authentication.update_strategies(API_V3, api_v3_options) do |_strategies|
   [:global_basic_auth, :user_basic_auth, :basic_auth_failure, :session]

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -143,10 +143,13 @@ module API
     end
 
     def self.auth_headers
-      scheme = OpenProject::Authentication::WWWAuthenticate.auth_scheme
-      realm = OpenProject::Authentication::WWWAuthenticate.realm
+      lambda do
+        header = OpenProject::Authentication::WWWAuthenticate.response_header(
+          scope: API_V3,
+          request_headers: env)
 
-      { 'WWW-Authenticate' => %(#{scheme} realm="#{realm}") }
+        {'WWW-Authenticate' => header}
+      end
     end
 
     ##

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -148,7 +148,7 @@ module API
           scope: API_V3,
           request_headers: env)
 
-        {'WWW-Authenticate' => header}
+        { 'WWW-Authenticate' => header }
       end
     end
 

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -143,7 +143,10 @@ module API
     end
 
     def self.auth_headers
-      { 'WWW-Authenticate' => %(Basic realm="#{OpenProject::Authentication::Realm.realm}") }
+      scheme = OpenProject::Authentication::WWWAuthenticate.auth_scheme
+      realm = OpenProject::Authentication::WWWAuthenticate.realm
+
+      { 'WWW-Authenticate' => %(#{scheme} realm="#{realm}") }
     end
 
     ##

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -48,12 +48,13 @@ module API
         end
       end
 
-      def error_response(rescued_error, error = nil, rescue_subclasses: nil, headers: {})
+      def error_response(rescued_error, error = nil, rescue_subclasses: nil, headers: ->() { {} })
         default_response = lambda do |e|
           representer = ::API::V3::Errors::ErrorRepresenter.new e
+          resp_headers = instance_exec &headers
           env['api.format'] = 'hal+json'
 
-          error_response status: e.code, message: representer.to_json, headers: headers
+          error_response status: e.code, message: representer.to_json, headers: resp_headers
         end
 
         response =

--- a/lib/open_project/authentication.rb
+++ b/lib/open_project/authentication.rb
@@ -80,8 +80,7 @@ module OpenProject
       module_function
 
       def pick_auth_scheme(supported_schemes, default_scheme, request_headers = {})
-        key = request_headers.keys.find { |h| h =~ /X-Authentication-Scheme$/i }
-        req_scheme = request_headers[key] if key
+        req_scheme = request_headers['X-Authentication-Scheme']
 
         if supported_schemes.include? req_scheme
           req_scheme

--- a/lib/open_project/authentication.rb
+++ b/lib/open_project/authentication.rb
@@ -97,7 +97,7 @@ module OpenProject
       end
 
       def default_realm
-        'OpenProject'
+        'OpenProject API'
       end
 
       def scope_realm(scope = nil)

--- a/lib/open_project/authentication.rb
+++ b/lib/open_project/authentication.rb
@@ -5,6 +5,13 @@ module OpenProject
   # OpenProject uses Warden strategies for request authentication.
   module Authentication
     class << self
+      ##
+      # Registers a given Warden strategy to be used for authentication.
+      #
+      # @param [Symbol] Name under which the strategy can be referred to.
+      # @param [Class] The strategy class.
+      # @param [String] The authentication scheme implemented by this strategy.
+      #                 Used in the WWW-Authenticate header in 401 responses.
       def add_strategy(name, clazz, auth_scheme)
         Warden::Strategies.add name, clazz
 
@@ -26,17 +33,13 @@ module OpenProject
       #                              for this scope. The default value ()
       #
       # @yield [strategies] A block returning the strategies to be used for this scope.
-      # @yieldparam [Array] strategies The strategies currently used by this scope. May be empty.
-      # @yieldreturn [Array] The strategies to be used by this scope.
+      # @yieldparam [Set] strategies The strategies currently used by this scope. May be empty.
+      # @yieldreturn [Set] The strategies to be used by this scope.
       def update_strategies(scope, opts = {}, &block)
         raise ArgumentError, "invalid scope: #{scope}" unless Scope.values.include? scope
 
         config = Manager.scope_config scope
-        current_strategies = Array(config.strategies)
-
-        config.store = opts[:store] if opts.include? :store
-        config.realm = opts[:realm] if opts.include? :realm
-        config.strategies = block.call current_strategies if block_given?
+        config.update! opts, &block
       end
 
       ##

--- a/lib/open_project/authentication.rb
+++ b/lib/open_project/authentication.rb
@@ -61,14 +61,34 @@ module OpenProject
       end
     end
 
-    module Realm
+    ##
+    # General options used in the WWW-Authenticate header returned to the user
+    # in case authentication failed (401).
+    module WWWAuthenticate
       module_function
 
+      ##
+      # Per default the scheme is 'Basic' which is recognized by the browser
+      # which will promt the user to provide basic auth credentials in order
+      # to authenticate.
+      #
+      # When using the APIv3 through Angular, e.g. in the work package view,
+      # this behaviour is not desired, however. If the user is not logged in
+      # the calls should just fail.
+      #
+      # It is impossible to suppress the prompt using Javascript.
+      # Hence we rename the auth scheme in a way that makes it still obvious
+      # to developers that it is basic auth but still unknown to the browser
+      # thereby avoiding the undesired prompt.
+      def auth_scheme
+        'BasicAuth'
+      end
+
       def realm
-        'OpenProject'
+        'OpenProject API'
       end
     end
   end
 end
 
-Warden::Strategies::BasicAuth.prepend OpenProject::Authentication::Realm
+Warden::Strategies::BasicAuth.prepend OpenProject::Authentication::WWWAuthenticate

--- a/lib/open_project/authentication/manager.rb
+++ b/lib/open_project/authentication/manager.rb
@@ -27,7 +27,7 @@ module OpenProject
         end
 
         def scope_config(scope)
-          config[scope] ||= ScopeSettings.new false
+          config[scope] ||= ScopeSettings.new
         end
 
         def failure_handlers
@@ -35,7 +35,7 @@ module OpenProject
         end
 
         def auth_scheme(name)
-          auth_schemes[name] ||= AuthSchemeInfo.new Set.new
+          auth_schemes[name] ||= AuthSchemeInfo.new
         end
 
         def auth_schemes
@@ -52,10 +52,26 @@ module OpenProject
         end
       end
 
-      class ScopeSettings < Struct.new(:store, :strategies, :realm)
+      class ScopeSettings
+        attr_accessor :store, :strategies, :realm
+
+        def initialize
+          @strategies = Set.new
+        end
+
+        def update!(opts, &block)
+          self.store = opts[:store] if opts.include? :store
+          self.realm = opts[:realm] if opts.include? :realm
+          self.strategies = block.call self.strategies if block_given?
+        end
       end
 
-      class AuthSchemeInfo < Struct.new(:strategies)
+      class AuthSchemeInfo
+        attr_accessor :strategies
+
+        def initialize
+          @strategies = Set.new
+        end
       end
     end
   end

--- a/lib/open_project/authentication/manager.rb
+++ b/lib/open_project/authentication/manager.rb
@@ -56,7 +56,7 @@ module OpenProject
         attr_accessor :store, :strategies, :realm
 
         def initialize
-          @store = false
+          @store = true
           @strategies = Set.new
         end
 

--- a/lib/open_project/authentication/manager.rb
+++ b/lib/open_project/authentication/manager.rb
@@ -56,6 +56,7 @@ module OpenProject
         attr_accessor :store, :strategies, :realm
 
         def initialize
+          @store = false
           @strategies = Set.new
         end
 

--- a/spec/controllers/api/v2/authentication_spec.rb
+++ b/spec/controllers/api/v2/authentication_spec.rb
@@ -100,4 +100,35 @@ describe Api::V2::AuthenticationController, type: :controller do
       end
     end
   end
+
+  describe 'WWW-Authenticate response header upon failure' do
+    let(:api_key) { user.api_key }
+    let(:user) { FactoryGirl.create(:admin) }
+    let(:ttl) { 42 }
+
+    before do
+      allow(Setting).to receive(:login_required?).and_return true
+      allow(Setting).to receive(:rest_api_enabled?).and_return true
+    end
+
+    it 'has Basic auth_scheme per default' do
+      get :index, format: 'xml', key: api_key.reverse
+
+      expect(response.status).to eq 401
+      expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="OpenProject"'
+    end
+
+    context 'with Session auth scheme requested' do
+      before do
+        request.env['X-Authentication-Scheme'] = 'Session'
+      end
+
+      it 'has Session auth scheme' do
+        get :index, format: 'xml', key: api_key.reverse
+
+        expect(response.status).to eq 401
+        expect(response.headers['WWW-Authenticate']).to eq 'Session realm="OpenProject"'
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v2/authentication_spec.rb
+++ b/spec/controllers/api/v2/authentication_spec.rb
@@ -115,7 +115,7 @@ describe Api::V2::AuthenticationController, type: :controller do
       get :index, format: 'xml', key: api_key.reverse
 
       expect(response.status).to eq 401
-      expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="OpenProject"'
+      expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="OpenProject API"'
     end
 
     context 'with Session auth scheme requested' do
@@ -127,7 +127,20 @@ describe Api::V2::AuthenticationController, type: :controller do
         get :index, format: 'xml', key: api_key.reverse
 
         expect(response.status).to eq 401
-        expect(response.headers['WWW-Authenticate']).to eq 'Session realm="OpenProject"'
+        expect(response.headers['WWW-Authenticate']).to eq 'Session realm="OpenProject API"'
+      end
+    end
+
+    context 'with another default realm' do
+      before do
+        allow(OpenProject::Authentication::WWWAuthenticate)
+          .to receive(:default_realm).and_return 'Narnia'
+      end
+
+      it 'has another realm' do
+        get :index, format: 'xml', key: api_key.reverse
+
+        expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="Narnia"'
       end
     end
   end

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -67,7 +67,7 @@ describe API::V3, type: :request do
 
         it 'should return the WWW-Authenticate header' do
           expect(response.header['WWW-Authenticate'])
-            .to include 'BasicAuth realm="OpenProject API"'
+            .to include 'Basic realm="OpenProject API"'
         end
       end
 
@@ -92,7 +92,37 @@ describe API::V3, type: :request do
 
         it 'should return the WWW-Authenticate header' do
           expect(response.header['WWW-Authenticate'])
-            .to include 'BasicAuth realm="OpenProject API"'
+            .to include 'Basic realm="OpenProject API"'
+        end
+      end
+
+      context 'with invalid credentials an X-Authentication-Scheme "Session"' do
+        let(:expected_message) { 'You did not provide the correct credentials.' }
+        let(:headers) do
+          auth = basic_auth(username, password.reverse)
+
+          auth.merge('X-Authentication-Scheme' => 'Session')
+        end
+
+        before do
+          get resource, {}, headers
+        end
+
+        it 'should return 401 unauthorized' do
+          expect(response.status).to eq 401
+        end
+
+        it 'should return the correct JSON response' do
+          expect(JSON.parse(response.body)).to eq response_401
+        end
+
+        it 'should return the correct content type header' do
+          expect(response.headers['Content-Type']).to eq 'application/hal+json; charset=utf-8'
+        end
+
+        it 'should return the WWW-Authenticate header' do
+          expect(response.header['WWW-Authenticate'])
+            .to include 'Session realm="OpenProject API"'
         end
       end
 

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -66,7 +66,8 @@ describe API::V3, type: :request do
         end
 
         it 'should return the WWW-Authenticate header' do
-          expect(response.header['WWW-Authenticate']).to include 'Basic realm="OpenProject"'
+          expect(response.header['WWW-Authenticate'])
+            .to include 'BasicAuth realm="OpenProject API"'
         end
       end
 
@@ -90,7 +91,8 @@ describe API::V3, type: :request do
         end
 
         it 'should return the WWW-Authenticate header' do
-          expect(response.header['WWW-Authenticate']).to include 'Basic realm="OpenProject"'
+          expect(response.header['WWW-Authenticate'])
+            .to include 'BasicAuth realm="OpenProject API"'
         end
       end
 


### PR DESCRIPTION
If anyone knows a better way to do this let me know. The motivation is that a user should not get to see a password prompt in the browser when their session expired while doing stuff in the work packages list.

WP [#20593](https://community.openproject.org/work_packages/20593)
