### PR TITLE
[Rubocop] set line length limit to 100

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,7 +125,7 @@ LineEndConcatenation:
   Enabled: false
 
 LineLength:
-  Max: 99
+  Max: 100
 
 MethodLength:
   Enabled: false


### PR DESCRIPTION
99 is really a stupid limit. We live in a decimal world, we should have decimal limits...

If you ask me we could even go as far as 120 characters, but surely someone living in a shell will disagree. So I am taking small steps :)
