### PR TITLE
correctly type button

### DIFF
--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -32,6 +32,7 @@ module.exports = function() {
                           'menubar=no, status=no, scrollbars=yes&quot;); return false;',
       HELP_LINK_HTML = jQuery('<button title="' + I18n.t('js.inplace.link_formatting_help') + '"' +
                               ' class="jstb_help icon icon-help" ' +
+                              ' type="button" ' +
                               'onclick="' + HELP_LINK_ONCLICK + '">' +
                               '<span class="hidden-for-sighted">' +
                               I18n.t('js.inplace.link_formatting_help') +

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -38,6 +38,7 @@ module Redmine
                       "height=640, menubar=no, status=no, scrollbars=yes\"); return false;"
           help_button = content_tag :button,
                                     '',
+                                    type: 'button',
                                     class: 'jstb_help icon icon-help',
                                     onclick: open_help,
                                     title: l(:setting_text_formatting) do


### PR DESCRIPTION
In 62e6cb3 I introduced the bug https://community.openproject.org/work_packages/20069. I couldn't understand why the solution of adding "type='button'" to the help button would fix it even after reading in the [specs](https://www.w3.org/wiki/HTML/Elements/button) that when the type attribute is missing, the button receives the default type "submit"

@NobodysNightmare could enlighten me: When you press enter, a form is submitted. Apparently, the browser actually seems to click the submit button. It seems to take the first submit button it can find which in this case would be the not correctly typed help button.
