### PR TITLE
prevent duplicate prepending of base path

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -203,7 +203,12 @@ openprojectApp
       $httpProvider.interceptors.push(function($q) {
         return {
           'request': function(config) {
-            if (!config.url.match('(^/templates|\\.html$)')) {
+            // OpenProject can run in a subpath e.g. https://mydomain/open_project.
+            // We append the path found as the base-tag value to all http requests
+            // to the server except:
+            //   * when the path is already appended
+            //   * when we are getting a template
+            if (!config.url.match('(^/templates|\\.html$|^' + window.appBasePath + ')')) {
               config.url = window.appBasePath + config.url;
             }
 


### PR DESCRIPTION
Routes generated statically need the base path to be appended to the
requested url. Routes received from the server do not need to have it
appended as they should already be fully qualified.

This is true at least for the routes in the api forms which the front end uses to get the available values (https://community.openproject.org/work_packages/20067). But I think it possible, that the same could be true for other routes. 
