### PR TITLE
[20180] Fix Work Package Legacy attributes layout

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -236,6 +236,10 @@ fieldset.form--fieldset
     .form--label + span.form--field-container
       display: block
 
+  &.-break-words > .form--label
+    text-overflow: ellipsis
+    overflow: hidden
+
 .form--label
   @include grid-content(2)
   @include grid-visible-overflow
@@ -534,11 +538,6 @@ fieldset.form--fieldset
   display: flex
   & > [data-tooltip], & > [class^="tooltip--"]
     padding-top: 0.6rem
-
-.form--field
-  & .-break-words > .form--label
-    text-overflow: ellipsis
-    overflow: hidden
 
 .form--list
   display: flex

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -535,6 +535,11 @@ fieldset.form--fieldset
   & > [data-tooltip], & > [class^="tooltip--"]
     padding-top: 0.6rem
 
+.form--field
+  & .-break-words > .form--label
+    text-overflow: ellipsis
+    overflow: hidden
+
 .form--list
   display: flex
   margin: 0

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -434,7 +434,7 @@ module WorkPackagesHelper
   end
 
   def work_package_form_field(required: false, classes: '')
-    div_class = 'form--field'
+    div_class = 'form--field -wide-label'
     div_class << " #{classes}"
     div_class << ' -required' if required
 

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -434,7 +434,7 @@ module WorkPackagesHelper
   end
 
   def work_package_form_field(required: false, classes: '')
-    div_class = 'form--field -wide-label'
+    div_class = 'form--field -wide-label -break-words'
     div_class << " #{classes}"
     div_class << ' -required' if required
 

--- a/app/views/work_packages/_two_column_attributes.html.erb
+++ b/app/views/work_packages/_two_column_attributes.html.erb
@@ -29,12 +29,12 @@ See doc/COPYRIGHT.rdoc for more details.
 <% left_attributes, right_attributes = attributes.in_groups(2, false) %>
 
 <div class="grid-block wrap">
-  <div class="form--column">
+  <div class="form--column medium-6">
     <% left_attributes.each do |attribute| %>
       <%= attribute.field %>
     <% end %>
   </div>
-  <div class="form--column">
+  <div class="form--column medium-6">
     <% right_attributes.each do |attribute| %>
       <%= attribute.field %>
     <% end %>

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -284,7 +284,7 @@ describe WorkPackagesHelper, type: :helper do
       expect(helper.work_package_form_category_attribute(form,
                                                          stub_work_package,
                                                          project: stub_project).field)
-        .to be_html_eql("<div class=\"form--field \">#{label_placeholder}
+        .to be_html_eql("<div class=\"form--field -wide-label -break-words \">#{label_placeholder}
                          <span class=\"form--field-container\">category html</span>
                          </div>")
     end
@@ -438,7 +438,7 @@ describe WorkPackagesHelper, type: :helper do
   describe '#work_package_form_custom_values_attribute' do
     let(:stub_custom_value) { FactoryGirl.build_stubbed(:work_package_custom_value) }
     let(:field_content) { 'field contents' }
-    let(:expected) { "<div class=\"form--field \">#{field_content}</div>" }
+    let(:expected) { "<div class=\"form--field -wide-label -break-words \">#{field_content}</div>" }
 
     before do
       allow(stub_work_package).to receive(:custom_field_values).and_return([stub_custom_value])


### PR DESCRIPTION
This will address an issue that popped up with labels being to small in comparison to their values which lead to some ugly design issues in the old legacy form.

It should meet the requirements of https://community.openproject.org/work_packages/20180. It could also resolve the issues in IE (https://community.openproject.org/work_packages/20052).
