### PR TITLE
[19632] Realign the checkboxes in the WP List

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -120,7 +120,7 @@ tr.issue
   &.idnt-9 td.subject
     padding-left: 12.5em
 
-/* Work Package hierarchy layout
+/* Work Package hierarchy layout */
 
 tr
   &.work-package

--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -129,6 +129,7 @@ table.workpackages-table
       &.checkbox
         min-width: 0
         width: 20px
+        padding: 7px 5px 3px 7px
       &.id
         min-width: 0
         width: 50px

--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -129,7 +129,7 @@ table.workpackages-table
       &.checkbox
         min-width: 0
         width: 20px
-        padding: 7px 5px 3px 7px
+        line-height: 1
       &.id
         min-width: 0
         width: 50px


### PR DESCRIPTION
This should meet the requirements of https://community.openproject.org/work_packages/19632.

It realigns the checkboxes in the Work package list to be more in line with the text next to it.
