### PR TITLE
[20169] Use $primary-color for select2 item highlighting

### DIFF
--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -62,7 +62,7 @@
 .select2-results .select2-highlighted {
   border-radius: 5px;
 
-  background-color: #24B3E7;
+  background-color: $drop-down-selected-bg-color;
   font-weight:bold;
 }
 .select2-results .select2-result-unselectable {
@@ -172,7 +172,7 @@ $se2-width: 100%;
   }
 
   &.select2-dropdown-open {
-    
+
     .select2-choice {
       background-color: $se2-theme-selectable-color;
     }

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -216,7 +216,7 @@
     padding: 0
 
     .select2-highlighted
-      background: $header-item-bg-hover-color !important
+      background: $primary-color !important
       border-radius: 0 !important
       font-weight: bold !important
       color: $header-drop-down-item-font-hover-color

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -165,7 +165,7 @@ $my-page-edit-box-border-color:                 $primary-color-dark !default
 
 $drop-down-unselected-font-color:               $main-menu-font-color !default
 $drop-down-selected-font-color:                 $main-menu-font-color !default
-$drop-down-selected-bg-color:                   #24B3E7 !default
+$drop-down-selected-bg-color:                   $primary-color !default
 
 $action-menu-bg-color:                          #FFFFFF
 


### PR DESCRIPTION
This should meet the requirements of https://community.openproject.org/work_packages/20169.

It replaces the hard coded `#24B3E7` background for highlighted items with the `$primary-color`.
