### PR TITLE
Eliminate the color #008BD0

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -32,6 +32,7 @@
 // This is a "junk-drawer" containing CSS rule sets that could not be easily
 // placed elsewhere. Pleade DO NOT add to this file. Instead MOVE, refactor or
 // REMOVE with ruthlessness.
+@import open_project_global/variables
 
 
 #watchers
@@ -668,7 +669,7 @@ div.indent
       width: 700px
 
 .required
-  color: #008BD0
+  color: $primary-color-dark
 
 /*Gannt chart fix IE 6 */
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -263,10 +263,10 @@ fieldset.form--fieldset
     &::after
       @include default-transition
       content:  '*'
-      color:    #008BD0
+      color:    $primary-color-dark
       padding:  0 0.325rem
     &:hover::after
-      color:    smartscale(#008BD0, 30%)
+      color:    $primary-color
 
 .form--field-container
   @include grid-content(10)

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -29,10 +29,8 @@
 $inplace-edit--border-color: #ddd
 $inplace-edit--dark-background: #f8f8f8
 $inplace-edit--color--very-dark: #cacaca
-$inplace-edit--color-highlight: #0a97dd
-$inplace-edit--selected-date-border-color: #008bd0
-$inplace-edit--color-highlight: #0a97dd
-
+$inplace-edit--color-highlight: $primary-color
+$inplace-edit--selected-date-border-color: $primary-color-dark
 
 %inline-date-picker-container-position-absolute
   display: none

--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -160,11 +160,11 @@ select
  * ╰───────────────────────────────────────────────────────────────────╯
 
 a.tl-discreet-link, input.tl-discreet-link
-  color: #4b4b4b
+  color: $body-font-color
   font-weight: normal
 
 a.tl-discreet-link:hover, input.icon:hover
-  color: #008BD0
+  color: $primary-color-dark
   text-decoration: underline
 
 #content .timeline


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20267
## Description

In custom themes some components would still appear blue-ish, because they were using the hard coded color `#008BD0`. I removed all occurences of this color, but it is still possible that someone came up with another custom blue tone that I did not yet find in the code base.

After applying this fix your custom theme should feature less blue and more of your primary color and its darker counterpart.

**Note**: I've chosen the darker primary color in most places, because it has a high enough contrast ratio to be at least AA accessible using the default theme (on white background).

We should probably have guidelines for themes that state something about which colors should ideally have a good contrast against which other (background) colors.
