### PR TITLE
[20253] Use the queries path when no project id is present

### DIFF
--- a/frontend/app/services/query-service.js
+++ b/frontend/app/services/query-service.js
@@ -376,7 +376,12 @@ module.exports = function(
     },
 
     deleteQuery: function() {
-      var url = PathHelper.apiProjectQueryPath(query.project_id, query.id);
+      var url;
+      if(_.isNull(query.project_id)) {
+        url = PathHelper.apiQueryPath(query.id);
+      } else {
+        url = PathHelper.apiProjectQueryPath(query.project_id, query.id);
+      }
       return QueryService.doQuery(url, query.toUpdateParams(), 'DELETE', function(response){
         QueryService.fetchAvailableGroupedQueries(query.project_id);
 


### PR DESCRIPTION
This will fix a problem where it was not possible to delete a query in the work packages list when it was not scoped to a project, e.g. https://community.openproject.org/work_packages.

This should meet the requirements of https://community.openproject.org/work_packages/20253.
