### PR TITLE
Require bundler >= 1.5.0 (#19172).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@
 
 source 'https://rubygems.org'
 
+if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.5.0')
+  abort "OpenProject requires Bundler 1.5.0 or higher (you're using #{Bundler::VERSION}).\nPlease update with 'gem update bundler'." 
+end
+
 gem "rails", "~> 3.2.21"
 
 gem "coderay", "~> 1.0.9"


### PR DESCRIPTION
":x64_mingw" is defined in bundler 1.4.0.rc.1.
https://github.com/bundler/bundler/blob/master/CHANGELOG.md#140rc1-2013-09-29

> add support for the x64-mingw32 platform

https://github.com/bundler/bundler/pull/2590/files#diff-76f6360610f33190a6dd9c84ceb86b91R27

stackoverflow suggests adding check in Gemfile.
http://stackoverflow.com/questions/18383402/how-to-specify-minimum-bundler-version-for-gemfile

Bundler did not release 1.4.0, so we need to suggest using 1.5.0.

git-svn-id: http://svn.redmine.org/redmine/trunk@14065 e93f8b46-1217-0410-a6f0-8f06a7374b81
