### PR TITLE
sqlite3: use '1=1' instead of Arel::Nodes::True.new

### DIFF
--- a/app/models/version/project_sharing.rb
+++ b/app/models/version/project_sharing.rb
@@ -120,7 +120,7 @@ module Version::ProjectSharing
     when 'hierarchy'
       project_sharing_hierarchy_join_condition(sharing_table, projects_table)
     when 'system'
-      Arel::Nodes::True.new
+      '1=1'
     else
       sharing_table[:id].eq(projects_table[:id])
     end


### PR DESCRIPTION
This is a part of #3040.
This certificates no breaking MySQL and PostgreSQL.

https://github.com/git/git/blob/v2.4.3/Documentation/SubmittingPatches#L37

> (1) Make separate commits for logically separate changes.

https://mercurial.selenic.com/wiki/ContributingChanges#Organizing_patches

> implement one clear step in your process
> be sent as a separate email
