### PR TITLE
sqlite3: fix db migrate index name

### DIFF
--- a/db/migrate/20130409133702_create_timelines_planning_element_types.rb
+++ b/db/migrate/20130409133702_create_timelines_planning_element_types.rb
@@ -45,7 +45,7 @@ class CreateTimelinesPlanningElementTypes < ActiveRecord::Migration
     end
 
     add_index :timelines_planning_element_types, :color_id
-    add_index :timelines_planning_element_types, :project_type_id
+    add_index :timelines_planning_element_types, :project_type_id, name: 'idx_tlpet'
   end
 
   def self.down

--- a/db/migrate/20130409133705_create_timelines_alternate_dates.rb
+++ b/db/migrate/20130409133705_create_timelines_alternate_dates.rb
@@ -39,7 +39,7 @@ class CreateTimelinesAlternateDates < ActiveRecord::Migration
       t.timestamps
 
     end
-    add_index :timelines_alternate_dates, :planning_element_id
+    add_index :timelines_alternate_dates, :planning_element_id, name: 'idx_tadpei'
     add_index :timelines_alternate_dates, :scenario_id
   end
 


### PR DESCRIPTION
```
==  RemoveProjectTypeIdFromTimelinesPlanningElementTypes: migrating
===========
-- change_table(:timelines_planning_element_types)
rake aborted!
StandardError: An error has occurred, this and all later migrations
canceled:
Index name
'temp_index_altered_timelines_planning_element_types_on_project_type_id'
on table 'altered_timelines_planning_element_types' is too long; the limit
is 64
characters/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:573:in
`add_index_options'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:351:in
`add_index'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:539:in
`block in copy_table_indexes'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:522:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:522:in
`copy_table_indexes'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:515:in
`copy_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:488:in
`move_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:481:in
`block in alter_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:480:in
`alter_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:418:in
`block in remove_column'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:417:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:417:in
`remove_column'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_definitions.rb:394:in
`remove'
/home/travis/build/marutosi/openproject/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb:33:in
`block in up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:243:in
`change_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in
`block in method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in
`block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in
`say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in
`method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:334:in
`method_missing'
/home/travis/build/marutosi/openproject/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb:32:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:370:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in
`block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in
`block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in
`with_connection'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:389:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:528:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:720:in
`block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`call'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`block in ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/transactions.rb:208:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:719:in
`block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:570:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:551:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/railties/databases.rake:193:in
`block (2 levels) in <top (required)>'
/home/travis/build/marutosi/openproject/lib/tasks/ci.rake:90:in `block (3
levels) in <top (required)>'
ArgumentError: Index name
'temp_index_altered_timelines_planning_element_types_on_project_type_id'
on table 'altered_timelines_planning_element_types' is too long; the limit
is 64 characters
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:573:in
`add_index_options'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:351:in
`add_index'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:539:in
`block in copy_table_indexes'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:522:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:522:in
`copy_table_indexes'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:515:in
`copy_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:488:in
`move_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:481:in
`block in alter_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:480:in
`alter_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:418:in
`block in remove_column'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:417:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:417:in
`remove_column'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_definitions.rb:394:in
`remove'
/home/travis/build/marutosi/openproject/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb:33:in
`block in up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/schema_statements.rb:243:in
`change_table'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in
`block in method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in
`block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in
`say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in
`method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:334:in
`method_missing'
/home/travis/build/marutosi/openproject/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb:32:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:370:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in
`block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in
`block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in
`with_connection'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:389:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:528:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:720:in
`block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`call'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`block in ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/transactions.rb:208:in
`transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in
`ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:719:in
`block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in
`each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:570:in
`up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:551:in
`migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/railties/databases.rake:193:in
`block (2 levels) in <top (required)>'
/home/travis/build/marutosi/openproject/lib/tasks/ci.rake:90:in `block (3
levels) in <top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

This is a part of #3040.
This certificates no breaking MySQL and PostgreSQL.

https://github.com/git/git/blob/v2.4.3/Documentation/SubmittingPatches#L37

> (1) Make separate commits for logically separate changes.

https://mercurial.selenic.com/wiki/ContributingChanges#Organizing_patches

> implement one clear step in your process be sent as a separate email
