### PR TITLE
sqlite3: fix  db/migrate/migration_utils/customizable_utils.rb

### DIFF
--- a/db/migrate/migration_utils/customizable_utils.rb
+++ b/db/migrate/migration_utils/customizable_utils.rb
@@ -102,8 +102,9 @@ module Migration::Utils
             OR cft.type_id IS NULL
         SQL
       else
+        str_false = postgres? ? 'FALSE' : "'f'"
         delete <<-SQL
-          DELETE FROM custom_values AS cvd
+          DELETE FROM custom_values
           WHERE EXISTS
           (
             SELECT w.id, cf.id, cfp.project_id, p.name, cft.type_id
@@ -113,9 +114,9 @@ module Migration::Utils
               JOIN projects AS p ON (w.project_id = p.id)
               LEFT JOIN custom_fields_projects AS cfp ON (cv.custom_field_id = cfp.custom_field_id AND w.project_id = cfp.project_id)
               LEFT JOIN custom_fields_types AS cft ON (cv.custom_field_id = cft.custom_field_id AND w.type_id = cft.type_id)
-            WHERE (cfp.project_id IS NULL AND cf.is_for_all = FALSE
+            WHERE (cfp.project_id IS NULL AND cf.is_for_all = #{str_false}
               OR cft.type_id IS NULL)
-              AND cv.id = cvd.id
+              AND cv.id = custom_values.id
            );
         SQL
       end


### PR DESCRIPTION
Contributor cannot reopen PR closed by stupid repository owner. 

```
==  AddMissingCustomizableJournals: migrating =================================
-- Add missing customizable journals
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:
SQLite3::SQLException: near "AS": syntax error:           DELETE FROM custom_values AS cvd
          WHERE EXISTS
          (
            SELECT w.id, cf.id, cfp.project_id, p.name, cft.type_id
            FROM work_packages AS w
              JOIN custom_values AS cv ON (w.id = cv.customized_id AND cv.customized_type = 'WorkPackage')
              JOIN custom_fields AS cf ON (cv.custom_field_id = cf.id)
              JOIN projects AS p ON (w.project_id = p.id)
              LEFT JOIN custom_fields_projects AS cfp ON (cv.custom_field_id = cfp.custom_field_id AND w.project_id = cfp.project_id)
              LEFT JOIN custom_fields_types AS cft ON (cv.custom_field_id = cft.custom_field_id AND w.type_id = cft.type_id)
            WHERE (cfp.project_id IS NULL AND cf.is_for_all = FALSE
              OR cft.type_id IS NULL)
              AND cv.id = cvd.id
           );
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `initialize'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `new'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `prepare'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:246:in `block in exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:242:in `exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:268:in `exec_delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:101:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in `block in method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in `method_missing'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:105:in `delete_invalid_work_package_custom_values'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:41:in `add_missing_customizable_journals'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:38:in `block in up'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:37:in `block (2 levels) in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:446:in `suppress_messages'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:36:in `block in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:35:in `say_with_time_silently'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:37:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in `with_connection'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:389:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:528:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:720:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `call'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `block in ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/transactions.rb:208:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:719:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:570:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:551:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/railties/databases.rake:193:in `block (2 levels) in <top (required)>'
/home/travis/build/marutosi/openproject/lib/tasks/ci.rake:90:in `block (3 levels) in <top (required)>'
ActiveRecord::StatementInvalid: SQLite3::SQLException: near "AS": syntax error:           DELETE FROM custom_values AS cvd
          WHERE EXISTS
          (
            SELECT w.id, cf.id, cfp.project_id, p.name, cft.type_id
            FROM work_packages AS w
              JOIN custom_values AS cv ON (w.id = cv.customized_id AND cv.customized_type = 'WorkPackage')
              JOIN custom_fields AS cf ON (cv.custom_field_id = cf.id)
              JOIN projects AS p ON (w.project_id = p.id)
              LEFT JOIN custom_fields_projects AS cfp ON (cv.custom_field_id = cfp.custom_field_id AND w.project_id = cfp.project_id)
              LEFT JOIN custom_fields_types AS cft ON (cv.custom_field_id = cft.custom_field_id AND w.type_id = cft.type_id)
            WHERE (cfp.project_id IS NULL AND cf.is_for_all = FALSE
              OR cft.type_id IS NULL)
              AND cv.id = cvd.id
           );
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `initialize'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `new'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `prepare'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:246:in `block in exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:242:in `exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:268:in `exec_delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:101:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in `block in method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in `method_missing'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:105:in `delete_invalid_work_package_custom_values'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:41:in `add_missing_customizable_journals'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:38:in `block in up'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:37:in `block (2 levels) in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:446:in `suppress_messages'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:36:in `block in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:35:in `say_with_time_silently'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:37:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in `with_connection'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:389:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:528:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:720:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `call'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `block in ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/transactions.rb:208:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:719:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:570:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:551:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/railties/databases.rake:193:in `block (2 levels) in <top (required)>'
/home/travis/build/marutosi/openproject/lib/tasks/ci.rake:90:in `block (3 levels) in <top (required)>'
SQLite3::SQLException: near "AS": syntax error
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `initialize'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `new'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `prepare'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:246:in `block in exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:242:in `exec_query'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/sqlite_adapter.rb:268:in `exec_delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:101:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `delete'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in `block in method_missing'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in `method_missing'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:105:in `delete_invalid_work_package_custom_values'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/customizable_utils.rb:41:in `add_missing_customizable_journals'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:38:in `block in up'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:37:in `block (2 levels) in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:446:in `suppress_messages'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:36:in `block in say_with_time_silently'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/home/travis/build/marutosi/openproject/db/migrate/migration_utils/utils.rb:35:in `say_with_time_silently'
/home/travis/build/marutosi/openproject/db/migrate/20131018134590_add_missing_customizable_journals.rb:37:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:410:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in `with_connection'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:389:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:528:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:720:in `block (2 levels) in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `call'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `block in ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/transactions.rb:208:in `transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:775:in `ddl_transaction'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:719:in `block in migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `each'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:700:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:570:in `up'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/migration.rb:551:in `migrate'
/home/travis/build/marutosi/openproject/vendor/bundle/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/railties/databases.rake:193:in `block (2 levels) in <top (required)>'
/home/travis/build/marutosi/openproject/lib/tasks/ci.rake:90:in `block (3 levels) in <top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)

```

This is a part of #3040.
This certificates no breaking MySQL and PostgreSQL.

https://github.com/git/git/blob/v2.4.3/Documentation/SubmittingPatches#L37

> (1) Make separate commits for logically separate changes.

https://mercurial.selenic.com/wiki/ContributingChanges#Organizing_patches

> implement one clear step in your process be sent as a separate email
