### PR TITLE
[18930] Fix failing specs inplace edit

### DIFF
--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/shared_examples'
+require 'features/work_packages/details/inplace_editor/shared_contexts'
 require 'features/work_packages/details/inplace_editor/work_package_field'
 
 describe 'description inplace editor', js: true do
+  include_context 'maximized window'
+
   let(:project) { FactoryGirl.create :project_with_types, is_public: true }
   let(:property_name) { :description }
   let(:property_title) { 'Description' }

--- a/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
@@ -29,7 +29,6 @@
 # maximizes the window for any given page
 # is needed for certain situations where the details pane must be visible
 
-
 shared_context 'maximized window' do
   def maximize!
     page.driver.browser.manage.window.maximize

--- a/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
@@ -28,6 +28,14 @@
 
 # maximizes the window for any given page
 # is needed for certain situations where the details pane must be visible
-def maximize(page)
-  page.driver.browser.manage.window.maximize
+
+
+shared_context 'maximized window' do
+  def maximize!
+    page.driver.browser.manage.window.maximize
+  end
+
+  before do
+    maximize!
+  end
 end

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -95,7 +95,10 @@ shared_examples 'a cancellable field' do
     end
 
     it 'focuses the trigger link' do
-      expect(page).to have_selector("#{field.field_selector} #{field.trigger_link_selector}:focus")
+      active_class_name = page.evaluate_script('document.activeElement.className')
+      trigger_link_focused = "a.#{active_class_name}" == field.trigger_link_selector
+
+      expect(trigger_link_focused).to be_truthy
     end
   end
 

--- a/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
@@ -11,6 +11,7 @@ describe 'subject inplace editor', js: true do
   let(:field) { WorkPackageField.new page, property_name }
 
   before do
+    maximize(page)
     allow(User).to receive(:current).and_return(user)
     visit project_work_packages_path(project)
     row = page.find("#work-package-#{work_package.id}")

--- a/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/shared_examples'
+require 'features/work_packages/details/inplace_editor/shared_contexts'
 require 'features/work_packages/details/inplace_editor/work_package_field'
 
 describe 'subject inplace editor', js: true do
+  include_context 'maximized window'
+
   let(:project) { FactoryGirl.create :project_with_types, is_public: true }
   let(:property_name) { :subject }
   let(:property_title) { 'Subject' }
@@ -11,7 +14,6 @@ describe 'subject inplace editor', js: true do
   let(:field) { WorkPackageField.new page, property_name }
 
   before do
-    maximize(page)
     allow(User).to receive(:current).and_return(user)
     visit project_work_packages_path(project)
     row = page.find("#work-package-#{work_package.id}")

--- a/spec/support/page.rb
+++ b/spec/support/page.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# maximizes the window for any given page
+# is needed for certain situations where the details pane must be visible
+def maximize(page)
+  page.driver.browser.manage.window.maximize
+end


### PR DESCRIPTION
This will address problems we found with the rspec capybara specs on our internal CI. 

Technically, this is considered housekeeping (https://community.openproject.org/work_packages/18714).
