### PR TITLE
[20261] [Details Pane] superfluous warning on page leave

### DIFF
--- a/app/assets/javascripts/warn_leaving_unsaved.js
+++ b/app/assets/javascripts/warn_leaving_unsaved.js
@@ -28,11 +28,17 @@
 
 
 var warnLeavingUnsavedMessage;
+
+var removeChangedData = function(){
+  jQuery('textarea').removeData('changed');
+};
+
 function warnLeavingUnsaved(message) {
   warnLeavingUnsavedMessage = message;
-  jQuery('form').submit(function(){
-    jQuery('textarea').removeData('changed');
-  });
+
+  jQuery('form').submit(removeChangedData);
+  jQuery('form button').click(removeChangedData);
+
   jQuery('textarea').change(function(){
     jQuery(this).data('changed', 'changed');
   });

--- a/frontend/app/templates/components/activity_comment.html
+++ b/frontend/app/templates/components/activity_comment.html
@@ -1,5 +1,5 @@
 <div class="activity-comment" ng-if="canAddComment">
-  <form name="commentForm">
+  <form name="commentForm" ng-submit="$parent.createComment()">
     <label for="add-comment-text" class="hidden-for-sighted">
       {{ $parent.title }}
     </label>
@@ -13,7 +13,6 @@
               data-wp_autocomplete_url="{{ autocompletePath }}">
     </textarea>
     <button class="button"
-            ng-click="$parent.createComment()"
             ng-disabled="commentForm.$invalid || $parent.processingComment">
       <i class="icon-yes icon-left"></i>{{ $parent.buttonTitle }}
     </button>

--- a/frontend/app/templates/components/activity_comment.html
+++ b/frontend/app/templates/components/activity_comment.html
@@ -1,5 +1,5 @@
 <div class="activity-comment" ng-if="canAddComment">
-  <form name="commentForm" ng-submit="$parent.createComment()">
+  <form name="commentForm">
     <label for="add-comment-text" class="hidden-for-sighted">
       {{ $parent.title }}
     </label>
@@ -13,6 +13,7 @@
               data-wp_autocomplete_url="{{ autocompletePath }}">
     </textarea>
     <button class="button"
+            ng-click="$parent.createComment()"
             ng-disabled="commentForm.$invalid || $parent.processingComment">
       <i class="icon-yes icon-left"></i>{{ $parent.buttonTitle }}
     </button>

--- a/spec/features/work_packages/details/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/activity_comments_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'activity comments', js: true do
+  let(:project) { FactoryGirl.create :project_with_types, is_public: true }
+  let!(:work_package) { FactoryGirl.create(:work_package, project: project )}
+  let(:user) { FactoryGirl.create :admin }
+
+  before do
+    allow(User).to receive(:current).and_return(user)
+    visit project_work_packages_path(project)
+    current_window.resize_to(1440, 800)
+    row = page.find("#work-package-#{work_package.id}")
+    row.double_click
+    expect(find('#add-comment-text')).to be_present
+  end
+
+  it 'should alert user if navigating with unsaved form' do
+    page.execute_script("jQuery('#add-comment-text').val('Foobar').trigger('change')")
+    visit root_path
+    page.driver.browser.switch_to.alert.accept
+    expect(current_path).to eq(root_path)
+  end
+
+  it 'should not alert if comment has been submitted' do
+    page.execute_script("jQuery('#add-comment-text').val('Foobar').trigger('change')")
+    page.execute_script("jQuery('#add-comment-text').siblings('button').trigger('click')")
+    visit root_path
+    expect(current_path).to eq(root_path)
+  end
+end

--- a/spec/features/work_packages/details/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/activity_comments_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'activity comments', js: true do
   let(:project) { FactoryGirl.create :project_with_types, is_public: true }
-  let!(:work_package) { FactoryGirl.create(:work_package, project: project )}
+  let!(:work_package) { FactoryGirl.create(:work_package, project: project) }
   let(:user) { FactoryGirl.create :admin }
 
   before do


### PR DESCRIPTION
Warning message was being displayed due to a form submit event not being triggered in [this file](https://github.com/opf/openproject/blob/dev/app/assets/javascripts/warn_leaving_unsaved.js#L33-L35).
I've changed the trigger for the createComment method to be form submit, rather than the button click.
