### PR TITLE
Reintroduce warning banner for old bundler versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,22 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.5.0')
+  abort <<-Message
+
+  *****************************************************
+  *                                                   *
+  *   OpenProject requires bundler version >= 1.5.0   *
+  *                                                   *
+  *   Please install bundler with:                    *
+  *                                                   *
+  *   gem install bundler                             *
+  *                                                   *
+  *****************************************************
+
+  Message
+end
+
 source 'https://rubygems.org'
 
 gem "rails", "~> 3.2.21"

--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,9 @@ if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.5.0')
   *                                                   *
   *   OpenProject requires bundler version >= 1.5.0   *
   *                                                   *
-  *   Please install bundler with:                    *
+  *   Please update bundler with:                     *
   *                                                   *
-  *   gem install bundler                             *
+  *   gem update bundler                              *
   *                                                   *
   *****************************************************
 


### PR DESCRIPTION
## Description

This PR is at first intended as discussion point. @linki removed this warning some time ago, however I see that it makes sense.

Without the warning message an older bundler version will output something like this:

```
`ruby_20` is not a valid platform. The available options are: [:ruby, :ruby_18, :ruby_19, :mri, :mri_18, :mri_19, :rbx, :jruby, :mswin, :mingw, :mingw_18, :mingw_19]
```

It is not quite apparent that an update of the local bundler version will fix the issue. Stating this explicitly is therefore quite helpful.

I also believe that though bundler 1.5 is over a year old now that does not mean the error will not happen anymore. At least I do not regularly update all my gems.

I therefore vote to re-enable that warning banner, but other opinions are welcome as well ^^
