### PR TITLE
CVE-2015-1855: update Ruby to 2.1.6

### DIFF
--- a/packaging/setup
+++ b/packaging/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo "ruby '2.1.5'" > Gemfile.local
+echo "ruby '2.1.6'" > Gemfile.local
 
 cp -f packaging/conf/configuration.yml config/configuration.yml
 sed -i "s|config.serve_static_assets = false|config.serve_static_assets = true|" config/environments/production.rb


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability/
