### PR TITLE
.pkgr.yml: add CentOS/RHEL 7

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -12,6 +12,8 @@ targets:
       - ImageMagick-devel
   centos-6:
     <<: *redhat
+  centos-7:
+    <<: *redhat
   sles-12:
     build_dependencies:
       - ImageMagick-devel


### PR DESCRIPTION
http://blog.packager.io/post/118789120901/debian-8-centos-rhel-7-and-sles-12-now-available
