### PR TITLE
[18714] Pin select2 3.5.2

### DIFF
--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -39,6 +39,7 @@
     "jquery": "1.11.0",
     "angular": "1.3.14",
     "angular-animate": "1.3.14",
-    "moment": "9bc879e7b146c484b499b3135b8d84e8425f8ec4"
+    "moment": "9bc879e7b146c484b499b3135b8d84e8425f8ec4",
+    "select2": "3.5.2"
   }
 }


### PR DESCRIPTION
This will pin the dependency to select2 to 3.5.2

I noticed it while doing a quick reinstall of all the node_modules and bower deps.
