### PR TITLE
Allow raising exceptions from notification jobs

### DIFF
--- a/app/workers/mail_notification_job.rb
+++ b/app/workers/mail_notification_job.rb
@@ -30,6 +30,8 @@
 ##
 # Requires including class to implement #notification_mail.
 module MailNotificationJob
+  mattr_accessor :raise_exceptions
+
   def perform
     notify
   end
@@ -40,6 +42,7 @@ module MailNotificationJob
     # Since we cannot recover from this error we catch it and move on.
     Rails.logger.error "Cannot deliver notification (#{self.inspect})
                         as required record was not found: #{e}".squish
+    raise e if raise_exceptions
   end
 
   def error(_job, e)

--- a/spec/workers/mail_notification_jobs_spec.rb
+++ b/spec/workers/mail_notification_jobs_spec.rb
@@ -64,8 +64,17 @@ describe 'mail notification jobs', type: :model do
         expect(mail).not_to be_present
       end
 
-      it 'deos not raise an error but fails silently' do
+      it 'does not raise an error but fails silently' do
         expect{job.perform}.not_to raise_error
+      end
+
+      context 'raising exceptions' do
+        before { MailNotificationJob.raise_exceptions = true }
+        after { MailNotificationJob.raise_exceptions = false }
+
+        it 'raises an error' do
+          expect { job.perform }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
     end
 


### PR DESCRIPTION
Some RecordNotFound exceptions require an investigation and the possibility to rerun the job like [here](https://community.openproject.org/work_packages/19961).
With help of this feature the behavior might be configured as the following: MailNotificationJob.raise_exceptions = true
If it is put into the initialization then exceptions will raise.
If it is not configured, it is considered as false which sticks to default behavior - silent skipping of exceptions.
