### PR TITLE
extend allow_attribute_update with action

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -169,12 +169,14 @@ module OpenProject::Plugins
         end
       end
 
-      base.send(:define_method, :allow_attribute_update) do |model, attribute, &block|
+      base.send(:define_method, :allow_attribute_update) do |model, actions, attribute, &block|
         config.to_prepare do
           model_name = model.to_s.camelize
           namespace = model_name.pluralize
-          contract_class = "::API::V3::#{namespace}::#{model_name}Contract".constantize
-          contract_class.attribute attribute, &block
+          Array(actions).each do |action|
+            contract_class = "::API::V3::#{namespace}::#{action.to_s.camelize}Contract".constantize
+            contract_class.attribute attribute, &block
+          end
         end
       end
 


### PR DESCRIPTION
As we now have not only an update action but also create actions we also
have two types of contracts (Create and update). As the attributes that
are allowed to be changed might differ between the two, we enable a
plugin to specify for which action it wants to extend the updatable
attributes.

This enables plugins to adapt the correct contract. This got broken by #2990
