### PR TITLE
[19427] Fixed empty message content bug

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -44,8 +44,8 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= f.select :board_id, @project.boards.collect {|b| [b.name, b.id]}, label: Board.name.humanize %>
   </div>
 <% end %>
-<div class="form--field">
-  <%= f.text_area :content, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' }, 'data-wp_autocomplete_url' => work_packages_auto_complete_path(project_id: @project, format: :json) %>
+<div class="form--field -required">
+  <%= f.text_area :content, required: true, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' }, 'data-wp_autocomplete_url' => work_packages_auto_complete_path(project_id: @project, format: :json) %>
   <%= wikitoolbar_for(replying ? 'reply_content' : 'message_content') %>
 </div>
 <%= render :partial => 'attachments/form' %>


### PR DESCRIPTION
The message content in a forum cannot be empty any more. This doesn't fix the bug but avoids it, since it can't be reproduced anymore.
https://community.openproject.org/work_packages/19427
