### PR TITLE
[19972] Move `New subproject` button to the project settings

### DIFF
--- a/app/views/my/page.html.erb
+++ b/app/views/my/page.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <li class="toolbar-item" title="<%= l(:label_personalize_page) %>">
     <%= link_to({ action: 'page_layout' }, accesskey: accesskey(:edit), class: 'button') do %>
       <i class="button--icon icon-settings"></i>
-      <span class="button--text"></span>
+      <span class="hidden-for-sighted"><%= l(:label_personalize_page) %></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/my/page.html.erb
+++ b/app/views/my/page.html.erb
@@ -28,10 +28,10 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <% breadcrumb_paths(l(:label_my_page)) %>
 <%= toolbar title: l(:label_my_page) do %>
-  <li class="toolbar-item">
+  <li class="toolbar-item" title="<%= l(:label_personalize_page) %>">
     <%= link_to({ action: 'page_layout' }, accesskey: accesskey(:edit), class: 'button') do %>
-      <i class="button--icon icon-edit"></i>
-      <span class="button--text"><%= l(:label_personalize_page) %></span>
+      <i class="button--icon icon-settings"></i>
+      <span class="button--text"></span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/projects/settings.html.erb
+++ b/app/views/projects/settings.html.erb
@@ -29,11 +29,18 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title(l(:label_settings)) -%>
 <% breadcrumb_paths(l(:label_settings)) %>
 <%= toolbar title: l(:label_settings) do %>
+  <% if User.current.allowed_to?(:add_subprojects, @project) %>
+    <li class="toolbar-item">
+      <%= link_to new_project_path(parent_id: @project), class: 'button -alt-highlight' do %>
+        <i class="icon-add"></i> <%= l(:label_subproject_new) %>
+      <% end %>
+    </li>
+  <% end %>
   <% if @project.copy_allowed? %>
     <li class="toolbar-item">
       <%= link_to copy_from_project_path(@project, coming_from: :settings), class: 'button copy', accesskey: accesskey(:copy) do %>
         <i class="button--icon icon-copy"></i>
-        <span class="button--text"><%= l(:button_copy) %></span>
+        <span class="button--text"><%= l(:label_copy_project) %></span>
       <% end %>
     </li>
   <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -27,16 +27,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l(:label_overview) do %>
-  <% if User.current.allowed_to?(:add_subprojects, @project) %>
-    <li class="toolbar-item">
-      <%= link_to({:controller => '/projects', :action => 'new', :parent_id => @project}, :class => 'button -alt-highlight') do %>
-        <i class="button--icon icon-add"></i>
-        <span class="button--text"><%= l(:label_subproject_new) %></span>
-      <% end %>
-    </li>
-  <% end %>
-<% end %>
+<%= toolbar title: l(:label_overview) %>
+
 <% breadcrumb_paths(l(:label_overview)) %>
 
 <div class="grid-block medium-up-2">


### PR DESCRIPTION
This will also remove the button from the default project show page and rename the copy button to `copy project`.

It also replaces the `personalize page` button with the settings gear icon.

Should meet the requirements of https://community.openproject.org/work_packages/19972
