### PR TITLE
password only required for new users

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -94,8 +94,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% unless OpenProject::Configuration.disable_password_choice? %>
           <div class="form--field">
             <%= f.password_field :password,
-                                 :required => true,
-                                 :size => 25,
+                                 :required => @user.new_record?,
                                  :disabled => assign_random_password_enabled %>
             <div class="form--field-instructions">
               <%= password_complexity_requirements %>
@@ -103,8 +102,7 @@ See doc/COPYRIGHT.rdoc for more details.
           </div>
           <div class="form--field">
             <%= f.password_field :password_confirmation,
-                                 :required => true,
-                                 :size => 25,
+                                 :required => @user.new_record?,
                                  :disabled => assign_random_password_enabled %>
           </div>
         <% end %>


### PR DESCRIPTION
Because after that, passwords do not have to be set mandatorily for
every user update. But for new users it of course is a required field.

https://community.openproject.org/work_packages/20320
