### PR TITLE
[19811] Work around white space wrapping in Firefox

### DIFF
--- a/app/assets/stylesheets/content/_attributes_table.sass
+++ b/app/assets/stylesheets/content/_attributes_table.sass
@@ -47,6 +47,8 @@
       white-space:    nowrap
       overflow:       hidden
       text-overflow:  ellipsis
+      &.icon
+        white-space: normal
 
   &.-hidden
     display: none

--- a/frontend/app/templates/work_packages/tabs/_work_package_relations.html
+++ b/frontend/app/templates/work_packages/tabs/_work_package_relations.html
@@ -41,7 +41,7 @@
                 </span>
                 <empty-element ng-if="!relatedWorkPackage.embedded.assignee"></empty-element>
               </td>
-              <td>
+              <td class="icon">
                 <accessible-by-keyboard ng-if="handler.canDeleteRelation(relation)"
                                         execute="handler.removeRelation(this)">
                   <icon-wrapper icon-name="delete"


### PR DESCRIPTION
This will prevent the cutting of of the delete icon - the initial problem here
is fixed by suppressing the whitespace property via an `icon` class in the table
cell holding the icon.

Should meet the requirements of https://community.openproject.org/work_packages/19811
