### PR TITLE
Fix running of specs with rspec executable

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -27,3 +27,4 @@
 #++
 
 --color
+--exclude-pattern spec/legacy/**/*_spec.rb


### PR DESCRIPTION
Continuation of #2786

Legacy specs should be filtered out by default when using `rspec`
executable with no arguments or a path that contains both legacy and
non-legacy specs (e.g. `rspec spec`).

As noted in 1a0e2b90, suites must be run separately for time-being.
