### PR TITLE
[20138] use absolute urls for header linking in ToCs

### DIFF
--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -379,7 +379,12 @@ module OpenProject
         item = strip_tags(content).strip
         anchor = item.gsub(%r{[^\w\s\-]}, '').gsub(%r{\s+(\-+\s*)?}, '-')
         @parsed_headings << [level, anchor, item]
-        "<a name=\"#{anchor}\"></a>\n<h#{level} #{attrs}>#{content}<a href=\"##{anchor}\" class=\"wiki-anchor\">&para;</a></h#{level}>"
+        url = full_url anchor
+        if url
+          "<a name=\"#{anchor}\"></a>\n<h#{level} #{attrs}>#{content}<a href=\"#{url}\" class=\"wiki-anchor\">&para;</a></h#{level}>"
+        else
+          "<h#{level} #{attrs}>#{content}</h#{level}>"
+        end
       end
     end
 
@@ -408,7 +413,12 @@ module OpenProject
             elsif started
               out << '</li><li>'
             end
-            out << "<a href=\"##{anchor}\">#{item}</a>"
+            url = full_url anchor
+            if url
+              out << "<a href=\"#{url}\">#{item}</a>"
+            else
+              out << "#{item}"
+            end
             current = level
             started = true
           end
@@ -417,6 +427,20 @@ module OpenProject
           out << '</div></fieldset>'
         end
       end
+    end
+
+    #
+    # displays the current url plus an optional anchor
+    #
+    def full_url(anchor_name = '')
+      return nil if current_request.nil?
+      current = url_for
+      return current if anchor_name.blank?
+      "#{current}##{anchor_name}"
+    end
+
+    def current_request
+      request rescue nil
     end
   end
 end

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -379,12 +379,8 @@ module OpenProject
         item = strip_tags(content).strip
         anchor = item.gsub(%r{[^\w\s\-]}, '').gsub(%r{\s+(\-+\s*)?}, '-')
         @parsed_headings << [level, anchor, item]
-        url = full_url anchor
-        if url
-          "<a name=\"#{anchor}\"></a>\n<h#{level} #{attrs}>#{content}<a href=\"#{url}\" class=\"wiki-anchor\">&para;</a></h#{level}>"
-        else
-          "<h#{level} #{attrs}>#{content}</h#{level}>"
-        end
+        url = full_url(anchor)
+        "<a name=\"#{anchor}\"></a>\n<h#{level} #{attrs}>#{content}<a href=\"#{url}\" class=\"wiki-anchor\">&para;</a></h#{level}>"
       end
     end
 
@@ -414,11 +410,7 @@ module OpenProject
               out << '</li><li>'
             end
             url = full_url anchor
-            if url
-              out << "<a href=\"#{url}\">#{item}</a>"
-            else
-              out << "#{item}"
-            end
+            out << "<a href=\"#{url}\">#{item}</a>"
             current = level
             started = true
           end
@@ -433,7 +425,7 @@ module OpenProject
     # displays the current url plus an optional anchor
     #
     def full_url(anchor_name = '')
-      return nil if current_request.nil?
+      return "##{anchor_name}" if current_request.nil?
       current = url_for
       return current if anchor_name.blank?
       "#{current}##{anchor_name}"

--- a/spec/legacy/unit/helpers/application_helper_spec.rb
+++ b/spec/legacy/unit/helpers/application_helper_spec.rb
@@ -394,14 +394,23 @@ EXPECTED
     assert_equal expected.gsub(%r{[\r\n\t]}, ''), format_text(raw).gsub(%r{[\r\n\t]}, '')
   end
 
-  it 'should headings' do
+  it 'should headings without url' do
+    undef request
     raw = 'h1. Some heading'
     expected = %|<a name="Some-heading"></a>\n<h1 >Some heading<a href="#Some-heading" class="wiki-anchor">&para;</a></h1>|
 
     assert_equal expected, format_text(raw)
   end
 
+  it 'should headings with url' do
+    raw = 'h1. Some heading'
+    expected = %|<a name="Some-heading"></a>\n<h1 >Some heading<a href="/issues#Some-heading" class="wiki-anchor">&para;</a></h1>|
+
+    assert_equal expected, format_text(raw)
+  end
+
   it 'should table of content' do
+    undef request
     @project.wiki.start_page = 'Wiki'
     @project.wiki.save!
     FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Wiki'
@@ -464,6 +473,7 @@ RAW
   end
 
   it 'should table of content should contain included page headings' do
+    undef request
     @project.wiki.start_page = 'Wiki'
     @project.save!
     page  = FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Wiki'

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -573,39 +573,83 @@ WIKI_TEXT
 
     subject(:html) { format_text(wiki_text) }
 
-    it 'emits a table of contents for headings h1-h4' do
-      expect(html).to be_html_eql(%{
-        <fieldset class='form--fieldset -collapsible'>
-          <legend class='form--fieldset-legend' title='Show/Hide table of contents' onclick='toggleFieldset(this);'>
-            <a href='javascript:'>Table of Contents</a>
-          </legend>
-          <div>
-            <ul class="toc">
-              <li>
-                <a href="#Orange">Orange</a>
-                <ul>
-                  <li>
-                    <a href="#Varietes">Varietes</a>
-                    <ul>
-                      <li>
-                        <a href="#Common-Oranges">Common Oranges</a>
-                        <ul>
-                          <li><a href="#Valencia">Valencia</a></li>
-                          <li><a href="#Harts-Tardiff-Valencia">Hart's Tardiff Valencia</a></li>
-                        </ul>
-                      </li>
-                      <li><a href="#Navel-Oranges">Navel Oranges</a></li>
-                      <li><a href="#Blood-Oranges">Blood Oranges</a></li>
-                      <li><a href="#Acidless-Oranges">Acidless Oranges</a></li>
-                    </ul>
-                  </li>
-                  <li><a href="#Attributes">Attributes</a></li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </fieldset>
-      }).at_path('fieldset')
+    context 'w/ request present' do
+      let(:request) { ActionController::TestRequest.new }
+      let(:url_for) { '/test' }
+
+      it 'emits a table of contents for headings h1-h4 with links present' do
+        expect(html).to be_html_eql(%{
+          <fieldset class='form--fieldset -collapsible'>
+            <legend class='form--fieldset-legend' title='Show/Hide table of contents' onclick='toggleFieldset(this);'>
+              <a href='javascript:'>Table of Contents</a>
+            </legend>
+            <div>
+              <ul class="toc">
+                <li>
+                  <a href="/test#Orange">Orange</a>
+                  <ul>
+                    <li>
+                      <a href="/test#Varietes">Varietes</a>
+                      <ul>
+                        <li>
+                          <a href="/test#Common-Oranges">Common Oranges</a>
+                          <ul>
+                            <li><a href="/test#Valencia">Valencia</a></li>
+                            <li><a href="/test#Harts-Tardiff-Valencia">Hart's Tardiff Valencia</a></li>
+                          </ul>
+                        </li>
+                        <li><a href="/test#Navel-Oranges">Navel Oranges</a></li>
+                        <li><a href="/test#Blood-Oranges">Blood Oranges</a></li>
+                        <li><a href="/test#Acidless-Oranges">Acidless Oranges</a></li>
+                      </ul>
+                    </li>
+                    <li><a href="/test#Attributes">Attributes</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </fieldset>
+        }).at_path('fieldset')
+      end
+    end
+
+    context 'w/o request present' do
+      let(:request) { nil }
+
+      it 'emits a table of contents for headings h1-h4 with anchors' do
+        expect(html).to be_html_eql(%{
+          <fieldset class='form--fieldset -collapsible'>
+            <legend class='form--fieldset-legend' title='Show/Hide table of contents' onclick='toggleFieldset(this);'>
+              <a href='javascript:'>Table of Contents</a>
+            </legend>
+            <div>
+              <ul class="toc">
+                <li>
+                  <a href="#Orange">Orange</a>
+                  <ul>
+                    <li>
+                      <a href="#Varietes">Varietes</a>
+                      <ul>
+                        <li>
+                          <a href="#Common-Oranges">Common Oranges</a>
+                          <ul>
+                            <li><a href="#Valencia">Valencia</a></li>
+                            <li><a href="#Harts-Tardiff-Valencia">Hart's Tardiff Valencia</a></li>
+                          </ul>
+                        </li>
+                        <li><a href="#Navel-Oranges">Navel Oranges</a></li>
+                        <li><a href="#Blood-Oranges">Blood Oranges</a></li>
+                        <li><a href="#Acidless-Oranges">Acidless Oranges</a></li>
+                      </ul>
+                    </li>
+                    <li><a href="#Attributes">Attributes</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </fieldset>
+        }).at_path('fieldset')
+      end
     end
   end
 


### PR DESCRIPTION
This will use the absolute URLs to a resource for rendering the anchors. It
prevents the interfering of the Angular router with the Url, leading to
faulty redirects.

It also removes the links when no request is present (in the case of mailers).

Should meet the requirements of https://community.openproject.org/work_packages/20138
