### PR TITLE
[18714] Repair broken cukes for creating a new subproject

### DIFF
--- a/features/projects/create.feature
+++ b/features/projects/create.feature
@@ -35,14 +35,14 @@ Feature: Creating Projects
 
   @javascript
   Scenario: Creating a Subproject
-    When I go to the overview page of the project "Parent"
+    When I go to the settings page of the project "Parent"
      And I follow "New subproject"
      And I fill in "project_name" with "child"
      And I press "Save"
     Then I should be on the settings page of the project called "child"
 
   Scenario: Creating a Subproject
-    When I go to the overview page of the project "Parent"
+    When I go to the settings page of the project "Parent"
      And I follow "New subproject"
     Then I should not see "Responsible"
 


### PR DESCRIPTION
These cukes broke as the button for the new subproject was moved around in #3136.

Technically, this would be housekeeping (https://community.openproject.org/work_packages/18714)
