### PR TITLE
Fix/focus for specs

### DIFF
--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -40,8 +40,8 @@ describe 'Work package index accessibility', type: :feature do
   def visit_index_page
     work_packages_page.visit_index
     # ensure the page is loaded before expecting anything
-    find('.advanced-filters--filters select option', text: /\AAssignee\Z/,
-                                                     visible: false)
+    expect(page).to have_selector('#operators-status_id', visible: false),
+                    "Page was not fully loaded"
   end
 
   before do

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -221,20 +221,20 @@ describe 'Work package index accessibility', type: :feature do
 
     context 'focus' do
       let(:first_link_selector) do
-        'table.list tbody tr:first-child a:focus, table.keyboard-accessible-list tbody tr:first-child a:focus'
+        'table.keyboard-accessible-list tbody tr:first-child td.id a'
       end
       let(:second_link_selector) do
-        'table.list tbody tr:nth-child(2) a:focus, table.keyboard-accessible-list tbody tr:nth-child(2) a:focus'
+        'table.keyboard-accessible-list tbody tr:nth-child(2) td.id a'
       end
 
       it 'navigates with J' do
         find('body').native.send_keys('j')
-        expect(page).to have_selector(first_link_selector)
+        expect(page).to have_focus_on(first_link_selector)
       end
 
       it 'navigates with K' do
         find('body').native.send_keys('k')
-        expect(page).to have_selector(second_link_selector)
+        expect(page).to have_focus_on(second_link_selector)
       end
     end
 
@@ -263,7 +263,7 @@ describe 'Work package index accessibility', type: :feature do
           element.native.send_keys(keys)
         end
 
-        it { expect(page).to have_selector(target_link + ':focus') }
+        it { expect(page).to have_focus_on(target_link) }
 
         describe 'reset' do
           before do
@@ -273,7 +273,7 @@ describe 'Work package index accessibility', type: :feature do
             expect(page).not_to have_selector(target_link)
           end
 
-          it { expect(page).to have_selector(source_link + ':focus') }
+          it { expect(page).to have_focus_on(source_link) }
         end
 
       end
@@ -312,7 +312,7 @@ describe 'Work package index accessibility', type: :feature do
           # expect it to disappear
           expect(page).not_to have_selector('.ng-modal-window')
           # expect the gear to be focused
-          expect(page).to have_selector('#work-packages-settings-button:focus')
+          expect(page).to have_focus_on('#work-packages-settings-button')
         end
       end
     end

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -5,6 +5,7 @@ require 'features/work_packages/details/inplace_editor/work_package_field'
 
 describe 'description inplace editor', js: true do
   include_context 'maximized window'
+  include_context 'ensure wp table loaded'
 
   let(:project) { FactoryGirl.create :project_with_types, is_public: true }
   let(:property_name) { :description }
@@ -22,9 +23,7 @@ describe 'description inplace editor', js: true do
 
   before do
     allow(User).to receive(:current).and_return(user)
-    visit project_work_packages_path(project)
-    row = page.find("#work-package-#{work_package.id}")
-    row.double_click
+    visit project_work_packages_path(project) + "/#{work_package.id}/overview"
   end
 
   context 'in read state' do

--- a/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_contexts.rb
@@ -38,3 +38,11 @@ shared_context 'maximized window' do
     maximize!
   end
 end
+
+# Ensure the page is completely loaded before the next spec is run.
+# The status filter is loaded very late in the page setup.
+shared_context 'ensure wp table loaded' do
+  after do
+    expect(page).to have_selector('#operators-status_id', visible: false)
+  end
+end

--- a/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
@@ -5,6 +5,7 @@ require 'features/work_packages/details/inplace_editor/work_package_field'
 
 describe 'subject inplace editor', js: true do
   include_context 'maximized window'
+  include_context 'ensure wp table loaded'
 
   let(:project) { FactoryGirl.create :project_with_types, is_public: true }
   let(:property_name) { :subject }
@@ -15,9 +16,7 @@ describe 'subject inplace editor', js: true do
 
   before do
     allow(User).to receive(:current).and_return(user)
-    visit project_work_packages_path(project)
-    row = page.find("#work-package-#{work_package.id}")
-    row.double_click
+    visit project_work_packages_path(project) + "/#{work_package.id}/overview"
   end
 
   context 'in read state' do

--- a/spec/support/matchers/has_focus_on.rb
+++ b/spec/support/matchers/has_focus_on.rb
@@ -1,0 +1,49 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Extending Capybara to circumvent problems with selecting the focused element:
+# http://opensourcetester.co.uk/2011/07/11/selenium-webdriver-focus/
+
+module Capybara
+  class Session
+    def has_focus_on?(selector)
+      starting_time = Time.now
+      return_value = false
+
+      while !return_value && Time.now - starting_time < Capybara.default_wait_time
+
+        focused_element = self.driver.browser.switch_to.active_element
+
+        return_value = find(selector).native == focused_element
+      end
+
+      return_value
+    end
+  end
+end


### PR DESCRIPTION
Aims to improve the stability of accessibility specs by:
- Ensure to have the wp table page loaded to avoid conflicts between specs.
- Use a custom matcher for accessibility specs regarding focus to work around issues that selenium has with css `:focus` matchers.  
