### PR TITLE
remove rack definition from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,8 +118,6 @@ gem 'unicorn'
 # Gems we don't depend directly on, but specify here to make sure we don't use a vulnerable
 # version. Please add a link to a security advisory when adding a Gem here.
 
-gem 'rack', '~>1.4.6'
-
 gem 'i18n', '~> 0.6.8'
 # see https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,6 @@ DEPENDENCIES
   pry-stack_explorer
   quiet_assets
   rabl (= 0.9.3)
-  rack (~> 1.4.6)
   rack-protection!
   rack-test (~> 0.6.2)
   rack_session_access


### PR DESCRIPTION
Original PR is #3147.

It is managed by Gefile.lock.
It should be updated by "bundle update rack".
For example #2953.

@myabc is wrong.
https://github.com/opf/openproject/pull/3147#issuecomment-112861712

https://github.com/rails/rails/blob/v3.2.22/actionpack/actionpack.gemspec#L26

> s.add_dependency('rack', '~> 1.4.5')

So, you can update by "bundle update rack".
https://bitbucket.org/marutosi/openproject-pr3147-rack/commits/a978bf65b6ceb2c0f5fb8f86e92275b6b8cf6cd5
