### PR TITLE
Reduce space needed by search and help top menu item

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -241,8 +241,39 @@
       top_menus.push(new_menu);
     });
   };
+
+  // expands .search_btn inside the given wrapper
+  // to an input .search_field with the button appended to the right.
+  $.fn.expandableSearch = function () {
+    var wrapper = $(this)
+      , form = wrapper.closest('form')
+      , btn = wrapper.find('.search_btn')
+      , input = wrapper.find('.search_field')
+      , evtns = 'click.expandableSearch';
+
+    btn.click(function() {
+      if (wrapper.hasClass('search-collapsed')) {
+        wrapper.toggleClass('search-collapsed search-expanded');
+        input.focus();
+
+        // Hide the input for click on other objects
+        $(document).on(evtns, function(evt) {
+          if(!$(evt.target).closest(wrapper).length) {
+            wrapper.toggleClass('search-collapsed search-expanded');
+            $(document).off(evtns);
+          }
+        });
+
+        return false;
+      } else {
+        form.submit();
+      }
+    });
+  };
+
 }(jQuery));
 
 jQuery(document).ready(function($) {
   $("#top-menu-items").top_menu();
+  $("#top-menu-search .search-wrapper").expandableSearch();
 });

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -51,37 +51,46 @@
   %absolute-layout-mode &
     position: absolute
 
-  #search
-    margin: 5px 25px 0 0
+  #top-menu-search
     float: left
-  #search_wrap
+  .search-wrapper
     position: relative
-    top: 6px
-  .search_field
-    border: $header-search-field-border
-    border-radius: 25px
-    width: 180px
-    outline: 0
-    padding: 7px 30px 7px 10px
-    font-size: 0.75rem
-    color: $header-search-field-font-color
+  .search_btn
+    display: block
+    height: $header-height
+    line-height: $header-height
+    @include default-font($header-item-font-color, $header-item-font-size)
+    &:hover
+      text-decoration: none
+  .search-collapsed
+    .search_field
+      display: none
+    .search_btn
+      &:hover
+        background: $header-item-bg-hover-color
+        color: $header-item-font-hover-color
+  .search-expanded
+    padding-top: 8px
+    .search_field
+      margin: 0
+      padding: 0 10px
+      display: inline-block
+      border: $header-search-field-border
+      border-radius: 25px
+      border: $header-search-field-border
+      width: 180px
+      outline: 0
+      font-size: 0.75rem
+    .search_btn
+      position: absolute
+      top: 0
+      right: 0
+      color: $header-drop-down-item-font-color
+      background: transparent
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
   :-moz-placeholder
     color: $header-search-field-font-color
-  span#magnifier
-    @include icon-common
-    position: absolute
-    top:   9px
-    right: 9px
-    &:after
-      display: inline-block
-      content: "\e0a1"
-      -webkit-transform: scaleX(-1)
-      -moz-transform: scaleX(-1)
-      -o-transform: scaleX(-1)
-      -ms-transform: scaleX(-1)
-      transform: scaleX(-1)
   ul
     margin: 0
     padding: 0

--- a/app/views/search/_mini_form.html.erb
+++ b/app/views/search/_mini_form.html.erb
@@ -26,17 +26,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<div id="search">
+<div id="top-menu-search">
   <%= label_tag("q", l(:label_search), :class => "hidden-for-sighted") %>
 
   <%= form_tag(search_path(@project), method: :get) do %>
     <%= hidden_field_tag(controller.default_search_scope, 1, :project_id => nil) if controller.default_search_scope %>
 
-    <div id='search_wrap'>
-
+    <div class="search-wrapper search-collapsed">
       <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder), :accesskey => accesskey(:quick_search) %>
-      <span id="magnifier"></span>
-
+      <a id="top-menu-search-icon" class="search_btn search-form-normal">
+         <i class="icon5 icon-search ellipsis"></i>
+      </a>
     </div>
 
   <% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -42,7 +42,7 @@ Redmine::MenuManager.map :top_menu do |menu|
             last: true
   menu.push :help, OpenProject::Info.help_url,
             last: true,
-            caption: I18n.t('label_help'),
+            caption: '',
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
                     class: 'icon5 icon-help' }
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -61,6 +61,7 @@ end
 
 When(/^I search globally for "([^"]*)"$/) do |query|
   steps %{
+    And I click link "top-menu-search-icon"
     And I fill in "#{query}" for "q"
     And I press the "return" key on element "#q"
     And I wait for the AJAX requests to finish
@@ -69,6 +70,7 @@ end
 
 When(/^I search for "([^"]*)" after having searched$/) do |query|
   steps %{
+    And I click link "top-menu-search-icon"
     And I fill in "#{query}" for "q" within "#content"
     And I press "Submit" within "#content"
     And I wait for the AJAX requests to finish


### PR DESCRIPTION
This commit changes two top menu items:
1. Search is by default collapsed to its magnifier icon
   - Upon clicking it, it is expanded and focus given to the search
     field
   - Clicking any hierarchy not in below the wrapper, the search is
     collapsed again
2. The help button remains as a '?' icon, and loses the caption.

Relevant work package:
https://community.openproject.org/work_packages/20540
