### PR TITLE
Restructure "Module" menu in header navigation

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -41,24 +41,6 @@ See doc/COPYRIGHT.rdoc for more details.
       <% end %>
     </li>
   <% end %>
-  <% if User.current.allowed_to?(:view_work_packages, nil, :global => true) %>
-    <li class="toolbar-item">
-      <%= link_to l(:label_work_package_view_all),work_packages_path, class: 'button' %>
-    </li>
-  <% end %>
-  <% if User.current.allowed_to?(:view_time_entries, nil, :global => true) %>
-    <li class="toolbar-item">
-      <%= link_to l(:label_overall_spent_time), time_entries_path, class: 'button' %>
-    </li>
-  <% end %>
-  <% if User.current.allowed_to?(:view_news, nil, :global => true) %>
-    <li class="toolbar-item">
-      <%= link_to l(:label_news_view_all), news_index_path, class: 'button' %>
-    </li>
-  <% end %>
-  <li class="toolbar-item">
-    <%= link_to l(:label_overall_activity), activities_path, class: 'button' %>
-  </li>
 <% end %>
 
 <div class="wiki">

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -36,10 +36,20 @@ Redmine::MenuManager.map :top_menu do |menu|
             if: Proc.new { User.current.logged? }
   # projects menu will be added by
   # Redmine::MenuManager::TopMenuHelper#render_projects_top_menu_node
-  menu.push :administration,
-            { controller: '/admin', action: 'projects' },
-            if: Proc.new { User.current.admin? },
-            last: true
+  menu.push :work_packages,
+            { controller: '/work_packages' },
+            caption: I18n.t('label_work_package_plural'),
+            if: Proc.new {  User.current.allowed_to?(:view_work_packages, nil, :global => true) }
+  menu.push :news,
+            { controller: '/news' },
+            if: Proc.new { User.current.allowed_to?(:view_news, nil, :global => true) }
+  menu.push :activity,
+            { controller: '/activity' },
+            if: Proc.new { User.current.logged? }
+  menu.push :time_sheet,
+            { controller: '/time_entries' },
+            caption: I18n.t('label_time_sheet_menu'),
+            if: Proc.new { User.current.allowed_to?(:view_time_entries, nil, global: true) }
   menu.push :help, OpenProject::Info.help_url,
             last: true,
             caption: I18n.t('label_help'),
@@ -48,6 +58,9 @@ Redmine::MenuManager.map :top_menu do |menu|
 end
 
 Redmine::MenuManager.map :account_menu do |menu|
+  menu.push :administration,
+            { controller: '/admin', action: 'projects' },
+            if: Proc.new { User.current.admin? }
   menu.push :my_account,
             { controller: '/my', action: 'account' },
             if: Proc.new { User.current.logged? }

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -43,9 +43,6 @@ Redmine::MenuManager.map :top_menu do |menu|
   menu.push :news,
             { controller: '/news' },
             if: Proc.new { User.current.allowed_to?(:view_news, nil, :global => true) }
-  menu.push :activity,
-            { controller: '/activity' },
-            if: Proc.new { User.current.logged? }
   menu.push :time_sheet,
             { controller: '/time_entries' },
             caption: I18n.t('label_time_sheet_menu'),

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -965,6 +965,7 @@ de:
   label_this_week: "aktuelle Woche"
   label_this_year: "aktuelles Jahr"
   label_time_entry_plural: "Benötigte Zeit"
+  label_time_sheet_menu: "Zeiterfassung"
   label_time_tracking: "Zeiterfassung"
   label_today: "heute"
   label_top_menu: "Hauptmenü"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -964,6 +964,7 @@ en:
   label_this_week: "this week"
   label_this_year: "this year"
   label_time_entry_plural: "Spent time"
+  label_time_sheet_menu: "Time Sheet"
   label_time_tracking: "Time tracking"
   label_today: "today"
   label_top_menu: "Top Menu"


### PR DESCRIPTION
This effectively changes the following menus:

**Top Menu**
- Removed Administration item
- Added Item 'Work Packages' -> /work_packages
- Added Item 'News' -> /news
- Added Item 'Time Sheet' -> /time_entries (if user has a project with
      view time log permission)

**My Menu**
- Added Administration item as first position

Relevant work package:
https://community.openproject.org/work_packages/20269
