### PR TITLE
[20484] Add a name to the empty options in dropdowns in Work Package details pane

### DIFF
--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -146,10 +146,9 @@ module.exports = function(
     });
 
     if (!WorkPackageFieldService.isRequired(workPackage, field)) {
-      var nullValueLabel = I18n.t('js.inplace.null_value_label');
       var arrayWithEmptyOption = [{
         href: null,
-        name: nullValueLabel
+        name: I18n.t('js.inplace.null_value_label')
       }];
       options = arrayWithEmptyOption.concat(options);
     }

--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -146,7 +146,11 @@ module.exports = function(
     });
 
     if (!WorkPackageFieldService.isRequired(workPackage, field)) {
-      var arrayWithEmptyOption = [{ href: null }];
+      var nullValueLabel = I18n.t('js.inplace.null_value_label');
+      var arrayWithEmptyOption = [{
+        href: null,
+        name: nullValueLabel
+      }];
       options = arrayWithEmptyOption.concat(options);
     }
 


### PR DESCRIPTION
This will add an "empty" label to dropdown options select, based on the
"no value label" already existing in the translations.

This only applies if the field is **not required**

Should meet the requirements (accidental fix) for https://community.openproject.org/work_packages/20484.
