### PR TITLE
Reduce space needed by search and help top menu item

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -245,28 +245,37 @@
   // expands .search_btn inside the given wrapper
   // to an input .search_field with the button appended to the right.
   $.fn.expandableSearch = function () {
-    var wrapper = $(this)
-      , form = wrapper.closest('form')
-      , btn = wrapper.find('.search_btn')
-      , input = wrapper.find('.search_field')
-      , evtns = 'click.expandableSearch';
+    var wrapper = $(this),
+      form = wrapper.closest('form'),
+      btn = wrapper.find('.search_btn'),
+      input = wrapper.find('.search_field');
 
-    btn.click(function() {
-      if (wrapper.hasClass('search-collapsed')) {
-        wrapper.toggleClass('search-collapsed search-expanded');
-        input.focus();
+    $(btn).on('click mousedown focus keypress', function(evt) {
+      if (wrapper.hasClass('search-expanded')) {
+        // Submit only when clicked or enter on btn
+        if (evt.type === 'mousedown' ||
+           (evt.type === 'keypress' && evt.which === 13)) {
+          form.submit();
+        }
 
-        // Hide the input for click on other objects
-        $(document).on(evtns, function(evt) {
-          if(!$(evt.target).closest(wrapper).length) {
-            wrapper.toggleClass('search-collapsed search-expanded');
-            $(document).off(evtns);
-          }
+      } else {
+        wrapper.addClass('search-expanded');
+        // Avoid access key focus
+        setTimeout(function() { input.focus() });
+
+        // Hide on lost focus
+        $(wrapper).on('focusout', function() {
+          // Allow DOM to propagate new focus
+          setTimeout(function() {
+            // Hide unless icon clicked
+            if (wrapper.find(':active,:focus').length === 0) {
+              wrapper.removeClass('search-expanded');
+              $(wrapper).off('focusout');
+            }
+          }, 10);
         });
 
-        return false;
-      } else {
-        form.submit();
+        evt.preventDefault();
       }
     });
   };

--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -242,47 +242,8 @@
     });
   };
 
-  // expands .search_btn inside the given wrapper
-  // to an input .search_field with the button appended to the right.
-  $.fn.expandableSearch = function () {
-    var wrapper = $(this),
-      form = wrapper.closest('form'),
-      btn = wrapper.find('.search_btn'),
-      input = wrapper.find('.search_field');
-
-    $(btn).on('click mousedown focus keypress', function(evt) {
-      if (wrapper.hasClass('search-expanded')) {
-        // Submit only when clicked or enter on btn
-        if (evt.type === 'mousedown' ||
-           (evt.type === 'keypress' && evt.which === 13)) {
-          form.submit();
-        }
-
-      } else {
-        wrapper.addClass('search-expanded');
-        // Avoid access key focus
-        setTimeout(function() { input.focus() });
-
-        // Hide on lost focus
-        $(wrapper).on('focusout', function() {
-          // Allow DOM to propagate new focus
-          setTimeout(function() {
-            // Hide unless icon clicked
-            if (wrapper.find(':active,:focus').length === 0) {
-              wrapper.removeClass('search-expanded');
-              $(wrapper).off('focusout');
-            }
-          }, 10);
-        });
-
-        evt.preventDefault();
-      }
-    });
-  };
-
 }(jQuery));
 
 jQuery(document).ready(function($) {
   $("#top-menu-items").top_menu();
-  $("#top-menu-search .search-wrapper").expandableSearch();
 });

--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -241,8 +241,39 @@
       top_menus.push(new_menu);
     });
   };
+
+  // expands .search_btn inside the given wrapper
+  // to an input .search_field with the button appended to the right.
+  $.fn.expandableSearch = function () {
+    var wrapper = $(this)
+      , form = wrapper.closest('form')
+      , btn = wrapper.find('.search_btn')
+      , input = wrapper.find('.search_field')
+      , evtns = 'click.expandableSearch';
+
+    btn.click(function() {
+      if (wrapper.hasClass('search-collapsed')) {
+        wrapper.toggleClass('search-collapsed search-expanded');
+        input.focus();
+
+        // Hide the input for click on other objects
+        $(document).on(evtns, function(evt) {
+          if(!$(evt.target).closest(wrapper).length) {
+            wrapper.toggleClass('search-collapsed search-expanded');
+            $(document).off(evtns);
+          }
+        });
+
+        return false;
+      } else {
+        form.submit();
+      }
+    });
+  };
+
 }(jQuery));
 
 jQuery(document).ready(function($) {
   $("#top-menu-items").top_menu();
+  $("#top-menu-search .search-wrapper").expandableSearch();
 });

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -62,18 +62,15 @@
     @include default-font($header-item-font-color, $header-item-font-size)
     &:hover
       text-decoration: none
-  .search-collapsed
-    .search_field
-      display: none
-    .search_btn
-      &:hover
-        background: $header-item-bg-hover-color
-        color: $header-item-font-hover-color
+      background: $header-item-bg-hover-color
+      color: $header-item-font-hover-color
+  .search_field
+    display: none
   .search-expanded
-    padding-top: 8px
+    padding-top: 9px
     .search_field
       margin: 0
-      padding: 0 10px
+      padding: 0 20px 0 10px
       display: inline-block
       border: $header-search-field-border
       border-radius: 25px
@@ -81,12 +78,20 @@
       width: 180px
       outline: 0
       font-size: 0.75rem
+      &::-ms-clear
+        margin-right: 5px
+        width: 20px
     .search_btn
       position: absolute
       top: 0
       right: 0
       color: $header-drop-down-item-font-color
       background: transparent
+      -webkit-transform: scaleX(-1)
+      -moz-transform: scaleX(-1)
+      -o-transform: scaleX(-1)
+      -ms-transform: scaleX(-1)
+      transform: scaleX(-1)
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
   :-moz-placeholder

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -51,47 +51,6 @@
   %absolute-layout-mode &
     position: absolute
 
-  #top-menu-search
-    float: left
-  .search-wrapper
-    position: relative
-  .search_btn
-    display: block
-    height: $header-height
-    line-height: $header-height
-    @include default-font($header-item-font-color, $header-item-font-size)
-    &:hover
-      text-decoration: none
-      background: $header-item-bg-hover-color
-      color: $header-item-font-hover-color
-  .search_field
-    display: none
-  .search-expanded
-    padding-top: 9px
-    .search_field
-      margin: 0
-      padding: 0 20px 0 10px
-      display: inline-block
-      border: $header-search-field-border
-      border-radius: 25px
-      border: $header-search-field-border
-      width: 180px
-      outline: 0
-      font-size: 0.75rem
-      &::-ms-clear
-        margin-right: 5px
-        width: 20px
-    .search_btn
-      position: absolute
-      top: 0
-      right: 0
-      color: $header-drop-down-item-font-color
-      background: transparent
-      -webkit-transform: scaleX(-1)
-      -moz-transform: scaleX(-1)
-      -o-transform: scaleX(-1)
-      -ms-transform: scaleX(-1)
-      transform: scaleX(-1)
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
   :-moz-placeholder
@@ -194,6 +153,55 @@
       font-weight: normal
     table td
       padding: 3px
+
+.top-menu-search
+  display: inline-block
+  &:not(.-collapsed) > div
+    position: relative
+    padding-top: 9px
+
+.top-menu-search--wrapper
+  float: left
+
+.top-menu-search--button
+  line-height: $header-height
+  height: $header-height
+  @include default-font($header-item-font-color, $header-item-font-size)
+  background: transparent
+  &:hover
+    text-decoration: none
+
+  .top-menu-search:not(.-collapsed) &
+    position: absolute
+    top: 0
+    right: 0
+    color: $header-drop-down-item-font-color
+    -webkit-transform: scaleX(-1)
+    -moz-transform: scaleX(-1)
+    -o-transform: scaleX(-1)
+    -ms-transform: scaleX(-1)
+    transform: scaleX(-1)
+
+  .top-menu-search.-collapsed &
+    display: block
+    &:hover
+      background: $header-item-bg-hover-color
+      color: $header-item-font-hover-color
+
+input.top-menu-search--input
+  margin: 0
+  padding: 0 20px 0 10px
+  display: inline-block
+  border: $header-search-field-border
+  border-radius: 25px
+  width: 180px
+  outline: 0
+  font-size: 0.75rem
+  &::-ms-clear
+    margin-right: 5px
+    width: 20px
+  .top-menu-search.-collapsed &
+    display: none
 
 #quick-search
   float: right

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -51,37 +51,46 @@
   %absolute-layout-mode &
     position: absolute
 
-  #search
-    margin: 5px 25px 0 0
+  #top-menu-search
     float: left
-  #search_wrap
+  .search-wrapper
     position: relative
-    top: 6px
-  .search_field
-    border: $header-search-field-border
-    border-radius: 25px
-    width: 180px
-    outline: 0
-    padding: 7px 30px 7px 10px
-    font-size: 0.75rem
-    color: $header-search-field-font-color
+  .search_btn
+    display: block
+    height: $header-height
+    line-height: $header-height
+    @include default-font($header-item-font-color, $header-item-font-size)
+    &:hover
+      text-decoration: none
+  .search-collapsed
+    .search_field
+      display: none
+    .search_btn
+      &:hover
+        background: $header-item-bg-hover-color
+        color: $header-item-font-hover-color
+  .search-expanded
+    padding-top: 8px
+    .search_field
+      margin: 0
+      padding: 0 10px
+      display: inline-block
+      border: $header-search-field-border
+      border-radius: 25px
+      border: $header-search-field-border
+      width: 180px
+      outline: 0
+      font-size: 0.75rem
+    .search_btn
+      position: absolute
+      top: 0
+      right: 0
+      color: $header-drop-down-item-font-color
+      background: transparent
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
   :-moz-placeholder
     color: $header-search-field-font-color
-  span#magnifier
-    @include icon-common
-    position: absolute
-    top:   9px
-    right: 9px
-    &:after
-      display: inline-block
-      content: "\e0a1"
-      -webkit-transform: scaleX(-1)
-      -moz-transform: scaleX(-1)
-      -o-transform: scaleX(-1)
-      -ms-transform: scaleX(-1)
-      transform: scaleX(-1)
   ul
     margin: 0
     padding: 0

--- a/app/views/search/_mini_form.html.erb
+++ b/app/views/search/_mini_form.html.erb
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="search-wrapper">
       <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder) %>
       <a id="top-menu-search-icon" class="search_btn search-form-normal"
+         title="<%= l(:label_search) %>"
          accesskey="<%= accesskey(:quick_search) %>" tabindex="0">
          <i class="icon5 icon-search ellipsis"></i>
       </a>

--- a/app/views/search/_mini_form.html.erb
+++ b/app/views/search/_mini_form.html.erb
@@ -32,13 +32,12 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag(search_path(@project), method: :get) do %>
     <%= hidden_field_tag(controller.default_search_scope, 1, :project_id => nil) if controller.default_search_scope %>
 
-    <div class="search-wrapper search-collapsed">
-      <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder), :accesskey => accesskey(:quick_search) %>
-      <a id="top-menu-search-icon" class="search_btn search-form-normal">
+    <div class="search-wrapper">
+      <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder) %>
+      <a id="top-menu-search-icon" class="search_btn search-form-normal"
+         accesskey="<%= accesskey(:quick_search) %>" tabindex="0">
          <i class="icon5 icon-search ellipsis"></i>
       </a>
     </div>
-
   <% end %>
-
 </div>

--- a/app/views/search/_mini_form.html.erb
+++ b/app/views/search/_mini_form.html.erb
@@ -26,19 +26,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<div id="top-menu-search">
+<div class="top-menu-search--wrapper">
   <%= label_tag("q", l(:label_search), :class => "hidden-for-sighted") %>
 
   <%= form_tag(search_path(@project), method: :get) do %>
     <%= hidden_field_tag(controller.default_search_scope, 1, :project_id => nil) if controller.default_search_scope %>
 
-    <div class="search-wrapper">
-      <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder) %>
-      <a id="top-menu-search-icon" class="search_btn search-form-normal"
-         title="<%= l(:label_search) %>"
-         accesskey="<%= accesskey(:quick_search) %>" tabindex="0">
-         <i class="icon5 icon-search ellipsis"></i>
-      </a>
-    </div>
+    <expandable-search class="top-menu-search" ng-class="{'-collapsed': collapsed === true}">
+      <div>
+        <%= text_field_tag 'q', @question, :size => 20, :class => 'top-menu-search--input', :placeholder => l(:search_input_placeholder) %>
+        <a id="top-menu-search-button"
+           class="top-menu-search--button search-form-normal"
+           title="<%= l(:label_search) %>"
+           accesskey="<%= accesskey(:quick_search) %>" tabindex="0">
+           <i class="icon5 icon-search ellipsis"></i>
+        </a>
+      </div>
+    </expandable-search>
   <% end %>
 </div>

--- a/app/views/search/_mini_form.html.erb
+++ b/app/views/search/_mini_form.html.erb
@@ -26,17 +26,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<div id="search">
+<div id="top-menu-search">
   <%= label_tag("q", l(:label_search), :class => "hidden-for-sighted") %>
 
   <%= form_tag(search_path(@project), method: :get) do %>
     <%= hidden_field_tag(controller.default_search_scope, 1, :project_id => nil) if controller.default_search_scope %>
 
-    <div id='search_wrap'>
-
+    <div class="search-wrapper search-collapsed">
       <%= text_field_tag 'q', @question, :size => 20, :class => 'search_field', :placeholder => l(:search_input_placeholder), :accesskey => accesskey(:quick_search) %>
-      <span id="magnifier"></span>
-
+      <a id="top-menu-search-icon" class="search_btn search-form-normal">
+         <i class="icon5 icon-search ellipsis"></i>
+      </a>
     </div>
 
   <% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -42,7 +42,7 @@ Redmine::MenuManager.map :top_menu do |menu|
             last: true
   menu.push :help, OpenProject::Info.help_url,
             last: true,
-            caption: I18n.t('label_help'),
+            caption: '',
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
                     class: 'icon5 icon-help' }
 end

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -44,6 +44,7 @@ Redmine::MenuManager.map :top_menu do |menu|
             last: true,
             caption: '',
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
+                    title: I18n.t('label_help'),
                     class: 'icon5 icon-help' }
 end
 

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -61,6 +61,7 @@ end
 
 When(/^I search globally for "([^"]*)"$/) do |query|
   steps %{
+    And I click link "top-menu-search-icon"
     And I fill in "#{query}" for "q"
     And I press the "return" key on element "#q"
     And I wait for the AJAX requests to finish
@@ -69,6 +70,7 @@ end
 
 When(/^I search for "([^"]*)" after having searched$/) do |query|
   steps %{
+    And I click link "top-menu-search-icon"
     And I fill in "#{query}" for "q" within "#content"
     And I press "Submit" within "#content"
     And I wait for the AJAX requests to finish

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -61,7 +61,7 @@ end
 
 When(/^I search globally for "([^"]*)"$/) do |query|
   steps %{
-    And I click link "top-menu-search-icon"
+    And I click link "top-menu-search-button"
     And I fill in "#{query}" for "q"
     And I press the "return" key on element "#q"
     And I wait for the AJAX requests to finish
@@ -70,7 +70,7 @@ end
 
 When(/^I search for "([^"]*)" after having searched$/) do |query|
   steps %{
-    And I click link "top-menu-search-icon"
+    And I click link "top-menu-search-button"
     And I fill in "#{query}" for "q" within "#content"
     And I press "Submit" within "#content"
     And I wait for the AJAX requests to finish

--- a/frontend/app/ui_components/expandable-search.js
+++ b/frontend/app/ui_components/expandable-search.js
@@ -1,0 +1,73 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+module.exports = function(ENTER_KEY) {
+  return {
+    restrict: 'E',
+    replace: true,
+    link: function(scope, elem) {
+      var btn = elem.find('a'),
+        input = elem.find('input'),
+        setCollapsed;
+
+      // Search is collapsed initially
+      scope.collapsed = true;
+      setCollapsed = function(collapsedState) {
+          scope.collapsed = collapsedState;
+          scope.$apply();
+        };
+
+      btn.on('click mousedown focus keypress', function(evt) {
+        if (scope.collapsed === true) {
+          setCollapsed(false);
+          // Avoid access key focus
+          setTimeout(function() { input.focus(); });
+
+          // Hide on lost focus
+          elem.on('focusout', function() {
+            // Allow DOM to propagate new focus
+            setTimeout(function() {
+              // Hide unless icon clicked
+              if (elem.find(':active,:focus').length === 0) {
+                setCollapsed(true);
+                $(elem).off('focusout');
+              }
+            }, 10);
+          });
+          evt.preventDefault();
+        } else {
+          // Submit only when clicked or enter on btn
+          if (evt.type === 'mousedown' ||
+             (evt.type === 'keypress' && evt.which === ENTER_KEY)) {
+            elem.closest('form').submit();
+          }
+        }
+      });
+    }
+  };
+};

--- a/frontend/app/ui_components/index.js
+++ b/frontend/app/ui_components/index.js
@@ -55,6 +55,7 @@ angular.module('openproject.uiComponents')
     'ConfigurationService',
     require('./flash-message-directive')
   ])
+  .directive('expandableSearch', ['ENTER_KEY', require('./expandable-search')])
   .directive('focus', ['FocusHelper', require('./focus-directive')])
   .constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex], select')
   .service('FocusHelper', ['$timeout', 'FOCUSABLE_SELECTOR', require(

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -200,7 +200,7 @@ module Redmine::MenuManager::MenuHelper
   def render_single_menu_node(item, caption, url, selected)
     link_text    = you_are_here_info(selected) + caption
     html_options = item.html_options(selected: selected)
-    html_options[:title] = caption
+    html_options[:title] ||= caption
 
     html_options[:lang] = menu_item_locale(item)
 


### PR DESCRIPTION
This commit changes two top menu items:
1. Search is by default collapsed to its magnifier icon
   - Upon clicking it, it is expanded and focus given to the search
     field
   - Clicking any hierarchy not in below the wrapper, the search is
     collapsed again
2. The help button remains as a '?' icon, and loses the caption.

Relevant work package:
https://community.openproject.org/work_packages/20540
