### PR TITLE
Fix for module items pointing to wrong routes in some cases

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -37,14 +37,14 @@ Redmine::MenuManager.map :top_menu do |menu|
   # projects menu will be added by
   # Redmine::MenuManager::TopMenuHelper#render_projects_top_menu_node
   menu.push :work_packages,
-            { controller: '/work_packages' },
+            { controller: '/work_packages', project_id: nil, action: 'index' },
             caption: I18n.t('label_work_package_plural'),
             if: Proc.new { User.current.allowed_to?(:view_work_packages, nil, global: true) }
   menu.push :news,
-            { controller: '/news' },
+            { controller: '/news', project_id: nil, action: 'index' },
             if: Proc.new { User.current.allowed_to?(:view_news, nil, global: true) }
   menu.push :time_sheet,
-            { controller: '/time_entries' },
+            { controller: '/time_entries', project_id: nil, action: 'show' },
             caption: I18n.t('label_time_sheet_menu'),
             if: Proc.new { User.current.allowed_to?(:view_time_entries, nil, global: true) }
   menu.push :help, OpenProject::Info.help_url,


### PR DESCRIPTION
The global routes defined in Module menu items are being overridden to their project counterparts in some cases.

This PR overrides  the project_id and in turn, disables the `:find_optional_project` filter which causes incorrect routes when within the respective project routes.

Related work package: https://community.openproject.org/work_packages/20613
