### PR TITLE
[20544] Add an empty option to grouping menu

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -399,6 +399,7 @@ de:
       btn_preview_enable: "Vorschau"
       btn_preview_disable: "Vorschau deaktivieren"
       null_value_label: "Kein Wert"
+      clear_value_label: "-"
       errors:
         required: '%{field} ist ein Pflichtfeld'
         number: '%{field} ist keine gültige Zahl'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -402,6 +402,7 @@ en:
       btn_preview_enable: "Preview"
       btn_preview_disable: "Disable preview"
       null_value_label: "No value"
+      clear_value_label: "-"
       errors:
         required: '%{field} cannot be empty'
         number: '%{field} is not a valid number'

--- a/frontend/app/work_packages/controllers/dialogs/group-by.js
+++ b/frontend/app/work_packages/controllers/dialogs/group-by.js
@@ -37,7 +37,7 @@ module.exports = function($scope,
   this.closeMe = groupingModal.deactivate;
 
   var emptyOption = {
-    title: I18n.t('js.inplace.null_value_label')
+    title: I18n.t('js.inplace.clear_value_label')
   };
 
   $scope.vm = {};

--- a/frontend/app/work_packages/controllers/dialogs/group-by.js
+++ b/frontend/app/work_packages/controllers/dialogs/group-by.js
@@ -26,10 +26,19 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function($scope, $filter, groupingModal, QueryService, WorkPackagesTableService) {
+module.exports = function($scope,
+                          $filter,
+                          groupingModal,
+                          QueryService,
+                          WorkPackagesTableService,
+                          I18n) {
 
   this.name    = 'GroupBy';
   this.closeMe = groupingModal.deactivate;
+
+  var emptyOption = {
+    title: I18n.t('js.inplace.null_value_label')
+  };
 
   $scope.vm = {};
 
@@ -42,9 +51,11 @@ module.exports = function($scope, $filter, groupingModal, QueryService, WorkPack
   $scope.workPackageTableData = WorkPackagesTableService.getWorkPackagesTableData();
 
   $scope.$watch('workPackageTableData.groupableColumns', function(groupableColumns) {
-    if (!groupableColumns) return;
+    if (!groupableColumns) {
+      return;
+    }
 
-    $scope.vm.groupableColumns   = [{}].concat(groupableColumns);
+    $scope.vm.groupableColumns   = [emptyOption].concat(groupableColumns);
     $scope.vm.selectedColumnName = QueryService.getGroupBy();
   });
 

--- a/frontend/app/work_packages/controllers/index.js
+++ b/frontend/app/work_packages/controllers/index.js
@@ -159,6 +159,7 @@ angular.module('openproject.workPackages.controllers')
     'groupingModal',
     'QueryService',
     'WorkPackagesTableService',
+    'I18n',
     require('./dialogs/group-by')
   ])
   .factory('saveModal', ['btfModal', function(btfModal) {


### PR DESCRIPTION
This will add the "no value" label to the group by modal selection on the WP List.

It should meet the requirements of https://community.openproject.org/work_packages/20544.

For consistency, I also added the label to the empty option in the sort by modal.

:pray: Hopefully Travis agrees here.
