### PR TITLE
prevent check-boxes crashing into their label

### DIFF
--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -29,17 +29,17 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'type' %>
 
 <div class="grid-block">
-  <div class="grid-content">
+  <div class="grid-content medium-6">
     <section class="form--section">
       <!--[form:type]-->
-      <div class="form--field"><%= f.text_field :name, :required => true, :disabled => @type.is_standard? %></div>
-      <div class="form--field"><%= f.check_box :is_in_roadmap %></div>
-      <div class="form--field"><%= f.select :color_id, options_for_colors(controller.type) %></div>
-      <div class="form--field"><%= f.check_box :in_aggregation %></div>
-      <div class="form--field"><%= f.check_box :is_default %></div>
-      <div class="form--field"><%= f.check_box :is_milestone %></div>
+      <div class="form--field -wide-label"><%= f.text_field :name, :required => true, :disabled => @type.is_standard? %></div>
+      <div class="form--field -wide-label"><%= f.check_box :is_in_roadmap %></div>
+      <div class="form--field -wide-label"><%= f.select :color_id, options_for_colors(controller.type) %></div>
+      <div class="form--field -wide-label"><%= f.check_box :in_aggregation %></div>
+      <div class="form--field -wide-label"><%= f.check_box :is_default %></div>
+      <div class="form--field -wide-label"><%= f.check_box :is_milestone %></div>
       <% if WorkPackageCustomField.all.any? %>
-        <div class="form--field">
+        <div class="form--field -wide-label">
           <%= styled_label_tag nil, l(:label_custom_field_plural) %>
           <div class="form--field-container -vertical">
             <% WorkPackageCustomField.all.each do |field| %>
@@ -54,7 +54,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <%= hidden_field_tag 'type[custom_field_ids][]', '' %>
       <% end %>
       <% if controller.type.new_record? && @types.any? %>
-        <div class="form--field">
+        <div class="form--field -wide-label">
           <%= styled_label_tag 'copy_workflow_from', l(:label_copy_workflow_from) %>
           <%= styled_select_tag(:copy_workflow_from, content_tag("option") + options_from_collection_for_select(@types, :id, :name)) %>
         </div>
@@ -64,7 +64,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= styled_button_tag l(controller.type.new_record? ? :button_create : :button_save),
         class: '-highlight -with-icon icon-yes' %>
   </div>
-  <div class="grid-content">
+  <div class="grid-content medium-6">
     <% if @projects.any? %>
       <fieldset class="form--fieldset" id="type_project_ids">
         <legend class="form--fieldset-legend"><%= l(:label_project_plural) %></legend>


### PR DESCRIPTION
This tries to prevent check-boxes overlapping their labels on the type administration (`types/:id/edit`). I applied the `wide-label` modifier class as the labels are quite long. That should prevent the overlapping as the page's min size stops the shrinking with enough space left.

https://community.openproject.org/work_packages/19979
