### PR TITLE
Fix unstable focusing of search form in Firefox

### DIFF
--- a/frontend/app/ui_components/expandable-search.js
+++ b/frontend/app/ui_components/expandable-search.js
@@ -45,8 +45,13 @@ module.exports = function(ENTER_KEY) {
       btn.on('click mousedown focus keypress', function(evt) {
         if (scope.collapsed === true) {
           setCollapsed(false);
-          // Avoid access key focus
-          setTimeout(function() { input.focus(); });
+          // Force focus to the search input
+          // The somewhat arbitrary delay of 20ms is required
+          // since Firefox blocks focus changing events
+          // immdetiately after an element is focused.
+          // Smaller delays will cause Firefox to ignore that focus
+          // Relevant: http://stackoverflow.com/questions/7046798
+          setTimeout(function() { input.focus(); }, 20);
 
           // Hide on lost focus
           elem.on('focusout', function() {


### PR DESCRIPTION
This should fix the bug introduced by https://github.com/opf/openproject/pull/3156
and reported in https://community.openproject.org/work_packages/20540#note-11

It seems that Firefox has a bug that it does not tolerate a focus event
trigged in the few ms after focus has been gained on another element.

I was able to reproduce this behavior in some Firefox versions for focus of {0,10} ms.
It does not seem to occur to with the given 20ms delay.

Related: http://stackoverflow.com/questions/704679
Relevant work package: https://community.openproject.org/work_packages/20540
