### PR TITLE
Enable RHEL / CentOS 7 on packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -14,6 +14,10 @@ targets:
       - ImageMagick-devel
   centos-6:
     <<: *redhat
+  centos-7:
+    <<: *redhat
+    dependencies:
+      - epel-release
   sles-12:
     build_dependencies:
       - ImageMagick-devel


### PR DESCRIPTION
This is to enable the building of packages for CentOS / RHEL 7 using Packager.io. It is different than #3118 in that it adds the required EPEL dependency to make the installer work.
