### PR TITLE
open help in new tab

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -52,7 +52,8 @@ Redmine::MenuManager.map :top_menu do |menu|
             caption: '',
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
                     title: I18n.t('label_help'),
-                    class: 'icon5 icon-help' }
+                    class: 'icon5 icon-help',
+                    target: '_blank' }
 end
 
 Redmine::MenuManager.map :account_menu do |menu|


### PR DESCRIPTION
Please note that the implementation of what to do on target='_blank' is
browser specific but they should open up a new tab. Alternatively they
can open up a new window. The specification can be found here:
http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context-names

https://community.openproject.org/work_packages/20627
