### PR TITLE
[20628] Change OpenProject URL url in footer

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,7 +75,7 @@ password_days_valid:
 software_name:
   default: OpenProject
 software_url:
-  default: 'https://community.openproject.org/'
+  default: 'https://www.openproject.org/'
 attachment_max_size:
   format: int
   default: 5120


### PR DESCRIPTION
This changes the default URL value to https://www.openproject.org/.

:warning: When testing this, make sure to clear your cache (`rake tmp:clear`).

Should meet the requirements of https://community.openproject.org/work_packages/20628.
