### PR TITLE
[20569] Make unsetting assignee and responsible possible again

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -399,6 +399,7 @@ de:
       btn_preview_enable: "Vorschau"
       btn_preview_disable: "Vorschau deaktivieren"
       null_value_label: "Kein Wert"
+      clear_value_label: "-"
       errors:
         required: '%{field} ist ein Pflichtfeld'
         number: '%{field} ist keine gültige Zahl'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -402,6 +402,7 @@ en:
       btn_preview_enable: "Preview"
       btn_preview_disable: "Disable preview"
       null_value_label: "No value"
+      clear_value_label: "-"
       errors:
         required: '%{field} cannot be empty'
         number: '%{field} is not a valid number'

--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -148,7 +148,7 @@ module.exports = function(
     if (!WorkPackageFieldService.isRequired(workPackage, field)) {
       var arrayWithEmptyOption = [{
         href: null,
-        name: I18n.t('js.inplace.null_value_label')
+        name: I18n.t('js.inplace.clear_value_label')
       }];
       options = arrayWithEmptyOption.concat(options);
     }
@@ -165,7 +165,10 @@ module.exports = function(
         return _.extend({}, item._links.self, { name: item.name });
       });
       if (!WorkPackageFieldService.isRequired(workPackage, field)) {
-        var arrayWithEmptyOption = [{ href: null }];
+        var arrayWithEmptyOption = [{
+          href: null,
+          name: I18n.t('js.inplace.clear_value_label')
+        }];
         options = arrayWithEmptyOption.concat(options);
       }
       return options;


### PR DESCRIPTION
This adds the previously added no value label (see #3158) to linked value seelcts as well in the inplace editor.

I took the liberty and replaced the "No value" label for a more consistent "-".

Should meet the test failure of https://community.openproject.org/work_packages/20569
