### PR TITLE
fix changing status during WP move/copy

### DIFF
--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -53,12 +53,12 @@ class WorkPackages::MovesController < ApplicationController
                                        :responsible_id,
                                        :start_date,
                                        :due_date,
+                                       :status_id,
                                        :priority_id,
                                        :follow,
                                        :new_type_id,
                                        :new_project_id,
-                                       ids: [],
-                                       status_id: [])
+                                       ids: [])
 
       if r = work_package.move_to_project(@target_project, new_type,  copy: @copy,
                                                                       attributes: permitted_params,

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -711,7 +711,7 @@ class WorkPackage < ActiveRecord::Base
           h[v.custom_field_id] = v.value
           h
         end
-      work_package.status = if options[:attributes] && options[:attributes][:status_id]
+      work_package.status = if options[:attributes] && options[:attributes][:status_id].present?
                               Status.find_by_id(options[:attributes][:status_id])
                             else
                               status

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -319,7 +319,7 @@ describe WorkPackages::MovesController, type: :controller do
                  new_type_id: target_project.types.first.id, # FIXME see #1868
                  assigned_to_id: target_user.id,
                  responsible_id: target_user.id,
-                 status_id: [target_status],
+                 status_id: target_status,
                  start_date: start_date,
                  due_date: due_date
           end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/5798
## Description

apparently the status_id param was set to expect an array of values while being moved in this commit: d7f399ab8db059153d2792f9db94450150c7ffdb
Probably because the spec started to expect that when it was moved to be an RSpec test.
I am not sure if this was ever a valid thing outside the tests...
