### PR TITLE
[Rubocop] Enforce semantic block delimiters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,12 @@ Attr:
 BlockNesting:
   Enabled: false
 
+BlockDelimiters:
+  Enabled: true
+  EnforcedStyle: semantic
+  IgnoredMethods:
+    - default_scope
+
 Blocks:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -187,7 +187,7 @@ group :development do
   gem 'thin'
   gem 'faker'
   gem 'quiet_assets'
-  gem 'rubocop', '~> 0.28'
+  gem 'rubocop', '~> 0.32'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,11 +289,11 @@ GEM
     omniauth (1.2.1)
       hashie (>= 1.2, < 3)
       rack (~> 1.0)
-    parser (2.2.0.2)
+    parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
     pg (0.17.1)
     polyglot (0.3.5)
-    powerpack (0.0.9)
+    powerpack (0.1.1)
     prototype-rails (3.2.1)
       rails (~> 3.2)
     pry (0.9.12.6)
@@ -401,10 +401,10 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.0)
-    rubocop (0.28.0)
+    rubocop (0.32.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.0.pre.7, < 3.0)
-      powerpack (~> 0.0.6)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-duration (3.2.0)
@@ -412,7 +412,7 @@ GEM
       i18n
       iso8601
     ruby-prof (0.13.0)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
     rubytree (0.8.3)
       json (>= 1.7.5)
       structured_warnings (>= 0.1.3)
@@ -553,7 +553,7 @@ DEPENDENCIES
   rspec-example_disabler!
   rspec-legacy_formatters
   rspec-rails (~> 3.2.0)
-  rubocop (~> 0.28)
+  rubocop (~> 0.32)
   ruby-duration (~> 3.2.0)
   ruby-prof
   ruby-progressbar
@@ -576,3 +576,6 @@ DEPENDENCIES
   warden (~> 1.2)
   warden-basic_auth (~> 0.2.0)
   will_paginate (~> 3.0)
+
+BUNDLED WITH
+   1.10.4


### PR DESCRIPTION
:warning: **Merge target TBD.** #3186 reformats a large amount of code with these rubocop settings.

Continuation of #1944. Relates to #3027.

N.B. This is a new feature of Rubocop 0.30.0:
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md

> The `semantic` style enforces braces around functional blocks, where
> the primary purpose of the block is to return a value and do..end
> for procedural blocks, where the primary purpose of the block is its
> side-effects.

See more: http://devblog.avdi.org/2011/07/26/the-procedurefunction-block-convention-in-ruby/

Hound CI currently uses Rubocop 0.29.0. To ensure Hound does not flag
our semantic block style, we need to keep the `Blocks` cop config in
our `.rubocop.yml` until they upgrade.
