### PR TITLE
update webpack to avoid karma fails

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -793,49 +793,7 @@
           "version": "0.6.1"
         },
         "rimraf": {
-          "version": "2.3.2",
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "minimatch": {
-                  "version": "2.0.4",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "version": "2.3.2"
         },
         "semver": {
           "version": "2.3.2"
@@ -1247,6 +1205,151 @@
         }
       }
     },
+    "node-libs-browser": {
+      "version": "0.5.2",
+      "dependencies": {
+        "assert": {
+          "version": "1.3.0"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.7"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.2.2",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8"
+            },
+            "ieee754": {
+              "version": "1.1.6"
+            },
+            "is-array": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1"
+        },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "dependencies": {
+            "pbkdf2-compat": {
+              "version": "2.0.1"
+            },
+            "ripemd160": {
+              "version": "0.2.0"
+            },
+            "sha.js": {
+              "version": "2.2.6"
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.4"
+        },
+        "events": {
+          "version": "1.0.2"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "dependencies": {
+            "Base64": {
+              "version": "0.2.1"
+            },
+            "inherits": {
+              "version": "2.0.1"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0"
+        },
+        "os-browserify": {
+          "version": "0.1.2"
+        },
+        "path-browserify": {
+          "version": "0.0.0"
+        },
+        "process": {
+          "version": "0.11.1"
+        },
+        "punycode": {
+          "version": "1.3.2"
+        },
+        "querystring-es3": {
+          "version": "0.2.1"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1"
+            },
+            "isarray": {
+              "version": "0.0.1"
+            },
+            "inherits": {
+              "version": "2.0.1"
+            }
+          }
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31"
+        },
+        "timers-browserify": {
+          "version": "1.4.1"
+        },
+        "tty-browserify": {
+          "version": "0.0.0"
+        },
+        "url": {
+          "version": "0.10.3",
+          "dependencies": {
+            "querystring": {
+              "version": "0.2.0"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1"
+            }
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1"
+            }
+          }
+        }
+      }
+    },
     "polyfill-function-prototype-bind": {
       "version": "0.0.1"
     },
@@ -1289,13 +1392,33 @@
       }
     },
     "webpack": {
-      "version": "1.7.3",
+      "version": "1.10.0",
       "dependencies": {
+        "async": {
+          "version": "0.9.2"
+        },
+        "clone": {
+          "version": "1.0.2"
+        },
+        "enhanced-resolve": {
+          "version": "0.8.6",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8"
+            }
+          }
+        },
         "esprima": {
           "version": "1.2.5"
         },
+        "interpret": {
+          "version": "0.5.2"
+        },
+        "memory-fs": {
+          "version": "0.2.0"
+        },
         "mkdirp": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "dependencies": {
             "minimist": {
               "version": "0.0.8"
@@ -1306,15 +1429,21 @@
           "version": "0.6.1",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2"
+              "version": "0.0.3"
             },
             "minimist": {
               "version": "0.0.10"
             }
           }
         },
+        "supports-color": {
+          "version": "1.3.1"
+        },
+        "tapable": {
+          "version": "0.1.9"
+        },
         "uglify-js": {
-          "version": "2.4.19",
+          "version": "2.4.23",
           "dependencies": {
             "async": {
               "version": "0.2.10"
@@ -1323,15 +1452,18 @@
               "version": "0.1.34",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0"
+                  "version": "0.1.1"
                 }
               }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2"
             },
             "yargs": {
               "version": "3.5.4",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.0.2"
+                  "version": "1.1.0"
                 },
                 "decamelize": {
                   "version": "1.0.0"
@@ -1343,204 +1475,26 @@
                   "version": "0.0.2"
                 }
               }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "async": {
-          "version": "0.9.0"
-        },
-        "enhanced-resolve": {
-          "version": "0.8.4",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "3.0.6"
-            }
-          }
-        },
-        "memory-fs": {
-          "version": "0.2.0"
-        },
-        "clone": {
-          "version": "0.1.19"
-        },
-        "webpack-core": {
-          "version": "0.5.0",
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.2",
-              "dependencies": {
-                "amdefine": {
-                  "version": "0.1.0"
-                }
-              }
-            }
-          }
-        },
-        "node-libs-browser": {
-          "version": "0.4.3",
-          "dependencies": {
-            "assert": {
-              "version": "1.3.0"
-            },
-            "browserify-zlib": {
-              "version": "0.1.4",
-              "dependencies": {
-                "pako": {
-                  "version": "0.2.6"
-                }
-              }
-            },
-            "buffer": {
-              "version": "3.1.2",
-              "dependencies": {
-                "base64-js": {
-                  "version": "0.0.8"
-                },
-                "ieee754": {
-                  "version": "1.1.4"
-                },
-                "is-array": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4"
-                }
-              }
-            },
-            "constants-browserify": {
-              "version": "0.0.1"
-            },
-            "crypto-browserify": {
-              "version": "3.2.8",
-              "dependencies": {
-                "pbkdf2-compat": {
-                  "version": "2.0.1"
-                },
-                "ripemd160": {
-                  "version": "0.2.0"
-                },
-                "sha.js": {
-                  "version": "2.2.6"
-                }
-              }
-            },
-            "domain-browser": {
-              "version": "1.1.4"
-            },
-            "events": {
-              "version": "1.0.2"
-            },
-            "http-browserify": {
-              "version": "1.7.0",
-              "dependencies": {
-                "Base64": {
-                  "version": "0.2.1"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                }
-              }
-            },
-            "https-browserify": {
-              "version": "0.0.0"
-            },
-            "os-browserify": {
-              "version": "0.1.2"
-            },
-            "path-browserify": {
-              "version": "0.0.0"
-            },
-            "process": {
-              "version": "0.10.1"
-            },
-            "punycode": {
-              "version": "1.3.2"
-            },
-            "querystring-es3": {
-              "version": "0.2.1"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                }
-              }
-            },
-            "stream-browserify": {
-              "version": "1.0.0",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1"
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31"
-            },
-            "timers-browserify": {
-              "version": "1.4.0"
-            },
-            "tty-browserify": {
-              "version": "0.0.0"
-            },
-            "url": {
-              "version": "0.10.3",
-              "dependencies": {
-                "querystring": {
-                  "version": "0.2.0"
-                }
-              }
-            },
-            "util": {
-              "version": "0.10.3",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1"
-                }
-              }
-            },
-            "vm-browserify": {
-              "version": "0.0.4",
-              "dependencies": {
-                "indexof": {
-                  "version": "0.0.1"
-                }
-              }
             }
           }
         },
         "watchpack": {
-          "version": "0.2.3",
+          "version": "0.2.8",
           "dependencies": {
             "chokidar": {
-              "version": "1.0.0-rc5",
+              "version": "1.0.3",
               "dependencies": {
                 "anymatch": {
-                  "version": "1.2.1",
+                  "version": "1.3.0",
                   "dependencies": {
                     "micromatch": {
-                      "version": "2.1.5",
+                      "version": "2.1.6",
                       "dependencies": {
                         "arr-diff": {
                           "version": "1.0.1",
                           "dependencies": {
                             "array-slice": {
-                              "version": "0.2.2"
+                              "version": "0.2.3"
                             }
                           }
                         },
@@ -1551,13 +1505,13 @@
                               "version": "1.8.1",
                               "dependencies": {
                                 "fill-range": {
-                                  "version": "2.2.0",
+                                  "version": "2.2.2",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "1.1.2"
                                     },
                                     "isobject": {
-                                      "version": "0.2.0"
+                                      "version": "1.0.0"
                                     },
                                     "randomatic": {
                                       "version": "1.1.0"
@@ -1573,15 +1527,15 @@
                               "version": "0.2.0"
                             },
                             "repeat-element": {
-                              "version": "1.1.0"
+                              "version": "1.1.2"
                             }
                           }
                         },
                         "debug": {
-                          "version": "2.1.3",
+                          "version": "2.2.0",
                           "dependencies": {
                             "ms": {
-                              "version": "0.7.0"
+                              "version": "0.7.1"
                             }
                           }
                         },
@@ -1611,13 +1565,13 @@
                           }
                         },
                         "parse-glob": {
-                          "version": "3.0.0",
+                          "version": "3.0.2",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.2.0"
                             },
                             "is-dotfile": {
-                              "version": "1.0.0"
+                              "version": "1.0.1"
                             },
                             "is-extglob": {
                               "version": "1.0.0"
@@ -1625,191 +1579,13 @@
                           }
                         },
                         "regex-cache": {
-                          "version": "0.3.0",
+                          "version": "0.4.2",
                           "dependencies": {
-                            "benchmarked": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "ansi": {
-                                  "version": "0.3.0"
-                                },
-                                "benchmark": {
-                                  "version": "1.0.0"
-                                },
-                                "chalk": {
-                                  "version": "1.0.0",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.0.1"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3"
-                                    },
-                                    "has-ansi": {
-                                      "version": "1.0.3",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "1.1.1"
-                                        },
-                                        "get-stdin": {
-                                          "version": "4.0.1"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "2.0.1",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "1.1.1"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "extend-shallow": {
-                                  "version": "1.1.2"
-                                },
-                                "file-reader": {
-                                  "version": "1.0.0",
-                                  "dependencies": {
-                                    "extend-shallow": {
-                                      "version": "0.2.0",
-                                      "dependencies": {
-                                        "array-slice": {
-                                          "version": "0.2.2"
-                                        }
-                                      }
-                                    },
-                                    "map-files": {
-                                      "version": "0.3.0",
-                                      "dependencies": {
-                                        "globby": {
-                                          "version": "0.1.1",
-                                          "dependencies": {
-                                            "array-differ": {
-                                              "version": "0.1.0"
-                                            },
-                                            "array-union": {
-                                              "version": "0.1.0",
-                                              "dependencies": {
-                                                "array-uniq": {
-                                                  "version": "0.1.1"
-                                                }
-                                              }
-                                            }
-                                          }
-                                        },
-                                        "relative": {
-                                          "version": "0.1.6",
-                                          "dependencies": {
-                                            "normalize-path": {
-                                              "version": "0.1.1"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "read-yaml": {
-                                      "version": "1.0.0",
-                                      "dependencies": {
-                                        "js-yaml": {
-                                          "version": "3.2.7",
-                                          "dependencies": {
-                                            "argparse": {
-                                              "version": "1.0.2",
-                                              "dependencies": {
-                                                "lodash": {
-                                                  "version": "3.6.0"
-                                                },
-                                                "sprintf-js": {
-                                                  "version": "1.0.2"
-                                                }
-                                              }
-                                            },
-                                            "esprima": {
-                                              "version": "2.0.0"
-                                            }
-                                          }
-                                        },
-                                        "xtend": {
-                                          "version": "4.0.0"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "for-own": {
-                                  "version": "0.1.3",
-                                  "dependencies": {
-                                    "for-in": {
-                                      "version": "0.1.4"
-                                    }
-                                  }
-                                },
-                                "has-values": {
-                                  "version": "0.1.3"
-                                }
-                              }
+                            "is-equal-shallow": {
+                              "version": "0.1.3"
                             },
-                            "chalk": {
-                              "version": "0.5.1",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "1.1.0"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3"
-                                },
-                                "has-ansi": {
-                                  "version": "0.1.0",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "0.2.1"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "0.3.0",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "0.2.1"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "0.2.0"
-                                }
-                              }
-                            },
-                            "micromatch": {
-                              "version": "1.6.2",
-                              "dependencies": {
-                                "extglob": {
-                                  "version": "0.2.0"
-                                },
-                                "parse-glob": {
-                                  "version": "2.1.1",
-                                  "dependencies": {
-                                    "glob-base": {
-                                      "version": "0.1.1"
-                                    },
-                                    "glob-path-regex": {
-                                      "version": "1.0.0"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "to-key": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "arr-map": {
-                                  "version": "1.0.0"
-                                },
-                                "for-in": {
-                                  "version": "0.1.4"
-                                }
-                              }
+                            "is-primitive": {
+                              "version": "2.0.0"
                             }
                           }
                         }
@@ -1827,15 +1603,18 @@
                   "version": "1.2.0"
                 },
                 "is-binary-path": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "dependencies": {
                     "binary-extensions": {
-                      "version": "1.3.0"
+                      "version": "1.3.1"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "1.1.3"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0"
                 },
                 "readdirp": {
                   "version": "1.3.0",
@@ -1847,10 +1626,10 @@
                       "version": "0.2.14",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0"
+                          "version": "2.6.4"
                         },
                         "sigmund": {
-                          "version": "1.0.0"
+                          "version": "1.0.1"
                         }
                       }
                     },
@@ -1874,25 +1653,35 @@
                   }
                 },
                 "fsevents": {
-                  "version": "0.3.5",
+                  "version": "0.3.6",
                   "dependencies": {
                     "nan": {
-                      "version": "1.5.3"
+                      "version": "1.8.4"
                     }
                   }
                 }
               }
             },
             "graceful-fs": {
-              "version": "3.0.6"
+              "version": "3.0.8"
             }
           }
         },
-        "tapable": {
-          "version": "0.1.8"
-        },
-        "supports-color": {
-          "version": "1.3.1"
+        "webpack-core": {
+          "version": "0.6.5",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.2",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Since this morning, running `npm run karma` on a clean install (after e.g. having deleted `frontend/node_modules` or when being a CI) fails.

I have no clue why it would fail all of a sudden.

Updating `webpack` helps however. 

This PR is the result of running:

`npm update webpack && npm shrinkwrap && ./scripts/clean-shrinkwrap.js`
