### PR TITLE
correct reference to timelog edit

### DIFF
--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -85,7 +85,7 @@ module.exports = function() {
       return path;
     },
     timeEntryPath: function(timeEntryIdentifier) {
-      return '/time_entries/' + timeEntryIdentifier;
+      return PathHelper.staticBase + '/time_entries/' + timeEntryIdentifier;
     },
     timeEntryNewPath: function(workPackageId) {
       return PathHelper.timeEntriesPath(null, workPackageId) + '/new';


### PR DESCRIPTION
In sub uri settings, the sub uri is required.

However there are other routes that look fishy and should probably be checked. However, I don't feel qualified to do that.

https://community.openproject.org/work_packages/20677
