### PR TITLE
[20276] Prevent overlapping of label for file input

### DIFF
--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -58,7 +58,7 @@ an attachments_attributes= and not every model supports this we build a nested f
             </div>
           </div>
         </div>
-        <div class="form--field">
+        <div class="form--field -wide-label">
           <label class="form--label">
             <%= l(:label_optional_description) %>
           </label>


### PR DESCRIPTION
This will fix some overlapping in IE10 and IE11 for the file description labels in the nested form.
It should only concern styling and might thereby be a low hanging fruit.

Should meet the requirements of https://community.openproject.org/work_packages/20276.

Note: This concerns smaller resolutions. The problem solved here was that the label for the file field overlapped into the `input` field itself on smaller window sizes.
