### PR TITLE
[20476] Truncate very long subject names

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -29,6 +29,7 @@
 
 module WorkPackagesHelper
   include AccessibilityHelper
+  include ERB::Util
   extend DeprecatedAlias
 
   def work_package_breadcrumb
@@ -656,6 +657,15 @@ module WorkPackagesHelper
     end
 
     ret
+  end
+
+  def truncated_subject(work_package, options = {})
+    return '' unless work_package.is_a? WorkPackage
+    subject = h(work_package.to_s)
+    length = options.fetch :length, 100
+    ellipsis = options.fetch :omission, '...'
+    return subject unless subject.length > length
+    truncate subject, length: length, omission: ellipsis
   end
 
   private

--- a/app/views/work_packages/show.html.erb
+++ b/app/views/work_packages/show.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% work_package_breadcrumb %>
 
-<%= content_tag('h2', h(work_package.to_s), class: 'legacy-heading') %>
+<%= content_tag('h2', truncated_subject(work_package, length: 120), class: 'legacy-heading', title: h(work_package.to_s)) %>
 
 <%= render :partial => 'layouts/action_menu_specific' %>
 

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -497,24 +497,26 @@ describe WorkPackagesHelper, type: :helper do
 
   describe '#truncated_subject' do
     let(:work_package) { FactoryGirl.build(:work_package, subject: seriously_long_subject) }
+    let(:type) { work_package.type.name }
     let(:seriously_long_subject) {
       %{Loremipsumdolorsitamet,consecteturadipisicingelit,
         seddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua.
         Utenimadminimveniam,Excepteursintoccaecatcupidatatnonproident,
-        suntinculpaquiofficiadeseruntmollitanimidestlaborum}.squish }
+        suntinculpaquiofficiadeseruntmollitanimidestlaborum}.squish
+    }
     it 'should should truncate the work package\'s subject' do
-      expected_subject = %{Type No. 1 #: Loremipsumdolorsitamet,consecteturadipisicingelit,
+      expected_subject = %{#{type} #: Loremipsumdolorsitamet,consecteturadipisicingelit,
         seddoeiusmodtemporincididuntutla...}.squish
       expect(truncated_subject(work_package)).to eql(expected_subject)
     end
 
     it 'should be able to truncate with a different ellipsis' do
-      expected_subject = %{Type No. 1 #: Loremipsumdolorsitamet,consecteturadipisicingelit,
+      expected_subject = %{#{type} #: Loremipsumdolorsitamet,consecteturadipisicingelit,
         seddoeiusmodtemporincididuntutla---}.squish
       expect(truncated_subject(work_package, omission: '---')).to eql(expected_subject)
     end
     it 'should be able to truncate with a different length' do
-      expected_subject = %{Type No. 1 #: Lor...}
+      expected_subject = %{#{type} #: Lor...}
       expect(truncated_subject(work_package, length: 20)).to eql(expected_subject)
     end
   end

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -494,4 +494,28 @@ describe WorkPackagesHelper, type: :helper do
       expect(attribute.field).to have_text(status1.name)
     end
   end
+
+  describe '#truncated_subject' do
+    let(:work_package) { FactoryGirl.build(:work_package, subject: seriously_long_subject) }
+    let(:seriously_long_subject) {
+      %{Loremipsumdolorsitamet,consecteturadipisicingelit,
+        seddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua.
+        Utenimadminimveniam,Excepteursintoccaecatcupidatatnonproident,
+        suntinculpaquiofficiadeseruntmollitanimidestlaborum}.squish }
+    it 'should should truncate the work package\'s subject' do
+      expected_subject = %{Type No. 1 #: Loremipsumdolorsitamet,consecteturadipisicingelit,
+        seddoeiusmodtemporincididuntutla...}.squish
+      expect(truncated_subject(work_package)).to eql(expected_subject)
+    end
+
+    it 'should be able to truncate with a different ellipsis' do
+      expected_subject = %{Type No. 1 #: Loremipsumdolorsitamet,consecteturadipisicingelit,
+        seddoeiusmodtemporincididuntutla---}.squish
+      expect(truncated_subject(work_package, omission: '---')).to eql(expected_subject)
+    end
+    it 'should be able to truncate with a different length' do
+      expected_subject = %{Type No. 1 #: Lor...}
+      expect(truncated_subject(work_package, length: 20)).to eql(expected_subject)
+    end
+  end
 end


### PR DESCRIPTION
This PR will force truncation for very long subjects of WorkPackages in the legacy view.

This should meet the requirements of https://community.openproject.org/work_packages/20476.

Note: although I introduced a possible solution, I do not see the problem personally, as this might be the mother of all edge cases.
