### PR TITLE
Reissue: Fixes links in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@
 
 OpenProject is a web-based project management software. Its key features are:
 
-* [Work Package Tracking](https://openproject.org/features/work-packages/)
-* [Project Timelines](https://openproject.org/features/timelines/)
-* [Wikis](https://openproject.org/features/wiki/)
-* [Forums](https://openproject.org/features/more/)
+* [Work Package Tracking](https://www.openproject.org/features/work-packages/)
+* [Project Timelines](https://www.openproject.org/features/timelines/)
+* [Wikis](https://www.openproject.org/features/wiki/)
+* [Forums](https://www.openproject.org/help/user-guides/forum/)
 
 Via plugins, it also supports:
 
-* [Meeting Management](https://openproject.org/features/more/)
-* [Scrum Process Support](https://openproject.org/features/agile-scrum/)
-* [Time and Cost Reporting](https://openproject.org/features/time-and-costs/)
-* and [others](https://openproject.org/download/install-plugins/).
+* [Meeting Management](https://www.openproject.org/help/user-guides/meetings/)
+* [Scrum Process Support](https://www.openproject.org/features/agile-scrum/)
+* [Time and Cost Reporting](https://www.openproject.org/help/user-guides/time-costs/)
+* and [others](https://www.openproject.org/download/install-plugins/).
 
 More information and screenshots can be found on [openproject.org](https://www.openproject.org).
 
 ## Installation
 
 If you want to run an instance of OpenProject in production (or for evaluation), refer to our
-in-depth [installation guides](https://openproject.org/download/).
+in-depth [installation guides](https://www.openproject.org/download/).
 
 If you're a developer wanting to set-up a local environment for contributing to OpenProject or
 developing plugins, you should refer instead to our [Quick Start for Developers](doc/QUICK_START.md).


### PR DESCRIPTION
## Description

Yesterday I merged PR https://github.com/opf/openproject/pull/3206 into `release/4.2`, ignoring the fact that it was based on the `dev` branch. This ensured some git chaos.

Today I am walking the safe-route and reissue said PR against `release/4.2`, but will do a proper PR that someone else but me will have to merge into `release/4.2` ;-)
## Original Description

Some of them showed a 404, most of them redirect permanently to
www.openproject.org.
