### PR TITLE
Feature journal aggregation

### DIFF
--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -45,6 +45,8 @@ class AggregatedJournal
       combined_journals = combined_journals.merge(journal)
     end
 
+    combined_journals['notes'] =
+      @journals.map(&:attributes).map { |hash| hash['notes'] }.compact.first
     combined_journals.symbolize_keys
   end
 end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class AggregatedJournal
+  def initialize(*journals)
+    @journals = journals
+  end
+end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -29,6 +29,22 @@
 
 class AggregatedJournal
   def initialize(*journals)
+    journals.combination(2).each do |journal_a, journal_b|
+      unless JournalAggregator.are_mergeable?(journal_a, journal_b)
+        raise ArgumentError.new('The given journals have to be mergeable.')
+      end
+    end
     @journals = journals
+  end
+
+  def journaled_attributes
+    ordered_journals = @journals.map(&:attributes).sort_by { |journal| journal[:id] }
+
+    combined_journals = {}
+    ordered_journals.each do |journal|
+      combined_journals = combined_journals.merge(journal)
+    end
+
+    combined_journals.symbolize_keys
   end
 end

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -63,7 +63,7 @@ class JournalAggregator
       return false
     end
 
-    if journal_a.author != journal_b.author
+    if journal_a.user_id != journal_b.user_id
       return false
     end
 
@@ -73,7 +73,7 @@ class JournalAggregator
     end
 
     # Never merge comments
-    unless nil_or_empty?(journal_a.notes) && nil_or_empty?(journal_b.notes)
+    if !nil_or_empty?(journal_a.notes) && !nil_or_empty?(journal_b.notes)
       return false
     end
 

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -36,12 +36,15 @@ class JournalAggregator
 
     while current_journal = journal_queue.shift
       journal_queue.each do |merge_candidate|
-        if are_mergeable?(current_journal, merge_candidate)
-          current_journal = merge(current_journal, merge_candidate)
-          journal_queue.delete(merge_candidate)
+        if are_compatible?(current_journal, merge_candidate)
+          if are_mergeable?(current_journal, merge_candidate)
+            current_journal = merge(current_journal, merge_candidate)
+            journal_queue.delete(merge_candidate)
+          else
+            aggregated_journals << current_journal
+            next
+          end
         end
-
-        # TODO: early exit when no further merges for this WP are possible
       end
 
       aggregated_journals << current_journal
@@ -58,13 +61,13 @@ class JournalAggregator
     AggregatedJournal.new(journal_a, journal_b)
   end
 
+  def self.are_compatible?(journal_a, journal_b)
+    journal_a.journable_id == journal_b.journable_id
+  end
+
   def self.are_mergeable?(journal_a, journal_b)
     if journal_a.equal?(journal_b)
       return true
-    end
-
-    if journal_a.journable_id != journal_b.journable_id
-      return false
     end
 
     if journal_a.user_id != journal_b.user_id

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -1,0 +1,92 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class JournalAggregator
+  MAX_TEMPORAL_DISTANCE = 300 # Maximum time between two journals in seconds
+
+  def self.merge_journals(journals_array)
+    aggregated_journals = journals_array.dup
+    advance = journals_array.count == 0
+    while advance
+      result = aggregated_journals.dup
+      aggregated_journals.combination(2).each do |journal_a, journal_b|
+        if are_mergeable?(journal_a, journal_b)
+          result + [merge(journal_a, journal_b)]
+          result - [journal_a, journal_b]
+        end
+      end
+      advance = (aggregated_journals - result).empty?
+      aggregated_journals = result
+    end
+  end
+
+  def self.merge(journal_a, journal_b)
+    if !are_mergeable?(journal_a, journal_b)
+      raise ArgumentError.new('The given journals cannot be merged.')
+    end
+
+    AggregatedJournal.new(journal_a, journal_b)
+  end
+
+  def self.are_mergeable?(journal_a, journal_b)
+    if journal_a.equal?(journal_b)
+      return true
+    end
+
+    if journal_a.journable_id != journal_b.journable_id
+      return false
+    end
+
+    if journal_a.author != journal_b.author
+      return false
+    end
+
+    # The journals need to be consecutive
+    if (journal_a.id - journal_b.id).abs != 1
+      return false
+    end
+
+    # Never merge comments
+    unless nil_or_empty?(journal_a.notes) && nil_or_empty?(journal_b.notes)
+      return false
+    end
+
+    if (journal_a.created_at - journal_b.created_at).abs > MAX_TEMPORAL_DISTANCE
+      return false
+    end
+
+    true
+  end
+
+  private
+
+  def self.nil_or_empty?(variable)
+    variable.nil? || variable.empty?
+  end
+end

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -35,7 +35,7 @@ class JournalAggregator
     journal_queue = journals_array.dup.sort_by &:created_at
 
     while current_journal = journal_queue.shift
-      journal_queue.each do |merge_candidate|
+      journal_queue.dup.each do |merge_candidate|
         if are_compatible?(current_journal, merge_candidate)
           if are_mergeable?(current_journal, merge_candidate)
             current_journal = merge(current_journal, merge_candidate)

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -41,7 +41,7 @@ class JournalAggregator
           result - [journal_a, journal_b]
         end
       end
-      advance = (aggregated_journals - result).empty?
+      advance = (aggregated_journals - result).any?
       aggregated_journals = result
     end
   end

--- a/app/models/journal_aggregator.rb
+++ b/app/models/journal_aggregator.rb
@@ -83,7 +83,7 @@ class JournalAggregator
       end
 
       # Never merge comments
-      if !nil_or_empty?(journal_a.notes) && !nil_or_empty?(journal_b.notes)
+      if journal_a.notes.present? && journal_b.notes.present?
         return false
       end
 
@@ -93,11 +93,5 @@ class JournalAggregator
 
       true
     end
-  end
-
-  private
-
-  def self.nil_or_empty?(variable)
-    variable.nil? || variable.empty?
   end
 end

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -1,0 +1,69 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++require 'rspec'
+
+require 'spec_helper'
+
+describe AggregatedJournal, type: :model do
+  let(:journal_a) do
+    FactoryGirl.build(:journal,
+                      journable_id: 5,
+                      id: 5,
+                      created_at: Time.now,
+                      notes: 'Some random note')
+  end
+
+  context 'invalid constructor arguments' do
+    let(:journal_b) { FactoryGirl.build(:journal, journable_id: journal_a.journable_id + 5) }
+
+    it 'should throw for invalid arguments' do
+      expect { AggregatedJournal.new(journal_a, journal_b) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'valid constructor arguments' do
+    context 'artificial arguments' do
+      let(:journal_b) do
+        FactoryGirl.build(
+          :journal,
+          journable_id: journal_a.journable_id,
+          id: journal_a.id + 1,
+          user_id: journal_a.user_id,
+          created_at: journal_a.created_at + 0.5 * JournalAggregator::MAX_TEMPORAL_DISTANCE,
+          activity_type: 'work_packages')
+      end
+
+      it 'aggregates attributes from both journals' do
+        aggregated_journal = AggregatedJournal.new(journal_a, journal_b)
+        expect(aggregated_journal.journaled_attributes).to include(
+           activity_type: 'work_packages',
+           notes: 'Some random note')
+      end
+    end
+  end
+end

--- a/spec/models/journal_aggregator_spec.rb
+++ b/spec/models/journal_aggregator_spec.rb
@@ -1,0 +1,111 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++require 'rspec'
+
+require 'spec_helper'
+
+describe JournalAggregator do
+  let(:user) { FactoryGirl.build(:user) }
+  let(:journal_a) do
+    FactoryGirl.build(:journal,
+                      journable_id: 5,
+                      user_id: user,
+                      id: 5,
+                      notes: 'Please note:',
+                      created_at: Time.now)
+  end
+
+  shared_examples_for 'does merge' do
+    it 'should merge' do
+      expect(JournalAggregator.are_mergeable?(journal_a, journal_b)).to be_truthy
+    end
+  end
+
+  shared_examples_for 'does not merge' do
+    it 'should merge' do
+      expect(JournalAggregator.are_mergeable?(journal_a, journal_b)).to be_falsey
+    end
+  end
+
+  describe '#are_mergeable?' do
+    context 'equal journals' do
+      it_behaves_like 'does merge' do
+        let(:journal_b) { journal_a }
+      end
+    end
+
+    context 'differing journable_id' do
+      let(:journal_b) { FactoryGirl.build(:journal, journable_id: journal_a.journable_id + 5) }
+
+      it_behaves_like 'does not merge'
+    end
+
+    context 'differing author' do
+      let(:another_user) { FactoryGirl.build(:user) }
+      let(:journal_b) { FactoryGirl.build(:journal, user_id: another_user) }
+
+     it_behaves_like 'does not merge'
+    end
+
+    context 'discontinuous ids' do
+      let(:journal_b) { FactoryGirl.build(:journal, id: journal_a.id + 2) }
+
+      it_behaves_like 'does not merge'
+    end
+
+    context 'two comments' do
+      let(:journal_b) { FactoryGirl.build(:journal, notes: 'I am a different note') }
+
+      it_behaves_like 'does not merge'
+    end
+
+    context 'too much time between journals' do
+      let(:journal_b) do
+        FactoryGirl.build(
+          :journal,
+          created_at: journal_a.created_at + 2 * JournalAggregator::MAX_TEMPORAL_DISTANCE)
+      end
+
+      it_behaves_like 'does not merge'
+    end
+
+    context 'two mergeable journals' do
+      let(:journal_b) do
+        FactoryGirl.build(
+          :journal,
+          journable_id: journal_a.journable_id,
+          user_id: journal_a.user_id,
+          id: journal_a.id + 1,
+          created_at: journal_a.created_at + 0.5 * JournalAggregator::MAX_TEMPORAL_DISTANCE
+        )
+      end
+
+      it_behaves_like 'does merge'
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to provide means to aggregate journal entries. This should then be used later on to combine e.g. updating the properties of a work package and commenting on it into a single journal. Aggregated journals should never be written.

https://community.openproject.org/work_packages/20686
