### PR TITLE
[18714] Remove bundler version note

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,6 +582,3 @@ DEPENDENCIES
   warden (~> 1.2)
   warden-basic_auth (~> 0.2.0)
   will_paginate (~> 3.0)
-
-BUNDLED WITH
-   1.10.5


### PR DESCRIPTION
This will remove the bundler version note when using new `bundler` versions.

This is technically [Housekeeping](https://community.openproject.org/work_packages/18714).

---

Note @NobodysNightmare: this PR does not merge `dev` into any release branch :wink:

If this is wanted earlier, this can also be merged against `release/4.3`
