### PR TITLE
allow addTranslation to be agnostic of whether the locale exists

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GIT
 
 GIT
   remote: https://github.com/opf/openproject-translations.git
-  revision: c2bc109e391545b46ae3ae4409341d6e374d08b4
+  revision: 272f3ed98adc417acc36aeb51f41d6eb3d947c58
   branch: release/4.2
   specs:
     openproject-translations (4.2.0)

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -32,7 +32,12 @@ var I18n = require('./vendor/i18n');
 I18n.translations.en = require("locales/js-en.yml").en;
 
 I18n.addTranslations = function(locale, translations) {
-  I18n.translations[locale] = _.merge(I18n.translations[locale], translations);
+  if (I18n.translations[locale] === undefined) {
+    I18n.translations[locale] = translations;
+  }
+  else {
+    I18n.translations[locale] = _.merge(I18n.translations[locale], translations);
+  }
 };
 
 require('angular-animate');


### PR DESCRIPTION
This requires merging of https://github.com/opf/openproject-translations/pull/21first. After translations is merged, this PR needs another commit updating translations's sha in the Gemfile.lock.
