### PR TITLE
rely on translation of deprecated X-Header-Format to HTTP_X_HEADER_FORMAT

### DIFF
--- a/lib/open_project/authentication.rb
+++ b/lib/open_project/authentication.rb
@@ -83,7 +83,7 @@ module OpenProject
       module_function
 
       def pick_auth_scheme(supported_schemes, default_scheme, request_headers = {})
-        req_scheme = request_headers['X-Authentication-Scheme']
+        req_scheme = request_headers['HTTP_X_AUTHENTICATION_SCHEME']
 
         if supported_schemes.include? req_scheme
           req_scheme

--- a/spec/controllers/api/v2/authentication_spec.rb
+++ b/spec/controllers/api/v2/authentication_spec.rb
@@ -120,7 +120,7 @@ describe Api::V2::AuthenticationController, type: :controller do
 
     context 'with Session auth scheme requested' do
       before do
-        request.env['X-Authentication-Scheme'] = 'Session'
+        request.env['HTTP_X_AUTHENTICATION_SCHEME'] = 'Session'
       end
 
       it 'has Session auth scheme' do

--- a/spec/legacy/support/legacy_assertions.rb
+++ b/spec/legacy/support/legacy_assertions.rb
@@ -294,7 +294,7 @@ module LegacyAssertionsAndHelpers
       context "should not send www authenticate when header accept auth is session #{http_method} #{url}" do
         context 'without credentials' do
           before do
-            send(http_method, url, parameters, 'X-Authentication-Scheme' => 'Session')
+            send(http_method, url, parameters, 'HTTP_X_AUTHENTICATION_SCHEME' => 'Session')
           end
           it { should respond_with failure_code }
           it { should_respond_with_content_type_based_on_url(url) }

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -101,7 +101,7 @@ describe API::V3, type: :request do
         let(:headers) do
           auth = basic_auth(username, password.reverse)
 
-          auth.merge('X-Authentication-Scheme' => 'Session')
+          auth.merge('HTTP_X_AUTHENTICATION_SCHEME' => 'Session')
         end
 
         before do


### PR DESCRIPTION
has to go into 4.3 too and will as soon as 4.2 is merged into 4.3
