### PR TITLE
add a one-shot database setup script

### DIFF
--- a/bin/setup_database
+++ b/bin/setup_database
@@ -12,8 +12,27 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Preparing database =="
 
-  # fails silently if database already exists
-  system "#{rake} db:create"
+  # wait until the database server is up and running as seen from our app
+  # creates the target database as a side effect so we don't need to later
+  loop do
+    # indicates whether our server is up
+    # we can't use db:create only as it always returns success
+    connection_established = begin
+      # fails silently if database already exists
+      system "#{rake} db:create"
+      # returns true if server runs and database exists (therefore the create)
+      system "#{rake} db:version"
+    end
+
+    # exit the loop in case of success, otherwise retry in 10 seconds
+    if connection_established
+      puts "database is awake!"
+      break
+    else
+      puts "waiting for database to wake up..."
+      sleep 10 # seconds
+    end
+  end
 
   # is a schema.rb present (we don't check it in yet)
   schema_exists = File.exist?('db/schema.rb')

--- a/bin/setup_database
+++ b/bin/setup_database
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'pathname'
+require 'fileutils'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+
+FileUtils.chdir APP_ROOT do
+  # if there's a binstub for rake we use that, like the template suggests
+  # if not, we're falling back to whatever is in your path
+  rake = File.exist?('bin/rake') ? 'ruby bin/rake' : 'bundle exec rake'
+
+  puts "== Preparing database =="
+
+  # fails silently if database already exists
+  system "#{rake} db:create"
+
+  # is a schema.rb present (we don't check it in yet)
+  schema_exists = File.exist?('db/schema.rb')
+
+  # are we creating a completely new database (as opposed to updating)
+  # migrate status will complain about a missing schema_migrations table
+  # feel free to change this to a more appropriate check. for now, this works.
+  fresh_database = `#{rake} db:migrate:status` =~ /table does not exist/
+
+  # let's first make sure that a schema.rb is present
+  # once we check-in schema.rb, this can be removed
+  unless schema_exists
+    # one way to create schema.rb is to run migrations
+    system "#{rake} db:migrate"
+  end
+
+  # check whether we have pending migrations, if not we can skip migrations
+  # once we check in schema.rb we can move this call into the !fresh_database
+  # branch of the next if statement
+  pending_migrations = !system("#{rake} db:abort_if_pending_migrations")
+
+  # normally, at this point we have a schema.rb and possibly an empty database
+  # or a database pending some migrations. in case of a new database we run
+  # db:setup, which will db:schema:load and then seed. for existing datbases
+  # we run migrations and don't seed (because we did that in the past)
+  if fresh_database
+    # system "#{rake} db:setup"
+
+    # so far for the theory, db:setup doesn't work right now because we have
+    # seed data in our migrations which would be missing. in order to move
+    # forward, we do it the old way and hope we can use the line above soon.
+    if pending_migrations
+      system "#{rake} db:migrate"
+    end
+
+    # fresh databases need to be seeded
+    system "#{rake} db:seed"
+  else
+    if pending_migrations
+      system "#{rake} db:migrate"
+    end
+  end
+end


### PR DESCRIPTION
a ruby script living at `bin/setup_database` that set's up your database, surprise.

tldr; setup your database con and ruby environment, run the script and your done
# what it does
- creates the database if needed (in your env (note: it also creates test db when running in dev))
- ensures `schema.rb` exists (see below)
- for new databases: creates all tables and adds seed data (e.g. when setting up a new openproject instance)
- for existing databases: runs pending migrations if there are any (e.g. after new deployment)
# preconditions
- ensure postgres/mysql server is running
- configure db connection (`database.yml`, env vars)
- bundle

then run `./bin/setup_database`
# notes

script might look weird at first glance but it's actually very handy.

first of all it differentiates between new databases and existing databases. new databases need to run seeds/demo data. existing ones don't. both need to create all tables, of course. people will say that seed data is created on-demand (recreated if not already there) but in practice it doesn't really work. think about demo data as seeds. when i delete the demo project i don't want it to come back again. so at the very least you need to differentiate between seeds that have to be there (e.g. admin account) and demo data (default categories and such...)

anyways, second major point is our missing `schema.rb`. the second part of the script assumes we have a working `schema.rb`/`db/seeds` combination so we can run `rake db:setup`. but we don't. so on fresh OP checkouts we need to create `schema.rb` first (one way of doing that is by migrating the db, but that's just coincidence..). long story short, i expect `schema.rb` to be checked in at some poitn and then this script can become simpler. for now, it just does what it should in most if not all cases.
# caveats

adding seed data into `db/seeds` won't be executed for existing instances <= let's discuss this

this is just the first shot, need to flesh out the details, happy to receive feedback. more doc in the file.
# goal

the goal is to have a script that i can fire and forget whenever i want and it does the right thing. my target was to have an easy way to bootstrap openproject in a container. @oliverguenther pointed out another use case: switching between different OP versions and/or plugin combinations requires down- and up-migration between the different migration sets.
