### PR TITLE
Ensure bin/plugin_info is launched from the root directory

### DIFF
--- a/frontend/rails-plugins.conf.js
+++ b/frontend/rails-plugins.conf.js
@@ -36,8 +36,11 @@ var path = require('path'),
 var PLUGIN_INFO_CMD_PATH = path.join(__dirname, '..', 'bin', 'plugin_info');
 
 function runPluginsInfo() {
+  var currentWorkingDir = process.cwd();
+  // Make sure we're in the root directory to launch the plugin_info script
   process.chdir(path.join(__dirname, '..'));
   var fullCmd = exec(PLUGIN_INFO_CMD_PATH, { silent: false });
+  process.chdir(currentWorkingDir);
   return fullCmd.code === 0 ? fullCmd.output : '{}';
 }
 

--- a/frontend/rails-plugins.conf.js
+++ b/frontend/rails-plugins.conf.js
@@ -36,7 +36,8 @@ var path = require('path'),
 var PLUGIN_INFO_CMD_PATH = path.join(__dirname, '..', 'bin', 'plugin_info');
 
 function runPluginsInfo() {
-  var fullCmd = exec(PLUGIN_INFO_CMD_PATH, { silent: true });
+  process.chdir(path.join(__dirname, '..'));
+  var fullCmd = exec(PLUGIN_INFO_CMD_PATH, { silent: false });
   return fullCmd.code === 0 ? fullCmd.output : '{}';
 }
 


### PR DESCRIPTION
The heroku ruby buildpack used on Packager.io sets BUNDLE_GEMFILE to
./Gemfile, which was causing plugins to not be picked up because the
plugin_info script was incorrectly trying to load a Gemfile from the
frontend/ directory.

/cc @kgalli @lindenthal @jonasheinrich 
