### PR TITLE
Feature/update translations for 4 2 1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/openproject-translations.git
-  revision: 272f3ed98adc417acc36aeb51f41d6eb3d947c58
+  revision: 5426a677ccb6c28f348b71facfb5f9a06e74b864
   branch: release/4.2
   specs:
-    openproject-translations (4.2.0)
+    openproject-translations (4.2.1)
       crowdin-api (~> 0.2.4)
       mixlib-shellout (~> 2.1.0)
       rails (~> 3.2.14)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1234,6 +1234,7 @@ en:
   project_module_news: "News"
   project_module_repository: "Repository"
   project_module_time_tracking: "Time tracking"
+  project_module_timelines: "Timelines"
   project_module_wiki: "Wiki"
 
   # possible query parameters (e.g. issue queries),


### PR DESCRIPTION
Via updating op-translations this:
- Removes unsupported (not on crowdin) languages and adds translations for the language name: https://community.openproject.org/work_packages/20801
- Uses shorter german I18n for moving columns and by that avoid problems with the menu: https://community.openproject.org/work_packages/20835

Additionally, it introduces the missing I18n key for https://community.openproject.org/work_packages/20797
