### PR TITLE
Journal aggregation (SQL based approach)

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -189,10 +189,10 @@ class Journal < ActiveRecord::Base
 
   def predecessor
     @predecessor ||= self.class
-                       .where(journable_type: journable_type, journable_id: journable_id)
-                       .where("#{self.class.table_name}.version < ?", version)
-                       .order("#{self.class.table_name}.version DESC")
-                       .first
+                     .where(journable_type: journable_type, journable_id: journable_id)
+                     .where("#{self.class.table_name}.version < ?", version)
+                     .order("#{self.class.table_name}.version DESC")
+                     .first
   end
 
   def journalized_object_type

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -188,10 +188,11 @@ class Journal < ActiveRecord::Base
   end
 
   def predecessor
-    @predecessor ||= Journal.where('journable_type = ? AND journable_id = ? AND version < ?',
-                                   journable_type, journable_id, version)
-                     .order('version DESC')
-                     .first
+    @predecessor ||= self.class
+                       .where(journable_type: journable_type, journable_id: journable_id)
+                       .where("#{self.class.table_name}.version < ?", version)
+                       .order("#{self.class.table_name}.version DESC")
+                       .first
   end
 
   def journalized_object_type

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -65,6 +65,7 @@ class Journal::AggregatedJournal < Journal
                #{table_name}.journable_type,
                #{table_name}.user_id,
                #{table_name}.notes,
+               #{table_name}.id \"notes_id\",
                #{table_name}.activity_type,
                COALESCE(addition.created_at, #{table_name}.created_at) \"created_at\",
                COALESCE(addition.id, #{table_name}.id) \"id\",

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -141,14 +141,14 @@ class Journal::AggregatedJournal < Journal
     # to be considered for aggregation. This takes the current instance settings for temporal
     # proximity into account.
     def sql_beyond_aggregation_time?(predecessor, successor)
-      aggregation_time = 3600.to_i
+      aggregation_time_seconds = Setting.journal_aggregation_time_minutes.to_i * 60
 
       if OpenProject::Database.mysql?
         difference = "TIMESTAMPDIFF(second, #{predecessor}.created_at, #{successor}.created_at)"
-        threshold = aggregation_time
+        threshold = aggregation_time_seconds
       else
         difference = "(#{successor}.created_at - #{predecessor}.created_at)"
-        threshold = "interval '#{aggregation_time} second'"
+        threshold = "interval '#{aggregation_time_seconds} second'"
       end
 
       "(#{difference} > #{threshold})"

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -154,4 +154,8 @@ class Journal::AggregatedJournal < Journal
       "(#{difference} > #{threshold})"
     end
   end
+
+  def initial?
+    predecessor.nil?
+  end
 end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -158,4 +158,11 @@ class Journal::AggregatedJournal < Journal
   def initial?
     predecessor.nil?
   end
+
+  # ARs automagic addition of dynamic columns (those not present in the physical table) seems
+  # not to work with PostgreSQL and simply return a string for unknown columns.
+  # Thus we need to ensure manually that this column is correctly casted.
+  def notes_id
+    ActiveRecord::ConnectionAdapters::Column.value_to_integer(attributes['notes_id'])
+  end
 end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -58,9 +58,5 @@ class Journal::AggregatedJournal < Journal
 
       "#{difference} > #{threshold}"
     end
-
-    def mysql?
-      ActiveRecord::Base.connection.instance_values['config'][:adapter] == 'mysql2'
-    end
   end
 end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -48,7 +48,7 @@ class Journal::AggregatedJournal < Journal
     def sql_beyond_aggregation_time?
       aggregation_time = 3600.to_i
 
-      if mysql?
+      if OpenProject::Database.mysql?
         difference = "TIMESTAMPDIFF(second, #{table_name}.created_at, successor.created_at)"
         threshold = aggregation_time
       else

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -30,13 +30,13 @@
 # Similar to regular Journals, but under the following circumstances journals are aggregated:
 #  * they are in temporal proximity
 #  * they belong to the same resource
-#  * they were performed by the same user
+#  * they were created by the same user (i.e. the same user edited the journable)
 #  * no other user has an own journal on the same object between the aggregated ones
 # When a user commented (added a note) twice within a short time, the second comment will
 # "open" a new aggregation, since we do not want to merge comments in any way.
 # The term "aggregation" means the following when applied to our journaling:
-#  * ignore/hide old journal rows (since every journal row contains a full copy of the journaled)
-#    object, dropping intermediate rows will just increase the diff of the following journal
+#  * ignore/hide old journal rows (since every journal row contains a full copy of the journaled
+#    object, dropping intermediate rows will just increase the diff of the following journal)
 #  * in case an older row had notes, take the notes from the older row, since they shall not
 #    be dropped
 class Journal::AggregatedJournal < Journal
@@ -46,8 +46,9 @@ class Journal::AggregatedJournal < Journal
     def default_scope
       # Using the roughly aggregated groups from :sql_rough_group we need to merge journals
       # where an entry with empty notes follows an entry containing notes, so that the notes
-      # from the main entry are taken, while the remaining information from the more recent entry
-      # are taken. We therefore join the rough groups with itself _wherever a merge would be valid_.
+      # from the main entry are taken, while the remaining information is taken from the
+      # more recent entry. We therefore join the rough groups with itself
+      # _wherever a merge would be valid_.
       # Since the results are already pre-merged, this can only happen if Our first entry (master)
       # had a comment and its successor (addition) had no comment, but can be merged.
       # This alone would, however, leave the addition in the result set, leaving a "no change"
@@ -97,7 +98,7 @@ class Journal::AggregatedJournal < Journal
     end
 
     # The "group_number" required in :sql_rough_group has to be generated differently depending on
-    # the DBMS used. This method returns the apropriate statement to be used inside a select to
+    # the DBMS used. This method returns the appropriate statement to be used inside a SELECT to
     # obtain the current group number.
     # The :uid parameter allows to define non-conflicting variable names (for MySQL).
     def sql_group_counter(uid)
@@ -111,7 +112,7 @@ class Journal::AggregatedJournal < Journal
 
     # MySQL requires some initialization to be performed before being able to count the groups.
     # This method allows to inject further FROM sources to achieve that in a single SQL statement.
-    # Sadly MySQL requires the whole statement to be wrapped in parenthesis, while PostreSQL
+    # Sadly MySQL requires the whole statement to be wrapped in parenthesis, while PostgreSQL
     # prohibits that.
     def sql_rough_group_from_clause(uid)
       if OpenProject::Database.mysql?

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class Journal::AggregatedJournal < Journal
+  self.table_name = 'journals'
+
+  def self.default_scope
+    joins("LEFT OUTER JOIN journals successor ON successor.version = #{self.table_name}.version+1 AND
+										  successor.journable_id = #{self.table_name}.journable_id AND
+                                          successor.journable_type = #{self.table_name}.journable_type")
+    .where("#{self.table_name}.user_id != successor.user_id OR
+            (successor.created_at - #{self.table_name}.created_at) > 3600 OR
+            #{self.table_name}.notes != '' OR
+            successor.user_id is NULL")
+    .select("#{self.table_name}.*")
+  end
+end

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -132,12 +132,6 @@ module Redmine
           { description: :notes }.reverse_merge options
         end
       end
-
-      # We can't use a :has_many relation as this would try to delete journals upon deleting the
-      # journalized object (there is nothing like "dependent: ignore").
-      def aggregated_journals
-        Journal::AggregatedJournal.where(journable_type: self.class.name, journable_id: id)
-      end
     end
   end
 end

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -89,9 +89,14 @@ module Redmine
           (journal_hash[:except] ||= []) << primary_key << inheritance_column <<
             :updated_on << :updated_at << :lock_version << :lft << :rgt
 
-          prepare_journaled_options(journal_hash)
+          journals_options = prepare_journaled_options(journal_hash)
+          aggregated_journals_options = prepare_journaled_options(journal_hash.merge(
+                                            journal_class: Journal::AggregatedJournal
+                                            # TODO: override :dependent attribute
+                                          ))
 
-          has_many :journals, journal_hash, &block
+          has_many :journals, journals_options, &block
+          has_many :aggregated_journals, aggregated_journals_options, &block
         end
 
         private

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -59,11 +59,6 @@ module Redmine
       end
 
       module ClassMethods
-        attr_writer :journal_class_name
-        def journal_class_name
-          defined?(@journal_class_name) ? @journal_class_name : superclass.journal_class_name
-        end
-
         def plural_name
           name.underscore.pluralize
         end
@@ -74,8 +69,6 @@ module Redmine
         # To apply more than on activity, use acts_as_activity
         def acts_as_journalized(options = {}, &block)
           activity_hash, event_hash, journal_hash = split_option_hashes(options)
-
-          self.journal_class_name = journal_hash.delete(:class_name) || "#{name.gsub('::', '_')}Journal"
 
           return if journaled?
 
@@ -99,39 +92,6 @@ module Redmine
           prepare_journaled_options(journal_hash)
 
           has_many :journals, journal_hash, &block
-        end
-
-        def journal_class
-          if Object.const_defined?(journal_class_name)
-            jclass = Object.const_get(journal_class_name)
-            if jclass.superclass == Journal
-              jclass
-            else
-              # We are running into some nasty reloaded things in here. Journal
-              # is a reloaded version, jclass.superclass is an older version
-              # from a previous request.
-              #
-              # So we are just removing the const and triggering ourselves
-              # recursively to create a new up-to-date version of the
-              # journal_class with working superclass pointers.
-              Object.send :remove_const, journal_class_name
-              journal_class
-            end
-          else
-            Object.const_set(journal_class_name, Class.new(Journal)).tap do |c|
-              # Run after the inherited hook to associate with the parent record.
-              # This eager loads the associated project (for permissions) if possible
-              if project_assoc = reflect_on_association(:project).try(:name)
-                include_option = ", :include => :#{project_assoc}"
-              end
-              c.class_eval("belongs_to :journaled, :class_name => '#{name}' #{include_option}")
-              c.class_eval("belongs_to :#{name.gsub('::', '_').underscore},
-                  :foreign_key => 'journaled_id' #{include_option}")
-              c.class_eval("def self.journaled_class
-                              #{self}
-                            end")
-            end
-          end
         end
 
         private

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
@@ -86,8 +86,8 @@ module Redmine::Acts::Journalized
       def prepare_journaled_options_with_creation(options)
         result = prepare_journaled_options_without_creation(options)
 
-        vestal_journals_options[:only] = Array(options.delete(:only)).map(&:to_s).uniq if options[:only]
-        vestal_journals_options[:except] = Array(options.delete(:except)).map(&:to_s).uniq if options[:except]
+        vestal_journals_options[:only] = Array(result.delete(:only)).map(&:to_s).uniq if result[:only]
+        vestal_journals_options[:except] = Array(result.delete(:except)).map(&:to_s).uniq if result[:except]
 
         result
       end

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/options.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/options.rb
@@ -89,17 +89,16 @@ module Redmine::Acts::Journalized
       # standard +has_many+ associations.
       def prepare_journaled_options(options)
         result_options =  options.symbolize_keys
-        journal_class = result_options.delete(:journal_class) || Journal
         result_options.reverse_merge!(Configuration.options)
         result_options.reverse_merge!(
-          class_name: journal_class.name,
+          class_name: Journal.name,
           dependent: :delete_all,
           foreign_key: :journable_id,
           conditions: { journable_type: to_s },
           as: :journable
         )
         result_options.reverse_merge!(
-          order: "#{journal_class.table_name}.version ASC"
+          order: "#{Journal.table_name}.version ASC"
         )
 
         class_attribute :vestal_journals_options

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/options.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/options.rb
@@ -88,25 +88,28 @@ module Redmine::Acts::Journalized
       # The method is overridden in feature modules that require specific options outside the
       # standard +has_many+ associations.
       def prepare_journaled_options(options)
-        options.symbolize_keys!
-        options.reverse_merge!(Configuration.options)
-        options.reverse_merge!(
-          class_name: Journal.name,
+        result_options =  options.symbolize_keys
+        journal_class = result_options.delete(:journal_class) || Journal
+        result_options.reverse_merge!(Configuration.options)
+        result_options.reverse_merge!(
+          class_name: journal_class.name,
           dependent: :delete_all,
           foreign_key: :journable_id,
           conditions: { journable_type: to_s },
           as: :journable
         )
-        options.reverse_merge!(
-          order: "#{Journal.table_name}.version ASC"
+        result_options.reverse_merge!(
+          order: "#{journal_class.table_name}.version ASC"
         )
 
         class_attribute :vestal_journals_options
-        self.vestal_journals_options = options.dup
+        self.vestal_journals_options = result_options.dup
 
-        options.merge!(
-          extend: Array(options[:extend]).unshift(Versions)
+        result_options.merge!(
+          extend: Array(result_options[:extend]).unshift(Versions)
         )
+
+        result_options
       end
     end
   end

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -76,4 +76,18 @@ describe Journal::AggregatedJournal, type: :model do
       end
     end
   end
+
+  context 'WP updated after aggregation timeout expired' do
+    before do
+      work_package.status = FactoryGirl.build(:status)
+      work_package.save!
+      work_package.journals.second.created_at += 1.day # one day delay should always be long enough
+      work_package.journals.second.save!
+    end
+
+    it 'returns both journals' do
+      is_expected.to match_array [aggregated_journal_for(work_package.journals.first),
+                                  aggregated_journal_for(work_package.journals.second)]
+    end
+  end
 end

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -70,7 +70,7 @@ describe Journal::AggregatedJournal, type: :model do
   let(:user2) { FactoryGirl.create(:user) }
   let(:initial_author) { user1 }
 
-  subject { described_class.order('id ASC').to_a }
+  subject { described_class.aggregated_journals.order('id ASC').to_a }
 
   before do
     allow(User).to receive(:current).and_return(initial_author)

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -121,6 +121,8 @@ describe Journal::AggregatedJournal, type: :model do
         end
 
         context 'adding a second comment' do
+          let(:notes) { 'Another comment, unrelated to the first one.' }
+
           before do
             expect(work_package.update_by!(new_author, notes: notes)).to be_truthy
           end
@@ -173,10 +175,12 @@ describe Journal::AggregatedJournal, type: :model do
   end
 
   context 'WP updated after aggregation timeout expired' do
+    let(:delay) { (Setting.journal_aggregation_time_minutes.to_i + 1).minutes }
+
     before do
       work_package.status = FactoryGirl.build(:status)
       work_package.save!
-      work_package.journals.second.created_at += 1.day # one day delay should always be long enough
+      work_package.journals.second.created_at += delay
       work_package.journals.second.save!
     end
 

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -79,6 +79,10 @@ describe Journal::AggregatedJournal, type: :model do
     expect(subject.first.notes_id).to eql work_package.journals.first.id
   end
 
+  it 'is the initial journal' do
+    expect(subject.first.initial?).to be_truthy
+  end
+
   context 'WP updated immediately after uncommented change' do
     let(:notes) { nil }
 
@@ -95,6 +99,10 @@ describe Journal::AggregatedJournal, type: :model do
       it 'returns a single aggregated journal' do
         expect(subject.count).to eql 1
         expect(subject.first).to be_equivalent_to_journal work_package.journals.second
+      end
+
+      it 'is the initial journal' do
+        expect(subject.first.initial?).to be_truthy
       end
 
       context 'with a comment' do
@@ -114,6 +122,11 @@ describe Journal::AggregatedJournal, type: :model do
             expect(subject.count).to eql 2
             expect(subject.first).to be_equivalent_to_journal work_package.journals.second
             expect(subject.second).to be_equivalent_to_journal work_package.journals.last
+          end
+
+          it 'has one initial journal and one non-initial journal' do
+            expect(subject.first.initial?).to be_truthy
+            expect(subject.second.initial?).to be_falsey
           end
         end
 

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -70,7 +70,7 @@ describe Journal::AggregatedJournal, type: :model do
   let(:user2) { FactoryGirl.create(:user) }
   let(:initial_author) { user1 }
 
-  subject { described_class.aggregated_journals.order('id ASC').to_a }
+  subject { described_class.aggregated_journals.sort_by &:id }
 
   before do
     allow(User).to receive(:current).and_return(initial_author)

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -1,0 +1,79 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++require 'rspec'
+
+require 'spec_helper'
+
+describe Journal::AggregatedJournal, type: :model do
+  let(:work_package) {
+    FactoryGirl.build(:work_package)
+  }
+  let(:user1) { FactoryGirl.create(:user) }
+  let(:user2) { FactoryGirl.create(:user) }
+  let(:initial_author) { user1 }
+
+  subject { described_class.all }
+
+  def aggregated_journal_for(journal)
+    Journal::AggregatedJournal.new(journal.attributes, without_protection: true)
+  end
+
+  before do
+    allow(User).to receive(:current).and_return(initial_author)
+    work_package.save!
+  end
+
+  it 'returns the one and only journal' do
+    is_expected.to match_array [aggregated_journal_for(work_package.journals.first)]
+  end
+
+  context 'WP updated immediately after last change' do
+    before do
+      allow(User).to receive(:current).and_return(new_author)
+      work_package.status = FactoryGirl.build(:status)
+      work_package.save!
+    end
+
+    context 'by author of last change' do
+      let(:new_author) { initial_author }
+
+      it 'returns a single aggregated journal' do
+        is_expected.to match_array [aggregated_journal_for(work_package.journals.second)]
+      end
+    end
+
+    context 'by a different author' do
+      let(:new_author) { user2 }
+
+      it 'returns both journals' do
+        is_expected.to match_array [aggregated_journal_for(work_package.journals.first),
+                                    aggregated_journal_for(work_package.journals.second)]
+      end
+    end
+  end
+end

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -203,4 +203,17 @@ describe Journal::AggregatedJournal, type: :model do
       expect(subject.second).to be_equivalent_to_journal other_wp.journals.first
     end
   end
+
+  context 'passing a journable as parameter' do
+    subject { described_class.aggregated_journals(journable: work_package).sort_by &:id }
+    let(:other_wp) { FactoryGirl.build(:work_package) }
+    before do
+      other_wp.save!
+    end
+
+    it 'only returns the journal for the requested work package' do
+      expect(subject.count).to eq 1
+      expect(subject.first).to be_equivalent_to_journal work_package.journals.first
+    end
+  end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20686
## Dependencies

This PR depends on https://github.com/opf/openproject/pull/3247
## Description

This PR adds the ability to obtain aggregated journals. Journals are aggregated if they succeed eachother on the same journalizable and were issued within a defined timespan.

This PR chooses a different implementation approach than https://github.com/opf/openproject/pull/3216, which I do not want to throw away (yet).
## TODO
- [x] lookup a journal for editing (by id, exposed via `notes_id`)
- ~~determine earliest/latest `created_at`~~
- [x] create index over (`journalized_type`, `journalized_id`, `version`)
  - extracted into https://github.com/opf/openproject/pull/3247
- [x] use the actual setting to determine the timespan
- [x] final performance test after rebasing onto https://github.com/opf/openproject/pull/3247
