### PR TITLE
fix update_by! when not providing notes

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -444,7 +444,7 @@ class WorkPackage < ActiveRecord::Base
   end
 
   def update_by(user, attributes)
-    add_journal(user, attributes.delete(:notes)) if attributes[:notes]
+    add_journal(user, attributes.delete(:notes) || '')
 
     add_time_entry_for(user, attributes.delete(:time_entry))
     attributes.delete(:attachments)

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -52,9 +52,8 @@ module API
           end
 
           link :self do
-            path = api_v3_paths.work_package_schema(represented.project.id, represented.type.id)
-
             unless form_embedded
+              path = api_v3_paths.work_package_schema(represented.project.id, represented.type.id)
               { href: path }
             end
           end

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -81,6 +81,26 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
 
+    describe 'self link' do
+      it_behaves_like 'has an untitled link' do
+        let(:link) { 'self' }
+        let(:href) {
+          api_v3_paths.work_package_schema(work_package.project.id, work_package.type.id)
+        }
+      end
+
+      context 'embedded in a form' do
+        let(:embedded) { true }
+
+        # In a form there is no guarantee that the current state contains a valid WP
+        let(:work_package) { FactoryGirl.build(:work_package, type: nil) }
+
+        it_behaves_like 'has no link' do
+          let(:link) { 'self' }
+        end
+      end
+    end
+
     describe '_type' do
       it 'is indicated as Schema' do
         is_expected.to be_json_eql('Schema'.to_json).at_path('_type')

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1245,10 +1245,28 @@ describe WorkPackage, type: :model do
       expect(instance.subject).to eq('New subject')
     end
 
-    it "should create a journal with the journal's 'notes' attribute set to the supplied" do
-      instance.update_by!(user,  notes: 'blubs')
+    describe 'creates a journal entry' do
+      it 'with the supplied notes' do
+        instance.update_by!(user, notes: 'blubs')
+        expect(instance.journals.last.notes).to eq('blubs')
+      end
 
-      expect(instance.journals.last.notes).to eq('blubs')
+      it 'by the given user' do
+        instance.update_by!(user, notes: 'blubs')
+        expect(instance.journals.last.user).to eq(user)
+      end
+
+      context 'without supplying journal notes' do
+        it 'creates an entry by the given user' do
+          instance.update_by!(user, subject: 'blubs')
+          expect(instance.journals.last.user).to eq(user)
+        end
+
+        it 'has empty journal notes' do
+          instance.update_by!(user, subject: 'blubs')
+          expect(instance.journals.last.notes).to eq('')
+        end
+      end
     end
 
     it 'should attach an attachment' do


### PR DESCRIPTION
Found and fixed during another PR: https://github.com/opf/openproject/pull/3230

Issuing as separate PR, because the original PR might or might not be merged in its current form.
## Description

This PR fixes the behaviour of `update_by!(user, attributes)`:
- previously the created Journal Entry would have been made by
  - the specified user if `notes` (a comment) were provided for the journal entry
  - `User.current` if no `notes` were provided
- now the journal entry is always made by the specified user

This PR also addresses an issue with the WP form rendering an HTTP 500 for a payload with an invalid type:

``` JSON
{
    "_links": {
        "type": { "href": "/api/v3/types/300" }
    },
    "lockVersion": 107
}
```

This issue was found by a flickering test in this PR.
