### PR TITLE
Remove access to APIv2 from WP list view

### DIFF
--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -221,14 +221,8 @@ module.exports = function() {
     apiPrioritiesPath: function() {
       return PathHelper.apiV2 + '/planning_element_priorities';
     },
-    apiProjectStatusesPath: function(projectIdentifier) {
-      return PathHelper.apiV2ProjectPath(projectIdentifier) + '/statuses';
-    },
     apiProjectWorkPackageTypesPath: function(projectIdentifier) {
       return PathHelper.apiV2ProjectPath(projectIdentifier) + '/planning_element_types';
-    },
-    apiStatusesPath: function() {
-      return PathHelper.apiV2 + '/statuses';
     },
     apiV2ProjectPath: function(projectIdentifier) {
       return PathHelper.apiV2 + PathHelper.projectPath(projectIdentifier);
@@ -258,6 +252,9 @@ module.exports = function() {
     },
     apiV3TypePath: function(typeId) {
       return PathHelper.apiV3 + '/types/' + typeId;
+    },
+    apiStatusesPath: function() {
+      return PathHelper.apiV3 + '/statuses';
     },
     // Static
     staticUserPath: function(userId) {

--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -218,9 +218,6 @@ module.exports = function() {
     },
 
     // API V2
-    apiPrioritiesPath: function() {
-      return PathHelper.apiV2 + '/planning_element_priorities';
-    },
     apiProjectWorkPackageTypesPath: function(projectIdentifier) {
       return PathHelper.apiV2ProjectPath(projectIdentifier) + '/planning_element_types';
     },
@@ -243,6 +240,9 @@ module.exports = function() {
     },
     apiV3WorkPackagePath: function(workPackageId) {
       return PathHelper.apiV3 + '/work_packages/' + workPackageId;
+    },
+    apiPrioritiesPath: function() {
+      return PathHelper.apiV3 + '/priorities';
     },
     apiV3ProjectsPath: function(projectIdentifier) {
       return PathHelper.apiV3 + PathHelper.projectsPath() + '/' + projectIdentifier;

--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -217,17 +217,6 @@ module.exports = function() {
       return PathHelper.apiWorkPackagesPath() + '/column_sums';
     },
 
-    // API V2
-    apiProjectWorkPackageTypesPath: function(projectIdentifier) {
-      return PathHelper.apiV2ProjectPath(projectIdentifier) + '/planning_element_types';
-    },
-    apiV2ProjectPath: function(projectIdentifier) {
-      return PathHelper.apiV2 + PathHelper.projectPath(projectIdentifier);
-    },
-    apiWorkPackageTypesPath: function() {
-      return PathHelper.apiV2 + '/planning_element_types';
-    },
-
     // API V3
     apiQueryStarPath: function(queryId) {
       return PathHelper.apiV3QueryPath(queryId) + '/star';
@@ -255,6 +244,12 @@ module.exports = function() {
     },
     apiStatusesPath: function() {
       return PathHelper.apiV3 + '/statuses';
+    },
+    apiProjectWorkPackageTypesPath: function(projectIdentifier) {
+      return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/types';
+    },
+    apiWorkPackageTypesPath: function() {
+      return PathHelper.apiV3 + '/types';
     },
     // Static
     staticUserPath: function(userId) {

--- a/frontend/app/services/priority-service.js
+++ b/frontend/app/services/priority-service.js
@@ -38,7 +38,7 @@ module.exports = function($http, PathHelper) {
     doQuery: function(url, params) {
       return $http.get(url, { params: params })
         .then(function(response){
-          return response.data.planning_element_priorities;
+          return response.data._embedded.elements;
         });
     }
   };

--- a/frontend/app/services/status-service.js
+++ b/frontend/app/services/status-service.js
@@ -29,22 +29,14 @@
 module.exports = function($http, PathHelper) {
 
   var StatusService = {
-    getStatuses: function(projectIdentifier) {
-      var url;
-
-      if(projectIdentifier) {
-        url = PathHelper.apiProjectStatusesPath(projectIdentifier);
-      } else {
-        url = PathHelper.apiStatusesPath();
-      }
-
-      return StatusService.doQuery(url);
+    getStatuses: function(_projectIdentifier) {
+      return StatusService.doQuery(PathHelper.apiStatusesPath());
     },
 
     doQuery: function(url, params) {
       return $http.get(url, { params: params })
         .then(function(response){
-          return response.data.statuses;
+          return response.data._embedded.elements;
         });
     }
   };

--- a/frontend/app/services/status-service.js
+++ b/frontend/app/services/status-service.js
@@ -29,7 +29,7 @@
 module.exports = function($http, PathHelper) {
 
   var StatusService = {
-    getStatuses: function(_projectIdentifier) {
+    getStatuses: function() {
       return StatusService.doQuery(PathHelper.apiStatusesPath());
     },
 

--- a/frontend/app/services/type-service.js
+++ b/frontend/app/services/type-service.js
@@ -45,7 +45,7 @@ module.exports = function($http, PathHelper) {
     doQuery: function(url, params) {
       return $http.get(url, { params: params })
         .then(function(response){
-          return response.data.planning_element_types;
+          return response.data._embedded.elements;
         });
     }
   };


### PR DESCRIPTION
## Description

This PR removes all calls to the deprecated APIv2 from the WP list view.
This still leaves a lot of calls to the experimental API, but lets do one step after another ;-)
