### PR TITLE
update caypbara and selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,11 +158,11 @@ group :test do
   gem 'rspec-activemodel-mocks'
   gem 'rspec-example_disabler', git: "https://github.com/finnlabs/rspec-example_disabler.git"
   gem 'rspec-legacy_formatters'
-  gem 'capybara', '~> 2.3.0'
+  gem 'capybara', '~> 2.4.4'
   gem 'capybara-screenshot', '~> 1.0.4'
   gem 'capybara-select2', github: 'goodwill/capybara-select2'
   gem 'capybara-ng', '~> 0.2.1'
-  gem 'selenium-webdriver', '~> 2.45.0'
+  gem 'selenium-webdriver', '~> 2.46.2'
   gem 'timecop', '~> 0.7.1'
 
   gem 'rb-readline', "~> 0.5.1" # ruby on CI needs this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     byebug (2.7.0)
       columnize (~> 0.3)
       debugger-linecache (~> 1.2)
-    capybara (2.3.0)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -208,7 +208,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.2.0)
       i18n (~> 0.5)
-    ffi (1.9.8)
+    ffi (1.9.10)
     fog (1.23.0)
       fog-brightbox
       fog-core (~> 1.23)
@@ -424,7 +424,7 @@ GEM
       structured_warnings (>= 0.1.3)
     rubyzip (1.1.6)
     sass (3.4.12)
-    selenium-webdriver (2.45.0)
+    selenium-webdriver (2.46.2)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
@@ -492,7 +492,7 @@ DEPENDENCIES
   autoprefixer-rails
   awesome_nested_set
   bourbon (~> 4.2.0)
-  capybara (~> 2.3.0)
+  capybara (~> 2.4.4)
   capybara-ng (~> 0.2.1)
   capybara-screenshot (~> 1.0.4)
   capybara-select2!
@@ -566,7 +566,7 @@ DEPENDENCIES
   rubytree (~> 0.8.3)
   sass (~> 3.4.12)
   sass-rails!
-  selenium-webdriver (~> 2.45.0)
+  selenium-webdriver (~> 2.46.2)
   shoulda-context (~> 1.2)
   shoulda-matchers (~> 2.8)
   simplecov (= 0.8.0.pre)

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/shared_examples'
 require 'features/work_packages/details/inplace_editor/shared_contexts'
 require 'features/work_packages/details/inplace_editor/work_package_field'
+require 'features/work_packages/work_packages_page'
 
 describe 'description inplace editor', js: true do
   include_context 'maximized window'
@@ -19,12 +20,12 @@ describe 'description inplace editor', js: true do
   }
   let(:user) { FactoryGirl.create :admin }
   let(:field) { WorkPackageField.new page, property_name }
+  let(:work_packages_page) { WorkPackagesPage.new(project) }
 
   before do
     allow(User).to receive(:current).and_return(user)
-    visit project_work_packages_path(project)
 
-    ensure_wp_table_loaded
+    work_packages_page.visit_index
 
     row = page.find("#work-package-#{work_package.id}")
     row.double_click

--- a/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/shared_examples'
 require 'features/work_packages/details/inplace_editor/shared_contexts'
 require 'features/work_packages/details/inplace_editor/work_package_field'
+require 'features/work_packages/work_packages_page'
 
 describe 'subject inplace editor', js: true do
   include_context 'maximized window'
@@ -11,11 +12,13 @@ describe 'subject inplace editor', js: true do
   let(:property_title) { 'Subject' }
   let!(:work_package) { FactoryGirl.create :work_package, project: project }
   let(:user) { FactoryGirl.create :admin }
+  let(:work_packages_page) { WorkPackagesPage.new(project) }
   let(:field) { WorkPackageField.new page, property_name }
 
   before do
     allow(User).to receive(:current).and_return(user)
-    visit project_work_packages_path(project)
+
+    work_packages_page.visit_index
 
     ensure_wp_table_loaded
 

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -29,6 +29,7 @@
 class WorkPackagesPage
   include Rails.application.routes.url_helpers
   include Capybara::DSL
+  include RSpec::Matchers
 
   def initialize(project = nil)
     @project = project
@@ -36,6 +37,8 @@ class WorkPackagesPage
 
   def visit_index
     visit index_path
+
+    ensure_index_page_loaded
   end
 
   def visit_new
@@ -64,6 +67,8 @@ class WorkPackagesPage
 
   def select_query(query)
     visit query_path(query)
+
+    ensure_index_page_loaded
   end
 
   def find_filter(filter_name)
@@ -78,5 +83,11 @@ class WorkPackagesPage
 
   def query_path(query)
     "#{index_path}?query_id=#{query.id}"
+  end
+
+  def ensure_index_page_loaded
+    if Capybara.current_driver == Capybara.javascript_driver
+      expect(page).to have_selector('.advanced-filters--filter', visible: false)
+    end
   end
 end


### PR DESCRIPTION
Updated capybara and selenium.

Additionally, it should stabilize spec flickers by ensuring to have loaded the work package index page before testing.
