### PR TITLE
Add unique index over journals(journable_type, journable_id, version)

### DIFF
--- a/db/migrate/20150716133712_add_unique_index_on_journals.rb
+++ b/db/migrate/20150716133712_add_unique_index_on_journals.rb
@@ -1,0 +1,99 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class AddUniqueIndexOnJournals < ActiveRecord::Migration
+  def up
+    cleanup_duplicate_journals
+    add_index :journals, [:journable_type, :journable_id, :version], unique: true
+  end
+
+  def down
+    remove_index :journals, [:journable_type, :journable_id, :version]
+  end
+
+  private
+
+  def cleanup_duplicate_journals
+    duplicate_pairs = find_duplicate_journal_ids
+
+    if duplicate_pairs.any?
+      say "Found #{duplicate_pairs.count} journals with at least one duplicate!"
+      say_with_time 'Safely removing duplicates...' do
+        duplicate_pairs.each do |current_id, duplicate_id|
+          say "Comparing journals ##{current_id} & ##{duplicate_id} for equality", subitem: true
+
+          current = Journal.find(current_id)
+          duplicate = Journal.find(duplicate_id)
+
+          if journals_equivalent?(current, duplicate)
+            say "Deleting journal ##{current.id}...", subitem: true
+            current.destroy
+          else
+            abort_migration(current, duplicate)
+          end
+        end
+      end
+    end
+  end
+
+  def find_duplicate_journal_ids
+    this = Journal.table_name
+    Journal
+      .joins("INNER JOIN #{this} other
+      ON #{this}.journable_id = other.journable_id AND
+         #{this}.journable_type = other.journable_type AND
+         #{this}.version = other.version")
+      .where("#{this}.id < other.id")
+      .select("#{this}.id id, other.id duplicate_id")
+      .uniq_by(&:id)
+      .map { |pair| [pair.id, pair.duplicate_id] }
+  end
+
+  def journals_equivalent?(a, b)
+    records_equivalent?(a, b) && records_equivalent?(a.data, b.data)
+  end
+
+  def records_equivalent?(a, b)
+    if a.nil? || b.nil?
+      return a == b
+    end
+
+    ignored = [:id, :journal_id, :created_at, :updated_at]
+    a.attributes.symbolize_keys.except(*ignored) == b.attributes.symbolize_keys.except(*ignored)
+  end
+
+  def abort_migration(current, duplicate)
+    say "Won't delete ##{current.id}, because its content is different from ##{duplicate.id}",
+        subitem: true
+    say 'You have to manually decide whether it is safe to delete one of both journals.',
+        subitem: true
+    say 'Aborting migration...', subitem: true
+
+    raise "Can't continue migration safely because of duplicate journals!"
+  end
+end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20914
## Description

The triplet [journable_type, journable_id, version] should never be duplicated. If it was, this would indicate corrupt data.
We know, that it is possible for such data to get into our database, we are not yet sure **how** that happens.
Our best explanation is that this happens during concurrent database updates (e.g. clicking a button twice).

To prevent more corrupt data from getting into the database I added a unique index to enforce that constraint. The index does not come without its benefits: We will need it later anyway when performing more heavy requests involving all three columns. But it should also help today, as usual queries already filter for `journable_id` and `journable_type`.

Adding this index will only work if the data is in a healthy state. The migration will therefore try to delete duplicate entries. Deletion will only happen under the following circumstances:
- both journals are equivalent (match in everything, but `id` and `created_at`)
- the data for both journals is equivalent (e.g. the `work_package_journal`; except: `journal_id`, as this is the foreign key into the table where we look for duplication)
## Sample output

```
==  AddUniqueIndexOnJournals: migrating =======================================
-- Found 2 journals with at least one duplicate!
-- Safely removing duplicates...
   -> Comparing journals #1165 & #1168 for equality
   -> Deleting journal #1165...
   -> Comparing journals #1168 & #1169 for equality
   -> Deleting journal #1168...
   -> 0.1526s
-- add_index(:journals, [:journable_type, :journable_id, :version], {:unique=>true})
   -> 0.0718s
==  AddUniqueIndexOnJournals: migrated (0.2449s) ==============================

```
## Considerations

:warning: **This PR adds a migration that deletes entries from the database!**

You might want to apply an _extra careful review_, because we really should be sure that this one is doing what it is intended to do.
