### PR TITLE
Fix code syntax highlighting output.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -320,7 +320,10 @@ module ApplicationHelper
   end
 
   def syntax_highlight(name, content)
-    Redmine::SyntaxHighlighting.highlight_by_filename(content, name)
+    highlighted = Redmine::SyntaxHighlighting.highlight_by_filename(content, name)
+    highlighted.each_line do |line|
+      yield highlighted.html_safe? ? line.html_safe : line
+    end
   end
 
   def to_path_param(path)

--- a/app/views/common/_file.html.erb
+++ b/app/views/common/_file.html.erb
@@ -30,11 +30,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <table class="filecontent CodeRay">
     <tbody>
       <% line_num = 1 %>
-      <% syntax_highlight(filename, to_utf8_for_attachments(content)).each_line do |line| %>
+      <% syntax_highlight(filename, to_utf8_for_attachments(content)) do |line| %>
         <tr>
           <th class="line-num" id="L<%= line_num %>"><a href="#L<%= line_num %>"><%= line_num %></a></th>
           <td class="line-code">
-            <pre><%=raw line %></pre>
+            <pre><%= line %></pre>
           </td>
         </tr>
         <% line_num += 1 %>

--- a/app/views/repositories/annotate.html.erb
+++ b/app/views/repositories/annotate.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <table class="filecontent annotate CodeRay">
     <tbody>
       <% line_num = 1 %>
-      <% syntax_highlight(@path, to_utf8_for_repositories(@annotate.content)).each_line do |line| %>
+      <% syntax_highlight(@path, to_utf8_for_repositories(@annotate.content)) do |line| %>
         <% revision = @annotate.revisions[line_num-1] %>
         <tr class="bloc-<%= revision.nil? ? 0 : colors[revision.identifier || revision.revision] %>">
           <th class="line-num" id="L<%= line_num %>"><a href="#L<%= line_num %>"><%= line_num %></a></th>

--- a/lib/redmine/syntax_highlighting.rb
+++ b/lib/redmine/syntax_highlighting.rb
@@ -53,7 +53,11 @@ module Redmine
         # the correct source encoding before passing it to ERB::Util.html_escape
         def highlight_by_filename(text, filename)
           language = ::CodeRay::FileType[filename]
-          language ? ::CodeRay.scan(text, language).html.html_safe : ERB::Util.h(::CodeRay.scan(text, :text).text)
+          if language
+            ::CodeRay.scan(text, language).html.html_safe
+          else
+            ERB::Util.h(::CodeRay.scan(text, :text).text)
+          end
         end
 
         # Highlights +text+ using +language+ syntax


### PR DESCRIPTION
When annotating a file in the repository for whose language CodeRay supports,
the output is not properly rendered as HTML, but escaped.

As CodeRay escapes any items for HTML before output, we can safely
assign syntax lines to HTML when highlighted.
If text is output from CodeRay (no language set), we want to escape it
instead.

Relevant work package: https://community.openproject.org/work_packages/20924
