### PR TITLE
Hide the module menu when user is anonymous and login is required.

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -39,14 +39,23 @@ Redmine::MenuManager.map :top_menu do |menu|
   menu.push :work_packages,
             { controller: '/work_packages', project_id: nil, action: 'index' },
             caption: I18n.t('label_work_package_plural'),
-            if: Proc.new { User.current.allowed_to?(:view_work_packages, nil, global: true) }
+            if: Proc.new {
+              (User.current.logged? || !Setting.login_required?) &&
+                User.current.allowed_to?(:view_work_packages, nil, global: true)
+            }
   menu.push :news,
             { controller: '/news', project_id: nil, action: 'index' },
-            if: Proc.new { User.current.allowed_to?(:view_news, nil, global: true) }
+            if: Proc.new {
+              (User.current.logged? || !Setting.login_required?) &&
+                User.current.allowed_to?(:view_news, nil, global: true)
+            }
   menu.push :time_sheet,
             { controller: '/time_entries', project_id: nil, action: 'index' },
             caption: I18n.t('label_time_sheet_menu'),
-            if: Proc.new { User.current.allowed_to?(:view_time_entries, nil, global: true) }
+            if: Proc.new {
+              (User.current.logged? || !Setting.login_required?) &&
+                User.current.allowed_to?(:view_time_entries, nil, global: true)
+            }
   menu.push :help, OpenProject::Info.help_url,
             last: true,
             caption: '',


### PR DESCRIPTION
The public permission of `:view_news` causes the Module menu to always
render when the user is anonymous, even when the Setting
`login_required` is enabled.

This workaround hides the module menu in this specific case, consistent
to the other menus (cf. render_projects_top_menu_node).

Relevant work package: https://community.openproject.org/work_packages/20935
