### PR TITLE
Setting.clear_cache!

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -201,6 +201,15 @@ class Setting < ActiveRecord::Base
     end
   end
 
+  # clears all settings from the cache. #delete_matched might not be supported
+  # by every implementation. in this case we fall back to clearing the entire
+  # cache. if #clear is also not supported we just yawn and fail together.
+  def self.clear_cache!
+    Rails.cache.delete_matched /\/openproject\/settings\/.*/
+  rescue NotImplementedError
+    Rails.cache.clear
+  end
+
   def self.cache_key(name)
     RequestStore.store[:settings_updated_on] ||= Setting.maximum(:updated_on)
     most_recent_settings_change = (RequestStore.store[:settings_updated_on] || Time.now.utc).to_i

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -206,7 +206,7 @@ class Setting < ActiveRecord::Base
   # cache. if #clear is also not supported we just yawn and fail together.
   def self.clear_cache!
     Rails.cache.delete_matched /\/openproject\/settings\/.*/
-  rescue NotImplementedError
+  rescue NotImplementedError, NoMethodError
     Rails.cache.clear
   end
 


### PR DESCRIPTION
- clears all cached settings

todos, that came up:
- check how it behaves with cache namespaces (we want to scope everything by namespace): `delete_matched` will respect the namespace, i.e. don't delete anything in another namespace. `clear` clears all namespaces.
- `delete_matched` isn't even implemented by `DalliStore`, so maybe we shouldn't fall back to `clear` that early
- we also need to rescue from `NoMethodError` because implementations not necessarily descend from the base class
