### PR TITLE
[ci skip] Allow notification-box.warning to be severe without being a…

### DIFF
--- a/app/assets/stylesheets/content/_notifications.lsg
+++ b/app/assets/stylesheets/content/_notifications.lsg
@@ -36,6 +36,17 @@
 </div>
 ```
 
+## Severe warning
+
+```
+<div class="notification-box -warning -severe">
+  <a href="#" class="notification-box--close">&times;</a>
+  <div class="notification-box--content">
+    <p>This is a warning with severe consequences. You should not ignore it.</p>
+  </div>
+</div>
+```
+
 ## Success
 
 ```

--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -124,6 +124,10 @@ $nm-padding-box: rem-calc(10px)
       @include messages-icon
       @extend %nm-icon-warning
 
+    &.-severe
+      background-color: $nm-color-error-background
+      border-color: $nm-color-error-border
+
   //@hack adapting to provided styles
   //messy I dont have all the details for a magic resolve, this might change
   & p, & ul


### PR DESCRIPTION
In the review of https://github.com/opf/openproject/pull/3196, a
notification box with error style was used to communicate a warning
prior to repository deletion with _severe_ consequences
(removal of files outside OpenProject).

This commit suggests to add a `-severe` switch to warning notifications
to signal such a severe decision while NOT being an error.

The implementation re-uses the error colors (as red is often used
to communicate severe warnings - cf. GitHub danger zone, Bootstrap
styles).

I envision this notification to be used in other aspects of the
application, with at least project destroy_info to be of the same
severity that I argue this to be included in the core.

Relevant work package: https://community.openproject.org/work_packages/20999
