### PR TITLE
Typed Settings

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -246,7 +246,7 @@ class AccountController < ApplicationController
         elsif user.password_expired?
           return if redirect_if_password_change_not_allowed(user)
           render_password_change(I18n.t(:notice_account_password_expired,
-                                        days: Setting.password_days_valid.to_i))
+                                        days: Setting.password_days_valid))
         else
           invalid_credentials
         end
@@ -440,7 +440,7 @@ class AccountController < ApplicationController
     logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
                 " at #{Time.now.utc}"
 
-    if Setting.brute_force_block_after_failed_logins.to_i == 0
+    if Setting.brute_force_block_after_failed_logins == 0
       flash_hash[:error] = I18n.t(:notice_account_invalid_credentials)
     else
       flash_hash[:error] = I18n.t(:notice_account_invalid_credentials_or_blocked)

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -33,7 +33,7 @@ class ActivitiesController < ApplicationController
   accept_key_auth :index
 
   def index
-    @days = Setting.activity_days_default.to_i
+    @days = Setting.activity_days_default
 
     if params[:from]
       begin; @date_to = params[:from].to_date + 1; rescue; end

--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -193,9 +193,9 @@ module Api
       def per_page_param
         case params[:format]
         when 'csv', 'pdf'
-          Setting.work_packages_export_limit.to_i
+          Setting.work_packages_export_limit
         when 'atom'
-          Setting.feeds_limit.to_i
+          Setting.feeds_limit
         else
           super
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -573,7 +573,7 @@ class ApplicationController < ActionController::Base
   def render_feed(items, options = {})
     @items = items || []
     @items.sort! { |x, y| y.event_datetime <=> x.event_datetime }
-    @items = @items.slice(0, Setting.feeds_limit.to_i)
+    @items = @items.slice(0, Setting.feeds_limit)
     @title = options[:title] || Setting.app_title
     render template: 'common/feed', layout: false, content_type: 'application/atom+xml'
   end
@@ -751,11 +751,11 @@ class ApplicationController < ActionController::Base
   def session_expired?
     !api_request? && current_user.logged? &&
       (session_ttl_enabled? && (session[:updated_at].nil? ||
-                               (session[:updated_at] + Setting.session_ttl.to_i.minutes) < Time.now))
+                               (session[:updated_at] + Setting.session_ttl.minutes) < Time.now))
   end
 
   def session_ttl_enabled?
-    Setting.session_ttl_enabled? && Setting.session_ttl.to_i >= 5
+    Setting.session_ttl_enabled? && Setting.session_ttl >= 5
   end
 
   def permitted_params

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -36,7 +36,7 @@ class AttachmentsController < ApplicationController
     if @attachment.is_diff?
       @diff = File.new(@attachment.diskfile, 'rb').read
       render action: 'diff'
-    elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
+    elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.kilobyte
       @content = File.new(@attachment.diskfile, 'rb').read
       render action: 'file'
     else

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -82,7 +82,7 @@ class BoardsController < ApplicationController
       format.atom {
         @messages = @board.messages.order(["#{Message.table_name}.sticked_on ASC", sort_clause].compact.join(', '))
                     .includes(:author, :board)
-                    .limit(Setting.feeds_limit.to_i)
+                    .limit(Setting.feeds_limit)
 
         render_feed(@messages, title: "#{@project}: #{@board}")
       }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -65,7 +65,7 @@ class ProjectsController < ApplicationController
       }
       format.atom {
         projects = Project.visible.find(:all, order: 'created_on DESC',
-                                              limit: Setting.feeds_limit.to_i)
+                                              limit: Setting.feeds_limit)
         render_feed(projects, title: "#{Setting.app_title}: #{l(:label_project_latest)}")
       }
     end
@@ -249,7 +249,7 @@ class ProjectsController < ApplicationController
 
   def add_current_user_to_project_if_not_admin(project)
     unless User.current.admin?
-      r = Role.givable.find_by_id(Setting.new_project_user_role_id.to_i) || Role.givable.first
+      r = Role.givable.find_by_id(Setting.new_project_user_role_id) || Role.givable.first
       m = Member.new do |member|
         member.user = User.current
         member.role_ids = [r].map(&:id) # member.roles = [r] fails, this works

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -117,7 +117,7 @@ class RepositoriesController < ApplicationController
   def changes
     @entry = @repository.entry(@path, @rev)
     (show_error_not_found; return) unless @entry
-    @changesets = @repository.latest_changesets(@path, @rev, Setting.repository_log_display_limit.to_i)
+    @changesets = @repository.latest_changesets(@path, @rev, Setting.repository_log_display_limit)
     @properties = @repository.properties(@path, @rev)
     @changeset = @repository.find_changeset_by_name(@rev)
   end
@@ -143,7 +143,7 @@ class RepositoriesController < ApplicationController
     @content = @repository.cat(@path, @rev)
     (show_error_not_found; return) unless @content
     if 'raw' == params[:format] ||
-       (@content.size && @content.size > Setting.file_max_size_displayed.to_i.kilobyte) ||
+       (@content.size && @content.size > Setting.file_max_size_displayed.kilobyte) ||
        !is_entry_text_data?(@content, @path)
       # Force the download
       send_opt = { filename: filename_for_content_disposition(@path.split('/').last) }

--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -91,7 +91,7 @@ class TimelogController < ApplicationController
                                          include: [:project, :activity, :user, { work_package: :type }],
                                          conditions: cond.conditions,
                                          order: "#{TimeEntry.table_name}.created_on DESC",
-                                         limit: Setting.feeds_limit.to_i)
+                                         limit: Setting.feeds_limit)
         render_feed(entries, title: l(:label_spent_time))
       }
       format.csv {

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -435,9 +435,9 @@ class WorkPackagesController < ApplicationController
   def per_page_param
     case params[:format]
     when 'csv', 'pdf'
-      Setting.work_packages_export_limit.to_i
+      Setting.work_packages_export_limit
     when 'atom'
-      Setting.feeds_limit.to_i
+      Setting.feeds_limit
     else
       super
     end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -52,8 +52,8 @@ class Attachment < ActiveRecord::Base
   mount_uploader :file, OpenProject::Configuration.file_uploader
 
   def filesize_below_allowed_maximum
-    if filesize > Setting.attachment_max_size.to_i.kilobytes
-      errors.add(:file, :file_too_large, count: Setting.attachment_max_size.to_i.kilobytes)
+    if filesize > Setting.attachment_max_size.kilobytes
+      errors.add(:file, :file_too_large, count: Setting.attachment_max_size.kilobytes)
     end
   end
 

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -206,7 +206,7 @@ class Changeset < ActiveRecord::Base
   end
 
   def fix_work_package(work_package)
-    status = Status.find_by_id(Setting.commit_fix_status_id.to_i)
+    status = Status.find_by_id(Setting.commit_fix_status_id)
     if status.nil?
       logger.warn("No status matches commit_fix_status_id setting (#{Setting.commit_fix_status_id})") if logger
       return work_package
@@ -247,8 +247,8 @@ class Changeset < ActiveRecord::Base
   end
 
   def log_time_activity
-    if Setting.commit_logtime_activity_id.to_i > 0
-      TimeEntryActivity.find_by_id(Setting.commit_logtime_activity_id.to_i)
+    if Setting.commit_logtime_activity_id > 0
+      TimeEntryActivity.find_by_id(Setting.commit_logtime_activity_id)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,11 +123,11 @@ class User < Principal
   scope :not_blocked, lambda { create_blocked_scope(false) }
 
   def self.create_blocked_scope(blocked)
-    block_duration = Setting.brute_force_block_minutes.to_i.minutes
+    block_duration = Setting.brute_force_block_minutes.minutes
     blocked_if_login_since = Time.now - block_duration
     negation = blocked ? '' : 'NOT'
     where("#{negation} (failed_login_count >= ? AND last_failed_login_on > ?)",
-          Setting.brute_force_block_after_failed_logins.to_i,
+          Setting.brute_force_block_after_failed_logins,
           blocked_if_login_since)
   end
 
@@ -291,7 +291,7 @@ class User < Principal
     # Make sure there's only 1 token that matches the key
     if tokens.size == 1
       token = tokens.first
-      if (token.created_on > Setting.autologin.to_i.day.ago) && token.user && token.user.active?
+      if (token.created_on > Setting.autologin.day.ago) && token.user && token.user.active?
         token.user.log_successful_login
         token.user
       end
@@ -403,7 +403,7 @@ class User < Principal
   # Brute force prevention - public instance methods
   #
   def failed_too_many_recent_login_attempts?
-    block_threshold = Setting.brute_force_block_after_failed_logins.to_i
+    block_threshold = Setting.brute_force_block_after_failed_logins
     return false if block_threshold == 0  # disabled
     (last_failed_login_within_block_time? and
             failed_login_count >= block_threshold)
@@ -777,7 +777,7 @@ class User < Principal
       if former_passwords_include?(password)
         errors.add(:password,
                    I18n.t(:reused,
-                          count: Setting[:password_count_former_banned].to_i,
+                          count: Setting.password_count_former_banned,
                           scope: [:activerecord,
                                   :errors,
                                   :models,
@@ -805,8 +805,8 @@ class User < Principal
   end
 
   def former_passwords_include?(password)
-    return false if Setting[:password_count_former_banned].to_i == 0
-    ban_count = Setting[:password_count_former_banned].to_i
+    return false if Setting.password_count_former_banned == 0
+    ban_count = Setting.password_count_former_banned
     # make reducing the number of banned former passwords immediately effective
     # by only checking this number of former passwords
     passwords[0, ban_count].any? { |f| f.same_as_plain_password?(password) }
@@ -814,7 +814,7 @@ class User < Principal
 
   def clean_up_former_passwords
     # minimum 1 to keep the actual user password
-    keep_count = [1, Setting[:password_count_former_banned].to_i].max
+    keep_count = [1, Setting.password_count_former_banned].max
     (passwords[keep_count..-1] || []).each(&:destroy)
   end
 
@@ -890,7 +890,7 @@ class User < Principal
   # Brute force prevention - instance methods
   #
   def last_failed_login_within_block_time?
-    block_duration = Setting.brute_force_block_minutes.to_i.minutes
+    block_duration = Setting.brute_force_block_minutes.minutes
     last_failed_login_on and
       Time.now - last_failed_login_on < block_duration
   end

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -43,7 +43,7 @@ class UserPassword < ActiveRecord::Base
   end
 
   def expired?
-    days_valid = Setting.password_days_valid.to_i.days
+    days_valid = Setting.password_days_valid.days
     return false if days_valid == 0
     created_at < (Time.now - days_valid)
   end

--- a/app/views/attachments/_form.html.erb
+++ b/app/views/attachments/_form.html.erb
@@ -52,6 +52,6 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
   <span class="add_another_file">
     <%= link_to l(:label_add_another_file), '#', :onclick => 'addFileField(); return false;' %>
-    (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.to_i.kilobytes) %>)
+    (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.kilobytes) %>)
   </span>
 </fieldset>

--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -73,7 +73,7 @@ an attachments_attributes= and not every model supports this we build a nested f
     </div>
     <span class="add_another_file">
       <%= link_to l(:label_add_another_file), '#', :onclick => 'addFileField(); return false;' %>
-      (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.to_i.kilobytes) %>)
+      (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.kilobytes) %>)
     </span>
   </div>
 </fieldset>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,6 +110,7 @@ host_name:
 protocol:
   default: http
 feeds_enabled:
+  format: bool
   default: 1
 feeds_limit:
   format: int

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,7 @@ welcome_text:
   default:
 log_requesting_user:
   default: 0
-  format: int
+  format: bool
 login_required:
   default: 0
 self_registration:

--- a/lib/open_project/passwords.rb
+++ b/lib/open_project/passwords.rb
@@ -89,14 +89,14 @@ module OpenProject
       # to be accepted, as specified in settings and checked to be within
       # reasonable bounds (>= 0, <= number of active rules).
       def self.min_adhered_rules
-        min = Setting.password_min_adhered_rules.to_i
+        min = Setting.password_min_adhered_rules
         # ensure value is in interval [0, active_rules.size]
         [[0, min].max, active_rules.size].min
       end
 
       # Returns the minimum password length as specified in settings.
       def self.min_length
-        Setting.password_min_length.to_i
+        Setting.password_min_length
       end
 
       # Returns a text describing the active password complexity rules,

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -431,7 +431,7 @@ describe AccountController, type: :controller do
           user.save!
 
           # Make sure we don't get a specific message when brute-force protection is enabled
-          with_settings(brute_force_block_after_failed_logins: '0') do
+          with_settings(brute_force_block_after_failed_logins: 0) do
             post :omniauth_login
           end
         end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -112,7 +112,7 @@ describe MessagesController, type: :controller do
       end
 
       context 'invalid attachment' do
-        let(:max_filesize) { Setting.attachment_max_size.to_i.kilobytes }
+        let(:max_filesize) { Setting.attachment_max_size.kilobytes }
 
         before do
           allow_any_instance_of(Attachment).to receive(:filesize).and_return(max_filesize + 1)

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -174,7 +174,7 @@ describe SettingsController, type: :controller do
         end
 
         it 'sets the minimum password length to 42' do
-          expect(Setting[:password_min_length]).to eq '42'
+          expect(Setting[:password_min_length]).to eq 42
         end
 
         it 'sets the active character classes to lowercase and uppercase' do
@@ -182,15 +182,15 @@ describe SettingsController, type: :controller do
         end
 
         it 'sets the required number of classes to 7' do
-          expect(Setting[:password_min_adhered_rules]).to eq '7'
+          expect(Setting[:password_min_adhered_rules]).to eq 7
         end
 
         it 'sets passwords to expire after 13 days' do
-          expect(Setting[:password_days_valid]).to eq '13'
+          expect(Setting[:password_days_valid]).to eq 13
         end
 
         it 'bans the last 80 passwords' do
-          expect(Setting[:password_count_former_banned]).to eq '80'
+          expect(Setting[:password_count_former_banned]).to eq 80
         end
 
         it 'sets the lost password option to the nonsensical 3' do
@@ -210,7 +210,7 @@ describe SettingsController, type: :controller do
         end
 
         it 'does not set the minimum password length to 42' do
-          expect(Setting[:password_min_length]).to eq '10'
+          expect(Setting[:password_min_length]).to eq 10
         end
 
         it 'does not set the active character classes to lowercase and uppercase' do
@@ -218,15 +218,15 @@ describe SettingsController, type: :controller do
         end
 
         it 'does not set the required number of classes to 7' do
-          expect(Setting[:password_min_adhered_rules]).to eq '0'
+          expect(Setting[:password_min_adhered_rules]).to eq 0
         end
 
         it 'does not set passwords to expire after 13 days' do
-          expect(Setting[:password_days_valid]).to eq '365'
+          expect(Setting[:password_days_valid]).to eq 365
         end
 
         it 'does not ban the last 80 passwords' do
-          expect(Setting[:password_count_former_banned]).to eq '2'
+          expect(Setting[:password_count_former_banned]).to eq 2
         end
 
         it 'does not set the lost password option to the nonsensical 3' do

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -963,7 +963,7 @@ describe WorkPackagesController, type: :controller do
       end
 
       context 'invalid attachment' do
-        let(:max_filesize) { Setting.attachment_max_size.to_i.kilobytes }
+        let(:max_filesize) { Setting.attachment_max_size.kilobytes }
 
         before do
           allow_any_instance_of(Attachment).to receive(:filesize).and_return(max_filesize + 1)
@@ -1022,7 +1022,7 @@ describe WorkPackagesController, type: :controller do
       end
 
       context 'invalid attachment' do
-        let(:max_filesize) { Setting.attachment_max_size.to_i.kilobytes }
+        let(:max_filesize) { Setting.attachment_max_size.kilobytes }
 
         before do
           allow_any_instance_of(Attachment).to receive(:filesize).and_return(max_filesize + 1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -329,7 +329,7 @@ describe User, type: :model do
     end
 
     it { expect(@u.valid?).to be_falsey }
-    it { expect(@u.errors[:password]).to include I18n.t('activerecord.errors.messages.too_short', count: Setting.password_min_length.to_i) }
+    it { expect(@u.errors[:password]).to include I18n.t('activerecord.errors.messages.too_short', count: Setting.password_min_length) }
   end
 
   describe '#random_password' do

--- a/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
@@ -75,7 +75,7 @@ describe 'API v3 Attachments by work package resource', type: :request do
     let(:max_file_size) { 1 } # given in kiB
 
     before do
-      allow(Setting).to receive(:attachment_max_size).and_return max_file_size.to_s
+      allow(Setting).to receive(:attachment_max_size).and_return max_file_size
       post request_path, request_parts
     end
 

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -31,9 +31,14 @@
 # The original settings are restored afterwards.
 def with_settings(options, &_block)
   saved_settings = options.keys.inject({}) do |h, k|
-    h[k] = Setting[k].is_a?(Symbol) ?
-              Setting[k] :
-              Setting[k].dup
+    begin
+      # try to store a duplicate, but use the original where :dup is not available (int, bool, sym)
+      # apparently this is the only way to determine if dup will work
+      h[k] = Setting[k].dup
+    rescue
+      h[k] = Setting[k]
+    end
+
     h
   end
 


### PR DESCRIPTION
## Work Package

I see this PR as part of general housekeeping tasks around OpenProject: https://community.openproject.org/work_packages/18714
## Description

Calling `Setting.foo_setting` currently most of the times returns a string in many cases where you actually expect other types to be returned (such as numbers and booleans).

This PR proposes to use the already existing and sporadically used `format` option of the settings to correctly type the return value of `Setting` calls.

I can see this breaking in many places, because currently code is written like this:

```
if Setting.foo_setting == '1'
  call_me Setting.bar_setting.to_i
end
```

But I think I should be worth it long-term-ish. Just want to gather some feedback before adding format information to the whole `settings.yml`.
## Considerations
- stuff will break
- you need to clear the rails cache for changes in return values to become visible
