### PR TITLE
Aggregate journals in APIv3

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -30,6 +30,7 @@
 class Journal < ActiveRecord::Base
   self.table_name = 'journals'
 
+  include JournalChanges
   include JournalFormatter
   include FormatHooks
 
@@ -134,57 +135,6 @@ class Journal < ActiveRecord::Base
     if journable && !journable.changed?
       journable.touch
     end
-  end
-
-  def get_changes
-    return {} if data.nil?
-
-    if @changes.nil?
-      @changes = HashWithIndifferentAccess.new
-
-      if predecessor.nil?
-        @changes = data.journaled_attributes.select { |_, v| !v.nil? }
-                   .inject({}) { |h, (k, v)| h[k] = [nil, v]; h }
-      else
-        normalized_data = JournalManager.normalize_newlines(data.journaled_attributes)
-        normalized_predecessor_data = JournalManager.normalize_newlines(predecessor.data.journaled_attributes)
-
-        normalized_data.select do |k, v|
-          # we dont record changes for changes from nil to empty strings and vice versa
-          pred = normalized_predecessor_data[k]
-          v != pred && (v.present? || pred.present?)
-        end.each do |k, v|
-          @changes[k] = [normalized_predecessor_data[k], v]
-        end
-      end
-
-      @changes.merge!(get_association_changes predecessor, 'attachable', 'attachments', :attachment_id, :filename)
-      @changes.merge!(get_association_changes predecessor, 'customizable', 'custom_fields', :custom_field_id, :value)
-    end
-
-    @changes
-  end
-
-  def get_association_changes(predecessor, journal_association, association, key, value)
-    changes = {}
-    journal_assoc_name = "#{journal_association}_journals"
-
-    if predecessor.nil?
-      send(journal_assoc_name).each_with_object(changes) { |a, h| h["#{association}_#{a.send(key)}"] = [nil, a.send(value)] }
-    else
-      current = send(journal_assoc_name).map(&:attributes)
-      predecessor_attachable_journals = predecessor.send(journal_assoc_name).map(&:attributes)
-
-      merged_journals = JournalManager.merge_reference_journals_by_id current,
-                                                                      predecessor_attachable_journals,
-                                                                      key.to_s
-
-      changes.merge! JournalManager.added_references(merged_journals, association, value.to_s)
-      changes.merge! JournalManager.removed_references(merged_journals, association, value.to_s)
-      changes.merge! JournalManager.changed_references(merged_journals, association, value.to_s)
-    end
-
-    changes
   end
 
   def predecessor

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -110,6 +110,7 @@ class Journal::AggregatedJournal
             successor.id IS NULL)"
 
       if journable
+        raise 'journable has no id' if journable.id.nil?
         sql += " AND predecessor.journable_type = '#{journable.class.name}' AND
                      predecessor.journable_id = #{journable.id}"
       end

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -221,9 +221,11 @@ class Journal::AggregatedJournal
 
   def predecessor
     unless defined? @predecessor
+      version_sql = "COALESCE(addition.version, #{Journal.table_name}.version)"
       raw_journal = self.class.query_aggregated_journals(journable: journable)
-                    .where("#{Journal.table_name}.version < ?", version)
-                    .order("#{Journal.table_name}.version DESC")
+                    .where("#{version_sql} < ?", version)
+                    .except(:order)
+                    .order("#{version_sql} DESC")
                     .first
 
       @predecessor = raw_journal ? Journal::AggregatedJournal.new(raw_journal) : nil

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -127,7 +127,7 @@ class Journal::AggregatedJournal
         group_counter = mysql_group_count_variable(uid)
         "(#{group_counter} := #{group_counter} + 1)"
       else
-        'row_number() OVER ()'
+        'row_number() OVER (ORDER BY predecessor.version ASC)'
       end
     end
 

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -54,10 +54,10 @@ module API
                exec_context: :decorator,
                render_nil: false
 
-      def self.self_link(path: nil, title_getter: -> (*) { represented.name })
+      def self.self_link(path: nil, id_attribute: :id, title_getter: -> (*) { represented.name })
         link :self do
           path = _type.underscore unless path
-          link_object = { href: api_v3_paths.send(path, represented.id) }
+          link_object = { href: api_v3_paths.send(path, represented.send(id_attribute)) }
           title = instance_eval(&title_getter)
           link_object[:title] = title if title
 

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -40,30 +40,27 @@ module API
           route_param :id do
 
             before do
-              @activity = Journal.find(params[:id])
-              @representer = ActivityRepresenter.new(@activity, current_user: current_user)
-            end
+              @activity = Journal::AggregatedJournal.with_notes_id(params[:id])
+              raise API::Errors::NotFound unless @activity
 
-            get do
               authorize(:view_project, context: @activity.journable.project)
-              @representer
             end
 
             helpers do
               def save_activity(activity)
-                if activity.save
-                  representer = ActivityRepresenter.new(activity)
-
-                  representer
-                else
+                unless activity.save
                   fail ::API::Errors::ErrorBase.create_and_merge_errors(activity.errors)
                 end
               end
 
               def authorize_edit_own(activity)
-                return authorize({ controller: :journals, action: :edit }, context: @activity.journable.project)
-                raise API::Errors::Unauthorized.new(current_user) unless activity.editable_by?(current_user)
+                authorize({ controller: :journals, action: :edit },
+                          context: activity.journable.project)
               end
+            end
+
+            get do
+              ActivityRepresenter.new(@activity, current_user: current_user)
             end
 
             params do
@@ -71,11 +68,12 @@ module API
             end
 
             patch do
-              authorize_edit_own(@activity)
+              editable_activity = Journal.find(@activity.notes_id)
+              authorize_edit_own(editable_activity)
+              editable_activity.notes = params[:comment]
+              save_activity(editable_activity)
 
-              @activity.notes = params[:comment]
-
-              save_activity(@activity)
+              ActivityRepresenter.new(@activity.reloaded, current_user: current_user)
             end
 
           end

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -1,0 +1,65 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'api/v3/activities/activity_representer'
+
+module API
+  module V3
+    module Activities
+      class ActivitiesByWorkPackageAPI < ::API::OpenProjectAPI
+        resource :activities do
+          helpers do
+            def save_work_package(work_package)
+              if work_package.save
+                journals = ::Journal::AggregatedJournal.aggregated_journals(
+                  journable: work_package)
+                Activities::ActivityRepresenter.new(journals.last, current_user: current_user)
+              else
+                fail ::API::Errors::ErrorBase.create_and_merge_errors(work_package.errors)
+              end
+            end
+          end
+
+          params do
+            requires :comment, type: String
+          end
+          post do
+            authorize({ controller: :journals, action: :new },
+                      context: @work_package.project) do
+              raise ::API::Errors::NotFound.new
+            end
+
+            @work_package.journal_notes = params[:comment]
+
+            save_work_package(@work_package)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -48,16 +48,14 @@ module API
 
         link :user do
           {
-            href: api_v3_paths.user(represented.user.id),
-            title: "#{represented.user.name} - #{represented.user.login}"
+            href: api_v3_paths.user(represented.user.id)
           }
         end
 
         link :update do
           {
-            href: api_v3_paths.activity(represented.id),
-            method: :patch,
-            title: "#{represented.id}"
+            href: api_v3_paths.activity(represented.notes_id),
+            method: :patch
           } if current_user_allowed_to_edit?
         end
 

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -36,6 +36,7 @@ module API
         include API::V3::Utilities
 
         self_link path: :activity,
+                  id_attribute: :notes_id,
                   title_getter: -> (*) { nil }
 
         link :workPackage do
@@ -60,7 +61,9 @@ module API
           } if current_user_allowed_to_edit?
         end
 
-        property :id, render_nil: true
+        property :id,
+                 getter: -> (*) { notes_id },
+                 render_nil: true
         property :comment,
                  exec_context: :decorator,
                  getter: -> (*) {

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -307,7 +307,7 @@ module API
         end
 
         def activities
-          represented.journals.map do |activity|
+          ::Journal::AggregatedJournal.aggregated_journals(journable: represented).map do |activity|
             ::API::V3::Activities::ActivityRepresenter.new(activity, current_user: current_user)
           end
         end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -83,8 +83,9 @@ module API
               helpers do
                 def save_work_package(work_package)
                   if work_package.save
-                    Activities::ActivityRepresenter.new(work_package.journals.last,
-                                                        current_user: current_user)
+                    journals = ::Journal::AggregatedJournal.aggregated_journals(
+                      journable: represented)
+                    Activities::ActivityRepresenter.new(journals.last, current_user: current_user)
                   else
                     fail ::API::Errors::ErrorBase.create_and_merge_errors(work_package.errors)
                   end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -26,7 +26,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'api/v3/activities/activity_representer'
 require 'api/v3/work_packages/work_package_representer'
 
 module API
@@ -79,36 +78,9 @@ module API
               end
             end
 
-            resource :activities do
-              helpers do
-                def save_work_package(work_package)
-                  if work_package.save
-                    journals = ::Journal::AggregatedJournal.aggregated_journals(
-                      journable: work_package)
-                    Activities::ActivityRepresenter.new(journals.last, current_user: current_user)
-                  else
-                    fail ::API::Errors::ErrorBase.create_and_merge_errors(work_package.errors)
-                  end
-                end
-              end
-
-              params do
-                requires :comment, type: String
-              end
-              post do
-                authorize({ controller: :journals, action: :new },
-                          context: @work_package.project) do
-                  raise ::API::Errors::NotFound.new
-                end
-
-                @work_package.journal_notes = params[:comment]
-
-                save_work_package(@work_package)
-              end
-            end
-
             mount ::API::V3::WorkPackages::WatchersAPI
             mount ::API::V3::Relations::RelationsAPI
+            mount ::API::V3::Activities::ActivitiesByWorkPackageAPI
             mount ::API::V3::Attachments::AttachmentsByWorkPackageAPI
             mount ::API::V3::WorkPackages::UpdateFormAPI
           end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -84,7 +84,7 @@ module API
                 def save_work_package(work_package)
                   if work_package.save
                     journals = ::Journal::AggregatedJournal.aggregated_journals(
-                      journable: represented)
+                      journable: work_package)
                     Activities::ActivityRepresenter.new(journals.last, current_user: current_user)
                   else
                     fail ::API::Errors::ErrorBase.create_and_merge_errors(work_package.errors)

--- a/lib/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+#-- encoding: UTF-8
+module JournalChanges
+  def get_changes
+    return {} if data.nil?
+    return @changes if @changes
+
+    @changes = HashWithIndifferentAccess.new
+
+    if predecessor.nil?
+      @changes = data.journaled_attributes.select { |_, v| !v.nil? }
+                   .inject({}) { |h, (k, v)| h[k] = [nil, v]; h }
+    else
+      normalized_data = JournalManager.normalize_newlines(data.journaled_attributes)
+      normalized_predecessor_data = JournalManager.normalize_newlines(predecessor.data.journaled_attributes)
+
+      normalized_data.select do |k, v|
+        # we dont record changes for changes from nil to empty strings and vice versa
+        pred = normalized_predecessor_data[k]
+        v != pred && (v.present? || pred.present?)
+      end.each do |k, v|
+        @changes[k] = [normalized_predecessor_data[k], v]
+      end
+    end
+
+    @changes.merge!(get_association_changes predecessor, 'attachable', 'attachments', :attachment_id, :filename)
+    @changes.merge!(get_association_changes predecessor, 'customizable', 'custom_fields', :custom_field_id, :value)
+  end
+
+  def get_association_changes(predecessor, journal_association, association, key, value)
+    changes = {}
+    journal_assoc_name = "#{journal_association}_journals"
+
+    if predecessor.nil?
+      send(journal_assoc_name).each_with_object(changes) { |a, h| h["#{association}_#{a.send(key)}"] = [nil, a.send(value)] }
+    else
+      current = send(journal_assoc_name).map(&:attributes)
+      predecessor_journals = predecessor.send(journal_assoc_name).map(&:attributes)
+
+      merged_journals = JournalManager.merge_reference_journals_by_id current,
+                                                                      predecessor_journals,
+                                                                      key.to_s
+
+      changes.merge! JournalManager.added_references(merged_journals, association, value.to_s)
+      changes.merge! JournalManager.removed_references(merged_journals, association, value.to_s)
+      changes.merge! JournalManager.changed_references(merged_journals, association, value.to_s)
+    end
+
+    changes
+  end
+end

--- a/lib/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -69,11 +69,11 @@ module JournalChanges
         h[changed_attribute] = [nil, new_value]
       }
     else
-      new_attributes = send(journal_assoc_name).map(&:attributes)
-      old_attributes = predecessor.send(journal_assoc_name).map(&:attributes)
+      new_journals = send(journal_assoc_name).map(&:attributes)
+      old_journals = predecessor.send(journal_assoc_name).map(&:attributes)
 
-      merged_journals = JournalManager.merge_reference_journals_by_id new_attributes,
-                                                                      old_attributes,
+      merged_journals = JournalManager.merge_reference_journals_by_id new_journals,
+                                                                      old_journals,
                                                                       key.to_s
 
       changes.merge! JournalManager.added_references(merged_journals, association, value.to_s)

--- a/spec/lib/api/v3/activities/activity_representer_spec.rb
+++ b/spec/lib/api/v3/activities/activity_representer_spec.rb
@@ -31,11 +31,16 @@ require 'spec_helper'
 describe ::API::V3::Activities::ActivityRepresenter do
   let(:current_user) { FactoryGirl.create(:user,  member_in_project: project, member_through_role: role) }
   let(:work_package) { FactoryGirl.build(:work_package) }
-  let(:journal) { FactoryGirl.build(:work_package_journal, journable: work_package, user: current_user) }
+  let(:journal) { Journal::AggregatedJournal.aggregated_journals.first }
   let(:project) { work_package.project }
   let(:permissions) { %i(edit_own_work_package_notes) }
   let(:role) { FactoryGirl.create :role, permissions: permissions }
   let(:representer) { described_class.new(journal, current_user: current_user) }
+
+  before do
+    allow(User).to receive(:current).and_return(current_user)
+    work_package.save!
+  end
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -87,7 +87,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
 
         context 'no start date' do
-          let(:work_package) { FactoryGirl.build(:work_package, start_date: nil) }
+          let(:work_package) { FactoryGirl.build(:work_package, id: 42, start_date: nil) }
 
           it 'renders as null' do
             is_expected.to be_json_eql(nil.to_json).at_path('startDate')
@@ -102,7 +102,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
 
         context 'no due date' do
-          let(:work_package) { FactoryGirl.build(:work_package, due_date: nil) }
+          let(:work_package) { FactoryGirl.build(:work_package, id: 42, due_date: nil) }
 
           it 'renders as null' do
             is_expected.to be_json_eql(nil.to_json).at_path('dueDate')
@@ -288,7 +288,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       describe 'assignee' do
         context 'assignee is set' do
           let(:work_package) {
-            FactoryGirl.build(:work_package, assigned_to: FactoryGirl.build(:user))
+            FactoryGirl.build(:work_package, id: 42, assigned_to: FactoryGirl.build(:user))
           }
 
           it_behaves_like 'has a titled link' do
@@ -308,7 +308,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       describe 'responsible' do
         context 'responsible is set' do
           let(:work_package) {
-            FactoryGirl.build(:work_package, responsible: FactoryGirl.build(:user))
+            FactoryGirl.build(:work_package, id: 42, responsible: FactoryGirl.build(:user))
           }
 
           it_behaves_like 'has a titled link' do

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -137,6 +137,10 @@ describe Journal::AggregatedJournal, type: :model do
             expect(subject.first.initial?).to be_truthy
             expect(subject.second.initial?).to be_falsey
           end
+
+          it 'has the first as predecessor of the second journal' do
+            expect(subject.second.predecessor).to be_equivalent_to_journal subject.first
+          end
         end
 
         context 'adding another change without comment' do
@@ -159,6 +163,14 @@ describe Journal::AggregatedJournal, type: :model do
           it 'indicates the ID of the earlier journal via notes_id' do
             expect(subject.first.notes_id).to eql work_package.journals.second.id
           end
+
+          it 'is the initial journal' do
+            expect(subject.first.initial?).to be_truthy
+          end
+
+          it 'has no predecessor' do
+            expect(subject.first.predecessor).to be_nil
+          end
         end
       end
     end
@@ -170,6 +182,10 @@ describe Journal::AggregatedJournal, type: :model do
         expect(subject.count).to eql 2
         expect(subject.first).to be_equivalent_to_journal work_package.journals.first
         expect(subject.second).to be_equivalent_to_journal work_package.journals.second
+      end
+
+      it 'has the first as predecessor of the second journal' do
+        expect(subject.second.predecessor).to be_equivalent_to_journal subject.first
       end
     end
   end

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'rack/test'
 
-describe API::V3::WorkPackages::WorkPackagesAPI, type: :request do
+describe API::V3::Activities::ActivitiesByWorkPackageAPI, type: :request do
   include API::V3::Utilities::PathHelper
 
   let(:admin) { FactoryGirl.create(:admin) }

--- a/spec/requests/api/v3/support/authorization.rb
+++ b/spec/requests/api/v3/support/authorization.rb
@@ -28,27 +28,16 @@
 
 require 'spec_helper'
 
-shared_examples_for 'handling anonymous user' do |type, path|
+shared_examples_for 'handling anonymous user' do
   context 'anonymous user' do
-    let(:get_path) { path % [id] }
-
-    context 'when access for anonymous user is allowed' do
-      before { get get_path }
-
-      it 'should respond with 200' do
-        expect(subject.status).to eq(200)
-      end
-
-      it 'should respond with correct type' do
-        expect(subject.body).to include_json(type.to_json).at_path('_type')
-        expect(subject.body).to be_json_eql(id.to_json).at_path('id')
-      end
+    before do
+      allow(User).to receive(:current).and_return(User.anonymous)
     end
 
     context 'when access for anonymous user is not allowed' do
       before do
         allow(Setting).to receive(:login_required?).and_return(true)
-        get get_path
+        get path
       end
 
       it_behaves_like 'unauthenticated access'

--- a/spec/requests/api/v3/user_resource_spec.rb
+++ b/spec/requests/api/v3/user_resource_spec.rb
@@ -66,8 +66,8 @@ describe 'API v3 User resource', type: :request do
       end
     end
 
-    it_behaves_like 'handling anonymous user', 'User', '/api/v3/users/%s' do
-      let(:id) { user.id }
+    it_behaves_like 'handling anonymous user' do
+      let(:path) { api_v3_paths.user user.id }
     end
   end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20688
## Description

Starting with this PR the APIv3 activities return their results in an aggregated form.
Some work on the `Journal::AggregatedJournals` was still neccessary.

**WP legcy form (non-aggregated)**
![non-aggregated](https://cloud.githubusercontent.com/assets/453584/8877643/a1349582-3226-11e5-853b-9e7bc6afe8e3.PNG)

**inplace view (aggregated)**
![aggregated](https://cloud.githubusercontent.com/assets/453584/8877642/a1343b32-3226-11e5-9a44-7a4558b6253a.PNG)
