### PR TITLE
APIv3 blueprint: Add revisions endpoint

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2139,6 +2139,84 @@ For more details and all possible responses see the general specification of [Fo
                 "message": "The request body was not empty."
             }
 
+
+# Group Revisions
+
+Revisions are sets of updates to files in the context of repositories linked in OpenProject.
+
+## Linked Properties
+|  Link            | Description                                         | Type          | Constraints | Supported operations |
+|:----------------:| --------------------------------------------------- | ------------- | ----------- | -------------------- |
+| self             | This revision                                       | Revision      | not null    | READ                 |
+| project          | The project to which the revision belongs           | Project       | not null    | READ                 |
+| committer        | The user that committed this revision, if defined   | User          |             | READ                 |
+
+
+## Local Properties
+| Property       | Description                                             | Type        | Constraints | Supported operations |
+|:--------------:| --------------------------------------------------------| ----------- | ----------- | -------------------- |
+| id             | Revisions's id                                          | Integer     | x > 0       | READ                 |
+| identifier     | The SCM identifier of the revision (e.g. SHA hash)      | String      | not null    | READ                 |
+| committerName  | The name of the author that committed this revision     | String      | not null    | READ                 |
+| message        | The commit message of the revision                      | Formattable | not null    | READ                 |
+| committedAt    | The time this revision was committed to the repository  | DateTime    | not null    | READ                 |
+
+## Revision [/api/v3/revisions/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "Revision",
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/revisions/1"
+                    },
+                    "project" {
+                        "href": "/api/v3/projects/1"
+                    },
+                    "committer": {
+                        "href": "/api/v3/users/1"
+                    },
+                },
+                "id": 1,
+                "identifier": "11f4b07dff4f4ce9548a52b7d002daca7cd63ec6",
+                "committerName": "Some Developer",
+                "message": {
+                    "format": "plain",
+                    "raw": "This revision provides new features\n\nAn elaborate description",
+                    "html": "<p>This revision provides new features<br/><br/>An elaborate description</p>"
+                },
+                "committedAt": "2015-07-21T13:36:59Z"
+            }
+
+## View revision [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... Revision id
+
++ Response 200 (application/hal+json)
+
+    [Revision][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the revision does not exist or the client does not have sufficient permissions
+    to see it.
+
+    **Required permission:** view changesets for the project the repository is created in.
+
+    *Note: A client without sufficient permissions shall not be able to test for the existence of a revision.
+    That's why a 404 is returned here, even if a 403 might be more appropriate.*
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The specified revision does not exist."
+            }
+
 # Group Schemas
 
 ## Linked Properties
@@ -3155,6 +3233,7 @@ Note that due to sharing this might be more than the versions *defined* by that 
 | category           | The category of the work package                                                                                                                      | Category     |              | READ / WRITE          |                                           |
 | priority           | The priority of the work package                                                                                                                      | Priority     | not null     | READ / WRITE          |                                           |
 | project            | The project to which the work package belongs                                                                                                         | Project      | not null     | READ                  |                                           |
+| revisions          | Revisions that are referencing the work package                                                                                                       | Revision     |              | READ                  | **Permission** view changesets            |
 | responsible        | The person that is responsible for the overall outcome                                                                                                | User         |              | READ / WRITE          |                                           |
 | status             | The current status of the work package                                                                                                                | Status       | not null     | READ / WRITE          |                                           |
 | timeEntries        | All time entries logged on the work package. Please note that this is a link to an HTML resource for now and as such, the link is subject to change.  | N/A          |              | READ                  | **Permission** view time entries          |

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2145,21 +2145,21 @@ For more details and all possible responses see the general specification of [Fo
 Revisions are sets of updates to files in the context of repositories linked in OpenProject.
 
 ## Linked Properties
-|  Link            | Description                                         | Type          | Constraints | Supported operations |
-|:----------------:| --------------------------------------------------- | ------------- | ----------- | -------------------- |
-| self             | This revision                                       | Revision      | not null    | READ                 |
-| project          | The project to which the revision belongs           | Project       | not null    | READ                 |
-| committer        | The user that committed this revision, if defined   | User          |             | READ                 |
+|  Link            | Description                                                                                       | Type          | Constraints | Supported operations |
+|:----------------:| --------------------------------------------------------------------------------------------------| ------------- | ----------- | -------------------- |
+| self             | This revision                                                                                     | Revision      | not null    | READ                 |
+| project          | The project to which the revision belongs                                                         | Project       | not null    | READ                 |
+| author           | The user that added this revision, if the committerName was mapped to a user in OpenProject       | User          |             | READ                 |
 
 
 ## Local Properties
-| Property       | Description                                             | Type        | Constraints | Supported operations |
-|:--------------:| --------------------------------------------------------| ----------- | ----------- | -------------------- |
-| id             | Revisions's id                                          | Integer     | x > 0       | READ                 |
-| identifier     | The SCM identifier of the revision (e.g. SHA hash)      | String      | not null    | READ                 |
-| committerName  | The name of the author that committed this revision     | String      | not null    | READ                 |
-| message        | The commit message of the revision                      | Formattable | not null    | READ                 |
-| committedAt    | The time this revision was committed to the repository  | DateTime    | not null    | READ                 |
+| Property       | Description                                                                                                                                                 | Type        | Constraints | Supported operations |
+|:--------------:| ------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------- | ----------- | -------------------- |
+| id             | Revisions's id, assigned by OpenProject                                                                                                                     | Integer     | x > 0       | READ                 |
+| identifier     | The SCM identifier of the revision (e.g. SHA hash)                                                                                                          | String      | not null    | READ                 |
+| committerName  | The name of the author that committed this revision. Note that this name is retrieved from the repository and does not identify a user in OpenProject.      | String      | not null    | READ                 |
+| message        | The commit message of the revision                                                                                                                          | Formattable | not null    | READ                 |
+| createdAt      | The time this revision was committed to the repository                                                                                                      | DateTime    | not null    | READ                 |
 
 ## Revision [/api/v3/revisions/{id}]
 
@@ -2175,7 +2175,7 @@ Revisions are sets of updates to files in the context of repositories linked in 
                     "project" {
                         "href": "/api/v3/projects/1"
                     },
-                    "committer": {
+                    "author": {
                         "href": "/api/v3/users/1"
                     },
                 },
@@ -2187,7 +2187,7 @@ Revisions are sets of updates to files in the context of repositories linked in 
                     "raw": "This revision provides new features\n\nAn elaborate description",
                     "html": "<p>This revision provides new features<br/><br/>An elaborate description</p>"
                 },
-                "committedAt": "2015-07-21T13:36:59Z"
+                "createdAt": "2015-07-21T13:36:59Z"
             }
 
 ## View revision [GET]
@@ -3233,8 +3233,8 @@ Note that due to sharing this might be more than the versions *defined* by that 
 | category           | The category of the work package                                                                                                                      | Category     |              | READ / WRITE          |                                           |
 | priority           | The priority of the work package                                                                                                                      | Priority     | not null     | READ / WRITE          |                                           |
 | project            | The project to which the work package belongs                                                                                                         | Project      | not null     | READ                  |                                           |
-| revisions          | Revisions that are referencing the work package                                                                                                       | Revision     |              | READ                  | **Permission** view changesets            |
 | responsible        | The person that is responsible for the overall outcome                                                                                                | User         |              | READ / WRITE          |                                           |
+| revisions          | Revisions that are referencing the work package                                                                                                       | Revision     |              | READ                  | **Permission** view changesets            |
 | status             | The current status of the work package                                                                                                                | Status       | not null     | READ / WRITE          |                                           |
 | timeEntries        | All time entries logged on the work package. Please note that this is a link to an HTML resource for now and as such, the link is subject to change.  | N/A          |              | READ                  | **Permission** view time entries          |
 | type               | The type of the work package                                                                                                                          | Type         | not null     | READ / WRITE          |                                           |
@@ -3329,6 +3329,9 @@ the human readable name of custom fields.*
                     "responsible": {
                         "href": "/api/v3/users/23",
                         "title": "Laron Leuschke - Alaina5788"
+                    },
+                    "revisions": {
+                        "href": "/api/v3/work_packages/1528/revisions"
                     },
                     "assignee": {
                         "href": "/api/v3/users/11",

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2149,7 +2149,7 @@ Revisions are sets of updates to files in the context of repositories linked in 
 |:----------------:| --------------------------------------------------------------------------------------------------| ------------- | ----------- | -------------------- |
 | self             | This revision                                                                                     | Revision      | not null    | READ                 |
 | project          | The project to which the revision belongs                                                         | Project       | not null    | READ                 |
-| author           | The user that added this revision, if the committerName was mapped to a user in OpenProject       | User          |             | READ                 |
+| author           | The user that added this revision, if the authorName was mapped to a user in OpenProject       | User          |             | READ                 |
 
 
 ## Local Properties
@@ -2157,7 +2157,7 @@ Revisions are sets of updates to files in the context of repositories linked in 
 |:--------------:| ------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------- | ----------- | -------------------- |
 | id             | Revisions's id, assigned by OpenProject                                                                                                                     | Integer     | x > 0       | READ                 |
 | identifier     | The SCM identifier of the revision (e.g. SHA hash)                                                                                                          | String      | not null    | READ                 |
-| committerName  | The name of the author that committed this revision. Note that this name is retrieved from the repository and does not identify a user in OpenProject.      | String      | not null    | READ                 |
+| authorName     | The name of the author that committed this revision. Note that this name is retrieved from the repository and does not identify a user in OpenProject.      | String      | not null    | READ                 |
 | message        | The commit message of the revision                                                                                                                          | Formattable | not null    | READ                 |
 | createdAt      | The time this revision was committed to the repository                                                                                                      | DateTime    | not null    | READ                 |
 
@@ -2181,7 +2181,7 @@ Revisions are sets of updates to files in the context of repositories linked in 
                 },
                 "id": 1,
                 "identifier": "11f4b07dff4f4ce9548a52b7d002daca7cd63ec6",
-                "committerName": "Some Developer",
+                "authorName": "Some Developer",
                 "message": {
                     "format": "plain",
                     "raw": "This revision provides new features\n\nAn elaborate description",
@@ -4018,6 +4018,120 @@ Gets a list of users that are able to be watchers of the specified work package.
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
                 "message": "The specified work package does not exist."
             }
+
+## Revisions [/api/v3/work_packages/{id}/revisions]
+
++ Model
+    + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/api/v3/work_packages/42/revisions" },
+                    "filter": {
+                        "href": "/api/v3/work_packages/42/revisions",
+                        "templated": true
+                    }
+                },
+                "total": 2,
+                "count": 2,
+                "_type": "Collection",
+                "_embedded": {
+                  "elements": [
+                    {
+                        "_type": "Revision",
+                        "_links": {
+                            "self": {
+                                "href": "/api/v3/revisions/13",
+                            },
+                            "project": {
+                                "href": "/api/v3/projects/1",
+                                "title": "A Test Project
+                            },
+                            "author": {
+                                "href": "/api/v3/users/1",
+                                "title": "John Sheppard - j.sheppard"
+                            }
+                        },
+                        "id": 13,
+                        "identifier": "11f4b07dff4f4ce9548a52b7d002daca7cd63ec6",
+                        "authorName": "John Sheppard",
+                        "message": {
+                            "format": "plain",
+                            "raw": "This revision provides new features\n\nAn elaborate description",
+                            "html": "<p>This revision provides new features<br/><br/>An elaborate description</p>"
+                        },
+                        "createdAt": "2015-07-21T13:36:59Z",
+                    },
+                    {
+                        "_type": "Revision",
+                        "_links": {
+                            "self": {
+                                "href": "/api/v3/revisions/14",
+                            },
+                            "project": {
+                                "href": "/api/v3/projects/1",
+                                "title": "A Test Project
+                            },
+                            "author": {
+                                "href": "/api/v3/users/2",
+                                "title": "Jim Sheppard - j.sheppard"
+                            }
+                        },
+                        "id": 13,
+                        "identifier": "029ed72a3b7b7c4ab332b1f6eaa6576e7c946059",
+                        "authorName": "j1msheppard",
+                        "message": {
+                            "format": "plain",
+                            "raw": "This revision fixes some stuff\n\nMore information here",
+                            "html": "<p>This revision fixes some stuff<br/><br/>More information here</p>"
+                        },
+                        "createdAt": "2015-06-30T08:47:00Z",
+                    }]
+                }
+            }
+
+
+## Revisions [GET]
+
+Gets a list of revisions that are linked to this work package, e.g., because it is referenced in the commit message of the revision.
+
++ Parameters
+    + id (required, integer, `1`) ... work package id
+
++ Response 200 (application/hal+json)
+
+    [Revisions][]
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** view changesets of the project this work package is contained in
+
+    *Note that you will only receive this error, if you are at least allowed to see the corresponding project.*
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to see linked revisions for this work package."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the project does not exist or the client does not have sufficient permissions to see it.
+
+    **Required permission:** view project
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The specified project does not exist."
+            }
+
 
 ## Comment WorkPackage [/api/v3/work_packages/{id}/activities]
 


### PR DESCRIPTION
This commit provides the specification of a `revisions` APIv3 endpoint.
It is used to look up references from work packages made by revision
commit messages in the frontend.

Relevant work package: https://community.openproject.org/work_packages/19342
