### PR TITLE
Change feature spec broken by openproject-checkout.

### DIFF
--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -140,7 +140,7 @@ describe 'Create repository', type: :feature, js: true do
         find('input[type="radio"][value="managed"]').set(true)
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).not_to have_selector('button', text: I18n.t(:button_save))
+        expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked')
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
     end


### PR DESCRIPTION
The checkout plugin overrides behavior in the core which leads
to the repository settings form submit button to be displayed
even though the core feature expects it to be hidden.

As the surrounding spec is relevant for the plugin, too, and should not
be skipped / disabled, this commit instead reworks the test to check
for a different aspect of the page to ensure the request was successful.
