### PR TITLE
Add capybara matcher to wait for jQuery ajax request to complete

### DIFF
--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -140,6 +140,8 @@ describe 'Create repository', type: :feature, js: true do
         find('input[type="radio"][value="managed"]').set(true)
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
+        expect(page).to have_completed_ajax
+
         expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked')
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
@@ -151,6 +153,8 @@ describe 'Create repository', type: :feature, js: true do
         find('input[name="repository[url]"]').set(url)
 
         find('button[type="submit"]', text: I18n.t(:button_create)).click
+
+        expect(page).to have_completed_ajax
 
         expect(page).to have_selector('button[type="submit"]', text: I18n.t(:button_save))
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))

--- a/spec/support/matchers/have_completed_ajax.rb
+++ b/spec/support/matchers/have_completed_ajax.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+::RSpec::Matchers.define :have_completed_ajax do
+  match do |page|
+
+    # Will raise Timeout::Error
+    Timeout.timeout(Capybara.default_wait_time) do
+      loop do
+        active_xhrs = page.evaluate_script('jQuery.active')
+        return true if active_xhrs.zero?
+
+        sleep 0.5
+      end
+    end
+  end
+end


### PR DESCRIPTION
As requests concerning asynchronous form creation in repository settings
are flickering, a potential workaround may be to ensure the asynchronous
requests are completed.

We can exploit jQuery's internal ajax status counter for this task
as proposed in https://robots.thoughtbot.com/automatically-wait-for-ajax-with-capybara.

This _may_ provide more robustness in the CI feature specs.
