### PR TITLE
Retry features raising Net::ReadTimeouts using rspec-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,7 @@ group :test do
   gem 'rspec-activemodel-mocks'
   gem 'rspec-example_disabler', git: "https://github.com/finnlabs/rspec-example_disabler.git"
   gem 'rspec-legacy_formatters'
+  gem 'rspec-retry'
   gem 'capybara', '~> 2.4.4'
   gem 'capybara-screenshot', '~> 1.0.4'
   gem 'capybara-select2', github: 'goodwill/capybara-select2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,8 @@ GEM
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
+    rspec-retry (0.4.2)
+      rspec-core
     rspec-support (3.3.0)
     rubocop (0.32.1)
       astrolabe (~> 1.3)
@@ -559,6 +561,7 @@ DEPENDENCIES
   rspec-example_disabler!
   rspec-legacy_formatters
   rspec-rails (~> 3.3.0)
+  rspec-retry
   rubocop (~> 0.32)
   ruby-duration (~> 3.2.0)
   ruby-prof

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,6 +116,15 @@ RSpec.configure do |config|
 
   Capybara.default_wait_time = 4
 
+  # Allow flickering tests to retry when timeouts occur.
+  # This configuration retries specs that fail with Net::ReadTimeout
+  # to repeat once after a wait time of two seconds.
+  config.verbose_retry = true
+  config.default_sleep_interval = 2
+  # This is really a 'try_count' (2 = run once + repeat once on error)
+  config.default_retry_count = 2
+  config.exceptions_to_retry = [Net::ReadTimeout]
+
   config.after(:each) do
     OpenProject::RspecCleanup.cleanup
   end


### PR DESCRIPTION
This PR adds the facility of restarting specs when encountering
a `Net::ReadTimeout` exception.
