### PR TITLE
Add revisions API and linked property for work packages

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -4108,7 +4108,7 @@ Gets a list of revisions that are linked to this work package, e.g., because it 
 
     **Required permission:** view changesets of the project this work package is contained in
 
-    *Note that you will only receive this error, if you are at least allowed to see the corresponding project.*
+    *Note that you will only receive this error, if you are at least allowed to see the corresponding work package.*
 
     + Body
 
@@ -4120,16 +4120,16 @@ Gets a list of revisions that are linked to this work package, e.g., because it 
 
 + Response 404 (application/hal+json)
 
-    Returned if the project does not exist or the client does not have sufficient permissions to see it.
+    Returned if the work package does not exist or the client does not have sufficient permissions to see it.
 
-    **Required permission:** view project
+    **Required permission:** view work package
 
     + Body
 
             {
                 "_type": "Error",
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
-                "message": "The specified project does not exist."
+                "message": "The specified work project does not exist."
             }
 
 

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -41,14 +41,14 @@ module API
         link :project do
           {
             href: api_v3_paths.project(represented.project.id),
-            title: "#{represented.project.name}"
+            title: represented.project.name
           }
         end
 
         link :author do
           {
             href: api_v3_paths.user(represented.user.id),
-            title: "#{represented.user.name} - #{represented.user.login}"
+            title: represented.user.name
           } unless represented.user.nil?
         end
 

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -58,7 +58,9 @@ module API
         property :message,
                  exec_context: :decorator,
                  getter: -> (*) {
-                   ::API::Decorators::Formattable.new(represented.comments, format: 'plain')
+                   ::API::Decorators::Formattable.new(represented.comments,
+                                                      object: represented,
+                                                      format: 'plain')
                  },
                  render_nil: true
 

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -27,8 +27,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-API::V3::Utilities::DateTimeFormatter
-
 module API
   module V3
     module Repositories
@@ -65,8 +63,9 @@ module API
                  render_nil: true
 
         property :created_at,
+                 exec_context: :decorator,
                  getter: -> (*) {
-                   DateTimeFormatter::format_datetime(committed_on)
+                   datetime_formatter.format_datetime(represented.committed_on)
                  }
 
         def _type

--- a/lib/api/v3/repositories/revisions_api.rb
+++ b/lib/api/v3/repositories/revisions_api.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -26,32 +25,36 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
-
 module API
   module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+    module Repositories
+      class RevisionsAPI < ::API::OpenProjectAPI
+        resources :revisions do
+          params do
+            requires :id, desc: 'Revision id'
+          end
+          route_param :id do
+            helpers do
+              attr_reader :revision
 
-      get '/' do
-        RootRepresenter.new({})
+              def revision_representer
+                RevisionRepresenter.new(@revision)
+              end
+            end
+
+            before do
+              @revision = Changeset.find(params[:id])
+
+              authorize(:view_changesets, context: @revision.project) do
+                raise API::Errors::NotFound.new
+              end
+            end
+
+            get do
+              revision_representer
+            end
+          end
+        end
       end
     end
   end

--- a/lib/api/v3/repositories/revisions_api.rb
+++ b/lib/api/v3/repositories/revisions_api.rb
@@ -38,14 +38,14 @@ module API
               attr_reader :revision
 
               def revision_representer
-                RevisionRepresenter.new(@revision)
+                RevisionRepresenter.new(revision)
               end
             end
 
             before do
               @revision = Changeset.find(params[:id])
 
-              authorize(:view_changesets, context: @revision.project) do
+              authorize(:view_changesets, context: revision.project) do
                 raise API::Errors::NotFound.new
               end
             end

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'api/v3/repositories/revisions_collection_representer'
+
+module API
+  module V3
+    module Repositories
+      class RevisionsByWorkPackageAPI < ::API::OpenProjectAPI
+        resources :revisions do
+          before do
+            authorize(:view_changesets, context: work_package.project) do
+              raise API::Errors::NotFound.new
+            end
+          end
+
+          get do
+            self_path = api_v3_paths.attachments_by_work_package(work_package.id)
+
+            revisions = work_package.changesets
+            RevisionsCollectionRepresenter.new(revisions,
+                                               revisions.count,
+                                               self_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -35,12 +35,12 @@ module API
         resources :revisions do
           before do
             authorize(:view_changesets, context: work_package.project) do
-              raise API::Errors::NotFound.new
+              raise API::Errors::Unauthorized.new
             end
           end
 
           get do
-            self_path = api_v3_paths.attachments_by_work_package(work_package.id)
+            self_path = api_v3_paths.work_package_revisions(work_package.id)
 
             revisions = work_package.changesets
             RevisionsCollectionRepresenter.new(revisions,

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -34,9 +34,7 @@ module API
       class RevisionsByWorkPackageAPI < ::API::OpenProjectAPI
         resources :revisions do
           before do
-            authorize(:view_changesets, context: work_package.project) do
-              raise API::Errors::Unauthorized.new
-            end
+            authorize(:view_changesets, context: work_package.project)
           end
 
           get do

--- a/lib/api/v3/repositories/revisions_collection_representer.rb
+++ b/lib/api/v3/repositories/revisions_collection_representer.rb
@@ -1,0 +1,38 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Repositories
+      class RevisionsCollectionRepresenter < ::API::Decorators::Collection
+        element_decorator ::API::V3::Repositories::RevisionRepresenter
+      end
+    end
+  end
+end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -114,6 +114,10 @@ module API
             "#{root}/relations/#{id}"
           end
 
+          def self.revision(id)
+            "#{root}/revisions/#{id}"
+          end
+
           def self.render_markup(format: nil, link: nil)
             format = format || Setting.text_formatting
             format = 'plain' if format == '' # Setting will return '' for plain

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -204,6 +204,10 @@ module API
             "#{work_package_relations(work_package_id)}/#{id}"
           end
 
+          def self.work_package_revisions(id)
+            "#{work_package(id)}/revisions"
+          end
+
           def self.work_package_schema(project_id, type_id)
             "#{root}/work_packages/schemas/#{project_id}-#{type_id}"
           end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -128,6 +128,12 @@ module API
           } if current_user_allowed_to(:add_work_package_watchers, context: represented.project)
         end
 
+        link :revisions do
+          {
+            href: api_v3_paths.work_package_revisions(represented.id)
+          } if current_user_allowed_to(:view_changesets, context: represented.project)
+        end
+
         link :watch do
           {
             href: api_v3_paths.work_package_watchers(represented.id),

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -284,6 +284,14 @@ module API
 
         property :activities, embedded: true, exec_context: :decorator
 
+        property :revisions,
+                 embedded: true,
+                 exec_context: :decorator,
+                 if: -> (*) {
+                   current_user_allowed_to(:view_changesets,
+                                           context: represented.project)
+                 }
+
         property :version,
                  embedded: true,
                  exec_context: :decorator,
@@ -309,6 +317,12 @@ module API
         def activities
           represented.journals.map do |activity|
             ::API::V3::Activities::ActivityRepresenter.new(activity, current_user: current_user)
+          end
+        end
+
+        def revisions
+          represented.changesets.map do |revision|
+            ::API::V3::Repositories::RevisionRepresenter.new(revision, current_user: current_user)
           end
         end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -290,14 +290,6 @@ module API
 
         property :activities, embedded: true, exec_context: :decorator
 
-        property :revisions,
-                 embedded: true,
-                 exec_context: :decorator,
-                 if: -> (*) {
-                   current_user_allowed_to(:view_changesets,
-                                           context: represented.project)
-                 }
-
         property :version,
                  embedded: true,
                  exec_context: :decorator,
@@ -323,12 +315,6 @@ module API
         def activities
           represented.journals.map do |activity|
             ::API::V3::Activities::ActivityRepresenter.new(activity, current_user: current_user)
-          end
-        end
-
-        def revisions
-          represented.changesets.map do |revision|
-            ::API::V3::Repositories::RevisionRepresenter.new(revision, current_user: current_user)
           end
         end
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -109,6 +109,7 @@ module API
             mount ::API::V3::WorkPackages::WatchersAPI
             mount ::API::V3::Relations::RelationsAPI
             mount ::API::V3::Attachments::AttachmentsByWorkPackageAPI
+            mount ::API::V3::Repositories::RevisionsByWorkPackageAPI
             mount ::API::V3::WorkPackages::UpdateFormAPI
           end
 

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -1,0 +1,117 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Repositories::RevisionRepresenter do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:representer) { described_class.new(revision) }
+
+  let(:project) { FactoryGirl.build :project }
+  let(:repository) { FactoryGirl.build :repository_subversion, project: project}
+  let(:revision) {
+    FactoryGirl.build(:changeset,
+                      id: 42,
+                      revision: '1234',
+                      repository: repository,
+                      comments: commit_message,
+                      committer: 'foo bar <foo@example.org>',
+                      committed_on: DateTime.now,
+                      )
+  }
+
+  let(:commit_message) { 'Some commit message' }
+
+  context 'generation' do
+    subject(:generated) { representer.to_json }
+
+    it { is_expected.to include_json('Revision'.to_json).at_path('_type') }
+
+    describe 'revision' do
+      it { is_expected.to have_json_path('id') }
+
+      it_behaves_like 'API V3 formattable', 'message' do
+        let(:format) { 'plain' }
+        let(:raw) { revision.comments }
+        let(:html) { '<p>' + revision.comments + '</p>' }
+      end
+
+      describe 'identifier' do
+        it { is_expected.to have_json_path('identifier') }
+        it { is_expected.to be_json_eql('1234'.to_json).at_path('identifier') }
+      end
+
+      describe 'createdAt' do
+        it_behaves_like 'has UTC ISO 8601 date and time' do
+          let(:date) { revision.committed_on }
+          let(:json_path) { 'createdAt' }
+        end
+      end
+
+      describe 'authorName' do
+        it { is_expected.to have_json_path('authorName') }
+        it { is_expected.to be_json_eql('foo bar '.to_json).at_path('authorName') }
+      end
+    end
+
+
+    context 'with referencing commit message' do
+      let(:work_package) { FactoryGirl.build_stubbed(:work_package, project: project) }
+      let(:commit_message) { "Totally references ##{work_package.id}" }
+      let(:html_reference) {
+        id = work_package.id
+
+        str = "Totally references <a href=\"/work_packages/#{id}\""
+        str << " class=\"issue work_package status-1 priority-1 parent\""
+        str << " title=\"#{work_package.subject} (#{work_package.status})\">"
+        str << "##{id}</a>"
+      }
+
+      before do
+        allow(WorkPackage).to receive(:find_by_id).and_return(work_package)
+      end
+
+      it_behaves_like 'API V3 formattable', 'message' do
+        let(:format) { 'plain' }
+        let(:raw) { revision.comments }
+        let(:html) { '<p>' + html_reference + '</p>' }
+      end
+    end
+
+    context 'with linked user as author' do
+      let(:user) { FactoryGirl.build(:user) }
+      before do
+        allow(revision).to receive(:user).and_return(user)
+      end
+
+      it { is_expected.to have_json_path('_links/author') }
+      it { is_expected.to be_json_eql(user.name.to_json).at_path('_links/author/title') }
+    end
+  end
+end

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Repositories::RevisionRepresenter do
   let(:representer) { described_class.new(revision) }
 
   let(:project) { FactoryGirl.build :project }
-  let(:repository) { FactoryGirl.build :repository_subversion, project: project}
+  let(:repository) { FactoryGirl.build :repository_subversion, project: project }
   let(:revision) {
     FactoryGirl.build(:changeset,
                       id: 42,
@@ -79,7 +79,6 @@ describe ::API::V3::Repositories::RevisionRepresenter do
         it { is_expected.to be_json_eql('foo bar '.to_json).at_path('authorName') }
       end
     end
-
 
     context 'with referencing commit message' do
       let(:work_package) { FactoryGirl.build_stubbed(:work_package, project: project) }

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -51,7 +51,7 @@ describe ::API::V3::Repositories::RevisionRepresenter do
   context 'generation' do
     subject(:generated) { representer.to_json }
 
-    it { is_expected.to include_json('Revision'.to_json).at_path('_type') }
+    it { is_expected.to be_json_eql('Revision'.to_json).at_path('_type') }
 
     describe 'revision' do
       it { is_expected.to have_json_path('id') }
@@ -103,14 +103,25 @@ describe ::API::V3::Repositories::RevisionRepresenter do
       end
     end
 
-    context 'with linked user as author' do
-      let(:user) { FactoryGirl.build(:user) }
-      before do
-        allow(revision).to receive(:user).and_return(user)
+    describe 'author' do
+      context 'with no linked user' do
+        it_behaves_like 'has no link' do
+          let(:link) { 'author' }
+        end
       end
 
-      it { is_expected.to have_json_path('_links/author') }
-      it { is_expected.to be_json_eql(user.name.to_json).at_path('_links/author/title') }
+      context 'with linked user as author' do
+        let(:user) { FactoryGirl.build(:user) }
+        before do
+          allow(revision).to receive(:user).and_return(user)
+        end
+
+        it_behaves_like 'has a titled link' do
+          let(:link) { 'author' }
+          let(:href) { api_v3_paths.user(user.id) }
+          let(:title) { user.name }
+        end
+      end
     end
   end
 end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -239,6 +239,16 @@ describe ::API::V3::Utilities::PathHelper do
     end
   end
 
+  describe 'revisions paths' do
+    describe '#revision' do
+      subject { helper.revision 1 }
+
+      it_behaves_like 'api v3 path'
+
+      it { is_expected.to eql('/api/v3/revisions/1') }
+    end
+  end
+
   describe 'schemas paths' do
     describe '#work_package_schema' do
       subject { helper.work_package_schema 1, 2 }
@@ -397,6 +407,14 @@ describe ::API::V3::Utilities::PathHelper do
       it_behaves_like 'api v3 work packages path'
 
       it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/relations\/1/) }
+    end
+
+    describe '#work_package_revisions' do
+      subject { helper.work_package_revisions 42 }
+
+      it_behaves_like 'api v3 work packages path'
+
+      it { is_expected.to eql('/api/v3/work_packages/42/revisions') }
     end
 
     describe '#work_package_form' do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -738,28 +738,6 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         it { is_expected.to have_json_type(Array).at_path('_embedded/activities') }
         it { is_expected.to have_json_size(0).at_path('_embedded/activities') }
       end
-
-      describe 'linked revisions' do
-        context 'when no revisions available' do
-          it 'contains an empty linked property revisions' do
-            expect(subject).to have_json_size(0).at_path('_embedded/revisions')
-          end
-        end
-
-        context 'when revisions available' do
-          let(:repository) { FactoryGirl.build(:repository_subversion) }
-          let(:rev1) { FactoryGirl.build(:changeset, repository: repository) }
-          let(:rev2) { FactoryGirl.build(:changeset, repository: repository) }
-
-          before do
-            allow(work_package).to receive(:changesets).and_return([rev1, rev2])
-          end
-
-          it 'contains the linked revision' do
-            expect(subject).to have_json_size(2).at_path('_embedded/revisions')
-          end
-        end
-      end
     end
   end
 end

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -327,8 +327,8 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
       describe 'revisions' do
         context 'when the user lacks the view_changesets permission' do
-          it 'should not have a link to revisions' do
-            expect(subject).not_to have_json_path('_links/revisions/href')
+          it_behaves_like 'has no link' do
+            let(:link) { 'revisions' }
           end
         end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -55,8 +55,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       :add_work_package_watchers,
       :delete_work_package_watchers,
       :manage_work_package_relations,
-      :add_work_package_notes,
-      :view_changesets
+      :add_work_package_notes
     ]
   }
   let(:role) { FactoryGirl.create :role, permissions: permissions }
@@ -322,6 +321,26 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         context 'responsible is not set' do
           it_behaves_like 'has an empty link' do
             let(:link) { 'responsible' }
+          end
+        end
+      end
+
+      describe 'revisions' do
+        context 'when the user lacks the view_changesets permission' do
+          it 'should not have a link to revisions' do
+            expect(subject).not_to have_json_path('_links/revisions/href')
+          end
+        end
+
+        context 'when the user has the required permission' do
+          let(:revision_permissions) { [:view_changesets] }
+          let(:role) { FactoryGirl.create :role, permissions: permissions + revision_permissions }
+
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'revisions' }
+            let(:href) {
+              api_v3_paths.work_package_revisions(work_package.id)
+            }
           end
         end
       end

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -55,7 +55,8 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       :add_work_package_watchers,
       :delete_work_package_watchers,
       :manage_work_package_relations,
-      :add_work_package_notes
+      :add_work_package_notes,
+      :view_changesets
     ]
   }
   let(:role) { FactoryGirl.create :role, permissions: permissions }
@@ -736,6 +737,28 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       describe 'activities' do
         it { is_expected.to have_json_type(Array).at_path('_embedded/activities') }
         it { is_expected.to have_json_size(0).at_path('_embedded/activities') }
+      end
+
+      describe 'linked revisions' do
+        context 'when no revisions available' do
+          it 'contains an empty linked property revisions' do
+            expect(subject).to have_json_size(0).at_path('_embedded/revisions')
+          end
+        end
+
+        context 'when revisions available' do
+          let(:repository) { FactoryGirl.build(:repository_subversion) }
+          let(:rev1) { FactoryGirl.build(:changeset, repository: repository) }
+          let(:rev2) { FactoryGirl.build(:changeset, repository: repository) }
+
+          before do
+            allow(work_package).to receive(:changesets).and_return([rev1, rev2])
+          end
+
+          it 'contains the linked revision' do
+            expect(subject).to have_json_size(2).at_path('_embedded/revisions')
+          end
+        end
       end
     end
   end

--- a/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
@@ -49,11 +49,6 @@ describe 'API v3 Revisions by work package resource', type: :request do
 
   before do
     allow(User).to receive(:current).and_return current_user
-    FactoryGirl.create_list(:changeset,
-                            5,
-                            comments: "This commit references ##{work_package.id}",
-                            repository: repository
-    )
   end
 
   describe '#get' do
@@ -67,6 +62,36 @@ describe 'API v3 Revisions by work package resource', type: :request do
       expect(subject.status).to eq(200)
     end
 
-    it_behaves_like 'API V3 collection response', 5, 5, 'Revision'
+    it_behaves_like 'API V3 collection response', 0, 0, 'Revision'
+
+
+    context 'with existing revisions' do
+      before do
+        FactoryGirl.create_list(:changeset,
+                                5,
+                                comments: "This commit references ##{work_package.id}",
+                                repository: repository
+        )
+        get get_path
+      end
+
+      it_behaves_like 'API V3 collection response', 5, 5, 'Revision'
+    end
+
+    context 'user unauthorized to view work package' do
+      let(:current_user) { FactoryGirl.create(:user) }
+
+      it 'should respond with 404' do
+        expect(subject.status).to eq(404)
+      end
+    end
+
+    context 'user unauthorized to view revisions' do
+      let(:permissions) { [:view_work_packages] }
+
+      it 'should respond with 403' do
+        expect(subject.status).to eq(403)
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
@@ -1,0 +1,72 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Revisions by work package resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+  include FileHelpers
+
+  let(:current_user) {
+    FactoryGirl.create(:user,
+                       member_in_project: project,
+                       member_through_role: role)
+  }
+  let(:project) { FactoryGirl.create(:project, is_public: false) }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { [:view_work_packages, :view_changesets] }
+  let(:repository) { FactoryGirl.create(:repository_subversion, project: project) }
+  let(:work_package) { FactoryGirl.create(:work_package, author: current_user, project: project) }
+
+  subject(:response) { last_response }
+
+  before do
+    allow(User).to receive(:current).and_return current_user
+    FactoryGirl.create_list(:changeset,
+                            5,
+                            comments: "This commit references ##{work_package.id}",
+                            repository: repository
+    )
+  end
+
+  describe '#get' do
+    let(:get_path) { api_v3_paths.work_package_revisions work_package.id }
+
+    before do
+      get get_path
+    end
+
+    it 'should respond with 200' do
+      expect(subject.status).to eq(200)
+    end
+
+    it_behaves_like 'API V3 collection response', 5, 5, 'Revision'
+  end
+end

--- a/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
@@ -44,6 +44,7 @@ describe 'API v3 Revisions by work package resource', type: :request do
   let(:permissions) { [:view_work_packages, :view_changesets] }
   let(:repository) { FactoryGirl.create(:repository_subversion, project: project) }
   let(:work_package) { FactoryGirl.create(:work_package, author: current_user, project: project) }
+  let(:revisions) { [] }
 
   subject(:response) { last_response }
 
@@ -55,6 +56,7 @@ describe 'API v3 Revisions by work package resource', type: :request do
     let(:get_path) { api_v3_paths.work_package_revisions work_package.id }
 
     before do
+      revisions.each do |rev| rev.save! end
       get get_path
     end
 
@@ -66,14 +68,13 @@ describe 'API v3 Revisions by work package resource', type: :request do
 
 
     context 'with existing revisions' do
-      before do
-        FactoryGirl.create_list(:changeset,
-                                5,
-                                comments: "This commit references ##{work_package.id}",
-                                repository: repository
+      let(:revisions) {
+        FactoryGirl.build_list(:changeset,
+                               5,
+                               comments: "This commit references ##{work_package.id}",
+                               repository: repository
         )
-        get get_path
-      end
+      }
 
       it_behaves_like 'API V3 collection response', 5, 5, 'Revision'
     end

--- a/spec/requests/api/v3/repositories/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_resource_spec.rb
@@ -59,31 +59,8 @@ describe 'API v3 Revisions resource', type: :request do
 
   describe '#get' do
     let(:get_path) { api_v3_paths.revision revision.id }
-    let(:expected_response) do
-      {
-        '_type' => 'Revision',
-        '_links' => {
-          'self' => {
-            'href' => "http://localhost:3000/api/v3/revisions/#{revision.id}"
-          },
-          'project' => {
-            'href' => "http://localhost:3000/api/v3/projects/#{project.id}",
-            'title' => project.title
-          },
-        },
-        'id' => revision.id,
-        'identifier' => revision.identifier,
-        'authorName' => revision.author,
-        'message' => {
-          'format' => 'plain',
-          'raw' => 'Some commit message',
-          'html' =>'<p>Some commit message</p>',
-        },
-        'createdAt' => revision.committed_on.utc.iso8601
-      }
-    end
 
-    context 'when acting as a user with permission to view work package' do
+    context 'when acting as a user with permission to view revisions' do
       before(:each) do
         allow(User).to receive(:current).and_return current_user
         get get_path
@@ -94,15 +71,15 @@ describe 'API v3 Revisions resource', type: :request do
       end
 
       describe 'response body' do
-        subject(:parsed_response) { JSON.parse(last_response.body) }
+        subject(:response) { last_response.body }
 
         it 'should respond with revision in HAL+JSON format' do
-          expect(parsed_response['id']).to eq(revision.id)
+          is_expected.to be_json_eql(revision.id.to_json).at_path('id')
         end
       end
 
       context 'requesting nonexistent revision' do
-        let(:get_path) { api_v3_paths.work_package 909090 }
+        let(:get_path) { api_v3_paths.revision 909090 }
 
         it_behaves_like 'not found'
       end
@@ -111,15 +88,6 @@ describe 'API v3 Revisions resource', type: :request do
     context 'when acting as an user without permission to view work package' do
       before(:each) do
         allow(User).to receive(:current).and_return unauthorized_user
-        get get_path
-      end
-
-      it_behaves_like 'not found'
-    end
-
-    context 'when acting as an anonymous user' do
-      before(:each) do
-        allow(User).to receive(:current).and_return User.anonymous
         get get_path
       end
 

--- a/spec/requests/api/v3/repositories/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_resource_spec.rb
@@ -44,16 +44,17 @@ describe 'API v3 Revisions resource', type: :request do
   let(:repository) {
     FactoryGirl.create(:repository_subversion, project: project)
   }
-  let(:project) do
+  let(:project) {
     FactoryGirl.create(:project, identifier: 'test_project', is_public: false)
-  end
-  let(:role) do
+  }
+  let(:role) {
     FactoryGirl.create(:role,
                        permissions: [:view_changesets])
-  end
-  let(:current_user) do
+  }
+  let(:current_user) {
     FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
-  end
+  }
+
   let(:unauthorized_user) { FactoryGirl.create(:user) }
 
   describe '#get' do

--- a/spec/requests/api/v3/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/revisions_resource_spec.rb
@@ -1,0 +1,128 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Revisions resource', type: :request do
+  include Rack::Test::Methods
+  include Capybara::RSpecMatchers
+  include API::V3::Utilities::PathHelper
+
+  let(:revision) {
+    FactoryGirl.create(:changeset,
+                       repository: repository,
+                       comments: 'Some commit message',
+                       committer: 'foo bar <foo@example.org>'
+    )
+  }
+  let(:repository) {
+    FactoryGirl.create(:repository_subversion, project: project)
+  }
+  let(:project) do
+    FactoryGirl.create(:project, identifier: 'test_project', is_public: false)
+  end
+  let(:role) do
+    FactoryGirl.create(:role,
+                       permissions: [:view_changesets])
+  end
+  let(:current_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:unauthorized_user) { FactoryGirl.create(:user) }
+
+  describe '#get' do
+    let(:get_path) { api_v3_paths.revision revision.id }
+    let(:expected_response) do
+      {
+        '_type' => 'Revision',
+        '_links' => {
+          'self' => {
+            'href' => "http://localhost:3000/api/v3/revisions/#{revision.id}"
+          },
+          'project' => {
+            'href' => "http://localhost:3000/api/v3/projects/#{project.id}",
+            'title' => project.title
+          },
+        },
+        'id' => revision.id,
+        'identifier' => revision.identifier,
+        'authorName' => revision.author,
+        'message' => {
+          'format' => 'plain',
+          'raw' => 'Some commit message',
+          'html' =>'<p>Some commit message</p>',
+        },
+        'createdAt' => revision.committed_on.utc.iso8601
+      }
+    end
+
+    context 'when acting as a user with permission to view work package' do
+      before(:each) do
+        allow(User).to receive(:current).and_return current_user
+        get get_path
+      end
+
+      it 'should respond with 200' do
+        expect(last_response.status).to eq(200)
+      end
+
+      describe 'response body' do
+        subject(:parsed_response) { JSON.parse(last_response.body) }
+
+        it 'should respond with revision in HAL+JSON format' do
+          expect(parsed_response['id']).to eq(revision.id)
+        end
+      end
+
+      context 'requesting nonexistent revision' do
+        let(:get_path) { api_v3_paths.work_package 909090 }
+
+        it_behaves_like 'not found'
+      end
+    end
+
+    context 'when acting as an user without permission to view work package' do
+      before(:each) do
+        allow(User).to receive(:current).and_return unauthorized_user
+        get get_path
+      end
+
+      it_behaves_like 'not found'
+    end
+
+    context 'when acting as an anonymous user' do
+      before(:each) do
+        allow(User).to receive(:current).and_return User.anonymous
+        get get_path
+      end
+
+      it_behaves_like 'not found'
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the following items to the APIv3:
- `WorkPackageRepresenter`: Added linked property `revisions` for
  revisions that are linked to this commit (by commit references).
- `RevisionsAPI, RevisionRepresenter`: Browse revision information by ID

relevant work package: https://community.openproject.org/work_packages/19342
