### PR TITLE
Allow increased wait time for JS-induced redirect

### DIFF
--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -140,7 +140,8 @@ describe 'Create repository', type: :feature, js: true do
         find('input[type="radio"][value="managed"]').set(true)
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked')
+        expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked',
+                                      wait: 10)
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
     end
@@ -152,7 +153,9 @@ describe 'Create repository', type: :feature, js: true do
 
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).to have_selector('button[type="submit"]', text: I18n.t(:button_save))
+        expect(page).to have_selector('button[type="submit"]',
+                                      text: I18n.t(:button_save),
+                                      wait: 10)
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
     end

--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -140,8 +140,8 @@ describe 'Create repository', type: :feature, js: true do
         find('input[type="radio"][value="managed"]').set(true)
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked',
-                                      wait: 10)
+        expect(page).to have_selector('div.flash.notice')
+        expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked')
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
     end
@@ -153,9 +153,8 @@ describe 'Create repository', type: :feature, js: true do
 
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).to have_selector('button[type="submit"]',
-                                      text: I18n.t(:button_save),
-                                      wait: 10)
+        expect(page).to have_selector('div.flash.notice')
+        expect(page).to have_selector('button[type="submit"]', text: I18n.t(:button_save))
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end
     end


### PR DESCRIPTION
Tries to select other element first after page redraw.

By selecting an entirely different element on the settings page
(e.g., the flash message), the button and radio elements are
being available afterwards and do not return a capybara cache error.
