### PR TITLE
don't use random language as user's language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,6 +227,13 @@ class ApplicationController < ActionController::Base
     I18n.fallbacks.defaults = fallbacks
   end
 
+  ##
+  # Sets the language for the current request.
+  # The language is determined with the following priority:
+  #
+  #   1. The language as configured by the user.
+  #   2. The first language defined in the Accept-Language header sent by the browser.
+  #   3. OpenProject's default language defined in the settings.
   def set_localization
     lang = nil
     lang = find_language(User.current.language) if User.current.logged?

--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -109,8 +109,10 @@ module Redmine
       end
     end
 
+    ##
+    # Returns the given language if it is valid or nil otherwise.
     def find_language(lang)
-      valid_languages.detect { |l| l =~ /#{lang}/i }
+      valid_languages.detect { |l| l =~ /#{lang}/i } if lang.present?
     end
 
     def set_language_if_valid(lang)

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -131,21 +131,24 @@ module OpenProject
     end
 
     describe 'find_language' do
-      it 'is nil if language is not active' do
+      before do
         allow(Setting).to receive(:available_languages).and_return([:de])
+      end
 
+      it 'is nil if language is not active' do
         expect(find_language(:en)).to be_nil
       end
 
-      it 'is the language if it is active' do
-        allow(Setting).to receive(:available_languages).and_return([:de])
+      it 'is nil if no language is given' do
+        expect(find_language('')).to be_nil
+        expect(find_language(nil)).to be_nil
+      end
 
+      it 'is the language if it is active' do
         expect(find_language(:de)).to eql :de
       end
 
       it 'can be found by uppercase if it is active' do
-        allow(Setting).to receive(:available_languages).and_return([:de])
-
         expect(find_language(:DE)).to eql :de
       end
     end


### PR DESCRIPTION
If a user's language is not set ('') the code
just used any valid language.

WP [#21119](https://community.openproject.org/work_packages/21119)
