### PR TITLE
Allow configuration to disable arbitrary SCM types

### DIFF
--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -188,9 +188,14 @@ module RepositoriesHelper
     scms = OpenProject::Scm::Manager.enabled
     vendor = repository.nil? ? nil : repository.vendor
 
+    ## Set selected vendor
     if vendor && !repository.new_record?
       scms[vendor] = vendor
     end
+
+    # Remove repositories that were configured to have no
+    # available types left.
+    scms.reject! { |_, klass| klass.available_types.empty? }
 
     scms = [default_selected_option] + scms.keys
     options_for_select(scms, vendor)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -92,7 +92,7 @@ class Repository < ActiveRecord::Base
   end
 
   def self.available_types
-    []
+    supported_types - disabled_types
   end
 
   ##
@@ -293,7 +293,7 @@ class Repository < ActiveRecord::Base
     repository.attributes = args
     repository.project = project
 
-    verify_scm_type!(repository, type) unless type.nil?
+    set_verified_type!(repository, type) unless type.nil?
 
     repository.configure(type, args)
 
@@ -317,7 +317,7 @@ class Repository < ActiveRecord::Base
 
   ##
   # Verifies that the chosen scm type can be selected
-  def self.verify_scm_type!(repository, type)
+  def self.set_verified_type!(repository, type)
     if repository.class.available_types.include? type
       repository.scm_type = type
     else

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -38,7 +38,7 @@ class Repository::Git < Repository
   end
 
   def configure(scm_type, _args)
-    if scm_type == MANAGED_TYPE
+    if scm_type == self.class.managed_type
       unless manageable?
         raise OpenProject::Scm::Exceptions::RepositoryBuildError.new(
           I18n.t('repositories.managed.error_not_manageable')
@@ -54,11 +54,11 @@ class Repository::Git < Repository
     super(params)
   end
 
-  def supported_types
+  def self.available_types
     types = [:local]
-    types << MANAGED_TYPE if manageable?
+    types << managed_type if manageable?
 
-    types
+    types - disabled_types
   end
 
   def managed_repo_created

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -54,11 +54,11 @@ class Repository::Git < Repository
     super(params)
   end
 
-  def self.available_types
+  def self.supported_types
     types = [:local]
     types << managed_type if manageable?
 
-    types - disabled_types
+    types
   end
 
   def managed_repo_created

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -39,7 +39,7 @@ class Repository::Subversion < Repository
   end
 
   def configure(scm_type, _args)
-    if scm_type == MANAGED_TYPE
+    if scm_type == self.class.managed_type
       unless manageable?
         raise OpenProject::Scm::Exceptions::RepositoryBuildError.new(
           I18n.t('repositories.managed.error_not_manageable')
@@ -55,11 +55,11 @@ class Repository::Subversion < Repository
     super(params).merge(params.permit(:login, :password))
   end
 
-  def supported_types
+  def self.available_types
     types = [:existing]
-    types << MANAGED_TYPE if manageable?
+    types << managed_type if manageable?
 
-    types
+    types - disabled_types
   end
 
   def managed_repo_created

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -55,11 +55,11 @@ class Repository::Subversion < Repository
     super(params).merge(params.permit(:login, :password))
   end
 
-  def self.available_types
+  def self.supported_types
     types = [:existing]
     types << managed_type if manageable?
 
-    types - disabled_types
+    types
   end
 
   def managed_repo_created

--- a/app/views/repositories/settings/_vendor_form.html.erb
+++ b/app/views/repositories/settings/_vendor_form.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% if repository.new_record? %>
-  <% scm_types = repository.supported_types %>
+  <% scm_types = repository.class.available_types %>
   <div class="attributes-group -toggleable" data-switch="scm_type">
     <% scm_types.each do |type|%>
       <%= render partial: "/repositories/settings/vendor_attribute_groups",

--- a/app/workers/scm/create_repository_job.rb
+++ b/app/workers/scm/create_repository_job.rb
@@ -78,7 +78,7 @@ class Scm::CreateRepositoryJob
   end
 
   def config
-    @config ||= repository.scm.config
+    @config ||= repository.class.scm_config
   end
 
   def repository

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -221,17 +221,33 @@ default:
   #   Enable managed repositories for this vendor. This allows OpenProject to
   #   take control over the given path to create and delete repositories directly
   #   when created in the frontend.
+  #   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
+  # disabled_types:
+  #   Disable specific repository types for this particular vendor. This allows
+  #   to restrict the available choices a project administrator has for creating repositories
+  #   See the example below for available types
+  #
+  #   Available types for git:
+  #     - :local (Local repositories, registered using a local path)
+  #     - :managed (Managed repositores, available IF :manages path is set below)
+  #   Available types for subversion:
+  #     - :existing (Existing subversion repositories by URL - local using file:/// or remote
+  #                 using one of the supported URL schemes (e.g., https://, svn+ssh:// )
+  #     - :managed (Managed repositores, available IF :manages path is set below)
   #
   # Examplary configuration
   #
   # scm:
   #   Git:
   #     client_command: /usr/local/bin/git
-  #     manages: /tmp/git
+  #     disabled_types:
+  #       - :local
+  #     manages: /opt/repositories/git
   #   Subversion:
-  #     # Use command below to override the default svn command taken from path.
   #     client_command: /usr/local/bin/svn
-  #     manages: /tmp/svn
+  #     disabled_types:
+  #       - :existing
+  #     manages: /opt/repositories/svn
 
   # Key used to encrypt sensitive data in the database (SCM and LDAP passwords).
   # If you don't want to enable data encryption, just leave it blank.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1269,6 +1269,7 @@ en:
       unavailable: "The repository is unavailable."
       unlink_failed_unmanageable: "The repository was deleted, but its directory could not be removed, because it is no longer manageable by OpenProject."
       exception_title: "Cannot access the repository: %{message}"
+      disabled_or_unknown_type: "The selected type %{type} is disabled or no longer available for the SCM vendor %{vendor}."
       disabled_or_unknown_vendor: "The SCM vendor %{vendor} is disabled or no longer available."
     git:
       instructions:

--- a/lib/open_project/scm/adapters/base.rb
+++ b/lib/open_project/scm/adapters/base.rb
@@ -35,6 +35,10 @@ module OpenProject
       class Base
         attr_accessor :url, :root_url
 
+        def self.vendor
+          name.demodulize
+        end
+
         def initialize(url, root_url = nil)
           self.url = url
           self.root_url = root_url
@@ -57,7 +61,7 @@ module OpenProject
         end
 
         def vendor
-          self.class.name.demodulize
+          self.class.vendor
         end
 
         def info

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -44,7 +44,7 @@ module OpenProject
         end
 
         def client_command
-          @client_command ||= config[:client_command] || 'git'
+          @client_command ||= self.class.config[:client_command] || 'git'
         end
 
         def client_version

--- a/lib/open_project/scm/adapters/local_client.rb
+++ b/lib/open_project/scm/adapters/local_client.rb
@@ -32,20 +32,25 @@ module OpenProject
   module Scm
     module Adapters
       module LocalClient
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+
+        module ClassMethods
+          ##
+          # Reads the configuration for this strategy from OpenProject's `configuration.yml`.
+          def config
+            ['scm', vendor].inject(OpenProject::Configuration) do |acc, key|
+              HashWithIndifferentAccess.new acc[key]
+            end
+          end
+        end
+
         ##
         # Determines local capabilities for SCM creation.
         # Overridden by including classes when SCM may be remote.
         def local?
           true
-        end
-
-        ##
-        # Reads the configuration for this strategy from OpenProject's `configuration.yml`.
-        def config
-          scm_config = OpenProject::Configuration
-          ['scm', vendor].inject(scm_config) do |acc, key|
-            HashWithIndifferentAccess.new acc[key]
-          end
         end
 
         ##

--- a/lib/open_project/scm/adapters/subversion.rb
+++ b/lib/open_project/scm/adapters/subversion.rb
@@ -36,11 +36,11 @@ module OpenProject
         include LocalClient
 
         def client_command
-          @client_command ||= config[:client_command] || 'svn'
+          @client_command ||= self.class.config[:client_command] || 'svn'
         end
 
         def svnadmin_command
-          @svnadmin_command ||= (config[:svnadmin_command] || 'svnadmin')
+          @svnadmin_command ||= (self.class.config[:svnadmin_command] || 'svnadmin')
         end
 
         def client_version

--- a/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
@@ -44,7 +44,7 @@ describe OpenProject::Scm::Adapters::Git do
   }
 
   before do
-    allow(adapter).to receive(:config).and_return(config)
+    allow(adapter.class).to receive(:config).and_return(config)
   end
 
   describe 'client information' do

--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -36,7 +36,7 @@ describe OpenProject::Scm::Adapters::Subversion do
   let(:adapter) { OpenProject::Scm::Adapters::Subversion.new url, root_url }
 
   before do
-    allow(adapter).to receive(:config).and_return(config)
+    allow(adapter.class).to receive(:config).and_return(config)
   end
 
   describe 'client information' do

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -37,7 +37,21 @@ describe Repository::Git, type: :model do
   before do
     allow(Setting).to receive(:enabled_scm).and_return(['Git'])
     allow(instance).to receive(:scm).and_return(adapter)
-    allow(adapter).to receive(:config).and_return(config)
+    allow(adapter.class).to receive(:config).and_return(config)
+  end
+
+  describe 'available types' do
+    it 'allow local by default' do
+      expect(instance.class.available_types).to eq([:local])
+    end
+
+    context 'with disabled typed' do
+      let(:config) { { disabled_types: [:local, :managed] } }
+
+      it 'does not have any types' do
+        expect(instance.class.available_types).to be_empty
+      end
+    end
   end
 
   describe 'managed git' do
@@ -53,6 +67,16 @@ describe Repository::Git, type: :model do
 
       it 'is manageable' do
         expect(instance.manageable?).to be true
+        expect(instance.class.available_types).to eq([:local, :managed])
+      end
+
+      context 'with disabled managed typed' do
+        let(:config) { { disabled_types: [:managed] } }
+
+        it 'is no longer manageable' do
+          expect(instance.class.available_types).to eq([:local])
+          expect(instance.manageable?).to be false
+        end
       end
 
       context 'and associated project' do


### PR DESCRIPTION
This PR provides:
- Configuration options for disabling any number of available
  types of that particular SCM vendor.
- Changes to the underlying structure to allow determination
  of which types are available on a class level.

The larger number of changes in this PR are caused by the latter point, as it was previously not necessary to read the SCM config on a class level. Thus a number of settings on the modules `LocalClient` and `ManageableRepository` have shifted, however are unchanged in functionality.

Relevant work package: https://community.openproject.org/work_packages/21050
