### PR TITLE
Remove outdated flash message

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -109,13 +109,8 @@ class RepositoriesController < ApplicationController
   end
 
   def destroy
-    if @project.repository.manageable?
-      flash[:notice] = I18n.t('repositories.delete_sucessful')
-    else
-      flash[:warning] = I18n.t('repositories.errors.unlink_failed_unmanageable')
-    end
-
     @project.repository.destroy
+    flash[:notice] = I18n.t('repositories.delete_sucessful')
     redirect_to settings_repository_tab_path
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1267,7 +1267,6 @@ en:
       path_permission_failed: "An error occurred trying to create the following path: %{path}. Please ensure that OpenProject may write to that folder."
       unauthorized: "You're not authorized to access the repository or the credentials are invalid."
       unavailable: "The repository is unavailable."
-      unlink_failed_unmanageable: "The repository was deleted, but its directory could not be removed, because it is no longer manageable by OpenProject."
       exception_title: "Cannot access the repository: %{message}"
       disabled_or_unknown_type: "The selected type %{type} is disabled or no longer available for the SCM vendor %{vendor}."
       disabled_or_unknown_vendor: "The SCM vendor %{vendor} is disabled or no longer available."


### PR DESCRIPTION
Managed repositories are always deleted, even if the configuration
states otherwise.

The specific flash message concerning deletion of managed repositories
is thus wrong and was removed.
