### PR TITLE
Re-add missing repository seed.

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -107,6 +107,10 @@ time_entry_activities = []
   time_entry_activities << time_entry_activity
 end
 
+repository = Repository::Subversion.create!(project: project,
+                                            url: 'file:///tmp/foo/bar.svn',
+                                            scm_type: 'existing')
+
 print 'Creating objects for...'
 user_count.times do |count|
   login = "#{Faker::Name.first_name}#{rand(10000)}"


### PR DESCRIPTION
This creates an exemplary existing subversion repository
in order to attach some changesets to it.
It was removed in the filesystem adapter removal and since
then no changesets were added to the seed.

[ci skip]
