### PR TITLE
Disable letter_opener for the course of development seeds

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -27,6 +27,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+# Disable mail delivery for the duration of this task
+ActionMailer::Base.perform_deliveries = false
+
+# Avoid asynchronous DeliverWorkPackageCreatedJob
+Delayed::Worker.delay_jobs = false
+
 # remove password-reset flag from admin user
 # (the default password is OK in dev mode)
 admin = User.where(login: 'admin').first


### PR DESCRIPTION
When seeding with ActiveMailer set to :letter_opener, an innumerable
number of tabs are opened due to work package update notifications being
sent.

This commit disables this behavior for the duration of the development
seeds by changing the mailer method and, more importantly, the delayed
job delivering those notifications.
