### PR TITLE
Aggregate diffs

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -90,8 +90,8 @@ class JournalsController < ApplicationController
   def diff
     if valid_diff?
       field = params[:field].parameterize.underscore.to_sym
-      from = @journal.changed_data[field][0]
-      to = @journal.changed_data[field][1]
+      from = @journal.details[field][0]
+      to = @journal.details[field][1]
 
       @diff = Redmine::Helpers::Diff.new(to, from)
       @journable = @journal.journable

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -88,13 +88,15 @@ class JournalsController < ApplicationController
   end
 
   def diff
+    journal = Journal::AggregatedJournal.for_journal(@journal)
+
     if valid_diff?
       field = params[:field].parameterize.underscore.to_sym
-      from = @journal.details[field][0]
-      to = @journal.details[field][1]
+      from = journal.details[field][0]
+      to = journal.details[field][1]
 
       @diff = Redmine::Helpers::Diff.new(to, from)
-      @journable = @journal.journable
+      @journable = journal.journable
       respond_to do |format|
         format.html {}
         format.js { render partial: 'diff', locals: { diff: @diff } }

--- a/app/helpers/planning_elements_helper.rb
+++ b/app/helpers/planning_elements_helper.rb
@@ -98,6 +98,6 @@ module PlanningElementsHelper
 
     formatter.send(:format_details,
                    attribute,
-                   journal.changed_data[attribute])
+                   journal.details[attribute])
   end
 end

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -173,9 +173,9 @@ module WorkPackagesHelper
 
       ['start_date', 'due_date'].each do |date|
         if changed_dates[date].nil? &&
-           journal.changed_data[date] &&
-           journal.changed_data[date].first
-          changed_dates[date] = " (<del>#{journal.changed_data[date].first}</del>)".html_safe
+           journal.details[date] &&
+           journal.details[date].first
+          changed_dates[date] = " (<del>#{journal.details[date].first}</del>)".html_safe
         end
       end
     end

--- a/app/models/activity/work_package_activity_provider.rb
+++ b/app/models/activity/work_package_activity_provider.rb
@@ -65,7 +65,7 @@ class Activity::WorkPackageActivityProvider < Activity::BaseActivityProvider
     state = ''
     journal = Journal.find(event['event_id'])
 
-    if journal.changed_data.empty? && !journal.initial?
+    if journal.details.empty? && !journal.initial?
       state = '-note'
     else
       state = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(event['status_closed']) ? '-closed' : '-edit'

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -102,6 +102,7 @@ class Journal < ActiveRecord::Base
     get_changes
   end
 
+  # TODO Evaluate whether this can be removed without disturbing any migrations
   alias_method :changed_data, :details
 
   def new_value_for(prop)

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -223,6 +223,11 @@ class Journal::AggregatedJournal
     # proximity into account.
     def sql_beyond_aggregation_time?(predecessor, successor)
       aggregation_time_seconds = Setting.journal_aggregation_time_minutes.to_i.minutes
+      if aggregation_time_seconds == 0
+        # if aggregation is disabled, we consider everything to be beyond aggregation time
+        # even if creation dates are exactly equal
+        return '(true = true)'
+      end
 
       if OpenProject::Database.mysql?
         difference = "TIMESTAMPDIFF(second, #{predecessor}.created_at, #{successor}.created_at)"

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -41,6 +41,12 @@
 #    be dropped
 class Journal::AggregatedJournal
   class << self
+    # Returns the aggregated journal that contains the specified (vanilla) journal.
+    def for_journal(vanilla_journal)
+      Journal::AggregatedJournal.aggregated_journals(journable: vanilla_journal.journable)
+                  .detect { |journal| journal.version >= vanilla_journal.version }
+    end
+
     def with_notes_id(notes_id)
       raw_journal = query_aggregated_journals
                       .where("#{table_name}.id = ?", notes_id)

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -41,10 +41,13 @@
 #    be dropped
 class Journal::AggregatedJournal
   class << self
-    # Returns the aggregated journal that contains the specified (vanilla) journal.
-    def for_journal(vanilla_journal)
-      Journal::AggregatedJournal.aggregated_journals(journable: vanilla_journal.journable)
-                  .detect { |journal| journal.version >= vanilla_journal.version }
+    # Returns the aggregated journal that contains the specified (vanilla/pure) journal.
+    def for_journal(pure_journal)
+      raw = Journal::AggregatedJournal.query_aggregated_journals(journable: pure_journal.journable)
+            .where("#{version_projection} >= ?", pure_journal.version)
+            .first
+
+      raw ? Journal::AggregatedJournal.new(raw) : nil
     end
 
     def with_notes_id(notes_id)

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -156,7 +156,7 @@ class JournalManager
                              journable_type: journal_class_name(journable.class),
                              version: version,
                              activity_type: journable.send(:activity_type),
-                             changed_data: journable.attributes.symbolize_keys }
+                             details: journable.attributes.symbolize_keys }
 
       create_journal journable, journal_attributes, user, notes
     end
@@ -166,17 +166,19 @@ class JournalManager
     type = base_class(journable.class)
     extended_journal_attributes = journal_attributes.merge(journable_type: journal_class_name(type))
                                   .merge(notes: notes)
-                                  .except(:changed_data)
+                                  .except(:details)
                                   .except(:id)
 
     unless extended_journal_attributes.has_key? :user_id
       extended_journal_attributes[:user_id] = user.id
     end
 
-    journal_attributes[:changed_data] = normalize_newlines(journal_attributes[:changed_data])
+    journal_attributes[:details] = normalize_newlines(journal_attributes[:details])
 
     journal = journable.journals.build extended_journal_attributes
-    journal.data = create_journal_data journal.id, type, valid_journal_attributes(type, journal_attributes[:changed_data])
+    journal.data = create_journal_data journal.id,
+                                       type,
+                                       valid_journal_attributes(type, journal_attributes[:details])
 
     create_association_data journable, journal
 

--- a/app/models/journal_notification_mailer.rb
+++ b/app/models/journal_notification_mailer.rb
@@ -66,12 +66,12 @@ class JournalNotificationMailer
 
     def notify_for_status?(journal)
       Setting.notified_events.include?('status_updated') &&
-        journal.changed_data.has_key?(:status_id)
+        journal.details.has_key?(:status_id)
     end
 
     def notify_for_priority(journal)
       Setting.notified_events.include?('work_package_priority_updated') &&
-        journal.changed_data.has_key?(:priority_id)
+        journal.details.has_key?(:priority_id)
     end
 
     def delivery_time

--- a/app/models/legacy_journal.rb
+++ b/app/models/legacy_journal.rb
@@ -117,6 +117,7 @@ class LegacyJournal < ActiveRecord::Base
     attributes['changed_data'] || {}
   end
 
+  # TODO Evaluate whether this can be removed without disturbing any migrations
   alias_method :changed_data, :details
 
   def new_value_for(prop)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -209,7 +209,7 @@ class WorkPackage < ActiveRecord::Base
         journal = o.last_journal
         t = 'work_package'
 
-        t << if journal && journal.changed_data.empty? && !journal.initial?
+        t << if journal && journal.details.empty? && !journal.initial?
                '-note'
              else
                status = Status.find_by_id(o.status_id)

--- a/app/views/api/v2/planning_element_journals/_journal.api.rabl
+++ b/app/views/api/v2/planning_element_journals/_journal.api.rabl
@@ -37,13 +37,13 @@ node :user do |journal|
 end
 
 node :changes do |journal|
-    journal.changed_data.map do |attribute, changes|
+    journal.details.map do |attribute, details|
       user_friendly_attribute, old, new = user_friendly_change(journal, attribute)
       {
           technical: {
               name: attribute.to_s,
-              old:  changes.first,
-              new:  changes.last
+              old:  details.first,
+              new:  details.last
           },
           user_friendly: {
               name: user_friendly_attribute,

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -47,7 +47,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       end
       xml.content "type" => "html" do
         xml.text! '<ul>'
-        change.changed_data.each do |detail|
+        change.details.each do |detail|
           change_content = change.render_detail(detail, :no_html => false)
           xml.text!(content_tag(:li, change_content)) if change_content.present?
         end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -133,6 +133,10 @@ Then /^there should be a user with the following:$/ do |table|
   end
 end
 
+Given 'journals are not being aggregated' do
+  Setting.journal_aggregation_time_minutes = 0
+end
+
 ##
 # admin users list
 #

--- a/features/work_packages/diff_on_show.feature
+++ b/features/work_packages/diff_on_show.feature
@@ -55,6 +55,7 @@ Feature: Having an inline diff view for work package description changes
   Scenario: A work package with a changed description has a callable diff showing the changes inline
     Given the work_package "wp1" is updated with the following:
       | description | Altered description |
+    And journals are not being aggregated
 
     When I go to the page of the work package "wp1"
 

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -71,6 +71,7 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
   end
 
   def link(key, options)
+
     url_attr = default_attributes(options).merge(controller: '/journals',
                                                  action: 'diff',
                                                  id: @journal.id,

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
@@ -95,7 +95,7 @@ module Redmine::Acts::Journalized
         backward ? chain.pop : chain.shift unless from_number == 1 || to_number == 1
 
         chain.inject({}) do |changes, journal|
-          changes.append_changes!(backward ? journal.changed_data.reverse_changes : journal.changed_data)
+          changes.append_changes!(backward ? journal.details.reverse_changes : journal.details)
         end
       end
 

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
@@ -113,10 +113,10 @@ module Redmine::Acts::Journalized
           # Try to find the real initial values
           unless journals.empty?
             journals[1..-1].each do |journal|
-              unless journal.changed_data[name].nil?
+              unless journal.details[name].nil?
                 # Found the first change in journals
                 # Copy the first value as initial change value
-                initial_changes[name] = journal.changed_data[name].first
+                initial_changes[name] = journal.details[name].first
                 break
               end
             end
@@ -180,9 +180,9 @@ module Redmine::Acts::Journalized
       # Specifies the attributes used during journal creation. This is separated into its own
       # method so that it can be overridden by the VestalVersions::Users feature.
       def journal_attributes
-        attributes = { journaled_id: id, activity_type: activity_type,
-                       changed_data: journal_changes, version: last_version + 1,
-                       notes: journal_notes, user_id: (journal_user.try(:id) || User.current.try(:id))
+        { journaled_id: id, activity_type: activity_type,
+          details: journal_changes, version: last_version + 1,
+          notes: journal_notes, user_id: (journal_user.try(:id) || User.current.try(:id))
         }.merge(extra_journal_attributes || {})
       end
     end

--- a/lib/plugins/acts_as_journalized/test/changes_test.rb
+++ b/lib/plugins/acts_as_journalized/test/changes_test.rb
@@ -34,7 +34,7 @@ class ChangesTest < Test::Unit::TestCase
     setup do
       @user = User.create(name: 'Steve Richert')
       @user.update_attribute(:last_name, 'Jobs')
-      @changes = @user.journals.last.changed_data
+      @changes = @user.journals.last.details
     end
 
     should 'be a hash' do
@@ -73,7 +73,7 @@ class ChangesTest < Test::Unit::TestCase
       @user.first_name = 'Stephen'
       model_changes = @user.changed_data
       @user.save
-      changes = @user.journals.last.changed_data
+      changes = @user.journals.last.details
       assert_equal model_changes, changes
     end
   end

--- a/lib/plugins/acts_as_journalized/test/creation_test.rb
+++ b/lib/plugins/acts_as_journalized/test/creation_test.rb
@@ -81,7 +81,7 @@ class CreationTest < Test::Unit::TestCase
 
     should 'not contain Rails timestamps' do
       %w(created_at created_on updated_at updated_on).each do |timestamp|
-        assert_does_not_contain @user.journals.last.changed_data.keys, timestamp
+        assert_does_not_contain @user.journals.last.details.keys, timestamp
       end
     end
 
@@ -93,7 +93,7 @@ class CreationTest < Test::Unit::TestCase
       end
 
       should 'only contain the specified columns' do
-        assert_equal @only, @user.journals.last.changed_data.keys
+        assert_equal @only, @user.journals.last.details.keys
       end
 
       teardown do
@@ -110,7 +110,7 @@ class CreationTest < Test::Unit::TestCase
 
       should 'not contain the specified columns' do
         @except.each do |column|
-          assert_does_not_contain @user.journals.last.changed_data.keys, column
+          assert_does_not_contain @user.journals.last.details.keys, column
         end
       end
 
@@ -128,7 +128,7 @@ class CreationTest < Test::Unit::TestCase
       end
 
       should 'respect only the :only options' do
-        assert_equal @only, @user.journals.last.changed_data.keys
+        assert_equal @only, @user.journals.last.details.keys
       end
 
       teardown do

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -70,7 +70,7 @@ describe MessagesController, type: :controller do
         describe '#journal' do
           let(:attachment_id) { "attachments_#{Message.last.attachments.first.id}" }
 
-          subject { Message.last.journals.last.changed_data }
+          subject { Message.last.journals.last.details }
 
           it { is_expected.to have_key attachment_id }
 
@@ -143,13 +143,13 @@ describe MessagesController, type: :controller do
         end
 
         describe '#key' do
-          subject { message.journals.last.changed_data }
+          subject { message.journals.last.details }
 
           it { is_expected.to have_key attachment_id }
         end
 
         describe '#value' do
-          subject { message.journals.last.changed_data[attachment_id].last }
+          subject { message.journals.last.details[attachment_id].last }
 
           it { is_expected.to eq(filename) }
         end
@@ -180,13 +180,13 @@ describe MessagesController, type: :controller do
         let(:attachment_id) { "attachments_#{attachment.id}" }
 
         describe '#key' do
-          subject { message.journals.last.changed_data }
+          subject { message.journals.last.details }
 
           it { is_expected.to have_key attachment_id }
         end
 
         describe '#value' do
-          subject { message.journals.last.changed_data[attachment_id].first }
+          subject { message.journals.last.details[attachment_id].first }
 
           it { is_expected.to eq(filename) }
         end

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -954,7 +954,7 @@ describe WorkPackagesController, type: :controller do
         describe '#journal' do
           let(:attachment_id) { "attachments_#{new_work_package.attachments.first.id}" }
 
-          subject { new_work_package.journals.last.changed_data }
+          subject { new_work_package.journals.last.details }
 
           it { is_expected.to have_key attachment_id }
 

--- a/spec/legacy/unit/journal_spec.rb
+++ b/spec/legacy/unit/journal_spec.rb
@@ -78,9 +78,9 @@ describe Journal, type: :model do
     end
 
     journal = issue.reload.journals.first
-    assert_equal [nil, 'Test initial journal'], journal.changed_data[:subject]
-    assert_equal [nil, @project.id], journal.changed_data[:project_id]
-    assert_equal [nil, 'Some content'], journal.changed_data[:description]
+    assert_equal [nil, 'Test initial journal'], journal.details[:subject]
+    assert_equal [nil, @project.id], journal.details[:project_id]
+    assert_equal [nil, 'Some content'], journal.details[:description]
   end
 
   specify 'creating a journal should update the updated_on value of the parent record (touch)' do

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -120,6 +120,14 @@ describe Journal::AggregatedJournal, type: :model do
         expect(subject.first.successor).to be_nil
       end
 
+      it 'returns the single journal for both original journals' do
+        expect(described_class.for_journal work_package.journals.first)
+          .to be_equivalent_to_journal subject.first
+
+        expect(described_class.for_journal work_package.journals.second)
+          .to be_equivalent_to_journal subject.first
+      end
+
       context 'with a comment' do
         let(:notes) { 'This is why I changed it.' }
 
@@ -152,6 +160,19 @@ describe Journal::AggregatedJournal, type: :model do
 
           it 'has the second as successor of the first journal' do
             expect(subject.first.successor).to be_equivalent_to_journal subject.second
+          end
+
+          it 'returns the same aggregated journal for the first two originals' do
+            expect(described_class.for_journal work_package.journals.first)
+              .to be_equivalent_to_journal subject.first
+
+            expect(described_class.for_journal work_package.journals.second)
+              .to be_equivalent_to_journal subject.first
+          end
+
+          it 'returns a different aggregated journal for the last original' do
+            expect(described_class.for_journal work_package.journals.last)
+              .to be_equivalent_to_journal subject.second
           end
         end
 

--- a/spec/models/user_deletion_spec.rb
+++ b/spec/models/user_deletion_spec.rb
@@ -95,13 +95,13 @@ describe User, 'deletion', type: :model do
     it { expect(associated_instance.journals.first.user).to eq(user2) }
     it 'should update first journal changes' do
       associations.each do |association|
-        expect(associated_instance.journals.first.changed_data[association_key association].last).to eq(user2.id)
+        expect(associated_instance.journals.first.details[association_key association].last).to eq(user2.id)
       end
     end
     it { expect(associated_instance.journals.last.user).to eq(substitute_user) }
     it 'should update second journal changes' do
       associations.each do |association|
-        expect(associated_instance.journals.last.changed_data[association_key association].last).to eq(substitute_user.id)
+        expect(associated_instance.journals.last.details[association_key association].last).to eq(substitute_user.id)
       end
     end
   end
@@ -157,14 +157,14 @@ describe User, 'deletion', type: :model do
     it { expect(associated_instance.journals.first.user).to eq(substitute_user) }
     it 'should update the first journal' do
       associations.each do |association|
-        expect(associated_instance.journals.first.changed_data[association_key association].last).to eq(substitute_user.id)
+        expect(associated_instance.journals.first.details[association_key association].last).to eq(substitute_user.id)
       end
     end
     it { expect(associated_instance.journals.last.user).to eq(user2) }
     it 'should update the last journal' do
       associations.each do |association|
-        expect(associated_instance.journals.last.changed_data[association_key association].first).to eq(substitute_user.id)
-        expect(associated_instance.journals.last.changed_data[association_key association].last).to eq(user2.id)
+        expect(associated_instance.journals.last.details[association_key association].first).to eq(substitute_user.id)
+        expect(associated_instance.journals.last.details[association_key association].last).to eq(user2.id)
       end
     end
   end
@@ -233,13 +233,13 @@ describe User, 'deletion', type: :model do
     it { expect(associated_instance.journals.first.user).to eq(user2) }
     it 'should update first journal changes' do
       associations.each do |association|
-        expect(associated_instance.journals.first.changed_data[association_key association].last).to eq(user2.id)
+        expect(associated_instance.journals.first.details[association_key association].last).to eq(user2.id)
       end
     end
     it { expect(associated_instance.journals.last.user).to eq(substitute_user) }
     it 'should update second journal changes' do
       associations.each do |association|
-        expect(associated_instance.journals.last.changed_data[association_key association].last).to eq(substitute_user.id)
+        expect(associated_instance.journals.last.details[association_key association].last).to eq(substitute_user.id)
       end
     end
   end
@@ -443,11 +443,11 @@ describe User, 'deletion', type: :model do
     end
     it { expect(associated_instance.journals.first.user).to eq(user2) }
     it 'should update first journal changes' do
-      expect(associated_instance.journals.first.changed_data[:user_id].last).to eq(user2.id)
+      expect(associated_instance.journals.first.details[:user_id].last).to eq(user2.id)
     end
     it { expect(associated_instance.journals.last.user).to eq(substitute_user) }
     it 'should update second journal changes' do
-      expect(associated_instance.journals.last.changed_data[:user_id].last).to eq(substitute_user.id)
+      expect(associated_instance.journals.last.details[:user_id].last).to eq(substitute_user.id)
     end
   end
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -163,7 +163,7 @@ describe WorkPackage, type: :model do
       end
 
       context 'last created journal' do
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it 'contains all changes' do
           [:subject, :description, :type_id, :status_id, :priority_id,
@@ -233,7 +233,7 @@ describe WorkPackage, type: :model do
       end
 
       context 'new attachment' do
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it { is_expected.to have_key attachment_id }
 
@@ -255,7 +255,7 @@ describe WorkPackage, type: :model do
       context 'attachment removed' do
         before { work_package.attachments.delete(attachment) }
 
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it { is_expected.to have_key attachment_id }
 
@@ -286,7 +286,7 @@ describe WorkPackage, type: :model do
       context 'new custom value' do
         include_context 'work package with custom value'
 
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it { is_expected.to have_key custom_field_id }
 
@@ -306,7 +306,7 @@ describe WorkPackage, type: :model do
           work_package.save!
         end
 
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it { is_expected.to have_key custom_field_id }
 
@@ -341,7 +341,7 @@ describe WorkPackage, type: :model do
           work_package.save!
         end
 
-        subject { work_package.journals.last.changed_data }
+        subject { work_package.journals.last.details }
 
         it { is_expected.to have_key custom_field_id }
 

--- a/spec/models/work_package/work_package_planning_spec.rb
+++ b/spec/models/work_package/work_package_planning_spec.rb
@@ -249,7 +249,7 @@ describe WorkPackage, type: :model do
     it "has an initial journal, so that it's creation shows up in activity" do
       expect(pe.journals.size).to eq(1)
 
-      changes = pe.journals.first.changed_data.to_hash
+      changes = pe.journals.first.details.to_hash
 
       expect(changes.size).to eq(11)
 
@@ -271,7 +271,7 @@ describe WorkPackage, type: :model do
       pe.update_attribute(:due_date, Date.new(2012, 2, 1))
 
       expect(pe.journals.size).to eq(2)
-      changes = pe.journals.last.changed_data
+      changes = pe.journals.last.details
 
       expect(changes.size).to eq(1)
 
@@ -311,7 +311,7 @@ describe WorkPackage, type: :model do
         pe.reload
 
         expect(pe.journals.size).to eq(3)
-        changes = pe.journals.last.changed_data
+        changes = pe.journals.last.details
 
         expect(changes.size).to eq(1)
         expect(changes).to include(:start_date)

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1491,20 +1491,20 @@ describe WorkPackage, type: :model do
       it 'should not include certain attributes' do
         recreated_journal = @issue.recreate_initial_journal!
 
-        expect(recreated_journal.changed_data.include?('rgt')).to eq(false)
-        expect(recreated_journal.changed_data.include?('lft')).to eq(false)
-        expect(recreated_journal.changed_data.include?('lock_version')).to eq(false)
-        expect(recreated_journal.changed_data.include?('updated_at')).to eq(false)
-        expect(recreated_journal.changed_data.include?('updated_on')).to eq(false)
-        expect(recreated_journal.changed_data.include?('id')).to eq(false)
-        expect(recreated_journal.changed_data.include?('type')).to eq(false)
-        expect(recreated_journal.changed_data.include?('root_id')).to eq(false)
+        expect(recreated_journal.details.include?('rgt')).to eq(false)
+        expect(recreated_journal.details.include?('lft')).to eq(false)
+        expect(recreated_journal.details.include?('lock_version')).to eq(false)
+        expect(recreated_journal.details.include?('updated_at')).to eq(false)
+        expect(recreated_journal.details.include?('updated_on')).to eq(false)
+        expect(recreated_journal.details.include?('id')).to eq(false)
+        expect(recreated_journal.details.include?('type')).to eq(false)
+        expect(recreated_journal.details.include?('root_id')).to eq(false)
       end
 
       it 'should not include useless transitions' do
         recreated_journal = @issue.recreate_initial_journal!
 
-        recreated_journal.changed_data.values.each do |change|
+        recreated_journal.details.values.each do |change|
           expect(change.first).not_to eq(change.last)
         end
       end

--- a/spec/support/identical_ext.rb
+++ b/spec/support/identical_ext.rb
@@ -34,9 +34,9 @@ Journal.class_eval do
     recreated = o.attributes
 
     original.except!('created_at')
-    changed_data.except!('created_on')
+    details.except!('created_on')
     recreated.except!('created_at')
-    o.changed_data.except!('created_on')
+    o.details.except!('created_on')
 
     original.identical?(recreated)
   end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21035
## Description

Changes diff view for descriptions etc. to show the diff of the corresponding aggregated journal.
Thereby clicking on a diff link in the activity tab (e.g. of the details pane) leads to a correct diff for the displayed activity (in case the description was changed twice).

This PR also unifies the methods `details`, `get_changes` and `changed_data` of the `Journal` (which are all aliases of eachother). That means that occurences of `changed_data` have been replaced by `details`. In the long term the goal is to remove one or two methods of this alias chain.
## Note

Since the legacy WP view does not aggregate journals, it will now link to unmatching diffs. This is deliberate, since the legacy WP view is going to vanish in OP 5.0.
