### PR TITLE
initialize files to prevent operations on undefined

### DIFF
--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -39,6 +39,7 @@ module.exports = function(
   };
 
   var attachmentsController = function(scope, element, attrs) {
+    scope.files = [];
 
     var workPackage = scope.workPackage(),
         upload = function(event, workPackage) {


### PR DESCRIPTION
No WP, just something that I came across.
