### PR TITLE
bump bundler to 1.10.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -549,8 +549,8 @@ DEPENDENCIES
   pry-stack_explorer
   quiet_assets
   rabl (= 0.9.3)
-  rack-attack
   rack (~> 1.4.7)
+  rack-attack
   rack-protection!
   rack-test (~> 0.6.2)
   rack_session_access
@@ -592,4 +592,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
## Description

Probably I am the only one nagged by my too new bundler always updating our `Gemfile.lock`, so I'll just push the update as PR.

In the [words of the bundler team](http://bundler.io/blog/2015/06/24/version-1-10-released.html#bundled-with):

>  The absolute worst case once everyone has upgraded to Bundler 1.9.10 or higher is a single commit per version of Bundler, followed by no git churn.
