### PR TITLE
Capybara cache error: Use find selector after JS redirect

### DIFF
--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -140,7 +140,7 @@ describe 'Create repository', type: :feature, js: true do
         find('input[type="radio"][value="managed"]').set(true)
         find('button[type="submit"]', text: I18n.t(:button_create)).click
 
-        expect(page).to have_selector('div.flash.notice')
+        expect(find('div.flash.notice')).not_to be_nil
         expect(page).to have_selector('input[name="scm_type"][value="managed"]:checked')
         expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
       end


### PR DESCRIPTION
This one has no ticket.

On occasions, the CI reports the same feature spec to be failing
due to a StaleElementReferenceError, however the stacktrace suggests
that this error stems from the extraction of node texts after the actual
query within one retry of the synchronized selection.

The stacktrace begins that error inside `synchronized` and deep within
`result.failure_message`.
https://github.com/jnicklas/capybara/blob/120daaa8563d8b06f4727580ab58cd04cb5856aa/lib/capybara/node/matchers.rb#L97

Thus this commit suggests to use the simplest `find` selector to locate
the element, which does not access its contents.

The backtrace in question:

```
/home/jenkins/.rvm/gems/ruby-2.1.5/gems/selenium-webdriver-2.46.2/lib/selenium/webdriver/common/element.rb:127:in `text'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/selenium/node.rb:4:in `visible_text'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/element.rb:61:in `block in text'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/base.rb:80:in `synchronize'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/element.rb:57:in `text'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/result.rb:47:in `map'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/result.rb:47:in `failure_message'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/matchers.rb:97:in `block in assert_selector'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/base.rb:84:in `synchronize'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/node/matchers.rb:93:in `assert_selector'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/session.rb:676:in `block (2 levels) in <class:Session>'
     /home/jenkins/.rvm/gems/ruby-2.1.5/gems/capybara-2.4.4/lib/capybara/rspec/matchers.rb:23:in `matches?'
     ./spec/features/repositories/create_repository_spec.rb:143:in `block (4 levels) in <top (required)>'
```
