### PR TITLE
Show comments of initial journal

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -47,8 +47,10 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def work_package_added(user, work_package, author)
+  def work_package_added(user, journal, author)
+    work_package = journal.journable.reload
     @issue = work_package # instance variable is used in the view
+    @journal = journal
 
     set_work_package_headers(work_package)
 

--- a/app/views/user_mailer/work_package_added.html.erb
+++ b/app/views/user_mailer/work_package_added.html.erb
@@ -28,5 +28,6 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= t(:text_work_package_added, :id => "##{@issue.id}", :author => @issue.author) %>
+<%= format_text(@journal.notes, :only_path => false) %>
 <hr />
 <%= render :partial => 'issue_details', :locals => { :issue => @issue } %>

--- a/app/views/user_mailer/work_package_added.text.erb
+++ b/app/views/user_mailer/work_package_added.text.erb
@@ -29,5 +29,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= t(:text_work_package_added, :id => "##{@issue.id}", :author => @issue.author) %>
 
+<%= @journal.notes if @journal.notes? %>
 ----------------------------------------
 <%= render :partial => 'issue_details', :locals => { :issue => @issue } %>

--- a/app/workers/deliver_work_package_notification_job.rb
+++ b/app/workers/deliver_work_package_notification_job.rb
@@ -45,7 +45,7 @@ class DeliverWorkPackageNotificationJob
     notification_receivers(work_package).uniq.each do |recipient|
       mail = User.execute_as(recipient) {
         if journal.initial?
-          UserMailer.work_package_added(recipient, work_package, author)
+          UserMailer.work_package_added(recipient, journal, author)
         else
           UserMailer.work_package_updated(recipient, journal, author)
         end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -84,6 +84,7 @@ en:
     label_collapse_all: "Collapse all"
     label_commented_on: "commented on"
     label_contains: "contains"
+    label_created_on: "created on"
     label_equals: "is"
     label_expand: "Expand"
     label_expanded: "expanded"

--- a/frontend/app/templates/work_packages/tabs/_user_activity.html
+++ b/frontend/app/templates/work_packages/tabs/_user_activity.html
@@ -22,7 +22,7 @@
   <img class="avatar" ng-src="{{ userAvatar }}" alt="Avatar" title="{{userName}}" ng-if="userAvatar" />
   <span class="user" ng-if="userActive"><a ng-href="{{ userPath(userId) }}" name="{{ currentAnchor }}" ng-bind="userName"></a></span>
   <span class="user" ng-if="!userActive">{{ userName }}</span>
-  <span class="date">{{ I18n.t('js.label_commented_on') }} <op-date-time date-time-value="activity.props.createdAt"/></op-date-time>
+  <span class="date">{{ isInitial ? I18n.t('js.label_created_on') : I18n.t('js.label_commented_on') }} <op-date-time date-time-value="activity.props.createdAt" /></span>
   <span class="user-comment wiki">
     <div ng-if="inEdit">
       <form name="editCommentForm">
@@ -49,7 +49,7 @@
           class="message"
           ng-show="activity.props._type == 'Activity::Comment'"
           ng-bind-html="comment"/>
-    <ul class="work-package-details-activities-messages">
+    <ul class="work-package-details-activities-messages" ng-if="!isInitial">
       <li ng-repeat="detail in details track by $index">
         <span class="message" ng-bind-html="detail"/>
       </li>

--- a/frontend/app/templates/work_packages/tabs/activity.html
+++ b/frontend/app/templates/work_packages/tabs/activity.html
@@ -4,6 +4,7 @@
         <li ng-repeat="activity in activities"
             class="work-package-details-activities-activity"
             ng-init="activityNo    = activitiesSortedInDescendingOrder && activities.length - $index || $index + 1;
+                     isInitial     = activityNo == 1;
                      currentDate   = (activity.props.createdAt|date:'longDate');
                      currentAnchor = 'note-' + activityNo">
           <h3 class="activity-date"
@@ -12,6 +13,7 @@
           <user-activity work-package="workPackage"
                          activity="activity"
                          activity-no="activityNo"
+                         is-initial="isInitial"
                          input-element-id="'add-comment-text'">
           </user-activity>
         </li>

--- a/frontend/app/templates/work_packages/tabs/overview.html
+++ b/frontend/app/templates/work_packages/tabs/overview.html
@@ -61,10 +61,12 @@
       <li ng-repeat="activity in activities | latestItems:activitiesSortedInDescendingOrder:3"
           class="work-package-details-activities-activity"
           ng-init="currentAnchor = 'note-' + ($index+1);
-                   activityNo = activities.length - $index;">
+                   activityNo = activities.length - $index;
+                   isInitial = activityNo == 1;">
         <user-activity work-package="workPackage"
                        activity="activity"
                        activity-no="activityNo"
+                       is-initial="isInitial"
                        input-element-id="'add-comment-text'"
                        autocomplete-path="{{ autocompletePath }}">
         </user-activity>

--- a/frontend/app/work_packages/controllers/work-package-details-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-details-controller.js
@@ -174,8 +174,7 @@ module.exports = function($scope,
 
   function displayedActivities(workPackage) {
     var activities = workPackage.embedded.activities;
-    // remove first activity (assumes activities are sorted chronologically)
-    activities.splice(0, 1);
+
     if ($scope.activitiesSortedInDescendingOrder) {
       activities.reverse();
     }

--- a/frontend/app/work_packages/tabs/user-activity-directive.js
+++ b/frontend/app/work_packages/tabs/user-activity-directive.js
@@ -45,6 +45,7 @@ module.exports = function($uiViewScroll,
       workPackage: '=',
       activity: '=',
       activityNo: '=',
+      isInitial: '=',
       inputElementId: '='
     },
     link: function(scope, element, attrs, exclusiveEditController) {

--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-spec.js
@@ -72,15 +72,15 @@ describe('OpenProject', function() {
         it('should render the last 3 activites', function() {
           expect(
             $('ul li:nth-child(1) div.comments-number').getText()
-          ).to.eventually.equal('#3');
+          ).to.eventually.equal('#4');
 
           expect(
             $('ul li:nth-child(2) div.comments-number').getText()
-          ).to.eventually.equal('#2');
+          ).to.eventually.equal('#3');
 
           expect(
             $('ul li:nth-child(3) div.comments-number').getText()
-          ).to.eventually.equal('#1');
+          ).to.eventually.equal('#2');
         });
 
         it('should contain the activities details', function() {

--- a/frontend/tests/unit/tests/work_packages/tabs/user-activity-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/tabs/user-activity-directive-test.js
@@ -49,7 +49,7 @@ describe('userActivity Directive', function() {
 
     beforeEach(inject(function($rootScope, $compile, $uiViewScroll, $timeout, $location, I18n, PathHelper, ActivityService, UsersHelper) {
       var html;
-      html = '<div exclusive-edit class="exclusive-edit"><user-activity work-package="workPackage" activity="activity" activity-no="activityNo" input-element-id="inputElementId"></user-activity></div>';
+      html = '<div exclusive-edit class="exclusive-edit"><user-activity work-package="workPackage" activity="activity" activity-no="activityNo" is-initial="isInitial" input-element-id="inputElementId"></user-activity></div>';
 
       rootScope = $rootScope;
       scope = $rootScope.$new();
@@ -107,8 +107,9 @@ describe('userActivity Directive', function() {
                   html: '<strong>Type</strong> changed'
                 },
               ]
-            },
+            }
           };
+          scope.isInitial = false;
           compile();
         });
 
@@ -163,6 +164,18 @@ describe('userActivity Directive', function() {
 
             expect(detail1).to.eq(scope.activity.props.details[0].html);
             expect(detail2).to.eq(scope.activity.props.details[1].html);
+          });
+
+          context('for initial journal', function() {
+            beforeEach(function() {
+              scope.isInitial = true;
+              compile();
+            });
+            it('should not render activity details', function() {
+              var listFinder = element.find('ul.work-package-details-activities-messages');
+
+              expect(listFinder).to.have.length(0);
+            });
           });
         });
       });

--- a/spec/legacy/functional/user_mailer_spec.rb
+++ b/spec/legacy/functional/user_mailer_spec.rb
@@ -201,7 +201,7 @@ describe UserMailer, type: :mailer do
   it 'should email headers' do
     user  = FactoryGirl.create(:user)
     issue = FactoryGirl.create(:work_package)
-    mail = UserMailer.work_package_added(user, issue, user)
+    mail = UserMailer.work_package_added(user, issue.journals.first, user)
     assert mail.deliver
     assert_not_nil mail
     assert_equal 'bulk', mail.header['Precedence'].to_s
@@ -212,7 +212,7 @@ describe UserMailer, type: :mailer do
     Setting.plain_text_mail = 1
     user  = FactoryGirl.create(:user)
     issue = FactoryGirl.create(:work_package)
-    UserMailer.work_package_added(user, issue, user).deliver
+    UserMailer.work_package_added(user, issue.journals.first, user).deliver
     mail = ActionMailer::Base.deliveries.last
     assert_match /text\/plain/, mail.content_type
     assert_equal 0, mail.parts.size
@@ -223,7 +223,7 @@ describe UserMailer, type: :mailer do
     Setting.plain_text_mail = 0
     user  = FactoryGirl.create(:user)
     issue = FactoryGirl.create(:work_package)
-    UserMailer.work_package_added(user, issue, user).deliver
+    UserMailer.work_package_added(user, issue.journals.first, user).deliver
     mail = ActionMailer::Base.deliveries.last
     assert_match /multipart\/alternative/, mail.content_type
     assert_equal 2, mail.parts.size
@@ -264,7 +264,7 @@ describe UserMailer, type: :mailer do
   it 'should issue add message id' do
     user  = FactoryGirl.create(:user)
     issue = FactoryGirl.create(:work_package)
-    mail = UserMailer.work_package_added(user, issue, user)
+    mail = UserMailer.work_package_added(user, issue.journals.first, user)
     mail.deliver
     assert_not_nil mail
     assert_equal UserMailer.generate_message_id(issue, user), mail.message_id
@@ -318,7 +318,7 @@ describe UserMailer, type: :mailer do
       ActionMailer::Base.deliveries.clear
       with_settings available_languages: ['en', 'de'] do
         I18n.locale = 'en'
-        assert UserMailer.work_package_added(user, issue, user).deliver
+        assert UserMailer.work_package_added(user, issue.journals.first, user).deliver
         assert_equal 1, ActionMailer::Base.deliveries.size
         mail = last_email
         assert_equal ['foo@bar.de'], mail.to
@@ -338,7 +338,7 @@ describe UserMailer, type: :mailer do
       with_settings available_languages: ['en', 'de'],
                     default_language: 'de' do
         I18n.locale = 'de'
-        assert UserMailer.work_package_added(user, issue, user).deliver
+        assert UserMailer.work_package_added(user, issue.journals.first, user).deliver
         assert_equal 1, ActionMailer::Base.deliveries.size
         mail = last_email
         assert_equal ['foo@bar.de'], mail.to

--- a/spec/legacy/unit/lib/redmine/hook_spec.rb
+++ b/spec/legacy/unit/lib/redmine/hook_spec.rb
@@ -156,17 +156,17 @@ describe 'Redmine::Hook::Manager' do # FIXME: naming (RSpec-port)
 
   it 'should call_hook_should_not_change_the_default_url_for_email_notifications' do
     user = User.find(1)
-    issue = WorkPackage.find(1)
+    issue = FactoryGirl.create(:work_package)
 
     ActionMailer::Base.deliveries.clear
-    UserMailer.work_package_added(user, issue, user).deliver
+    UserMailer.work_package_added(user, issue.journals.first, user).deliver
     mail = ActionMailer::Base.deliveries.last
 
     @hook_module.add_listener(TestLinkToHook)
     hook_helper.call_hook(:view_layouts_base_html_head)
 
     ActionMailer::Base.deliveries.clear
-    UserMailer.work_package_added(user, issue, user).deliver
+    UserMailer.work_package_added(user, issue.journals.first, user).deliver
     mail2 = ActionMailer::Base.deliveries.last
 
     assert_equal mail.text_part.body.encoded, mail2.text_part.body.encoded

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -108,7 +108,7 @@ describe UserMailer, type: :mailer do
 
   describe '#work_package_added' do
     before do
-      UserMailer.work_package_added(recipient, work_package, user).deliver
+      UserMailer.work_package_added(recipient, journal, user).deliver
     end
 
     it_behaves_like 'mail is sent'

--- a/spec/workers/mail_notification_jobs/deliver_work_package_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/deliver_work_package_notification_job_spec.rb
@@ -52,7 +52,10 @@ describe DeliverWorkPackageNotificationJob, type: :model do
   end
 
   it 'sends a mail' do
-    expect(UserMailer).to receive(:work_package_added).with(recipient, work_package, author)
+    expect(UserMailer).to receive(:work_package_added).with(
+                            recipient,
+                            an_instance_of(Journal::AggregatedJournal),
+                            author)
     subject.perform
   end
 
@@ -79,7 +82,7 @@ describe DeliverWorkPackageNotificationJob, type: :model do
 
     it 'uses the deleted user as author' do
       expect(UserMailer).to receive(:work_package_added)
-                              .with(recipient, work_package, DeletedUser.first)
+                              .with(anything, anything, DeletedUser.first)
 
       subject.perform
     end
@@ -93,7 +96,7 @@ describe DeliverWorkPackageNotificationJob, type: :model do
     end
 
     it 'raises an error' do
-      expect { subject.perform }.to raise_error
+      expect { subject.perform }.to raise_error('aggregated journal got outdated')
     end
   end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21114
## Description

Since the aggregation of journals, it is possible that a comment becomes part of the journal that created a work package.
It also makes sense to comment on the creation of a work package (e.g. to assign it right after creating it).

Therefore this PR allows to see the comment for the WP creation, in case there is one.
