### PR TITLE
Fix "new authentication mode" link

### DIFF
--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title l(:label_administration), l(:label_auth_source_plural) %>
 <%= toolbar title: l(:label_auth_source_plural) do %>
   <li class="toolbar-item">
-    <%= link_to new_auth_source_path, class: 'button -alt-highlight' do %>
+    <%= link_to({ action: 'new' }, class: 'button -alt-highlight') do %>
       <i class="button--icon icon-add"></i>
       <span class="button--text"><%= l(:label_auth_source_new) %></span>
     <% end %>


### PR DESCRIPTION
## OpenProject references

Found this while working on https://community.openproject.org/work_packages/21130.
It is already documented on the forums here: https://community.openproject.org/topics/4869
## Description

The link for the "new authentication mode" button wrongfully pointed to `auth_sources/new` instead of `ldap_auth_sources/new`.

This lead to an abstract auth source being created, which was later editable as LDAP auth source, but did not behave like one.
