### PR TITLE
Fix/attachment download link

### DIFF
--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -221,12 +221,6 @@ module API
           def self.work_packages_by_project(project_id)
             "#{project(project_id)}/work_packages"
           end
-
-          def self.root_path
-            @@root_path ||= Class.new.tap do |c|
-              c.extend(::API::V3::Utilities::PathHelper)
-            end.root_path
-          end
         end
 
         def api_v3_paths

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -34,6 +34,8 @@ module API
         include API::Utilities::UrlHelper
 
         class ApiV3Path
+          extend API::Utilities::UrlHelper
+
           def self.root
             "#{root_path}api/v3"
           end
@@ -47,7 +49,7 @@ module API
           end
 
           def self.attachment_download(id)
-            Rails.application.routes.url_helpers.attachment_path(id)
+            attachment_path(id)
           end
 
           def self.attachments_by_work_package(id)

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -312,10 +312,6 @@ describe ::API::V3::Utilities::PathHelper do
   end
 
   describe 'work packages paths' do
-    shared_examples_for 'api v3 work packages path' do
-      it { is_expected.to match(/^\/api\/v3\/work_packages/) }
-    end
-
     describe '#work_packages' do
       subject { helper.work_packages }
 
@@ -337,7 +333,7 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#work_package_relations' do
       subject { helper.work_package_relations 42 }
 
-      it_behaves_like 'api v3 work packages path', '/work_packages/42/relations'
+      it_behaves_like 'api v3 path', '/work_packages/42/relations'
     end
 
     describe '#work_package_relation' do

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -31,8 +31,21 @@ require 'spec_helper'
 describe ::API::V3::Utilities::PathHelper do
   let(:helper) { Class.new.tap { |c| c.extend(::API::V3::Utilities::PathHelper) }.api_v3_paths }
 
-  shared_examples_for 'api v3 path' do
-    it { is_expected.to match(/^\/api\/v3/) }
+  shared_examples_for 'path' do |url|
+    it 'provides the path' do
+      is_expected.to match(url)
+    end
+
+    it 'prepends the sub uri if configured' do
+      allow(OpenProject::Configuration).to receive(:rails_relative_url_root)
+        .and_return('/open_project')
+
+      is_expected.to match("/open_project#{url}")
+    end
+  end
+
+  shared_examples_for 'api v3 path' do |url|
+    it_behaves_like 'path', "/api/v3#{url}"
   end
 
   describe '#root' do
@@ -44,87 +57,67 @@ describe ::API::V3::Utilities::PathHelper do
   describe '#activity' do
     subject { helper.activity 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/activities\/1/) }
+    it_behaves_like 'api v3 path', '/activities/1'
   end
 
   describe '#attachment' do
     subject { helper.attachment 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/attachments/1') }
+    it_behaves_like 'api v3 path', '/attachments/1'
   end
 
   describe '#attachment_download' do
     subject { helper.attachment_download 1 }
 
-    it { is_expected.to eql('/attachments/1') }
+    it_behaves_like 'path', '/attachments/1'
   end
 
   describe '#attachments_by_work_package' do
     subject { helper.attachments_by_work_package 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/work_packages/1/attachments') }
+    it_behaves_like 'api v3 path', '/work_packages/1/attachments'
   end
 
   describe '#available_assignees' do
     subject { helper.available_assignees 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/projects\/42\/available_assignees/) }
+    it_behaves_like 'api v3 path', '/projects/42/available_assignees'
   end
 
   describe '#available_responsibles' do
     subject { helper.available_responsibles 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/projects\/42\/available_responsibles/) }
+    it_behaves_like 'api v3 path', '/projects/42/available_responsibles'
   end
 
   describe '#available_watchers' do
     subject { helper.available_watchers 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/available_watchers/) }
+    it_behaves_like 'api v3 path', '/work_packages/42/available_watchers'
   end
 
   describe '#categories' do
     subject { helper.categories 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/projects\/42\/categories/) }
+    it_behaves_like 'api v3 path', '/projects/42/categories'
   end
 
   describe '#category' do
     subject { helper.category 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/categories\/42/) }
+    it_behaves_like 'api v3 path', '/categories/42'
   end
 
   describe '#configuration' do
     subject { helper.configuration }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/configuration') }
+    it_behaves_like 'api v3 path', '/configuration'
   end
 
   describe '#create_work_package_form' do
     subject { helper.create_work_package_form 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/projects/42/work_packages/form') }
+    it_behaves_like 'api v3 path', '/projects/42/work_packages/form'
   end
 
   describe '#render_markup' do
@@ -134,9 +127,7 @@ describe ::API::V3::Utilities::PathHelper do
       allow(Setting).to receive(:text_formatting).and_return('by-the-settings')
     end
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/render/super_fancy?context=link-ish') }
+    it_behaves_like 'api v3 path', '/render/super_fancy?context=link-ish'
 
     context 'no link given' do
       subject { helper.render_markup(format: 'super_fancy') }
@@ -165,17 +156,13 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#priorities' do
       subject { helper.priorities }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/priorities/) }
+      it_behaves_like 'api v3 path', '/priorities'
     end
 
     describe '#priority' do
       subject { helper.priority 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/priorities\/1/) }
+      it_behaves_like 'api v3 path', '/priorities/1'
     end
   end
 
@@ -183,59 +170,45 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#projects' do
       subject { helper.projects }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/projects/) }
+      it_behaves_like 'api v3 path', '/projects'
     end
 
     describe '#project' do
       subject { helper.project 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/projects\/1/) }
+      it_behaves_like 'api v3 path', '/projects/1'
     end
   end
 
   describe '#query' do
     subject { helper.query 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/queries\/1/) }
+    it_behaves_like 'api v3 path', '/queries/1'
   end
 
   describe '#query_star' do
     subject { helper.query_star 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/queries/1/star') }
+    it_behaves_like 'api v3 path', '/queries/1/star'
   end
 
   describe '#query_unstar' do
     subject { helper.query_unstar 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to eql('/api/v3/queries/1/unstar') }
+    it_behaves_like 'api v3 path', '/queries/1/unstar'
   end
 
   describe 'relations paths' do
     describe '#relation' do
       subject { helper.relation 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/relations/) }
+      it_behaves_like 'api v3 path', '/relations'
     end
 
     describe '#relation' do
       subject { helper.relation 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/relations\/1/) }
+      it_behaves_like 'api v3 path', '/relations/1'
     end
   end
 
@@ -243,9 +216,7 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#revision' do
       subject { helper.revision 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to eql('/api/v3/revisions/1') }
+      it_behaves_like 'api v3 path', '/revisions/1'
     end
   end
 
@@ -253,9 +224,7 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#work_package_schema' do
       subject { helper.work_package_schema 1, 2 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/schemas\/1-2/) }
+      it_behaves_like 'api v3 path', '/work_packages/schemas/1-2'
     end
   end
 
@@ -263,17 +232,13 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#statuses' do
       subject { helper.statuses }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/statuses/) }
+      it_behaves_like 'api v3 path', '/statuses'
     end
 
     describe '#status' do
       subject { helper.status 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/statuses\/1/) }
+      it_behaves_like 'api v3 path', '/statuses/1'
     end
   end
 
@@ -281,9 +246,7 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#string_object' do
       subject { helper.string_object 'foo' }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to eql('/api/v3/string_objects?value=foo') }
+      it_behaves_like 'api v3 path', '/string_objects?value=foo'
 
       it 'escapes correctly' do
         value = 'foo/bar baz'
@@ -294,9 +257,7 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#status' do
       subject { helper.status 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to match(/^\/api\/v3\/statuses\/1/) }
+      it_behaves_like 'api v3 path', '/statuses/1'
     end
   end
 
@@ -304,66 +265,50 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#types' do
       subject { helper.types }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to eql('/api/v3/types') }
+      it_behaves_like 'api v3 path', '/types'
     end
 
     describe '#types_by_project' do
       subject { helper.types_by_project 12 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to eql('/api/v3/projects/12/types') }
+      it_behaves_like 'api v3 path', '/projects/12/types'
     end
 
     describe '#type' do
       subject { helper.type 1 }
 
-      it_behaves_like 'api v3 path'
-
-      it { is_expected.to eql('/api/v3/types/1') }
+      it_behaves_like 'api v3 path', '/types/1'
     end
   end
 
   describe '#user' do
     subject { helper.user 1 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/users\/1/) }
+    it_behaves_like 'api v3 path', '/users/1'
   end
 
   describe '#version' do
     subject { helper.version 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/versions\/42/) }
+    it_behaves_like 'api v3 path', '/versions/42'
   end
 
   describe '#versions_by_project' do
     subject { helper.versions_by_project 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/projects\/42\/versions/) }
+    it_behaves_like 'api v3 path', '/projects/42/versions'
   end
 
   describe '#projects_by_version' do
     subject { helper.projects_by_version 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/versions\/42\/projects/) }
+    it_behaves_like 'api v3 path', '/versions/42/projects'
   end
 
   describe '#work_packages_by_project' do
     subject { helper.work_packages_by_project 42 }
 
-    it_behaves_like 'api v3 path'
-
-    it { is_expected.to match(/^\/api\/v3\/projects\/42\/work_packages/) }
+    it_behaves_like 'api v3 path', '/projects/42/work_packages'
   end
 
   describe 'work packages paths' do
@@ -374,71 +319,55 @@ describe ::API::V3::Utilities::PathHelper do
     describe '#work_packages' do
       subject { helper.work_packages }
 
-      it_behaves_like 'api v3 work packages path'
+      it_behaves_like 'api v3 path', '/work_packages'
     end
 
     describe '#work_package' do
       subject { helper.work_package 1 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/1/) }
+      it_behaves_like 'api v3 path', '/work_packages/1'
     end
 
     describe '#work_package_activities' do
       subject { helper.work_package_activities 42 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/activities/) }
+      it_behaves_like 'api v3 path', '/work_packages/42/activities'
     end
 
     describe '#work_package_relations' do
       subject { helper.work_package_relations 42 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/relations/) }
+      it_behaves_like 'api v3 work packages path', '/work_packages/42/relations'
     end
 
     describe '#work_package_relation' do
       subject { helper.work_package_relation 1, 42 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/relations\/1/) }
+      it_behaves_like 'api v3 path', '/work_packages/42/relations/1'
     end
 
     describe '#work_package_revisions' do
       subject { helper.work_package_revisions 42 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to eql('/api/v3/work_packages/42/revisions') }
+      it_behaves_like 'api v3 path', '/work_packages/42/revisions'
     end
 
     describe '#work_package_form' do
       subject { helper.work_package_form 1 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/1\/form/) }
+      it_behaves_like 'api v3 path', '/work_packages/1/form'
     end
 
     describe '#work_package_watchers' do
       subject { helper.work_package_watchers 1 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/1\/watchers/) }
+      it_behaves_like 'api v3 path', '/work_packages/1/watchers'
     end
 
     describe '#watcher' do
       subject { helper.watcher 1, 42 }
 
-      it_behaves_like 'api v3 work packages path'
-
-      it { is_expected.to match(/^\/api\/v3\/work_packages\/42\/watchers\/1/) }
+      it_behaves_like 'api v3 path', '/work_packages/42/watchers/1'
     end
   end
 end


### PR DESCRIPTION
Consists of multiple part:
- Fixes the attachment download link in the api v3 when OpenProject is run inside a sub uri: https://community.openproject.org/work_packages/21183
- The fix also includes the newly created possibility to call all paths/urls defined in rails on the api v3 path helper itself.  
- Refactors the path helper to not use a work around for simple `extend`.
- Refactors the specs for the api v3 paths to avoid duplication and ensures that each path is also working for a sub uri setting.
