### PR TITLE
Fix LDAP Connection test

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -40,7 +40,9 @@ class AuthSource < ActiveRecord::Base
   def authenticate(_login, _password)
   end
 
+  # implemented by a subclass, should raise when no connection is possible and not raise on success
   def test_connection
+    raise I18n.t('auth_source.using_abstract_auth_source')
   end
 
   def auth_method_name

--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -53,10 +53,11 @@ class LdapAuthSource < AuthSource
 
   # test the connection to the LDAP
   def test_connection
-    ldap_con = initialize_ldap_con(account, account_password)
-    ldap_con.open {}
+    unless authenticate_dn(account, account_password)
+      raise I18n.t('auth_source.ldap_error', error_message: I18n.t('auth_source.ldap_auth_failed'))
+    end
   rescue  Net::LDAP::LdapError => text
-    raise 'LdapError: ' + text.to_s
+    raise I18n.t('auth_source.ldap_error', error_message: text.to_s)
   end
 
   def auth_method_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1091,6 +1091,11 @@ en:
   label_keyboard_shortcut_focus_next_item: "Focus next list element (on some lists only)"
   label_visible_elements: Visible elements
 
+  auth_source:
+    using_abstract_auth_source: "Can't use an abstract authentication source."
+    ldap_error: "LDAP-Error: %{error_message}"
+    ldap_auth_failed: "Could not authenticate at the LDAP-Server."
+
   macro_execution_error: "Error executing the macro %{macro_name}"
   macro_unavailable: "Macro %{macro_name} cannot be displayed."
 


### PR DESCRIPTION
## OpenProject Work Package

Fixed while working on https://community.openproject.org/work_packages/21130
## Description

The old implementation of the test did not recognize bad login credentials for the LDAP account used to read the directory.
We now use `bind` to verify our credentials explicitly.

This PR also adds proper translations for the involved error messages and adds an error message to the test routine of the abstract `AuthSource`. Usually this error should not be visible, because one should not be able to create an abstract auth source. But in case it does happen (see https://github.com/opf/openproject/pull/3313), you at least get a correct error message.
