### PR TITLE
Remove repository project hierarchy

### DIFF
--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -70,10 +70,6 @@ class Repository::Subversion < Repository
     true
   end
 
-  def repository_identifier
-    "#{super}.svn"
-  end
-
   def repo_log_encoding
     'UTF-8'
   end

--- a/app/services/scm/delete_managed_repository_service.rb
+++ b/app/services/scm/delete_managed_repository_service.rb
@@ -40,7 +40,6 @@ Scm::DeleteManagedRepositoryService = Struct.new :repository do
       # Create necessary changes to repository to mark
       # it as managed by OP, but delete asynchronously.
       managed_path = repository.root_url
-      parents = repository.parent_projects
 
       if File.directory?(managed_path)
         ##
@@ -50,7 +49,7 @@ Scm::DeleteManagedRepositoryService = Struct.new :repository do
         # Instead, this will be refactored into a single service wrapper for
         # creating and deleting repositories, which provides transactional DB access
         # as well as filesystem access.
-        Scm::DeleteRepositoryJob.new(managed_path, parents).perform
+        Scm::DeleteRepositoryJob.new(managed_path).perform
       end
 
       true

--- a/app/workers/scm/delete_repository_job.rb
+++ b/app/workers/scm/delete_repository_job.rb
@@ -35,43 +35,16 @@
 # creation and deletion of repositories BOTH on the database and filesystem.
 # Until then, a synchronous process is more failsafe.
 class Scm::DeleteRepositoryJob
-  def initialize(managed_path, parents)
+  def initialize(managed_path)
     @managed_path = managed_path
-    @parents = parents
   end
 
   def perform
     # Delete the repository project itself.
     FileUtils.remove_dir(@managed_path)
-
-    # Traverse all parent directories within repositories,
-    # searching for empty project directories.
-    remove_empty_parents
   end
 
   def destroy_failed_jobs?
     true
-  end
-
-  private
-
-  def remove_empty_parents
-    parent_path = Pathname.new(@managed_path).parent
-
-    ##
-    # Iterate the hierarchy in reverse, looking
-    # for empty directories that equal the parent identifier name
-    # but are empty.
-    @parents.reverse_each do |parent|
-      # Stop unless the given parent path is the parent project path
-      break unless parent_path.basename.to_s == parent
-
-      # Stop deletion upon finding a non-empty parent repository
-      break unless parent_path.exist? && parent_path.children.empty?
-
-      FileUtils.rmdir(parent_path)
-
-      parent_path = parent_path.parent
-    end
   end
 end

--- a/lib/open_project/scm/manageable_repository.rb
+++ b/lib/open_project/scm/manageable_repository.rb
@@ -50,7 +50,7 @@ module OpenProject
         # Reads from configuration whether new repositories of this kind
         # may be managed from OpenProject.
         def manageable?
-          ! (disabled_types.include?(managed_type) || managed_root.nil?)
+          !(disabled_types.include?(managed_type) || managed_root.nil?)
         end
 
         ##
@@ -88,7 +88,7 @@ module OpenProject
       # Used only in the creation of a repository, at a later point
       # in time, it is referred to in the root_url
       def managed_repository_path
-        File.join(self.class.managed_root, repository_path)
+        File.join(self.class.managed_root, repository_identifier)
       end
 
       ##
@@ -100,26 +100,6 @@ module OpenProject
         "file://#{managed_repository_path}"
       end
 
-      ##
-      # Determine the parent path of the given project
-      def parent_projects_path
-        File.join(*parent_projects)
-      end
-
-      ##
-      # Determine all parent projects of this repository
-      def parent_projects
-        parent_parts = []
-        p = project
-        while p.parent
-          parent_id = p.parent.identifier.to_s
-          parent_parts.unshift(parent_id)
-          p = p.parent
-        end
-
-        parent_parts
-      end
-
       protected
 
       ##
@@ -128,20 +108,6 @@ module OpenProject
       # append '.git' to that path.
       def repository_identifier
         project.identifier
-      end
-
-      private
-
-      ##
-      # Generate a uniquely identified path from the project
-      # hierarchy.
-      def repository_path
-        parent_path = parent_projects_path
-        if parent_path.empty?
-          repository_identifier
-        else
-          File.join(parent_path, repository_identifier)
-        end
       end
     end
   end

--- a/spec/app/services/scm/delete_managed_repository_service_spec.rb
+++ b/spec/app/services/scm/delete_managed_repository_service_spec.rb
@@ -95,25 +95,17 @@ describe Scm::DeleteManagedRepositoryService do
       let(:parent) { FactoryGirl.create(:project) }
       let(:project) { FactoryGirl.create(:project, parent: parent) }
       let(:repo_path) {
-        Pathname.new(File.join(tmpdir, 'svn', parent.identifier, "#{project.identifier}.svn"))
+        Pathname.new(File.join(tmpdir, 'svn', project.identifier))
       }
 
-      it 'deletes the parent path when empty' do
+      it 'does not delete anything but the repository itself' do
         expect(service.call).to be true
         path = Pathname.new(repository.root_url)
         expect(path).to eq(repo_path)
 
         expect(path.exist?).to be false
-        expect(path.parent.exist?).to be false
-      end
-
-      it 'keeps the parent path when not empty' do
-        other_repo = repo_path.parent + 'foobar'
-        other_repo.mkdir
-
-        expect(service.call).to be true
-        expect(repo_path.exist?).to be false
-        expect(repo_path.parent.exist?).to be true
+        expect(path.parent.exist?).to be true
+        expect(path.parent.to_s).to eq(repository.class.managed_root)
       end
     end
   end

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -63,7 +63,7 @@ describe Repository::Git, type: :model do
     context 'with managed config' do
       let(:config) { { manages: managed_path } }
       let(:project) { FactoryGirl.build :project }
-      let(:identifier) { "#{project.identifier}.git" }
+      let(:identifier) { project.identifier + '.git' }
 
       it 'is manageable' do
         expect(instance.manageable?).to be true
@@ -102,7 +102,7 @@ describe Repository::Git, type: :model do
 
         it 'outputs the correct hierarchy path' do
           expect(instance.managed_repository_path)
-            .to eq(File.join(managed_path, parent.identifier, identifier))
+            .to eq(File.join(managed_path, identifier))
         end
       end
     end

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -66,7 +66,6 @@ describe Repository::Subversion, type: :model do
     context 'with managed config' do
       let(:config) { { manages: managed_path } }
       let(:project) { FactoryGirl.build :project }
-      let(:identifier) { "#{project.identifier}.svn" }
 
       it 'is manageable' do
         expect(instance.manageable?).to be true
@@ -88,8 +87,7 @@ describe Repository::Subversion, type: :model do
         end
 
         it 'outputs valid managed paths' do
-          expect(instance.repository_identifier).to eq(identifier)
-          path = File.join(managed_path, identifier)
+          path = File.join(managed_path, project.identifier)
           expect(instance.managed_repository_path).to eq(path)
           expect(instance.managed_repository_url).to eq("file://#{path}")
         end
@@ -105,7 +103,7 @@ describe Repository::Subversion, type: :model do
 
         it 'outputs the correct hierarchy path' do
           expect(instance.managed_repository_path)
-            .to eq(File.join(managed_path, parent.identifier, identifier))
+            .to eq(File.join(managed_path, project.identifier))
         end
       end
     end


### PR DESCRIPTION
This commit removes the project hierarchy introduced with
repository management.
They are not required, incompatible with mod_dav_svn and provide
little to none advantage to storing all repositories in a flat
structure for the scale we require.

Relevant work package: https://community.openproject.org/work_packages/21190
