### PR TITLE
fix links in subfolder deployments

### DIFF
--- a/frontend/app/services/query-service.js
+++ b/frontend/app/services/query-service.js
@@ -395,9 +395,9 @@ module.exports = function(
 
     getQueryPath: function(query) {
       if (query.project_id) {
-        return PathHelper.projectPath(query.project_id) + PathHelper.workPackagesPath() + '?query_id=' + query.id;
+        return PathHelper.staticProjectWorkPackagesPath(query.project_id) + '?query_id=' + query.id;
       } else {
-        return PathHelper.workPackagesPath() + '?query_id=' + query.id;
+        return PathHelper.staticWorkPackagesPath() + '?query_id=' + query.id;
       }
     },
 

--- a/frontend/app/templates/work_packages/inplace_editor/custom/display/version.html
+++ b/frontend/app/templates/work_packages/inplace_editor/custom/display/version.html
@@ -1,7 +1,7 @@
 <div class="version-wrapper">
     <span ng-if="!displayPaneController.getReadValue()">-</span>
     <span ng-if="displayPaneController.getReadValue() && customEditorController.isVersionLinkViewable()">
-      <a href="{{customEditorController.pathHelper.versionPath(displayPaneController.getReadValue().props.id)}}">
+      <a href="{{customEditorController.pathHelper.staticVersionPath(displayPaneController.getReadValue().props.id)}}">
         {{displayPaneController.getReadValue().props.name}}
       </a>
     </span>


### PR DESCRIPTION
## OpenProject work packages
- https://community.openproject.org/work_packages/21164
- https://community.openproject.org/work_packages/21184
## Description

Creating a "starred" query (one that is listed in the left hand side menu) from the WP list, the client will immediately add the corresponding menu item to the menu on the left.
The link for the immediately added item was wrong for subdirectory installations.

This PR always prepends the correct URL prefix.

edit: I started adding other subdirectory path fixes to this PR
