### PR TITLE
Disallow setting the owner of a repository folder

### DIFF
--- a/app/workers/scm/create_repository_job.rb
+++ b/app/workers/scm/create_repository_job.rb
@@ -48,8 +48,8 @@ class Scm::CreateRepositoryJob
     # e.g., initializing an empty scm repository within it
     repository.managed_repo_created
 
-    # Ensure ownership after creation
-    ensure_ownership(mode, config[:owner], config[:group])
+    # Ensure group ownership after creation
+    ensure_group(mode, config[:group])
   end
 
   def destroy_failed_jobs?
@@ -67,14 +67,14 @@ class Scm::CreateRepositoryJob
   end
 
   ##
-  # Overrides the owner/group permission of the created repository
+  # Overrides the group permission of the created repository
   # after the adapter was able to work in the directory.
-  def ensure_ownership(mode, owner, group)
+  def ensure_group(mode, group)
     FileUtils.chmod_R(mode, repository.root_url)
 
-    # Note that this is effectively a noop when owner or group is nil,
+    # Note that this is effectively a noop when group is nil,
     # and then permissions remain OPs runuser/-group
-    FileUtils.chown_R(owner, group, repository.root_url)
+    FileUtils.chown_R(nil, group, repository.root_url)
   end
 
   def config

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -222,6 +222,13 @@ default:
   #   take control over the given path to create and delete repositories directly
   #   when created in the frontend.
   #   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
+  # mode:
+  #   The file mode to set the repository folder to (defaults to 0700).
+  #   Important: The user running OpenProject must be a member of this group in order to have the
+  #   privilege to set the group ownership.
+  # group:
+  #   The group that should own the repository folder.
+  #   Note: The owner is always the user that runs OpenProject!
   # disabled_types:
   #   Disable specific repository types for this particular vendor. This allows
   #   to restrict the available choices a project administrator has for creating repositories

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -224,10 +224,11 @@ default:
   #   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
   # mode:
   #   The file mode to set the repository folder to (defaults to 0700).
-  #   Important: The user running OpenProject must be a member of this group in order to have the
-  #   privilege to set the group ownership.
+  #
   # group:
   #   The group that should own the repository folder.
+  #   Important: The user running OpenProject must be a member of this group in order to have the
+  #   privilege to set the group ownership.  
   #   Note: The owner is always the user that runs OpenProject!
   # disabled_types:
   #   Disable specific repository types for this particular vendor. This allows


### PR DESCRIPTION
The original repository management epic allows to define
an owner that a created repository is`chown`'d to.

As this will fail for non-root users on *nix systems,
this PR removes this functionality in favor of setting
only the group because otherwise, the repository creation will raise a permission error.

This is allowed by non-privileged users _as long as_ users are
member of this group.

This has no associated work package.
