### PR TITLE
Repository form: Toggle not only inputs, but selects

### DIFF
--- a/app/views/repositories/settings/repository_form.js.erb
+++ b/app/views/repositories/settings/repository_form.js.erb
@@ -23,13 +23,13 @@
 		oldTargets
 			.slideUp(500)
 			.prop('hidden', true)
-			.find('input')
+			.find('input,select')
 			.prop('disabled', true);
 
 		newTarget
 			.slideDown(500)
 			.prop('hidden', false)
-			.find('input')
+			.find('input,select')
 			.not('[aria-disabled="true"]')
 			.prop('disabled', false);
 	};


### PR DESCRIPTION
When toggling the SCM type, form elements must be disabled manually
due to a big with fieldset[disabled] on IE10/11.

This commit adds the missing select selector to catch the
path_encoding select re-introduced in https://github.com/opf/openproject/pull/3296
