### PR TITLE
prevent too long Request-URLs for many watchers

### DIFF
--- a/app/views/work_packages/_form.html.erb
+++ b/app/views/work_packages/_form.html.erb
@@ -84,9 +84,10 @@ See doc/COPYRIGHT.rdoc for more details.
           <% block.each do |user| %>
             <div class="form--field -wide-label">
               <%= f.collection_check_box(:watcher_user_ids,
-                                                     user.id,
-                                                     work_package.watched_by?(user) && work_package.visible?(user),
-                                                     user.name) %>
+                                         user.id,
+                                         work_package.watched_by?(user) && work_package.visible?(user),
+                                         user.name,
+                                         unchecked_value: nil) %>
             </div>
           <% end %>
         </div>

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -82,19 +82,20 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def collection_check_box(field,
-                           value,
+                           checked_value,
                            checked,
-                           text = field.to_s + "_#{value}",
+                           text = field.to_s + "_#{checked_value}",
                            options = {})
 
-    label_for = "#{sanitized_object_name}_#{field}_#{value}".to_sym
+    label_for = "#{sanitized_object_name}_#{field}_#{checked_value}".to_sym
+    unchecked_value = options.delete(:unchecked_value) { '' }
 
     input_options = options.reverse_merge(multiple: true,
                                           checked: checked,
                                           for: label_for,
                                           label: text)
 
-    check_box(field, input_options, value, '')
+    check_box(field, input_options, checked_value, unchecked_value)
   end
 
   def fields_for_custom_fields(record_name, record_object = nil, options = {}, &block)


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21199
## Description

This PR fixes issues with WP creation in projects where many watchers are available.
For the `work_packages/new` form, we go back to the previously used way of not sending any data for empty checkboxes, which is perfectly fine for a collection of users to be added as watchers.
This saves us many bytes of URI length and therefore reduces problems with too long URIs being generated on type change.

The generated HTML will change from something like

``` HTML
<input name="work_package[watcher_user_ids][]" type="hidden" value="">
<input id="foo" name="work_package[watcher_user_ids][]" type="checkbox" value="123">
```

to

``` HTML
<input id="foo" name="work_package[watcher_user_ids][]" type="checkbox" value="123">
```
