### PR TITLE
hide global queries from project-scoped WP lists

### DIFF
--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -167,7 +167,7 @@ module Api::Experimental
         # User can see public queries and his own queries
         visible = ARCondition.new(['is_public = ? OR user_id = ?', true, (User.current.logged? ? User.current.id : 0)])
         # Project specific queries and global queries
-        visible << (@project.nil? ? ['project_id IS NULL'] : ['project_id IS NULL OR project_id = ?', @project.id])
+        visible << (@project.nil? ? ['project_id IS NULL'] : ['project_id = ?', @project.id])
         @visible_queries = Query.find(:all,
                                       select: 'id, name, is_public',
                                       order: 'name ASC',


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20545
