### PR TITLE
[APIv3] Specify changes to revisions endpoint

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2149,17 +2149,19 @@ Revisions are sets of updates to files in the context of repositories linked in 
 |:----------------:| --------------------------------------------------------------------------------------------------| ------------- | ----------- | -------------------- |
 | self             | This revision                                                                                     | Revision      | not null    | READ                 |
 | project          | The project to which the revision belongs                                                         | Project       | not null    | READ                 |
-| author           | The user that added this revision, if the authorName was mapped to a user in OpenProject       | User          |             | READ                 |
+| author           | The user that added this revision, if the authorName was mapped to a user in OpenProject          | User          |             | READ                 |
+| showRevision     | A URL to the repository view (outside APIv3) showing this revision                                | -             | not null    | READ                 |
 
 
 ## Local Properties
-| Property       | Description                                                                                                                                                 | Type        | Constraints | Supported operations |
-|:--------------:| ------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------- | ----------- | -------------------- |
-| id             | Revisions's id, assigned by OpenProject                                                                                                                     | Integer     | x > 0       | READ                 |
-| identifier     | The SCM identifier of the revision (e.g. SHA hash)                                                                                                          | String      | not null    | READ                 |
-| authorName     | The name of the author that committed this revision. Note that this name is retrieved from the repository and does not identify a user in OpenProject.      | String      | not null    | READ                 |
-| message        | The commit message of the revision                                                                                                                          | Formattable | not null    | READ                 |
-| createdAt      | The time this revision was committed to the repository                                                                                                      | DateTime    | not null    | READ                 |
+| Property                | Description                                                                                                                                                 | Type        | Constraints | Supported operations |
+|:-----------------------:| ------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------- | ----------- | -------------------- |
+| id                      | Revisions's id, assigned by OpenProject                                                                                                                     | Integer     | x > 0       | READ                 |
+| identifier              | The raw SCM identifier of the revision (e.g. full SHA hash)                                                                                                 | String      | not null    | READ                 |
+| formattedIdentifier     | The SCM identifier of the revision, formatted (e.g. shortened unambiguous SHA hash). May be identical to identifier in many cases                           | String      | not null    | READ                 |
+| authorName              | The name of the author that committed this revision. Note that this name is retrieved from the repository and does not identify a user in OpenProject.      | String      | not null    | READ                 |
+| message                 | The commit message of the revision                                                                                                                          | Formattable | not null    | READ                 |
+| createdAt               | The time this revision was committed to the repository                                                                                                      | DateTime    | not null    | READ                 |
 
 ## Revision [/api/v3/revisions/{id}]
 
@@ -2178,9 +2180,13 @@ Revisions are sets of updates to files in the context of repositories linked in 
                     "author": {
                         "href": "/api/v3/users/1"
                     },
+                    "showRevision": {
+                        "href": "/projects/identifier/repository/revision/11f4b07"
+                    }
                 },
                 "id": 1,
                 "identifier": "11f4b07dff4f4ce9548a52b7d002daca7cd63ec6",
+                "formattedIdentifier": "11f4b07",
                 "authorName": "Some Developer",
                 "message": {
                     "format": "plain",
@@ -4050,10 +4056,14 @@ Gets a list of users that are able to be watchers of the specified work package.
                             "author": {
                                 "href": "/api/v3/users/1",
                                 "title": "John Sheppard - j.sheppard"
+                            },
+                            "showRevision": {
+                                "href": "/projects/identifier/repository/revision/11f4b07"
                             }
                         },
                         "id": 13,
                         "identifier": "11f4b07dff4f4ce9548a52b7d002daca7cd63ec6",
+                        "formattedIdentifier": "11f4b07",
                         "authorName": "John Sheppard",
                         "message": {
                             "format": "plain",
@@ -4076,9 +4086,13 @@ Gets a list of users that are able to be watchers of the specified work package.
                                 "href": "/api/v3/users/2",
                                 "title": "Jim Sheppard - j.sheppard"
                             }
+                            "showRevision": {
+                                "href": "/projects/identifier/repository/revision/029ed72a"
+                            }
                         },
                         "id": 13,
                         "identifier": "029ed72a3b7b7c4ab332b1f6eaa6576e7c946059",
+                        "formattedIdentifier": "029ed72a",
                         "authorName": "j1msheppard",
                         "message": {
                             "format": "plain",


### PR DESCRIPTION
This commit introduces two changes to the revision endpoint:
1. A `formattedIdentifier` which may either contain a shortened
   identifier (e.g., an unambiguous SHA-1 hash fraction for Git) or be identitical to
   `identifier` (for SVN).
2. A `showRevision` link which escapes the scope of the APIv3, but
   provides a reference to the repository view on that particular revision
   entry.

Stems from frontend development (https://github.com/opf/openproject/pull/3323) of the revisions activity work package: https://community.openproject.org/work_packages/15422
