### PR TITLE
Extend revision representer with identifier and revision link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -360,7 +360,8 @@ OpenProject::Application.routes.draw do
       end
 
       get '/revision(/:rev)', rev: /[a-z0-9\.\-_]+/,
-                              action: :revision
+                              action: :revision,
+                              as: 'show_revision'
 
       get '(/revisions/:rev)(/*path)', action: :show,
                                        format: false,

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -50,8 +50,16 @@ module API
           } unless represented.user.nil?
         end
 
+        link :showRevision do
+          {
+            href: api_v3_paths.show_revision(represented.project.identifier,
+                                             represented.identifier)
+          }
+        end
+
         property :id
         property :identifier
+        property :format_identifier, as: :formattedIdentifier
         property :author, as: :authorName
         property :message,
                  exec_context: :decorator,

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -130,6 +130,10 @@ module API
             path
           end
 
+          def self.show_revision(project_id, identifier)
+            show_revision_project_repository_path(project_id, identifier)
+          end
+
           def self.statuses
             "#{root}/statuses"
           end

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -67,6 +67,14 @@ describe ::API::V3::Repositories::RevisionRepresenter do
         it { is_expected.to be_json_eql('1234'.to_json).at_path('identifier') }
       end
 
+      describe 'formattedIdentifier' do
+        before do
+          allow(revision).to receive(:format_identifier).and_return('123')
+        end
+        it { is_expected.to have_json_path('formattedIdentifier') }
+        it { is_expected.to be_json_eql('123'.to_json).at_path('formattedIdentifier') }
+      end
+
       describe 'createdAt' do
         it_behaves_like 'has UTC ISO 8601 date and time' do
           let(:date) { revision.committed_on }
@@ -121,6 +129,13 @@ describe ::API::V3::Repositories::RevisionRepresenter do
           let(:href) { api_v3_paths.user(user.id) }
           let(:title) { user.name }
         end
+      end
+    end
+
+    describe 'showRevision' do
+      it_behaves_like 'has an untitled link' do
+        let(:link) { 'showRevision' }
+        let(:href) { api_v3_paths.show_revision(project.identifier, revision.identifier) }
       end
     end
   end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -218,6 +218,12 @@ describe ::API::V3::Utilities::PathHelper do
 
       it_behaves_like 'api v3 path', '/revisions/1'
     end
+
+    describe '#show_revision' do
+      subject { helper.show_revision 'foo', 1234 }
+
+      it_behaves_like 'path', '/projects/foo/repository/revision/1234'
+    end
   end
 
   describe 'schemas paths' do


### PR DESCRIPTION
This commit extends the revision endpoint with a link
to the (non-api) revision view as well as the formatted
identifier from the Changeset model.

Specification in: https://github.com/opf/openproject/pull/3326
Relevant work package: https://community.openproject.org/work_packages/15422
