### PR TITLE
[20900] Blue background missing for 'Colors' menu item

### DIFF
--- a/app/controllers/planning_element_type_colors_controller.rb
+++ b/app/controllers/planning_element_type_colors_controller.rb
@@ -39,6 +39,8 @@ class PlanningElementTypeColorsController < ApplicationController
   helper :timelines
   layout 'admin'
 
+  menu_item :colors
+
   def index
     @colors = PlanningElementTypeColor.all
     respond_to do |format|


### PR DESCRIPTION
corrected naming so that colors menu item gets correct background when selected

https://community.openproject.org/work_packages/20900
