### PR TITLE
[21142] Field name overlaps field box in modal view

### DIFF
--- a/app/views/work_packages/_form.html.erb
+++ b/app/views/work_packages/_form.html.erb
@@ -30,8 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= call_hook(:view_work_packages_form_details_top, { :issue => work_package, :form => f }) %>
 
 <div class="grid-block">
-  <div class="form--column">
-    <div class="form--field">
+  <div class="form--column medium-6">
+    <div class="form--field -break-words">
       <%= f.select :type_id, work_package_form_type_selectable_types(project), {}, class: '-narrow' %>
       <%= observe_field :work_package_type_id, url: work_package_form_type_observable_url(work_package, project),
                                                   update: :attributes,
@@ -40,8 +40,8 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
   </div>
   <% if user_can_manage_subtasks?(project) %>
-    <div class="form--column">
-      <div class="form--field">
+    <div class="form--column medium-6">
+      <div class="form--field -break-words">
         <%= f.text_field :parent_id, title: l(:description_autocomplete) %>
       </div>
     </div>


### PR DESCRIPTION
words in the field label are broken now if they are so long that they overlap the field

https://community.openproject.org/work_packages/21142
