### PR TITLE
set locale before API v3 request

### DIFF
--- a/app/services/set_localization_service.rb
+++ b/app/services/set_localization_service.rb
@@ -1,0 +1,66 @@
+class SetLocalizationService
+  attr_reader :user, :http_accept_header
+  include Redmine::I18n
+
+  def initialize(user, http_accept_header)
+    @user = user
+    @http_accept_header = http_accept_header
+  end
+
+  ##
+  # Sets the locale.
+  # The locale is determined with the following priority:
+  #
+  #   1. The language as configured by the user.
+  #   2. The first language defined in the Accept-Language header sent by the browser.
+  #   3. OpenProject's default language defined in the settings.
+
+  def perform
+    lang = user_language || header_language || default_language
+
+    set_language_if_valid(lang)
+  end
+
+  private
+
+  def user_language
+    find_language(user.language) if user.logged?
+  end
+
+  def header_language
+    accept_lang = parse_qvalues(http_accept_header).first
+
+    lang = if accept_lang
+             accept_lang = accept_lang.downcase
+             find_language(accept_lang) || find_language(accept_lang.split('-').first)
+           end
+
+    lang
+  end
+
+  def default_language
+    Setting.default_language
+  end
+
+  # qvalues http header parser
+  # code taken from webrick
+  def parse_qvalues(value)
+    tmp = []
+    if value
+      parts = value.split(/,\s*/)
+      parts.each do |part|
+        match = /\A([^\s,]+?)(?:;\s*q=(\d+(?:\.\d+)?))?\z/.match(part)
+        if match
+          val = match[1]
+          q = (match[2] || 1).to_f
+          tmp.push([val, q])
+        end
+      end
+      tmp = tmp.sort_by { |_val, q| -q }
+      tmp.map! { |val, _q| val }
+    end
+    return tmp
+  rescue
+    nil
+  end
+end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -89,6 +89,10 @@ module API
         end
       end
 
+      def set_localization
+        SetLocalizationService.new(User.current, env['HTTP_ACCEPT_LANGUAGE']).perform
+      end
+
       def logged_in?
         # An admin SystemUser is anonymous but still a valid user to be logged in.
         current_user && (current_user.admin? || !current_user.anonymous?)
@@ -178,6 +182,7 @@ module API
     # run authentication before each request
     before do
       authenticate
+      set_localization
     end
 
     version 'v3', using: :path do

--- a/spec/requests/api/v3/locale_spec.rb
+++ b/spec/requests/api/v3/locale_spec.rb
@@ -1,0 +1,77 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+# This takes the schema endpoint to test localization as there
+# are localized strings in the response.
+
+describe 'API localization', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { FactoryGirl.create(:project) }
+  let(:type) { FactoryGirl.create(:type) }
+  let(:schema_path) { api_v3_paths.work_package_schema project.id, type.id }
+  let(:current_user) { FactoryGirl.build(:user, member_in_project: project, language: :fr) }
+
+  describe 'GET /api/v3/work_packages/schemas/:id' do
+    before do
+      allow(User).to receive(:current).and_return(current_user)
+    end
+
+    context 'with the user having selected a language' do
+      before do
+        get schema_path
+      end
+
+      it "responds in the user's locale" do
+        expected_i18n = WorkPackage.human_attribute_name(:subject,
+                                                         locale: current_user.language).to_json
+
+        expect(last_response.body).to be_json_eql(expected_i18n).at_path('subject/name')
+      end
+    end
+
+    context 'when sending a header and not having a language selected' do
+      before do
+        current_user.language = nil
+
+        header 'ACCEPT_LANGUAGE', 'de,en-US;q=0.8,en;q=0.6'
+        get schema_path
+      end
+
+      it "responds in the user's locale" do
+        expected_i18n = WorkPackage.human_attribute_name(:subject, locale: 'de').to_json
+
+        expect(last_response.body).to be_json_eql(expected_i18n).at_path('subject/name')
+      end
+    end
+  end
+end

--- a/spec/services/set_localization_service_spec.rb
+++ b/spec/services/set_localization_service_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe SetLocalizationService do
+  let(:user) { FactoryGirl.build_stubbed(:user, language: user_language) }
+  let(:http_accept_header) { "#{http_accept_language},en-US;q=0.8,en;q=0.6" }
+  let(:instance) { described_class.new(user, http_accept_header) }
+  let(:user_language) { :bogus_language }
+  let(:http_accept_language) { :http_accept_language }
+  let(:default_language) { :default_language }
+
+  before do
+    allow(I18n).to receive(:locale=).with(:en)
+    allow(instance).to receive(:valid_languages).and_return [user_language,
+                                                             http_accept_language,
+                                                             default_language]
+    allow(Setting).to receive(:default_language).and_return(default_language)
+  end
+
+  def expect_locale(locale)
+    expect(I18n).to receive(:locale=).with(locale)
+  end
+
+  shared_examples_for 'falls back to the header' do
+    it 'falls back to the header' do
+      expect_locale(http_accept_language)
+
+      instance.perform
+    end
+  end
+
+  shared_examples_for "falls back to the instane's default language" do
+    it "falls back to the instance's default language" do
+      expect_locale(default_language)
+
+      instance.perform
+    end
+  end
+
+  context 'for a logged in user' do
+    it "sets the language to the user's selected language" do
+      expect_locale(user_language)
+
+      instance.perform
+    end
+
+    context 'with the language not being valid' do
+      before do
+        allow(instance).to receive(:valid_languages).and_return [http_accept_language,
+                                                                 default_language]
+      end
+
+      it_behaves_like 'falls back to the header'
+    end
+
+    context 'with the user not having a language selected' do
+      before do
+        user.language = nil
+      end
+
+      it_behaves_like 'falls back to the header'
+
+      context 'with the header not being valid' do
+        before do
+          allow(instance).to receive(:valid_languages).and_return [user_language,
+                                                                   default_language]
+        end
+
+        it_behaves_like "falls back to the instane's default language"
+      end
+
+      context 'with no header set' do
+        let(:http_accept_header) { nil }
+
+        it_behaves_like "falls back to the instane's default language"
+      end
+    end
+  end
+
+  context 'for an anonymous user' do
+    let(:user) { FactoryGirl.build_stubbed(:anonymous) }
+
+    it_behaves_like 'falls back to the header'
+
+    context 'with no header set' do
+      let(:http_accept_header) { nil }
+
+      it_behaves_like "falls back to the instane's default language"
+    end
+  end
+end


### PR DESCRIPTION
The mechanism was extracted from the rails stack where the locale is
taken based on (in that order):
- The user's preferences
- The accept_language header
- The system settings

Only languages, that are enabled by the instance are valid. If one is
selected (e.g user preference), that is not enabled by the instance, a
fallback is taken.

https://community.openproject.org/work_packages/21219
