### PR TITLE
Add better contextual view hooks to navigation and empty view

### DIFF
--- a/app/views/repositories/_navigation.html.erb
+++ b/app/views/repositories/_navigation.html.erb
@@ -40,6 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% end %>
   </li>
   <% end %>
+  <%= call_hook(:repositories_navigation_toolbar, { repository: @repository, project: @project }) %>
   <% if User.current.allowed_to?(:manage_repository, @project) %>
     <li class="toolbar-item">
       <%= link_to settings_project_path(@project, tab: 'repository') , class: 'button' do %>

--- a/app/views/repositories/empty.html.erb
+++ b/app/views/repositories/empty.html.erb
@@ -35,3 +35,5 @@ See doc/COPYRIGHT.rdoc for more details.
 </div>
 <%= call_hook(:view_repositories_show_contextual,
     { repository: @repository, project: @project }) %>
+<%= call_hook(:repositories_below_empty_warning,
+    { repository: @repository, project: @project }) %>


### PR DESCRIPTION
This commit adds distinguishable view hooks for plugins wanting
to:
- Add a toolbar item to the repository navigation
- Show contextual information specifically on the empty repository
  screen
