### PR TITLE
[20248] Display errors in the WP details pane via NotificationsService

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -166,6 +166,7 @@ en:
     label_wait: "Please wait for configuration..."
     label_upload_counter: "%{done} of %{count} files finished"
     label_successful_update: 'Successful update'
+    label_validation_error: "The work package could not be saved due to the following errors:"
 
 
     text_are_you_sure: "Are you sure?"

--- a/frontend/app/services/notifications-service.js
+++ b/frontend/app/services/notifications-service.js
@@ -27,7 +27,7 @@
 //++
 
 module.exports = function(I18n, $rootScope) {
-
+  'use strict';
   // private
   var createNotification = function(message) {
     if(typeof message === 'string') {

--- a/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
+++ b/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
@@ -3,10 +3,6 @@
       <div class="inplace-edit--write-value" ng-include="templateUrl" ng-click="editPaneController.markActive()" tabindex="-1">
       </div>
     <div class="inplace-edit--dashboard">
-      <div class="inplace-edit--errors" ng-show="editPaneController.error">
-        <i class="icon-attention2 inplace-edit--errors--icon"></i>
-        <div class="inplace-edit--errors--text" ng-bind="editPaneController.error" role="alert" aria-live="polite"></div>
-      </div>
       <div class="inplace-edit--controls" ng-hide="fieldController.state.isBusy || !editPaneController.isActive()">
         <accessible-by-keyboard execute="editPaneController.submit(false)" class="inplace-edit--control inplace-edit--control--save">
           <icon-wrapper icon-name="yes" icon-title="{{ editPaneController.saveTitle }}">

--- a/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
@@ -32,7 +32,20 @@ module.exports = function(
   FocusHelper,
   $timeout,
   ApiHelper,
-  $rootScope) {
+  $rootScope,
+  NotificationsService,
+  I18n) {
+  'use strict';
+
+  var showErrors = function() {
+    var errors  = EditableFieldsState.errors;
+    if (_.isEmpty(_.keys(errors))) {
+      return;
+    }
+    var errorMessages = _.map(errors);
+    NotificationsService.addError(I18n.t('js.label_validation_error'), errorMessages);
+  };
+
   return {
     transclude: true,
     replace: true,
@@ -42,7 +55,6 @@ module.exports = function(
     controllerAs: 'editPaneController',
     controller: function($scope, WorkPackageService) {
       var vm = this;
-      var acknowledgedValidationErrors = ['required', 'number'];
 
       // go full retard
       var uploadPendingAttachments = function(wp) {
@@ -52,9 +64,10 @@ module.exports = function(
       this.submit = function(notify) {
         var fieldController = $scope.fieldController;
         var pendingFormChanges = getPendingFormChanges();
+        var detectedViolations = [];
         pendingFormChanges[fieldController.field] = fieldController.writeValue;
         if (vm.editForm.$invalid) {
-          var detectedViolations = [];
+          var acknowledgedValidationErrors = Object.keys(vm.editForm.$error);
           acknowledgedValidationErrors.forEach(function(error) {
             if (vm.editForm.$error[error]) {
               detectedViolations.push(I18n.t('js.inplace.errors.' + error, {
@@ -62,47 +75,48 @@ module.exports = function(
               }));
             }
           });
-          if (detectedViolations.length) {
-            EditableFieldsState.errors = EditableFieldsState.errors || {};
-            EditableFieldsState.errors[fieldController.field] = detectedViolations.join(' ');
-            return false;
-          }
         }
-        fieldController.state.isBusy = true;
-        WorkPackageService.loadWorkPackageForm(EditableFieldsState.workPackage).then(
-          function(form) {
-            EditableFieldsState.workPackage.form = form;
-            if (_.isEmpty(form.embedded.validationErrors.props)) {
-              var result = WorkPackageService.updateWorkPackage(
-                EditableFieldsState.workPackage,
-                notify
-              );
-              result.then(angular.bind(this, function(updatedWorkPackage) {
-                $scope.$emit('workPackageUpdatedInEditor', updatedWorkPackage);
-                $scope.$emit(
-                  'workPackageRefreshRequired',
-                  function() {
-                    fieldController.state.isBusy = false;
-                    fieldController.isEditing = false;
-                    fieldController.updateWriteValue();
-                    EditableFieldsState.errors = null;
-                  }
+        if (detectedViolations.length) {
+          EditableFieldsState.errors = EditableFieldsState.errors || {};
+          EditableFieldsState.errors[fieldController.field] = detectedViolations.join(' ');
+          showErrors();
+        } else {
+          fieldController.state.isBusy = true;
+          WorkPackageService.loadWorkPackageForm(EditableFieldsState.workPackage).then(
+            function(form) {
+              EditableFieldsState.workPackage.form = form;
+              if (_.isEmpty(form.embedded.validationErrors.props)) {
+                var result = WorkPackageService.updateWorkPackage(
+                  EditableFieldsState.workPackage,
+                  notify
                 );
-                uploadPendingAttachments(updatedWorkPackage);
-              })).catch(setFailure);
-            } else {
-              afterError();
-              EditableFieldsState.errors = {};
-               _.forEach(form.embedded.validationErrors.props, function(error, field) {
-                if(field === 'startDate' || field === 'dueDate') {
-                  EditableFieldsState.errors['date'] = error.message;
-                } else {
-                  EditableFieldsState.errors[field] = error.message;
-                }
-              });
-            }
-          }).catch(setFailure);
-
+                result.then(angular.bind(this, function(updatedWorkPackage) {
+                  $scope.$emit('workPackageUpdatedInEditor', updatedWorkPackage);
+                  $scope.$emit(
+                    'workPackageRefreshRequired',
+                    function() {
+                      fieldController.state.isBusy = false;
+                      fieldController.isEditing = false;
+                      fieldController.updateWriteValue();
+                      EditableFieldsState.errors = null;
+                    }
+                  );
+                  uploadPendingAttachments(updatedWorkPackage);
+                })).catch(setFailure);
+              } else {
+                afterError();
+                EditableFieldsState.errors = {};
+                 _.forEach(form.embedded.validationErrors.props, function(error, field) {
+                  if(field === 'startDate' || field === 'dueDate') {
+                    EditableFieldsState.errors['date'] = error.message;
+                  } else {
+                    EditableFieldsState.errors[field] = error.message;
+                  }
+                });
+                showErrors();
+              }
+            }).catch(setFailure);
+        }
 
       };
 
@@ -214,18 +228,6 @@ module.exports = function(
       scope.$on('workPackageRefreshed', function() {
         scope.editPaneController.discardEditing();
       });
-      scope.$watch('editableFieldsState.errors', function(errors) {
-        scope.editPaneController.error = null;
-        if (!_.isEmpty(errors)) {
-          // uncomment when we are sure we can bind every message to every field
-          // scope
-          //  .editPaneController
-          //  .error = errors[scope.fieldController.field] || errors['_common'];
-          scope.editPaneController.error = _.map(errors, function(error) {
-            return error;
-          }).join('\n');
-        }
-      }, true);
 
       scope.$watch('fieldController.isEditing', function(isEditing) {
         if (isEditing && !EditableFieldsState.forcedEditState) {

--- a/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
@@ -114,7 +114,7 @@ module.exports = function(
                   }
                 });
               }
-            }).catch(setFailure).finally(showErrors);
+            }).catch(setFailure);
         }
 
       };
@@ -159,6 +159,7 @@ module.exports = function(
         EditableFieldsState.errors = {
           '_common': ApiHelper.getErrorMessage(e)
         };
+        showErrors();
       }
     },
     link: function(scope, element, attrs, fieldController) {

--- a/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
@@ -113,9 +113,8 @@ module.exports = function(
                     EditableFieldsState.errors[field] = error.message;
                   }
                 });
-                showErrors();
               }
-            }).catch(setFailure);
+            }).catch(setFailure).finally(showErrors);
         }
 
       };

--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -43,6 +43,9 @@ module.exports = function(
 
     var workPackage = scope.workPackage(),
         upload = function(event, workPackage) {
+          if (angular.isUndefined(scope.files)) {
+            return;
+          };
           if (scope.files.length > 0) {
             workPackageAttachmentsService.upload(workPackage, scope.files).then(function() {
               scope.files = [];

--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -45,7 +45,7 @@ module.exports = function(
         upload = function(event, workPackage) {
           if (angular.isUndefined(scope.files)) {
             return;
-          };
+          }
           if (scope.files.length > 0) {
             workPackageAttachmentsService.upload(workPackage, scope.files).then(function() {
               scope.files = [];

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -94,5 +94,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
     <div id="ajax-indicator" style="display:none;"><span>Loading...</span></div>
   </div>
+  <notifications></notifications>
 </body>
 </html>

--- a/frontend/tests/integration/mocks/work-packages/821.json
+++ b/frontend/tests/integration/mocks/work-packages/821.json
@@ -92,6 +92,9 @@
     },
     "schema": {
       "href": "/api/v3/work_packages/schemas/1-7"
+    },
+    "attachments": {
+      "href": "/api/v3/work_packages/821/attachments"
     }
   },
   "id": 821,

--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
@@ -63,11 +63,13 @@ describe('OpenProject', function(){
           subjectEditor(821).then(function(editor) {
             editor.$('.inplace-editing--trigger-link').click();
             editor.$('.inplace-edit--control--save a').click();
-
             return editor;
-          }).then(function(editor) {
-            expect(editor.$('.inplace-edit--errors').isDisplayed())
-              .to.eventually.be.true;
+          }).then(function() {
+            // damn those dirty ap.. i mean animations.
+            setTimeout(function() {
+              expect($('.notification-box.-error').isDisplayed())
+                .to.be.true;
+            }, 1000);
           });
         });
       });

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -60,11 +60,6 @@ shared_examples 'having a single validation point' do
     field.cancel_by_click
     other_field.cancel_by_click
   end
-
-  it 'displays validation for all inputs' do
-    expect(other_field.errors_element).to be_visible
-    expect(other_field.errors_text).to eq "#{property_title} cannot be empty"
-  end
 end
 
 shared_examples 'a required field' do
@@ -76,11 +71,6 @@ shared_examples 'a required field' do
 
   after do
     field.cancel_by_click
-  end
-
-  it 'displays a required validation' do
-    expect(field.errors_element).to be_visible
-    expect(field.errors_text).to eq "#{property_title} cannot be empty"
   end
 end
 


### PR DESCRIPTION
This PR is a recreation of the original PR (which went against `release/4.3` which is obsolete now).

The original PR can be found at #3279 .

Original PR Text:

---

This will change the current errors (which are attached to the the individual field at the moment) into a notification provided by the previously introduced `NotificationsService`.

This Pr will thereby meet the requirements for https://community.openproject.org/work_packages/20248.
## Things left to do/discuss
- [x] Accessibility - I think the plan from the specification might or might not work (currently, the focus stays with the erroneous field
- [x] "continue editing" - see above

Addendum: both discussions have been resolved in the original PR.
## Out of scope
- "Create another WP like this" functionality in successful updates and/or after successful creation
