### PR TITLE
Pass user_id instead of whole User model object in DeleteUserJob

### DIFF
--- a/app/services/delete_user_service.rb
+++ b/app/services/delete_user_service.rb
@@ -39,7 +39,7 @@ class DeleteUserService < Struct.new :user, :actor
       # as destroying users is a lengthy process we handle it in the background
       # and lock the account now so that no action can be performed with it
       user.lock!
-      Delayed::Job.enqueue DeleteUserJob.new(user)
+      Delayed::Job.enqueue DeleteUserJob.new(user.id)
 
       logout! if self_delete?
 

--- a/app/workers/delete_user_job.rb
+++ b/app/workers/delete_user_job.rb
@@ -28,8 +28,8 @@
 #++
 
 class DeleteUserJob
-  def initialize(user)
-    @user_id = user.id
+  def initialize(user_id)
+    @user_id = user_id
   end
 
   def perform


### PR DESCRIPTION
There is no sense in saving whole active record in favor of an id in DeleteUserJob.
