### PR TITLE
update syck

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       railties (~> 3.0)
     structured_warnings (0.1.4)
     svg-graph (1.0.5)
-    syck (1.0.1)
+    syck (1.0.5)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)


### PR DESCRIPTION
Syck `1.0.1` doesn't build for me on Ubuntu 15.04. `1.0.5` on the other hand works just fine.
