### PR TITLE
[21289] Notification box overlaps login menu

### DIFF
--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -97,6 +97,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
 
 .notification-box
   @extend %notification
+  z-index: 21
   +notification-layout($x: left, $y: top, $size: auto, $offset: rem-calc(0))
   +notification-style($background: $nm-color-background, $color: $nm-font-color, $padding: $nm-padding-box, $radius: $nm-border-radius)
   .notification-icon

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -44,7 +44,7 @@
   height: $header-height
   width: 100%
   padding: 0
-  z-index: 21
+  z-index: 22
   position: relative
   border-bottom: $header-border-bottom-width solid $header-border-bottom-color
 


### PR DESCRIPTION
decreased the z-index of the notification box to position it behind the top menu

https://community.openproject.org/work_packages/21289
