### PR TITLE
Feature/git smart http

### DIFF
--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -91,19 +91,41 @@ class SysController < ActionController::Base
   end
 
   def repo_auth
-    @project = Project.find_by(identifier: params[:repository])
-
-    if (%w(GET PROPFIND REPORT OPTIONS).include?(params[:method]) &&
-        @authenticated_user.allowed_to?(:browse_repository, @project)) ||
-       @authenticated_user.allowed_to?(:commit_access, @project)
+    project = Project.find_by(identifier: params[:repository])
+    if authorized?(project, @authenticated_user)
       render text: 'Access granted'
-      return
+    else
+      render text: 'Not allowed', status: 403 # default to deny
     end
-
-    render text: 'Not allowed', status: 403 # default to deny
   end
 
-  protected
+  private
+
+  def authorized?(project, user)
+    if git_auth?
+      authorized_with_git?(project, user, params[:uri], params[:location])
+    else
+      authorized_with_subversion?(project, user, params[:method])
+    end
+  end
+
+  def git_auth?
+    params[:git_smart_http] == '1'
+  end
+
+  def authorized_with_git?(project, user, uri, location)
+    read_only = !%r{^#{location}/*[^/]+/+(info/refs\?service=)?git\-receive\-pack$}o.match(uri)
+
+    (read_only && user.allowed_to?(:browse_repository, project)) ||
+      user.allowed_to?(:commit_access, project)
+  end
+
+  def authorized_with_subversion?(project, user, method)
+    read_only = %w(GET PROPFIND REPORT OPTIONS).include?(method)
+
+    (read_only && user.allowed_to?(:browse_repository, project)) ||
+      user.allowed_to?(:commit_access, project)
+  end
 
   def check_enabled
     User.current = nil

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -99,6 +99,10 @@ class Repository < ActiveRecord::Base
     @scm
   end
 
+  def self.authorization_policy
+    nil
+  end
+
   def self.scm_config
     scm_adapter_class.config
   end

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -84,6 +84,10 @@ class Repository::Git < Repository
     'UTF-8'
   end
 
+  def self.authorization_policy
+    ::Scm::GitAuthorizationPolicy
+  end
+
   # Returns the identifier for the given git changeset
   def self.changeset_identifier(changeset)
     changeset.scmid

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -51,6 +51,10 @@ class Repository::Subversion < Repository
     end
   end
 
+  def self.authorization_policy
+    ::Scm::SubversionAuthorizationPolicy
+  end
+
   def self.permitted_params(params)
     super(params).merge(params.permit(:login, :password))
   end

--- a/app/policies/scm/authorization_policy.rb
+++ b/app/policies/scm/authorization_policy.rb
@@ -1,0 +1,72 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This capsulates permissions a user has for a work package.  It caches based
+# on the work package's project and is thus optimized for the context menu.
+#
+# This is no conern but it was placed here so that it will be removed together
+# with the rest of the experimental API.
+
+class Scm::AuthoriziationPolicy
+  attr_reader :project, :user
+
+  def initialize(project, user)
+    @user = user
+    @project = project
+  end
+
+  ##
+  # Determines the authorization status for the user of this project
+  # for a given repository request.
+  # May be overridden by descendents when more than the read/write distinction
+  # is necessary.
+  def authorized?(params)
+    (readonly_request?(params) && read_access?) || write_access?
+  end
+
+  protected
+
+  ##
+  # Determines whether the given request is a read access
+  # Must be implemented by descendents of this policy.
+  def readonly_request?(_params)
+    raise NotImplementedError
+  end
+
+  ##
+  # Returns whether the user has read access permission to the repository
+  def read_access?
+    user.allowed_to?(:browse_repository, project)
+  end
+
+  ##
+  # Returns whether the user has read/write access permission to the repository
+  def write_access?
+    user.allowed_to?(:commit_access, project)
+  end
+end

--- a/app/policies/scm/git_authorization_policy.rb
+++ b/app/policies/scm/git_authorization_policy.rb
@@ -1,0 +1,44 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This capsulates permissions a user has for a work package.  It caches based
+# on the work package's project and is thus optimized for the context menu.
+#
+# This is no conern but it was placed here so that it will be removed together
+# with the rest of the experimental API.
+
+class Scm::GitAuthorizationPolicy < Scm::AuthoriziationPolicy
+  private
+
+  def readonly_request?(params)
+    uri = params[:uri]
+    location = params[:location]
+
+    !%r{^#{location}/*[^/]+/+(info/refs\?service=)?git\-receive\-pack$}o.match(uri)
+  end
+end

--- a/app/policies/scm/git_authorization_policy.rb
+++ b/app/policies/scm/git_authorization_policy.rb
@@ -32,6 +32,7 @@
 # This is no conern but it was placed here so that it will be removed together
 # with the rest of the experimental API.
 
+require 'scm/authorization_policy'
 class Scm::GitAuthorizationPolicy < Scm::AuthoriziationPolicy
   private
 

--- a/app/policies/scm/subversion_authorization_policy.rb
+++ b/app/policies/scm/subversion_authorization_policy.rb
@@ -32,6 +32,7 @@
 # This is no conern but it was placed here so that it will be removed together
 # with the rest of the experimental API.
 
+require 'scm/authorization_policy'
 class Scm::SubversionAuthorizationPolicy < Scm::AuthoriziationPolicy
   private
 

--- a/app/policies/scm/subversion_authorization_policy.rb
+++ b/app/policies/scm/subversion_authorization_policy.rb
@@ -1,0 +1,42 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# This capsulates permissions a user has for a work package.  It caches based
+# on the work package's project and is thus optimized for the context menu.
+#
+# This is no conern but it was placed here so that it will be removed together
+# with the rest of the experimental API.
+
+class Scm::SubversionAuthorizationPolicy < Scm::AuthoriziationPolicy
+  private
+
+  def readonly_request?(params)
+    method = params[:method]
+    %w(GET PROPFIND REPORT OPTIONS).include?(method)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -514,6 +514,7 @@ OpenProject::Application.routes.draw do
   end
 
   scope controller: 'sys' do
+    match '/sys/repo_auth', action: 'repo_auth', via: [:get, :post]
     match '/sys/projects.:format', action: 'projects', via: :get
     match '/sys/projects/:id/repository/update_storage', action: 'update_required_storage', via: :get
     match '/sys/projects/:id/repository.:format', action: 'create_project_repository', via: :post

--- a/doc/subversion_and_git_integration.md
+++ b/doc/subversion_and_git_integration.md
@@ -41,7 +41,7 @@ All things in that repository should be accessible by the apache system user and
 We provide an example apache configuration. Some details are explained inline as comments.
 
     # Load OpenProject per module used to authenticate requests against the user database.
-    # Be sure that the OpenProjectAuthentication.pm script in located in your perl path.
+    # Be sure that the OpenProjectAuthentication.pm script is located in your perl path.
     PerlSwitches -I/srv/www/perl-lib -T
     PerlLoadModule Apache::OpenProjectAuthentication
     

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -69,7 +69,7 @@ module OpenProject
         ##
         # Create a bare repository for the current path
         def initialize_bare_git
-          capture_git(%w[init --bare])
+          capture_git(%w[init --bare --shared])
         end
 
         ##

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -28,208 +28,568 @@
 
 require 'spec_helper'
 
-module OpenProjectRepositoryAuthenticationSpecs
-  describe SysController, type: :controller do
-    let(:commit_role) {
-      FactoryGirl.create(:role, permissions: [:commit_access,
-                                              :browse_repository])
+describe SysController, type: :controller do
+  let(:commit_role) {
+    FactoryGirl.create(:role, permissions: [:commit_access,
+                                            :browse_repository])
+  }
+  let(:browse_role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
+  let(:guest_role) { FactoryGirl.create(:role, permissions: []) }
+  let(:valid_user_password) { 'Top Secret Password' }
+  let(:valid_user) {
+    FactoryGirl.create(:user,
+                       login: 'johndoe',
+                       password: valid_user_password,
+                       password_confirmation: valid_user_password)
+  }
+
+  before(:each) do
+    FactoryGirl.create(:non_member, permissions: [:browse_repository])
+    DeletedUser.first # creating it first in order to avoid problems with should_receive
+
+    random_project = FactoryGirl.create(:project, is_public: false)
+    @member = FactoryGirl.create(:member,
+                                 user: valid_user,
+                                 roles: [browse_role],
+                                 project: random_project)
+    allow(Setting).to receive(:sys_api_key).and_return('12345678')
+    allow(Setting).to receive(:sys_api_enabled?).and_return(true)
+    allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(true)
+  end
+
+  describe 'svn' do
+    describe 'repo_auth' do
+      context 'for valid login, but no access to repo_auth' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: 'without-access',
+               method: 'GET'
+        end
+
+        it 'should respond 403 not allowed' do
+          expect(response.code).to eq('403')
+          expect(response.body).to eq('Not allowed')
+        end
+      end
+
+      context 'for valid login and user has read permission (role reporter) for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [browse_role],
+                                       project: @project)
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+        end
+
+        it 'should respond 200 okay dokay for GET' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET'
+
+          expect(response.code).to eq('200')
+        end
+
+        it 'should respond 403 not allowed for POST' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'POST'
+
+          expect(response.code).to eq('403')
+        end
+      end
+
+      context 'for valid login and user has rw permission (role developer) for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [commit_role],
+                                       project: @project)
+          valid_user.save
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+        end
+
+        it 'should respond 200 okay dokay for GET' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET'
+
+          expect(response.code).to eq('200')
+        end
+
+        it 'should respond 200 okay dokay for POST' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'POST'
+
+          expect(response.code).to eq('200')
+        end
+      end
+
+      context 'for invalid login and user has role manager for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [commit_role],
+                                       project: @project)
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password + 'made invalid'
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET'
+        end
+
+        it 'should respond 401 auth required' do
+          expect(response.code).to eq('401')
+        end
+      end
+
+      context 'for valid login and user is not member for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET'
+        end
+
+        it 'should respond 403 not allowed' do
+          expect(response.code).to eq('403')
+        end
+      end
+
+      context 'for valid login and project is public' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: true)
+
+          random_project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [browse_role],
+                                       project: random_project)
+
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET'
+        end
+
+        it 'should respond 200 OK' do
+          expect(response.code).to eq('200')
+        end
+      end
+
+      context 'for invalid credentials' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET'
+        end
+
+        it 'should respond 401 auth required' do
+          expect(response.code).to eq('401')
+          expect(response.body).to eq('Authorization required')
+        end
+      end
+
+      context 'for invalid api key' do
+        before(:each) do
+          @key = 'invalid'
+        end
+
+        it 'should respond 403 for valid username/password' do
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET'
+
+          expect(response.code).to eq('403')
+          expect(response.body)
+            .to eq('Access denied. Repository management WS is disabled or key is invalid.')
+        end
+
+        it 'should respond 403 for invalid username/password' do
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              'invalid',
+              'invalid'
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET'
+
+          expect(response.code).to eq('403')
+          expect(response.body)
+            .to eq('Access denied. Repository management WS is disabled or key is invalid.')
+        end
+      end
+    end
+  end
+
+  describe 'git' do
+    describe 'repo_auth' do
+      context 'for valid login, but no access to repo_auth' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: 'without-access',
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+        end
+
+        it 'should respond 403 not allowed' do
+          expect(response.code).to eq('403')
+          expect(response.body).to eq('Not allowed')
+        end
+      end
+
+      context 'for valid login and user has read permission (role reporter) for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [browse_role],
+                                       project: @project)
+
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+        end
+
+        it 'should respond 200 okay dokay for read-only access' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+
+          expect(response.code).to eq('200')
+        end
+
+        it 'should respond 403 not allowed for write (push)' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'POST',
+               git_smart_http: '1',
+               uri: "/git/#{@project.identifier}/git-receive-pack",
+               location: '/git'
+
+          expect(response.code).to eq('403')
+        end
+      end
+
+      context 'for valid login and user has rw permission (role developer) for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [commit_role],
+                                       project: @project)
+          valid_user.save
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+        end
+
+        it 'should respond 200 okay dokay for GET' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+
+          expect(response.code).to eq('200')
+        end
+
+        it 'should respond 200 okay dokay for POST' do
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'POST',
+               git_smart_http: '1',
+               uri: "/git/#{@project.identifier}/git-receive-pack",
+               location: '/git'
+
+          expect(response.code).to eq('200')
+        end
+      end
+
+      context 'for invalid login and user has role manager for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [commit_role],
+                                       project: @project)
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password + 'made invalid'
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+        end
+
+        it 'should respond 401 auth required' do
+          expect(response.code).to eq('401')
+        end
+      end
+
+      context 'for valid login and user is not member for project' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: false)
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+        end
+
+        it 'should respond 403 not allowed' do
+          expect(response.code).to eq('403')
+        end
+      end
+
+      context 'for valid login and project is public' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          @project = FactoryGirl.create(:project, is_public: true)
+
+          random_project = FactoryGirl.create(:project, is_public: false)
+          @member = FactoryGirl.create(:member,
+                                       user: valid_user,
+                                       roles: [browse_role],
+                                       project: random_project)
+
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+          post 'repo_auth',
+               key: @key,
+               repository: @project.identifier,
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+        end
+
+        it 'should respond 200 OK' do
+          expect(response.code).to eq('200')
+        end
+      end
+
+      context 'for invalid credentials' do
+        before(:each) do
+          @key = Setting.sys_api_key
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+        end
+
+        it 'should respond 401 auth required' do
+          expect(response.code).to eq('401')
+          expect(response.body).to eq('Authorization required')
+        end
+      end
+
+      context 'for invalid api key' do
+        before(:each) do
+          @key = 'invalid'
+        end
+
+        it 'should respond 403 for valid username/password' do
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              valid_user.login,
+              valid_user_password
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+
+          expect(response.code).to eq('403')
+          expect(response.body)
+            .to eq('Access denied. Repository management WS is disabled or key is invalid.')
+        end
+
+        it 'should respond 403 for invalid username/password' do
+          request.env['HTTP_AUTHORIZATION'] =
+            ActionController::HttpAuthentication::Basic.encode_credentials(
+              'invalid',
+              'invalid'
+            )
+
+          post 'repo_auth',
+               key: @key,
+               repository: 'any-repo',
+               method: 'GET',
+               git_smart_http: '1',
+               uri: '/git',
+               location: '/git'
+
+          expect(response.code).to eq('403')
+          expect(response.body)
+            .to eq('Access denied. Repository management WS is disabled or key is invalid.')
+        end
+      end
+    end
+  end
+
+  before(:each) do
+    Rails.cache.clear
+    allow(Rails.cache).to receive(:kind_of?).with(anything).and_return(false)
+  end
+
+  describe '#cached_user_login' do
+    let(:cache_key) {
+      OpenProject::RepositoryAuthentication::CACHE_PREFIX +
+        Digest::SHA1.hexdigest("#{valid_user.login}#{valid_user_password}")
     }
-    let(:browse_role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
-    let(:guest_role) { FactoryGirl.create(:role, permissions: []) }
-    let(:valid_user_password) { 'Top Secret Password' }
-    let(:valid_user) {
-      FactoryGirl.create(:user,
-                         login: 'johndoe',
-                         password: valid_user_password,
-                         password_confirmation: valid_user_password)
-    }
+    let(:cache_expiry) { OpenProject::RepositoryAuthentication::CACHE_EXPIRES_AFTER }
 
-    before(:each) do
-      FactoryGirl.create(:non_member, permissions: [:browse_repository])
-      DeletedUser.first # creating it first in order to avoid problems with should_receive
-
-      random_project = FactoryGirl.create(:project, is_public: false)
-      @member = FactoryGirl.create(:member,
-                                   user: valid_user,
-                                   roles: [browse_role],
-                                   project: random_project)
-      allow(Setting).to receive(:sys_api_key).and_return('12345678')
-      allow(Setting).to receive(:sys_api_enabled?).and_return(true)
-      allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(true)
+    it 'should call user_login only once when called twice' do
+      expect(controller).to receive(:user_login).once.and_return(valid_user)
+      2.times { controller.send(:cached_user_login, valid_user.login, valid_user_password) }
     end
 
-    describe '#repo_auth', 'for valid login, but no access to repo_auth' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-        post 'repo_auth', key: @key, repository: 'without-access', method: 'GET'
-      end
-
-      it 'should respond 403 not allowed' do
-        expect(response.code).to eq('403')
-        expect(response.body).to eq('Not allowed')
-      end
+    it 'should return the same as user_login for valid creds' do
+      expect(controller.send(:cached_user_login, valid_user.login, valid_user_password))
+        .to eq(controller.send(:user_login, valid_user.login, valid_user_password))
     end
 
-    describe '#repo_auth', 'for valid login and user has browse repository permission (role reporter) for project' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        @project = FactoryGirl.create(:project, is_public: false)
-        @member = FactoryGirl.create(:member,
-                                     user: valid_user,
-                                     roles: [browse_role],
-                                     project: @project)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-      end
-
-      it 'should respond 200 okay dokay for GET' do
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'GET'
-        expect(response.code).to eq('200')
-      end
-
-      it 'should respond 403 not allowed for POST' do
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'POST'
-        expect(response.code).to eq('403')
-      end
+    it 'should return the same as user_login for invalid creds' do
+      expect(controller.send(:cached_user_login, 'invalid', 'invalid'))
+        .to eq(controller.send(:user_login, 'invalid', 'invalid'))
     end
 
-    describe '#repo_auth', 'for valid login and user has commit access permission (role developer) for project' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        @project = FactoryGirl.create(:project, is_public: false)
-        @member = FactoryGirl.create(:member,
-                                     user: valid_user,
-                                     roles: [commit_role],
-                                     project: @project)
-        valid_user.save
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-      end
+    it 'should use cache' do
+      # allow the cache to return something reasonable for
+      # other requests, while ensuring that it is not queried
+      # with the cache key in question
 
-      it 'should respond 200 okay dokay for GET' do
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'GET'
-        expect(response.code).to eq('200')
-      end
+      # unfortunately, and_call_original currently fails
+      allow(Rails.cache).to receive(:fetch) do |*args|
+        expect(args.first).not_to eq(cache_key)
 
-      it 'should respond 200 okay dokay for POST' do
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'POST'
-        expect(response.code).to eq('200')
+        name = args.first.split('/').last
+        Marshal.dump(Setting.send(:find_or_default, name).value)
       end
+      # Rails.cache.should_receive(:fetch).with(anything).and_call_original
+      expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: cache_expiry) \
+        .and_return(Marshal.dump(valid_user.id.to_s))
+      controller.send(:cached_user_login, valid_user.login, valid_user_password)
     end
 
-    describe '#repo_auth', 'for invalid login and user has role manager for project' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        @project = FactoryGirl.create(:project, is_public: false)
-        @member = FactoryGirl.create(:member,
-                                     user: valid_user,
-                                     roles: [commit_role],
-                                     project: @project)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password + 'made invalid')
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'GET'
+    describe 'with caching disabled' do
+      before do
+        allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(false)
       end
 
-      it 'should respond 401 auth required' do
-        expect(response.code).to eq('401')
-      end
-    end
-
-    describe '#repo_auth', 'for valid login and user is not member for project' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        @project = FactoryGirl.create(:project, is_public: false)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'GET'
-      end
-
-      it 'should respond 403 not allowed' do
-        expect(response.code).to eq('403')
-      end
-    end
-
-    describe '#repo_auth', 'for valid login and project is public' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        @project = FactoryGirl.create(:project, is_public: true)
-
-        random_project = FactoryGirl.create(:project, is_public: false)
-        @member = FactoryGirl.create(:member,
-                                     user: valid_user,
-                                     roles: [browse_role],
-                                     project: random_project)
-
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-        post 'repo_auth', key: @key, repository: @project.identifier, method: 'GET'
-      end
-
-      it 'should respond 200 OK' do
-        expect(response.code).to eq('200')
-      end
-    end
-
-    describe '#repo_auth', 'for invalid credentials' do
-      before(:each) do
-        @key = Setting.sys_api_key
-        post 'repo_auth', key: @key, repository: 'any-repo', method: 'GET'
-      end
-
-      it 'should respond 401 auth required' do
-        expect(response.code).to eq('401')
-        expect(response.body).to eq('Authorization required')
-      end
-    end
-
-    describe '#repo_auth', 'for invalid api key' do
-      before(:each) do
-        @key = 'invalid'
-      end
-
-      it 'should respond 403 for valid username/password' do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(valid_user.login, valid_user_password)
-        post 'repo_auth', key: @key, repository: 'any-repo', method: 'GET'
-        expect(response.code).to eq('403')
-        expect(response.body).to eq('Access denied. Repository management WS is disabled or key is invalid.')
-      end
-
-      it 'should respond 403 for invalid username/password' do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('invalid', 'invalid')
-        post 'repo_auth', key: @key, repository: 'any-repo', method: 'GET'
-        expect(response.code).to eq('403')
-        expect(response.body).to eq('Access denied. Repository management WS is disabled or key is invalid.')
-      end
-    end
-
-    before(:each) do
-      Rails.cache.clear
-      allow(Rails.cache).to receive(:kind_of?).with(anything).and_return(false)
-    end
-
-    describe '#cached_user_login' do
-      let(:cache_key) {
-        OpenProject::RepositoryAuthentication::CACHE_PREFIX +
-          Digest::SHA1.hexdigest("#{valid_user.login}#{valid_user_password}")
-      }
-      let(:cache_expiry) { OpenProject::RepositoryAuthentication::CACHE_EXPIRES_AFTER }
-
-      it 'should call user_login only once when called twice' do
-        expect(controller).to receive(:user_login).once.and_return(valid_user)
-        2.times { controller.send(:cached_user_login, valid_user.login, valid_user_password) }
-      end
-
-      it 'should return the same as user_login for valid creds' do
-        expect(controller.send(:cached_user_login, valid_user.login, valid_user_password))
-          .to eq(controller.send(:user_login, valid_user.login, valid_user_password))
-      end
-
-      it 'should return the same as user_login for invalid creds' do
-        expect(controller.send(:cached_user_login, 'invalid', 'invalid'))
-          .to eq(controller.send(:user_login, 'invalid', 'invalid'))
-      end
-
-      it 'should use cache' do
+      it 'should not use a cache' do
         # allow the cache to return something reasonable for
         # other requests, while ensuring that it is not queried
         # with the cache key in question
-
+        #
         # unfortunately, and_call_original currently fails
         allow(Rails.cache).to receive(:fetch) do |*args|
           expect(args.first).not_to eq(cache_key)
@@ -237,32 +597,8 @@ module OpenProjectRepositoryAuthenticationSpecs
           name = args.first.split('/').last
           Marshal.dump(Setting.send(:find_or_default, name).value)
         end
-        # Rails.cache.should_receive(:fetch).with(anything).and_call_original
-        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: cache_expiry) \
-          .and_return(Marshal.dump(valid_user.id.to_s))
+
         controller.send(:cached_user_login, valid_user.login, valid_user_password)
-      end
-
-      describe 'with caching disabled' do
-        before do
-          allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(false)
-        end
-
-        it 'should not use a cache' do
-          # allow the cache to return something reasonable for
-          # other requests, while ensuring that it is not queried
-          # with the cache key in question
-          #
-          # unfortunately, and_call_original currently fails
-          allow(Rails.cache).to receive(:fetch) do |*args|
-            expect(args.first).not_to eq(cache_key)
-
-            name = args.first.split('/').last
-            Marshal.dump(Setting.send(:find_or_default, name).value)
-          end
-
-          controller.send(:cached_user_login, valid_user.login, valid_user_password)
-        end
       end
     end
 


### PR DESCRIPTION
(This is https://github.com/opf/openproject/pull/1629, refactored and updated for dev

This PR extends `OpenProjectAuthentication.pm` to allow Git Smart HTTP of repositories from OpenProject with access through Apache, while authorization is largely identical to the subversion repositories.
### Original PR:

I'd like to see git supported in our authentication scripts (just like we support svn).

This PR aims to do that.

see: https://www.openproject.org/work_packages/14383
