### PR TITLE
Accessible translation

### DIFF
--- a/app/views/reportings/new.html.erb
+++ b/app/views/reportings/new.html.erb
@@ -55,7 +55,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </label>
 
       <% if User.current.impaired? %>
-        <%= f.select(:reporting_to_project_id, @reporting_to_project_candidates.collect { |p| [p.name, p.id] }) %>
+        <%= f.select(:reporting_to_project_id, @reporting_to_project_candidates.collect { |p| [p.name, p.id] }, no_label: true) %>
       <% else %>
         <%= select("reporting", :reporting_to_project_id,
                  options_for_select([]),

--- a/app/views/reportings/new.html.erb
+++ b/app/views/reportings/new.html.erb
@@ -55,7 +55,9 @@ See doc/COPYRIGHT.rdoc for more details.
       </label>
 
       <% if User.current.impaired? %>
-        <%= f.select(:reporting_to_project_id, @reporting_to_project_candidates.collect { |p| [p.name, p.id] }, no_label: true) %>
+        <%= f.select(:reporting_to_project_id,
+                     @reporting_to_project_candidates.collect { |p| [p.name, p.id] },
+                     no_label: true) %>
       <% else %>
         <%= select("reporting", :reporting_to_project_id,
                  options_for_select([]),


### PR DESCRIPTION
This fixes a seemingly missing translation for a string only occuring in accesibility mode.

https://community.openproject.org/work_packages/21181

As it turns out the translation is not missing, because the string is superfluous.

Thanks to @ulferts for teaching me about select, select2 and uiselect as well as their suitability regarding accessibility.
