### PR TITLE
Always require sys-filesystem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'date_validator', '~> 0.7.1'
 gem 'ruby-duration', '~> 3.2.0'
 
 # provide compatible filesystem information for available storage
-gem 'sys-filesystem', '~> 1.1.4', require: false
+gem 'sys-filesystem', '~> 1.1.4'
 
 # We rely on this specific version, which is the latest as of now (end of 2013),
 # because we have to apply to it a bugfix which could break things in other versions.

--- a/lib/open_project/storage.rb
+++ b/lib/open_project/storage.rb
@@ -27,7 +27,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'sys/filesystem'
 module OpenProject
   module Storage
     class << self
@@ -85,7 +84,7 @@ module OpenProject
       end
 
       def read_fs_info(dir)
-        stat = Sys::Filesystem.stat(dir)
+        stat = ::Sys::Filesystem.stat(dir)
 
         {
           dir: dir,


### PR DESCRIPTION
There seems to be a load issue regarding sys-filesytem
on some travis runs:

https://travis-ci.org/opf/openproject/jobs/76416841

```
  1) AdminController should info
     Failure/Error: get :info
     LoadError:
       cannot load such file -- sys/filesystem
     # ./lib/open_project/storage.rb:30:in `<top (required)>'
     # ./app/controllers/admin_controller.rb:97:in `info'
     # ./spec/legacy/functional/admin_controller_spec.rb:105:in `block (2 levels) in <top (required)>'
```

This fix requires sys-filesystem at all times.
