### PR TITLE
[fix] perm might be nil. in that case just ignore it.

### DIFF
--- a/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
+++ b/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
@@ -191,13 +191,13 @@ module Redmine
               allowed_projects = []
 
               user.projects_by_role.each do |role, projects|
-                allowed_projects << projects.map(&:id) if role.allowed_to?(perm.name)
+                allowed_projects << projects.map(&:id) if perm && role.allowed_to?(perm.name)
               end
 
               stmt = projects_table[:id].in(allowed_projects.uniq)
             end
 
-            if (Role.anonymous.allowed_to?(perm.name) || Role.non_member.allowed_to?(perm.name)) && !is_member
+            if perm && (Role.anonymous.allowed_to?(perm.name) || Role.non_member.allowed_to?(perm.name)) && !is_member
               public_project = projects_table[:is_public].eq(true)
 
               stmt = stmt ? stmt.or(public_project) : public_project


### PR DESCRIPTION
https://community.openproject.org/work_packages/21285
https://community.openproject.org/work_packages/21309

```
irb(main):001:0> Redmine::AccessControl.permission(:view_changesets)
=> nil
```

trips up our deployments at this location (undefined method name on nil). i think the system should handle missing permisisons more gracefully. in this case it's save to just ignore the permission. any thoughts?
