### PR TITLE
[21206] Add basic checkout instructions

### DIFF
--- a/app/assets/javascripts/settings.js.erb
+++ b/app/assets/javascripts/settings.js.erb
@@ -59,7 +59,7 @@ See doc/COPYRIGHT.rdoc for more details.
         fieldset = $(this).closest('fieldset');
 
         fieldset
-          .find('input,select,textarea')
+          .find('input,select')
           .filter(':not([type=checkbox])')
           .filter(':not([type=hidden])')
           .removeAttr('required') // Rails 4.0 still seems to use attribute

--- a/app/assets/javascripts/settings.js.erb
+++ b/app/assets/javascripts/settings.js.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
     /** Sync SCM vendor select when enabled SCMs are changed */
-    $('[name="settings[enabled_scm][]"]').change(function () {
+    $('[name="settings[enabled_scm][]"]').change(function() {
       var wasDisabled = !this.checked,
         vendor = this.value,
         select = $('#settings_repositories_automatic_managed_vendor'),
@@ -51,7 +51,19 @@ See doc/COPYRIGHT.rdoc for more details.
       if (wasDisabled && option.prop('selected')) {
         select.val('');
       }
-
     });
+
+    /** Toggle repository checkout fieldsets required when option is disabled */
+    $('.settings-repositories--checkout-toggle').change(function() {
+      var wasChecked = this.checked,
+        fieldset = $(this).closest('fieldset');
+
+        fieldset
+          .find('input,select,textarea')
+          .filter(':not([type=checkbox])')
+          .filter(':not([type=hidden])')
+          .removeAttr('required') // Rails 4.0 still seems to use attribute
+          .prop('required', wasChecked);
+    })
   });
 }(jQuery));

--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -38,6 +38,25 @@
 </form>
 ```
 
+## Forms: Bordered compressed style (less padding)
+
+```
+<form class="form -bordered -compressed">
+  <div class="form--field -required">
+    <label class="form--label">Text:</label>
+    <div class="form--field-container">
+      <div class="form--text-field-container">
+        <input type="text" class="form--text-field">
+      </div>
+    </div>
+  </div>
+
+  <hr class="form--separator">
+  <button class="button -highlight">Save</button>
+  <button class="button">Cancel</button>
+</form>
+```
+
 ## Forms: Standard layout
 
 ```

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -58,6 +58,9 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
     background-color: $content-form-bg-color
     border: $content-form-border
 
+    &.-compressed
+      padding: 10px 20px 0 20px
+
 .form--separator
   border: 0
   border-bottom: 1px solid $content-form-separator-color
@@ -327,6 +330,9 @@ fieldset.form--fieldset
 .form--field-instructions
   @extend %form--field-after-container
   font-style: italic
+
+  &.-no-italic
+    font-style: normal
 
 .form--field-extra-actions
   @extend %form--field-after-container

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -386,6 +386,10 @@ fieldset.form--fieldset
 .form--text-field
   @extend %input-style
 
+  &[readonly].-clickable
+    cursor: pointer
+    background: white
+
 .form--text-field,
 #{$text-input-selectors}
   line-height: 1.5

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -308,6 +308,11 @@ class RepositoriesController < ApplicationController
     @repository = @project.repository
     (render_404; return false) unless @repository
 
+    # Prepare checkout instructions
+    # available on all pages (even empty!)
+    @instructions = ::Scm::CheckoutInstructionsService.new(@repository)
+
+    # Asserts repository availability, or renders an appropriate error
     @repository.scm.check_availability!
 
     @path = params[:path] || ''

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -48,6 +48,8 @@ class SettingsController < ApplicationController
         if value.is_a?(Array)
           # remove blank values in array settings
           value.delete_if(&:blank?)
+        elsif value.is_a?(Hash)
+          value.delete_if { |_, v| v.blank? }
         else
           value = value.strip
         end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -129,6 +129,10 @@ class Repository < ActiveRecord::Base
     false
   end
 
+  def supports_checkout_info?
+    true
+  end
+
   def entry(path = nil, identifier = nil)
     scm.entry(path, identifier)
   end

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -60,7 +60,8 @@ class Scm::CheckoutInstructionsService
   ##
   # Returns the instructions defined in the settings.
   def instructions
-    checkout_settings['text']
+    checkout_settings['text'].presence ||
+      I18n.t("repositories.checkout.default_instructions.#{repository.vendor}")
   end
 
   ##
@@ -85,7 +86,7 @@ class Scm::CheckoutInstructionsService
   ##
   # Determines whether permissions for the given repository
   # are available.
-  def permission?
+  def manages_permissions?
     repository.managed?
   end
 
@@ -98,7 +99,7 @@ class Scm::CheckoutInstructionsService
   #
   # Note that this information is only applicable when the repository is managed,
   # because otherwise OpenProject does not control the repository permissions.
-  # Use +permission?+ to check whether this is the case.
+  # Use +manages_permissions?+ to check whether this is the case.
   #
   def permission
     project = repository.project
@@ -116,7 +117,7 @@ class Scm::CheckoutInstructionsService
   #
   # Note that this information is only applicable when the repository is managed,
   # because otherwise OpenProject does not control the repository permissions.
-  # Use +permission?+ to check whether this is the case.
+  # Use +manages_permissions?+ to check whether this is the case.
   def may_checkout?
     [:readwrite, :read].include?(permission)
   end
@@ -126,7 +127,7 @@ class Scm::CheckoutInstructionsService
   #
   # Note that this information is only applicable when the repository is managed,
   # because otherwise OpenProject does not control the repository permissions.
-  # Use +permission?+ to check whether this is the case.
+  # Use +manages_permissions?+ to check whether this is the case.
   def may_commit?
     permission == :readwrite
   end

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -80,7 +80,7 @@ class Scm::CheckoutInstructionsService
 
   def checkout_enabled?
     checkout_settings['enabled'].to_i > 0
-  end  
+  end
 
   ##
   # Determines whether permissions for the given repository

--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -10,17 +10,18 @@
               <%= instructions.checkout_command %>
             </div>
             <div class="form--text-field-container -xwide">
-                <input type="text" class="form--text-field"
+                <input type="text" class="form--text-field -clickable"
                 onclick="this.focus(); this.select()"
                 readonly="readonly" value="<%= instructions.checkout_url %>">
             </div>
         </div>
         <div class="form--field-instructions -no-italic">
           <%= simple_format instructions.instructions %>
-          <% if instructions.permission? %>
+          <% if instructions.manages_permissions? %>
             <p>
               <span><%= l('repositories.checkout.access_permission') %></span>
               <strong><%= l("repositories.checkout.access.#{instructions.permission}") %></strong>
+            </p>
           <% end %>
         </div>
     </div>

--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -1,0 +1,29 @@
+<% if instructions.present? && instructions.available? %>
+<form class="form -bordered -compressed">
+  <fieldset class="form--fieldset -collapsible">
+    <legend class="form--fieldset-legend" title="<%= l('repositories.checkout.instructions') %>"
+            onclick="toggleFieldset(this);"><%= l('repositories.checkout.instructions') %></legend>
+    <div class="form--field">
+        <label class="form--label"><%= l('repositories.checkout.url') %></label>
+        <div class="form--field-container">
+            <div class="form--field-affix">
+              <%= instructions.checkout_command %>
+            </div>
+            <div class="form--text-field-container -xwide">
+                <input type="text" class="form--text-field"
+                onclick="this.focus(); this.select()"
+                readonly="readonly" value="<%= instructions.checkout_url %>">
+            </div>
+        </div>
+        <div class="form--field-instructions -no-italic">
+          <%= simple_format instructions.instructions %>
+          <% if instructions.permission? %>
+            <p>
+              <span><%= l('repositories.checkout.access_permission') %></span>
+              <strong><%= l("repositories.checkout.access.#{instructions.permission}") %></strong>
+          <% end %>
+        </div>
+    </div>
+  </fieldset>
+</form>
+<% end %>

--- a/app/views/repositories/empty.html.erb
+++ b/app/views/repositories/empty.html.erb
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
              message: l('repositories.errors.empty_repository')) %></p>
   </div>
 </div>
+<%= render partial: 'checkout_instructions', locals: { repository: @repository, instructions: @instructions } %>
 <%= call_hook(:view_repositories_show_contextual,
     { repository: @repository, project: @project }) %>
 <%= call_hook(:repositories_below_empty_warning,

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= render partial: 'checkout_instructions', locals: { repository: @repository, instructions: @instructions } %>
 <%= call_hook(:view_repositories_show_contextual, { :repository => @repository, :project => @project }) %>
 
 

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -87,7 +87,9 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= setting_text_field :repository_log_display_limit, :size => 6 %></div>
     <div class="form--field"><%= setting_check_box :repository_authentication_caching_enabled %></div>
   </section>
-  <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= l(:text_work_packages_ref_in_commit_messages) %></legend>
+  <%= render partial: 'repositories_checkout' %>
+  <fieldset class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= l(:text_work_packages_ref_in_commit_messages) %></legend>
     <div class="form--field">
       <%= setting_text_field :commit_ref_keywords, :size => 30 %>
       <div class="form--field-instructions"><%= l(:text_comma_separated) %></div>

--- a/app/views/settings/_repositories_checkout.html.erb
+++ b/app/views/settings/_repositories_checkout.html.erb
@@ -1,0 +1,36 @@
+<fieldset class="form--fieldset">
+  <legend class="form--fieldset-legend"><%= l('repositories.checkout.instructions') %></legend>
+  <% OpenProject::Scm::Manager.registered.each do |vendor, klass| %>
+      <% vendor = vendor.to_s %>
+      <% setting_base = "settings[repository_checkout_data][#{vendor}]" %>
+      <% enabled = Setting.repository_checkout_data[vendor]['enabled'].to_i > 0 %>
+      <fieldset class="form--fieldset -collapsible collapsed">
+        <legend class="form--fieldset-legend" title="<%= klass.vendor_name %>" onclick="toggleFieldset(this);">
+          <a href="javascript:"><%= klass.vendor_name %>
+            <span class="fieldset-toggle-state-label hidden-for-sighted">expanded</span>
+          </a>
+        </legend>
+        <div class="form--field">
+          <% key = "#{setting_base}[enabled]" %>
+          <input type="hidden" name="<%= key %>" value="0" id="<% "#{key}_hidden" %>" />
+          <%= setting_label key, label: :setting_repository_checkout_display %>
+          <%= styled_check_box_tag key, 1, enabled, class: 'settings-repositories--checkout-toggle' %>
+          <div class="form--field-instructions"><%= l('repositories.checkout.enable_instructions_text') %></div>
+        </div>
+        <div class="form--field">
+          <% key = "#{setting_base}[base_url]" %>
+          <%= setting_label key, label: :setting_repository_checkout_base_url %>
+          <%= styled_text_field_tag key, Setting.repository_checkout_data[vendor]['base_url'],
+                                    type: 'url', required: enabled %>
+          <div class="form--field-instructions"><%= simple_format l('repositories.checkout.base_url_text') %></div>
+        </div>
+        <div class="form--field">
+          <% key = "#{setting_base}[text]" %>
+          <%= setting_label key, label: :setting_repository_checkout_text %>
+          <%= styled_text_area_tag key, Setting.repository_checkout_data[vendor]['text'],
+                                    required: enabled %>
+          <div class="form--field-instructions"><%= l('repositories.checkout.text_instructions') %></div>
+        </div>
+      </fieldset>
+  <% end %>
+</fieldset>

--- a/app/views/settings/_repositories_checkout.html.erb
+++ b/app/views/settings/_repositories_checkout.html.erb
@@ -7,7 +7,6 @@
       <fieldset class="form--fieldset -collapsible collapsed">
         <legend class="form--fieldset-legend" title="<%= klass.vendor_name %>" onclick="toggleFieldset(this);">
           <a href="javascript:"><%= klass.vendor_name %>
-            <span class="fieldset-toggle-state-label hidden-for-sighted">expanded</span>
           </a>
         </legend>
         <div class="form--field">
@@ -28,7 +27,7 @@
           <% key = "#{setting_base}[text]" %>
           <%= setting_label key, label: :setting_repository_checkout_text %>
           <%= styled_text_area_tag key, Setting.repository_checkout_data[vendor]['text'],
-                                    required: enabled %>
+                                    placeholder: l("repositories.checkout.default_instructions.#{vendor}") %>
           <div class="form--field-instructions"><%= l('repositories.checkout.text_instructions') %></div>
         </div>
       </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1286,7 +1286,18 @@ en:
 
   repositories:
     autofetch_information: "Check this if you want repositories to be updated automatically when accessing the repository module page.\nThis encompasses the retrieval of commits from the repository and refreshing the required disk storage."
-    checkout_instructions: "Checkout instructions"
+    checkout:
+      access:
+        readwrite: 'Read + Write'
+        read: 'Read-only'
+        none: 'No checkout access, you may only view the repository through this application.'
+      access_permission: 'Your permissions on this repository:'
+      url: "Checkout URL"
+      base_url_text: "The base URL to use for generating checkout URLs (e.g., https://myserver.example.org/repos/).\nNote: The base URL is only used for rewriting checkout URLs in managed repositories. Other repositories are not altered"
+      enable_instructions_text: "Displays checkout instructions defined below on all repository-related pages."
+      instructions: "Checkout instructions"
+      text_instructions: "This text is displayed alongside the checkout URL for guidance on how to check out the repository."
+      not_available: "Checkout instructions are not available for this repository"
     create_managed_delay: "Please note: The repository is managed, it is created asynchronously on the disk and will be available shortly."
     create_successful: "The repository has been registered."
     delete_sucessful: "The repository has been deleted."
@@ -1413,6 +1424,9 @@ en:
   setting_repositories_encodings: "Repositories encodings"
   setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
   setting_repository_storage_cache_minutes: "Repository disk size cache"
+  setting_repository_checkout_display: "Show checkout instructions"
+  setting_repository_checkout_base_url: "Checkout base URL"
+  setting_repository_checkout_text: "Checkout instruction text"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_rest_api_enabled: "Enable REST web service"
   setting_self_registration: "Self-registration"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1293,7 +1293,14 @@ en:
         none: 'No checkout access, you may only view the repository through this application.'
       access_permission: 'Your permissions on this repository:'
       url: "Checkout URL"
-      base_url_text: "The base URL to use for generating checkout URLs (e.g., https://myserver.example.org/repos/).\nNote: The base URL is only used for rewriting checkout URLs in managed repositories. Other repositories are not altered"
+      base_url_text: "The base URL to use for generating checkout URLs (e.g., https://myserver.example.org/repos/).\nNote: The base URL is only used for rewriting checkout URLs in managed repositories. Other repositories are not altered."
+      default_instructions:
+        git: |-
+          The data contained in this repository can be downloaded to your computer with Git using the checkout information below.
+          Please consult the documentation of Git if you need more information on the checkout procedure and available clients.
+        subversion: |-
+          The data contained in this repository can be downloaded to your computer with Subversion using the checkout information below.
+          Please consult the documentation of Subversion if you need more information on the checkout procedure and available clients.
       enable_instructions_text: "Displays checkout instructions defined below on all repository-related pages."
       instructions: "Checkout instructions"
       text_instructions: "This text is displayed alongside the checkout URL for guidance on how to check out the repository."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -285,14 +285,8 @@ repository_checkout_data:
   default:
     git:
       enabled: 0
-      text: |-
-        The data contained in this repository can be downloaded to your computer with Git using the checkout information below.
-        Please consult the documentation of Git if you need more information on the checkout procedure and available clients.
     subversion:
       enabled: 0
-      text: |-
-        The data contained in this repository can be downloaded to your computer with Subversion using the checkout information below.
-        Please consult the documentation of Subversion if you need more information on the checkout procedure and available clients.
 api_max_page_size:
   format: int
   default: 500

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -280,6 +280,19 @@ journal_aggregation_time_minutes:
 repository_storage_cache_minutes:
   default: 720
   format: int
+repository_checkout_data:
+  serialized: true
+  default:
+    git:
+      enabled: 0
+      text: |-
+        The data contained in this repository can be downloaded to your computer with Git using the checkout information below.
+        Please consult the documentation of Git if you need more information on the checkout procedure and available clients.
+    subversion:
+      enabled: 0
+      text: |-
+        The data contained in this repository can be downloaded to your computer with Subversion using the checkout information below.
+        Please consult the documentation of Subversion if you need more information on the checkout procedure and available clients.
 api_max_page_size:
   format: int
   default: 500

--- a/lib/open_project/scm/adapters/base.rb
+++ b/lib/open_project/scm/adapters/base.rb
@@ -33,6 +33,8 @@ module OpenProject
   module Scm
     module Adapters
       class Base
+        include CheckoutInstructions
+
         attr_accessor :url, :root_url
 
         def self.vendor

--- a/lib/open_project/scm/adapters/checkout_instructions.rb
+++ b/lib/open_project/scm/adapters/checkout_instructions.rb
@@ -69,7 +69,7 @@ module OpenProject
         # assume a relative resource.
         def with_trailing_slash(url)
           url = url.to_s
-          
+
           url << '/' unless url.end_with?('/')
           url
         end

--- a/lib/open_project/scm/adapters/checkout_instructions.rb
+++ b/lib/open_project/scm/adapters/checkout_instructions.rb
@@ -1,0 +1,79 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module Scm
+    module Adapters
+      module CheckoutInstructions
+        ##
+        # Returns the checkout URL for the given repository
+        # based on this adapter's knowledge
+        def checkout_url(repository, base_url, path)
+          checkout_url = if local?
+                           ::URI.join(with_trailing_slash(base_url),
+                                      repository.repository_identifier)
+                         else
+                           url
+                         end
+
+          if subtree_checkout? && path.present?
+            ::URI.join(with_trailing_slash(checkout_url), path)
+          else
+            checkout_url
+          end
+        end
+
+        ##
+        # Returns whether the SCM vendor supports subtree checkout
+        def subtree_checkout?
+          false
+        end
+
+        ##
+        # Returns the checkout command for this vendor
+        def checkout_command
+          raise NotImplementedError
+        end
+
+        private
+
+        ##
+        # Ensure URL has a trailing slash.
+        # Needed for base URL, because URI.join will otherwise
+        # assume a relative resource.
+        def with_trailing_slash(url)
+          url = url.to_s
+          
+          url << '/' unless url.end_with?('/')
+          url
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -43,6 +43,10 @@ module OpenProject
           @path_encoding = path_encoding.presence || 'UTF-8'
         end
 
+        def checkout_command
+          'git clone'
+        end
+
         def client_command
           @client_command ||= self.class.config[:client_command] || 'git'
         end

--- a/lib/open_project/scm/adapters/subversion.rb
+++ b/lib/open_project/scm/adapters/subversion.rb
@@ -80,6 +80,14 @@ module OpenProject
           @password = password
         end
 
+        def checkout_command
+          'svn checkout'
+        end
+
+        def subtree_checkout?
+          true
+        end
+
         ##
         # Checks the status of this repository and throws unless it can be accessed
         # correctly by the adapter.

--- a/lib/open_project/scm/manageable_repository.rb
+++ b/lib/open_project/scm/manageable_repository.rb
@@ -100,8 +100,6 @@ module OpenProject
         "file://#{managed_repository_path}"
       end
 
-      protected
-
       ##
       # Repository relative path from scm managed root.
       # Will be overridden by including models to, e.g.,

--- a/spec/app/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/app/services/scm/checkout_instructions_service_spec.rb
@@ -1,0 +1,176 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe Scm::CheckoutInstructionsService do
+  let(:user) { FactoryGirl.build(:user) }
+  let(:project) { FactoryGirl.build(:project) }
+
+  let(:url) { 'file:///tmp/some/svn/repo' }
+  let(:repository) {
+    FactoryGirl.build(:repository_subversion,
+                      url: url,
+                      project: project)
+  }
+
+  let(:base_url) { 'http://example.org/svn/' }
+  let(:checkout_hash) {
+    {
+      'git' => { 'enabled' => '0' },
+      'subversion' => { 'enabled' => '1',
+                        'text' => 'foo',
+                        'base_url' => base_url
+                      }
+    }
+  }
+
+  subject(:service) { Scm::CheckoutInstructionsService.new(repository, user) }
+
+  before do
+    allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
+  end
+
+  describe '#checkout_url' do
+    shared_examples 'builds the correct URL' do
+      it 'builds the correct URL' do
+        expect(service.checkout_url)
+          .to eq(URI("http://example.org/svn/#{project.identifier}"))
+      end
+
+      it 'builds a subpath' do
+        expect(service.checkout_url('foo/bar'))
+          .to eq(URI("http://example.org/svn/#{project.identifier}/foo/bar"))
+      end
+    end
+
+    it_behaves_like 'builds the correct URL'
+
+    context 'with missing trailing slash' do
+      it_behaves_like 'builds the correct URL'
+    end
+  end
+
+  describe '#checkout_command' do
+    it 'returns the SCM vendor command' do
+      expect(service.checkout_command).to eq('svn checkout')
+    end
+  end
+
+  describe '#settings' do
+    it 'svn is available for checkout' do
+      expect(service.available?).to be true
+      expect(service.checkout_enabled?).to be true
+    end
+
+    it 'has the correct settings' do
+      expect(Setting.repository_checkout_data['subversion']['enabled']).to eq('1')
+      expect(service.instructions).to eq('foo')
+      expect(service.checkout_base_url).to eq(base_url)
+    end
+
+    context 'missing checkout base URL' do
+      let(:base_url) { '' }
+
+      it 'is not available for checkout even when enabled' do
+        expect(service.checkout_base_url).to eq(base_url)
+        expect(service.checkout_enabled?).to be true
+        expect(service.available?).to be false
+      end
+    end
+
+    context 'disabled repository' do
+      let(:repository) { FactoryGirl.build(:repository_git) }
+
+      it 'git is not available for checkout' do
+        expect(service.available?).to be false
+        expect(service.checkout_enabled?).to be false
+      end
+    end
+  end
+
+  describe '#permission' do
+    context 'with no managed repository' do
+      it 'is not applicable' do
+        expect(service.permission?).to be false
+      end
+    end
+
+    context 'with managed repository' do
+      before do
+        allow(repository).to receive(:managed?).and_return(true)
+      end
+
+      it 'is applicable' do
+        expect(service.permission?).to be true
+      end
+
+      it 'returns the correct permissions' do
+        expect(user)
+          .to receive(:allowed_to?).with(:commit_access, any_args)
+          .and_return(true, false, false)
+
+        expect(user)
+          .to receive(:allowed_to?).with(:browse_repository, any_args)
+          .and_return(true, false)
+
+        expect(service.permission).to eq(:readwrite)
+        expect(service.permission).to eq(:read)
+        expect(service.permission).to eq(:none)
+      end
+
+      it 'returns the correct permissions for commit access' do
+        allow(user)
+          .to receive(:allowed_to?).with(:commit_access, any_args)
+          .and_return(true)
+
+        expect(service.may_commit?).to be true
+        expect(service.may_checkout?).to be true
+      end
+
+      it 'returns the correct permissions for read access' do
+        allow(user)
+          .to receive(:allowed_to?).with(:commit_access, any_args)
+                .and_return(false)
+        allow(user)
+          .to receive(:allowed_to?).with(:browse_repository, any_args)
+                .and_return(true)
+
+        expect(service.may_commit?).to be false
+        expect(service.may_checkout?).to be true
+      end
+
+      it 'returns the correct permissions for no access' do
+        allow(user).to receive(:allowed_to?).and_return(false)
+
+        expect(service.may_commit?).to be false
+        expect(service.may_checkout?).to be false
+      end
+    end
+  end
+end

--- a/spec/app/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/app/services/scm/checkout_instructions_service_spec.rb
@@ -156,10 +156,10 @@ describe Scm::CheckoutInstructionsService do
       it 'returns the correct permissions for read access' do
         allow(user)
           .to receive(:allowed_to?).with(:commit_access, any_args)
-                .and_return(false)
+          .and_return(false)
         allow(user)
           .to receive(:allowed_to?).with(:browse_repository, any_args)
-                .and_return(true)
+          .and_return(true)
 
         expect(service.may_commit?).to be false
         expect(service.may_checkout?).to be true

--- a/spec/app/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/app/services/scm/checkout_instructions_service_spec.rb
@@ -40,11 +40,12 @@ describe Scm::CheckoutInstructionsService do
   }
 
   let(:base_url) { 'http://example.org/svn/' }
+  let(:text) { 'foo' }
   let(:checkout_hash) {
     {
       'git' => { 'enabled' => '0' },
       'subversion' => { 'enabled' => '1',
-                        'text' => 'foo',
+                        'text' => text,
                         'base_url' => base_url
                       }
     }
@@ -79,6 +80,21 @@ describe Scm::CheckoutInstructionsService do
   describe '#checkout_command' do
     it 'returns the SCM vendor command' do
       expect(service.checkout_command).to eq('svn checkout')
+    end
+  end
+
+  describe '#instructions' do
+    it 'returns the setting when defined' do
+      expect(service.instructions).to eq('foo')
+    end
+
+    context 'no setting defined' do
+      let(:text) { nil }
+
+      it 'returns the default translated instructions' do
+        expect(service.instructions)
+          .to eq(I18n.t("repositories.checkout.default_instructions.subversion"))
+      end
     end
   end
 
@@ -117,7 +133,7 @@ describe Scm::CheckoutInstructionsService do
   describe '#permission' do
     context 'with no managed repository' do
       it 'is not applicable' do
-        expect(service.permission?).to be false
+        expect(service.manages_permissions?).to be false
       end
     end
 
@@ -127,7 +143,7 @@ describe Scm::CheckoutInstructionsService do
       end
 
       it 'is applicable' do
-        expect(service.permission?).to be true
+        expect(service.manages_permissions?).to be true
       end
 
       it 'returns the correct permissions' do

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -155,11 +155,12 @@ describe RepositoriesController, type: :controller do
         allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
         get :show, project_id: project.identifier
       end
-        it 'renders an empty warning view' do
-          expect(response).to render_template 'repositories/empty'
-          expect(response).to render_template partial: 'repositories/_checkout_instructions'
-          expect(response.code).to eq('200')
-        end
+
+      it 'renders an empty warning view' do
+        expect(response).to render_template 'repositories/empty'
+        expect(response).to render_template partial: 'repositories/_checkout_instructions'
+        expect(response.code).to eq('200')
+      end
     end
   end
 

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -138,6 +138,29 @@ describe RepositoriesController, type: :controller do
         expect(response.code).to eq('200')
       end
     end
+
+    context 'with #show and checkout' do
+      render_views
+
+      let(:checkout_hash) {
+        {
+          'subversion' => { 'enabled' => '1',
+                            'text' => 'foo',
+                            'base_url' => 'http://localhost'
+          }
+        }
+      }
+
+      before do
+        allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
+        get :show, project_id: project.identifier
+      end
+        it 'renders an empty warning view' do
+          expect(response).to render_template 'repositories/empty'
+          expect(response).to render_template partial: 'repositories/_checkout_instructions'
+          expect(response.code).to eq('200')
+        end
+    end
   end
 
   describe 'with filesystem repository' do


### PR DESCRIPTION
This commit adds very basic checkout instructions similar
to `openproject-checkout` to repositories.
### Issues
- Uses table style for checkout component, as exact styling is unclear
  - Adds compressed table style with less padding
- Checkout settings are best organized in a Hash with keys per SCM vendor. Using default settings, a lot of new setting values would be introduced. While this works fine, there are some caveats:
  - Checks for Hash in SettingsController
  - Currently can't use SettingsHelper, as it requires single setting
    values
### To decide
- [ ]  subtree checkout (May be out of scope, even though service functionality is there)
### Features
#### Checkout instructions

![bildschirmfoto 2015-08-20 um 18 22 48](https://cloud.githubusercontent.com/assets/459462/9388950/bb6b8a08-4768-11e5-8cd9-583de3eb0ad1.png)
#### Checkout instructions settings

![bildschirmfoto 2015-08-20 um 18 32 49](https://cloud.githubusercontent.com/assets/459462/9389181/f567f5b0-4769-11e5-8125-636975618d55.png)

Relevant work package: https://community.openproject.org/work_packages/21206
