### PR TITLE
[16204] Horizontal line below tabs is too short in broad screens

### DIFF
--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -41,7 +41,7 @@
     margin: 0
     bottom: 0
     padding-left: 1em
-    width: 2000px
+    width: 100%
     border-bottom: 1px solid #bbbbbb
     overflow: hidden
     li


### PR DESCRIPTION
set width to 100% so that it won't be too short

https://community.openproject.org/work_packages/16204
