### PR TITLE
[16204] Horizontal line below tabs is too short in broad screens (2)

### DIFF
--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -35,13 +35,11 @@
   z-index: 1
   overflow: hidden
   ul
-    position: absolute
-    left: 0
-    right: 60px
-    margin: 0
+    position: relative
+    margin-top: 0.75rem
+    margin-left: 0
     bottom: 0
     padding-left: 1em
-    width: 100%
     border-bottom: 1px solid #bbbbbb
     overflow: hidden
     li


### PR DESCRIPTION
removed the absolute position of the horizontal line to make this a more elegant solution

https://community.openproject.org/work_packages/16204
