### PR TITLE
Fix protractor exception in timeout'ed expect

### DIFF
--- a/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/details-pane-editable-spec.js
@@ -65,11 +65,8 @@ describe('OpenProject', function(){
             editor.$('.inplace-edit--control--save a').click();
             return editor;
           }).then(function() {
-            // damn those dirty ap.. i mean animations.
-            setTimeout(function() {
-              expect($('.notification-box.-error').isDisplayed())
-                .to.be.true;
-            }, 1000);
+            expect($('.notification-box.-error').isDisplayed())
+                .to.eventually.be.true;
           });
         });
       });


### PR DESCRIPTION
The setTimeout expect causes the spec to fire reproducably
in other contexts and raises an exception, blocking the whole test run.

Caused failures in jobs:
- https://travis-ci.org/opf/openproject/jobs/76531345
- https://travis-ci.org/opf/openproject/jobs/76482755
- https://travis-ci.org/opf/openproject/jobs/76470180
- ...
