### PR TITLE
[16002] Margin and color of members icon wrong

### DIFF
--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -188,7 +188,7 @@ $icon-font-file-formats: eot woff ttf
 // used for icons in the content area, which appear in context (menus)
 .action-menu .icon:before,
 .icon-context:before
-  padding: 0 10px 0 0
+  @include icon-context-rules
 
 .legacy-pagination .previous_page:before,
 .legacy-pagination .next_page:after


### PR DESCRIPTION
Used the 'icon-context-rules'-mixin for the right color of class 'icon-context'

https://community.openproject.org/work_packages/16002
