### PR TITLE
Fix/sprockets dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,8 +102,10 @@ group :production do
   gem 'dalli', '~> 2.7.2'
 end
 
-gem 'sprockets',        git: 'https://github.com/tessi/sprockets.git', branch: '2_2_2_backport2'
-gem 'sprockets-rails',  git: 'https://github.com/finnlabs/sprockets-rails.git', branch: 'backport'
+gem 'sprockets',       git: 'https://github.com/finnlabs/sprockets.git',
+                       branch: '2_2_3_backport2'
+gem 'sprockets-rails', git: 'https://github.com/finnlabs/sprockets-rails.git',
+                       branch: 'backport_w_2_2_3_sprockets'
 gem 'non-stupid-digest-assets'
 gem 'sass-rails',        git: 'https://github.com/guilleiguaran/sass-rails.git', branch: 'backport'
 gem 'sass',             '~> 3.4.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,13 +22,24 @@ GIT
 
 GIT
   remote: https://github.com/finnlabs/sprockets-rails.git
-  revision: e069c097056e28e3cd4adc4ee8bb2a895c71bfc1
-  branch: backport
+  revision: 7599ca4e7c5ff3cad552591e0e990570d34863d7
+  branch: backport_w_2_2_3_sprockets
   specs:
     sprockets-rails (2.0.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
-      sprockets (= 2.2.2.backport2)
+      sprockets (= 2.2.3.backport2)
+
+GIT
+  remote: https://github.com/finnlabs/sprockets.git
+  revision: be18cf9420ea5606b0824dae1bc6965505f7c82b
+  branch: 2_2_3_backport2
+  specs:
+    sprockets (2.2.3.backport2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
 
 GIT
   remote: https://github.com/guilleiguaran/sass-rails.git
@@ -56,17 +67,6 @@ GIT
   revision: a2cd95c3e3c1a4f7a9566efdab5ce59c886cb05f
   specs:
     prototype_legacy_helper (0.0.0)
-
-GIT
-  remote: https://github.com/tessi/sprockets.git
-  revision: 1e56fd0a92a9fda93dab4550ab3cf82138d097ac
-  branch: 2_2_2_backport2
-  specs:
-    sprockets (2.2.2.backport2)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -551,8 +551,8 @@ DEPENDENCIES
   pry-stack_explorer
   quiet_assets
   rabl (= 0.9.3)
-  rack-attack
   rack (~> 1.4.7)
+  rack-attack
   rack-protection!
   rack-test (~> 0.6.2)
   rack_session_access
@@ -594,4 +594,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
The 2_2_2_backport2 at https://github.com/tessi/sprockets/tree/2_2_2_backport2 actually has the version 2.2.3 leading to an invalid dependency with sprockets-rails.
This fix relies on a clone of the repo to fix the branch structure. 

Note, that this is discontinued in OP 5.0 where we again rely on the standard sprockets.
