### PR TITLE
Remove remaining "outdated" ActiveRecord finders

### DIFF
--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -73,7 +73,7 @@ class WorkPackages::AutoCompletesController < ApplicationController
   def find_project
     project_id = (params[:work_package] && params[:work_package][:project_id]) || params[:project_id]
     return nil unless project_id
-    Project.find_by_id(project_id)
+    Project.find_by(id: project_id)
   end
 
   def determine_scope

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -316,7 +316,7 @@ class Journal::AggregatedJournal
   end
 
   def data
-    @data ||= "Journal::#{journable_type}Journal".constantize.find_by_journal_id(id)
+    @data ||= "Journal::#{journable_type}Journal".constantize.find_by(journal_id: id)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -491,10 +491,6 @@ class User < Principal
     where(['LOWER(mail) = ?', mail.to_s.downcase]).first
   end
 
-  def self.find_all_by_mails(mails)
-    where(['LOWER(mail) IN (?)', mails])
-  end
-
   def to_s
     name
   end

--- a/app/services/move_work_package_service.rb
+++ b/app/services/move_work_package_service.rb
@@ -167,14 +167,14 @@ class MoveWorkPackageService
     new_category = if work_package.category.nil?
                      nil
                    else
-                     new_project.categories.find_by_name(work_package.category.name)
+                     new_project.categories.find_by(name: work_package.category.name)
                    end
     work_package.category = new_category
   end
 
   def assign_status_or_default(work_package, status_id)
     status = if status_id.present?
-               Status.find_by_id(status_id)
+               Status.find_by(id: status_id)
              else
                self.work_package.status
              end

--- a/app/workers/deliver_work_package_notification_job.rb
+++ b/app/workers/deliver_work_package_notification_job.rb
@@ -69,7 +69,7 @@ class DeliverWorkPackageNotificationJob
   end
 
   def raw_journal
-    @raw_journal ||= Journal.find_by_id(@journal_id)
+    @raw_journal ||= Journal.find_by(id: @journal_id)
   end
 
   def work_package
@@ -77,6 +77,6 @@ class DeliverWorkPackageNotificationJob
   end
 
   def author
-    @author ||= User.find_by_id(@author_id) || DeletedUser.first
+    @author ||= User.find_by(id: @author_id) || DeletedUser.first
   end
 end

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -68,7 +68,7 @@ class EnqueueWorkPackageNotificationJob
   end
 
   def raw_journal
-    @raw_journal ||= Journal.find_by_id(@journal_id)
+    @raw_journal ||= Journal.find_by(id: @journal_id)
   end
 
   def work_package

--- a/db/seeds/builtin_roles.rb
+++ b/db/seeds/builtin_roles.rb
@@ -27,7 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-if Role.find_by_builtin(Role::BUILTIN_NON_MEMBER).nil?
+if Role.find_by(builtin: Role::BUILTIN_NON_MEMBER).nil?
   role = Role.new
 
   role.name = 'Non member'
@@ -36,7 +36,7 @@ if Role.find_by_builtin(Role::BUILTIN_NON_MEMBER).nil?
   role.save!
 end
 
-if Role.find_by_builtin(Role::BUILTIN_ANONYMOUS).nil?
+if Role.find_by(builtin: Role::BUILTIN_ANONYMOUS).nil?
   role = Role.new
 
   role.name = 'Anonymous'

--- a/db/seeds/workflows.rb
+++ b/db/seeds/workflows.rb
@@ -43,13 +43,14 @@ if WorkPackage.where(type_id: nil).any? || Journal::WorkPackageJournal.where(typ
 
   WorkPackage.transaction do
     green_color = colors[I18n.t(:default_color_green_light)]
-    standard_type = Type.find_or_create_by_is_standard(true, name: 'none',
-                                                             position: 0,
-                                                             color_id: green_color,
-                                                             is_default: true,
-                                                             is_in_roadmap: true,
-                                                             in_aggregation: true,
-                                                             is_milestone: false)
+    standard_type = Type.find_or_create_by(is_standard: true,
+                                           name: 'none',
+                                           position: 0,
+                                           color_id: green_color,
+                                           is_default: true,
+                                           is_in_roadmap: true,
+                                           in_aggregation: true,
+                                           is_milestone: false)
 
     # Adds the standard type to all existing projects
     #

--- a/spec/legacy/unit/journal_spec.rb
+++ b/spec/legacy/unit/journal_spec.rb
@@ -38,7 +38,7 @@ describe Journal, type: :model do
   end
 
   it 'create should send email notification' do
-    issue = WorkPackage.find(:first)
+    issue = WorkPackage.first
     if issue.journals.empty?
       issue.add_journal(User.current, 'This journal represents the creationa of journal version 1')
       issue.save

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -145,7 +145,7 @@ describe Repository::Subversion, type: :model do
 
         expect(instance.changesets.count).to eq(12)
         expect(instance.changes.count).to eq(21)
-        expect(instance.changesets.find_by_revision('1').comments).to eq('Initial import.')
+        expect(instance.changesets.find_by(revision: '1').comments).to eq('Initial import.')
       end
 
       it 'should fetch changesets incremental' do
@@ -207,7 +207,7 @@ describe Repository::Subversion, type: :model do
       it 'should show the identifier' do
         instance.fetch_changesets
         instance.reload
-        c = instance.changesets.find_by_revision('1')
+        c = instance.changesets.find_by(revision: '1')
         expect(c.revision).to eq(c.identifier)
       end
 
@@ -228,7 +228,7 @@ describe Repository::Subversion, type: :model do
       it 'should format identifier' do
         instance.fetch_changesets
         instance.reload
-        c = instance.changesets.find_by_revision('1')
+        c = instance.changesets.find_by(revision: '1')
         expect(c.format_identifier).to eq(c.revision)
       end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20325
## Description

This PR deals with finders that were removed during the Rails 4 development, but could sneak back in, because development on the `dev` branch went on as usual, thereby generating new occurences of the removed finders.

Those include:
- [really deprecated](https://github.com/rails/activerecord-deprecated_finders) finders
- not so much encouraged finders (like `find_by_id` etc)
## Related Plugin PRs
- https://github.com/finnlabs/openproject-backlogs/pull/157
- https://github.com/finnlabs/openproject-costs/pull/156
- https://github.com/finnlabs/openproject-my_project_page/pull/56
- https://github.com/finnlabs/openproject-reporting/pull/75
