### PR TITLE
[21326] Wiki settings dropdown cut off when content not large enough

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -495,6 +495,8 @@ div.issue hr
     margin-bottom: 6px
 
 #content
+  min-height: 250px
+
   h3
     margin: 12px 0 6px
   h2 + h3


### PR DESCRIPTION
Set a minimum height for the context so that the menu won't be larger. Unfortunately the overflow of the content cannot be simply set to visible because other sides would be destroyed by that.

https://community.openproject.org/work_packages/21326
