### PR TITLE
[21327] long words destroy headline in timelines package overview

### DIFF
--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -31,6 +31,8 @@ body.controller-work_packages.action-update
   #content
     h2
       padding-right: 340px
+      overflow: hidden
+      text-overflow: ellipsis
 
 h1
   color:              $h1-font-color


### PR DESCRIPTION
set the overflow values so that the headline will be punctuated

https://community.openproject.org/work_packages/21327
