### PR TITLE
Feature/membership table hook

### DIFF
--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -60,8 +60,6 @@ See doc/COPYRIGHT.rdoc for more details.
               <col highlight-col>
               <%= call_hook(:view_projects_settings_members_table_colgroup, :project => @project) %>
               <col>
-              <col highlight-col>
-              <col highlight-col>
             </colgroup>
             <thead>
               <tr>

--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -58,6 +58,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <colgroup>
               <col highlight-col>
               <col highlight-col>
+              <%= call_hook(:view_projects_settings_members_table_colgroup, :project => @project) %>
               <col>
               <col highlight-col>
               <col highlight-col>
@@ -82,8 +83,8 @@ See doc/COPYRIGHT.rdoc for more details.
                     </div>
                   </div>
                 </th>
-                <th></th>
                 <%= call_hook(:view_projects_settings_members_table_header, :project => @project) %>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -113,6 +114,7 @@ See doc/COPYRIGHT.rdoc for more details.
                           "$('member-#{member.id}-roles').show(); $('member-#{member.id}-roles-form').hide(); return false;",
                           class: 'button -small' %></p>
                         <% end %>
+                        <%= call_hook(:view_projects_settings_members_table_row, { :project => @project, :member => member}) %>
                         <td class="buttons">
                           <%= link_to_function l(:button_edit), "$('member-#{member.id}-roles').hide(); $('member-#{member.id}-roles-form').show(); return false;", :class => 'icon icon-edit' %>
                           <%= link_to(l(:button_delete), {:controller => '/members', :action => 'destroy', :id => member, :page => params[:page]},
@@ -123,7 +125,6 @@ See doc/COPYRIGHT.rdoc for more details.
                         </td>
                       <% end %>
                     </td>
-                    <%= call_hook(:view_projects_settings_members_table_row, { :project => @project, :member => member}) %>
                   </tr>
               <% end %>
             </tbody>

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -38,6 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <colgroup>
             <col highlight-col>
             <col highlight-col>
+            <%= call_hook(:view_users_memberships_table_colgroup, :user => @user )%>
             <col>
           </colgroup>
           <thead>
@@ -60,8 +61,8 @@ See doc/COPYRIGHT.rdoc for more details.
                   </div>
                 </div>
               </th>
-              <th></th>
               <%= call_hook(:view_users_memberships_table_header, :user => @user )%>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -91,6 +92,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   class: 'button -small' %></p>
                     <% end %>
                   </td>
+                  <%= call_hook(:view_users_memberships_table_row, :user => @user, :membership => membership, :roles => roles, :projects => projects )%>
                   <td class="buttons">
                     <%= link_to_function l(:button_edit), "$('member-#{membership.id}-roles').hide(); $('member-#{membership.id}-roles-form').show(); return false;", :class => 'icon icon-edit' %>
                     <%= link_to(l(:button_delete), { :controller => 'users',
@@ -101,7 +103,6 @@ See doc/COPYRIGHT.rdoc for more details.
                                           :method => :post,
                                           :class => 'icon icon-delete') if membership.deletable? %>
                   </td>
-                  <%= call_hook(:view_users_memberships_table_row, :user => @user, :membership => membership, :roles => roles, :projects => projects )%>
                 </tr>
               <% end %>
             </tbody>


### PR DESCRIPTION
This moves the hook on the members/membership table. The place before the button column is the better place for plugins to extend the table.

Additionally, this removes dom that was added specifically for a plugin.
