### PR TITLE
[20841] Move project custom fields to its own tab

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -96,7 +96,7 @@ jQuery(document).ready(function ($) {
 });
 
 function checkAll(selector, checked) {
-  jQuery('#' + selector + ' input:checkbox').each(function() {
+  jQuery('#' + selector + ' input:checkbox').not(':disabled').each(function() {
     this.checked = checked;
   });
 }

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -95,13 +95,10 @@ jQuery(document).ready(function ($) {
   });
 });
 
-function checkAll (id, checked) {
-  var els = Element.descendants(id);
-  for (var i = 0; i < els.length; i++) {
-    if (els[i].disabled === false) {
-      els[i].checked = checked;
-    }
-  }
+function checkAll(selector, checked) {
+  jQuery('#' + selector + ' input:checkbox').each(function() {
+    this.checked = checked;
+  });
 }
 
 function toggleCheckboxesBySelector(selector) {

--- a/app/assets/stylesheets/content/_flash_messages.sass
+++ b/app/assets/stylesheets/content/_flash_messages.sass
@@ -42,6 +42,7 @@
 
 .flash
   display: none
+  padding: 15px 5px
 
   &.ng-leave
     @include animation(0.5s fade-out)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,7 +36,9 @@ class ProjectsController < ApplicationController
 
   before_filter :disable_api
   before_filter :find_project, except: [:index, :level_list, :new, :create]
-  before_filter :authorize, only: [:show, :settings, :edit, :update, :modules, :types, :custom_fields]
+  before_filter :authorize, only: [
+    :show, :settings, :edit, :update, :modules, :types, :custom_fields
+  ]
   before_filter :authorize_global, only: [:new, :create]
   before_filter :require_admin, only: [:archive, :unarchive, :destroy, :destroy_info]
   before_filter :jump_to_project_menu_item, only: :show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -188,6 +188,17 @@ class ProjectsController < ApplicationController
     redirect_to action: 'settings', id: @project, tab: 'modules'
   end
 
+  def custom_fields
+    @project.work_package_custom_field_ids = params[:project][:work_package_custom_field_ids]
+    if @project.save
+      flash[:notice] = l(:notice_successful_update)
+    else
+      flash[:error] = l(:notice_project_cannot_update_custom_fields)
+    end
+
+    redirect_to action: 'settings', id: @project, tab: 'custom_fields'
+  end
+
   def archive
     flash[:error] = l(:error_can_not_archive_project) unless @project.archive
     redirect_to(url_for(controller: '/admin', action: 'projects', status: params[:status]))

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,7 +36,7 @@ class ProjectsController < ApplicationController
 
   before_filter :disable_api
   before_filter :find_project, except: [:index, :level_list, :new, :create]
-  before_filter :authorize, only: [:show, :settings, :edit, :update, :modules, :types]
+  before_filter :authorize, only: [:show, :settings, :edit, :update, :modules, :types, :custom_fields]
   before_filter :authorize_global, only: [:new, :create]
   before_filter :require_admin, only: [:archive, :unarchive, :destroy, :destroy_info]
   before_filter :jump_to_project_menu_item, only: :show

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -32,21 +32,76 @@ module ProjectsHelper
 
   def link_to_version(version, html_options = {}, options = {})
     return '' unless version && version.is_a?(Version)
-    link_to_if version.visible?, options[:before_text].to_s.html_safe + format_version_name(version), { controller: '/versions', action: 'show', id: version }, html_options
+
+    link_name = options[:before_text].to_s.html_safe + format_version_name(version)
+    link_to_if version.visible?,
+               link_name,
+               { controller: '/versions', action: 'show', id: version },
+               html_options
   end
 
   def project_settings_tabs
-    tabs = [{ name: 'info', action: :edit_project, partial: 'projects/edit', label: :label_information_plural },
-            { name: 'modules', action: :select_project_modules, partial: 'projects/settings/modules', label: :label_module_plural },
-            { name: 'members', action: :manage_members, partial: 'projects/settings/members', label: :label_member_plural },
-            { name: 'custom_fields', action: :edit_project, partial: 'projects/settings/custom_fields', label: :label_custom_field_plural },
-            { name: 'versions', action: :manage_versions, partial: 'projects/settings/versions', label: :label_version_plural },
-            { name: 'categories', action: :manage_categories, partial: 'projects/settings/categories', label: :label_work_package_category_plural },
-            { name: 'repository', action: :manage_repository, partial: 'repositories/settings', label: :label_repository },
-            { name: 'boards', action: :manage_boards, partial: 'projects/settings/boards', label: :label_board_plural },
-            { name: 'activities', action: :manage_project_activities, partial: 'projects/settings/activities', label: :enumeration_activities },
-            { name: 'types', action: :manage_types, partial: 'projects/settings/types', label: :label_type_plural }
-           ]
+    tabs = [
+      {
+        name: 'info',
+        action: :edit_project,
+        partial: 'projects/edit',
+        label: :label_information_plural
+      },
+      {
+        name: 'modules',
+        action: :select_project_modules,
+        partial: 'projects/settings/modules',
+        label: :label_module_plural },
+      {
+        name: 'members',
+        action: :manage_members,
+        partial: 'projects/settings/members',
+        label: :label_member_plural
+      },
+      {
+        name: 'custom_fields',
+        action: :edit_project,
+        partial: 'projects/settings/custom_fields',
+        label: :label_custom_field_plural
+      },
+      {
+        name: 'versions',
+        action: :manage_versions,
+        partial: 'projects/settings/versions',
+        label: :label_version_plural
+      },
+      {
+        name: 'categories',
+        action: :manage_categories,
+        partial: 'projects/settings/categories',
+        label: :label_work_package_category_plural
+      },
+      {
+        name: 'repository',
+        action: :manage_repository,
+        partial: 'repositories/settings',
+        label: :label_repository
+      },
+      {
+        name: 'boards',
+        action: :manage_boards,
+        partial: 'projects/settings/boards',
+        label: :label_board_plural
+      },
+      {
+        name: 'activities',
+        action: :manage_project_activities,
+        partial: 'projects/settings/activities',
+        label: :enumeration_activities
+      },
+      {
+        name: 'types',
+        action: :manage_types,
+        partial: 'projects/settings/types',
+        label: :label_type_plural
+      }
+    ]
     tabs.select { |tab| User.current.allowed_to?(tab[:action], @project) }
   end
 
@@ -61,6 +116,7 @@ module ProjectsHelper
       Project.project_tree(projects) do |project, _level|
         # set the project environment to please macros.
         @project = project
+
         if ancestors.empty? || project.is_descendant_of?(ancestors.last)
           s << "<ul class='projects #{ancestors.empty? ? 'root' : nil}'>\n"
         else
@@ -71,14 +127,22 @@ module ProjectsHelper
             s << "</ul></li>\n"
           end
         end
+
         classes = (ancestors.empty? ? 'root' : 'child')
         s << "<li class='#{classes}'><div class='#{classes}'>" +
           link_to_project(project, {}, { class: 'project' }, true)
-        s << "<div class='wiki description'>#{format_text(project.short_description, project: project)}</div>" unless project.description.blank?
+
+        unless project.description.blank?
+          formatted_text = format_text(project.short_description, project: project)
+          s << "<div class='wiki description'>#{formatted_text}</div>"
+        end
+
         s << "</div>\n"
         ancestors << project
       end
+
       s << ("</li></ul>\n" * ancestors.size)
+
       @project = original_project
     end
     s.html_safe
@@ -90,6 +154,7 @@ module ProjectsHelper
     versions.each do |version|
       grouped[version.project.name] << [version.name, version.id]
     end
+
     # Add in the selected
     if selected && !versions.include?(selected)
       grouped[selected.project.name] << [selected.name, selected.id]

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -39,6 +39,7 @@ module ProjectsHelper
     tabs = [{ name: 'info', action: :edit_project, partial: 'projects/edit', label: :label_information_plural },
             { name: 'modules', action: :select_project_modules, partial: 'projects/settings/modules', label: :label_module_plural },
             { name: 'members', action: :manage_members, partial: 'projects/settings/members', label: :label_member_plural },
+            { name: 'custom_fields', action: :edit_project, partial: 'projects/settings/custom_fields', label: :label_custom_field_plural },
             { name: 'versions', action: :manage_versions, partial: 'projects/settings/versions', label: :label_version_plural },
             { name: 'categories', action: :manage_categories, partial: 'projects/settings/categories', label: :label_work_package_category_plural },
             { name: 'repository', action: :manage_repository, partial: 'repositories/settings', label: :label_repository },

--- a/app/views/projects/_edit.html.erb
+++ b/app/views/projects/_edit.html.erb
@@ -27,9 +27,11 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= labelled_tabular_form_for @altered_project, url: project_path(@project) do |f| %>
-  <%= render partial: 'form', locals: { f: f,
-                                        project: @altered_project,
-                                        renderTypes: false } %>
+  <%= render partial: 'form', locals: {
+                                f: f,
+                                project: @altered_project,
+                                renderTypes: false
+                              } %>
 
-  <%= f.button l(:button_save), class: 'button -highlight -with-icon icon-yes' %>
+  <%= f.button l(:button_update), class: 'button -highlight -with-icon icon-yes' %>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -33,34 +33,42 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <section class="form--section">
   <%= render partial: "projects/form/project_attributes",
-             locals: { project: project,
-                       form: f } %>
+             locals: { project: project, form: f } %>
 
-  <%= call_hook(:view_projects_form,
-                project: project,
-                form: f) %>
+  <%= call_hook(:view_projects_form, project: project, form: f) %>
 </section>
 
+<% unless project.new_record? %>
+  <section class="form--section">
+    <%= render partial: "projects/form/required_storage",
+               locals: { project: project, storage: project.count_required_storage } %>
+  </section>
+<% end %>
+
 <% if project.new_record? %>
-  <div>
-    <%= render partial: "projects/form/modules",
-               locals: { form: f } %>
-  </div>
+  <section class="form--section">
+    <%= render partial: "projects/form/modules", locals: { form: f } %>
+  </section>
 
   <%= javascript_tag 'observeProjectModules();' %>
-<% else %>
-
-  <%= render partial: "projects/form/required_storage",
-             locals: { project: project, storage: project.count_required_storage } %>
-
 <% end %>
 
 <% if (project.new_record? || project.module_enabled?('work_package_tracking')) && renderTypes %>
-  <div>
+  <section class="form--section">
     <%= render partial: 'projects/form/types',
-               locals: { f: f,
-                         project: project } %>
-  </div>
+               locals: { f: f, project: project } %>
+  </section>
+<% end %>
+
+<% if project.new_record? %>
+  <section class="form--section">
+    <%= render partial: 'projects/form/custom_fields',
+               locals: {
+                 form: f,
+                 project: project,
+                 work_package_custom_fields: @issue_custom_fields
+                } %>
+  </section>
 <% end %>
 
 <!--[eoform:project]-->

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -1,0 +1,110 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<fieldset class="form--fieldset -with-control" id="project_types">
+  <legend class="form--fieldset-legend"><%=l(:label_enabled_project_activities)%></legend>
+
+  <div class="generic-table--container">
+    <div class="generic-table--results-container">
+      <table interactive-table role="grid" class="generic-table">
+        <colgroup>
+          <col highlight-col>
+          <col highlight-col>
+          <col highlight-col>
+          <% TimeEntryActivity.new.available_custom_fields.each do |value| %>
+              <col highlight-col>
+          <% end %>
+          </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Enumeration.human_attribute_name(:active) %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Enumeration.human_attribute_name(:name) %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= l(:enumeration_system_activity) %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <% TimeEntryActivity.new.available_custom_fields.each do |value| %>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= h value.name %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+              <% end %>
+            </tr>
+          </thead>
+          <% @project.activities(true).each do |enumeration| %>
+           <%= fields_for "enumerations[#{enumeration.id}]", enumeration do |ff| %>
+              <tr>
+                <td>
+                  <%= label_tag "enumerations_#{enumeration.id}_active", "#{h(enumeration.name)} #{l(:description_active)}", :class => "hidden-for-sighted" %>
+                  <%= ff.check_box :active %>
+                </td>
+                <td>
+                  <%= ff.hidden_field :parent_id, :value => enumeration.id unless enumeration.project %>
+                  <%= h(enumeration) %>
+                </td>
+                <td><%= checked_image !enumeration.project %></td>
+                <% enumeration.custom_field_values.each do |value| %>
+                  <td>
+                    <%= custom_field_tag "enumerations[#{enumeration.id}]", value %>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          <% end %>
+        </table>
+        <div class="generic-table--header-background"></div>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -35,21 +35,18 @@ See doc/COPYRIGHT.rdoc for more details.
     </span>
   </div>
 
-  <ul class="form--list">
     <% work_package_custom_fields.each do |custom_field| %>
-      <li class="form--field -trailing-label">
+      <%
+        css_classes = custom_field.is_for_all? ? { disabled:  "disabled" } : {}
+        css_classes[:lang] = custom_field.name_locale
+      %>
 
-        <%
-          css_classes = custom_field.is_for_all? ? { disabled:  "disabled" } : {}
-          css_classes[:lang] = custom_field.name_locale
-        %>
-
-        <%= form.collection_check_box :work_package_custom_field_ids,
-                                      custom_field.id,
-                                      @project.all_work_package_custom_fields.include?(custom_field),
-                                      custom_field.name,
-                                      css_classes %>
-      </li>
-    <% end %>
-  </ul>
+    <div class="form--field">
+      <%= form.collection_check_box :work_package_custom_field_ids,
+                                    custom_field.id,
+                                    @project.all_work_package_custom_fields.include?(custom_field),
+                                    custom_field.name,
+                                    css_classes %>
+    </div>
+  <% end %>
 </fieldset>

--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <fieldset class="form--fieldset -with-control" id="project_issue_custom_fields">
-  <legend class="form--fieldset-legend"><%=l(:label_custom_field_plural)%></legend>
+  <legend class="form--fieldset-legend"><%=l(:label_enabled_project_custom_fields)%></legend>
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">
       (<%= check_all_links 'project_issue_custom_fields' %>)

--- a/app/views/projects/form/_modules.html.erb
+++ b/app/views/projects/form/_modules.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 %>
 
 <fieldset class="form--fieldset -with-control">
-  <legend class="form--fieldset-legend"><%= l(:text_select_project_modules) %></legend>
+  <legend class="form--fieldset-legend"><%= l(:label_enabled_project_modules) %></legend>
 
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -39,12 +39,12 @@ See doc/COPYRIGHT.rdoc for more details.
   <legend class="form--fieldset-legend"><%=l(:label_type_plural)%></legend>
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">
-      (<%= link_to(l(:button_check_all), "#", id: "check_all_types") + ' | ' + link_to(l(:button_uncheck_all), "#", id: "uncheck_all_types") %>)
+      (<%= check_all_links 'types-form' %>)
     </span>
   </div>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table types">
+      <table interactive-table role="grid" class="generic-table types" id="types-form">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
                          class: "ignored-by-flash-activation" %>
 
 <fieldset class="form--fieldset -with-control" id="project_types">
-  <legend class="form--fieldset-legend"><%=l(:label_type_plural)%></legend>
+  <legend class="form--fieldset-legend"><%=l(:label_enabled_project_types)%></legend>
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">
       (<%= check_all_links 'types-form' %>)

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -30,6 +30,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_project_new) %>
 <%= labelled_tabular_form_for @project do |f| %>
   <%= render :partial => 'form', :locals => { :f => f, :project => @project, :renderTypes => true } %>
-  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+  <%= styled_button_tag l(:button_create), class: '-highlight -with-icon icon-yes' %>
   <%= javascript_tag "Form.Element.focus('project_name');" %>
 <% end %>

--- a/app/views/projects/settings/_activities.html.erb
+++ b/app/views/projects/settings/_activities.html.erb
@@ -26,89 +26,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= form_tag(project_enumerations_path(@project), :method => :put, :class => "tabular") do %>
-   <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
-        <colgroup>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <% TimeEntryActivity.new.available_custom_fields.each do |value| %>
-              <col highlight-col>
-          <% end %>
-          </colgroup>
-          <thead>
-            <tr>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= Enumeration.human_attribute_name(:active) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= Enumeration.human_attribute_name(:name) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= l(:enumeration_system_activity) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <% TimeEntryActivity.new.available_custom_fields.each do |value| %>
-                <th>
-                  <div class="generic-table--sort-header-outer">
-                    <div class="generic-table--sort-header">
-                      <span>
-                        <%= h value.name %>
-                      </span>
-                    </div>
-                  </div>
-                </th>
-              <% end %>
-            </tr>
-          </thead>
-          <% @project.activities(true).each do |enumeration| %>
-           <%= fields_for "enumerations[#{enumeration.id}]", enumeration do |ff| %>
-              <tr>
-                <td>
-                  <%= label_tag "enumerations_#{enumeration.id}_active", "#{h(enumeration.name)} #{l(:description_active)}", :class => "hidden-for-sighted" %>
-                  <%= ff.check_box :active %>
-                </td>
-                <td>
-                  <%= ff.hidden_field :parent_id, :value => enumeration.id unless enumeration.project %>
-                  <%= h(enumeration) %>
-                </td>
-                <td><%= checked_image !enumeration.project %></td>
-                <% enumeration.custom_field_values.each do |value| %>
-                  <td>
-                    <%= custom_field_tag "enumerations[#{enumeration.id}]", value %>
-                  </td>
-                <% end %>
-              </tr>
-            <% end %>
-          <% end %>
-        </table>
-        <div class="generic-table--header-background"></div>
-    </div>
-  </div>
-  <div class="contextual">
-    <%= link_to(l(:button_reset), project_enumerations_path(@project),
-            :method => :delete,
-            data: { confirm: l(:text_are_you_sure) },
-            :class => 'icon icon-delete') %>
-  </div>
-  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+
+<%= form_tag  project_enumerations_path(@project),
+              method: :put,
+              class: "tabular" do %>
+
+  <%= render partial: 'projects/form/activities', locals: { project: @project } %>
+
+  <p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %></p>
 <% end %>
+
+<br/>

--- a/app/views/projects/settings/_boards.html.erb
+++ b/app/views/projects/settings/_boards.html.erb
@@ -26,81 +26,101 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% if @project.boards.any? %>
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
-        <colgroup>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col>
-          </colgroup>
-        <thead>
-          <tr>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Board.model_name.human %>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Board.human_attribute_name(:description) %>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%=l(:button_sort)%>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @project.boards.each do |board|
-            next if board.new_record? %>
-            <tr>
-              <td><%=h board.name %></td>
-              <td><%=h board.description %></td>
-              <td class="small-icons">
-                <% if authorize_for("boards", "edit") %>
-                  <%= reorder_links('board', {:controller => '/boards', :action => 'move', :project_id => @project, :id => board}) %>
-                <% end %>
-              </td>
-              <td class="buttons">
-                <%= link_to_if_authorized l(:button_edit), {:controller => '/boards', :action => 'edit', :project_id => @project, :id => board}, :class => 'icon icon-edit' %>
-                <%= link_to_if_authorized l(:button_delete), {:controller => '/boards', :action => 'destroy', :project_id => @project, :id => board}, data: { confirm: l(:text_are_you_sure) }, :method => :delete, :class => 'icon icon-delete' %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-      <div class="generic-table--header-background"></div>
-    </div>
-  </div>
-<% else %>
+
+<fieldset class="form--fieldset -with-control">
+  <legend class="form--fieldset-legend">
+    <%= l(:label_available_project_boards) %>
+  </legend>
+
+  <% if @project.boards.any? %>
     <div class="generic-table--container">
-    <div class="generic-table--no-results-container">
-      <h2 class="generic-table--no-results-title">
-        <i class="icon-info"></i>
-        <%= l(:label_nothing_display) %>
-      </h2>
-      <div class="generic-table--no-results-description">
-        <p class="nodata"><%= l(:label_no_data) %></p>
+      <div class="generic-table--results-container">
+        <table interactive-table role="grid" class="generic-table">
+          <colgroup>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col>
+            </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Board.model_name.human %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Board.human_attribute_name(:description) %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%=l(:button_sort)%>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @project.boards.each do |board|
+              next if board.new_record? %>
+              <tr>
+                <td><%=h board.name %></td>
+                <td><%=h board.description %></td>
+                <td class="small-icons">
+                  <% if authorize_for 'boards', 'edit' %>
+                    <%= reorder_links 'board', controller: '/boards',
+                                               action: 'move',
+                                               project_id: @project,
+                                               id: board %>
+                  <% end %>
+                </td>
+                <td class="buttons">
+                  <%= link_to_if_authorized l(:button_edit),
+                                            { controller: '/boards', action: 'edit', project_id: @project, id: board },
+                                            class: 'icon icon-edit' %>
+                  <%= link_to_if_authorized l(:button_delete),
+                                            { controller: '/boards', action: 'destroy', project_id: @project, id: board },
+                                            data: { confirm: l(:text_are_you_sure) },
+                                            method: :delete,
+                                            class: 'icon icon-delete' %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+        <div class="generic-table--header-background"></div>
       </div>
     </div>
-  </div>
-<% end %>
-<p><%= link_to_if_authorized l(:label_board_new), {:controller => '/boards', :action => 'new', :project_id => @project} %></p>
+  <% else %>
+      <div class="generic-table--container">
+      <div class="generic-table--no-results-container">
+        <h2 class="generic-table--no-results-title">
+          <i class="icon-info"></i>
+          <%= l(:label_nothing_display) %>
+        </h2>
+        <div class="generic-table--no-results-description">
+          <p class="nodata"><%= l(:label_no_data) %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</fieldset>
+<p>
+  <%= link_to_if_authorized l(:label_board_new), controller: '/boards',
+                                                 action: 'new',
+                                                 project_id: @project %>
+</p>

--- a/app/views/projects/settings/_boards.html.erb
+++ b/app/views/projects/settings/_boards.html.erb
@@ -120,7 +120,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% end %>
 </fieldset>
 <p>
-  <%= link_to_if_authorized l(:label_board_new), controller: '/boards',
-                                                 action: 'new',
-                                                 project_id: @project %>
+  <%= link_to_if_authorized l(:label_board_new),
+                            { controller: '/boards', action: 'new', project_id: @project },
+                            class: 'button -alt-highlight' %>
 </p>

--- a/app/views/projects/settings/_categories.html.erb
+++ b/app/views/projects/settings/_categories.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
+
 <fieldset class="form--fieldset -with-control">
   <legend class="form--fieldset-legend">
     <%= l(:label_available_project_work_package_categories) %>
@@ -104,6 +105,6 @@ See doc/COPYRIGHT.rdoc for more details.
 </fieldset
 <p>
   <%= link_to_if_authorized l(:label_work_package_category_new),
-                            controller: '/categories', action: 'new',
-                            project_id: @project %>
+                            { controller: '/categories', action: 'new', project_id: @project },
+                            class: 'button -alt-highlight' %>
 </p>

--- a/app/views/projects/settings/_categories.html.erb
+++ b/app/views/projects/settings/_categories.html.erb
@@ -26,73 +26,84 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% if @project.categories.any? %>
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
-        <colgroup>
-          <col highlight-col>
-          <col highlight-col>
-          <col>
-        </colgroup>
-        <thead>
-          <tr>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Category.model_name.human %>
-                  </span>
+<fieldset class="form--fieldset -with-control">
+  <legend class="form--fieldset-legend">
+    <%= l(:label_available_project_work_package_categories) %>
+  </legend>
+
+  <% if @project.categories.any? %>
+    <div class="generic-table--container">
+      <div class="generic-table--results-container">
+        <table interactive-table role="grid" class="generic-table">
+          <colgroup>
+            <col highlight-col>
+            <col highlight-col>
+            <col>
+          </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Category.model_name.human %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Category.human_attribute_name(:assigned_to) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Category.human_attribute_name(:assigned_to) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% for category in @project.categories %>
-            <% unless category.new_record? %>
-              <tr>
-                <td><%=h(category.name) %></td>
-                <td><%=h(category.assigned_to.name) if category.assigned_to %></td>
-                <td class="buttons">
-                  <%= link_to_if_authorized l(:button_edit), { :controller => '/categories', :action => 'edit', :id => category }, :class => 'icon icon-edit' %>
-                  <%= link_to_if_authorized l(:button_delete),
-                                    { :controller => '/categories',
-                                      :action => 'destroy',
-                                      :id => category },
-                                    data: { confirm: l(:text_are_you_sure) },
-                                    method: :delete,
-                                    :class => 'icon icon-delete' %>
-                </td>
-              </tr>
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% for category in @project.categories %>
+              <% unless category.new_record? %>
+                <tr>
+                  <td><%=h(category.name) %></td>
+                  <td><%=h(category.assigned_to.name) if category.assigned_to %></td>
+                  <td class="buttons">
+                    <%= link_to_if_authorized l(:button_edit),
+                                              { controller: '/categories', action: 'edit', id: category },
+                                              class: 'icon icon-edit' %>
+
+                    <%= link_to_if_authorized l(:button_delete),
+                                              { controller: '/categories', action: 'destroy', id: category },
+                                              data: { confirm: l(:text_are_you_sure) },
+                                              method: :delete,
+                                              class: 'icon icon-delete' %>
+                  </td>
+                </tr>
+              <% end %>
             <% end %>
-          <% end %>
-        </tbody>
-      </table>
-      <div class="generic-table--header-background"></div>
-    </div>
-  </div>
-<% else %>
-  <div class="generic-table--container">
-    <div class="generic-table--no-results-container">
-      <h2 class="generic-table--no-results-title">
-        <i class="icon-info"></i>
-        <%= l(:label_nothing_display) %>
-      </h2>
-      <div class="generic-table--no-results-description">
-        <p class="nodata"><%= l(:label_no_data) %></p>
+          </tbody>
+        </table>
+        <div class="generic-table--header-background"></div>
       </div>
     </div>
-  </div>
-<% end %>
-<p><%= link_to_if_authorized l(:label_work_package_category_new), :controller => '/categories', :action => 'new', :project_id => @project %></p>
+  <% else %>
+    <div class="generic-table--container">
+      <div class="generic-table--no-results-container">
+        <h2 class="generic-table--no-results-title">
+          <i class="icon-info"></i>
+          <%= l(:label_nothing_display) %>
+        </h2>
+        <div class="generic-table--no-results-description">
+          <p class="nodata"><%= l(:label_no_data) %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</fieldset
+<p>
+  <%= link_to_if_authorized l(:label_work_package_category_new),
+                            controller: '/categories', action: 'new',
+                            project_id: @project %>
+</p>

--- a/app/views/projects/settings/_custom_fields.html.erb
+++ b/app/views/projects/settings/_custom_fields.html.erb
@@ -27,40 +27,17 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= error_messages_for project %>
+<%= labelled_tabular_form_for @project,
+                              url: { action: 'custom_fields', id: @project },
+                              method: :put,
+                              html: { id: 'modules-form' } do |form| %>
 
-<!--[form:project]-->
+  <%= render  partial: "projects/form/custom_fields",
+              locals: {
+                project: @project,
+                form: form,
+                work_package_custom_fields: @issue_custom_fields
+              } %>
 
-<section class="form--section">
-  <%= render partial: "projects/form/project_attributes",
-             locals: { project: project,
-                       form: f } %>
-
-  <%= call_hook(:view_projects_form,
-                project: project,
-                form: f) %>
-</section>
-
-<% if project.new_record? %>
-  <div>
-    <%= render partial: "projects/form/modules",
-               locals: { form: f } %>
-  </div>
-
-  <%= javascript_tag 'observeProjectModules();' %>
-<% else %>
-
-  <%= render partial: "projects/form/required_storage",
-             locals: { project: project, storage: project.count_required_storage } %>
-
+  <p><%= form.button l(:button_save), class: 'button -highlight -with-icon icon-yes' %></p>
 <% end %>
-
-<% if (project.new_record? || project.module_enabled?('work_package_tracking')) && renderTypes %>
-  <div>
-    <%= render partial: 'projects/form/types',
-               locals: { f: f,
-                         project: project } %>
-  </div>
-<% end %>
-
-<!--[eoform:project]-->

--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -26,127 +26,157 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% if @project.shared_versions.any? %>
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
-        <colgroup>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col>
-        </colgroup>
-        <thead>
-          <tr>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.model_name.human %>
-                  </span>
+
+<fieldset class="form--fieldset -with-control">
+  <legend class="form--fieldset-legend">
+    <%= l(:label_available_project_versions) %>
+  </legend>
+
+  <% if @project.shared_versions.any? %>
+    <div class="generic-table--container">
+      <div class="generic-table--results-container">
+        <table interactive-table role="grid" class="generic-table">
+          <colgroup>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col highlight-col>
+            <col>
+          </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.model_name.human %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.human_attribute_name(:start_date) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.human_attribute_name(:start_date) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.human_attribute_name(:effective_date) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.human_attribute_name(:effective_date) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.human_attribute_name(:description) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.human_attribute_name(:description) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.human_attribute_name(:status) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.human_attribute_name(:status) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Version.human_attribute_name(:sharing) %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= Version.human_attribute_name(:sharing) %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= WikiPage.model_name.human %>
-                  </span>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= WikiPage.model_name.human %>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% for version in @project.shared_versions.sort %>
-            <tr class="version <%= 'shared' if version.project != @project %>">
-              <td class="name <%=h version.status %><% ' icon-context icon-link' if version.project != @project%>"><%= link_to_version version %></td>
-              <td class="date"><%= format_date(version.start_date) %></td>
-              <td class="date"><%= format_date(version.effective_date) %></td>
-              <td class="description"><%=h version.description %></td>
-              <td class="status"><%= l("version_status_#{version.status}") %></td>
-              <td class="sharing"><%=h format_version_sharing(version.sharing) %></td>
-              <td><%= link_to_if_authorized(h(version.wiki_page_title), {:controller => '/wiki', :action => 'show', :project_id => version.project, :id => Wiki.titleize(version.wiki_page_title)}) || h(version.wiki_page_title) unless version.wiki_page_title.blank? || version.project.wiki.nil? %></td>
-              <td class="buttons">
-                <% if version.project == @project %>
-                  <%= link_to_if_authorized l(:button_edit),   {:controller => '/versions', :action => 'edit', :id => version }, :class => 'icon icon-edit' %>
-                  <%= link_to_if_authorized l(:button_delete), {:controller => '/versions', :action => 'destroy', :id => version}, data: { confirm: l(:text_are_you_sure) }, :method => :delete, :class => 'icon icon-delete' %>
-                <% end %>
-              </td>
+              </th>
+              <th></th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
-      <div class="generic-table--header-background"></div>
-    </div>
-  </div>
-<% else %>
-  <div class="generic-table--container">
-    <div class="generic-table--no-results-container">
-      <h2 class="generic-table--no-results-title">
-        <i class="icon-info"></i>
-        <%= l(:label_nothing_display) %>
-      </h2>
-      <div class="generic-table--no-results-description">
-        <p class="nodata"><%= l(:label_no_data) %></p>
+          </thead>
+          <tbody>
+            <% for version in @project.shared_versions.sort %>
+              <tr class="version <%= 'shared' if version.project != @project %>">
+                <td class="name <%=h version.status %><% ' icon-context icon-link' if version.project != @project %>">
+                  <%= link_to_version version %>
+                </td>
+                <td class="date"><%= format_date(version.start_date) %></td>
+                <td class="date"><%= format_date(version.effective_date) %></td>
+                <td class="description"><%=h version.description %></td>
+                <td class="status"><%= l("version_status_#{version.status}") %></td>
+                <td class="sharing"><%=h format_version_sharing(version.sharing) %></td>
+                <td>
+                  <%= link_to_if_authorized( h(version.wiki_page_title),
+                                             { controller: '/wiki',
+                                               action: 'show',
+                                               project_id: version.project,
+                                               id: Wiki.titleize(version.wiki_page_title) }) ||
+                      h(version.wiki_page_title) unless version.wiki_page_title.blank? || version.project.wiki.nil? %>
+                </td>
+                <td class="buttons">
+                  <% if version.project == @project %>
+                    <%= link_to_if_authorized l(:button_edit),
+                                              { controller: '/versions', action: 'edit', id: version },
+                                              class: 'icon icon-edit' %>
+                    <%= link_to_if_authorized l(:button_delete),
+                                              { controller: '/versions', action: 'destroy', id: version },
+                                              data: { confirm: l(:text_are_you_sure) },
+                                              method: :delete,
+                                              class: 'icon icon-delete' %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+        <div class="generic-table--header-background"></div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% else %>
+    <div class="generic-table--container">
+      <div class="generic-table--no-results-container">
+        <h2 class="generic-table--no-results-title">
+          <i class="icon-info"></i>
+          <%= l(:label_nothing_display) %>
+        </h2>
+        <div class="generic-table--no-results-description">
+          <p class="nodata"><%= l(:label_no_data) %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</fieldset>
+
 <div class="contextual">
   <% if @project.versions.any? %>
-    <%= link_to l(:label_close_versions), close_completed_project_versions_path(@project), :method => :put %>
+    <%= link_to l(:label_close_versions),
+                close_completed_project_versions_path(@project),
+                method: :put %>
   <% end %>
 </div>
-<p><%= link_to_if_authorized l(:label_version_new), :controller => '/versions', :action => 'new', :project_id => @project %></p>
+
+<p>
+  <%= link_to_if_authorized l(:label_version_new),
+                            { controller: '/versions', action: 'new', project_id: @project },
+                            class: 'button -alt-highlight' %>
+</p>

--- a/app/views/repositories/_settings.html.erb
+++ b/app/views/repositories/_settings.html.erb
@@ -27,7 +27,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-
 <% is_creation_form = @repository.nil? || @repository.new_record? %>
 <%= form_for :repository,
              remote: true,
@@ -37,6 +36,12 @@ See doc/COPYRIGHT.rdoc for more details.
              method: is_creation_form ? 'POST' : 'PUT',
              builder: TabularFormBuilder,
              html: { class: 'form' } do |f| %>
+
+<fieldset class="form--fieldset -with-control">
+  <legend class="form--fieldset-legend">
+    <%= l(:label_available_project_repositories) %>
+  </legend>
+
   <%= error_messages_for 'repository' %>
   <%# Hide the select for existing repositories %>
   <% if is_creation_form %>
@@ -55,7 +60,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= render partial: "/repositories/settings/vendor_form",
                  locals: { form: f, repository: @repository } %>
   <% end %>
-  
+
   <%# Allow plugins to add additional information %>
   <%= call_hook :repository_settings_fields, repository: @repository, form: f %>
 
@@ -64,4 +69,5 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= render partial: "/repositories/settings/submit",
                locals: { form: f, is_creation_form: is_creation_form, project: @project } %>
   <% end %>
+</fieldset>
 <% end %>

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -45,7 +45,7 @@ Redmine::AccessControl.map do |map|
                  require: :loggedin
 
   map.permission :edit_project,
-                 { projects: [:settings, :edit, :update],
+                 { projects: [:settings, :edit, :update, :custom_fields],
                    members: [:paginate_users] },
                  require: :member
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -677,6 +677,7 @@ en:
   label_auth_source_plural: "Authentication modes"
   label_authentication: "Authentication"
   label_available_project_work_package_categories: 'Available work package categories'
+  label_available_project_boards: 'Available boards'
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_board_locked: "Locked"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,7 @@ en:
   label_duplicates: "duplicates"
   label_edit: "Edit"
   label_enable_multi_select: "Toggle multiselect"
+  label_enabled_project_custom_fields: 'Enabled custom fields'
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"
   label_enumeration_new: "New enumeration value"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,6 +679,7 @@ en:
   label_available_project_work_package_categories: 'Available work package categories'
   label_available_project_boards: 'Available boards'
   label_available_project_versions: 'Available versions'
+  label_available_project_repositories: 'Available repositories'
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_board_locked: "Locked"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -753,6 +753,7 @@ en:
   label_enable_multi_select: "Toggle multiselect"
   label_enabled_project_custom_fields: 'Enabled custom fields'
   label_enabled_project_types: 'Enabled types'
+  label_enabled_project_modules: 'Enabled modules'
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"
   label_enumeration_new: "New enumeration value"
@@ -1533,7 +1534,6 @@ en:
   text_regexp_info: "eg. ^[A-Z0-9]+$"
   text_repository_usernames_mapping: "Select or update the OpenProject user mapped to each username found in the repository log.\nUsers with the same OpenProject and repository username or email are automatically mapped."
   text_select_mail_notifications: "Select actions for which email notifications should be sent."
-  text_select_project_modules: "Select modules to enable for this project:"
   text_status_changed_by_changeset: "Applied in changeset %{value}."
   text_subprojects_destroy_warning: "Its subproject(s): %{value} will be also deleted."
   text_time_logged_by_changeset: "Applied in changeset %{value}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -676,6 +676,7 @@ en:
   label_auth_source_new: "New authentication mode"
   label_auth_source_plural: "Authentication modes"
   label_authentication: "Authentication"
+  label_available_project_work_package_categories: 'Available work package categories'
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_board_locked: "Locked"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1179,6 +1179,7 @@ en:
   notice_automatic_set_of_standard_type: "Set standard type automatically."
   notice_logged_out: "You have been logged out."
   error_types_in_use_by_work_packages: "The following types are still referenced by work packages: %{types}"
+  notice_project_cannot_update_custom_fields: "You cannot update the project's available custom fields."
 
   # Default format for numbers
   number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -754,6 +754,7 @@ en:
   label_enabled_project_custom_fields: 'Enabled custom fields'
   label_enabled_project_types: 'Enabled types'
   label_enabled_project_modules: 'Enabled modules'
+  label_enabled_project_activities: 'Enabled time tracking activities'
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"
   label_enumeration_new: "New enumeration value"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -752,6 +752,7 @@ en:
   label_edit: "Edit"
   label_enable_multi_select: "Toggle multiselect"
   label_enabled_project_custom_fields: 'Enabled custom fields'
+  label_enabled_project_types: 'Enabled types'
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"
   label_enumeration_new: "New enumeration value"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -678,6 +678,7 @@ en:
   label_authentication: "Authentication"
   label_available_project_work_package_categories: 'Available work package categories'
   label_available_project_boards: 'Available boards'
+  label_available_project_versions: 'Available versions'
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_board_locked: "Locked"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,6 +232,7 @@ OpenProject::Application.routes.draw do
             constraints: { coming_from: /(admin|settings)/ }
       match 'copy' => 'copy_projects#copy', via: :post
       put :modules
+      put :custom_fields
       put :archive
       put :unarchive
       patch :types

--- a/features/project_types/project_creation_with_type.feature
+++ b/features/project_types/project_creation_with_type.feature
@@ -45,21 +45,18 @@ Feature: Project creation with support for project type
 
   Scenario: The admin may create a project with a project type
     Given I am already admin
-     When I go to the admin page
-      And I follow the first link matching "Projects"
-      And I follow "New project"
-     Then I fill in "Fancy Pants" for "Name"
-      And I fill in "fancy-pants" for "Identifier"
-      And I check "Timelines"
-      And I select "Standard Project" from "Project type"
-      And I press "Save"
-
-     Then I should see a notice flash stating "Successful creation."
-
-     When the following types are enabled for projects of type "Standard Project"
-          | Phase     |
-          | Milestone |
-      And I go to the "types" tab of the settings page of the project called "Fancy Pants"
-
-     Then the "Phase" checkbox should be checked
-      And the "Milestone" checkbox should be checked
+    When I go to the admin page
+    And I follow the first link matching "Projects"
+    And I follow "New project"
+    Then I fill in "Fancy Pants" for "Name"
+    And I fill in "fancy-pants" for "Identifier"
+    And I check "Timelines"
+    And I select "Standard Project" from "Project type"
+    And I press "Create"
+    Then I should see a notice flash stating "Successful creation."
+    When the following types are enabled for projects of type "Standard Project"
+      | Phase     |
+      | Milestone |
+    And I go to the "types" tab of the settings page of the project called "Fancy Pants"
+    Then the "Phase" checkbox should be checked
+    And the "Milestone" checkbox should be checked

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -92,7 +92,7 @@ Feature: Project Settings
     When I am already admin
     And  I go to the settings page of the project "project1"
     And  I select "project2" from "Subproject of"
-    And  I click on "Save" within "#content"
+    And  I click on "Update" within "#content"
     And  I follow "Copy" within "#content"
     And  I fill in "Name" with "Copied Project"
     And  I fill in "Identifier" with "cp"

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -125,15 +125,15 @@ Feature: Project Settings
       | name  | type | editable | is_for_all |
       | cfBug | int  | true     | false      |
     And  I am already admin
-    And  I go to the settings page of the project "project1"
-    And  I check "cfBug" within "#content"
-    And  I press "Save" within "#content"
-    And  I follow "Copy" within "#content"
+    And  I go to the custom_fields tab of the settings page of the project "project1"
+    And  I check "cfBug"
+    And  I press "Save"
+    And  I follow "Copy"
     And  I fill in "Name" with "Copied Project"
     And  I fill in "Identifier" with "cp"
     And  I click on "Copy"
     Then I should see "Started to copy project"
-    And  I go to the settings page of the project "cp"
+    And  I go to the custom_fields tab of the settings page of the project "cp"
     Then the "cfBug" checkbox should be checked
 
   @javascript

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -85,7 +85,7 @@ Feature: Project Settings
     Then the "Identifier" field should not contain "project1" within "#content"
     And  the "Name" field should not contain "project1" within "#content"
 
-  @javascript
+
   Scenario: Copy a project with parent
     Given there are the following projects of type "Copy Project":
       | project2 |
@@ -101,7 +101,7 @@ Feature: Project Settings
     And  I go to the settings page of the project "cp"
     And  I should see "project2" within "#project_parent_id"
 
-  @javascript
+
   Scenario: Copy a project with types
     Given the following types are enabled for the project called "project1":
         | Name      |
@@ -119,7 +119,7 @@ Feature: Project Settings
     Then the "Phase1" checkbox should be checked
     And  the "Phase2" checkbox should be checked
 
-  @javascript
+
   Scenario: Copy a project with Custom Fields
     Given the following work package custom fields are defined:
       | name  | type | editable | is_for_all |
@@ -154,7 +154,7 @@ Feature: Project Settings
     Then  I should see "issue1" within "#content"
     And   I should see "issue2" within "#content"
 
-  @javascript
+
   Scenario: Copying a project with some planning elements
     Given there are the following work packages in project "project1":
       | subject | start_date | due_date   |

--- a/features/projects/create.feature
+++ b/features/projects/create.feature
@@ -36,23 +36,23 @@ Feature: Creating Projects
   @javascript
   Scenario: Creating a Subproject
     When I go to the settings page of the project "parent"
-     And I follow "New subproject"
-     And I fill in "project_name" with "child"
-     And I press "Save"
+    And I follow "New subproject"
+    And I fill in "project_name" with "child"
+    And I press "Create"
     Then I should be on the settings page of the project called "child"
 
   Scenario: Creating a Subproject
     When I go to the settings page of the project "parent"
-     And I follow "New subproject"
+    And I follow "New subproject"
     Then I should not see "Responsible"
 
   @javascript
   Scenario: Creating a Project with an already existing identifier
     When I go to the projects admin page
-     And I follow "New project"
-     And I fill in "project_name" with "Parent"
-     And I press "Save"
+    And I follow "New project"
+    And I fill in "project_name" with "Parent"
+    And I press "Create"
     Then I should be on the projects page
-     And I should see "Identifier has already been taken"
-     And I fill in "project_name" with "Parent 2"
-     And the "Identifier" field should contain "parent-2" within "#content"
+    And I should see "Identifier has already been taken"
+    And I fill in "project_name" with "Parent 2"
+    And the "Identifier" field should contain "parent-2" within "#content"

--- a/features/projects/default_settings.feature
+++ b/features/projects/default_settings.feature
@@ -58,7 +58,7 @@ Feature: Project Default Settings
     And I fill in "project_name" with "A New Hope"
     And I fill in "project_identifier" with "a-new-hope"
     And I uncheck "Wiki"
-    And I press "Save"
+    And I press "Create"
     And I go to the settings page of the project called "A New Hope"
     And I click on "tab-modules"
     Then the "Wiki" checkbox should not be checked

--- a/features/projects/settings.feature
+++ b/features/projects/settings.feature
@@ -74,19 +74,19 @@ Feature: Project Settings
     And I should see "Bob Bobbit" within ".generic-table"
     And I should see "alpha" within ".generic-table"
 
-  @javascript
+
   Scenario: Changing members per page keeps us on the members tab
     When I go to the settings page of the project "project1"
     And I follow "Members" within ".tabs"
     And I follow "20" within ".per_page_options" within "#tab-content-members"
     Then I should be on the members tab of the settings page of the project "project1"
 
-  @javascript
+
   Scenario: Adding a Work Package custom field to the project
     When the following issue custom fields are defined:
       | name             | type      | is_for_all |
       | My Custom Field  | text      | false      |
-    And I go to the settings page of the project "project1"
-    And I check "My Custom Field" within "#tab-content-info"
-    And I press "Save" within "#tab-content-info"
+    And I go to the custom_fields tab of the settings page of the project "project1"
+    And I check "My Custom Field"
+    And I press "Save"
     Then the "My Custom Field" checkbox should be checked

--- a/features/projects/visibility.feature
+++ b/features/projects/visibility.feature
@@ -27,21 +27,19 @@
 #++
 
 Feature: Project Visibility
-
-Background:
-        Given there is 1 project with the following:
-        | name            | Bob's Accounting     |
-        | identifier      | bobs-accounting      |
-
+  Background:
+    Given there is 1 project with the following:
+      | name            | Bob's Accounting     |
+      | identifier      | bobs-accounting      |
     Then the project "Bob's Accounting" is public
 
-Scenario: A Project is visible on the landing page if it is set to public
-      Given I am on the login page
-      Then I should see "Projects" within "#top-menu-items"
-      When I go to the overall Projects page
-      Then I should see "Bob's Accounting" within "#content"
+  Scenario: A Project is visible on the landing page if it is set to public
+    Given I am on the login page
+    Then I should see "Projects" within "#top-menu-items"
+    When I go to the overall Projects page
+    Then I should see "Bob's Accounting" within "#content"
 
-Scenario: Project is not visible on the landing page if it is not set to public
-       Given the project "Bob's Accounting" is not public
-       And I am on the login page
-       Then I should not see "Projects" within "#top-menu-items"
+  Scenario: Project is not visible on the landing page if it is not set to public
+    Given the project "Bob's Accounting" is not public
+    And I am on the login page
+    Then I should not see "Projects" within "#top-menu-items"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -183,23 +183,16 @@ describe ProjectsController, type: :controller do
       let(:type_feature) { FactoryGirl.create(:type_feature) }
       let(:types) { [type_standard, type_bug, type_feature] }
       let(:project) {
-        FactoryGirl.create(:project,
-                           types: types)
+        FactoryGirl.create(:project, types: types)
       }
       let(:work_package_standard) {
-        FactoryGirl.create(:work_package,
-                           project: project,
-                           type: type_standard)
+        FactoryGirl.create(:work_package, project: project, type: type_standard)
       }
       let(:work_package_bug) {
-        FactoryGirl.create(:work_package,
-                           project: project,
-                           type: type_bug)
+        FactoryGirl.create(:work_package, project: project, type: type_bug)
       }
       let(:work_package_feature) {
-        FactoryGirl.create(:work_package,
-                           project: project,
-                           type: type_feature)
+        FactoryGirl.create(:work_package, project: project, type: type_feature)
       }
 
       shared_examples_for :redirect do
@@ -208,7 +201,9 @@ describe ProjectsController, type: :controller do
         it { is_expected.to be_redirect }
       end
 
-      before do allow(User).to receive(:current).and_return user end
+      before do
+        allow(User).to receive(:current).and_return user
+      end
 
       shared_context 'work_packages' do
         before do
@@ -232,9 +227,7 @@ describe ProjectsController, type: :controller do
         let(:type_ids) { types.map(&:id) }
 
         before do
-          patch :types,
-                id: project.id,
-                project: { 'type_ids' => type_ids }
+          patch :types, id: project.id, project: { 'type_ids' => type_ids }
         end
 
         it_behaves_like :redirect
@@ -248,9 +241,7 @@ describe ProjectsController, type: :controller do
         let(:missing_types) { types }
 
         before do
-          patch :types,
-                id: project.id,
-                project: { 'type_ids' => [] }
+          patch :types, id: project.id, project: { 'type_ids' => [] }
         end
 
         it_behaves_like :redirect
@@ -281,6 +272,44 @@ describe ProjectsController, type: :controller do
           subject { flash[:notice].all? { |n| regex.match(n).nil? } }
 
           it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    describe '#custom_fields' do
+      let(:project) { FactoryGirl.create(:project) }
+      let(:custom_field_1) { FactoryGirl.create(:work_package_custom_field) }
+      let(:custom_field_2) { FactoryGirl.create(:work_package_custom_field) }
+      let(:request) do
+        put :custom_fields,
+            id: project.id,
+            project: {
+              work_package_custom_field_ids: [custom_field_1.id, custom_field_2.id]
+            }
+      end
+
+      context 'with valid project' do
+        before do
+          request
+        end
+
+        it { expect(response).to redirect_to(settings_project_path(project, 'custom_fields')) }
+
+        it 'sets flash[:notice]' do
+          expect(flash[:notice]).to eql(I18n.t(:notice_successful_update))
+        end
+      end
+
+      context 'with invalid project' do
+        before do
+          allow_any_instance_of(Project).to receive(:save).and_return(false)
+          request
+        end
+
+        it { expect(response).to redirect_to(settings_project_path(project, 'custom_fields')) }
+
+        it 'sets flash[:error]' do
+          expect(flash[:error]).to eql(I18n.t(:notice_project_cannot_update_custom_fields))
         end
       end
     end

--- a/spec/features/accessibility/custom_fields_spec.rb
+++ b/spec/features/accessibility/custom_fields_spec.rb
@@ -161,7 +161,7 @@ describe 'Custom field accessibility', type: :feature do
         before do
           allow(I18n).to receive(:locale).and_return locale
 
-          project_settings_page.visit_settings
+          project_settings_page.visit_settings_tab('custom_fields')
         end
       end
 

--- a/spec/features/projects/project_settings_page.rb
+++ b/spec/features/projects/project_settings_page.rb
@@ -35,16 +35,10 @@ class ProjectSettingsPage
   end
 
   def visit_settings
-    visit settings_path
+    visit settings_project_path(@project, tab: 'custom_fields')
   end
 
   def fieldset_label
     find 'fieldset#project_issue_custom_fields label'
-  end
-
-  private
-
-  def settings_path
-    settings_project_path(@project)
   end
 end

--- a/spec/features/projects/project_settings_page.rb
+++ b/spec/features/projects/project_settings_page.rb
@@ -38,7 +38,7 @@ class ProjectSettingsPage
     visit settings_path
   end
 
-  def visit_settings_tab tab
+  def visit_settings_tab(tab)
     visit settings_path(tab: tab)
   end
 
@@ -48,7 +48,7 @@ class ProjectSettingsPage
 
   private
 
-  def settings_path options = {}
+  def settings_path(options = {})
     settings_project_path(@project, options)
   end
 end

--- a/spec/features/projects/project_settings_page.rb
+++ b/spec/features/projects/project_settings_page.rb
@@ -35,10 +35,20 @@ class ProjectSettingsPage
   end
 
   def visit_settings
-    visit settings_project_path(@project, tab: 'custom_fields')
+    visit settings_path
+  end
+
+  def visit_settings_tab tab
+    visit settings_path(tab: tab)
   end
 
   def fieldset_label
     find 'fieldset#project_issue_custom_fields label'
+  end
+
+  private
+
+  def settings_path options = {}
+    settings_project_path(@project, options)
   end
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -30,64 +30,221 @@ require 'spec_helper'
 
 describe ProjectsController, type: :routing do
   describe 'index' do
-    it { expect(get('/projects')).to        route_to(controller: 'projects', action: 'index') }
-    it { expect(get('/projects.atom')).to   route_to(controller: 'projects', action: 'index', format: 'atom') }
-    it { expect(get('/projects.xml')).to    route_to(controller: 'projects', action: 'index', format: 'xml') }
+    it do
+      expect(get('/projects')).to route_to(
+        controller: 'projects', action: 'index'
+      )
+    end
+
+    it do
+      expect(get('/projects.atom')).to route_to(
+        controller: 'projects', action: 'index', format: 'atom'
+      )
+    end
+
+    it do
+      expect(get('/projects.xml')).to route_to(
+        controller: 'projects', action: 'index', format: 'xml'
+      )
+    end
   end
 
   describe 'show' do
-    it { expect(get('/projects/1')).to      route_to(controller: 'projects', action: 'show', id: '1') }
-    it { expect(get('/projects/1.xml')).to  route_to(controller: 'projects', action: 'show', id: '1', format: 'xml') }
-    it { expect(get('/projects/test')).to   route_to(controller: 'projects', action: 'show', id: 'test') }
+    it do
+      expect(get('/projects/1')).to route_to(
+        controller: 'projects', action: 'show', id: '1'
+      )
+    end
+
+    it do
+      expect(get('/projects/1.xml')).to route_to(
+        controller: 'projects', action: 'show', id: '1', format: 'xml'
+      )
+    end
+
+    it do
+      expect(get('/projects/test')).to route_to(
+        controller: 'projects', action: 'show', id: 'test'
+      )
+    end
   end
 
   describe 'new' do
-    it { expect(get('/projects/new')).to    route_to(controller: 'projects', action: 'new') }
+    it do
+      expect(get('/projects/new')).to route_to(
+        controller: 'projects', action: 'new'
+      )
+    end
   end
 
   describe 'create' do
-    it { expect(post('/projects')).to       route_to(controller: 'projects', action: 'create') }
-    it { expect(post('/projects.xml')).to   route_to(controller: 'projects', action: 'create', format: 'xml') }
+    it do
+      expect(post('/projects')).to route_to(
+        controller: 'projects', action: 'create'
+      )
+    end
+
+    it do
+      expect(post('/projects.xml')).to route_to(
+        controller: 'projects', action: 'create', format: 'xml'
+      )
+    end
   end
 
   describe 'update' do
-    it { expect(put('/projects/123')).to      route_to(controller: 'projects', action: 'update', id: '123') }
-    it { expect(put('/projects/123.xml')).to  route_to(controller: 'projects', action: 'update', id: '123', format: 'xml') }
+    it do
+      expect(put('/projects/123')).to route_to(
+        controller: 'projects', action: 'update', id: '123'
+      )
+    end
+
+    it do
+      expect(put('/projects/123.xml')).to route_to(
+        controller: 'projects', action: 'update', id: '123', format: 'xml'
+      )
+    end
   end
 
   describe 'destroy_info' do
-    it { expect(get('/projects/123/destroy_info')).to route_to(controller: 'projects', action: 'destroy_info', id: '123') }
+    it do
+      expect(get('/projects/123/destroy_info')).to route_to(
+        controller: 'projects', action: 'destroy_info', id: '123'
+      )
+    end
   end
 
   describe 'delete' do
-    it { expect(delete('/projects/123')).to     route_to(controller: 'projects', action: 'destroy', id: '123') }
-    it { expect(delete('/projects/123.xml')).to route_to(controller: 'projects', action: 'destroy', id: '123', format: 'xml') }
+    it do
+      expect(delete('/projects/123')).to route_to(
+        controller: 'projects', action: 'destroy', id: '123'
+      )
+    end
+
+    it do
+      expect(delete('/projects/123.xml')).to route_to(
+        controller: 'projects', action: 'destroy', id: '123', format: 'xml'
+      )
+    end
   end
 
   describe 'miscellaneous' do
-    it { expect(get('/projects/123/settings')).to     route_to(controller: 'projects', action: 'settings', id: '123') }
-    it { expect(put('projects/123/modules')).to       route_to(controller: 'projects', action: 'modules', id: '123') }
-    it { expect(put('projects/123/custom_fields')).to route_to(controller: 'projects', action: 'custom_fields', id: '123') }
-    it { expect(put('projects/123/archive')).to       route_to(controller: 'projects', action: 'archive', id: '123') }
-    it { expect(put('projects/123/unarchive')).to     route_to(controller: 'projects', action: 'unarchive', id: '123') }
-    it { expect(post('projects/123/copy')).to         route_to(controller: 'copy_projects', action: 'copy', id: '123') }
-    it { expect(get('projects/123/copy_project_from_settings')).to route_to(controller: 'copy_projects', action: 'copy_project', id: '123', coming_from: 'settings') }
+    it do
+      expect(get('/projects/123/settings')).to route_to(
+        controller: 'projects', action: 'settings', id: '123'
+      )
+    end
+
+    it do
+      expect(put('projects/123/modules')).to route_to(
+        controller: 'projects', action: 'modules', id: '123'
+      )
+    end
+
+    it do
+      expect(put('projects/123/custom_fields')).to route_to(
+        controller: 'projects', action: 'custom_fields', id: '123'
+      )
+    end
+
+    it do
+      expect(put('projects/123/archive')).to route_to(
+        controller: 'projects', action: 'archive', id: '123'
+      )
+    end
+
+    it do
+      expect(put('projects/123/unarchive')).to route_to(
+        controller: 'projects', action: 'unarchive', id: '123'
+      )
+    end
+
+    it do
+      expect(post('projects/123/copy')).to route_to(
+        controller: 'copy_projects', action: 'copy', id: '123'
+      )
+    end
+
+    it do
+      expect(get('projects/123/copy_project_from_settings')).to route_to(
+        controller: 'copy_projects', action: 'copy_project', id: '123',
+        coming_from: 'settings'
+      )
+    end
   end
 
   describe 'settings' do
-    it { expect(get('/projects/123/settings/info')).to          route_to(controller: 'projects', action: 'settings', id: '123', tab: 'info') }
-    it { expect(get('/projects/123/settings/modules')).to       route_to(controller: 'projects', action: 'settings', id: '123', tab: 'modules') }
-    it { expect(get('/projects/123/settings/members')).to       route_to(controller: 'projects', action: 'settings', id: '123', tab: 'members') }
-    it { expect(get('/projects/123/settings/custom_fields')).to route_to(controller: 'projects', action: 'settings', id: '123', tab: 'custom_fields') }
-    it { expect(get('/projects/123/settings/versions')).to      route_to(controller: 'projects', action: 'settings', id: '123', tab: 'versions') }
-    it { expect(get('/projects/123/settings/categories')).to    route_to(controller: 'projects', action: 'settings', id: '123', tab: 'categories') }
-    it { expect(get('/projects/123/settings/repositories')).to  route_to(controller: 'projects', action: 'settings', id: '123', tab: 'repositories') }
-    it { expect(get('/projects/123/settings/boards')).to        route_to(controller: 'projects', action: 'settings', id: '123', tab: 'boards') }
-    it { expect(get('/projects/123/settings/activities')).to    route_to(controller: 'projects', action: 'settings', id: '123', tab: 'activities') }
-    it { expect(get('/projects/123/settings/types')).to         route_to(controller: 'projects', action: 'settings', id: '123', tab: 'types') }
+    it do
+      expect(get('/projects/123/settings/info')).to route_to(
+        controller: 'projects', action: 'settings', id: '123', tab: 'info'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/modules')).to route_to(
+        controller: 'projects', action: 'settings', id: '123', tab: 'modules'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/members')).to route_to(
+        controller: 'projects', action: 'settings', id: '123', tab: 'members'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/custom_fields')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'custom_fields'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/versions')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'versions'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/categories')).to route_to(
+        controller: 'projects', action: 'settings', id: '123', tab: 'categories'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/repositories')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'repositories'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/boards')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'boards'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/activities')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'activities'
+      )
+    end
+
+    it do
+      expect(get('/projects/123/settings/types')).to route_to(
+        controller: 'projects', action: 'settings', id: '123',
+        tab: 'types'
+      )
+    end
   end
 
   describe 'types' do
-    it { expect(patch('/projects/123/types')).to route_to(controller: 'projects', action: 'types', id: '123') }
+    it do
+      expect(patch('/projects/123/types')).to route_to(
+        controller: 'projects', action: 'types', id: '123'
+      )
+    end
   end
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -30,29 +30,29 @@ require 'spec_helper'
 
 describe ProjectsController, type: :routing do
   describe 'index' do
-    it { expect(get('/projects')).to route_to(controller: 'projects', action: 'index') }
-    it { expect(get('/projects.atom')).to route_to(controller: 'projects', action: 'index', format: 'atom') }
-    it { expect(get('/projects.xml')).to route_to(controller: 'projects', action: 'index', format: 'xml') }
+    it { expect(get('/projects')).to        route_to(controller: 'projects', action: 'index') }
+    it { expect(get('/projects.atom')).to   route_to(controller: 'projects', action: 'index', format: 'atom') }
+    it { expect(get('/projects.xml')).to    route_to(controller: 'projects', action: 'index', format: 'xml') }
   end
 
   describe 'show' do
-    it { expect(get('/projects/1')).to route_to(controller: 'projects', action: 'show', id: '1') }
-    it { expect(get('/projects/1.xml')).to route_to(controller: 'projects', action: 'show', id: '1', format: 'xml') }
-    it { expect(get('/projects/test')).to route_to(controller: 'projects', action: 'show', id: 'test') }
+    it { expect(get('/projects/1')).to      route_to(controller: 'projects', action: 'show', id: '1') }
+    it { expect(get('/projects/1.xml')).to  route_to(controller: 'projects', action: 'show', id: '1', format: 'xml') }
+    it { expect(get('/projects/test')).to   route_to(controller: 'projects', action: 'show', id: 'test') }
   end
 
   describe 'new' do
-    it { expect(get('/projects/new')).to route_to(controller: 'projects', action: 'new') }
+    it { expect(get('/projects/new')).to    route_to(controller: 'projects', action: 'new') }
   end
 
   describe 'create' do
-    it { expect(post('/projects')).to route_to(controller: 'projects', action: 'create') }
-    it { expect(post('/projects.xml')).to route_to(controller: 'projects', action: 'create', format: 'xml') }
+    it { expect(post('/projects')).to       route_to(controller: 'projects', action: 'create') }
+    it { expect(post('/projects.xml')).to   route_to(controller: 'projects', action: 'create', format: 'xml') }
   end
 
   describe 'update' do
-    it { expect(put('/projects/123')).to route_to(controller: 'projects', action: 'update', id: '123') }
-    it { expect(put('/projects/123.xml')).to route_to(controller: 'projects', action: 'update', id: '123', format: 'xml') }
+    it { expect(put('/projects/123')).to      route_to(controller: 'projects', action: 'update', id: '123') }
+    it { expect(put('/projects/123.xml')).to  route_to(controller: 'projects', action: 'update', id: '123', format: 'xml') }
   end
 
   describe 'destroy_info' do
@@ -60,25 +60,34 @@ describe ProjectsController, type: :routing do
   end
 
   describe 'delete' do
-    it { expect(delete('/projects/123')).to route_to(controller: 'projects', action: 'destroy', id: '123') }
+    it { expect(delete('/projects/123')).to     route_to(controller: 'projects', action: 'destroy', id: '123') }
     it { expect(delete('/projects/123.xml')).to route_to(controller: 'projects', action: 'destroy', id: '123', format: 'xml') }
   end
 
-  describe 'miscellanous' do
-    it { expect(get('/projects/123/settings')).to route_to(controller: 'projects',      action: 'settings',     id: '123') }
-    it { expect(get('/projects/123/settings/members')).to route_to(controller: 'projects',      action: 'settings',     id: '123', tab: 'members') }
-    it { expect(put('projects/123/modules')).to route_to(controller: 'projects',      action: 'modules',      id: '123') }
-    it { expect(put('projects/123/archive')).to route_to(controller: 'projects',      action: 'archive',      id: '123') }
-    it { expect(put('projects/123/unarchive')).to route_to(controller: 'projects',      action: 'unarchive',    id: '123') }
+  describe 'miscellaneous' do
+    it { expect(get('/projects/123/settings')).to     route_to(controller: 'projects', action: 'settings', id: '123') }
+    it { expect(put('projects/123/modules')).to       route_to(controller: 'projects', action: 'modules', id: '123') }
+    it { expect(put('projects/123/custom_fields')).to route_to(controller: 'projects', action: 'custom_fields', id: '123') }
+    it { expect(put('projects/123/archive')).to       route_to(controller: 'projects', action: 'archive', id: '123') }
+    it { expect(put('projects/123/unarchive')).to     route_to(controller: 'projects', action: 'unarchive', id: '123') }
+    it { expect(post('projects/123/copy')).to         route_to(controller: 'copy_projects', action: 'copy', id: '123') }
     it { expect(get('projects/123/copy_project_from_settings')).to route_to(controller: 'copy_projects', action: 'copy_project', id: '123', coming_from: 'settings') }
-    it { expect(post('projects/123/copy')).to route_to(controller: 'copy_projects', action: 'copy',         id: '123') }
+  end
+
+  describe 'settings' do
+    it { expect(get('/projects/123/settings/info')).to          route_to(controller: 'projects', action: 'settings', id: '123', tab: 'info') }
+    it { expect(get('/projects/123/settings/modules')).to       route_to(controller: 'projects', action: 'settings', id: '123', tab: 'modules') }
+    it { expect(get('/projects/123/settings/members')).to       route_to(controller: 'projects', action: 'settings', id: '123', tab: 'members') }
+    it { expect(get('/projects/123/settings/custom_fields')).to route_to(controller: 'projects', action: 'settings', id: '123', tab: 'custom_fields') }
+    it { expect(get('/projects/123/settings/versions')).to      route_to(controller: 'projects', action: 'settings', id: '123', tab: 'versions') }
+    it { expect(get('/projects/123/settings/categories')).to    route_to(controller: 'projects', action: 'settings', id: '123', tab: 'categories') }
+    it { expect(get('/projects/123/settings/repositories')).to  route_to(controller: 'projects', action: 'settings', id: '123', tab: 'repositories') }
+    it { expect(get('/projects/123/settings/boards')).to        route_to(controller: 'projects', action: 'settings', id: '123', tab: 'boards') }
+    it { expect(get('/projects/123/settings/activities')).to    route_to(controller: 'projects', action: 'settings', id: '123', tab: 'activities') }
+    it { expect(get('/projects/123/settings/types')).to         route_to(controller: 'projects', action: 'settings', id: '123', tab: 'types') }
   end
 
   describe 'types' do
-    it do
-      expect(patch('/projects/123/types')).to route_to(controller: 'projects',
-                                                       action: 'types',
-                                                       id: '123')
-    end
+    it { expect(patch('/projects/123/types')).to route_to(controller: 'projects', action: 'types', id: '123') }
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/20841

**Note:**
- `edit_project` permission applies for the custom fields

**Edit:** 
removed the todos as I agreed with @lindenthal 
- to keep the headlines
- keep the check all
#### ToDos
- [x] One column view (it is easier to find the respective custom field) 
