### PR TITLE
Fix failing specs on config with cost plugin

### DIFF
--- a/spec/features/time_entry/csv_export_spec.rb
+++ b/spec/features/time_entry/csv_export_spec.rb
@@ -29,7 +29,9 @@
 require 'spec_helper'
 
 describe 'time entry csv export', type: :feature do
-  let(:project) { FactoryGirl.create(:project) }
+  # Force project to have only the required module activated
+  # This may otherwise break for non-core configurations
+  let(:project) { FactoryGirl.create(:project, enabled_module_names: %w(time_tracking)) }
   let(:role) { FactoryGirl.create(:role, permissions: [:view_time_entries]) }
   let(:work_package) { FactoryGirl.create(:work_package, project: project) }
   let(:project_time_entry) {
@@ -84,7 +86,7 @@ describe 'time entry csv export', type: :feature do
 
   context 'for a single project' do
     before do
-      visit project_time_entries_path(project.id)
+      visit project_time_entries_path(project.identifier)
       click_link('CSV')
     end
 


### PR DESCRIPTION
The cost plugin overrides the default time entries module.
However we can still convince the core to use the time entries module,
simply by restricting the enabled module set.
