### PR TITLE
Storage performance and accuracy improvements

### DIFF
--- a/spec/support/scm/countable_repository.rb
+++ b/spec/support/scm/countable_repository.rb
@@ -1,8 +1,12 @@
+require 'open3'
 shared_examples_for 'is a countable repository' do
   let(:job) { ::Scm::StorageUpdaterJob.new repository }
+  let(:cache_time) { 720 }
+
   before do
     allow(::Scm::StorageUpdaterJob).to receive(:new).and_return(job)
     allow(job).to receive(:repository).and_return(repository)
+    allow(Setting).to receive(:repository_storage_cache_minutes).and_return(cache_time)
   end
   it 'is countable' do
     expect(repository.scm).to be_storage_available
@@ -47,6 +51,32 @@ shared_examples_for 'is a countable repository' do
       expect(repository.update_required_storage).to be true
       expect(repository.storage_updated_at).to be >= 1.minute.ago
       expect(repository.update_required_storage).to be false
+    end
+  end
+
+  describe 'count methods' do
+    it 'uses du when available' do
+      expect(::Open3).to receive(:capture3).with('du', any_args)
+        .and_return(["1234\t.", '', 0])
+      expect(repository.scm).not_to receive(:count_storage_fallback)
+
+      expect(repository.scm.count_repository!).to eq(1234)
+    end
+
+    it 'falls back to using ruby when du is unavailable' do
+      expect(::Open3).to receive(:capture3).with('du', any_args)
+        .and_raise(SystemCallError.new 'foo')
+      expect(repository.scm).to receive(:count_storage_fallback).and_return(12345)
+
+      expect(repository.scm.count_repository!).to eq(12345)
+    end
+
+    it 'falls back to using ruby when du is incompatible' do
+      expect(::Open3).to receive(:capture3).with('du', any_args)
+        .and_return(['no output', nil, 1])
+      expect(repository.scm).to receive(:count_storage_fallback).and_return(12345)
+
+      expect(repository.scm.count_repository!).to eq(12345)
     end
   end
 end


### PR DESCRIPTION
### Synopsis
- [X] Introduces fast counting by shelling out to `du` (~25% performance bonus)
- [X] Fallback to `File.stat`, which still is ever so slightly faster than the current method

This PR allows storage counting to shell out to `du` for
GNU-compatible installations.

This commit allows storage counting to shell out to `du` where
available.

This commit allows storage counting to shell out to `du` where
available.

The method uses du with `-bs` to count the apparent file size in bytes.
Note that apparent size is NOT the same as the real required size on
file system, but is used to be consistent with other sizes displayed in
OpenProject (e.g., attachments size)

When du is either unavailable or incompatible, in that it doesn't
return the requested count, the ruby fallback counting method is used.

This method has been slightly altered to use `File.stat` instead of
`File.new(path).size` for reduced computational overhead compared to `du`.

Improves results from result in work package https://community.openproject.org/work_packages/18393.
