### PR TITLE
Profile RSpec runs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -28,3 +28,4 @@
 
 --color
 --exclude-pattern spec/legacy/**/*_spec.rb
+--profile


### PR DESCRIPTION
## Description

RSpec has a parameter called `--profile` that will print out the Top 10 slowest specs at the end of the run.

Including this parameter by default can:
- raise awareness of slow specs as you write them
- running on travis tell us which specs need dire improvement

I think there are no caveats in using this setting and it can only increase transparency. I will remove the WIP label once travis agrees that this is a good idea. Opinions are welcome.
