### PR TITLE
Fix/min width on table

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -133,6 +133,7 @@ table.generic-table
 
     td
       max-width: 300px
+      min-width: 150px
       overflow:  hidden
       text-overflow: ellipsis
       text-align: left
@@ -174,6 +175,7 @@ table.generic-table
     padding:      0 6px
     line-height:  $generic-table--header-height
     z-index:      1
+    min-width:    150px
 
     &:hover,
     &.hover

--- a/frontend/app/ui_components/interactive-table-directive.js
+++ b/frontend/app/ui_components/interactive-table-directive.js
@@ -101,6 +101,9 @@ module.exports = function($timeout, $window){
       }
 
       var setTableWidths = function() {
+        if(!getTable().is(':visible')) {
+          return;
+        }
         $timeout(function() {
           invalidateWidths();
           setTableContainerWidths();


### PR DESCRIPTION
This attempts to again fix the table width calculation. The edge cases this covers are:

Empty columns, where the heading used to get squased if there is more space required by the remaining table columns than exists.
Switching tabs on e.g. project configuration. Because the tables on tabs, that are not visible upon rendering have display:none, they do not have a width and our algorithm fails. Therefore we rather fall back to the browser behaviour. This is not ideal but it is better than before.  
