### PR TITLE
Remove last activity section from admin/projects

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -49,7 +49,7 @@ class AdminController < ApplicationController
     # after once sorting the list
     sort_clear
     sort_init 'lft'
-    sort_update %w(lft name is_public created_on updated_on required_disk_space)
+    sort_update %w(lft name is_public created_on required_disk_space)
     @status = params[:status] ? params[:status].to_i : 1
     c = ARCondition.new(@status == 0 ? 'status <> 0' : ['status = ?', @status])
 

--- a/app/views/admin/projects.html.erb
+++ b/app/views/admin/projects.html.erb
@@ -69,7 +69,6 @@ See doc/COPYRIGHT.rdoc for more details.
         <col highlight-col>
         <col highlight-col>
         <col highlight-col>
-        <col highlight-col>
         <col>
       </colgroup>
       <thead>
@@ -103,14 +102,6 @@ See doc/COPYRIGHT.rdoc for more details.
               <div class="generic-table--sort-header">
                 <%= sort_header_tag_with_lsg('created_on',
                                              caption: Project.human_attribute_name(:created_on)) %>
-              </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <%= sort_header_tag_with_lsg('updated_on',
-                                             caption: I18n.t(:label_last_activity)) %>
               </div>
             </div>
           </th>


### PR DESCRIPTION
The last activity information is not updated properly in the current
state, thus the column should not appear (yet).

This will be reversed once it is updated appropriately.
