### PR TITLE
Remove hard syck dependency, make it optional instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ env:
     - "TEST_SUITE=spec:legacy DB=postgres"
 
 before_install:
+  # TODO: Remove when bundler 1.10 is available on travis per default
+  - "gem install bundler"
   - "echo `firefox -v`"
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"

--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,6 @@ gem 'rack-protection', :git => "https://github.com/finnlabs/rack-protection.git"
 # https://github.com/kickstarter/rack-attack
 gem 'rack-attack'
 
-gem 'syck', :platforms => [:mri, :mingw, :x64_mingw], :require => false
-
 gem 'gon', '~> 4.0'
 
 # catch exceptions and send them to any airbrake compatible backend
@@ -181,6 +179,10 @@ end
 
 group :ldap do
   gem "net-ldap", '~> 0.8.0'
+end
+
+group :syck, optional: true do
+  gem "syck", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       railties (~> 3.0)
     structured_warnings (0.1.4)
     svg-graph (1.0.5)
-    syck (1.0.1)
+    syck (1.0.5)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)

--- a/db/migrate/migration_utils/legacy_journal_migrator.rb
+++ b/db/migrate/migration_utils/legacy_journal_migrator.rb
@@ -29,7 +29,7 @@
 
 require_relative 'db_worker'
 require_relative 'legacy_table_checker'
-require 'syck'
+require_relative 'legacy_yamler'
 
 module Migration
   class IncompleteJournalsError < ::StandardError
@@ -41,6 +41,7 @@ module Migration
   class LegacyJournalMigrator
     include DbWorker
     include LegacyTableChecker
+    include LegacyYamler
 
     attr_accessor :table_name,
                   :type,
@@ -274,17 +275,7 @@ module Migration
     def deserialize_changed_data(journal)
       changed_data = journal['changed_data']
       return Hash.new if changed_data.nil?
-
-      current_yamler = YAML::ENGINE.yamler || 'psych'
-      begin
-        # The change to 'syck' ensures that legacy data is correctly read from
-        # the 'legacy_journals' table. Otherwise, we would end up with false
-        # encoded data in the new journal.
-        YAML::ENGINE.yamler = 'syck'
-        YAML.load(changed_data)
-      ensure
-        YAML::ENGINE.yamler = current_yamler
-      end
+      load_with_sych(changed_data)
     end
 
     def deserialize_journal(journal)


### PR DESCRIPTION
This PR tries to remove the hard Syck dependency we currently have. As Syck has been removed a long time, we should no longer force its gem onto new installations.
### Syck was used in
- `db/migrate/20130612120042_migrate_serialized_yaml_from_syck_to_psych.rb`
- `db/migrate/utilities/legacy_journal_migrator.rb`

This PR lets these migrations test whether actual data is being transformed.
When any of these migrations find serialized YAML, we're going to assume that
it MIGHT be coming from Syck.

Thus we add a `LegacyYamler` helper that will dynamically require Syck
and fail with an elaborate message if it hasn't been installed using the
optional bundler group `bundle install --with syck`.

On new installations, both these points are skipped as no data is
retrieved from the queries.

This commit should effectively provide Rails 2.2. compatibility

To install with syck, users can do `bundle install --with syck`.
We may think about removing the legacy migrations at some point, though.
