### PR TITLE
Fix broken inline editing after adding/removing attachment

### DIFF
--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -49,6 +49,8 @@ module.exports = function(
           if (scope.files.length > 0) {
             workPackageAttachmentsService.upload(workPackage, scope.files).then(function() {
               scope.files = [];
+              // Reload work package in order to prevent version conflicts.
+              scope.$emit('workPackageRefreshRequired');
               loadAttachments();
             });
           }
@@ -79,6 +81,8 @@ module.exports = function(
       workPackageAttachmentsService.remove(file).then(function(file) {
         _.remove(scope.attachments, file);
         _.remove(scope.files, file);
+        // Reload work package in order to prevent version conflicts.
+        scope.$emit('workPackageRefreshRequired');
       }).finally(function() {
         _.remove(currentlyRemoving, file);
       });


### PR DESCRIPTION
Changing an attachment changes the version of a work package on the
server and since pessimistic concurrency is implemented this will lead to
version conflicts when editing a field. The fix was to simply reload the
current work package to get the most recent version.

edit by @NobodysNightmare:
OpenProject WP: https://community.openproject.org/work_packages/21111
