### PR TITLE
Add confirmation dialog to removing attachment

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -240,6 +240,7 @@ en:
         zero: "You cannot select any items"
     text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
     text_query_destroy_confirmation: "Are you sure you want to delete the selected query?"
+    text_attachment_destroy_confirmation: "Are you sure you want to delete this attachment?"
     timelines:
       cancel: Cancel
       change: "Change in planning"

--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -75,6 +75,9 @@ module.exports = function(
 
     var currentlyRemoving = [];
     scope.remove = function(file) {
+      if (!confirm(I18n.t('js.text_attachment_destroy_confirmation'))) {
+        return;
+      }
       currentlyRemoving.push(file);
       workPackageAttachmentsService.remove(file).then(function(file) {
         _.remove(scope.attachments, file);


### PR DESCRIPTION
This PR adds a confirmation dialog to the angular client when removing existing attachments.
