### PR TITLE
fix HTTP response of DELETE attachment

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -804,12 +804,12 @@ Permanently deletes the specified attachment.
 + Parameters
     + id (required, integer, `1`) ... Attachment id
 
-+ Response 202
++ Response 204
 
     Returned if the attachment was deleted successfully.
 
     Note that the response body is empty as of now. In future versions of the API a body
-    *might* be returned.
+    *might* be returned along with an appropriate HTTP status.
 
     + Body
 

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -53,7 +53,7 @@ module API
               authorize(:edit_work_packages, context: @attachment.container.project)
 
               @attachment.container.attachments.delete(@attachment)
-              status 202
+              status 204
             end
           end
         end

--- a/spec/requests/api/v3/attachments/attachment_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_spec.rb
@@ -92,8 +92,8 @@ describe 'API v3 Attachment resource', type: :request do
     context 'with required permissions' do
       let(:permissions) { [:view_work_packages, :edit_work_packages] }
 
-      it 'responds with 202' do
-        expect(subject.status).to eq 202
+      it 'responds with HTTP No Content' do
+        expect(subject.status).to eq 204
       end
 
       it 'deletes the attachment' do


### PR DESCRIPTION
this was wrongfully HTTP 202 ([Accepted](https://www.flickr.com/photos/girliemac/6540479079/in/album-72157628409467125/)), which would only be valid if we did the deletion in a delayed/deferred way.

For now using HTTP 204 ([No Content](https://www.flickr.com/photos/girliemac/6547319943/in/album-72157628409467125/)), since we have no response body.
