### PR TITLE
force id value in experimental API

### DIFF
--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -48,7 +48,7 @@ module Api
       def index
         @work_packages = current_work_packages
 
-        columns = @query.involved_columns
+        columns = @query.involved_columns + [:id]
 
         @column_names, @custom_field_column_ids = separate_columns_by_custom_fields(columns)
 


### PR DESCRIPTION
The `id` information needs to be returned in the api response so that links still work. The frontend will filter it out anyway
