### PR TITLE
Improve Attachment links

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -714,6 +714,12 @@ Updates an activity's comment and, on success, returns the updated activity.
 Attachments are files that were uploaded to OpenProject. Each attachment belongs to a single
 container (e.g. a work package or a board message).
 
+## Actions
+
+| Link                | Description                                                          | Condition                                    |
+|:-------------------:|----------------------------------------------------------------------| -------------------------------------------- |
+| delete              | Deletes this attachment                                              | **Permission**: edit on attachment container |
+
 ## Linked Properties
 |  Link            | Description                                         | Type          | Constraints | Supported operations |
 |:----------------:| --------------------------------------------------- | ------------- | ----------- | -------------------- |

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -50,6 +50,14 @@ module API
           }
         end
 
+        # visibility of this link is also work_package specific!
+        link :delete do
+          {
+            href: api_v3_paths.attachment(represented.id),
+            method: :delete
+          } if current_user_allowed_to(:edit_work_packages, context: represented.container.project)
+        end
+
         property :id
         property :file_name,
                  getter: -> (*) { filename }

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -125,7 +125,7 @@ module API
           {
             href: api_v3_paths.attachments_by_work_package(represented.id),
             method: :post
-          }
+          } if current_user_allowed_to(:edit_work_packages, context: represented.project)
         end
 
         link :availableWatchers do

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -51,8 +51,7 @@ module API
         link :update do
           {
             href: api_v3_paths.work_package_form(represented.id),
-            method: :post,
-            title: "Update #{represented.subject}"
+            method: :post
           } if current_user_allowed_to(:edit_work_packages, context: represented.project)
         end
 
@@ -65,8 +64,7 @@ module API
         link :updateImmediately do
           {
             href: api_v3_paths.work_package(represented.id),
-            method: :patch,
-            title: "Update #{represented.subject}"
+            method: :patch
           } if current_user_allowed_to(:edit_work_packages, context: represented.project)
         end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -220,24 +220,37 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
       describe 'update links' do
         describe 'update by form' do
-          it { expect(subject).to have_json_path('_links/update/href') }
-          it {
-            expect(subject).to be_json_eql("/api/v3/work_packages/#{work_package.id}/form".to_json)
-              .at_path('_links/update/href')
-          }
-          it { expect(subject).to be_json_eql('post'.to_json).at_path('_links/update/method') }
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'update' }
+            let(:href) { api_v3_paths.work_package_form(work_package.id) }
+          end
+
+          it 'is a post link' do
+            is_expected.to be_json_eql('post'.to_json).at_path('_links/update/method')
+          end
         end
 
         describe 'immediate update' do
-          it { expect(subject).to have_json_path('_links/updateImmediately/href') }
-          it {
-            expect(subject).to be_json_eql("/api/v3/work_packages/#{work_package.id}".to_json)
-              .at_path('_links/updateImmediately/href')
-          }
-          it {
-            expect(subject).to be_json_eql('patch'.to_json)
-              .at_path('_links/updateImmediately/method')
-          }
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'updateImmediately' }
+            let(:href) { api_v3_paths.work_package(work_package.id) }
+          end
+
+          it 'is a patch link' do
+            is_expected.to be_json_eql('patch'.to_json).at_path('_links/updateImmediately/method')
+          end
+        end
+
+        context 'user is not allowed to edit work packages' do
+          let(:permissions) { all_permissions - [:edit_work_packages] }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'update' }
+          end
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'updateImmediately' }
+          end
         end
       end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -49,7 +49,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
                       estimated_hours: 6.0)
   }
   let(:project) { work_package.project }
-  let(:permissions) {
+  let(:all_permissions) {
     [
       :view_work_packages,
       :view_work_package_watchers,
@@ -60,6 +60,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       :add_work_package_notes
     ]
   }
+  let(:permissions) { all_permissions }
   let(:role) { FactoryGirl.create :role, permissions: permissions }
 
   before(:each) do
@@ -465,6 +466,14 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
         it 'addAttachments is a post link' do
           is_expected.to be_json_eql('post'.to_json).at_path('_links/addAttachment/method')
+        end
+
+        context 'user is not allowed to edit work packages' do
+          let(:permissions) { all_permissions - [:edit_work_packages] }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'addAttachment' }
+          end
         end
       end
 


### PR DESCRIPTION
## Description

This PR improves links around attachments:
- `addAttachment` in `work_packages` will only show up, if the user is allowed to add an attachment
- added `delete` link to `attachments`, that indicates how to delete the attachment
