### PR TITLE
[21368] Horizontal scrollbar in WP list even if there's nothing to scroll (2)

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -234,6 +234,9 @@
     .form--field-container
       max-width: 400px
 
+.work-package-table--container
+  table.generic-table
+    width: calc(100% - 10px)
 
 %flex-grow-shrink-zero
   flex-grow: 0

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -236,6 +236,7 @@
 
 .work-package-table--container
   table.generic-table
+    // HACK: This prevents a horizontal scroll bar in the work package table when there is nothing to scroll
     width: calc(100% - 10px)
 
 %flex-grow-shrink-zero

--- a/frontend/app/ui_components/interactive-table-directive.js
+++ b/frontend/app/ui_components/interactive-table-directive.js
@@ -44,7 +44,11 @@ module.exports = function($timeout, $window){
       }
 
       function getOuterContainer() {
-        return element.parent('.generic-table--container');
+        return element.closest('.generic-table--container');
+      }
+
+      function isWorkPackagesTable () {
+        return element.closest('.work-package-table--container').length !== 0;
       }
 
       function getBackgrounds() {
@@ -76,7 +80,12 @@ module.exports = function($timeout, $window){
         } else {
           // ensure table stretches to container sizes
           getInnerContainer().css('width', '100%');
-          getBackgrounds().css('width', '100%');
+          if(isWorkPackagesTable()) {
+            getBackgrounds().css('width', 'calc(100% - 10px)');
+          }
+          else {
+            getBackgrounds().css('width', '100%');
+          }
         }
       }
 

--- a/frontend/app/ui_components/interactive-table-directive.js
+++ b/frontend/app/ui_components/interactive-table-directive.js
@@ -81,6 +81,8 @@ module.exports = function($timeout, $window){
           // ensure table stretches to container sizes
           getInnerContainer().css('width', '100%');
           if(isWorkPackagesTable()) {
+            // HACK: This prevents a horizontal scroll bar in
+            //       the work package table when there is nothing to scroll
             getBackgrounds().css('width', 'calc(100% - 10px)');
           }
           else {


### PR DESCRIPTION
This avoids horizontal scrollbars in the work packages table when they were not needed.

https://community.openproject.org/work_packages/21368
