### PR TITLE
Force english locale on browser profile

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,11 @@ Capybara.register_driver :selenium do |app|
   require 'selenium/webdriver'
   Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] ||
     Selenium::WebDriver::Firefox::Binary.path
-  Capybara::Selenium::Driver.new(app, browser: :firefox)
+
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile['intl.accept_languages'] = 'en'
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile)
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
This enforces the firefox instance used for capybara to accept an english locale only. This in turn causes the default langauge to be english, unless overridden by user settings or specs directly.

This fixes broken specs on machines with non-english browser locales.
