### PR TITLE
Always pass the current user into representers

### DIFF
--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -36,7 +36,7 @@ module API
 
         @link = ::API::V3::Utilities::ResourceLinkGenerator.make_link(group_key)
 
-        super(group_key)
+        super(group_key, current_user: nil)
       end
 
       link :valueLink do

--- a/lib/api/decorators/collection.rb
+++ b/lib/api/decorators/collection.rb
@@ -59,7 +59,7 @@ module API
       collection :elements,
                  getter: -> (*) {
                    represented.map { |model|
-                     element_decorator.new(model, current_user: current_user)
+                     element_decorator.create(model, current_user: current_user)
                    }
                  },
                  exec_context: :decorator,

--- a/lib/api/decorators/collection.rb
+++ b/lib/api/decorators/collection.rb
@@ -32,11 +32,11 @@ module API
     class Collection < ::API::Decorators::Single
       include API::Utilities::UrlHelper
 
-      def initialize(models, total, self_link, context: {})
+      def initialize(models, total, self_link, current_user:)
         @total = total
         @self_link = self_link
 
-        super(models, context)
+        super(models, current_user: current_user)
       end
 
       class_attribute :element_decorator_class
@@ -59,7 +59,7 @@ module API
       collection :elements,
                  getter: -> (*) {
                    represented.map { |model|
-                     element_decorator.new(model, context)
+                     element_decorator.new(model, current_user: current_user)
                    }
                  },
                  exec_context: :decorator,

--- a/lib/api/decorators/digest.rb
+++ b/lib/api/decorators/digest.rb
@@ -33,7 +33,7 @@ module API
       def initialize(model, algorithm:)
         @algorithm = algorithm
 
-        super(model)
+        super(model, current_user: nil)
       end
 
       property :algorithm,

--- a/lib/api/decorators/formattable.rb
+++ b/lib/api/decorators/formattable.rb
@@ -38,7 +38,9 @@ module API
 
         @format = 'plain' if @format.blank?
 
-        super(model)
+        # Note: TextFormatting actually makes use of User.current, if it was possible to pass a
+        # current_user explicitly, it would make sense to pass one here too.
+        super(model, current_user: nil)
       end
 
       property :format,

--- a/lib/api/decorators/link_object.rb
+++ b/lib/api/decorators/link_object.rb
@@ -42,7 +42,7 @@ module API
         @getter = getter
         @setter = setter
 
-        super(model)
+        super(model, current_user: nil)
       end
 
       property :href,

--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -38,7 +38,7 @@ module API
         Setting.api_max_page_size.to_i
       end
 
-      def initialize(models, self_link, query: {}, page: nil, per_page: nil, context: {})
+      def initialize(models, self_link, query: {}, page: nil, per_page: nil, current_user:)
         @self_link_base = self_link
         @query = query
         @page = page || 1
@@ -49,7 +49,7 @@ module API
         # see https://github.com/mislav/will_paginate/issues/449
         page_models = models.page(@page).per_page(@per_page).to_a
         full_self_link = make_page_link(page: @page, page_size: @per_page)
-        super(page_models, models.count, full_self_link, context: context)
+        super(page_models, models.count, full_self_link, current_user: current_user)
       end
 
       link :jumpTo do

--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -92,7 +92,7 @@ module API
                                            type: make_type(property),
                                            name_source: property,
                                            values_callback: -> {
-                                             represented.assignable_values(property, context)
+                                             represented.assignable_values(property, current_user)
                                            },
                                            value_representer:,
                                            link_factory:,
@@ -131,9 +131,9 @@ module API
       end
 
       attr_reader :form_embedded
-      def initialize(represented, context = {})
-        @form_embedded = context.delete(:form_embedded)
-        super
+      def initialize(represented, current_user:, form_embedded: false)
+        @form_embedded = form_embedded
+        super(represented, current_user: current_user)
       end
 
       private

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -44,6 +44,12 @@ module API
       class_attribute :as_strategy
       self.as_strategy = ::API::Utilities::CamelCasingStrategy.new
 
+      # Use this to create our own representers, giving them a chance to override the instantiation
+      # if desired.
+      def self.create(model, current_user:, embed_links: false)
+        new(model, current_user: current_user, embed_links: embed_links)
+      end
+
       def initialize(model, current_user:, embed_links: false)
         @current_user = current_user
         @embed_links = embed_links

--- a/lib/api/decorators/unpaginated_collection.rb
+++ b/lib/api/decorators/unpaginated_collection.rb
@@ -30,8 +30,8 @@
 module API
   module Decorators
     class UnpaginatedCollection < ::API::Decorators::Collection
-      def initialize(models, self_link, context: {})
-        super(models, models.count, self_link, context: context)
+      def initialize(models, self_link, current_user:)
+        super(models, models.count, self_link, current_user: current_user)
       end
     end
   end

--- a/lib/api/utilities/decorator_factory.rb
+++ b/lib/api/utilities/decorator_factory.rb
@@ -40,7 +40,7 @@ module API
       end
 
       def new(represented)
-        @decorator.new(represented, current_user: @current_user)
+        @decorator.create(represented, current_user: @current_user)
       end
 
       # Roar will actually call the prepare method, which delegates to new.

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -48,7 +48,9 @@ module API
           get do
             @activities = ::Journal::AggregatedJournal.aggregated_journals(journable: @work_package)
             self_link = api_v3_paths.work_package_activities @work_package.id
-            Activities::ActivityCollectionRepresenter.new(@activities, self_link)
+            Activities::ActivityCollectionRepresenter.new(@activities,
+                                                          self_link,
+                                                          current_user: current_user)
           end
 
           params do

--- a/lib/api/v3/attachments/attachment_metadata_representer.rb
+++ b/lib/api/v3/attachments/attachment_metadata_representer.rb
@@ -34,6 +34,10 @@ module API
   module V3
     module Attachments
       class AttachmentMetadataRepresenter < ::API::Decorators::Single
+        def initialize(attachment)
+          super(attachment, current_user: nil)
+        end
+
         property :file_name
         property :description,
                  getter: -> (*) {

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -46,7 +46,7 @@ module API
             end
 
             get do
-              AttachmentRepresenter.new(@attachment)
+              AttachmentRepresenter.new(@attachment, current_user: current_user)
             end
 
             delete do

--- a/lib/api/v3/attachments/attachments_by_work_package_api.rb
+++ b/lib/api/v3/attachments/attachments_by_work_package_api.rb
@@ -53,7 +53,11 @@ module API
           get do
             self_path = api_v3_paths.attachments_by_work_package(@work_package.id)
             attachments = @work_package.attachments
-            AttachmentCollectionRepresenter.new(attachments, self_path)
+            AttachmentCollectionRepresenter.new(attachments,
+                                                self_path,
+                                                context: {
+                                                  current_user: current_user
+                                                })
           end
 
           post do
@@ -79,7 +83,8 @@ module API
               raise ::API::Errors::ErrorBase.create_and_merge_errors(error.record.errors)
             end
 
-            ::API::V3::Attachments::AttachmentRepresenter.new(attachment)
+            ::API::V3::Attachments::AttachmentRepresenter.new(attachment,
+                                                              current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/attachments/attachments_by_work_package_api.rb
+++ b/lib/api/v3/attachments/attachments_by_work_package_api.rb
@@ -55,9 +55,7 @@ module API
             attachments = @work_package.attachments
             AttachmentCollectionRepresenter.new(attachments,
                                                 self_path,
-                                                context: {
-                                                  current_user: current_user
-                                                })
+                                                current_user: current_user)
           end
 
           post do

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -43,7 +43,7 @@ module API
             end
 
             get do
-              CategoryRepresenter.new(@category)
+              CategoryRepresenter.new(@category, current_user: current_user)
             end
           end
         end

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -41,7 +41,7 @@ module API
           get do
             self_link = api_v3_paths.categories(@project.identifier)
 
-            CategoryCollectionRepresenter.new(@categories, self_link)
+            CategoryCollectionRepresenter.new(@categories, self_link, current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/priorities/priorities_api.rb
+++ b/lib/api/v3/priorities/priorities_api.rb
@@ -42,7 +42,9 @@ module API
           end
 
           get do
-            PriorityCollectionRepresenter.new(@priorities, api_v3_paths.priorities)
+            PriorityCollectionRepresenter.new(@priorities,
+                                              api_v3_paths.priorities,
+                                              current_user: current_user)
           end
 
           route_param :id do

--- a/lib/api/v3/projects/available_assignees_api.rb
+++ b/lib/api/v3/projects/available_assignees_api.rb
@@ -36,7 +36,9 @@ module API
           get do
             available_assignees = @project.possible_assignees
             self_link = api_v3_paths.available_assignees(@project.id)
-            Users::UserCollectionRepresenter.new(available_assignees, self_link)
+            Users::UserCollectionRepresenter.new(available_assignees,
+                                                 self_link,
+                                                 current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/projects/available_responsibles_api.rb
+++ b/lib/api/v3/projects/available_responsibles_api.rb
@@ -36,7 +36,9 @@ module API
           get do
             available_responsibles = @project.possible_responsibles
             self_link = api_v3_paths.available_responsibles(@project.id)
-            Users::UserCollectionRepresenter.new(available_responsibles, self_link)
+            Users::UserCollectionRepresenter.new(available_responsibles,
+                                                 self_link,
+                                                 current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -40,7 +40,7 @@ module API
           route_param :id do
             before do
               @query = Query.find(params[:id])
-              @representer = QueryRepresenter.new(@query)
+              @representer = QueryRepresenter.new(@query, current_user: current_user)
               authorize_by_policy(:show) do
                 raise API::Errors::NotFound
               end

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -34,6 +34,18 @@ module API
   module V3
     module Relations
       class RelationRepresenter < ::API::Decorators::Single
+        def self.create(user, current_user:, work_package: nil)
+          new(user, current_user: current_user, work_package: work_package)
+        end
+
+        def initialize(user, current_user:, work_package: nil)
+          # FIXME: we should not change our representation depending on the embedding work package
+          # especially since we only change the type's direction, e.g. Blocks to Blocked,
+          # which makes no sense, since the relation itself is already directional (from->to)
+          @work_package = work_package
+          super(user, current_user: current_user)
+        end
+
         link :self do
           { href: api_v3_paths.relation(represented.id) }
         end
@@ -68,11 +80,7 @@ module API
         end
 
         def work_package
-          context[:work_package]
-        end
-
-        def current_user
-          context[:current_user]
+          @work_package
         end
       end
     end

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -49,7 +49,9 @@ module API
             end
 
             if relation.valid? && relation.save
-              representer = RelationRepresenter.new(relation, work_package: relation.to)
+              representer = RelationRepresenter.new(relation,
+                                                    work_package: relation.to,
+                                                    current_user: current_user)
               representer
             else
               fail ::API::Errors::Validation.new(nil, I18n.t('api_v3.errors.invalid_relation'))

--- a/lib/api/v3/repositories/revisions_api.rb
+++ b/lib/api/v3/repositories/revisions_api.rb
@@ -38,7 +38,7 @@ module API
               attr_reader :revision
 
               def revision_representer
-                RevisionRepresenter.new(revision)
+                RevisionRepresenter.new(revision, current_user: current_user)
               end
             end
 

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -41,7 +41,7 @@ module API
             self_path = api_v3_paths.work_package_revisions(work_package.id)
 
             revisions = work_package.changesets
-            RevisionsCollectionRepresenter.new(revisions, self_path)
+            RevisionsCollectionRepresenter.new(revisions, self_path, current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -51,7 +51,7 @@ module API
       mount ::API::V3::WorkPackages::WorkPackagesAPI
 
       get '/' do
-        RootRepresenter.new({})
+        RootRepresenter.new({}, current_user: current_user)
       end
     end
   end

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -42,13 +42,15 @@ module API
           end
 
           get do
-            StatusCollectionRepresenter.new(@statuses, api_v3_paths.statuses)
+            StatusCollectionRepresenter.new(@statuses,
+                                            api_v3_paths.statuses,
+                                            current_user: current_user)
           end
 
           route_param :id do
             before do
               status = Status.find(params[:id])
-              @representer = StatusRepresenter.new(status)
+              @representer = StatusRepresenter.new(status, current_user: current_user)
             end
 
             get do

--- a/lib/api/v3/string_objects/string_object_representer.rb
+++ b/lib/api/v3/string_objects/string_object_representer.rb
@@ -34,6 +34,11 @@ module API
   module V3
     module StringObjects
       class StringObjectRepresenter < ::API::Decorators::Single
+        # accepting current_user as argument to match common interface, we do not need it though
+        def initialize(string, current_user: nil)
+          super(string, current_user: nil)
+        end
+
         link :self do
           {
             href: api_v3_paths.string_object(represented)

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -41,13 +41,13 @@ module API
 
           get do
             types = Type.all
-            TypeCollectionRepresenter.new(types, api_v3_paths.types)
+            TypeCollectionRepresenter.new(types, api_v3_paths.types, current_user: current_user)
           end
 
           namespace ':id' do
             before do
               type = Type.find(params[:id])
-              @representer = TypeRepresenter.new(type)
+              @representer = TypeRepresenter.new(type, current_user: current_user)
             end
 
             get do

--- a/lib/api/v3/types/types_by_project_api.rb
+++ b/lib/api/v3/types/types_by_project_api.rb
@@ -42,7 +42,7 @@ module API
             types = @project.types
             TypeCollectionRepresenter.new(types,
                                           api_v3_paths.types_by_project(@project.id),
-                                          context: { current_user: current_user })
+                                          current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/users/user_collection_representer.rb
+++ b/lib/api/v3/users/user_collection_representer.rb
@@ -32,6 +32,24 @@ module API
     module Users
       class UserCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
         element_decorator ::API::V3::Users::UserRepresenter
+
+        def initialize(models, self_link, current_user:, work_package: nil)
+          @work_package = work_package
+          super(models, self_link, current_user: current_user)
+        end
+
+        # FIXME: this is part of the problem that UserRepresenter accepts a work package
+        # to render differently. Remove all of this special business once that is undone...
+        collection :elements,
+                   getter: -> (*) {
+                     represented.map { |model|
+                       element_decorator.new(model,
+                                             current_user: current_user,
+                                             work_package: @work_package)
+                     }
+                   },
+                   exec_context: :decorator,
+                   embedded: true
       end
     end
   end

--- a/lib/api/v3/users/user_collection_representer.rb
+++ b/lib/api/v3/users/user_collection_representer.rb
@@ -43,9 +43,9 @@ module API
         collection :elements,
                    getter: -> (*) {
                      represented.map { |model|
-                       element_decorator.new(model,
-                                             current_user: current_user,
-                                             work_package: @work_package)
+                       element_decorator.create(model,
+                                                current_user: current_user,
+                                                work_package: @work_package)
                      }
                    },
                    exec_context: :decorator,

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -36,6 +36,12 @@ module API
       class UserRepresenter < ::API::Decorators::Single
         include AvatarHelper
 
+        def initialize(user, current_user:, work_package: nil)
+          # FIXME: we should not change our representation depending on an embedding work package
+          @work_package = work_package
+          super(user, current_user: current_user)
+        end
+
         self_link
 
         link :lock do
@@ -112,13 +118,13 @@ module API
         end
 
         def current_user_is_admin
-          current_user && current_user.admin?
+          current_user.admin?
         end
 
         private
 
         def work_package
-          context[:work_package]
+          @work_package
         end
 
         def current_user_can_delete_represented?

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -36,6 +36,10 @@ module API
       class UserRepresenter < ::API::Decorators::Single
         include AvatarHelper
 
+        def self.create(user, current_user:, work_package: nil)
+          new(user, current_user: current_user, work_package: work_package)
+        end
+
         def initialize(user, current_user:, work_package: nil)
           # FIXME: we should not change our representation depending on an embedding work package
           @work_package = work_package

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -43,7 +43,7 @@ module API
 
           get do
             path = api_v3_paths.projects_by_version @version.id
-            Projects::ProjectCollectionRepresenter.new(@projects, path)
+            Projects::ProjectCollectionRepresenter.new(@projects, path, current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -47,14 +47,10 @@ module API
 
                 authorize_any(permissions, projects: projects, user: current_user)
               end
-
-              def context
-                { current_user: current_user }
-              end
             end
 
             get do
-              VersionRepresenter.new(@version, context)
+              VersionRepresenter.new(@version, current_user: current_user)
             end
 
             mount ::API::V3::Versions::ProjectsByVersionAPI

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -43,7 +43,7 @@ module API
           get do
             VersionCollectionRepresenter.new(@versions,
                                              api_v3_paths.versions_by_project(@project.id),
-                                             context: { current_user: current_user })
+                                             current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/watchers/watcher_representer.rb
+++ b/lib/api/v3/watchers/watcher_representer.rb
@@ -34,6 +34,10 @@ module API
   module V3
     module Watchers
       class WatcherRepresenter < ::API::Decorators::Single
+        def initialize(user)
+          super(user, current_user: nil)
+        end
+
         property :user,
                  exec_context: :decorator,
                  getter: -> (*) {

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -67,7 +67,7 @@ module API
             nil
           end
 
-          def assignable_values(_property, _context)
+          def assignable_values(_property, _current_user)
             nil
           end
 

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -44,10 +44,10 @@ module API
             @work_package.type
           end
 
-          def assignable_values(property, context)
+          def assignable_values(property, current_user)
             case property
             when :status
-              assignable_statuses_for(context[:current_user])
+              assignable_statuses_for(current_user)
             when :type
               project.try(:types)
             when :version

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -37,7 +37,8 @@ module API
           self_link = api_v3_paths.available_watchers(@work_package.id)
 
           ::API::V3::Users::UserCollectionRepresenter.new(available_watchers,
-                                                          self_link)
+                                                          self_link,
+                                                          current_user: current_user)
         end
 
         resources :watchers do
@@ -47,7 +48,7 @@ module API
               self_link = api_v3_paths.work_package_watchers(@work_package.id)
               Users::UserCollectionRepresenter.new(watchers,
                                                    self_link,
-                                                   context: { current_user: current_user })
+                                                   current_user: current_user)
             end
           end
 
@@ -81,7 +82,7 @@ module API
               }
             )
 
-            ::API::V3::Users::UserRepresenter.new(user)
+            ::API::V3::Users::UserRepresenter.new(user, current_user: current_user)
           end
 
           namespace ':user_id' do

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -45,11 +45,16 @@ module API
                        total_sums:,
                        page: nil,
                        per_page: nil,
-                       context: {})
+                       current_user:)
           @groups = groups
           @total_sums = total_sums
 
-          super(models, self_link, query: query, page: page, per_page: per_page, context: context)
+          super(models,
+                self_link,
+                query: query,
+                page: page,
+                per_page: per_page,
+                current_user: current_user)
         end
 
         property :groups,

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -182,10 +182,7 @@ module API
             per_page: params[:pageSize] ? params[:pageSize].to_i : nil,
             groups: groups,
             total_sums: sums,
-            context: {
-              current_user: current_user
-            }
-          )
+            current_user: current_user)
         end
 
         def convert_attribute(attribute, append_id: false)

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -348,7 +348,10 @@ module API
           self_path = api_v3_paths.attachments_by_work_package(represented.id)
           attachments = represented.attachments
           ::API::V3::Attachments::AttachmentCollectionRepresenter.new(attachments,
-                                                                      self_path)
+                                                                      self_path,
+                                                                      context: {
+                                                                        current_user: current_user
+                                                                      })
         end
 
         def relations

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -41,8 +41,10 @@ module API
                                                     WorkPackageRepresenter)
           end
 
-          def create(work_package, context = {})
-            create_class(work_package).new(work_package, context)
+          def create(work_package, current_user:, embed_links: false)
+            create_class(work_package).new(work_package,
+                                           current_user: current_user,
+                                           embed_links: embed_links)
           end
         end
 
@@ -231,7 +233,8 @@ module API
                         getter: :fixed_version,
                         title_getter: -> (*) {
                           represented.fixed_version.to_s_for_project(represented.project)
-                        }
+                        },
+                        embed_as: ::API::V3::Versions::VersionRepresenter
 
         links :children do
           visible_children.map do |child|
@@ -297,10 +300,6 @@ module API
                  exec_context: :decorator,
                  if: -> (*) { embed_links }
 
-        property :version,
-                 embedded: true,
-                 exec_context: :decorator,
-                 if: ->(*) { represented.fixed_version.present? && embed_links }
         property :watchers,
                  embedded: true,
                  exec_context: :decorator,
@@ -328,7 +327,8 @@ module API
           activities = ::Journal::AggregatedJournal.aggregated_journals(journable: represented)
           self_link = api_v3_paths.work_package_activities represented.id
           Activities::ActivityCollectionRepresenter.new(activities,
-                                                        self_link)
+                                                        self_link,
+                                                        current_user: current_user)
         end
 
         def watchers
@@ -338,10 +338,10 @@ module API
 
           # FIXME/LEGACY: we pass the WP as context?!? that makes a difference!!!
           # tl;dr: the embedded user representer must not be better than any other user representer
-          context = { current_user: current_user, work_package: represented }
           Users::UserCollectionRepresenter.new(watchers,
                                                self_link,
-                                               context: context)
+                                               current_user: current_user,
+                                               work_package: represented)
         end
 
         def attachments
@@ -349,9 +349,7 @@ module API
           attachments = represented.attachments
           ::API::V3::Attachments::AttachmentCollectionRepresenter.new(attachments,
                                                                       self_path,
-                                                                      context: {
-                                                                        current_user: current_user
-                                                                      })
+                                                                      current_user: current_user)
         end
 
         def relations
@@ -367,20 +365,8 @@ module API
           end
         end
 
-        def version
-          if represented.fixed_version.present?
-            Versions::VersionRepresenter.new(represented.fixed_version, current_user: current_user)
-          end
-        end
-
         def visible_children
           @visible_children ||= represented.children.select(&:visible?)
-        end
-
-        private
-
-        def version_policy
-          @version_policy ||= ::VersionPolicy.new(current_user)
         end
       end
     end

--- a/spec/decorators/single_spec.rb
+++ b/spec/decorators/single_spec.rb
@@ -35,27 +35,17 @@ describe ::API::Decorators::Single do
   let(:permissions) { [:view_work_packages] }
   let(:model) { Object.new }
 
-  context 'no user given' do
-    let(:single) { ::API::Decorators::Single.new(model, context: nil) }
+  let(:single) { ::API::Decorators::Single.new(model, current_user: user) }
 
-    it 'should not authorize an empty user' do
-      expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_falsey
-    end
+  it 'should authorize for a given permission' do
+    expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_truthy
   end
 
-  context 'user given' do
-    let(:single) { ::API::Decorators::Single.new(model, current_user: user) }
+  context 'unauthorized user' do
+    let(:permissions) { [] }
 
-    it 'should authorize for a given permission' do
-      expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_truthy
-    end
-
-    context 'unauthorized user' do
-      let(:permissions) { [] }
-
-      it 'should not authorize unauthorized user' do
-        expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_falsey
-      end
+    it 'should not authorize unauthorized user' do
+      expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_falsey
     end
   end
 end

--- a/spec/lib/api/v3/categories/category_collection_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_collection_representer_spec.rb
@@ -30,7 +30,11 @@ require 'spec_helper'
 
 describe ::API::V3::Categories::CategoryCollectionRepresenter do
   let(:categories) { FactoryGirl.build_list(:category, 3) }
-  let(:representer) { described_class.new(categories, '/api/v3/projects/1/categories') }
+  let(:representer) {
+    described_class.new(categories,
+                        '/api/v3/projects/1/categories',
+                        current_user: double('current_user'))
+  }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/categories/category_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_representer_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe ::API::V3::Categories::CategoryRepresenter do
   let(:category) { FactoryGirl.build(:category) }
   let(:user) { FactoryGirl.build(:user) }
-  let(:representer) { described_class.new(category) }
+  let(:representer) { described_class.new(category, current_user: double('current_user')) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/priorities/priority_collection_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_collection_representer_spec.rb
@@ -30,7 +30,9 @@ require 'spec_helper'
 
 describe ::API::V3::Priorities::PriorityCollectionRepresenter do
   let(:priorities)  { FactoryGirl.build_list(:priority, 3) }
-  let(:representer) { described_class.new(priorities, '/api/v3/priorities') }
+  let(:representer) {
+    described_class.new(priorities, '/api/v3/priorities', current_user: double('current_user'))
+  }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/priorities/priority_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_representer_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe ::API::V3::Priorities::PriorityRepresenter do
   let(:priority) { FactoryGirl.build(:priority) }
-  let(:representer) { described_class.new(priority) }
+  let(:representer) { described_class.new(priority, current_user: double('current_user')) }
 
   include API::V3::Utilities::PathHelper
 

--- a/spec/lib/api/v3/projects/project_collection_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_collection_representer_spec.rb
@@ -31,7 +31,10 @@ require 'spec_helper'
 describe ::API::V3::Projects::ProjectCollectionRepresenter do
   let(:self_link) { '/api/v3/versions/1/projects' }
   let(:projects) { FactoryGirl.build_list(:project, 3) }
-  let(:representer) { described_class.new(projects, self_link) }
+  let(:current_user) { FactoryGirl.build(:user) }
+  let(:representer) {
+    described_class.new(projects, self_link, current_user: current_user)
+  }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/queries/query_representer_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_spec.rb
@@ -34,7 +34,7 @@ describe ::API::V3::Queries::QueryRepresenter do
   let(:query) {
     FactoryGirl.build_stubbed(:query)
   }
-  let(:representer) { described_class.new(query) }
+  let(:representer) { described_class.new(query, current_user: double('current_user')) }
 
   subject { representer.to_json }
 

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe ::API::V3::Repositories::RevisionRepresenter do
   include ::API::V3::Utilities::PathHelper
 
-  let(:representer) { described_class.new(revision) }
+  let(:representer) { described_class.new(revision, current_user: double('current_user')) }
 
   let(:project) { FactoryGirl.build :project }
   let(:repository) { FactoryGirl.build :repository_subversion, project: project }

--- a/spec/lib/api/v3/root_representer_spec.rb
+++ b/spec/lib/api/v3/root_representer_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe ::API::V3::RootRepresenter do
   include ::API::V3::Utilities::PathHelper
 
-  let(:representer)  { described_class.new({}) }
+  let(:representer) { described_class.new({}, current_user: double('current_user')) }
   let(:app_title) { 'Foo Project' }
   let(:version) { 'The version is over 9000!' }
 

--- a/spec/lib/api/v3/statuses/status_collection_representer_spec.rb
+++ b/spec/lib/api/v3/statuses/status_collection_representer_spec.rb
@@ -32,7 +32,9 @@ describe ::API::V3::Statuses::StatusCollectionRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:statuses)  { FactoryGirl.build_list(:status, 3) }
-  let(:representer) { described_class.new(statuses, api_v3_paths.statuses) }
+  let(:representer) {
+    described_class.new(statuses, api_v3_paths.statuses, current_user: double('current_user'))
+  }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/statuses/status_representer_spec.rb
+++ b/spec/lib/api/v3/statuses/status_representer_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe ::API::V3::Statuses::StatusRepresenter do
   let(:status) { FactoryGirl.build(:status, id: 42) }
-  let(:representer) { described_class.new(status) }
+  let(:representer) { described_class.new(status, current_user: double('current_user')) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/spec/lib/api/v3/types/type_representer_spec.rb
+++ b/spec/lib/api/v3/types/type_representer_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe ::API::V3::Types::TypeRepresenter do
   let(:type) { FactoryGirl.build_stubbed(:type, color: FactoryGirl.build(:color)) }
-  let(:representer) { described_class.new(type) }
+  let(:representer) { described_class.new(type, current_user: double('current_user')) }
 
   include API::V3::Utilities::PathHelper
 

--- a/spec/lib/api/v3/users/user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_collection_representer_spec.rb
@@ -35,7 +35,11 @@ describe ::API::V3::Users::UserCollectionRepresenter do
                            created_on: Time.now,
                            updated_on: Time.now)
   }
-  let(:representer) { described_class.new(users, '/api/v3/work_package/1/watchers') }
+  let(:representer) {
+    described_class.new(users,
+                        '/api/v3/work_package/1/watchers',
+                        current_user: users.first)
+  }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -60,7 +60,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     }
     let(:versions) { [] }
 
-    subject { modified_class.new(schema, form_embedded: true).to_json }
+    subject { modified_class.new(schema, current_user: nil, form_embedded: true).to_json }
 
     describe 'basic custom field' do
       it_behaves_like 'has basic schema properties' do
@@ -202,7 +202,9 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       it 'on writing it sets on the represented' do
         expected = { custom_field.id => expected_setter }
         expect(represented).to receive(:custom_field_values=).with(expected)
-        modified_class.new(represented).from_json({ cf_path => json_value }.to_json)
+        modified_class
+          .new(represented, current_user: nil)
+          .from_json({ cf_path => json_value }.to_json)
       end
     end
 
@@ -370,7 +372,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     }
     let(:custom_value) { double('CustomValue', value: value) }
     let(:value) { '' }
-    subject { "{ \"_links\": #{modified_class.new(represented).to_json} }" }
+    subject { "{ \"_links\": #{modified_class.new(represented, current_user: nil).to_json} }" }
 
     before do
       allow(represented).to receive(:custom_value_for).with(custom_field).and_return(custom_value)
@@ -403,7 +405,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         expected = { custom_field.id => '2' }
 
         expect(represented).to receive(:custom_field_values=).with(expected)
-        modified_class.new(represented).from_json(json)
+        modified_class.new(represented, current_user: nil).from_json(json)
       end
 
       it 'accepts an empty link' do
@@ -411,7 +413,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         expected = { custom_field.id => nil }
 
         expect(represented).to receive(:custom_field_values=).with(expected)
-        modified_class.new(represented).from_json(json)
+        modified_class.new(represented, current_user: nil).from_json(json)
       end
     end
   end

--- a/spec/lib/api/v3/versions/version_collection_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_collection_representer_spec.rb
@@ -32,8 +32,7 @@ describe ::API::V3::Versions::VersionCollectionRepresenter do
   let(:self_link) { '/api/v3/projects/1/versions' }
   let(:versions) { FactoryGirl.build_list(:version, 3) }
   let(:user) { FactoryGirl.build_stubbed(:user) }
-  let(:context) { { current_user: user } }
-  let(:representer) { described_class.new(versions, self_link, context: context) }
+  let(:representer) { described_class.new(versions, self_link, current_user: user) }
 
   context 'generation' do
     subject(:collection) { representer.to_json }

--- a/spec/lib/api/v3/versions/version_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_spec.rb
@@ -31,8 +31,7 @@ require 'spec_helper'
 describe ::API::V3::Versions::VersionRepresenter do
   let(:version) { FactoryGirl.build_stubbed(:version) }
   let(:user) { FactoryGirl.build_stubbed(:user) }
-  let(:context) { { current_user: user } }
-  let(:representer) { described_class.new(version, context) }
+  let(:representer) { described_class.new(version, current_user: user) }
 
   include API::V3::Utilities::PathHelper
 

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -36,8 +36,7 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
                       project: project,
                       type: type)
   }
-  let(:context) { { current_user: user } }
-  let(:user) { double('current user') }
+  let(:current_user) { double('current user') }
 
   subject { described_class.new(work_package: work_package) }
 
@@ -58,9 +57,9 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
     end
 
     it 'calls through to the work package' do
-      expect(work_package).to receive(:new_statuses_allowed_to).with(user)
+      expect(work_package).to receive(:new_statuses_allowed_to).with(current_user)
         .and_return(status_result)
-      expect(subject.assignable_values(:status, context)).to eql(status_result)
+      expect(subject.assignable_values(:status, current_user)).to eql(status_result)
     end
 
     context 'changed work package' do
@@ -88,8 +87,8 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
 
       it 'calls through to the cloned work package' do
         expect(cloned_wp).to receive(:status=).with(stored_status)
-        expect(cloned_wp).to receive(:new_statuses_allowed_to).with(user)
-        expect(subject.assignable_values(:status, context)).to eql(status_result)
+        expect(cloned_wp).to receive(:new_statuses_allowed_to).with(current_user)
+        expect(subject.assignable_values(:status, current_user)).to eql(status_result)
       end
     end
   end
@@ -132,7 +131,7 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
 
     it 'calls through to the project' do
       expect(project).to receive(:types).and_return(result)
-      expect(subject.assignable_values(:type, context)).to eql(result)
+      expect(subject.assignable_values(:type, current_user)).to eql(result)
     end
   end
 
@@ -141,7 +140,7 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
 
     it 'calls through to the work package' do
       expect(work_package).to receive(:assignable_versions).and_return(result)
-      expect(subject.assignable_values(:version, context)).to eql(result)
+      expect(subject.assignable_values(:version, current_user)).to eql(result)
     end
   end
 
@@ -155,8 +154,8 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
     end
 
     it 'returns only active priorities' do
-      expect(subject.assignable_values(:priority, context).size).to be >= 1
-      subject.assignable_values(:priority, context).each do |priority|
+      expect(subject.assignable_values(:priority, current_user).size).to be >= 1
+      subject.assignable_values(:priority, current_user).each do |priority|
         expect(priority.active).to be_truthy
       end
     end
@@ -170,7 +169,7 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
     end
 
     it 'returns all categories of the project' do
-      expect(subject.assignable_values(:category, context)).to match_array([category])
+      expect(subject.assignable_values(:category, current_user)).to match_array([category])
     end
   end
 

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -32,8 +32,7 @@ describe ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
   let(:project) { FactoryGirl.build(:project) }
   let(:type) { FactoryGirl.build(:type) }
 
-  let(:context) { { current_user: user } }
-  let(:user) { double }
+  let(:current_user) { double }
   subject { described_class.new(project: project, type: type) }
 
   it 'has the project set' do
@@ -45,11 +44,11 @@ describe ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
   end
 
   it 'does not know assignable statuses' do
-    expect(subject.assignable_values(:status, context)).to eql(nil)
+    expect(subject.assignable_values(:status, current_user)).to eql(nil)
   end
 
   it 'does not know assignable versions' do
-    expect(subject.assignable_values(:version, context)).to eql(nil)
+    expect(subject.assignable_values(:version, current_user)).to eql(nil)
   end
 
   describe '#writable?' do

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -32,7 +32,6 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   let(:self_base_link) { '/api/v3/example' }
   let(:work_packages) { WorkPackage.all }
   let(:user) { FactoryGirl.build_stubbed(:user) }
-  let(:context) { { current_user: user } }
 
   let(:query) { {} }
   let(:groups) { nil }
@@ -52,7 +51,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
       total_sums: total_sums,
       page: page_parameter,
       per_page: page_size_parameter,
-      context: context)
+      current_user: user)
   }
 
   before do


### PR DESCRIPTION
## OpenProject work packages
- was written for https://community.openproject.org/work_packages/21386
- accidentially also fixes https://community.openproject.org/work_packages/21389
## Description

It was discovered that I forgot to pass the `current_user` into the `AttachmentRepresenter`. Upon further exploration, this error happened quite often and most representers either expect a user anyway or at least could legitimately do that in the future.

I therefore decided to enforce that the `current_user` is passed, for the following benefits:
- less error prone (we can't forget to pass the user, no more soft failures on permission check)
- common interface for all representers
- we can now always pass a `current_user`, allowing us to embed `versions` using the `linked_property` helper
## Related Plugin PRs

:warning: Merge together with: https://github.com/finnlabs/openproject-costs/pull/162
