### PR TITLE
Make bundler 1.10 optional groups optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,16 @@ group :ldap do
   gem "net-ldap", '~> 0.8.0'
 end
 
-group :syck, optional: true do
+
+
+# Optional groups are only available with Bundler 1.10+
+# We still want older bundlers to parse this gemfile correctly,
+# thus this rather ugly workaround is needed.
+if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.10.0')
+  group :syck, optional: true do
+    gem "syck", require: false
+  end
+else
   gem "syck", require: false
 end
 


### PR DESCRIPTION
Packager-based builds are currently broken due to an older bundler version that does not understand `optional: true` yet.

Optional groups are only available with Bundler 1.10+
We still want older bundlers to parse the gemfile correctly,
thus a workaround is needed.
