### PR TITLE
Revert optional syck parser group definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ env:
     - "TEST_SUITE=spec:legacy DB=postgres"
 
 before_install:
-  # TODO: Remove when bundler 1.10 is available on travis per default
-  - "gem install bundler"
   - "echo `firefox -v`"
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ gem 'rack-protection', :git => "https://github.com/finnlabs/rack-protection.git"
 # https://github.com/kickstarter/rack-attack
 gem 'rack-attack'
 
+gem "syck", '~> 1.0.5', require: false
 gem 'gon', '~> 4.0'
 
 # catch exceptions and send them to any airbrake compatible backend
@@ -179,20 +180,6 @@ end
 
 group :ldap do
   gem "net-ldap", '~> 0.8.0'
-end
-
-
-
-# Optional groups are only available with Bundler 1.10+
-# We still want older bundlers to parse this gemfile correctly,
-# thus this rather ugly workaround is needed for now.
-# TODO: Remove this when 1.10+ is widespread.
-if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.10.0')
-  group :syck, optional: true do
-    gem "syck", require: false
-  end
-else
-  gem "syck", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,7 +584,7 @@ DEPENDENCIES
   sprockets-rails!
   strong_parameters
   svg-graph
-  syck
+  syck (~> 1.0.5)
   thin
   timecop (~> 0.7.1)
   uglifier (>= 1.0.3)

--- a/db/migrate/migration_utils/legacy_yamler.rb
+++ b/db/migrate/migration_utils/legacy_yamler.rb
@@ -46,14 +46,20 @@ module Migration
       require 'syck'
       ::Syck
     rescue LoadError => e
+
+      ##
+      # This code will currently never be reached, as our Gemfile installs syck by default
+      # for the time being.
+      # Our goal is move syck into an optional bundler group, however that feature is still
+      # quite young and many of our bundlers do not yet understand its syntax.
+      # TODO: Make syck optional or get rid of it completely when feasible.
+
       abort = -> (str) { abort("\e[31m#{str}\e[0m") }
       abort.call <<-WARN
       It appears you have existing serialized YAML in your database.
-
       This YAML may have been serialized with Syck, which allowed to parse YAML
       that is now considered invalid given the default Ruby YAML parser (Psych),
       we need to convert that YAML to be Psych-compatible.
-
       Use `bundle install --with syck` to install the syck YAML parser
       and re-run the migrations.
       WARN


### PR DESCRIPTION
There are more issues with letting syck install optionally
than there are advantages.

For the time being, let's require syck at all times and think about
removing it when all potential uses in migrations are gone.
