### PR TITLE
Specification for MyPreferences APIv3 endpoint

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -545,13 +545,15 @@ a client should be able to discover further resources in the API.
 *Note: Currently there is no list action for projects available.*
 *A client will therefore have to know links to projects and can't (yet) discover them.*
 
-| Link                | Description                                      | Type          | Nullable | Supported operations |
-|:-------------------:| ------------------------------------------------ | ------------- | -------- | -------------------- |
-| configuration       | The configuration of this OpenProject instance   | Configuration |          | READ                 |
-| priorities          | List of available priorities                     | Collection    |          | READ                 |
-| statuses            | List of available work package statuses          | Collection    |          | READ                 |
-| types               | List of available work package types             | Collection    |          | READ                 |
-| workPackages        | List of all work packages                        | Collection    |          | READ                 |
+| Link                | Description                                      | Type            | Nullable | Supported operations | Condition |
+|:-------------------:| ------------------------------------------------ | --------------- | -------- | -------------------- | --------- |
+| configuration       | The configuration of this OpenProject instance   | Configuration   |          | READ                 |           |
+| user                | The user currently logged-in                     | User            |          | READ                 | logged in |
+| userPreferences     | The preferences of the logged-in user            | UserPreference  |          | READ                 | logged in |
+| priorities          | List of available priorities                     | Collection      |          | READ                 |           |
+| statuses            | List of available work package statuses          | Collection      |          | READ                 |           |
+| types               | List of available work package types             | Collection      |          | READ                 |           |
+| workPackages        | List of all work packages                        | Collection      |          | READ                 |           |
 
 ## Local Properties
 
@@ -569,6 +571,13 @@ a client should be able to discover further resources in the API.
                 "_links" : {
                     "configuration" : {
                         "href" : "/api/v3/configuration"
+                    },
+                    "user": {
+                        "href": "/api/v3/users/1",
+                        "title": "John Sheppard - admin"
+                    };
+                    "userPreferences" : {
+                        "href" : "/api/v3/my_preferences"
                     },
                     "priorities" : {
                         "href" : "/api/v3/priorities"
@@ -3151,6 +3160,121 @@ Permanently deletes the specified user account.
                 "_type": "Error",
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
                 "message": "The specified user does not exist."
+            }
+
+# Group UserPreferences
+
+## Linked Properties
+|  Link     | Description                                              | Type           | Constraints           | Supported operations |
+|:---------:|----------------------------------------------------------| -------------- | --------------------- | -------------------- |
+| self      | This UserPreferences                                     | UserPreferences| not null              | READ                 |
+| user      | The user that this preference belongs to                 | User           | not null              | READ                 |
+
+## Local Properties
+| Property               | Description                                                | Type       | Constraints | Supported operations |
+|:----------------------:| -----------------------------------------------------------| ---------- | ----------- | -------------------- |
+| hideMail               | Hide mail address from other users                         | Boolean    |             | READ / WRITE         |
+| timeZone               | Current selected time zone                                 | String     |             | READ / WRITE         |
+| theme                  | Current selected theme                                     | String     |             | READ / WRITE         |
+| commentSortDescending  | Sort comments in descending order                          | Boolean    |             | READ / WRITE         |
+| warnOnLeavingUnsaved   | Issue warning when leaving a page with unsaved text        | Boolean    |             | READ / WRITE         |
+| accessibilityMode      | Enable accessibility mode                                  | Boolean    |             | READ / WRITE         |
+
+## UserPreferences [/api/v3/my_preferences]
+
++ Model
+    + Body
+
+            {
+                "_type" : "UserPreferences",
+                "_links" : {
+                    "self" : {
+                        "href" : "/api/v3/my_preferences",
+                    },
+                    "user": {
+                        "href": "/api/v3/users/1",
+                        "title": "John Sheppard"
+                    }
+                },
+                "hideMail" : false,
+                "timeZone" : "Europe/Berlin",
+                "theme" : "OpenProject",
+                "commentSortDescending" : true,
+                "warnOnLeavingUnsaved" : true,
+                "accessibilityMode" : false
+            }
+
+
+## Show my preferences [GET]
+
++ Response 200 (application/hal+json)
+
+    [UserPreferences][]
+
++ Response 401 (application/hal+json)
+
+    Returned if no user is currently authenticated
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:Unauthenticated",
+                "message": "You need to be authenticated to access this resource."
+            }
+
+## Update UserPreferences [PATCH]
+
+When calling this endpoint the client provides a single object, containing the properties that it wants to change, in the body.
+
++ Request (application/json)
+
+        {
+            "accessibilityMode": true,
+            "timeZone": "Europe/Paris"
+        }
+
++ Response 200 (application/hal+json)
+
+    [UserPreferences][]
+
++ Response 400 (application/hal+json)
+
+    Occurs when the client did not send a valid JSON object in the request body.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
+                "message": "The request body was not a single JSON object."
+            }
+
++ Response 401 (application/hal+json)
+
+    Returned if no user is currently authenticated
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:Unauthenticated",
+                "message": "You need to be authenticated to access this resource."
+            }
+
++ Response 422 (application/hal+json)
+
+    Returned if the update contains invalid properties.
+    Reasons are:
+    * Specifying an invalid type
+    * Using an unknown time zone
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
+                "message": "Time zone is not set to one of the allowed values."
             }
 
 # Group Versions


### PR DESCRIPTION
To read and update `user_preferences` through the API, this commit
suggests to extend APIv3 with a MyPreference endpoint to read the
current preferences and provide updates to it.
