### PR TITLE
Update moment.js

### DIFF
--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -18,8 +18,8 @@
     "angular-truncate": "sparkalow/angular-truncate#fdf60fda265042d12e9414b5354b2cc52f1419de",
     "angular-feature-flags": "mjt01/angular-feature-flags",
     "jquery-migrate": "~1.2.1",
-    "moment": "finnlabs/moment#9bc879e7b146c484b499b3135b8d84e8425f8ec4",
-    "moment-timezone": "~0.3.1",
+    "moment": "~2.10.6",
+    "moment-timezone": "0.4.x",
     "angular-context-menu": "nickmessing/angular-context-menu#a908eccaec323cd66973d58af4965694bdff16a1",
     "angular-busy": "~4.1.1",
     "hyperagent": "manwithtwowatches/hyperagent#v0.4.2",
@@ -40,7 +40,6 @@
     "jquery": "1.11.0",
     "angular": "1.3.14",
     "angular-animate": "1.3.14",
-    "moment": "9bc879e7b146c484b499b3135b8d84e8425f8ec4",
     "select2": "3.5.2"
   }
 }


### PR DESCRIPTION
## Description

Due to a bug in moment.js we needed to switch to our own fork until the fix was merged into the main repository. By now this has been done, so we can switch back to the main repo.
## Problems

Due to my lack of bower knowledge, this does not work as I intended. Running `npm i` will keep my currently installed version of moment (`2.10.2`).
Only when I clear the old installation (`rm -rf frontend/bower_components/moment`) `npm i` decides that `2.10.6` is a good choice, albeit me specifying `~2.10.6`, which should be equivalent to `>=2.10.6 AND < 2.11.0`.
