### PR TITLE
[21392] Project menu shrink arrows are missing

### DIFF
--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -225,6 +225,9 @@ dt > .icon-changeset:before,
 .icon-copy:before
   content: "\e008"
 
+.icon-double-arrow-left:before
+  content: "\e009"
+
 .icon-duplicate:before
   content: "\e00b"
 


### PR DESCRIPTION
The icon was lost, probably during the update of the icon font. Now it is part if the font again.

https://community.openproject.org/work_packages/21392
