### PR TITLE
[21400] Indentation for subprojects on projects overview is too large

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -96,7 +96,7 @@ tr
       &.subject
         text-align: left
     &.idnt td.subject .icon-context:before
-      padding: 9px 0 0 10px
+      padding: 9px 0 0 5px
 
   &.entry
     border: 1px solid #f8f8f8


### PR DESCRIPTION
Sets the indentation of sub-projects smaller.

https://community.openproject.org/work_packages/21400
