### PR TITLE
[APIv3] Fix schema for version custom fields

### DIFF
--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -172,10 +172,8 @@ module API
                                                 type: 'Version',
                                                 name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
-                                                  # for now we ASSUME that every customized will
-                                                  # understand define that method if it has
-                                                  # version custom fields
-                                                  customized.assignable_versions
+                                                  customized.assignable_values(:version,
+                                                                               current_user)
                                                 },
                                                 value_representer: Versions::VersionRepresenter,
                                                 link_factory: -> (version) {

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -55,12 +55,15 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       double('WorkPackageSchema',
              project: double(id: 42),
              defines_assignable_values?: true,
-             available_custom_fields: [custom_field],
-             assignable_versions: versions)
+             available_custom_fields: [custom_field])
     }
     let(:versions) { [] }
 
     subject { modified_class.new(schema, form_embedded: true).to_json }
+
+    before do
+      allow(schema).to receive(:assignable_values).with(:version, anything).and_return(versions)
+    end
 
     describe 'basic custom field' do
       it_behaves_like 'has basic schema properties' do


### PR DESCRIPTION
## Description

I recently unified some schema methods (`assignable_versions`, `assignable_priorities`, etc.) into a single method called `assignable_values`.

Due to the power of completely isolated unit testing (using mocks), I did not discover that one class was still calling an old method.
