### PR TITLE
[21408] Textbox with Repository URL too small in IE 11

### DIFF
--- a/app/assets/stylesheets/scm.css.sass
+++ b/app/assets/stylesheets/scm.css.sass
@@ -77,6 +77,10 @@ li.change
 .repository--revision-toolbar
   margin-top: 3rem
 
+.toolbar-items
+  #repository-checkout-url
+    min-width: 350px
+
 .repository--checkout-instructions--url
   margin-top: 1rem
 


### PR DESCRIPTION
Set a 'min-width' so that the field doesn't get too small in any browser.

https://community.openproject.org/work_packages/21408
