### PR TITLE
[21414] Dropdown Arrow in work package table too close (IE and Firefox)

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -208,6 +208,7 @@ table.generic-table
     & > .dropdown-indicator
       width: 1em
       text-align: right
+      min-width: 1em
 
 .generic-table--header-background
   position:     absolute


### PR DESCRIPTION
This sets the min-width of the pulldown arrow thus it is displayed correctly in every browser.

https://community.openproject.org/work_packages/21414
