### PR TITLE
Small visual corrections for checkout

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -216,7 +216,6 @@ class RepositoriesController < ApplicationController
     (show_error_not_found; return) unless @entry
 
     @annotate = @repository.scm.annotate(@path, @rev)
-    (render_error l(:error_scm_annotate); return) if @annotate.nil? || @annotate.empty?
     @changeset = @repository.find_changeset_by_name(@rev)
   end
 

--- a/app/views/repositories/_breadcrumbs.html.erb
+++ b/app/views/repositories/_breadcrumbs.html.erb
@@ -52,7 +52,7 @@ dirs.each_with_index do |dir, index|
   rev_text = @changeset.nil? ? @rev : format_revision(@changeset)
 %>
 <span class="repository-bradcrumbs--identifier">
-  (<%= l('repositories.at_identifier', identifier: rev_text) unless rev_text.blank? %>)
+  <%= "(#{l('repositories.at_identifier', identifier: rev_text)})" if rev_text.present? %>
 </span>
 
 <% html_title(h(with_leading_slash(path))) -%>

--- a/app/views/repositories/annotate.html.erb
+++ b/app/views/repositories/annotate.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= call_hook(:view_repositories_show_contextual, { repository: @repository, project: @project }) %>
+<% html_title(l(:button_annotate)) %>
 <%= render partial: 'repository_header', locals: { empty: false } %>
 
 <div class="repository-breadcrumbs">
@@ -34,25 +35,39 @@ See doc/COPYRIGHT.rdoc for more details.
              locals: { path: @path, revision: @rev }.merge(kind: 'file') %>
 </div>
 <p><%= render partial: 'link_to_functions' %></p>
-<% colors = Hash.new {|k,v| k[v] = (k.size % 12) } %>
-<div class="autoscroll">
-  <table class="filecontent annotate CodeRay">
-    <tbody>
-      <% line_num = 1 %>
-      <% syntax_highlight(@path, to_utf8_for_repositories(@annotate.content)) do |line| %>
-        <% revision = @annotate.revisions[line_num-1] %>
-        <tr class="bloc-<%= revision.nil? ? 0 : colors[revision.identifier || revision.revision] %>">
-          <th class="line-num" id="L<%= line_num %>"><a href="#L<%= line_num %>"><%= line_num %></a></th>
-          <td class="revision">
-            <%= (revision.identifier ? link_to_revision(revision, @project) : format_revision(revision)) if revision %></td>
-          <td class="author"><%= h(revision.author.to_s.split('<').first) if revision %></td>
-          <td class="line-code">
-            <pre><%= line %></pre>
-          </td>
-        </tr>
-        <% line_num += 1 %>
-      <% end %>
-    </tbody>
-  </table>
-</div>
-<% html_title(l(:button_annotate)) -%>
+
+<% if @annotate.nil? || @annotate.empty? %>
+  <div class="generic-table--container">
+    <div class="generic-table--no-results-container">
+      <h2 class="generic-table--no-results-title">
+        <i class="icon-info"></i>
+        <%= l(:label_nothing_display) %>
+      </h2>
+      <div class="generic-table--no-results-description">
+        <p class="nodata"><%= l('repositories.warnings.cannot_annotate') %></p>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <% colors = Hash.new {|k,v| k[v] = (k.size % 12) } %>
+  <div class="autoscroll">
+    <table class="filecontent annotate CodeRay">
+      <tbody>
+        <% line_num = 1 %>
+        <% syntax_highlight(@path, to_utf8_for_repositories(@annotate.content)) do |line| %>
+          <% revision = @annotate.revisions[line_num-1] %>
+          <tr class="bloc-<%= revision.nil? ? 0 : colors[revision.identifier || revision.revision] %>">
+            <th class="line-num" id="L<%= line_num %>"><a href="#L<%= line_num %>"><%= line_num %></a></th>
+            <td class="revision">
+              <%= (revision.identifier ? link_to_revision(revision, @project) : format_revision(revision)) if revision %></td>
+            <td class="author"><%= h(revision.author.to_s.split('<').first) if revision %></td>
+            <td class="line-code">
+              <pre><%= line %></pre>
+            </td>
+          </tr>
+          <% line_num += 1 %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -599,7 +599,6 @@ en:
   error_no_default_work_package_status: "No default work package status is defined. Please check your configuration (Go to \"Administration -> Work package statuses\")."
   error_no_type_in_project: "No type is associated to this project. Please check the Project settings."
   error_omniauth_registration_timed_out: "The registration via an external authentication provider timed out. Please try again."
-  error_scm_annotate: "The entry does not exist or cannot be annotated."
   error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
   error_scm_not_found: "The entry or revision was not found in the repository."
   error_unable_delete_status: "The work package status cannot be deleted since it is used by at least one work package."
@@ -1380,6 +1379,8 @@ en:
     named_repository: "%{vendor_name} repository"
     update_settings_successful: "The settings have been sucessfully saved."
     url: "URL to repository"
+    warnings:
+      cannot_annotate: "This file cannot be annotated."
 
   search_input_placeholder: "search ..."
 

--- a/spec/legacy/functional/repositories_git_controller_spec.rb
+++ b/spec/legacy/functional/repositories_git_controller_spec.rb
@@ -233,9 +233,10 @@ describe RepositoriesController, 'Git', type: :controller do
 
   it 'should annotate binary file' do
     get :annotate, project_id: 3, path: 'images/edit.png'
-    assert_response 500
-    assert_tag tag: 'div', attributes: { id: /errorExplanation/ },
-               content: /cannot be annotated/
+    assert_response 200
+
+    assert_tag tag: 'p', attributes: { class: /nodata/ },
+               content: I18n.t('repositories.warnings.cannot_annotate')
   end
 
   it 'should revision' do


### PR DESCRIPTION
This PR provides:
- An integrated annotation warning display, when the entry could not be
  annotated (most often due to it being binary).
- Hide current rev_id for subversion when no branch/revision is given.

This has no related work package, but stems from direct coordination.
