### PR TITLE
Fix/storage updater errors

### DIFF
--- a/app/workers/scm/storage_updater_job.rb
+++ b/app/workers/scm/storage_updater_job.rb
@@ -41,21 +41,14 @@ class Scm::StorageUpdaterJob
   end
 
   def perform
+    repository = Repository.find @id
     bytes = repository.scm.count_repository!
 
     repository.update_attributes!(
       required_storage_bytes: bytes,
       storage_updated_at: Time.now,
     )
-  end
-
-  def destroy_failed_jobs?
-    true
-  end
-
-  private
-
-  def repository
-    @repository ||= Repository.find @id
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("StorageUpdater requested for Repository ##{@id}, which could not be found.")
   end
 end

--- a/app/workers/scm/storage_updater_job.rb
+++ b/app/workers/scm/storage_updater_job.rb
@@ -51,4 +51,13 @@ class Scm::StorageUpdaterJob
   rescue ActiveRecord::RecordNotFound
     Rails.logger.warn("StorageUpdater requested for Repository ##{@id}, which could not be found.")
   end
+
+  ##
+  # We don't want to repeat failing jobs here,
+  # as they might have failed due to I/O problems and thus,
+  # we rather keep the old outdated value until an event
+  # triggers the update again.
+  def max_attempts
+    1
+  end
 end


### PR DESCRIPTION
When a StorageUpdater job is registered, but the associated object
is vanished in between request and execution, the job fails and is
repeated.

It should instead succeed with a warning.

This also sets `max_attempts` for StorageUpdaterJob to 1,
as we prefer having an external event retrigger storage counting
rather than retrying from delayed_job.

The reason behind this is failing counting due to I/O or other
unforeseen issues (e.g. mount not available, .. ).

In this case, recounting soon after will not solve the problem
and only increase load on disk.
