### PR TITLE
Reset WP id for details pane display

### DIFF
--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -100,6 +100,7 @@ angular.module('openproject.services')
     '$rootScope',
     '$window',
     '$q',
+    '$cacheFactory',
     'AuthorisationService',
     'EditableFieldsState',
     'WorkPackageFieldService',

--- a/frontend/app/services/work-package-service.js
+++ b/frontend/app/services/work-package-service.js
@@ -36,12 +36,14 @@ module.exports = function($http,
     $rootScope,
     $window,
     $q,
+    $cacheFactory,
     AuthorisationService,
     EditableFieldsState,
     WorkPackageFieldService,
     NotificationsService
   ) {
-  var workPackage;
+  var workPackage,
+      workPackageCache = $cacheFactory('workPackageCache');
 
   function getPendingChanges(workPackage) {
     var data = {
@@ -333,6 +335,10 @@ module.exports = function($http,
       }
 
       return promise;
+    },
+
+    cache: function() {
+      return workPackageCache;
     }
   };
 

--- a/frontend/app/work_packages/controllers/work-package-details-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-details-controller.js
@@ -57,7 +57,7 @@ module.exports = function($scope,
   setWorkPackageScopeProperties(workPackage);
 
   $scope.I18n = I18n;
-  $scope.$parent.preselectedWorkPackageId = $scope.workPackage.props.id;
+  WorkPackageService.cache().put('preselectedWorkPackageId', $scope.workPackage.props.id);
   $scope.maxDescriptionLength = 800;
 
   function refreshWorkPackage(callback) {

--- a/frontend/app/work_packages/controllers/work-packages-list-controller.js
+++ b/frontend/app/work_packages/controllers/work-packages-list-controller.js
@@ -115,7 +115,7 @@ module.exports = function($scope, $rootScope, $state, $location, latestTab,
     setupWorkPackagesTable(json);
 
     if (json.work_packages.length) {
-      $scope.preselectedWorkPackageId = json.work_packages[0].id;
+      WorkPackageService.cache().put('preselectedWorkPackageId', $scope.preselectedWorkPackageId);
     }
   }
 
@@ -260,11 +260,16 @@ module.exports = function($scope, $rootScope, $state, $location, latestTab,
     $scope.maintainBackUrl();
   });
 
+  function nextAvailableWorkPackage() {
+    var selected = WorkPackageService.cache().get('preselectedWorkPackageId')
+    return selected || $scope.rows.first().object.id;
+  }
+
   $scope.openLatestTab = function() {
     $scope.settingUpPage = $state.go(
       latestTab.getStateName(),
       {
-        workPackageId: $scope.preselectedWorkPackageId,
+        workPackageId: nextAvailableWorkPackage(),
         'query_props': $location.search()['query_props']
       });
   };
@@ -273,7 +278,7 @@ module.exports = function($scope, $rootScope, $state, $location, latestTab,
     $scope.settingUpPage = $state.go(
       'work-packages.list.details.overview',
       {
-        workPackageId: $scope.preselectedWorkPackageId,
+        workPackageId: nextAvailableWorkPackage(),
         'query_props': $location.search()['query_props']
       });
   };

--- a/frontend/app/work_packages/controllers/work-packages-list-controller.js
+++ b/frontend/app/work_packages/controllers/work-packages-list-controller.js
@@ -115,7 +115,7 @@ module.exports = function($scope, $rootScope, $state, $location, latestTab,
     setupWorkPackagesTable(json);
 
     if (json.work_packages.length) {
-      WorkPackageService.cache().put('preselectedWorkPackageId', $scope.preselectedWorkPackageId);
+      WorkPackageService.cache().put('preselectedWorkPackageId', json.work_packages[0].id);
     }
   }
 

--- a/frontend/app/work_packages/controllers/work-packages-list-controller.js
+++ b/frontend/app/work_packages/controllers/work-packages-list-controller.js
@@ -261,7 +261,7 @@ module.exports = function($scope, $rootScope, $state, $location, latestTab,
   });
 
   function nextAvailableWorkPackage() {
-    var selected = WorkPackageService.cache().get('preselectedWorkPackageId')
+    var selected = WorkPackageService.cache().get('preselectedWorkPackageId');
     return selected || $scope.rows.first().object.id;
   }
 

--- a/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
+++ b/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
@@ -108,8 +108,7 @@ module.exports = function(PERMITTED_MORE_MENU_ACTIONS,
         var promise = WorkPackageService.performBulkDelete([workPackageDeletionId], true);
 
         promise.success(function(data, status) {
-          // TODO: Find a better way to access stuff from scope.$parent.$parent
-          scope.$parent.$parent.preselectedWorkPackageId = scope.$parent.$parent.rows[1].object.id;
+          WorkPackageService.cache().remove('preselectedWorkPackageId');
           $state.go('work-packages.list');
         });
       }

--- a/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
+++ b/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
@@ -104,9 +104,12 @@ module.exports = function(PERMITTED_MORE_MENU_ACTIONS,
       };
 
       function deleteSelectedWorkPackage() {
-        var promise = WorkPackageService.performBulkDelete([scope.workPackage.props.id], true);
+        var workPackageDeletionId = scope.workPackage.props.id;
+        var promise = WorkPackageService.performBulkDelete([workPackageDeletionId], true);
 
         promise.success(function(data, status) {
+          // TODO: Find a better way to access stuff from scope.$parent.$parent
+          scope.$parent.$parent.preselectedWorkPackageId = scope.$parent.$parent.rows[1].object.id;
           $state.go('work-packages.list');
         });
       }


### PR DESCRIPTION
This PR aims to enable the work package details pane to reopen when a preselected work package has been displayed and deleted beforehand.

https://community.openproject.org/work_packages/20961
