### PR TITLE
Improve error handling during mail delivery

### DIFF
--- a/app/models/journal_notification_mailer.rb
+++ b/app/models/journal_notification_mailer.rb
@@ -89,7 +89,7 @@ class JournalNotificationMailer
     end
 
     def notification_receivers(work_package)
-      work_package.recipients + work_package.watcher_recipients
+      (work_package.recipients + work_package.watcher_recipients).uniq
     end
   end
 end

--- a/app/models/journal_notification_mailer.rb
+++ b/app/models/journal_notification_mailer.rb
@@ -44,8 +44,13 @@ class JournalNotificationMailer
 
       # Send the notification on behalf of the predecessor in case it could not send it on its own
       if Journal::AggregatedJournal.hides_notifications?(aggregated, aggregated.predecessor)
-        job = DeliverWorkPackageNotificationJob.new(aggregated.predecessor.id, User.current.id)
-        Delayed::Job.enqueue job
+        work_package = aggregated.predecessor.journable
+        notification_receivers(work_package).each do |recipient|
+          job = DeliverWorkPackageNotificationJob.new(aggregated.predecessor.id,
+                                                      recipient.id,
+                                                      User.current.id)
+          Delayed::Job.enqueue job
+        end
       end
 
       job = EnqueueWorkPackageNotificationJob.new(journal.id, User.current.id)
@@ -81,6 +86,10 @@ class JournalNotificationMailer
     def find_aggregated_journal_for(raw_journal)
       wp_journals = Journal::AggregatedJournal.aggregated_journals(journable: raw_journal.journable)
       wp_journals.detect { |journal| journal.version == raw_journal.version }
+    end
+
+    def notification_receivers(work_package)
+      work_package.recipients + work_package.watcher_recipients
     end
   end
 end

--- a/app/workers/deliver_watcher_notification_job.rb
+++ b/app/workers/deliver_watcher_notification_job.rb
@@ -27,26 +27,23 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class DeliverWatcherNotificationJob
-  include OpenProject::BeforeDelayedJob
+class DeliverWatcherNotificationJob < DeliverNotificationJob
 
-  def initialize(watcher_id, watcher_setter_id)
+  def initialize(watcher_id, recipient_id, watcher_setter_id)
     @watcher_id = watcher_id
-    @watcher_setter_id = watcher_setter_id
+
+    super(recipient_id, watcher_setter_id)
   end
 
-  def perform
-    return unless @watcher_id
+  def render_mail(recipient:, sender:)
+    return nil unless watcher
 
-    watcher = Watcher.find(@watcher_id)
-    watcher_setter = User.find(@watcher_setter_id)
+    UserMailer.work_package_watcher_added(watcher.watchable, recipient, sender)
+  end
 
-    return unless watcher && watcher_setter
+  private
 
-    mail = User.execute_as(watcher.user) {
-      UserMailer.work_package_watcher_added(watcher.watchable, watcher.user, watcher_setter)
-    }
-
-    mail.deliver
+  def watcher
+    @watcher ||= Watcher.find_by(id: @watcher_id)
   end
 end

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -78,6 +78,6 @@ class EnqueueWorkPackageNotificationJob
   end
 
   def notification_receivers(work_package)
-    work_package.recipients + work_package.watcher_recipients
+    (work_package.recipients + work_package.watcher_recipients).uniq
   end
 end

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -63,8 +63,10 @@ class EnqueueWorkPackageNotificationJob
   end
 
   def deliver_notifications_for(journal)
-    job = DeliverWorkPackageNotificationJob.new(journal.id, @author_id)
-    Delayed::Job.enqueue job
+    notification_receivers(work_package).each do |recipient|
+      job = DeliverWorkPackageNotificationJob.new(journal.id, recipient.id, @author_id)
+      Delayed::Job.enqueue job
+    end
   end
 
   def raw_journal
@@ -73,5 +75,9 @@ class EnqueueWorkPackageNotificationJob
 
   def work_package
     @work_package ||= raw_journal.journable
+  end
+
+  def notification_receivers(work_package)
+    work_package.recipients + work_package.watcher_recipients
   end
 end

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -32,5 +32,5 @@ OpenProject::Notifications.subscribe('journal_created') do |payload|
 end
 
 OpenProject::Notifications.subscribe('watcher_added') do |payload|
-  WatcherNotificationMailer.handle_watcher(payload[:watcher_id], payload[:watcher_setter_id])
+  WatcherNotificationMailer.handle_watcher(payload[:watcher], payload[:watcher_setter])
 end

--- a/lib/services/create_watcher.rb
+++ b/lib/services/create_watcher.rb
@@ -42,8 +42,8 @@ class Services::CreateWatcher
         @work_package.watchers << @watcher
         success.(created: true)
         OpenProject::Notifications.send('watcher_added',
-                                        watcher_id: @watcher.id,
-                                        watcher_setter_id: User.current.id)
+                                        watcher: @watcher,
+                                        watcher_setter: User.current)
       else
         failure.(@watcher)
       end

--- a/spec/workers/mail_notification_jobs/deliver_watcher_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/deliver_watcher_notification_job_spec.rb
@@ -38,10 +38,8 @@ describe DeliverWatcherNotificationJob, type: :model do
   end
   let(:work_package) { FactoryGirl.build(:work_package, project: project) }
   let(:watcher) { FactoryGirl.create(:watcher, watchable: work_package, user: watcher_user) }
-  let(:watcher_id) { watcher.id }
-  let(:watcher_setter_id) { watcher_setter.id }
 
-  subject { described_class.new(watcher_id, watcher_setter_id) }
+  subject { described_class.new(watcher.id, watcher_user.id, watcher_setter.id) }
 
   before do
     # make sure no actual calls make it into the UserMailer


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21424
## Description

Change error handling during delivery to ensure the following:
- fail the mail delivery on a per-recipient basis 
  - That means redeliveries because of an error only affect the users that did not receive a mail
- only fail the delayed job for delivery errors (e.g. network issues, etc)
- do not fail the delayed job for rendering errors (which are likely to re-occur on each rendering)
  - rendering errors are only logged using the `Rails.logger`
  - **TODO (?):** send them away via airbrake/errbit
