### PR TITLE
[21368] Horizontal scrollbar in WP list even if there's nothing to scroll (3)

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -237,7 +237,7 @@
 .work-package-table--container
   table.generic-table
     // HACK: This prevents a horizontal scroll bar in the work package table when there is nothing to scroll
-    width: calc(100% - 10px)
+    width: calc(100% - 20px)
 
 %flex-grow-shrink-zero
   flex-grow: 0

--- a/frontend/app/ui_components/interactive-table-directive.js
+++ b/frontend/app/ui_components/interactive-table-directive.js
@@ -83,7 +83,7 @@ module.exports = function($timeout, $window){
           if(isWorkPackagesTable()) {
             // HACK: This prevents a horizontal scroll bar in
             //       the work package table when there is nothing to scroll
-            getBackgrounds().css('width', 'calc(100% - 10px)');
+            getBackgrounds().css('width', 'calc(100% - 20px)');
           }
           else {
             getBackgrounds().css('width', '100%');


### PR DESCRIPTION
This provides a solution to avoid horizontal scrollbars in all browsers if there is nothing to scroll. It was tried to fix earlier in https://github.com/opf/openproject/pull/3447, but as it seems Firefox and IE11 need more space subtracted. 

https://community.openproject.org/work_packages/21368
