### PR TITLE
[21428] unwanted border in modal view (Firefox)

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -244,6 +244,11 @@ fieldset.form--fieldset
     text-overflow: ellipsis
     overflow: hidden
 
+  &.-required
+    input.form--text-field:invalid
+      // avoids the box-shadow from Firefox at required input fields
+      box-shadow: none
+
 .form--label
   @include grid-content(2)
   @include grid-visible-overflow


### PR DESCRIPTION
This removes the box shadow for required and invalid input fields. Normally Firefox has a red shadow for such fields. This is now avoided.

https://community.openproject.org/work_packages/21428
