### PR TITLE
Ensure that concurrent version updates play well together

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,12 +190,6 @@ gem 'grape', '~> 0.10.1'
 gem 'roar',   '~> 1.0.0'
 gem 'reform', '~> 1.2.6', require: false
 
-# Use the commented pure ruby gems, if you have not the needed prerequisites on
-# board to compile the native ones.  Note, that their use is discouraged, since
-# their integration is propbably not that well tested and their are slower in
-# orders of magnitude compared to their native counterparts. You have been
-# warned.
-
 platforms :mri, :mingw, :x64_mingw do
   group :mysql2 do
     gem 'mysql2', '~> 0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,8 @@ gem 'gon', '~> 4.0'
 # don't require by default, instead load on-demand when actually configured
 gem 'airbrake', '~> 4.1.0', require: false
 
+gem 'transactional_lock', git: 'https://github.com/finnlabs/transactional_lock.git', branch: 'master'
+
 group :production do
   # we use dalli as standard memcache client
   # requires memcached 1.4+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,13 @@ GIT
     rspec-example_disabler (0.0.1)
 
 GIT
+  remote: https://github.com/finnlabs/transactional_lock.git
+  revision: fe82192efa0346e49d19bbe82865280fdae79487
+  branch: master
+  specs:
+    transactional_lock (0.1.0)
+
+GIT
   remote: https://github.com/opf/openproject-translations.git
   revision: a2a7d246c6212c0867970ee44c505f97e5c96ee3
   branch: dev
@@ -596,6 +603,7 @@ DEPENDENCIES
   sys-filesystem (~> 1.1.4)
   thin
   timecop (~> 0.7.1)
+  transactional_lock!
   unicorn
   warden (~> 1.2)
   warden-basic_auth (~> 0.2.1)

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -66,8 +66,6 @@ class Journal < ActiveRecord::Base
       Journal.transaction do
         # MySQL is very weak when combining transactions and locks. Using an emulation layer to
         # automatically release an advisory lock at the end of the transaction
-        # FIXME: still creates duplicates... because MySQL defaults to READ REPEATABLE isolation
-        # we need READ COMMITED, which is also the default for PostgreSQL
         TransactionalLock::AdvisoryLock.new('journals.write_lock').acquire
         yield
       end

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -161,6 +161,10 @@ class JournalManager
                                details: journable.attributes.symbolize_keys }
 
         journal = create_journal journable, journal_attributes, user, notes
+
+        # FIXME: this is required for the association to be correctly saved...
+        journable.journals.select(&:new_record?)
+
         journal.save!
         journal
       end

--- a/config/initializers/enforce_isolation_level.rb
+++ b/config/initializers/enforce_isolation_level.rb
@@ -1,0 +1,60 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# We need to ensure that we operate on a well-known TRANSACTION ISOLATION LEVEL
+# However, the default isolation level is different for MySQL and PostgreSQL and it is also
+# possible (at least for MySQL) to globally override the default for your DBMS installation.
+# Therefore we want to ensure that the isolation level is consistent on a session basis.
+# We chose READ COMMITTED as our expected default isolation level, this is the default of
+# PostgreSQL.
+module ConnectionIsolationLevel
+  module ConnectionPoolPatch
+    def new_connection
+      connection = super
+      ConnectionIsolationLevel.set_connection_isolation_level connection
+      connection
+    end
+  end
+
+  def self.set_connection_isolation_level(connection)
+    isolation_level = 'ISOLATION LEVEL READ COMMITTED'
+    if OpenProject::Database.mysql?
+      connection.execute("SET SESSION TRANSACTION #{isolation_level}")
+    else
+      connection.execute("SET SESSION CHARACTERISTICS AS TRANSACTION #{isolation_level}")
+    end
+  end
+end
+
+ActiveRecord::ConnectionAdapters::ConnectionPool.send(:prepend,
+                                                      ConnectionIsolationLevel::ConnectionPoolPatch)
+
+# in case the existing connection was created before our patch
+# N.B.: this assumes that our process only has this single thread, which is at least true today...
+ConnectionIsolationLevel.set_connection_isolation_level ActiveRecord::Base.connection

--- a/config/initializers/enforce_isolation_level.rb
+++ b/config/initializers/enforce_isolation_level.rb
@@ -44,7 +44,7 @@ module ConnectionIsolationLevel
 
   def self.set_connection_isolation_level(connection)
     isolation_level = 'ISOLATION LEVEL READ COMMITTED'
-    if OpenProject::Database.mysql?
+    if OpenProject::Database.mysql?(connection)
       connection.execute("SET SESSION TRANSACTION #{isolation_level}")
     else
       connection.execute("SET SESSION CHARACTERISTICS AS TRANSACTION #{isolation_level}")

--- a/config/initializers/transactional_lock.rb
+++ b/config/initializers/transactional_lock.rb
@@ -29,6 +29,8 @@
 
 OpenProject::Application.configure do
   config.after_initialize do
-    TransactionalLock.initialize
+    TransactionalLock.initialize do |config|
+      config.merge(default_timeout: 60)
+    end
   end
 end

--- a/config/initializers/transactional_lock.rb
+++ b/config/initializers/transactional_lock.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+OpenProject::Application.configure do
+  config.after_initialize do
+    TransactionalLock.initialize
+  end
+end

--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -45,22 +45,27 @@ module OpenProject
 
     # Get the raw name of the currently used database adapter.
     # This string is set by the used adapter gem.
-    def self.adapter_name
-      ActiveRecord::Base.connection.adapter_name
+    def self.adapter_name(connection)
+      connection.adapter_name
     end
 
-    # returns the identifier of the currently used database type
-    def self.name
+    # returns the identifier of the specified connection
+    # (defaults to ActiveRecord::Base.connection)
+    def self.name(connection = ActiveRecord::Base.connection)
       supported_adapters.find(proc { [:unknown, //] }) { |_adapter, regex|
-        adapter_name =~ regex
+        adapter_name(connection) =~ regex
       }[0]
     end
 
     # Provide helper methods to quickly check the database type
     # OpenProject::Database.mysql? returns true, if we have a MySQL DB
+    # Also allows specification of a connection e.g.
+    # OpenProject::Database.mysql?(my_connection)
     supported_adapters.keys.each do |adapter|
       (class << self; self; end).class_eval do
-        define_method(:"#{adapter.to_s}?") { send(:name) == adapter }
+        define_method(:"#{adapter.to_s}?") do |connection = ActiveRecord::Base.connection|
+          send(:name, connection) == adapter
+        end
       end
     end
 


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21300
## Description

This PR adds locking around the assignment of a journal version. This ensures that there are no intermittent `INSERT`s into the journals table between determining the latest version of a journable and actually adding the next version.
### PostgreSQL

For PSQL we can use a `SHARE ROW EXCLUSIVE` lock on the journals table. While held, this locks prevents:
- concurrent `INSERT`/`DELETE`/`UPDATE` statements
- concurrent acquisition of a `SHARE ROW EXCLUSIVE` lock (i.e. it is self-exclusive)

The lock is released upon `COMMIT` or `ROLLBACK` of the surrounding transaction, which is neccessary, because otherwise a concurrent transaction would not be able to see the changes of the lock bearer and therefore still try to insert an outdated value for `version`.
### MySQL

Opposed to PostgreSQL, in MySQL there are no locks that are released at the end of a transaction. Table locks of all kinds implicitly commit running transactions (and starting a transaction releases all table locks).
Advisory locks (the ones without meaning for the DBMS, but usable by applications) at least don't commit your transactions, but you must release them independently of your transactions.

This means we can use advisory locks to implement self exclusiveness, but we have to release it after our transaction finished (`COMMIT` or `ROLLBACK`) manually. Since the code starting the transaction should not know about the implementation details of the code relying on the advisory lock (those are oftentimes different parts of our application), I extracted the release-on-transaction-end behaviour into a separate gem called [transactional_lock](https://github.com/finnlabs/transactional_lock).

Note: Please see the transactional_lock gem as a part of this PR and include it in your review.

After review, we might want to publish it like any regular gem on rubygems.org and use it from there instead of using a git reference.
