### PR TITLE
Force disabled_types to be symbols

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -109,8 +109,9 @@ class Repository < ActiveRecord::Base
 
   ##
   # Retrieves the :disabled_types setting from `configuration.yml
+  # To avoid wrong set operations for string-based configuration, force them to symbols.
   def self.disabled_types
-    scm_config[:disabled_types] || []
+    (scm_config[:disabled_types] || []).map(&:to_sym)
   end
 
   def vendor

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -54,8 +54,16 @@ describe Repository::Git, type: :model do
       expect(instance.class.available_types).to eq([:local])
     end
 
-    context 'with disabled typed' do
+    context 'with disabled types' do
       let(:config) { { disabled_types: [:local, :managed] } }
+
+      it 'does not have any types' do
+        expect(instance.class.available_types).to be_empty
+      end
+    end
+
+    context 'with mixed disabled types' do
+      let(:config) { { disabled_types: [:local, 'managed'] } }
 
       it 'does not have any types' do
         expect(instance.class.available_types).to be_empty

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -57,8 +57,16 @@ describe Repository::Subversion, type: :model do
       expect(instance.class.available_types).to eq [:existing]
     end
 
-    context 'with disabled typed' do
+    context 'with disabled types' do
       let(:config) { { disabled_types: [:existing, :managed] } }
+
+      it 'does not have any types' do
+        expect(instance.class.available_types).to be_empty
+      end
+    end
+
+    context 'with mixed disabled types' do
+      let(:config) { { disabled_types: ['existing', :managed] } }
 
       it 'does not have any types' do
         expect(instance.class.available_types).to be_empty


### PR DESCRIPTION
To avoid exposed types from misconfiguration (or installations where
string-based configuration is a requirement), we convert the input from
`disabled_types` to be symbols.
