### PR TITLE
Avoid HTML escaping in truncation

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -91,7 +91,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% if e.project != @project %>
           <span class="project"><%= e.project %></span>
         <% end %>
-        <%= link_to highlight_tokens(truncate(e.event_title, :length => 255), @tokens), with_notes_anchor(e, @tokens) %>
+        <%= link_to highlight_tokens(truncate(e.event_title, escape: false, length: 255), @tokens), with_notes_anchor(e, @tokens) %>
       </dt>
       <dd><span class="description"><%= highlight_first([last_journal(e).try(:notes), e.event_description], @tokens) %></span>
         <span class="author"><%= format_time(e.event_datetime) %></span></dd>


### PR DESCRIPTION
This removes the default HTML escape in the search truncation,
as that happens afterwards in `highlight_tokens` and otherwise leads to
quoted text.

![bildschirmfoto 2015-09-09 um 15 51 03](https://cloud.githubusercontent.com/assets/459462/9763588/a864014a-570a-11e5-9a78-0516e619c0ce.png)
