### PR TITLE
respecify modal cuke step

### DIFF
--- a/features/step_definitions/timelines_then_steps.rb
+++ b/features/step_definitions/timelines_then_steps.rb
@@ -70,11 +70,11 @@ Then(/^I should see the column "(.*?)" immediately before the column "(.*?)" in 
 end
 
 Then(/^I should see a modal window$/) do
-  steps 'Then I should see a modal window with selector "#modalDiv"'
+  steps 'Then I should see a modal window with selector "#modalDiv.ui-dialog-content"'
 end
 
 Then(/^I should not see a modal window$/) do
-  page.should_not have_selector('#modalDiv')
+  page.should_not have_selector('#modalDiv.ui-dialog-content')
 end
 
 Then(/^(.*) in the modal$/) do |step|


### PR DESCRIPTION
The extra class requirement is necessary as the page always sports a div
with id modalDiv to be used in case a modal is to be shown. But only if
it is actually shown, will it have the additional class.
