### PR TITLE
Query Performance

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -149,14 +149,18 @@ module SettingsHelper
 
   def build_settings_matrix_body(settings, choices)
     choices.map { |choice|
-      text, value = (choice.is_a?(Array)) ? choice : [choice, choice]
+      value = choice[:value]
+      caption = choice[:caption] || value.to_s
+      exceptions = Array(choice[:except]).compact
       content_tag(:tr, class: 'form--matrix-row') do
-        content_tag(:td, text, class: 'form--matrix-cell') +
+        content_tag(:td, caption, class: 'form--matrix-cell') +
           settings.map { |setting|
             content_tag(:td, class: 'form--matrix-checkbox-cell') do
-              styled_check_box_tag("settings[#{setting}][]", value,
-                                   Setting.send(setting).include?(value),
-                                   id: "#{setting}_#{value}")
+              unless exceptions.include?(setting)
+                styled_check_box_tag("settings[#{setting}][]", value,
+                                     Setting.send(setting).include?(value),
+                                     id: "#{setting}_#{value}")
+              end
             end
           }.join.html_safe
       end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -31,7 +31,8 @@ class Query < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
   include Queries::WorkPackages::AvailableFilterOptions
 
-  alias_method :available_filters, :available_work_package_filters # referenced in plugin patches - currently there are only work package queries and filters
+  # referenced in plugin patches - currently there are only work package queries and filters
+  alias_method :available_filters, :available_work_package_filters
 
   @@user_filters = %w{assigned_to_id author_id watcher_id responsible_id}.freeze
 
@@ -61,37 +62,78 @@ class Query < ActiveRecord::Base
   # query.  If such a statement selects from two coluns named <table name>.id
   # the second one is taken to get the ids of the work packages.
   @@available_columns = [
-    QueryColumn.new(:id, sortable: "#{WorkPackage.table_name}.id", groupable: false),
-    QueryColumn.new(:project, sortable: "#{Project.table_name}.name", groupable: true),
-    QueryColumn.new(:type, sortable: "#{::Type.table_name}.position", groupable: true),
-    QueryColumn.new(:parent, sortable: ["#{WorkPackage.table_name}.root_id", "#{WorkPackage.table_name}.lft ASC"], default_order: 'desc'),
-    QueryColumn.new(:status, sortable: "#{Status.table_name}.position", groupable: true),
-    QueryColumn.new(:priority, sortable: "#{IssuePriority.table_name}.position", default_order: 'desc', groupable: true),
-    QueryColumn.new(:subject, sortable: "#{WorkPackage.table_name}.subject"),
+    QueryColumn.new(:id,
+                    sortable: "#{WorkPackage.table_name}.id",
+                    groupable: false),
+    QueryColumn.new(:project,
+                    sortable: "#{Project.table_name}.name",
+                    groupable: true),
+    QueryColumn.new(:type,
+                    sortable: "#{::Type.table_name}.position",
+                    groupable: true),
+    QueryColumn.new(:parent,
+                    sortable: ["#{WorkPackage.table_name}.root_id",
+                               "#{WorkPackage.table_name}.lft ASC"],
+                    default_order: 'desc'),
+    QueryColumn.new(:status,
+                    sortable: "#{Status.table_name}.position",
+                    groupable: true),
+    QueryColumn.new(:priority,
+                    sortable: "#{IssuePriority.table_name}.position",
+                    default_order: 'desc',
+                    groupable: true),
+    QueryColumn.new(:subject,
+                    sortable: "#{WorkPackage.table_name}.subject"),
     QueryColumn.new(:author,
                     sortable: ["#{User.table_name}.lastname",
                                "#{User.table_name}.firstname",
                                "#{WorkPackage.table_name}.author_id"],
                     groupable: true),
-    QueryColumn.new(:assigned_to, sortable: ["#{User.table_name}.lastname",
-                                             "#{User.table_name}.firstname",
-                                             "#{WorkPackage.table_name}.assigned_to_id"],
-                                  groupable: true),
-    QueryColumn.new(:responsible, sortable: ["#{User.table_name}.lastname",
-                                             "#{User.table_name}.firstname",
-                                             "#{WorkPackage.table_name}.responsible_id"],
-                                  groupable: "#{WorkPackage.table_name}.responsible_id",
-                                  join: 'LEFT OUTER JOIN users as responsible ON ' +
-                                        "(#{WorkPackage.table_name}.responsible_id = responsible.id)"),
-    QueryColumn.new(:updated_at, sortable: "#{WorkPackage.table_name}.updated_at", default_order: 'desc'),
-    QueryColumn.new(:category, sortable: "#{Category.table_name}.name", groupable: true),
-    QueryColumn.new(:fixed_version, sortable: ["#{Version.table_name}.effective_date", "#{Version.table_name}.name"], default_order: 'desc', groupable: true),
-    # Put empty start_dates and due_dates in the far future rather than in the far past
-    QueryColumn.new(:start_date, sortable: ["CASE WHEN #{WorkPackage.table_name}.start_date IS NULL THEN 1 ELSE 0 END", "#{WorkPackage.table_name}.start_date"]),
-    QueryColumn.new(:due_date, sortable: ["CASE WHEN #{WorkPackage.table_name}.due_date IS NULL THEN 1 ELSE 0 END", "#{WorkPackage.table_name}.due_date"]),
-    QueryColumn.new(:estimated_hours, sortable: "#{WorkPackage.table_name}.estimated_hours", summable: true),
-    QueryColumn.new(:done_ratio, sortable: "#{WorkPackage.table_name}.done_ratio", groupable: true),
-    QueryColumn.new(:created_at, sortable: "#{WorkPackage.table_name}.created_at", default_order: 'desc'),
+    QueryColumn.new(:assigned_to,
+                    sortable: ["#{User.table_name}.lastname",
+                               "#{User.table_name}.firstname",
+                               "#{WorkPackage.table_name}.assigned_to_id"],
+                    groupable: true),
+    QueryColumn.new(:responsible,
+                    sortable: ["#{User.table_name}.lastname",
+                               "#{User.table_name}.firstname",
+                               "#{WorkPackage.table_name}.responsible_id"],
+                    groupable: "#{WorkPackage.table_name}.responsible_id",
+                    join: 'LEFT OUTER JOIN users as responsible ON ' +
+                          "(#{WorkPackage.table_name}.responsible_id = responsible.id)"),
+    QueryColumn.new(:updated_at,
+                    sortable: "#{WorkPackage.table_name}.updated_at",
+                    default_order: 'desc'),
+    QueryColumn.new(:category,
+                    sortable: "#{Category.table_name}.name",
+                    groupable: true),
+    QueryColumn.new(:fixed_version,
+                    sortable: ["#{Version.table_name}.effective_date",
+                               "#{Version.table_name}.name"],
+                    default_order: 'desc',
+                    groupable: true),
+    # Put empty start_dates in the far future rather than in the far past
+    QueryColumn.new(:start_date,
+                    # Put empty start_dates in the far future rather than in the far past
+                    sortable: ["CASE WHEN #{WorkPackage.table_name}.start_date IS NULL
+                                THEN 1
+                                ELSE 0 END",
+                               "#{WorkPackage.table_name}.start_date"]),
+    QueryColumn.new(:due_date,
+                    # Put empty due_dates in the far future rather than in the far past
+                    sortable: ["CASE WHEN #{WorkPackage.table_name}.due_date IS NULL
+                                THEN 1
+                                ELSE 0 END",
+                               "#{WorkPackage.table_name}.due_date"]),
+    QueryColumn.new(:estimated_hours,
+                    sortable: "#{WorkPackage.table_name}.estimated_hours",
+                    summable: true),
+    QueryColumn.new(:done_ratio,
+                    sortable: "#{WorkPackage.table_name}.done_ratio",
+                    groupable: true),
+    QueryColumn.new(:created_at,
+                    sortable: "#{WorkPackage.table_name}.created_at",
+                    default_order: 'desc'),
   ]
   cattr_reader :available_columns
 

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -89,7 +89,7 @@ class Query < ActiveRecord::Base
     # Put empty start_dates and due_dates in the far future rather than in the far past
     QueryColumn.new(:start_date, sortable: ["CASE WHEN #{WorkPackage.table_name}.start_date IS NULL THEN 1 ELSE 0 END", "#{WorkPackage.table_name}.start_date"]),
     QueryColumn.new(:due_date, sortable: ["CASE WHEN #{WorkPackage.table_name}.due_date IS NULL THEN 1 ELSE 0 END", "#{WorkPackage.table_name}.due_date"]),
-    QueryColumn.new(:estimated_hours, sortable: "#{WorkPackage.table_name}.estimated_hours"),
+    QueryColumn.new(:estimated_hours, sortable: "#{WorkPackage.table_name}.estimated_hours", summable: true),
     QueryColumn.new(:done_ratio, sortable: "#{WorkPackage.table_name}.done_ratio", groupable: true),
     QueryColumn.new(:created_at, sortable: "#{WorkPackage.table_name}.created_at", default_order: 'desc'),
   ]

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -78,12 +78,13 @@ class ::Query::Results
   end
 
   def work_packages
-    WorkPackage.where(::Query.merge_conditions(query.statement, options[:conditions]))
-      .includes([:status, :project] + (options[:include] || []).uniq)
-      .includes(includes_for_columns(query.involved_columns))
-      .joins((query.group_by_column ? query.group_by_column.join : nil))
-      .order(order_option)
-      .references(:projects)
+    @work_packages ||= WorkPackage
+                       .where(::Query.merge_conditions(query.statement, options[:conditions]))
+                       .includes([:status, :project] + (options[:include] || []).uniq)
+                       .includes(includes_for_columns(query.involved_columns))
+                       .joins((query.group_by_column ? query.group_by_column.join : nil))
+                       .order(order_option)
+                       .references(:projects)
   end
 
   # Same as :work_packages, but returns a result sorted by the sort_criteria defined in the query.
@@ -91,7 +92,7 @@ class ::Query::Results
   # If there is a reason: This is a somewhat DRY way of using the sort criteria.
   # If there is no reason: The :work_package method can die over time and be replaced by this one.
   def sorted_work_packages
-    work_packages.order(query.sort_criteria_sql)
+    @sorted_work_packages ||= work_packages.order(query.sort_criteria_sql)
   end
 
   def versions
@@ -117,7 +118,7 @@ class ::Query::Results
   def all_sums_for_group(group)
     return nil unless query.grouped?
 
-    group_work_packages = all_work_packages.select { |wp| query.group_by_column.value(wp) == group }
+    group_work_packages = work_packages.select { |wp| query.group_by_column.value(wp) == group }
     query.available_columns.inject({}) { |result, column|
       sum = sum_of(column, group_work_packages)
       result[column] = sum unless sum.nil?

--- a/app/models/query/sums.rb
+++ b/app/models/query/sums.rb
@@ -73,21 +73,10 @@ module ::Query::Sums
 
   def sum_of(column, collection)
     return nil unless should_be_summed_up?(column)
-    # This is a workaround to be able to sum up currency with the redmine_costs plugin
-    values = collection.map { |issue|
-               column.respond_to?(:real_value) ?
-                 column.real_value(issue) :
-                 column.value(issue)
-             }.select { |value|
-               begin
-                 next if value.respond_to? :today? or value.is_a? String
-                 true if Float(value)
-               rescue ArgumentError, ::TypeError
-                 false
-               end
-             }
 
-    crunch(values.reduce :+)
+    sum = column.sum_of(collection)
+
+    crunch(sum)
   end
 
   def caching_issue(issue)
@@ -122,6 +111,6 @@ module ::Query::Sums
   end
 
   def should_be_summed_up?(column)
-    Setting.work_package_list_summable_columns.include?(column.name.to_s)
+    column.summable? && Setting.work_package_list_summable_columns.include?(column.name.to_s)
   end
 end

--- a/app/models/query/sums.rb
+++ b/app/models/query/sums.rb
@@ -63,6 +63,7 @@ module ::Query::Sums
       .uniq
       .inject({}) do |group_sums, current_group|
         work_packages_in_current_group = work_packages.select { |wp| query.group_by_column.value(wp) == current_group }
+        # TODO: sum_of only works fast when passing an AR::Relation
         group_sums.merge current_group => sum_of(column, work_packages_in_current_group)
       end
   end

--- a/app/models/query/sums.rb
+++ b/app/models/query/sums.rb
@@ -30,26 +30,22 @@
 module ::Query::Sums
   include ActionView::Helpers::NumberHelper
 
-  def all_work_packages
-    @all_work_packages ||= work_packages
-  end
-
   def next_in_same_group?(issue = cached_issue)
     caching_issue issue do |issue|
       !last_issue? &&
-        query.group_by_column.value(issue) == query.group_by_column.value(all_work_packages[issue_index + 1])
+        query.group_by_column.value(issue) == query.group_by_column.value(work_packages[issue_index + 1])
     end
   end
 
   def last_issue?(issue = cached_issue)
     caching_issue issue do |_issue|
-      issue_index == all_work_packages.size - 1
+      issue_index == work_packages.size - 1
     end
   end
 
   def issue_index(issue = cached_issue)
     caching_issue issue do |issue|
-      all_work_packages.find_index(issue)
+      work_packages.find_index(issue)
     end
   end
 
@@ -62,17 +58,17 @@ module ::Query::Sums
   end
 
   def grouped_sums(column)
-    all_work_packages
+    work_packages
       .map { |wp| query.group_by_column.value(wp) }
       .uniq
       .inject({}) do |group_sums, current_group|
-        work_packages_in_current_group = all_work_packages.select { |wp| query.group_by_column.value(wp) == current_group }
+        work_packages_in_current_group = work_packages.select { |wp| query.group_by_column.value(wp) == current_group }
         group_sums.merge current_group => sum_of(column, work_packages_in_current_group)
       end
   end
 
   def total_sum_of(column)
-    sum_of(column, all_work_packages)
+    sum_of(column, work_packages)
   end
 
   def sum_of(column, collection)
@@ -119,7 +115,7 @@ module ::Query::Sums
 
   def group_for_issue(issue = @current_issue)
     caching_issue issue do |issue|
-      all_work_packages.select do |is|
+      work_packages.select do |is|
         query.group_by_column.value(issue) == query.group_by_column.value(is)
       end
     end

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -28,13 +28,15 @@
 #++
 
 class QueryColumn
-  attr_accessor :name, :sortable, :groupable, :join, :default_order
+  attr_accessor :name, :sortable, :groupable, :summable, :join, :default_order
+  alias_method :summable?, :summable
   include Redmine::I18n
 
   def initialize(name, options = {})
     self.name = name
     self.sortable = options[:sortable]
     self.groupable = options[:groupable]
+    self.summable = options[:summable]
 
     self.join = options.delete(:join)
 
@@ -66,6 +68,10 @@ class QueryColumn
 
   def value(issue)
     issue.send name
+  end
+
+  def sum_of(work_packages)
+    work_packages.sum(name)
   end
 
   protected

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -71,7 +71,13 @@ class QueryColumn
   end
 
   def sum_of(work_packages)
-    work_packages.sum(name)
+    if work_packages.is_a?(Array)
+      # TODO: Sums::grouped_sums might call through here without an AR::Relation
+      # Ensure that this also calls using a Relation and drop this (slow!) implementation
+      work_packages.map { |wp| value(wp) }.compact.reduce(:+)
+    else
+      work_packages.sum(name)
+    end
   end
 
   protected

--- a/app/models/query_custom_field_column.rb
+++ b/app/models/query_custom_field_column.rb
@@ -56,13 +56,11 @@ class QueryCustomFieldColumn < QueryColumn
   def sum_of(work_packages)
     if work_packages.respond_to?(:joins)
       # we can't perform the aggregation on the SQL side. Try to filter useless rows to reduce work.
-      cv_alias = "joined_#{name}"
       work_packages = work_packages
-                      .joins("LEFT OUTER JOIN #{CustomValue.table_name} #{cv_alias} ON
-                              #{cv_alias}.customized_type='WorkPackage' AND
-                              #{cv_alias}.customized_id=#{WorkPackage.table_name}.id AND
-                              #{cv_alias}.custom_field_id=#{@cf.id}")
-                      .where("#{cv_alias}.value IS NOT NULL AND #{cv_alias}.value != ''")
+                      .joins(:custom_values)
+                      .where(custom_values: { custom_field: @cf })
+                      .where("#{CustomValue.table_name}.value IS NOT NULL")
+                      .where("#{CustomValue.table_name}.value != ''")
     end
 
     # TODO: eliminate calls of this method with an Array and drop the :compact call below

--- a/app/views/settings/_work_packages.html.erb
+++ b/app/views/settings/_work_packages.html.erb
@@ -36,8 +36,15 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= setting_text_field :work_packages_export_limit, :size => 6 %></div>
   </section>
   <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= l(:setting_column_options) %></legend>
+    <%
+       column_choices = Query.new.available_columns.map { |column|
+         choice = { caption: column.caption, value: column.name.to_s }
+         choice[:except] = :work_package_list_summable_columns unless column.summable?
+         choice
+       }
+    %>
     <%= settings_matrix([:work_package_list_default_columns, :work_package_list_summable_columns],
-  Query.new.available_columns.collect {|c| [c.caption, c.name.to_s]}, :label_choices => :setting_work_package_properties) %>
+                        column_choices, :label_choices => :setting_work_package_properties) %>
   </fieldset>
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
 <% end %>

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -87,9 +87,25 @@ describe SettingsHelper, type: :helper do
     end
 
     subject(:output) {
-      helper.settings_matrix [:field_a, :field_b], [
-        ['Popsickle', '1'], ['Jello', '2'], ['Ice Cream', '3'], 'Quarkspeise'
+      settings = [:field_a, :field_b]
+      choices = [
+        {
+          caption: 'Popsickle',
+          value: '1'
+        },
+        {
+          caption: 'Jello',
+          value: '2'
+        },
+        {
+          caption: 'Ice Cream',
+          value: '3'
+        },
+        {
+          value: 'Quarkspeise'
+        }
       ]
+      helper.settings_matrix settings, choices
     }
 
     it_behaves_like 'not wrapped in container'


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21447
## Description

Performance problems could be observed on the global WP list of a QA instance. Turns out the reason is, that the calculation of sums (which takes places even when not showing sums), involves requesting **all** work packages from the database and adding their column values on the rails side.

This PR applies the following fixes to improve the situation:
- for "normal" columns, the aggregation is done SQL side, we only request the sum via SQL
- for custom field columns I couldn't accomplish SQL side aggregation, however we only request work packages where the corresponding custom field has a value
  - this is a huge performance improvement assuming that custom fields are only sparsely filled
  - it might not be an improvement for densely filled custom fields (will probably be worse if there are multiple such summed columns)

Performance-wise improvements are possible (and should be pursuited) in the following areas:
- do not send a SQL query per summed column, but rather use a single SQL request to get all aggregations at once
- move aggregation for custom fields to the SQL side

This PR includes the following additional changes:
- `QueryColumn`s not indicate whether they are summable at all, thus it is not possible to try to sum up "subject" or "project" anymore
  - users are only presented a checkbox for columns that are indeed summable, so they do not try to enable summing for the subject
- summing is now performed inside the `QueryColumn` class, allowing subclasses to override the way sums are calculated
## Related PRs

:warning: Merge this PR only together with the following PRs:
- [Backlogs](https://github.com/finnlabs/openproject-backlogs/issues/169): indicate summable columns
- [Costs](https://github.com/finnlabs/openproject-costs/issues/164): indicate summable columns and fixes n+1 query
## Limitations

At the end I discovered that grouping a query is very slow on its own:
- determining the groups is done ruby-side
- building the group sums involves work package arrays and thus is also slow (can't be performed SQL side)

I decided to not tackle those issues in this PR. I merely added compatibility code to be able to handle the arrays passed by the grouping code. I propose to introduce the changes w.r.t. to grouping in a separate PR, as grouping only impedes the performance when it was explicitly enabled. It will also require further (and probably larger) rework of the query classes to support SQL side grouping.
