### PR TITLE
[21474] Long words are not punctuated in WP split view

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -42,6 +42,19 @@
   color: #777777
   font-style: italic
 
+  li
+    span
+      overflow: hidden
+      display: inline-block
+      text-overflow: ellipsis
+      max-width: 100%
+      vertical-align: top
+      //necessary for IE
+      white-space: nowrap
+  p
+    overflow: hidden
+    text-overflow: ellipsis
+
 .comments-number
   padding: 0
   float: right

--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -44,13 +44,11 @@
 
   li
     span
-      overflow: hidden
+      word-wrap: break-word
+      // important for IE
       display: inline-block
-      text-overflow: ellipsis
       max-width: 100%
       vertical-align: top
-      //necessary for IE
-      white-space: nowrap
   p
     overflow: hidden
     text-overflow: ellipsis

--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -50,8 +50,7 @@
       max-width: 100%
       vertical-align: top
   p
-    overflow: hidden
-    text-overflow: ellipsis
+    word-wrap: break-word
 
 .comments-number
   padding: 0


### PR DESCRIPTION
This sets the overflow-values so that long words are punctuated.

https://community.openproject.org/work_packages/21474
