### PR TITLE
Consistency in homescreen / menu labels

### DIFF
--- a/app/views/homescreen/blocks/_administration.html.erb
+++ b/app/views/homescreen/blocks/_administration.html.erb
@@ -13,8 +13,8 @@
                title: l(:label_user_plural) %>
   </li>
   <li>
-    <%= link_to l(:label_manage_groups), groups_path,
-                title: l(:label_manage_groups) %>
+    <%= link_to l(:label_group_plural), groups_path,
+                title: l(:label_group_plural) %>
   </li>
   <li>
     <%= link_to l(:label_role_and_permissions), roles_path,
@@ -40,8 +40,8 @@
 
   </li>
 	<li>
-    <%= link_to l(:label_advanced_settings), settings_path,
-               title: l(:label_advanced_settings) %>
+    <%= link_to l(:label_settings), settings_path,
+               title: l(:label_settings) %>
   </li>
   <%= call_hook(:homescreen_administration_links) %>
 </ul>

--- a/app/views/homescreen/blocks/_my_account.html.erb
+++ b/app/views/homescreen/blocks/_my_account.html.erb
@@ -8,8 +8,8 @@
     <%= link_to l(:label_profile), my_account_path, title: l(:label_profile) %>
   </li>
   <li>
-    <%= link_to l(:label_keyboard_shortcut_go_my_page), my_page_path,
-                title: l(:label_keyboard_shortcut_go_my_page) %>
+    <%= link_to l(:label_my_page), my_page_path,
+                title: l(:label_my_page) %>
   </li>
   <li>
     <%= link_to l(:button_change_password), my_password_path, title: l(:button_change_password) %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -120,7 +120,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :types,
             { controller: '/types' },
-            caption: :label_type_plural,
+            caption: :label_work_package_types,
             html: { class: 'icon2 icon-tracker' }
 
   menu.push :statuses,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -667,7 +667,6 @@ en:
   label_additional_workflow_transitions_for_assignee: "Additional transitions allowed when the user is the assignee"
   label_additional_workflow_transitions_for_author: "Additional transitions allowed when the user is the author"
   label_administration: "Administration"
-  label_advanced_settings: "Advanced settings"
   label_age: "Age"
   label_ago: "days ago"
   label_all: "all"

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -46,7 +46,7 @@ feature 'Admin menu items' do
       expect(page).to have_selector('a', text: I18n.t('label_user_plural'))
       expect(page).to have_selector('a', text: I18n.t('label_project_plural'))
       expect(page).to have_selector('a', text: I18n.t('label_role_plural'))
-      expect(page).to have_selector("a[title=#{I18n.t('label_type_plural')}]")
+      expect(page).to have_selector('a', text: I18n.t('label_work_package_types'))
     end
   end
 
@@ -62,7 +62,7 @@ feature 'Admin menu items' do
       expect(page).to have_selector('a', text: I18n.t('label_project_plural'))
 
       expect(page).not_to have_selector('a', text: I18n.t('label_role_plural'))
-      expect(page).not_to have_selector("a[title=#{I18n.t('label_type_plural')}]")
+      expect(page).not_to have_selector('a', text: I18n.t('label_work_package_types'))
     end
   end
 end


### PR DESCRIPTION
Provides consistency in labels:
- types -> work package types
- go to my page -> my page
- manage groups -> groups
- advanced settings -> settings
