### PR TITLE
[21477] Align labels in toolbar

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -67,6 +67,8 @@
   display: table
 
 .toolbar-items
+  display: flex
+  align-items: center
   li
     float: left
     &.toolbar-item
@@ -81,6 +83,9 @@
     &.-pressed, &:active
       background: $toolbar-item--bg-color-pressed
       box-shadow: inset 0 2px 3px rgba(0,0,0,.125)
+
+  label
+    margin: 0.5rem 0 0 0
 
   select
     //extend forms select


### PR DESCRIPTION
This aligns items of a toolbar with flexboxes. That is necessary because labels would otherwise be misaligned. The bug was noticed in backlogs plugin but is relevant for every toolbar in the system.

https://community.openproject.org/work_packages/21477
