### PR TITLE
Remove unused project work package route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,8 +315,6 @@ OpenProject::Application.routes.draw do
       get '/create_new' => 'work_packages#index', on: :collection
     end
 
-    get '/work_packages/:id(/:tab)' => 'work_packages#index', as: 'work_package'
-
     resources :activity, :activities, only: :index, controller: 'activities'
 
     resources :boards do

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.feature 'Work package index view' do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:project) { FactoryGirl.create(:project) }
+
+  before do
+    allow(User).to receive(:current).and_return(user)
+  end
+
+  scenario 'is reachable by clicking the sidebar menu item', js: true do
+    visit project_path(project)
+
+    within('#content') do
+      expect(page).to have_content('Overview')
+    end
+
+    within('#main-menu') do
+      click_link 'Work packages'
+    end
+
+    expect(current_path).to eql("/projects/#{project.identifier}/work_packages")
+    within('#content') do
+      expect(page).to have_content('Work packages')
+      expect(page).to have_content('No work packages to display')
+    end
+  end
+end


### PR DESCRIPTION
Besides being unused it mistakenly uses the project id as for the
work package which leads to a wrong link in the project sidebar.
