### PR TITLE
[19722] change headlines and unify styling of home screen blocks

### DIFF
--- a/app/assets/stylesheets/content/_widget_box.lsg
+++ b/app/assets/stylesheets/content/_widget_box.lsg
@@ -1,0 +1,51 @@
+# Widget Boxes
+
+```
+<form>
+  <section class="widget-boxes">
+    <div class="widget-box">
+      <h3 class="widget-box--header">
+        <span class="icon-context icon-home1"></span>
+        <span class="widget-box--header-title">Widget Box</span>
+      </h3>
+      <p class="widget-box--additional-info">This widget box can be used to display content belonging to one subject.</p>
+      <ul class="widget-box--arrow-links">
+        <li>
+          <a>Go to Link 1</a>
+        </li>
+        <li>
+          <a>Go to link 2</a>
+        </li>
+      </ul>
+    </div>
+
+    <div class="widget-box">
+      <h3 class="widget-box--header">
+        <span class="icon-context icon-home2"></span>
+        <span class="widget-box--header-title">Widget Box 2</span>
+      </h3>
+      <ul class="widget-box--enumeration">
+        <li>
+          Enum1
+        </li>
+        <li>
+          Enum2
+        </li>
+        <li>
+          Enum3
+        </li>
+        <li>
+          Enum4
+        </li>
+      </ul>
+      <div class="widget-box--buttons">
+        <a class="button -highlight">
+          <i class="button--icon icon-add"></i>
+          <span class="button--text">Add</span>
+        </a>
+      </div>
+    </div>
+  </section>
+</form>
+
+```

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -1,0 +1,106 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+@mixin widget-box--style
+  background: $widget-box-block-bg-color
+  border: 1px solid $widget-box-block-border-color
+  margin: 10px
+
+$widget-box--enumeration-width: 20px
+
+.widget-boxes--screen-header
+  margin-left: 10px
+
+.widget-boxes
+  display: flex
+  flex-flow: row wrap
+
+  .icon-context:before
+    padding-right: 5px
+
+  .widget-box
+    @include widget-box--style
+    padding: 10px 10px 10px 20px
+    flex: 1
+    flex-basis: 32%
+    display: flex
+    flex-direction: column
+    min-height: 250px
+    word-wrap: break-words
+    overflow: hidden
+
+    .widget-box--header
+      font-weight: bold
+      font-size: 1.25rem
+      border: none
+
+      .widget-box--header-title
+        vertical-align: middle
+      .icon:before,
+      .icon-context:before
+        vertical-align: middle
+
+
+    .widget-box--additional-info
+      margin: 0
+      font-size: 0.9rem
+      font-style: italic
+
+    .widget-box--enumeration
+      margin-left: 1.5rem
+      margin-top: 0.5rem
+      flex-grow: 2
+
+    .widget-box--arrow-links
+      list-style: none
+      margin: 0.5rem 0 1rem 0
+      flex-grow: 2
+
+      li:before
+        @include icon-common
+        @extend .icon-context
+        content: "\e03f"
+        display: inline-block
+        font-size: 0.6rem
+        color: $content-icon-link-color
+        width: $widget-box--enumeration-width
+
+      .-widget-box--arrow-multiline
+        &:before
+          float: left
+
+        &:after
+          clear: both
+          content: ""
+          display: table
+
+        > div
+          float: left
+          margin-bottom: 10px
+          //necessary for correct alignment even with long texts
+          width: calc(100% - #{$widget-box--enumeration-width})

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -70,6 +70,7 @@
 @import content/attributes_group
 @import content/attributes_table
 @import content/information_section
+@import content/widget_box
 
 @import content/work_package_details/activities_tab
 @import content/work_package_details/attachments_tab

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -195,8 +195,8 @@ $user-avatar-mini-width:                        20px !default
 
 $select-element-padding:                        3px, 24px, 3px, 3px
 
-$homescreen-content-bg-color:                   $body-background
-$homescreen-block-bg-color:                     $body-background
-$homescreen-block-border-color:                 $content-default-border-color
+$widget-box-content-bg-color:                   $body-background
+$widget-box-block-bg-color:                     $body-background
+$widget-box-block-border-color:                 $content-default-border-color
 $homescreen-footer-bg-color:                    $gray-light
 $homescreen-footer-icon-color:                  #7B827B

--- a/app/assets/stylesheets/specific/homescreen.sass
+++ b/app/assets/stylesheets/specific/homescreen.sass
@@ -26,90 +26,16 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@mixin homescreen-block-style
-  background: $homescreen-block-bg-color
-  border: 1px solid $homescreen-block-border-color
-  margin: 10px
-
-$homescreen--enumeration-width: 20px
-
 .controller-homescreen,
 .controller-homescreen #content
-  background: $homescreen-content-bg-color
+  background: $widget-box-content-bg-color
 
 .controller-homescreen #breadcrumb
   display: none
 
-.homescreen--header
-  margin-left: 10px
-
-.homescreen--blocks
-  display: flex
-  flex-flow: row wrap
-
-  .icon-context:before
-    padding-right: 5px
-
-  .homescreen--blocks--item
-    @include homescreen-block-style
-    padding: 10px 10px 10px 20px
-    flex: 1
-    flex-basis: 32%
-    display: flex
-    flex-direction: column
-    min-height: 250px
-    word-wrap: break-words
-    overflow: hidden
-
-    .homescreen--blocks--item-header
-      font-weight: bold
-      font-size: 1rem
-      text-transform: uppercase
-      border-color: $homescreen-block-border-color
-
-
-    .homescreen--additional-info
-      margin: 0
-      font-size: 0.9rem
-      font-style: italic
-
-    .homescreen--enumeration
-      margin-left: 1.5rem
-      margin-top: 0.5rem
-      flex-grow: 2
-
-    .homescreen--arrow-links
-      list-style: none
-      margin: 0.5rem 0 1rem 0
-      flex-grow: 2
-
-      li:before
-        @include icon-common
-        @extend .icon-context
-        content: "\e03f"
-        display: inline-block
-        font-size: 0.6rem
-        color: $content-icon-link-color
-        width: $homescreen--enumeration-width
-
-      .-homescreen--arrow-multiline
-        &:before
-          float: left
-
-        &:after
-          clear: both
-          content: ""
-          display: table
-
-        > div
-          float: left
-          margin-bottom: 10px
-          //necessary for correct alignment even with long texts
-          width: calc(100% - #{$homescreen--enumeration-width})
-
 
 .homescreen--links
-  @include homescreen-block-style
+  @include widget-box--style
   display: flex
   padding: 20px 20%
   align-items: center

--- a/app/views/homescreen/blocks/_administration.html.erb
+++ b/app/views/homescreen/blocks/_administration.html.erb
@@ -1,9 +1,9 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-settings"></span>
-  <%= l(:label_administration) %>
+  <span class="widget-box--header-title"><%= l(:label_administration) %></span>
 </h3>
 
-<ul class="homescreen--arrow-links">
+<ul class="widget-box--arrow-links">
   <li>
     <%= link_to l(:label_project_plural), settings_path(tab: :projects),
                title: l(:label_project_plural) %>

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -1,9 +1,9 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-op-icon"></span>
-  <%= l('homescreen.blocks.community') %>
+  <span class="widget-box--header-title"><%= l('homescreen.blocks.community') %></span>
 </h3>
 
-<ul class="homescreen--arrow-links">
+<ul class="widget-box--arrow-links">
   <li>
     <a href="https://www.openproject.org/open-source/release-notes/"
        title="<%= l(:label_release_notes) %>">

--- a/app/views/homescreen/blocks/_my_account.html.erb
+++ b/app/views/homescreen/blocks/_my_account.html.erb
@@ -1,9 +1,9 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <%= homescreen_user_avatar %>
-  <%= l(:label_my_account) %>
+  <span class="widget-box--header-title"><%= l(:label_my_account) %></span>
 </h3>
 
-<ul class="homescreen--arrow-links">
+<ul class="widget-box--arrow-links">
   <li>
     <%= link_to l(:label_profile), my_account_path, title: l(:label_profile) %>
   </li>

--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -1,18 +1,18 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-news"></span>
-  <%= l(:label_news_latest) %>
+  <span class="widget-box--header-title"><%= l(:label_news_latest) %></span>
 </h3>
 
 <% unless @news.empty? %>
-  <ul class="homescreen--arrow-links">
+  <ul class="widget-box--arrow-links">
   <% @news.each do |news| %>
-    <li class="-homescreen--arrow-multiline">
+    <li class="-widget-box--arrow-multiline">
       <div>
         <%= avatar(news.author, {class: 'avatar-mini'}) %>
         <%= link_to_project(news.project) + ': ' %>
         <%= link_to h(news.title), news_path(news) %>
         <br/>
-        <p class="homescreen--additional-info"><%= authoring news.created_on, news.author %></p>
+        <p class="widget-box--additional-info"><%= authoring news.created_on, news.author %></p>
       </div>
     </li>
   <% end %>

--- a/app/views/homescreen/blocks/_projects.html.erb
+++ b/app/views/homescreen/blocks/_projects.html.erb
@@ -1,11 +1,11 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-unit"></span>
-  <%= l(:label_project_plural) %>
+  <span class="widget-box--header-title"><%= l(:label_project_plural) %></span>
 </h3>
 
 <% unless @newest_projects.empty? %>
-  <p class="homescreen--additional-info"><%= l('homescreen.additional.projects') %></p>
-  <ul class="homescreen--arrow-links">
+  <p class="widget-box--additional-info"><%= l('homescreen.additional.projects') %></p>
+  <ul class="widget-box--arrow-links">
     <% @newest_projects.each do |project| %>
     <li>
       <%= link_to project, project_path(project), :title => project.short_description %>
@@ -15,7 +15,7 @@
   </ul>
 <% end %>
 
-<div class="homescreen--blocks--buttons">
+<div class="widget-box--blocks--buttons">
   <% if User.current.allowed_to?(:add_project, nil, global: true) %>
     <%= link_to new_project_path, class: 'button -alt-highlight' do %>
       <i class="button--icon icon-add"></i>

--- a/app/views/homescreen/blocks/_users.html.erb
+++ b/app/views/homescreen/blocks/_users.html.erb
@@ -1,12 +1,12 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-group"></span>
-  <%= l(:label_user_plural) %>
+  <span class="widget-box--header-title"><%= l(:label_user_plural) %></span>
 </h3>
 
-<p class="homescreen--additional-info"><%= l('homescreen.additional.users') %></p>
+<p class="widget-box--additional-info"><%= l('homescreen.additional.users') %></p>
 
 <% unless @newest_users.empty? %>
-<ul class="homescreen--arrow-links">
+<ul class="widget-box--arrow-links">
   <% @newest_users.each do |user| %>
   <li>
     <%= link_to user, user_path(user), :title => user.name %>
@@ -16,7 +16,7 @@
 </ul>
 <% end %>
 
-<div class="homescreen--blocks--buttons">
+<div class="widget-box--buttons">
   <% if User.current.admin? %>
     <%= link_to new_user_path, class: 'button -alt-highlight' do %>
       <i class="button--icon icon-add"></i>

--- a/app/views/homescreen/blocks/_welcome.html.erb
+++ b/app/views/homescreen/blocks/_welcome.html.erb
@@ -1,6 +1,6 @@
-<h3 class="homescreen--blocks--item-header">
+<h3 class="widget-box--header">
   <span class="icon-context icon-projects"></span>
-  <%= Setting.welcome_title.presence || organization_name %>
+  <span class="widget-box--header-title"><%= Setting.welcome_title.presence || organization_name %></span>
 </h3>
 
 <div class="wiki">

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -27,18 +27,18 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% breadcrumb_paths(nil) %>
-<div class="homescreen--header">
+<div class="widget-boxes--screen-header">
   <h2>
-    <span class="homescreen--header--icon"><%= organization_icon %></span>
+    <span><%= organization_icon %></span>
     <%= organization_name %>
   </h2>
 </div>
 
 <% if @homescreen[:blocks].any? %>
-  <section class="homescreen--blocks">
+  <section class="widget-boxes">
   <% @homescreen[:blocks].each do |block| %>
     <% if block[:if].nil? || instance_eval(&block[:if]) %>
-      <div class="homescreen--blocks--item">
+      <div class="widget-box">
       <%= render partial: "homescreen/blocks/#{block[:partial]}", locals: (block[:locals] || {}) %>
       </div>
     <% end %>

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -94,7 +94,7 @@ describe HomescreenController, type: :controller do
         end
 
         it 'renders the text' do
-          expect(response.body).to have_selector('.homescreen--blocks--item-header',
+          expect(response.body).to have_selector('.widget-box--header',
                                                  text: 'Woohoo!')
         end
       end


### PR DESCRIPTION
This changes the styling of the block headlines on the home screen according to the visuals. Further it unifies the styling in a 'widget-box'-component, so that it can be reused at other places. 

https://community.openproject.org/work_packages/19722
