### PR TITLE
Started restyling of inplace-controls

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -26,14 +26,6 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$inplace-edit--border-color: #ddd
-$inplace-edit--dark-background: #f8f8f8
-$inplace-edit--color--very-dark: #cacaca
-$inplace-edit--color--disabled: #999
-$inplace-edit--bg-color--disabled: #eee
-$inplace-edit--color-highlight: $primary-color
-$inplace-edit--selected-date-border-color: $primary-color-dark
-
 %inline-date-picker-container-position-absolute
   display: none
   z-index: 99999
@@ -152,31 +144,6 @@ $inplace-edit--selected-date-border-color: $primary-color-dark
     white-space: pre-line
     padding-left: 18px
 
-.inplace-edit--controls
-  display: inline-block
-  background: $inplace-edit--dark-background
-  border: 1px solid $inplace-edit--color--very-dark
-  box-shadow: 1px 1px 2px $inplace-edit--border-color
-  text-align: center
-  float: right
-  padding: 5px
-  line-height: 1.6rem
-  margin-top: -1px
-  // Having to get the element out of the normal dom flow to
-  // prevent the element overlapping and thereby blocking the click on
-  // inplace-editable elements below the current one.
-  position: absolute
-  right: 0
-
-// Disabled submit styles when not applicable
-.inplace-edit--control--save[disabled],
-.inplace-edit--control--send[disabled]
-  background-color: $inplace-edit--bg-color--disabled
-
-  span
-    color: $inplace-edit--color--disabled
-    cursor: not-allowed
-
 .inplace-edit--read
   @include grid-block
   overflow: visible
@@ -254,24 +221,51 @@ a.inplace-editing--trigger-link,
   border-width: 1px
   overflow: visible
 
-.inplace-edit--control
-  background: $inplace-edit--color--very-dark
-  width: 1.5rem
-  height: 1.5rem
-  line-height: 1.5rem
-  border: 1px solid $inplace-edit--dark-background
+.inplace-edit--controls
   display: inline-block
-  border-radius: 0.75rem
-  font-size: 0.75rem
+  background: $inplace-edit--dark-background
+  border: 1px solid $inplace-edit--color--very-dark
+  box-shadow: 2px 2px 4px $inplace-edit--border-color
+  text-align: center
+  float: right
+  padding: 5px
+  line-height: 1.6rem
+  margin-top: -1px
+  // Having to get the element out of the normal dom flow to
+  // prevent the element overlapping and thereby blocking the click on
+  // inplace-editable elements below the current one.
+  position: absolute
+  right: 0
 
-  &.-icons-2
-    width: 2.875rem
+// Disabled submit styles when not applicable
+.inplace-edit--control--save[disabled],
+.inplace-edit--control--send[disabled]
+  background-color: $inplace-edit--bg-color--disabled
+
+  span
+    color: $inplace-edit--color--disabled
+    cursor: not-allowed
+
+.inplace-edit--control
+  width: 1.75rem
+  height: 1.75rem
+  line-height: 1.75rem
+  display: inline-block
+  font-size: 0.9rem
 
   a
+    display: inline-block
+    width: 100%
+    height: 100%
+    border: 1px solid transparent
     color: $body-font-color
     text-decoration: none
 
-    .icon-context::before
+    &:hover, &:active
+      border-color: $inplace-edit--border-color
+      border-radius: 2px
+
+    .icon-context:before
       padding: 0
 // custom hack to have the jsToolbar in the same line as the "Description" title
 .inplace-edit.attribute-description

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -29,6 +29,7 @@
 $gray:                    #EAEAEA
 $gray-dark:               #878787
 $gray-light:              #F8F8F8
+$gray-lighter:            #E9E9E9
 
 $light-gray: #ccc
 
@@ -123,7 +124,7 @@ $main-menu-sidebar-h3-font-size:                15px !default
 
 $toolbar-title-color:                           #5F5F5F
 $toolbar-item--bg-color:                        #F8F8F8
-$toolbar-item--bg-color-pressed:                #E9E9E9
+$toolbar-item--bg-color-pressed:                $gray-lighter
 $toolbar-item--border-color:                    #DDD
 
 $breadcrumb-height:                             40px !default
@@ -203,3 +204,11 @@ $widget-box-block-bg-color:                     $body-background
 $widget-box-block-border-color:                 $content-default-border-color
 $homescreen-footer-bg-color:                    $gray-light
 $homescreen-footer-icon-color:                  #7B827B
+
+$inplace-edit--border-color:                    #ddd
+$inplace-edit--dark-background:                 $gray-light
+$inplace-edit--color--very-dark:                #cacaca
+$inplace-edit--color-highlight:                 $primary-color
+$inplace-edit--selected-date-border-color:      $primary-color-dark
+$inplace-edit--color--disabled:                 #999
+$inplace-edit--bg-color--disabled:              #eee

--- a/frontend/app/templates/work_packages/comment_field.html
+++ b/frontend/app/templates/work_packages/comment_field.html
@@ -31,10 +31,7 @@
             <accessible-by-keyboard execute="fieldController.submit(true)"
                                     ng-disabled="fieldController.isEmpty()"
                                     class="inplace-edit--control -icons-2 inplace-edit--control--send">
-              <span title="{{ fieldController.saveAndSendTitle }}">
-                <i class="icon-yes"></i>
-                <i class="icon-mail"></i>
-              </span>
+             <icon-wrapper icon-name="send-mail" icon-title="{{ editPaneController.saveAndSendTitle }}"></icon-wrapper>
             </accessible-by-keyboard>
             <accessible-by-keyboard execute="fieldController.discardEditing()" class="inplace-edit--control inplace-edit--control--cancel">
               <icon-wrapper icon-name="close" icon-title="{{ fieldController.cancelTitle }}">

--- a/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
+++ b/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
@@ -9,10 +9,8 @@
           </icon-wrapper>
         </accessible-by-keyboard>
         <accessible-by-keyboard execute="editPaneController.submit(true)" class="inplace-edit--control -icons-2 inplace-edit--control--send">
-            <span title="{{ editPaneController.saveAndSendTitle }}">
-              <i class="icon-yes"></i>
-              <i class="icon-mail"></i>
-            </span>
+            <icon-wrapper icon-name="send-mail" icon-title="{{ editPaneController.saveAndSendTitle }}">
+            </icon-wrapper>
         </accessible-by-keyboard>
         <accessible-by-keyboard execute="editPaneController.discardEditing()" class="inplace-edit--control inplace-edit--control--cancel">
           <icon-wrapper icon-name="close" icon-title="{{ editPaneController.cancelTitle }}">


### PR DESCRIPTION
This commit restyles the inplace control buttons (save, send, cancel)
according to the visual.
### TODOS
- [x] Fix width of new controls
- [x] Check that this restyle fixes the offset in other browsers

![bildschirmfoto 2015-09-16 um 15 18 45](https://cloud.githubusercontent.com/assets/459462/9910571/f4c14c3a-5c9d-11e5-8789-3ffc5e3a6ab7.png)

Relevant visual: http://clients.zzmedia.net/openproject/inplace-edit/
Work package: https://community.openproject.org/projects/openproject/work_packages/details/21528/overview
