### PR TITLE
Don't change cache store if already present

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -189,13 +189,10 @@ module OpenProject
       end
 
       def configure_cache(application_config)
-        # return if cache store is set and there is nothing to overwrite it
-        return if application_config.cache_store.present? \
-          && @config['rails_cache_store'].nil?
+        return unless override_cache_config? application_config
 
         # rails defaults to :file_store, use :dalli when :memcaches is configured in configuration.yml
-        cache_store = @config['rails_cache_store'].to_sym \
-          if @config['rails_cache_store'].respond_to? :to_sym
+        cache_store = @config['rails_cache_store'].try(:to_sym)
         if cache_store == :memcache
           cache_config = [:dalli_store]
           cache_config << @config['cache_memcache_server'] \
@@ -209,6 +206,13 @@ module OpenProject
         parameters = cache_parameters(@config)
         cache_config << parameters if parameters.size > 0
         application_config.cache_store = cache_config
+      end
+
+      def override_cache_config?(application_config)
+        # override if cache store is not set
+        # or there is something to overwrite it
+        application_config.cache_store.nil? \
+          || @config['rails_cache_store'].present?
       end
 
       private

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -194,7 +194,8 @@ module OpenProject
           && @config['rails_cache_store'].nil?
 
         # rails defaults to :file_store, use :dalli when :memcaches is configured in configuration.yml
-        cache_store = @config['rails_cache_store'].to_sym
+        cache_store = @config['rails_cache_store'].to_sym \
+          if @config['rails_cache_store'].respond_to? :to_sym
         if cache_store == :memcache
           cache_config = [:dalli_store]
           cache_config << @config['cache_memcache_server'] \

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -48,7 +48,7 @@ module OpenProject
       'scm_subversion_command'  => nil,
       'disable_browser_cache'   => true,
       # default cache_store is :file_store in production and :memory_store in development
-      'rails_cache_store'       => :file_store,
+      'rails_cache_store'       => nil,
       'cache_expires_in_seconds' => nil,
       'cache_namespace' => nil,
       # use dalli defaults for memcache
@@ -189,7 +189,9 @@ module OpenProject
       end
 
       def configure_cache(application_config)
-        return unless @config['rails_cache_store']
+        # return if cache store is set and there is nothing to overwrite it
+        return if application_config.cache_store.present? \
+          && @config['rails_cache_store'].nil?
 
         # rails defaults to :file_store, use :dalli when :memcaches is configured in configuration.yml
         cache_store = @config['rails_cache_store'].to_sym
@@ -197,7 +199,8 @@ module OpenProject
           cache_config = [:dalli_store]
           cache_config << @config['cache_memcache_server'] \
             if @config['cache_memcache_server']
-        elsif cache_store == :file_store
+        # default to :file_store
+        elsif cache_store.nil?
           cache_config = [:file_store, Rails.root.join('tmp/cache')]
         else
           cache_config = [cache_store]

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -213,4 +213,67 @@ describe OpenProject::Configuration do
     end
   end
 
+  describe '.configure_cache' do
+    let(:application_config) { Rails::Application::Configuration.new }
+
+    after do
+      # reload configuration to isolate specs
+      OpenProject::Configuration.load
+    end
+
+    context 'with cache store already set' do
+      before do
+        application_config.cache_store = 'foo'
+      end
+
+      context 'with additional cache store configuration' do
+        before do
+          OpenProject::Configuration['rails_cache_store'] = 'bar'
+        end
+
+        it 'changes the cache store' do
+          OpenProject::Configuration.send(:configure_cache, application_config)
+          expect(application_config.cache_store).to eq([:bar])
+        end
+      end
+
+      context 'without additional cache store configuration' do
+        before do
+          OpenProject::Configuration['rails_cache_store'] = nil
+        end
+
+        it 'does not change the cache store' do
+          OpenProject::Configuration.send(:configure_cache, application_config)
+          expect(application_config.cache_store).to eq('foo')
+        end
+      end
+    end
+
+    context 'without cache store already set' do
+      before do
+        application_config.cache_store = nil
+      end
+
+      context 'with additional cache store configuration' do
+        before do
+          OpenProject::Configuration['rails_cache_store'] = 'bar'
+        end
+
+        it 'changes the cache store' do
+          OpenProject::Configuration.send(:configure_cache, application_config)
+          expect(application_config.cache_store).to eq([:bar])
+        end
+      end
+
+      context 'without additional cache store configuration' do
+        before do
+          OpenProject::Configuration['rails_cache_store'] = nil
+        end
+        it 'defaults the cache store to :file_store' do
+          OpenProject::Configuration.send(:configure_cache, application_config)
+          expect(application_config.cache_store.first).to eq(:file_store)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Don't merge yet as tests are missing

[This PR](https://github.com/crohr/openproject/pull/1) introduced a default for the cache store what led to the behavior that the return in [this line](https://github.com/opf/openproject/blob/dev/lib/open_project/configuration.rb#L191) never happens. That is why a configuration made earlier, e.g. [here](https://github.com/opf/openproject/blob/dev/config/additional_environment.rb.example#L43) gets overwritten. 
This PR aims to stop this.

https://community.openproject.org/projects/openproject/work_packages/21536/activity
