### PR TITLE
Fail on missing represented objects

### DIFF
--- a/lib/api/decorators/formattable.rb
+++ b/lib/api/decorators/formattable.rb
@@ -61,6 +61,13 @@ module API
       def to_html
         format_text(represented, format: @format, object: @object)
       end
+
+      private
+
+      def model_required?
+        # the formatted string may also be nil, we are prepared for that
+        false
+      end
     end
   end
 end

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -57,6 +57,13 @@ module API
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator
       property :regular_expression, exec_context: :decorator
+
+      private
+
+      def model_required?
+        # we never pass a model to our superclass
+        false
+      end
     end
   end
 end

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -51,6 +51,8 @@ module API
       end
 
       def initialize(model, current_user:, embed_links: false)
+        raise 'no represented object passed' if model_required? && model.nil?
+
         @current_user = current_user
         @embed_links = embed_links
 
@@ -137,7 +139,15 @@ module API
         ::API::V3::Utilities::DateTimeFormatter
       end
 
+      # Override in subclasses to specify the JSON indicated "_type" of this representer
       def _type; end
+
+      # If a subclass does not depend on a model being passed to this class, it can override
+      # this method and return false. Otherwise it will be enforced that the model of each
+      # representer is non-nil.
+      def model_required?
+        true
+      end
     end
   end
 end

--- a/lib/api/v3/string_objects/string_object_representer.rb
+++ b/lib/api/v3/string_objects/string_object_representer.rb
@@ -52,8 +52,15 @@ module API
                  # (nil values are not supported by a string_objects URL anyway)
                  getter: -> (*) { represented || '' }
 
+        private
+
         def _type
           'StringObject'
+        end
+
+        def model_required?
+          # the string may also be nil, we are prepared for that
+          false
         end
       end
     end


### PR DESCRIPTION
## Description

This is an approach to fail earlier when creating broken representers. From time to time I see specs failing where the represented object is apparently nil (e.g. `id is undefined for nil`). I can't explain how those representers with nil models get created in the first place, because the failure occurs too late to get a useful stack trace.
