### PR TITLE
removed obsolete translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,6 @@ en:
       account for you.
     login_with_auth_provider: "or sign in with your existing account"
     signup_with_auth_provider: "or sign up using"
-    signup_with_password: "using user name and password."
     auth_source_login: Please login as <em>%{login}</em> to activate your account.
     omniauth_login: Please login to activate your account.
 


### PR DESCRIPTION
The removed translation is not in use any more. It was once before the according feature was changed to work differently. The translation should've been removed back then but was forgotten.
