### PR TITLE
Improve resilience for missing languages

### DIFF
--- a/app/services/set_localization_service.rb
+++ b/app/services/set_localization_service.rb
@@ -2,7 +2,7 @@ class SetLocalizationService
   attr_reader :user, :http_accept_header
   include Redmine::I18n
 
-  def initialize(user, http_accept_header)
+  def initialize(user, http_accept_header = nil)
     @user = user
     @http_accept_header = http_accept_header
   end
@@ -28,6 +28,7 @@ class SetLocalizationService
   end
 
   def header_language
+    return unless http_accept_header
     accept_lang = parse_qvalues(http_accept_header).first
 
     lang = if accept_lang

--- a/app/services/set_localization_service.rb
+++ b/app/services/set_localization_service.rb
@@ -24,19 +24,13 @@ class SetLocalizationService
   private
 
   def user_language
-    find_language(user.language) if user.logged?
+    find_language_or_prefix(user.language) if user.logged?
   end
 
   def header_language
     return unless http_accept_header
     accept_lang = parse_qvalues(http_accept_header).first
-
-    lang = if accept_lang
-             accept_lang = accept_lang.downcase
-             find_language(accept_lang) || find_language(accept_lang.split('-').first)
-           end
-
-    lang
+    find_language_or_prefix accept_lang
   end
 
   def default_language
@@ -63,5 +57,11 @@ class SetLocalizationService
     return tmp
   rescue
     nil
+  end
+
+  def find_language_or_prefix(language)
+    return nil unless language
+    language = language.to_s.downcase
+    find_language(language) || find_language(language.split('-').first)
   end
 end

--- a/lib/open_project/locale_helper.rb
+++ b/lib/open_project/locale_helper.rb
@@ -29,9 +29,12 @@
 
 module OpenProject
   module LocaleHelper
-    def with_locale_for(user, &block)
-      locale = user.language.presence || Setting.default_language.presence || I18n.default_locale
-      I18n.with_locale(locale, &block)
+    def with_locale_for(user)
+      previous_locale = I18n.locale
+      SetLocalizationService.new(user).call
+      yield
+    ensure
+      I18n.locale = previous_locale
     end
   end
 end

--- a/spec/services/set_localization_service_spec.rb
+++ b/spec/services/set_localization_service_spec.rb
@@ -43,6 +43,23 @@ describe SetLocalizationService do
       instance.call
     end
 
+    context 'with a language prefix being valid' do
+      let(:prefix) { 'someprefix' }
+      let(:user_language) { "#{prefix}-specific" }
+
+      before do
+        allow(instance).to receive(:valid_languages).and_return [prefix,
+                                                                 http_accept_language,
+                                                                 default_language]
+      end
+
+      it "sets the language to the valid prefix of the user's selected language" do
+        expect_locale(prefix)
+
+        instance.call
+      end
+    end
+
     context 'with the language not being valid' do
       before do
         allow(instance).to receive(:valid_languages).and_return [http_accept_language,
@@ -50,6 +67,22 @@ describe SetLocalizationService do
       end
 
       it_behaves_like 'falls back to the header'
+
+      context 'with a language prefix being valid' do
+        let(:prefix) { 'someprefix' }
+        let(:http_accept_header) { "#{prefix}-specific" }
+
+        before do
+          allow(instance).to receive(:valid_languages).and_return [prefix,
+                                                                   default_language]
+        end
+
+        it "sets the language to the valid prefix of the accept header" do
+          expect_locale(prefix)
+
+          instance.call
+        end
+      end
     end
 
     context 'with the user not having a language selected' do


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21426
## Description

On some instances I could observe users having a language set to `en-GB`, I am not yet sure on how they obtained this setting (since we only allow setting it to `en` by normal means). However, there is a legitimate way to fall back in that case that does not involve raising errors.

This PR unifies the `LocaleHelper` and the `SetLocalizationService` by making the former use the latter. It also lets the `SetLocalizationService` fall back to a language prefix if the fully specified language is not available (previously only done for HTTP indicated languages).
