### PR TITLE
[21557] Indentation of child elements in projects table too big

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -124,27 +124,44 @@ tr
     td.name a
       white-space: nowrap
     &.idnt td.project--hierarchy span
-      padding-left: 16px
       &.icon-context:before
-        padding: 9px 5px 0 10px
+        padding: 9px 5px 0 0px
     &.idnt-1 td.project--hierarchy
       padding-left: 0.5em
+      span
+        margin-left: -5px
     &.idnt-2 td.project--hierarchy
       padding-left: 2em
+      span
+        margin-left: calc(2 * -5px)
     &.idnt-3 td.project--hierarchy
       padding-left: 3.5em
+      span
+        margin-left: calc(3 * -5px)
     &.idnt-4 td.project--hierarchy
       padding-left: 5em
+      span
+        margin-left: calc(4 * -5px)
     &.idnt-5 td.project--hierarchy
       padding-left: 6.5em
+      span
+        margin-left: calc(5 * -5px)
     &.idnt-6 td.project--hierarchy
       padding-left: 8em
+      span
+        margin-left: calc(6 * -5px)
     &.idnt-7 td.project--hierarchy
       padding-left: 9.5em
+      span
+        margin-left: calc(7 * -5px)
     &.idnt-8 td.project--hierarchy
       padding-left: 11em
+      span
+        margin-left: calc(8 * -5px)
     &.idnt-9 td.project--hierarchy
       padding-left: 12.5em
+      span
+        margin-left: calc(9 * -5px)
 
   &.issue
     white-space: nowrap

--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -26,6 +26,14 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+$project-table--start-indentation: 0.5em
+$project-table--child-indentation: 1.1em
+$project-table--icon-distance: 5px
+
+@mixin calc-indentation($indentation)
+  // This does not work for big font-sizes
+  padding-left: calc(#{$indentation} * #{$project-table--child-indentation} + #{$project-table--start-indentation} - #{$project-table--icon-distance})
+
 table
   td
     padding: 3px 6px
@@ -127,41 +135,23 @@ tr
       &.icon-context:before
         padding: 9px 5px 0 0px
     &.idnt-1 td.project--hierarchy
-      padding-left: 0.5em
-      span
-        margin-left: -5px
+      @include calc-indentation(0)
     &.idnt-2 td.project--hierarchy
-      padding-left: 2em
-      span
-        margin-left: calc(2 * -5px)
+      @include calc-indentation(1)
     &.idnt-3 td.project--hierarchy
-      padding-left: 3.5em
-      span
-        margin-left: calc(3 * -5px)
+      @include calc-indentation(2)
     &.idnt-4 td.project--hierarchy
-      padding-left: 5em
-      span
-        margin-left: calc(4 * -5px)
+      @include calc-indentation(3)
     &.idnt-5 td.project--hierarchy
-      padding-left: 6.5em
-      span
-        margin-left: calc(5 * -5px)
+      @include calc-indentation(4)
     &.idnt-6 td.project--hierarchy
-      padding-left: 8em
-      span
-        margin-left: calc(6 * -5px)
+      @include calc-indentation(5)
     &.idnt-7 td.project--hierarchy
-      padding-left: 9.5em
-      span
-        margin-left: calc(7 * -5px)
+      @include calc-indentation(6)
     &.idnt-8 td.project--hierarchy
-      padding-left: 11em
-      span
-        margin-left: calc(8 * -5px)
+      @include calc-indentation(7)
     &.idnt-9 td.project--hierarchy
-      padding-left: 12.5em
-      span
-        margin-left: calc(9 * -5px)
+      @include calc-indentation(8)
 
   &.issue
     white-space: nowrap


### PR DESCRIPTION
This reduces the indentation of child elements. Since the icon is not aligned at its left border the negative margin is needed. 

https://community.openproject.org/work_packages/21557/activity

**Before**

![indentation_wrong](https://cloud.githubusercontent.com/assets/7457313/10015067/38b3e9dc-611e-11e5-81b2-08eb1dcab462.png)

**After**

![indentation_correct](https://cloud.githubusercontent.com/assets/7457313/10015071/3ecdf060-611e-11e5-8b1b-25031b2aa9ef.png)
