### PR TITLE
Remove unreached code after checkout in toolbar

### DIFF
--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -27,9 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <div id="repository--checkout-instructions" class="notification-box -info">
-  <% unless embedded %>
-    <a href="javscript:" title="{{ ::I18n.t('js.close_popup_title') }}" class="notification-box--close icon-context icon-close2"></a>
-  <% end %>
+  <a href="javscript:" title="{{ ::I18n.t('js.close_popup_title') }}" class="notification-box--close icon-context icon-close2"></a>
   <div class="notification-box--content">
     <p>
     <%= simple_format instructions.instructions %>
@@ -39,23 +37,5 @@ See doc/COPYRIGHT.rdoc for more details.
       <strong><%= l("repositories.checkout.access.#{instructions.permission}") %></strong>
     <% end %>
     </p>
-  <% if embedded %>
-    <div class="repository--checkout-instructions--url">
-      <form class="form">
-        <div class="form--field">
-          <div class="form--field-container">
-              <div class="form--field-affix">
-                <%= instructions.checkout_command %>
-              </div>
-              <div class="form--text-field-container -xwide">
-                  <input type="text" class="form--text-field -clickable"
-                  onclick="this.focus(); this.select()"
-                  readonly="readonly" value="<%= instructions.checkout_url %>">
-              </div>
-          </div>
-        </div>
-      </form>
-    </div>
-  <% end %>
   </div>
 </div>

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -80,7 +80,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% if @instructions && @instructions.available? %>
   <%= render partial: 'checkout_instructions',
-             locals: { repository: @repository, instructions: @instructions, embedded: false } %>
+             locals: { repository: @repository, instructions: @instructions } %>
 <% end %>
 
 


### PR DESCRIPTION
On empty repository pages, the checkout URL was included within the
notification box.

With the checkout URL residing in the toolbar, this is no longer used,
but some of the code was still missing.
