### PR TITLE
Show rails flash via angular NotificationsService

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,29 +185,6 @@ module ApplicationHelper
     [objects.compact, options]
   end
 
-  # Renders flash messages
-  def render_flash_messages
-    flash.map { |k, v| render_flash_message(k, v) }.join.html_safe
-  end
-
-  def join_flash_messages(messages)
-    if messages.respond_to?(:join)
-      messages.join('<br />').html_safe
-    else
-      messages
-    end
-  end
-
-  def render_flash_message(type, message, html_options = {})
-    css_classes = ["flash #{type} icon icon-#{type}", html_options.delete(:class)].join(' ')
-    html_options = { class: css_classes, role: 'alert' }.merge(html_options)
-    if User.current.impaired?
-      content_tag('div', content_tag('a', join_flash_messages(message), href: 'javascript:;'), html_options)
-    else
-      content_tag('div', join_flash_messages(message), html_options)
-    end
-  end
-
   # Renders tabs and their content
   def render_tabs(tabs)
     if tabs.any?

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -1,0 +1,45 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module FlashHelper
+
+  # Renders flash messages
+  def render_flash_messages
+    content_tag :'flash-messages', '', :'ng-init' => "messages = #{flash_to_json.html_safe}"
+  end
+
+  private
+
+  def flash_to_json
+    flash
+      .to_h
+      .to_json
+      .gsub('"', "'")
+  end
+end

--- a/frontend/app/ui_components/flash-messages-directive.js
+++ b/frontend/app/ui_components/flash-messages-directive.js
@@ -1,0 +1,55 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+module.exports = function(
+    NotificationsService,
+    $timeout
+    ) {
+  return {
+    restrict: 'E',
+    link: function(scope) {
+      $timeout(function() {
+        _.each(scope.messages, function(message, type) {
+          switch(type) {
+            case 'notice':
+              NotificationsService.addSuccess(message);
+              break;
+            case 'error':
+              NotificationsService.addError(message);
+              break;
+            case 'warning':
+              NotificationsService.addWarning(message);
+              break;
+            default:
+              NotificationsService.add(message);
+          }
+        });
+      });
+    }
+  };
+};

--- a/frontend/app/ui_components/index.js
+++ b/frontend/app/ui_components/index.js
@@ -105,4 +105,9 @@ angular.module('openproject.uiComponents')
   .filter('ancestorsExpanded', require('./filters/ancestors-expanded-filter'))
   .filter('latestItems', require('./filters/latest-items-filter'))
   .directive('highlightCol', [require('./highlight-col-directive')])
-  .directive('confirmPopup', ['$window', require('./confirm-popup-directive')]);
+  .directive('confirmPopup', ['$window', require('./confirm-popup-directive')])
+  .directive('flashMessages', [
+    'NotificationsService',
+    '$timeout',
+    require('./flash-messages-directive')
+  ]);

--- a/frontend/tests/unit/tests/ui_components/flash-messages-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/flash-messages-directive-test.js
@@ -1,0 +1,98 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+describe.only('flash messages directive', function() {
+  var angularCompile, element, scope, timeout, NotificationsService, input;
+
+  beforeEach(angular.mock.module('openproject.uiComponents'));
+  beforeEach(angular.mock.module('openproject.services', function($provide) {
+    NotificationsService = {
+      addSuccess: function() {},
+      addError: function() {},
+      addWarning: function() {},
+      add: function() {}
+    };
+
+    $provide.constant('NotificationsService', NotificationsService);
+  }));
+
+  beforeEach(inject(function($compile, $rootScope, $timeout) {
+    scope = $rootScope.$new();
+    angularCompile = $compile;
+    timeout = $timeout;
+  }));
+
+
+  var compile = function() {
+    element = angular.element(input);
+
+    angularCompile(element)(scope);
+    scope.$digest();
+    timeout.flush();
+  };
+
+  describe('element', function() {
+    it('should call the NotificationsService #addSuccess message', function() {
+      input = '<flash-messages ng-init="messages = {\'notice\': \'Success\'}"></flash-messages>';
+      sinon.spy(NotificationsService, 'addSuccess');
+
+      compile();
+
+      expect(NotificationsService.addSuccess).to.have.been.calledWith('Success');
+    });
+
+    it('should call the NotificationsService #addError message', function() {
+      input = '<flash-messages ng-init="messages = {\'error\': \'Error\'}"></flash-messages>';
+      sinon.spy(NotificationsService, 'addError');
+
+      compile();
+
+      expect(NotificationsService.addError).to.have.been.calledWith('Error');
+    });
+
+    it('should call the NotificationsService #addWarning message', function() {
+      input = '<flash-messages ng-init="messages = {\'warning\': \'Warning\'}"></flash-messages>';
+      sinon.spy(NotificationsService, 'addWarning');
+
+      compile();
+
+      expect(NotificationsService.addWarning).to.have.been.calledWith('Warning');
+    });
+
+    it('should fall back to NotificationService #add', function() {
+      input = '<flash-messages ng-init="messages = {\'bogus\': \'Bogus\'}"></flash-messages>';
+      sinon.spy(NotificationsService, 'add');
+
+      compile();
+
+      expect(NotificationsService.add).to.have.been.calledWith('Bogus');
+    });
+  });
+});

--- a/spec/helpers/flash_helper_spec.rb
+++ b/spec/helpers/flash_helper_spec.rb
@@ -1,0 +1,64 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe FlashHelper, type: :helper do
+  describe '#render_flash_messages' do
+    it 'renders a flash-messages tag' do
+      expect(helper.render_flash_messages).to be_html_eql( %{
+        <flash-messages ng-init="messages = {}"></flash-messages>
+      })
+    end
+
+    it 'renders the flash message as a serialized js object' do
+      flash[:notice] = "My notice"
+      flash[:error] = "OMG! Error"
+
+      expect(helper.render_flash_messages).to be_html_eql( %{
+        <flash-messages
+          ng-init=
+          "messages = {&#39;notice&#39;:&#39;My notice&#39;,&#39;error&#39;:&#39;OMG! Error&#39;}">
+        </flash-messages>
+      })
+    end
+
+    it 'renders the flash.now messages as a serialized js object' do
+      flash.now[:notice] = "My notice"
+      flash.now[:error] = "OMG! Error"
+
+      expect(helper.render_flash_messages).to be_html_eql( %{
+        <flash-messages
+          ng-init=
+          "messages = {&#39;notice&#39;:&#39;My notice&#39;,&#39;error&#39;:&#39;OMG! Error&#39;}">
+        </flash-messages>
+      })
+    end
+  end
+end


### PR DESCRIPTION
Injects all flash message that where formerly rendered by rails itself into the NotificationService written in Angular. 

Doing so, the flash messages now have the same L&F as the messages originating in Angular itself.

As such, it implements parts of https://community.openproject.org/work_packages/18623
#### TODO
- [ ] Adapt specs and cukes to the changed behaviour. The most severe problem is that a lot of cukes/specs that used to be able to run without js support now require js for the sake of the notifications. 
