### PR TITLE
Use promise in work-package-new-controller

### DIFF
--- a/frontend/app/work_packages/controllers/work-package-new-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-new-controller.js
@@ -106,7 +106,12 @@ module.exports = function(
     var field = angular.element('.work-packages--details--subject:first .inplace-edit--write')
                        .scope().editPaneController.submitField;
 
-    EditableFieldsState.submissionPromises = { subject: field };
+    EditableFieldsState.submissionPromises['work-package'] = {
+      field: 'subject',
+      thePromise: field,
+      prepend: true,
+    };
+
     WorkPackageFieldService.submitWorkPackageChanges(notify);
   }
 


### PR DESCRIPTION
The work package new controller used a wrong format for promisees, that effectively breaks creating new work packages in split view.
