### PR TITLE
use finn capybara-select2 until fix is upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ group :test do
   gem 'rspec-legacy_formatters'
   gem 'capybara', '~> 2.4.4'
   gem 'capybara-screenshot', '~> 1.0.4'
-  gem 'capybara-select2', github: 'goodwill/capybara-select2'
+  gem 'capybara-select2', github: 'finnlabs/capybara-select2'
   gem 'capybara-ng', '~> 0.2.1'
   gem 'selenium-webdriver', '~> 2.47.1'
   gem 'timecop', '~> 0.7.1'


### PR DESCRIPTION
`capybara-select2` uses `#first` where it should use `#find` which is why selecting things in select2 boxes fails randomly in specs if they don't run fast enough, Jan.
