### PR TITLE
[21560] Links in description wrap the line on details pane and full screen

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -107,7 +107,7 @@
   min-height: 20px
   width: 100%
   margin-bottom: -1px
-  
+
   // Resize done by angular-elastic
   &[msd-elastic]
     resize: none
@@ -191,6 +191,7 @@ a.inplace-edit--icon-wrapper
 .inplace-editing--trigger-container
   @include grid-block
   overflow: visible
+  width: 100%
 
 // need to specify the a explicitly as otherwise
 // the default class will win
@@ -200,6 +201,7 @@ a.inplace-editing--trigger-link,
   color: $body-font-color
   font-weight: inherit
   overflow: visible
+  width: 100%
 
   &:hover,
   &:focus,
@@ -220,6 +222,7 @@ a.inplace-editing--trigger-link,
   border-radius: 2px
   border-width: 1px
   overflow: visible
+  width: 100%
 
 .inplace-edit--controls
   display: inline-block

--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -47,14 +47,15 @@
 div[class*='work-packages--details--']
   width: 100%
   .inplace-edit--read
-    span:first-of-type
+    &>span:first-of-type
       width: 100%
   .inplace-edit--read-value
     width: 100%
     .dynamic-attribute
       width: 100%
 
-    div[class*='-wrapper']
+    .version-wrapper,
+    .spent-time-wrapper
       width: 100%
     span
       overflow: hidden

--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -46,10 +46,16 @@
 
 div[class*='work-packages--details--']
   width: 100%
+  .inplace-edit--read
+    span:first-of-type
+      width: 100%
   .inplace-edit--read-value
+    width: 100%
     .dynamic-attribute
       width: 100%
 
+    div[class*='-wrapper']
+      width: 100%
     span
       overflow: hidden
       text-overflow: ellipsis
@@ -58,11 +64,6 @@ div[class*='work-packages--details--']
       p
         overflow: inherit
         text-overflow: inherit
-
-      a
-        overflow: inherit
-        text-overflow: inherit
-        display: inherit
 
 .work-packages--details--subject
   @include grid-content


### PR DESCRIPTION
This removes the inherited value `block` from the links, which was responsible for the misalignment. The functionality of punctuated overflows is nevertheless given.

https://community.openproject.org/work_packages/21560/activity
