### PR TITLE
[21565] Field is too long on forgotten password site

### DIFF
--- a/app/views/account/password_recovery.html.erb
+++ b/app/views/account/password_recovery.html.erb
@@ -33,8 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
   <section class="form--section">
     <div class="form--field -required">
       <%= styled_label_tag 'new_password', User.human_attribute_name(:new_password) %>
-      <div class="form--field--container">
-        <%= styled_password_field_tag 'new_password', nil, :size => 25 %>
+      <div class="form--field-container">
+        <%= styled_password_field_tag 'new_password', nil, :size => 25, container_class: '-middle' %>
       </div>
       <div class="form--field-instructions">
         <%= password_complexity_requirements %>
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_label_tag 'new_password_confirmation',
             User.human_attribute_name(:new_password_confirmation) %>
       <div class="form--field-container">
-        <%= styled_password_field_tag 'new_password_confirmation', nil, :size => 25 %>
+        <%= styled_password_field_tag 'new_password_confirmation', nil, :size => 25, container_class: '-middle' %>
       </div>
     </div>
   </section>


### PR DESCRIPTION
This fixes a typo which led to the wrong class used. Further the fields width is controlled.

https://community.openproject.org/projects/openproject/work_packages/21565/activity
