### PR TITLE
Fix uploading files (attachements) in windows "500 Internal Server Er…

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -49,7 +49,10 @@ module FileUploader
         tmp = Tempfile.new 'op_uploaded_files'
         path = Pathname(tmp)
 
-        tmp.delete # delete temp file
+        tmp.unlink # delete temp file. In windows this fails silently.
+        tmp.close! # Closes the file handle (needed for windows to work). 
+                   # If the file wasn't unlinked because #unlink failed, 
+                   # then this method will attempt to do so again.
         path.mkdir # create temp directory
 
         path.to_s


### PR DESCRIPTION
Fix uploading files (attachements) in windows "500 Internal Server Error"

Fixes error: 

Errno::EEXIST (File exists @ dir_s_mkdir - C:/Windows/Temp/op_uploaded_files20150922-7276-go9otn):
  app/uploaders/file_uploader.rb:53:in `mkdir'
  app/uploaders/file_uploader.rb:53:in`mkdir'
  app/uploaders/file_uploader.rb:53:in `cache_dir'
  app/uploaders/file_uploader.rb:43:in`cache_dir'
  app/models/attachment.rb:146:in `file='
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:75:in`block in attach_files'
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:72:in `each_value'
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:72:in`attach_files'
  app/models/work_package.rb:441:in `update_by!'
  app/services/update_work_package_service.rb:42:in`update'
  app/controllers/work_packages_controller.rb:186:in `update'
  app/middleware/params_parser_with_exclusion.rb:40:in`call'
