### PR TITLE
[21564] Improve select field stylings

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -161,6 +161,9 @@
     &:last-of-type
       margin-bottom: 0
 
+  .user-field-user-link
+    display: inline
+
 .inplace-edit--preview
   border: 1px solid $inplace-edit--border-color
   padding: 0.375rem

--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -192,8 +192,18 @@ $se2-width: 100%;
 
 .select2-drop {
   .select2-search {
+    &:before {
+      content: "\e0a1";
+      font-family: "openproject-icon-font";
+      color: #E0E0E0;
+      position: absolute;
+      top: 8px;
+      right: 16px;
+    }
+
     .select2-input {
-      //possible background tweaks
+      background-image: none !important;
+      padding-right: 32px;
     }
   }
 

--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -197,13 +197,14 @@ $se2-width: 100%;
       font-family: "openproject-icon-font";
       color: #E0E0E0;
       position: absolute;
-      top: 8px;
+      top: 6px;
       right: 16px;
     }
 
     .select2-input {
       background-image: none !important;
       padding-right: 32px;
+      height: $se2-input-height !important;
     }
   }
 
@@ -218,8 +219,10 @@ $se2-width: 100%;
   }
 }
 
-input[type="text"].select2-input {
-  height: $se2-input-height;
+.select2-drop:not(.project-search-results) {
+  input[type="text"].select2-input {
+    height: $se2-input-height !important;
+  }
 }
 
 .columns-modal-content {

--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -121,7 +121,7 @@ $se2-input-height: rem-calc(34px);
 $se2-line-height: 30px;
 $se2-button-width: 28px;
 $se2-arrow-button-width: 18px;
-$se2-results-max-height: 500px;
+$se2-results-max-height: 200px;
 
 $se-multiple-input-line-height: 19px;
 $se-multiple-tags-line-height: 19px;
@@ -211,6 +211,8 @@ $se2-width: 100%;
   .select2-results {
     max-height: $se2-results-max-height;
     overflow: auto;
+    margin: 4px 9px 9px 0;
+    padding: 0 0 0 9px;
 
     .select2-highlighted {
       background-color: $se2-theme-selectable-color-highlighted;
@@ -222,6 +224,15 @@ $se2-width: 100%;
 .select2-drop:not(.project-search-results) {
   input[type="text"].select2-input {
     height: $se2-input-height !important;
+  }
+
+  .select2-search {
+    margin: 10px 0 6px 0;
+    padding: 0 9px;
+
+    input {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -226,7 +226,7 @@ input.top-menu-search--input
     margin: 0 0 10px 0
 
     &:before
-      top: 24px
+      top: 21px
       right: 26px
 
   .select2-search input.select2-input

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -225,17 +225,13 @@ input.top-menu-search--input
     background: $header-drop-down-projects-search-bg-color
     margin: 0 0 10px 0
 
-  .select2-search:before
-    content: "\e0a1"
-    font-family: "openproject-icon-font"
-    color: #E0E0E0
-    position: absolute
-    top: 24px
-    right: 26px
+    &:before
+      top: 24px
+      right: 26px
 
-  .select2-search input
+  .select2-search input.select2-input
     margin: 10px 10px
-    padding: 9px 7px 9px 10px
+    padding: 9px 32px 9px 10px !important
     border: none
     border-radius: 25px
     width: 92%


### PR DESCRIPTION
This removes the double search icon in project search dropdown. https://community.openproject.org/projects/openproject/work_packages/21564/activity

I also made the results container for all select2 fields a bit smaller and adjusted space aroung the search field.

Further when you click on the selectfield it opens now and won't show the user profile anymore.
It will only show when you really click on the link.
