### PR TITLE
[21575] Broken filter layout in Admin/Users (IE)

### DIFF
--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -98,5 +98,6 @@ $filters--border-color: $gray !default
   // 0. The elements will in sum take up more than 100% and thus the second
   // element will move to the next row.
   .simple-filters--filter,
+  .simple-filters--controls
     padding: 0
     @include breakpoint(large)


### PR DESCRIPTION
This removes the padding from the control-unit which is responsible for the broken layout in IE. 

https://community.openproject.org/projects/openproject/work_packages/21575/activity
