### PR TITLE
always clear delivieries so one does not have to worry about it

### DIFF
--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -104,8 +104,6 @@ describe NewsController, type: :controller do
 
   describe '#create' do
     it 'persists a news item and delivers email notifications' do
-      ActionMailer::Base.deliveries.clear
-
       become_member_with_permissions(project, user)
 
       with_settings notified_events: ['news_added'] do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -220,7 +220,6 @@ describe UsersController, type: :controller do
       end
 
       before do
-        ActionMailer::Base.deliveries.clear
         with_settings(available_languages: [:en, :de],
                       bcc_recipients: '1') do
           as_logged_in_user admin do
@@ -455,8 +454,6 @@ describe UsersController, type: :controller do
       }
 
       before do
-        ActionMailer::Base.deliveries.clear
-
         as_logged_in_user(admin) do
           put :update, id: user.id, user: { admin: false,
                                             firstname: 'Changed',

--- a/spec/legacy/functional/messages_controller_spec.rb
+++ b/spec/legacy/functional/messages_controller_spec.rb
@@ -88,7 +88,6 @@ describe MessagesController, type: :controller do
 
   it 'should post create' do
     session[:user_id] = 2
-    ActionMailer::Base.deliveries.clear
     allow(Setting).to receive(:notified_events).and_return ['message_posted']
 
     post :create, board_id: 1,

--- a/spec/legacy/functional/user_mailer_spec.rb
+++ b/spec/legacy/functional/user_mailer_spec.rb
@@ -42,7 +42,6 @@ describe UserMailer, type: :mailer do
     WorkPackage.delete_all
     Project.delete_all
     ::Type.delete_all
-    ActionMailer::Base.deliveries.clear
 
     User.current = User.anonymous
   end
@@ -323,7 +322,7 @@ describe UserMailer, type: :mailer do
       issue = FactoryGirl.create(:work_package)
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: 'de')
       FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
-      ActionMailer::Base.deliveries.clear
+
       with_settings available_languages: ['en', 'de'] do
         I18n.locale = 'en'
         assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
@@ -343,7 +342,7 @@ describe UserMailer, type: :mailer do
       issue = FactoryGirl.create(:work_package)
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: '') # (auto)
       FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
-      ActionMailer::Base.deliveries.clear
+
       with_settings available_languages: ['en', 'de'],
                     default_language: 'de' do
         I18n.locale = 'de'
@@ -402,7 +401,7 @@ describe UserMailer, type: :mailer do
   it 'should reminders' do
     user  = FactoryGirl.create(:user, mail: 'foo@bar.de')
     issue = FactoryGirl.create(:work_package, due_date: Date.tomorrow, assigned_to: user, subject: 'some issue')
-    ActionMailer::Base.deliveries.clear
+
     DueIssuesReminder.new(42).remind_users
     assert_equal 1, ActionMailer::Base.deliveries.size
     mail = ActionMailer::Base.deliveries.last
@@ -415,7 +414,6 @@ describe UserMailer, type: :mailer do
     user1  = FactoryGirl.create(:user, mail: 'foo1@bar.de')
     user2  = FactoryGirl.create(:user, mail: 'foo2@bar.de')
     issue = FactoryGirl.create(:work_package, due_date: Date.tomorrow, assigned_to: user1, subject: 'some issue')
-    ActionMailer::Base.deliveries.clear
 
     DueIssuesReminder.new(42, nil, nil, [user2.id]).remind_users
     assert_equal 0, ActionMailer::Base.deliveries.size

--- a/spec/legacy/functional/users_controller_spec.rb
+++ b/spec/legacy/functional/users_controller_spec.rb
@@ -224,7 +224,6 @@ describe UsersController, type: :controller do
   end
 
   it 'should update with password change should send a notification' do
-    ActionMailer::Base.deliveries.clear
     Setting.bcc_recipients = '1'
 
     put :update, id: 2, user: { password: 'newpassPASS!', password_confirmation: 'newpassPASS!' }, send_information: '1'

--- a/spec/legacy/support/legacy_assertions.rb
+++ b/spec/legacy/support/legacy_assertions.rb
@@ -34,6 +34,7 @@ module LegacyAssertionsAndHelpers
   # should not affect other tests.
   def reset_global_state!
     User.current = User.anonymous # reset current user in case it was changed in a test
+    ActionMailer::Base.deliveries.clear
   end
 
   ##

--- a/spec/legacy/unit/changeset_spec.rb
+++ b/spec/legacy/unit/changeset_spec.rb
@@ -35,7 +35,6 @@ describe Changeset, type: :model do
     with_settings notified_events: %w(work_package_updated) do
       WorkPackage.all.each(&:recreate_initial_journal!)
 
-      ActionMailer::Base.deliveries.clear
       Setting.commit_fix_status_id = Status.where(['is_closed = ?', true]).first.id
       Setting.commit_fix_done_ratio = '90'
       Setting.commit_ref_keywords = '*'

--- a/spec/legacy/unit/journal_spec.rb
+++ b/spec/legacy/unit/journal_spec.rb
@@ -43,14 +43,13 @@ describe Journal, type: :model do
       issue.add_journal(User.current, 'This journal represents the creationa of journal version 1')
       issue.save
     end
-    ActionMailer::Base.deliveries.clear
+
     issue.reload
     issue.update_attribute(:subject, 'New subject to trigger automatic journal entry')
     assert_equal 2, ActionMailer::Base.deliveries.size
   end
 
   it 'create should not send email notification if told not to' do
-    ActionMailer::Base.deliveries.clear
     issue = WorkPackage.first
     user = User.first
     journal = issue.add_journal(user, 'A note')

--- a/spec/legacy/unit/lib/redmine/hook_spec.rb
+++ b/spec/legacy/unit/lib/redmine/hook_spec.rb
@@ -158,7 +158,6 @@ describe 'Redmine::Hook::Manager' do # FIXME: naming (RSpec-port)
     user = User.find(1)
     issue = FactoryGirl.create(:work_package)
 
-    ActionMailer::Base.deliveries.clear
     UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
     mail = ActionMailer::Base.deliveries.last
 

--- a/spec/legacy/unit/mail_handler_spec.rb
+++ b/spec/legacy/unit/mail_handler_spec.rb
@@ -34,12 +34,10 @@ describe MailHandler, type: :model do
   FIXTURES_PATH = File.dirname(__FILE__) + '/../../fixtures/mail_handler'
 
   before do
-    ActionMailer::Base.deliveries.clear
     allow(Setting).to receive(:notified_events).and_return(Redmine::Notifiable.all.map(&:name))
   end
 
   it 'should add work package' do
-    ActionMailer::Base.deliveries.clear
     # This email contains: 'Project: onlinestore'
     issue = submit_email('ticket_on_given_project.eml', allow_override: 'fixed_version')
     assert issue.is_a?(WorkPackage)
@@ -335,7 +333,7 @@ describe MailHandler, type: :model do
 
   it 'should add work package should send email notification' do
     Setting.notified_events = ['work_package_added']
-    ActionMailer::Base.deliveries.clear
+
     # This email contains: 'Project: onlinestore'
     issue = submit_email('ticket_on_given_project.eml')
     assert issue.is_a?(WorkPackage)
@@ -385,7 +383,6 @@ describe MailHandler, type: :model do
 
   it 'should add work package note should send email notification' do
     WorkPackage.find(2).recreate_initial_journal!
-    ActionMailer::Base.deliveries.clear
     journal = submit_email('ticket_reply.eml')
     assert journal.is_a?(Journal)
     assert_equal 3, ActionMailer::Base.deliveries.size

--- a/spec/legacy/unit/repository_spec.rb
+++ b/spec/legacy/unit/repository_spec.rb
@@ -87,7 +87,6 @@ describe Repository, type: :model do
     Setting.commit_ref_keywords = 'refs , references, IssueID'
     Setting.commit_fix_keywords = 'fixes , closes'
     Setting.default_language = 'en'
-    ActionMailer::Base.deliveries.clear
 
     # make sure work package 1 is not already closed
     fixed_work_package = WorkPackage.find(1)

--- a/spec/legacy/unit/wiki_content_spec.rb
+++ b/spec/legacy/unit/wiki_content_spec.rb
@@ -54,7 +54,7 @@ describe WikiContent, type: :model do
 
   it 'should create should send email notification' do
     Setting.notified_events = ['wiki_content_added']
-    ActionMailer::Base.deliveries.clear
+
     page = WikiPage.new(wiki: @wiki, title: 'A new page')
     page.content = WikiContent.new(text: 'Content text', author: User.find(1), comments: 'My comment')
     assert page.save
@@ -74,7 +74,7 @@ describe WikiContent, type: :model do
 
   it 'should update should send email notification' do
     Setting.notified_events = ['wiki_content_updated']
-    ActionMailer::Base.deliveries.clear
+
     content = @page.content
     content.text = 'My new content'
     assert content.save

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -66,7 +66,6 @@ describe MailHandler, type: :model do
   # let(:a_custom_field) {FactoryGirl.create(:work_package_custom_field)}
 
   before do
-    ActionMailer::Base.deliveries.clear
     allow(Setting).to receive(:notified_events).and_return(Redmine::Notifiable.all.map(&:name))
     # we need both of these run first so the anonymous user is created and
     # there is a default work package priority to save any work packages
@@ -279,7 +278,6 @@ describe MailHandler, type: :model do
   # end
 
   it 'should add a work_package by create user on public project' do
-    ActionMailer::Base.deliveries.clear
     allow(Setting).to receive(:default_language).and_return('en')
     Role.non_member.update_attribute :permissions, [:add_work_packages]
     project.update_attribute :is_public, true

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -95,8 +95,6 @@ describe News, type: :model do
 
   describe '#save' do
     it 'sends email notifications when created' do
-      ActionMailer::Base.deliveries.clear
-
       user = FactoryGirl.create(:user)
       become_member_with_permissions(project, user)
       # reload

--- a/spec/models/work_package/work_package_action_mailer_spec.rb
+++ b/spec/models/work_package/work_package_action_mailer_spec.rb
@@ -72,6 +72,8 @@ describe WorkPackage, type: :model do
 
     context 'no notification' do
       before do
+        ActionMailer::Base.deliveries.clear # clear mails sent due to prior WP creation
+
         JournalManager.send_notification = false
 
         work_package.save!

--- a/spec/models/work_package/work_package_action_mailer_spec.rb
+++ b/spec/models/work_package/work_package_action_mailer_spec.rb
@@ -44,8 +44,6 @@ describe WorkPackage, type: :model do
     let(:work_package) { FactoryGirl.build(:work_package, project: project) }
 
     before do
-      ActionMailer::Base.deliveries.clear
-
       allow(work_package).to receive(:recipients).and_return([user_1])
       allow(work_package).to receive(:watcher_recipients).and_return([user_2])
 
@@ -74,8 +72,6 @@ describe WorkPackage, type: :model do
 
     context 'no notification' do
       before do
-        ActionMailer::Base.deliveries.clear
-
         JournalManager.send_notification = false
 
         work_package.save!

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -269,7 +269,6 @@ h4. things we like
         before(:each) do
           allow(User).to receive(:current).and_return current_user
           work_package
-          ActionMailer::Base.deliveries.clear
         end
 
         include_context 'patch request'

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -269,6 +269,7 @@ h4. things we like
         before(:each) do
           allow(User).to receive(:current).and_return current_user
           work_package
+          ActionMailer::Base.deliveries.clear # throw away mails due to work package creation
         end
 
         include_context 'patch request'

--- a/spec/requests/api/v3/work_packages/work_packages_by_project_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_by_project_resource_spec.rb
@@ -247,7 +247,6 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request do
       priority.save!
 
       FactoryGirl.create(:user_preference, user: current_user, others: { no_self_notified: false })
-      ActionMailer::Base.deliveries.clear
       post path, parameters.to_json, 'CONTENT_TYPE' => 'application/json'
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,7 @@ RSpec.configure do |config|
                                end
 
     DatabaseCleaner.start
+    ActionMailer::Base.deliveries.clear
   end
 
   config.after(:each) do


### PR DESCRIPTION
People like me may forget to clear `ActionMailer::Base.deliveries` by hand when they write specs (besides mailer specs) involving emails. This change is meant to make live easier for everyone. With it one does not have to worry about clearing the deliveries themselves. They will always be cleared.
