### PR TITLE
use updated upstream capybara-select2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ group :test do
   gem 'rspec-legacy_formatters'
   gem 'capybara', '~> 2.4.4'
   gem 'capybara-screenshot', '~> 1.0.4'
-  gem 'capybara-select2', github: 'finnlabs/capybara-select2'
+  gem 'capybara-select2', github: 'goodwill/capybara-select2'
   gem 'capybara-ng', '~> 0.2.1'
   gem 'selenium-webdriver', '~> 2.47.1'
   gem 'timecop', '~> 0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
       activerecord (>= 3.0.0)
 
 GIT
-  remote: git://github.com/finnlabs/capybara-select2.git
-  revision: 4088099ecc8a03c0c3155827a89a1a51057b0e38
+  remote: git://github.com/goodwill/capybara-select2.git
+  revision: 585192e4bb0db8d52e761ab68f08c17294806447
   specs:
     capybara-select2 (1.0.1)
       capybara


### PR DESCRIPTION
includes bugfix that prevents flickering specs involving select2

Revert "update capybara-select2 in gemfile.lock"
This reverts commit 5a7acefaa36df3a7b425b8313edb6d75450fdeff.

Revert "use finn capybara-select2 until fix is upstream"
This reverts commit 1c836ca983c17ce5e21b79df67476e7b2276197d.
