### PR TITLE
Experiment with angular-cache

### DIFF
--- a/app/assets/javascripts/openproject.js
+++ b/app/assets/javascripts/openproject.js
@@ -33,8 +33,8 @@ window.OpenProject = (function ($) {
   var OP = function (options) {
     options = options || {};
     this.urlRoot = options.urlRoot || "";
-
     this.loginUrl = options.loginUrl || "";
+    this.environment = options.environment || "";
 
     if (!/\/$/.test(this.urlRoot)) {
       this.urlRoot += '/';

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -554,6 +554,7 @@ module ApplicationHelper
     tags += javascript_tag(%{
       window.openProject = new OpenProject({
         urlRoot : '#{OpenProject::Configuration.rails_relative_url_root}',
+        environment: '#{Rails.env}',
         loginUrl: '#{url_for controller: '/account', action: 'login'}'
       });
       I18n.defaultLocale = "#{I18n.default_locale}";

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -235,8 +235,15 @@ openprojectApp
     '$window',
     'featureFlags',
     'TimezoneService',
+    'CacheService',
     'KeyboardShortcutService',
-    function($http, $rootScope, $window, flags, TimezoneService, KeyboardShortcutService) {
+    function($http,
+             $rootScope,
+             $window,
+             flags,
+             TimezoneService,
+             CacheService,
+             KeyboardShortcutService) {
       $http.defaults.headers.common.Accept = 'application/json';
 
       $rootScope.showNavigation =
@@ -246,6 +253,11 @@ openprojectApp
       flags.set($http.get('/javascripts/feature-flags.json'));
       TimezoneService.setupLocale();
       KeyboardShortcutService.activate();
+
+      // Disable the CacheService for test environment
+      if ($window.openProject.environment === 'test') {
+        CacheService.disableCaching();
+      }
 
       // at the moment of adding this code it was mostly used to
       // keep the previous state for the code to know where

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -59,6 +59,7 @@ require('angular-busy/dist/angular-busy.css');
 
 require('angular-context-menu');
 require('angular-elastic');
+require('angular-cache');
 require('mousetrap');
 require('ngFileUpload');
 
@@ -190,7 +191,8 @@ var openprojectApp = angular.module('openproject', [
   'cgBusy',
   'openproject.api',
   'openproject.templates',
-  'monospaced.elastic'
+  'monospaced.elastic',
+  'angular-cache'
 ]);
 
 window.appBasePath = jQuery('meta[name=app_base_path]').attr('content') ||

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -74,7 +74,8 @@ angular.module(
     'openproject.uiComponents',
     'openproject.helpers',
     'openproject.workPackages.config',
-    'openproject.workPackages.helpers'
+    'openproject.workPackages.helpers',
+    'angular-cache'
   ]);
 angular.module('openproject.helpers', ['openproject.services']);
 angular
@@ -191,8 +192,7 @@ var openprojectApp = angular.module('openproject', [
   'cgBusy',
   'openproject.api',
   'openproject.templates',
-  'monospaced.elastic',
-  'angular-cache'
+  'monospaced.elastic'
 ]);
 
 window.appBasePath = jQuery('meta[name=app_base_path]').attr('content') ||

--- a/frontend/app/services/cache-service.js
+++ b/frontend/app/services/cache-service.js
@@ -29,10 +29,14 @@
 module.exports = function(HALAPIResource,
                           $http,
                           $q,
-                          $window,
                           CacheFactory) {
 
+  // Temporary storage for currently resolving promises
   var _promises = {};
+
+  // Global switch to disable all caches
+  var disabled = false;
+
   var CacheService = {
 
     temporaryCache: function() {
@@ -55,12 +59,27 @@ module.exports = function(HALAPIResource,
         _cache = CacheFactory(identifier, params);
       }
 
+      if (disabled) {
+        _cache.disable();
+      }
+
       return _cache;
+    },
+
+    isCacheDisabled: function() {
+      return disabled;
+    },
+
+    enableCaching: function() {
+      disabled = false;
+    },
+
+    disableCaching: function() {
+      disabled = true;
     },
 
     loadResource: function(resource, force) {
       var key = resource.props.href,
-        cacheDisabled = $window.openProject.environment === 'test',
         cache = CacheService.temporaryCache(),
         cachedValue,
         _fetchResource = function() {
@@ -78,7 +97,7 @@ module.exports = function(HALAPIResource,
         };
 
       // Return early when frontend caching is not desired
-      if (cacheDisabled) {
+      if (cache.disabled) {
         return _fetchResource();
       }
 

--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -35,6 +35,13 @@ angular.module('openproject.services')
     require('./activity-service')
   ])
   .service('AuthorisationService', require('./authorisation-service'))
+  .service('CacheService', [
+    'HALAPIResource',
+    '$http',
+    '$q',
+    'CacheFactory',
+    require('./cache-service')
+  ])
   .service('GroupService', ['$http', 'PathHelper', require('./group-service')])
   .service('HookService', require('./hook-service'))
   .service('KeyboardShortcutService', [
@@ -83,6 +90,7 @@ angular.module('openproject.services')
     'HALAPIResource',
     '$http',
     'PathHelper',
+    'CacheService',
     require('./user-service')
   ])
   .service('VersionService', ['$http', 'PathHelper', require(

--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -39,7 +39,6 @@ angular.module('openproject.services')
     'HALAPIResource',
     '$http',
     '$q',
-    '$window',
     'CacheFactory',
     require('./cache-service')
   ])

--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -39,6 +39,7 @@ angular.module('openproject.services')
     'HALAPIResource',
     '$http',
     '$q',
+    '$window',
     'CacheFactory',
     require('./cache-service')
   ])

--- a/frontend/app/services/user-service.js
+++ b/frontend/app/services/user-service.js
@@ -38,7 +38,7 @@ module.exports = function(
       var path = PathHelper.apiV3UserPath(id),
         resource = HALAPIResource.setup(path);
 
-      return getUserByResource(resource);
+      return UserService.getUserByResource(resource);
     },
 
     getUserByResource: function(user, force) {

--- a/frontend/app/services/user-service.js
+++ b/frontend/app/services/user-service.js
@@ -36,9 +36,10 @@ module.exports = function(
   var UserService = {
     getUser: function(id) {
       var path = PathHelper.apiV3UserPath(id),
-          resource = HALAPIResource.setup(path);
+        resource = HALAPIResource.setup(path);
 
       return getUserByResource(resource);
+    },
 
     getUserByResource: function(user, force) {
       return CacheService.loadResource(user, force);

--- a/frontend/app/work_packages/activities/index.js
+++ b/frontend/app/work_packages/activities/index.js
@@ -39,6 +39,7 @@ angular.module('openproject.workPackages.activities')
     'PathHelper',
     'ActivityService',
     'UsersHelper',
+    'UserService',
     'ConfigurationService',
     'AutoCompleteHelper',
     'EditableFieldsState',

--- a/frontend/app/work_packages/activities/user-activity-directive.js
+++ b/frontend/app/work_packages/activities/user-activity-directive.js
@@ -75,7 +75,8 @@ module.exports = function($uiViewScroll,
       scope.userCanQuote = !!scope.workPackage.links.addComment;
       scope.accessibilityModeEnabled = ConfigurationService.accessibilityModeEnabled();
 
-      UserService.getUserByResource(scope.activity.links.user).then(function(user) {
+      var resource = UserService.getUserByResource(scope.activity.links.user);
+      resource.then(function(user) {
         scope.userId = user.props.id;
         scope.userName = user.props.name;
         scope.userAvatar = user.props.avatar;

--- a/frontend/app/work_packages/activities/user-activity-directive.js
+++ b/frontend/app/work_packages/activities/user-activity-directive.js
@@ -34,6 +34,7 @@ module.exports = function($uiViewScroll,
     PathHelper,
     ActivityService,
     UsersHelper,
+    UserService,
     ConfigurationService,
     AutoCompleteHelper,
     EditableFieldsState,
@@ -74,7 +75,7 @@ module.exports = function($uiViewScroll,
       scope.userCanQuote = !!scope.workPackage.links.addComment;
       scope.accessibilityModeEnabled = ConfigurationService.accessibilityModeEnabled();
 
-      scope.activity.links.user.fetch().then(function(user) {
+      UserService.getUserByResource(scope.activity.links.user).then(function(user) {
         scope.userId = user.props.id;
         scope.userName = user.props.name;
         scope.userAvatar = user.props.avatar;

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -18,6 +18,7 @@
     "angular-truncate": "sparkalow/angular-truncate#fdf60fda265042d12e9414b5354b2cc52f1419de",
     "angular-feature-flags": "mjt01/angular-feature-flags",
     "angular-elastic": "2.5.0",
+    "angular-cache": "~4.3.2",
     "jquery-migrate": "~1.2.1",
     "moment": "~2.10.6",
     "moment-timezone": "0.4.x",

--- a/frontend/tests/unit/tests/work_packages/activities/user-activity-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/activities/user-activity-directive-test.js
@@ -63,7 +63,7 @@ describe('userActivity Directive', function() {
 
     describe('element', function() {
       describe('with a valid user', function(){
-        beforeEach(function() {
+        beforeEach(inject(function($q) {
           scope.workPackage = {
             links: {
               addComment: true

--- a/frontend/tests/unit/tests/work_packages/activities/user-activity-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/activities/user-activity-directive-test.js
@@ -47,7 +47,7 @@ describe('userActivity Directive', function() {
       });
     });
 
-    beforeEach(inject(function($rootScope, $compile, $uiViewScroll, $timeout, $location, I18n, PathHelper, ActivityService, UsersHelper) {
+    beforeEach(inject(function($rootScope, $compile, $uiViewScroll, $timeout, $location, I18n, PathHelper, ActivityService, UsersHelper, UserService) {
       var html;
       html = '<user-activity work-package="workPackage" activity="activity" activity-no="activityNo" is-initial="isInitial" input-element-id="inputElementId"></user-activity>';
 
@@ -74,21 +74,20 @@ describe('userActivity Directive', function() {
           };
           scope.activity = {
             links: {
-              update: true,
               user: {
+                props: { href: '/api/v3/users/1' },
                 fetch: function() {
-                  return {
-                    then: function(cb) {
-                      cb({
-                        props: {
-                          id: 1,
-                          name: "John Doe",
-                          avatar: 'avatar.png',
-                          status: 1
-                        }
-                      }
-                    );}
-                  };
+                  var deferred = $q.defer();
+                  deferred.resolve({
+                    props: {
+                      id: 1,
+                      name: "John Doe",
+                      avatar: 'avatar.png',
+                      status: 1
+                    }
+                  });
+
+                  return deferred.promise;
                 }
               }
             },
@@ -114,7 +113,7 @@ describe('userActivity Directive', function() {
           };
           scope.isInitial = false;
           compile();
-        });
+        }));
 
         context("user's avatar", function() {
           it('should have an alt attribute', function() {
@@ -126,23 +125,28 @@ describe('userActivity Directive', function() {
           });
 
           describe('when being empty', function() {
-            beforeEach(function() {
-              scope.activity.links.user.fetch = function() {
-                return {
-                  then: function(cb) {
-                    cb({
-                      props: {
-                        id: 1,
-                        name: "John Doe",
-                        avatar: '',
-                        status: 1
-                      }
-                    });
-                  }
-                };
+            beforeEach(inject(function($q) {
+              scope.activity.links.user = {
+                props: {
+                  href: '/api/v3/users/2'
+                },
+                fetch: function() {
+                  var deferred = $q.defer();
+                  deferred.resolve({
+                    props: {
+                      id: 2,
+                      name: "John Doe",
+                      avatar: '',
+                      status: 1
+                    }
+                  });
+
+                  return deferred.promise;
+                }
               };
+
               compile();
-            });
+            }));
 
             it('should not be rendered', function() {
               expect(element.find('.avatar')).to.have.length(0);


### PR DESCRIPTION
This PR introduced a memory/sessionStorage cache using `angular-cache`. While angular has its own `$cacheFactory`, its options are rather limited and provide no integration with, e.g., the local and sessionStorage.

One prominent example where we should employ frontend-side caching
is the fetching of associated users in activities, which is the main driver for this PR.

For a large number of comments of the same user, that user is retrieved
once per activity, which causes a drastic overhead.

This commit introduces a simple wrapper around angular-cache to store
values in the sessionStorage.
### TODOS / Open questions
- [x] Multiple cache stores (e.g., one for persistence / seldomly-changed values in localStorage)
- [x] ~~Storing the promise in sessionStorage feels like magic, as I think some browsers limit the storage to string only. We should keep these things in memory, perhaps.~~ I'm now storing the returned data in the sessionStorage.

Note: Opening a page in a new tab or window will result in a fresh sessionStorage, so this is rather a `tab / window storage`.
