### PR TITLE
Updating transactional_lock gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,10 +30,11 @@ GIT
 
 GIT
   remote: https://github.com/finnlabs/transactional_lock.git
-  revision: fe82192efa0346e49d19bbe82865280fdae79487
+  revision: 6948b1d446db0da5645e68ffeeddca1c4944c3bc
   branch: master
   specs:
     transactional_lock (0.1.0)
+      activerecord (>= 4.0)
 
 GIT
   remote: https://github.com/opf/openproject-translations.git


### PR DESCRIPTION
## Description

The gem was accidentially not updated to the latest version in our repository. There should be no behavioural changes.

However, since you can never know for sure I'd like to wait for an additional run on travis.
