### PR TITLE
[packager] Require tzinfo-data needed for some installations after Rails 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'color-tools', '~> 1.3.0', require: 'color'
 
 gem 'ruby-progressbar'
 
+# Provide timezone info for TZInfo used by AR
+gem 'tzinfo-data'
+
 # to generate html-diffs (e.g. for wiki comparison)
 gem 'htmldiff'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,8 @@ GEM
     timecop (0.7.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.6)
+      tzinfo (>= 1.0.0)
     uber (0.0.13)
     unicorn (4.9.0)
       kgio (~> 2.6)
@@ -604,6 +606,7 @@ DEPENDENCIES
   thin
   timecop (~> 0.7.1)
   transactional_lock!
+  tzinfo-data
   unicorn
   warden (~> 1.2)
   warden-basic_auth (~> 0.2.1)


### PR DESCRIPTION
While updating packager for Rails 4.2, an error occurred building for
SUSE Linux: https://packager.io/gh/oliverguenther/openproject/build_runs/7#27109

> TZInfo::DataSourceNotFound: No source of timezone data could be found.
> Please refer to http://tzinfo.github.io/datasourcenotfound for help resolving this error.

The suggested solutions seems to be manually requiring tzinfo-data,
which itself packages the IANA tz database for ruby.
