### PR TITLE
[Fullscreen] Use events to refresh a single work package

### DIFF
--- a/frontend/app/work_packages/controllers/work-package-details-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-details-controller.js
@@ -51,7 +51,7 @@ module.exports = function($scope,
     latestTab.registerState(toState.name);
   });
 
-  $scope.$on('workPackageRefreshRequired', function(e, callback) {
+  $rootScope.$on('workPackageRefreshRequired', function(e, callback) {
     refreshWorkPackage(callback);
   });
 
@@ -72,9 +72,6 @@ module.exports = function($scope,
         }
       });
   }
-  $scope.refreshWorkPackage = refreshWorkPackage; // expose to child controllers
-  $rootScope.refreshWorkPackage = refreshWorkPackage; // expose to child controllers
-
   // Inform parent that work package is loaded so back url can be maintained
   $scope.$emit('workPackgeLoaded');
 

--- a/frontend/app/work_packages/controllers/work-package-new-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-new-controller.js
@@ -111,7 +111,7 @@ module.exports = function(
     var field = angular.element('.work-packages--details--subject:first .inplace-edit--write')
                        .scope().editPaneController.submitField;
 
-    EditableFieldsState.submissionPromises['work-package'] = {
+    EditableFieldsState.submissionPromises['work_package'] = {
       field: 'subject',
       thePromise: field,
       prepend: true,

--- a/frontend/app/work_packages/controllers/work-package-show-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-show-controller.js
@@ -68,7 +68,9 @@ module.exports = function($scope,
     latestTab.registerState(toState.name);
   });
 
-  $scope.$on('workPackageRefreshRequired', function(e, callback) {
+  // Listen to the event globally, as listeners are not necessarily
+  // in the child scope
+  $rootScope.$on('workPackageRefreshRequired', function(e, callback) {
     refreshWorkPackage(callback);
   });
 
@@ -191,7 +193,6 @@ module.exports = function($scope,
         }
       });
   }
-  $rootScope.refreshWorkPackage = refreshWorkPackage; // expose to child controllers
   $scope.wpPromise = WorkPackageService.getWorkPackage($scope.workPackage.props.id);
 
   // Inform parent that work package is loaded so back url can be maintained

--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -409,7 +409,7 @@ module.exports = function(
 
     $q.all(promises).then(function() {
       // Update work package after this call
-      $rootScope.refreshWorkPackage(callback);
+      $rootScope.$emit('workPackageRefreshRequired', callback);
       EditableFieldsState.errors = null;
       EditableFieldsState.submissionPromises = {};
       EditableFieldsState.currentField = null;


### PR DESCRIPTION
Avoids exposing the `refreshWorkPackage` function on the root scope.
