### PR TITLE
Always allow attachment upload for new work packages

### DIFF
--- a/frontend/app/services/work-package-service.js
+++ b/frontend/app/services/work-package-service.js
@@ -82,6 +82,7 @@ module.exports = function($http,
     initializeWorkPackage: function(projectIdentifier, initialData) {
       var changes = _.clone(initialData);
       var wp = {
+        isNew: true,
         embedded: {},
         props: {},
         links: {

--- a/frontend/app/work_packages/directives/work-package-attachments-directive.js
+++ b/frontend/app/work_packages/directives/work-package-attachments-directive.js
@@ -69,7 +69,7 @@ module.exports = function(
     scope.rejectedFiles = [];
     scope.size = ConversionService.fileSize;
 
-    scope.hasRightToUpload = !!workPackage.links.addAttachment;
+    scope.hasRightToUpload = !!(workPackage.links.addAttachment || workPackage.isNew);
 
     var currentlyRemoving = [];
     scope.remove = function(file) {


### PR DESCRIPTION
https://github.com/opf/openproject/commit/af73d607733c56d1369a9d914b9ce6dd5b352f43
introduced a check whether the work package contains a link addAttachment
(i.e., the user is allowed to :edit_work_packages).

For new work packages, this link is not available, thus we need to
provide some alternative as for now, when adding work packages it is
always possible to add attachments (given the :add_work_packages permission).
