### PR TITLE
Allow to add attachments to a WP on WP creation

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1029,7 +1029,7 @@ Instead the `fileName` inside the JSON of the metadata part will be used.
 
     Returned if the client does not have sufficient permissions.
 
-    **Required permission:** edit work package
+    **Required permission:** edit work package or add work package
 
     *Note that you will only receive this error, if you are at least allowed to see the work package.*
 

--- a/lib/api/v3/attachments/attachments_by_work_package_api.rb
+++ b/lib/api/v3/attachments/attachments_by_work_package_api.rb
@@ -59,7 +59,7 @@ module API
           end
 
           post do
-            authorize(:edit_work_packages, context: @work_package.project)
+            authorize_any [:edit_work_packages, :add_work_packages], projects: @work_package.project
 
             metadata = parse_metadata params[:metadata]
             file = params[:file]

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -125,7 +125,8 @@ module API
           {
             href: api_v3_paths.attachments_by_work_package(represented.id),
             method: :post
-          } if current_user_allowed_to(:edit_work_packages, context: represented.project)
+          } if current_user_allowed_to(:edit_work_packages, context: represented.project) ||
+               current_user_allowed_to(:add_work_packages, context: represented.project)
         end
 
         link :availableWatchers do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -457,6 +457,24 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         context 'user is not allowed to edit work packages' do
           let(:permissions) { all_permissions - [:edit_work_packages] }
 
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'addAttachment' }
+            let(:href) { api_v3_paths.attachments_by_work_package(work_package.id) }
+          end
+        end
+
+        context 'user is not allowed to add work packages' do
+          let(:permissions) { all_permissions - [:add_work_packages] }
+
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'addAttachment' }
+            let(:href) { api_v3_paths.attachments_by_work_package(work_package.id) }
+          end
+        end
+
+        context 'user is neither allowed to edit work packages nor to add them' do
+          let(:permissions) { all_permissions - [:edit_work_packages, :add_work_packages] }
+
           it_behaves_like 'has no link' do
             let(:link) { 'addAttachment' }
           end

--- a/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
@@ -129,5 +129,19 @@ describe 'API v3 Attachments by work package resource', type: :request do
         let(:message) { "File #{expanded_localization}" }
       end
     end
+
+    context 'only allowed to add work packages, but no edit permission' do
+      let(:permissions) { [:view_work_packages, :add_work_packages] }
+
+      it 'should respond with HTTP Created' do
+        expect(subject.status).to eq(201)
+      end
+    end
+
+    context 'only allowed to view work packages' do
+      let(:permissions) { [:view_work_packages] }
+
+      it_behaves_like 'unauthorized access'
+    end
   end
 end


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21612
## Description

This is the "easy" solution to allow adding attachments while adding a work package, with only the _add work packages_ permission.

The "better" solution would involve redesigning how attachments work and people would have to agree that it is actually a better approach. This would involve:
- uploading attachments without container
- linking uploaded attachments to a container (work package) when editing/creating that container (referring to them via their API-URL, e.g. `/api/v3/attachments/123`)
