### PR TITLE
[21598] Unify usage of input field affix

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -77,6 +77,9 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
       padding: 1rem !important
       margin: 0 0 1rem 0
 
+    input[type=text]
+      margin-bottom: 0
+
     em
       font-style: italic
 
@@ -615,8 +618,3 @@ input[readonly].-clickable
 
   li, div
     padding: 0
-
-
-.form--text-field-container
-  input[type=text]
-    margin-bottom: 0


### PR DESCRIPTION
This removes the the rule which sets the `margin-bottom` of all input fields to zero. This is responsible for the wrong affix layout. The removed rule is replaced in a more specific place so that it is only used when needed.

https://community.openproject.org/work_packages/21598/activity
