### PR TITLE
[21614] Center input fields in table cells

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -38,6 +38,8 @@ $generic-table--header-font-size: 0.875rem
 $generic-table--header-height: 40px
 $generic-table--footer-height: 34px
 
+$input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix'
+
 .generic-table--container
   position:     relative
   height:       100%
@@ -143,9 +145,16 @@ table.generic-table
       text-overflow: ellipsis
       text-align: left
       line-height: 34px
+      vertical-align: middle
 
-      &.icon-table
-        //
+      // Center input fields and select boxes vertically in tables
+      .form--field
+        margin: 0px
+      @each $inputElement in $input-elements
+        #{$inputElement}
+          margin-top: 0.5rem
+          margin-bottom: 0.5rem
+
       &.checkbox
         min-width: 0
         width: 20px

--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -42,7 +42,6 @@ table
 
   &.plugins
     td
-      vertical-align: middle
       &.configure
         text-align: right
         padding-right: 1em


### PR DESCRIPTION
This sets a uniform `margin-bottom` and `margin-top` for all input elements. Thus the elements do not have only a margin-bottom value and are now correctly aligned.

https://community.openproject.org/work_packages/21614/activity
