### PR TITLE
reworks workpackage index/show page routes

### DIFF
--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -32,8 +32,6 @@ angular.module('openproject')
   '$stateProvider',
   '$urlRouterProvider',
   function($stateProvider, $urlRouterProvider) {
-    var wpListStateCfg;
-
   // redirect to default activity tab when user lands at /work_packages/:id
   // TODO: Preserve #note-4 part of the URL.
   $urlRouterProvider.when('/work_packages/{id}', '/work_packages/{id}/activity');
@@ -71,7 +69,7 @@ angular.module('openproject')
           var wsPromise = WorkPackageService.getWorkPackage($stateParams.workPackageId);
 
           wsPromise.catch(function(){
-            location.href = '/projects'
+            location.href = '/projects';
           });
 
           return wsPromise;
@@ -110,10 +108,16 @@ angular.module('openproject')
       controllerAs: 'watchers'
     })
 
-    .state('work-packages.list', wpListStateCfg = {
-      url: '/projects/{projectPath}/work_packages?query_id&query_props',
+    .state('work-packages.list', {
+      url: '/{projects}/{projectPath}/work_packages?query_id&query_props',
       controller: 'WorkPackagesListController',
       templateUrl: '/templates/work_packages.list.html',
+      params: {
+        // value: null makes the parameter optional
+        // squash: true avoids duplicate slashes when the paramter is not provided
+        projectPath: { value: null, squash: true },
+        projects: { value: null, squash: true }
+      },
       reloadOnSearch: false,
       // HACK
       // This is to avoid problems with the css depending on which page the
@@ -123,15 +127,12 @@ angular.module('openproject')
       // states, we need to remove the trigger used in the CSS The correct fix
       // would be to alter the CSS.
       onEnter: function(){
-        jQuery('body').addClass('action-index');
+        angular.element('body').addClass('action-index');
       },
       onExit: function(){
-        jQuery('body').removeClass('action-index');
+        angular.element('body').removeClass('action-index');
       }
-      })
-    .state('work-packages.list-all', _.extend(_.clone(wpListStateCfg), {
-        url: '/work_packages?query_id&query_props'
-      }))
+    })
     .state('work-packages.list.new', {
       url: '/create_new?type',
       controller: 'WorkPackageNewController',

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -1,0 +1,93 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.feature 'Work package navigation' do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:work_package) { FactoryGirl.build(:work_package, project: project) }
+
+  before do
+    work_package.save!
+    allow(User).to receive(:current).and_return(user)
+  end
+
+  scenario 'all different angular based work package views', js: true do
+    # deep link global work package index
+    global_work_packages = Pages::WorkPackagesTable.new
+    global_work_packages.visit!
+
+    global_work_packages.expect_work_package_listed(work_package)
+
+    # open details pane for work package
+
+    split_work_package = global_work_packages.open_split_view(work_package)
+
+    split_work_package.expect_subject
+    split_work_package.expect_current_path
+
+    # open work package full screen
+
+    full_work_package = global_work_packages.open_full_screen(work_package)
+
+    full_work_package.expect_subject
+    full_work_package.expect_current_path
+
+    # deep link work package details pane
+
+    split_work_package.visit!
+    split_work_package.expect_subject
+
+    # deep link work package show
+
+    full_work_package.visit!
+    full_work_package.expect_subject
+
+    # deep link project work packages
+
+    project_work_packages = Pages::WorkPackagesTable.new(project)
+    project_work_packages.visit!
+
+    project_work_packages.expect_work_package_listed(work_package)
+
+    # open project work package details pane
+
+    split_project_work_package = project_work_packages.open_split_view(work_package)
+
+    split_project_work_package.expect_subject
+    split_project_work_package.expect_current_path
+
+    # open work package full screen
+
+    full_work_package = project_work_packages.open_full_screen(work_package)
+
+    full_work_package.expect_subject
+    full_work_package.expect_current_path
+  end
+end

--- a/spec/routing/work_packages_spec.rb
+++ b/spec/routing/work_packages_spec.rb
@@ -43,7 +43,7 @@ describe WorkPackagesController, type: :routing do
   it 'should connect GET /work_packages/:id/overview to work_packages#show' do
     expect(get('/work_packages/1/overview'))
       .to route_to(controller: 'work_packages',
-                   action: 'show', id: '1', tab: 'overview')
+                   action: 'show', id: '1', state: 'overview')
   end
 
   it 'should connect GET /projects/:project_id/work_packages/:id/overview to work_packages#index' do
@@ -52,6 +52,22 @@ describe WorkPackagesController, type: :routing do
                    action: 'index',
                    project_id: '1',
                    state: '2/overview')
+  end
+
+  it 'should connect GET /work_packages/details/:state to work_packages#index' do
+    expect(get('/work_packages/details/5/overview'))
+      .to route_to(controller: 'work_packages',
+                   action: 'index',
+                   state: '5/overview')
+  end
+
+  it 'should connect GET /projects/:project_id/work_packages/details/:id/:state' +
+     ' to work_packages#index' do
+    expect(get('/projects/1/work_packages/details/2/overview'))
+      .to route_to(controller: 'work_packages',
+                   action: 'index',
+                   project_id: '1',
+                   state: 'details/2/overview')
   end
 
   context 'when "/work_packages/:param1/:param2" is called with param1 being something other than an id' do
@@ -93,7 +109,7 @@ describe WorkPackagesController, type: :routing do
                                                      id: '1')
   end
 
-  it 'should connect POST /projects/:project_id/work_packages to work_packages#new' do
+  it 'should connect POST /projects/:project_id/work_packages to work_packages#create' do
     expect(post('/projects/1/work_packages')).to route_to(controller: 'work_packages',
                                                           action: 'create',
                                                           project_id: '1')

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -26,56 +26,36 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'support/pages/page'
+
 module Pages
-  class Page
-    include Capybara::DSL
-    include RSpec::Matchers
-    include OpenProject::StaticRouting::UrlHelpers
+  class FullWorkPackage < Page
 
-    def current_page?
-      URI.parse(current_url).path == path
+    attr_reader :work_package
+
+    def initialize(work_package)
+      @work_package = work_package
     end
 
-    def visit!
-      raise 'No path defined' unless path
-
-      visit path
-
-      self
-    end
-
-    def accept_alert_dialog!
-      alert_dialog.accept if selenium_driver?
-    end
-
-    def dismiss_alert_dialog!
-      alert_dialog.dismiss if selenium_driver?
-    end
-
-    def alert_dialog
-      page.driver.browser.switch_to.alert
-    end
-
-    def has_alert_dialog?
-      if selenium_driver?
-        begin
-          page.driver.browser.switch_to.alert
-        rescue Selenium::WebDriver::Error::NoAlertPresentError
-          false
-        end
+    def expect_subject
+      within(container) do
+        expect(page).to have_content(work_package.subject)
       end
     end
 
-    def selenium_driver?
-      Capybara.current_driver.to_s.include?('selenium')
+    def expect_current_path
+      current_path = URI.parse(current_url).path
+      expect(current_path).to eql path
     end
 
-    def set_items_per_page!(n)
-      Setting.per_page_options = "#{n}, 50, 100"
+    private
+
+    def container
+      find('.work-packages--show-view')
     end
 
     def path
-      nil
+      work_package_path(work_package.id, "activity")
     end
   end
 end

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -26,56 +26,49 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'support/pages/page'
+
 module Pages
-  class Page
-    include Capybara::DSL
-    include RSpec::Matchers
-    include OpenProject::StaticRouting::UrlHelpers
+  class WorkPackagesTable < Page
 
-    def current_page?
-      URI.parse(current_url).path == path
+    attr_reader :project
+
+    def initialize(project = nil)
+      @project = project
     end
 
-    def visit!
-      raise 'No path defined' unless path
-
-      visit path
-
-      self
-    end
-
-    def accept_alert_dialog!
-      alert_dialog.accept if selenium_driver?
-    end
-
-    def dismiss_alert_dialog!
-      alert_dialog.dismiss if selenium_driver?
-    end
-
-    def alert_dialog
-      page.driver.browser.switch_to.alert
-    end
-
-    def has_alert_dialog?
-      if selenium_driver?
-        begin
-          page.driver.browser.switch_to.alert
-        rescue Selenium::WebDriver::Error::NoAlertPresentError
-          false
-        end
+    def expect_work_package_listed(work_package)
+      within(table_container) do
+        expect(page).to have_content(work_package.subject)
       end
     end
 
-    def selenium_driver?
-      Capybara.current_driver.to_s.include?('selenium')
+    def open_split_view(work_package)
+      split_page = SplitWorkPackage.new(work_package, project)
+
+      page.driver.browser.mouse.double_click(row(work_package).native)
+
+      split_page
     end
 
-    def set_items_per_page!(n)
-      Setting.per_page_options = "#{n}, 50, 100"
+    def open_full_screen(work_package)
+      row(work_package).find_link(work_package.subject).click
+
+      FullWorkPackage.new(work_package)
     end
+
+    private
 
     def path
-      nil
+      project ? project_work_packages_path(project) : work_packages_path
+    end
+
+    def table_container
+      find('#content .work-package-table--container')
+    end
+
+    def row(work_package)
+      table_container.find("#work-package-#{work_package.id}")
     end
   end
 end


### PR DESCRIPTION
- Fixes deep linking to the details pane
- Get's rid of the duplicate routes
- Introduces optional path segments /projects/:project_identifier
