### PR TITLE
Bump selenium-webdriver to 2.47.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,7 +159,7 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0.4'
   gem 'capybara-select2', github: 'goodwill/capybara-select2'
   gem 'capybara-ng', '~> 0.2.1'
-  gem 'selenium-webdriver', '~> 2.45.0'
+  gem 'selenium-webdriver', '~> 2.47.1'
   gem 'timecop', '~> 0.7.1'
 
   gem 'rb-readline', "~> 0.5.1" # ruby on CI needs this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ GEM
       structured_warnings (>= 0.1.3)
     rubyzip (1.1.6)
     sass (3.4.12)
-    selenium-webdriver (2.45.0)
+    selenium-webdriver (2.47.1)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
@@ -559,7 +559,7 @@ DEPENDENCIES
   rubytree (~> 0.8.3)
   sass (~> 3.4.12)
   sass-rails!
-  selenium-webdriver (~> 2.45.0)
+  selenium-webdriver (~> 2.47.1)
   shoulda
   shoulda-matchers (~> 2.5.0)
   simplecov (= 0.8.0.pre)


### PR DESCRIPTION
This is a backport of 3faf92df5ff146a060b7ca93a9f882a832dff4d5. 

Original message was:
This fixes crashing Firefox upon starting protractor with
`directConnect: true`.
See 3faf92df5ff146a060b7ca93a9f882a832dff4d5 for the original commit.
