### PR TITLE
[21640] Fix misaligned buttons

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -38,7 +38,7 @@ $generic-table--header-font-size: 0.875rem
 $generic-table--header-height: 40px
 $generic-table--footer-height: 34px
 
-$input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix'
+$input-elements: input, 'input.form--text-field', select, 'select.form--select', '.form--field-affix', 'a.button'
 
 .generic-table--container
   position:     relative


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/3569 there is a `margin-top` and `margin-bottom` value set for all input elements in tables to align them vertically. When doing so a-tags that serve as buttons need this margin, too. This is done in this PR.

https://community.openproject.org/work_packages/21640/activity
