### PR TITLE
[19528] Button not on line for admin/groups/edit

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -171,6 +171,7 @@ table.generic-table
 
       &.buttons
         text-align: right
+        white-space: nowrap
 
     p
       padding: 0 8px
@@ -221,6 +222,9 @@ table.generic-table
       width: 1em
       text-align: right
       min-width: 1em
+
+  .generic-table--cell-controls
+    white-space: nowrap
 
 .generic-table--header-background
   position:     absolute

--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -78,9 +78,11 @@ See doc/COPYRIGHT.rdoc for more details.
                         <p><% roles.each do |role| %>
                             <label><%= check_box_tag 'membership[role_ids][]', role.id, membership.roles.include?(role) %> <%=h role %></label>
                           <% end %></p>
-                        <p><%= submit_tag l(:button_change), class: 'button -highlight -small' %>
+                        <p class="generic-table--cell-controls">
+                          <%= submit_tag l(:button_change), class: 'button -highlight -small' %>
                           <%= link_to_function l(:button_cancel), "$('member-#{membership.id}-roles').show(); $('member-#{membership.id}-roles-form').hide(); return false;",
-                    class: 'button -small' %></p>
+                                                                  class: 'button -small' %>
+                        </p>
                       <% end %>
                     </td>
                     <td class="buttons">


### PR DESCRIPTION
This avoids line-breaks for buttons in tables.

https://community.openproject.org/work_packages/19528/activity
