### PR TITLE
Use rails 4 secret_key_base

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -27,7 +27,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'yaml'
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.
@@ -37,26 +36,16 @@ require 'yaml'
 # no regular words or you'll be exposed to dictionary attacks.
 # You can use `rake secret` to generate a secure secret key.
 
-# Make sure your secret_key_base is kept private
+# Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
-# TODO: replace custom code with secrets.yml on upgrade to Rails 4.1
+development:
+  secret_key_base: e7fc3c2c8bec7b789b1ddbac5425c680055aadd3a3015e93f58fd5914dfebbaef30249414ea5813db5df619ebab246e96cf5b4f38d58b42452de85f5af6cf242
 
-begin
-  secret_token_config = YAML.load_file('config/secret_token.yml')
-  secret_token = secret_token_config['secret_token']
-rescue
-end
+test:
+  secret_key_base: e7fc3c2c8bec7b789b1ddbac5425c680055aadd3a3015e93f58fd5914dfebbaef30249414ea5813db5df619ebab246e96cf5b4f38d58b42452de85f5af6cf242
 
-OpenProject::Application.config.secret_token = if Rails.env.development? or Rails.env.test? or Rails.groups.include?('assets')
-                                                 ('x' * 30) # meets minimum requirement of 30 chars long
-                                               else
-                                                 ENV['SECRET_TOKEN'] || secret_token
-end
-
-if OpenProject::Application.config.secret_token.nil?
-  puts 'Error: secret_token empty!'
-  puts "Please set it with ENV variable 'SECRET_TOKEN' or "
-  puts "run 'rake generate_secret_token'"
-  exit 1
-end
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
This makes use of rails 4 secret_key_base functionality and removes the according deprecation warning `DEPRECATION WARNING: You didn't set`secret_key_base`.`
