### PR TITLE
Fix/journable baseclass

### DIFF
--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -199,7 +199,7 @@ class JournalManager
     journal_class_attributes = journal_class.columns.map(&:name)
 
     valid_journal_attributes = changed_data.select { |k, _v| journal_class_attributes.include?(k.to_s) }
-    valid_journal_attributes.except 'id', 'updated_at', 'updated_on'
+    valid_journal_attributes.except :id, :updated_at, :updated_on
   end
 
   def self.create_journal_data(_journal_id, type, changed_data)

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -255,11 +255,7 @@ class JournalManager
   end
 
   def self.base_class(type)
-    supertype = type.ancestors.find { |a| a != type and a.is_a? Class }
-
-    supertype = type if supertype == ActiveRecord::Base
-
-    supertype
+    type.base_class
   end
 
   def self.create_association_data(journable, journal)

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -91,10 +91,8 @@ module Redmine
 
           journal_hash = prepare_journaled_options(journal_hash)
 
-          journable_type = to_s
           has_many :journals, -> {
-            where(journable_type: journable_type)
-              .order("#{Journal.table_name}.version ASC")
+            order("#{Journal.table_name}.version ASC")
           }, journal_hash, &block
         end
 


### PR DESCRIPTION
Fixes various shortcomings of the acts_as_journalized implementation, the most severe one being the faulty implementation of the base_class which caused the backlogs plugin to create wrong journals for impediments. 

The other fixes are less severe:
- attribute mass assignment on protected attributes
- duplicate type checks on polymorphic association
