### PR TITLE
Properly require factory girl so testing in plugins works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,14 @@ group :test do
   gem 'rack-test', '~> 0.6.2'
   gem 'shoulda-context', '~> 1.2'
   gem 'launchy', '~> 2.3.0'
+
+  # Require factory_girl for usage with openproject plugins testing
+  # FactoryGirl needs to be available when loading app otherwise factory
+  # definitions from core are not available in the plugin thus specs break
+  gem 'factory_girl', '~> 4.5'
+  # require factory_girl_rails for convenience in core development
   gem 'factory_girl_rails', '~> 4.5', require: false
+
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'rack_session_access'
   gem 'database_cleaner', '~> 1.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,6 +537,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.0.2)
   equivalent-xml (~> 0.5.1)
   execjs (~> 2.4.0)
+  factory_girl (~> 4.5)
   factory_girl_rails (~> 4.5)
   faker
   fog (~> 1.23.0)


### PR DESCRIPTION
Running specs in plugins did not work since we changed the way
of loading factories in op:core. This fixes the factory not defined
errors when running plugin specs.
