### PR TITLE
[21494] Design issues on danger zone

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -93,7 +93,12 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
 
       span.icon,
       span.icon-context
+        display: inline-block
         vertical-align: middle
+        // This is an approximation necessary for vertical alignment (especially FF under Windows)
+        // This should be removable once the icon font is updated
+        // see: https://community.openproject.org/work_packages/21589/activity
+        margin-bottom: 0.0625em
         &:before
           padding-left: 0px
           color: $content-form-danger-zone-bg-color

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -69,6 +69,10 @@ class Repository::Git < Repository
     "#{super}.git"
   end
 
+  def repository_type
+    'Git'
+  end
+
   ##
   # Git doesn't like local urls when visiting
   # the repository, thus always use the path.

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -70,6 +70,10 @@ class Repository::Subversion < Repository
     scm.create_empty_svn
   end
 
+  def repository_type
+    'Subversion'
+  end
+
   def supports_directory_revisions?
     true
   end

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
   <section class="form--section">
     <h3 class="form--section-title">
-      <%= l('repositories.destroy.title', name: "<em>#{h(@repository.root_url)}</em>").html_safe %>
+      <%= l('repositories.destroy.title', type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
     </h3>
     <p>
       <%= l('repositories.destroy.confirmation', project_name: @project.identifier) %>

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
   <section class="form--section">
     <h3 class="form--section-title">
-      <%= l('repositories.destroy.title', type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
+      <%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
     </h3>
     <p>
       <%= l('repositories.destroy.confirmation', project_name: @project.identifier) %>
@@ -56,7 +56,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% else %>
 <div class="notification-box -warning">
   <div class="notification-box--content">
-    <p><strong><%= l('repositories.destroy.title', name: h(@repository.root_url)) %></strong><br /></p>
+    <p><strong><%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %></strong><br /></p>
     <p>
       <%= simple_format l('repositories.destroy.linked_text',
                         project_name: @project.identifier, url: @repository.url) %>

--- a/app/views/work_packages/bulk/destroy.html.erb
+++ b/app/views/work_packages/bulk/destroy.html.erb
@@ -69,6 +69,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="grid-block">
           <div class="form--field">
             <div class="form--text-field-container -xslim">
+              <%= styled_label_tag 'to_do_reassign_to_id', l(:text_reassign), class: 'form--label hidden-for-sighted' %>
               <%= f.text_field 'reassign_to_id', :placeholder => WorkPackage.human_attribute_name(:id), :value => params[:reassign_to_id], :size => 6, :onfocus => 'jQuery("#to_do_action_reassign").prop("checked", true);' %>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1375,7 +1375,7 @@ en:
       info: "Deleting the repository is an irreversible action."
       linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}.\nNote: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
       managed_path_note: "The following directory will be erased: %{path}"
-      title: "Do you really want to delete the repository %{name}?"
+      title: "Do you really want to delete the %{type} of the project %{project_name}?"
     errors:
       build_failed: "Unable to create the repository with the selected configuration. %{reason}"
       empty_repository: "The repository exists, but is empty. It does not contain any revisions yet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1375,7 +1375,7 @@ en:
       info: "Deleting the repository is an irreversible action."
       linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}.\nNote: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
       managed_path_note: "The following directory will be erased: %{path}"
-      title: "Do you really want to delete the %{type} of the project %{project_name}?"
+      title: "Do you really want to delete the %{repository_type} of the project %{project_name}?"
     errors:
       build_failed: "Unable to create the repository with the selected configuration. %{reason}"
       empty_repository: "The repository exists, but is empty. It does not contain any revisions yet."

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -84,7 +84,7 @@ describe 'Repository Settings', type: :feature, js: true do
     end
   end
 
-  shared_examples 'manages the repository with' do |name, type|
+  shared_examples 'manages the repository with' do |name, type, repository_type, project_name|
     let(:repository) {
       FactoryGirl.create("repository_#{name}".to_sym,
                          scm_type: type,
@@ -93,8 +93,8 @@ describe 'Repository Settings', type: :feature, js: true do
     it_behaves_like 'manages the repository', type
   end
 
-  it_behaves_like 'manages the repository with', 'subversion', 'existing'
-  it_behaves_like 'manages the repository with', 'git', 'local'
+  it_behaves_like 'manages the repository with', 'subversion', 'existing', 'Subversion - Repository', 'project'
+  it_behaves_like 'manages the repository with', 'git', 'local', 'Git - Repository', 'project'
 
   context 'managed repositories' do
     include_context 'with tmpdir'


### PR DESCRIPTION
This PR gives the icon a little margin to align it correctly. This is especially needed for FF under Windows. However it is useful for the other browser when the content gets zoomed. 
Further the header text for the danger zone of repos has changed, too.

https://community.openproject.org/work_packages/21494/activity
