### PR TITLE
[21678] Unify header distances in full screen view

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -90,7 +90,21 @@ body.controller-work_packages.action-show {
     width: 60%;
 
     .work-packages--panel-inner {
-      padding: 0px 20px 20px 0px;
+      padding: 2px 20px 20px 0px;
+
+      // These styles were taken over from the details tab styling.
+      // Thus the header and the details tab can be aligned on the same line.
+      .attributes-group:first-of-type {
+        margin-top: 0px;
+
+        .attributes-group--header-container {
+          padding-bottom: 2px;
+
+          h3.attributes-group--header-text {
+            line-height: $work-package-details--tab-height - 10px;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR takes the styles from the right panel of the full screen view and applies them to the left panel. Thus the two header elements are aligned on the same line.

https://community.openproject.org/work_packages/21678/activity
