### PR TITLE
[21676] Misaligned input fields on timeline edit

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -267,6 +267,7 @@ fieldset.form--fieldset
   @include grid-visible-overflow
   align-items: center
   margin-bottom: 0.825rem
+  height: 100%
 
   &.-vertical,
   .form.-vertical &

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -474,6 +474,12 @@ input[readonly].-clickable
   border: none
   padding-right: 0
 
+  &.select2-container
+    // styles adapted to input fields to align them
+    margin-bottom: 0.5rem
+    .select2-choice
+      height: 2.15rem
+
 .form--text-field,
 .form--select
   &.-tiny

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -515,6 +515,7 @@ input[readonly].-clickable
 
   .form--grouping-row
     @include grid-block(10)
+    align-items: center
 
   .form--grouping-row + .form--grouping-row
     @include grid-offset(2)


### PR DESCRIPTION
This PR gives the concerning select field the same margin as the input fields.

https://community.openproject.org/work_packages/21676/activity
