### PR TITLE
rely on fully qualified uris for HALAPI

### DIFF
--- a/frontend/app/api/hal-api-resource.js
+++ b/frontend/app/api/hal-api-resource.js
@@ -29,7 +29,7 @@
 /* globals Hyperagent */
 require('hyperagent');
 
-module.exports = function HALAPIResource($timeout, $q, PathHelper) {
+module.exports = function HALAPIResource($timeout, $q) {
   'use strict';
   var configure = function() {
     Hyperagent.configure('ajax', function(settings) {
@@ -61,12 +61,12 @@ module.exports = function HALAPIResource($timeout, $q, PathHelper) {
         params = {};
       }
       configure();
-      var url = PathHelper.appBasePath + PathHelper.apiV3 + '/' + uri;
+
       var link = new Hyperagent.Resource(_.extend({
-        url: url
+        url: uri
       }, params));
       if (params.method) {
-        link.props.href = url;
+        link.props.href = uri;
         link.props.method = params.method;
       }
       return link;

--- a/frontend/app/api/index.js
+++ b/frontend/app/api/index.js
@@ -29,5 +29,5 @@
 angular.module('openproject.api')
   .factory('HALAPIResource', ['$timeout',
       '$q',
-      'PathHelper', require('./hal-api-resource')
+      require('./hal-api-resource')
   ]);

--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -245,6 +245,9 @@ module.exports = function() {
     apiV3TypePath: function(typeId) {
       return PathHelper.apiV3 + '/types/' + typeId;
     },
+    apiV3UserPath: function(userId) {
+      return PathHelper.apiV3 + '/users/' + userId;
+    },
     apiStatusesPath: function() {
       return PathHelper.apiV3 + '/statuses';
     },

--- a/frontend/app/services/user-service.js
+++ b/frontend/app/services/user-service.js
@@ -32,8 +32,9 @@ module.exports = function(HALAPIResource, $http, PathHelper) {
 
   var UserService = {
     getUser: function(id) {
-      // TODO authorization
-      var resource = HALAPIResource.setup("users/" + id);
+      var path = PathHelper.apiV3UserPath(id),
+          resource = HALAPIResource.setup(path);
+
       return resource.fetch();
     },
 

--- a/frontend/app/services/work-package-service.js
+++ b/frontend/app/services/work-package-service.js
@@ -115,7 +115,9 @@ module.exports = function($http,
     },
 
     getWorkPackage: function(id) {
-      var resource = HALAPIResource.setup('work_packages/' + id);
+      var path = PathHelper.apiV3WorkPackagePath(id),
+          resource = HALAPIResource.setup(path);
+
       return resource.fetch().then(function (wp) {
         return $q.all([
           WorkPackageService.loadWorkPackageForm(wp),

--- a/frontend/tests/unit/tests/api/hal-api-resource-test.js
+++ b/frontend/tests/unit/tests/api/hal-api-resource-test.js
@@ -50,7 +50,7 @@ describe('HALAPIResource', function() {
 
   describe('setup', function() {
     var apiResource, resourceFunction;
-    var workPackageUri = 'work_packages/1';
+    var workPackageUri = 'api/v3/work_packages/1';
 
     beforeEach(inject(function($q) {
       apiResource = {
@@ -60,37 +60,17 @@ describe('HALAPIResource', function() {
 
     beforeEach(inject(function(HALAPIResource) {
       resourceFunction = sinon.stub(Hyperagent, 'Resource').returns(apiResource);
+      HALAPIResource.setup(workPackageUri);
     }));
 
     afterEach(function() {
       resourceFunction.restore();
     });
 
-    describe('with default (empty) base path', function() {
-      beforeEach(inject(function() {
-        HALAPIResource.setup(workPackageUri);
-      }));
-
-      it('makes an api setup call', function() {
-        expect(resourceFunction).to.have.been.calledWith({
-          url: "/api/v3/" + workPackageUri
-        });
-      });
-    });
-
-    describe('with custom appBasePath', function() {
-      beforeEach(inject(function() {
-        testPathHelper.appBasePath = '/whitelabel';
-
-        HALAPIResource.setup(workPackageUri);
-      }));
-
-      it('makes an api setup call', function() {
-        expect(resourceFunction).to.have.been.calledWith({
-          url: "/whitelabel/api/v3/" + workPackageUri
-        });
-      });
-    });
-
+   it('makes an api setup call', function() {
+     expect(resourceFunction).to.have.been.calledWith({
+       url: workPackageUri
+     });
+   });
   });
 });

--- a/frontend/tests/unit/tests/services/work-package-service-test.js
+++ b/frontend/tests/unit/tests/services/work-package-service-test.js
@@ -100,7 +100,7 @@ describe('WorkPackageService', function() {
     }));
 
     it('makes an api setup call', function() {
-      expect(setupFunction).to.have.been.calledWith("work_packages/" + workPackageId);
+      expect(setupFunction).to.have.been.calledWith("/api/v3/work_packages/" + workPackageId);
     });
 
     it('returns work package', function() {


### PR DESCRIPTION
As we should more and more rely on the links provided by the API, it makes less and less sense to construct the urls by ourselves. We can simply use the links, the api offers. There are still a lot of places that construct the uri manually. The HALAPIRessource adds to that manual construction by adding [appBasePath] + /api/v3 to every path provided to it. The callers do now have to care for that. The current callers have been altered so that they do by relying on the PathHelper which should reduce the places in which uris are constructed.

This is part of a bugfix for
https://community.openproject.org/work_packages/21695
but is also an improvement of the general code.
