### PR TITLE
[21679] White space under WP in full screen view

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -28,15 +28,9 @@
 
 body.controller-work_packages.action-show {
   overflow-x: auto;
-
-  #content {
-    padding-bottom: 0;
-    position: relative;
-  }
 }
 
 .work-packages--show-view {
-  height: calc(100vh - 161px);
 
   #toolbar {
     @include clearfix;

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -29,6 +29,9 @@
 .controller-work_packages.action-index
   @extend %absolute-layout-mode
 
+.controller-work_packages.action-show
+  @extend %absolute-layout-mode
+
 #content
   $flash-margins-padding: 10px
 


### PR DESCRIPTION
This PR shall avoid white space under WP in full screen view. This appears when the menu sidebar is larger than the viewable window.

https://community.openproject.org/work_packages/21679/activity
