### PR TITLE
[21671] Fix missing project scope in routes

### DIFF
--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -195,7 +195,8 @@ angular.module('openproject')
   '$rootElement',
   '$browser',
   '$rootScope',
-  function($location, $rootElement, $browser, $rootScope) {
+  '$state',
+  function($location, $rootElement, $browser, $rootScope, $state) {
     // Our application is still a hybrid one, meaning most routes are still
     // handled by Rails. As such, we disable the default link-hijacking that
     // Angular's HTML5-mode turns on.
@@ -221,6 +222,15 @@ angular.module('openproject')
           // hack to work around FF6 bug 684208 when scenario runner clicks on links
           window.angular['ff-684208-preventDefault'] = true;
         }
+      }
+    });
+
+    $rootScope.$on('$stateChangeStart', function(event, toState, toParams){
+      var matchListState = toState.name.match(/work-packages\.list.*/);
+
+      if (matchListState && !toParams.projects && toParams.projectPath) {
+        toParams.projects = 'projects';
+        $state.go(toState, toParams);
       }
     });
   }

--- a/frontend/tests/unit/tests/work_packages/routing-test.js
+++ b/frontend/tests/unit/tests/work_packages/routing-test.js
@@ -1,0 +1,50 @@
+describe('Routing', function () {
+  var $rootScope, $state, mockState = { go: function () {} };
+
+  beforeEach(module('openproject', function ($provide) {
+    $provide.value('$state', mockState);
+  }));
+
+  beforeEach(inject(function (_$rootScope_) {
+    $rootScope = _$rootScope_;
+  }));
+
+  describe('when the project id is set', function () {
+    var toState, toParams,
+        spy = sinon.spy(mockState, 'go'),
+        broadcast = function () {
+          $rootScope.$broadcast('$stateChangeStart', toState, toParams);
+        };
+
+    beforeEach(function () {
+      toState = { name: 'work-packages.list' };
+      toParams = { projectPath: 'my_project', projects: null };
+    });
+
+    it('sets the projects path segment to "projects" ', function () {
+      broadcast();
+      expect(toParams.projects).to.equal('projects');
+    });
+
+    it('routes to the given state', function () {
+      broadcast();
+      expect(spy.withArgs(toState, toParams).called).to.be.true;
+    });
+
+    it('routes to child states of work-packages.list', function () {
+      var childStates = ['child', 'my.other.child'];
+
+      childStates.forEach(function (childState) {
+        toState.name = 'work-packages.list.' + childState;
+        broadcast();
+        expect(spy.withArgs(toState, toParams).calledOnce).to.be.true;
+      });
+    });
+
+    it('is ignored on other routes than work-packages.list', function () {
+      toState.name = 'work-packages.other.route';
+      broadcast();
+      expect(spy.withArgs(toState, toParams).called).to.be.false;
+    })
+  });
+});


### PR DESCRIPTION
Add project scope to all routes  of work-packages.list where the project identifier (named projectPath) is set.
This should fix all work package routing errors related to the one referred to below.

https://community.openproject.org/work_packages/21671/activity
