### PR TITLE
[Gitolite Plugin] Core notifications to alleviate third-party repository plugins

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -150,6 +150,7 @@ class ProjectsController < ApplicationController
           redirect_to action: 'settings', id: @altered_project
         end
       end
+      OpenProject::Notifications.send('project_updated', project: @altered_project)
     else
       respond_to do |format|
         format.html do
@@ -215,6 +216,7 @@ class ProjectsController < ApplicationController
   def destroy
     @project_to_destroy = @project
 
+    OpenProject::Notifications.send('project_deletion_imminent', project: @project_to_destroy)
     @project_to_destroy.destroy
     respond_to do |format|
       format.html do redirect_to controller: '/admin', action: 'projects' end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -59,6 +59,7 @@ class RolesController < ApplicationController
       end
       flash[:notice] = l(:notice_successful_create)
       redirect_to action: 'index'
+      notify_changed_roles(:added, @role)
     else
       @permissions = @role.setable_permissions
       @roles = Role.order('builtin, position')
@@ -78,6 +79,7 @@ class RolesController < ApplicationController
     if @role.update_attributes(permitted_params.role)
       flash[:notice] = l(:notice_successful_update)
       redirect_to action: 'index'
+      notify_changed_roles(:updated, @role)
     else
       @permissions = @role.setable_permissions
       render action: 'edit'
@@ -88,6 +90,7 @@ class RolesController < ApplicationController
     @role = Role.find(params[:id])
     @role.destroy
     redirect_to action: 'index'
+    notify_changed_roles(:removed, @role)
   rescue
     flash[:error] =  l(:error_can_not_remove_role)
     redirect_to action: 'index'
@@ -108,6 +111,7 @@ class RolesController < ApplicationController
 
     flash[:notice] = l(:notice_successful_update)
     redirect_to action: 'index'
+    notify_changed_roles(:bulk_update, @roles)
   end
 
   def autocomplete_for_role
@@ -122,5 +126,11 @@ class RolesController < ApplicationController
     respond_to do |format|
       format.json
     end
+  end
+
+  private
+
+  def notify_changed_roles(action, changed_role)
+    OpenProject::Notifications.send(:roles_changed, action: action, role: changed_role)
   end
 end

--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -87,9 +87,8 @@ class SysController < ActionController::Base
   def authorized?(project, user)
     repository = project.repository
 
-    if repository
-      policy = repository.class.authorization_policy
-      policy.new(project, user).authorized?(params)
+    if repository && repository.class.authorization_policy
+      repository.class.authorization_policy.new(project, user).authorized?(params)
     else
       false
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -45,6 +45,9 @@ class Member < ActiveRecord::Base
   before_destroy :remove_from_category_assignments
   after_destroy :unwatch_from_permission_change
 
+  after_save :save_notification
+  after_destroy :destroy_notification
+
   def name
     principal.name
   end
@@ -213,5 +216,13 @@ class Member < ActiveRecord::Base
     if user
       Watcher.prune(user: user, project: project)
     end
+  end
+
+  def save_notification
+    ::OpenProject::Notifications.send(:member_updated, member: self)
+  end
+
+  def destroy_notification
+    ::OpenProject::Notifications.send(:member_removed, member: self)
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -138,6 +138,10 @@ class Repository < ActiveRecord::Base
     true
   end
 
+  def self.requires_checkout_base_url?
+    true
+  end
+
   def entry(path = nil, identifier = nil)
     scm.entry(path, identifier)
   end
@@ -410,7 +414,7 @@ class Repository < ActiveRecord::Base
     self.class.connection.delete("DELETE FROM #{cs} WHERE #{cs}.repository_id = #{id}")
   end
 
-  private
+  protected
 
   ##
   # Create local managed repository request when the built instance

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -71,12 +71,19 @@ class Scm::CheckoutInstructionsService
   end
 
   ##
+  # Determines whether the checkout URL may be built, i.e. all information is available
+  # This is the case when the base_url is set or the vendor doesn't use base URLs.
+  def checkout_url_buildable?
+    !repository.class.requires_checkout_base_url? || checkout_base_url.present?
+  end
+
+  ##
   # Returns whether the repository supports showing checkout information
   # and has been configured for it.
   def available?
     checkout_enabled? &&
       repository.supports_checkout_info? &&
-      checkout_base_url.present?
+      checkout_url_buildable?
   end
 
   def checkout_enabled?

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -355,7 +355,7 @@ module OpenProject
           end
         end
 
-        private
+        protected
 
         ##
         # Builds the full git arguments from the parameters


### PR DESCRIPTION
This commit provides some helpers to alleviate SCM vendor plugins:
- Provide code notifications when project, members and users are changed.
- Allow Repository:\* to determine base URL themselves
  (when no common URL is available)
- Open Git adapter for subclassing (Gitolite)

This code is mainly required for better integration of custom repository plugins, such as the [Gitolite plugin](https://github.com/oliverguenther/openproject-revisions_git), which is updated by OpenProject GmbH for the Technische Universität Darmstadt.

Relevant work packages:
https://community.openproject.org/work_packages/20412
https://community.openproject.org/work_packages/21537
