### PR TITLE
Use correct manual work package form path

### DIFF
--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -233,11 +233,17 @@ module.exports = function() {
     apiV3WorkPackagePath: function(workPackageId) {
       return PathHelper.apiV3 + '/work_packages/' + workPackageId;
     },
+    apiV3WorkPackageFormPath: function(projectIdentifier) {
+      return PathHelper.apiv3ProjectWorkPackagesPath(projectIdentifier) + '/form';
+    },
     apiPrioritiesPath: function() {
       return PathHelper.apiV3 + '/priorities';
     },
     apiV3ProjectsPath: function(projectIdentifier) {
       return PathHelper.apiV3 + PathHelper.projectsPath() + '/' + projectIdentifier;
+    },
+    apiv3ProjectWorkPackagesPath: function(projectIdentifier) {
+      return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/work_packages';
     },
     apiV3ProjectCategoriesPath: function(projectIdentifier) {
       return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/categories';

--- a/frontend/app/services/work-package-service.js
+++ b/frontend/app/services/work-package-service.js
@@ -88,9 +88,9 @@ module.exports = function($http,
         links: {
           update: HALAPIResource
             .setup(PathHelper
-              .projectWorkPackagesFormPath(projectIdentifier)),
+              .apiV3WorkPackageFormPath(projectIdentifier)),
           updateImmediately: HALAPIResource.setup(
-            PathHelper.projectWorkPackagesPath(projectIdentifier),
+            PathHelper.apiv3ProjectWorkPackagesPath(projectIdentifier),
             { method: 'post' }
           )
         }

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'features/work_packages/details/inplace_editor/work_package_field'
+require 'features/work_packages/work_packages_page'
+
+describe 'new work package', js: true do
+  let(:type_task) { FactoryGirl.create(:type_task) }
+  let(:types) { [type_task] }
+  let(:status) { FactoryGirl.build(:status, is_default: true) }
+  let(:priority) { FactoryGirl.build(:priority, is_default: true) }
+  let(:project) {
+    FactoryGirl.create(:project, types: types)
+  }
+
+  let(:user) { FactoryGirl.create :admin }
+  let(:work_packages_page) { WorkPackagesPage.new(project) }
+
+  let(:subject) { 'My subject' }
+  let(:description) { 'A description of the newly-created work package.' }
+
+  let(:subject_field) { WorkPackageField.new(page, :subject) }
+  let(:description_field) { WorkPackageField.new(page, :description) }
+
+  before do
+    status.save!
+    priority.save!
+
+    login_as(user)
+    allow(user.pref).to receive(:warn_on_leaving_unsaved).and_return('0')
+
+    work_packages_page.visit_index
+    work_packages_page.click_toolbar_button 'Work packages'
+
+    within '#tasksDropdown' do
+      click_link 'Task'
+    end
+  end
+
+  it 'sucessfully creates a work package' do
+    expect(page).to have_selector('.work-packages--details-content.-create-mode')
+
+    find('#work-package-subject input').set(subject)
+    find('#work-package-description textarea').set(description)
+
+    within '.work-packages--details-toolbar' do
+      click_button 'Save'
+    end
+
+    expect(page).to have_selector('.work-packages--details #tabs')
+    expect(subject_field.read_state_text).to eq(subject)
+    expect(description_field.read_state_text).to eq(description)
+  end
+end


### PR DESCRIPTION
The new controller builds its own API resource using the
static `/projects/:identifier/work_packages/form` path,
which was expanded with the `/api/v3` prefix until 0c768829e7cd63d5b9cbb85bd837dc2f20566c54.

With this commit, the resource was invalid and causes new work packages to be broken.
In order to restore the manual path, a new path helper was created.
