### PR TITLE
Use fuubar as the default formatter on dev machines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -193,6 +193,7 @@ group :development, :test do
   gem 'pry-rescue'
   gem 'pry-byebug', platforms: [:mri]
   gem 'pry-doc'
+  gem 'fuubar'
 end
 
 # API gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,9 @@ GEM
     formatador (0.2.5)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
+    fuubar (2.0.0)
+      rspec (~> 3.0)
+      ruby-progressbar (~> 1.4)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.6)
@@ -553,6 +556,7 @@ DEPENDENCIES
   faker
   fog (~> 1.23.0)
   friendly_id (~> 5.1.0)
+  fuubar
   globalize (~> 5.0.1)
   gon (~> 4.0)
   grape (~> 0.10.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,14 @@ RSpec.configure do |config|
   # Thanks a lot!
   config.use_transactional_fixtures = false
 
+  # Use fuubar as the defualt formatter, which outputs failures immediately while
+  # continuing to run the suite.
+  # Also may be disabled on the user's choice with a custom env variable
+  # Needs to remain disabled on the CI due to tty incompatibility
+  unless ENV['CI'] || ENV['RSPEC_USE_DEFAULT_FORMATTER']
+    config.formatter = 'Fuubar'
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
   end


### PR DESCRIPTION
Fuubar provides a custom rspec formatter with early failure output while the suite is running.

![bildschirmfoto 2015-10-09 um 09 53 58](https://cloud.githubusercontent.com/assets/459462/10388628/efd6763e-6e6b-11e5-83b2-980ae4669bf3.png)

<img width="969" alt="bildschirmfoto 2015-10-09 um 09 53 40" src="https://cloud.githubusercontent.com/assets/459462/10388630/f104b408-6e6b-11e5-9c9a-a07c805eae6e.png">
