### PR TITLE
don't mess things up for sqlite

### DIFF
--- a/config/initializers/enforce_isolation_level.rb
+++ b/config/initializers/enforce_isolation_level.rb
@@ -46,7 +46,7 @@ module ConnectionIsolationLevel
     isolation_level = 'ISOLATION LEVEL READ COMMITTED'
     if OpenProject::Database.mysql?(connection)
       connection.execute("SET SESSION TRANSACTION #{isolation_level}")
-    else
+    elsif OpenProject::Database.postgresql?(connection)
       connection.execute("SET SESSION CHARACTERISTICS AS TRANSACTION #{isolation_level}")
     end
   end


### PR DESCRIPTION
Part of WP [#21726](https://community.openproject.org/work_packages/21726/activity)

With this the app can be initialized with sqlite so we can precompile assets without a postgres/mysql db.
