### PR TITLE
[21592] Labels have extra margin-bottom

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -105,7 +105,6 @@ div.issue div.subject
     margin-top: 0.5em
 
 .buttons
-  margin-bottom: 1.4em
   margin-top: 1em
 
 div
@@ -498,12 +497,14 @@ a.has-thumb
   -o-text-overflow: ellipsis
   -ms-text-overflow: ellipsis
 
-label.label-with-input
-  display: block
-  white-space: nowrap
-  zoom: 1
-  margin-left: 0
-  float: none
+label
+  margin-bottom: 0rem
+  &.label-with-input
+    display: block
+    white-space: nowrap
+    zoom: 1
+    margin-left: 0
+    float: none
 
 #query_form_content
   padding-top: 10px

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -372,7 +372,7 @@ $form-padding: 0.375rem;
 
 // Labels
 // $form-label-fontsize: 0.9rem;
-// $form-label-margin: 0.5rem;
+// $form-label-margin: 0rem;
 // $form-label-color: #333;
 
 // Inline labels

--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -71,28 +71,17 @@
 .advanced-filters--number-field
   @extend .form--text-field, .form--text-field.-small
 
-%advanced-filters--filter-part
-  .inline-label
-    margin-bottom: 0
-  // adding the input rules to be more specific than the resets of
-  // foundation.
-  input, select
-    margin-bottom: 0
-
 .advanced-filters--filter-name
   @include grid-content(3)
-  @extend %advanced-filters--filter-part
   overflow-y: hidden
   white-space: nowrap
   text-overflow: ellipsis
 
 .advanced-filters--filter-operator
   @include grid-content(3)
-  @extend %advanced-filters--filter-part
 
 .advanced-filters--filter-value
   @include grid-content(5)
-  @extend %advanced-filters--filter-part
 
 .advanced-filters--remove-filter
   @include grid-content($size: shrink)
@@ -106,7 +95,6 @@
 
 .advanced-filters--add-filter
   @include advanced-filters--sizing
-  @extend %advanced-filters--filter-part
   align-items:      center
   padding:          0.25rem 0
 

--- a/app/assets/stylesheets/content/_buttons.sass
+++ b/app/assets/stylesheets/content/_buttons.sass
@@ -57,6 +57,8 @@ a.button
   transition-duration: 0.25s
   transition-timing-function: ease-out
 
+  margin-bottom: 0rem
+
   &:disabled
     @include button-disabled
 

--- a/app/assets/stylesheets/content/_buttons.sass
+++ b/app/assets/stylesheets/content/_buttons.sass
@@ -57,8 +57,6 @@ a.button
   transition-duration: 0.25s
   transition-timing-function: ease-out
 
-  margin-bottom: 0rem
-
   &:disabled
     @include button-disabled
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -36,6 +36,7 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
     border: $content-form-input-hover-border
 
   vertical-align: middle
+  margin-bottom: 0rem
 
 %label-style
   text-align: left
@@ -453,8 +454,10 @@ fieldset.form--fieldset
   @extend %input-style
 
 .form--text-field,
-#{$text-input-selectors}
+#{$text-input-selectors},
+select
   line-height: 1.5
+  margin-bottom: 0rem
 
 input[readonly].-clickable
   cursor: pointer
@@ -495,13 +498,13 @@ input[readonly].-clickable
     max-width: 100%
 
   .form &
-    margin-bottom: 0.5rem
+    margin-bottom: 0rem
 
 .form--text-area
   @extend %input-style
 
   .form &
-    margin-bottom: 0.5rem
+    margin-bottom: 0rem
 
 .form--radio-button-container
   //prevent radio-buttons from being cut at the border
@@ -567,6 +570,7 @@ input[readonly].-clickable
     flex-basis: auto
 
 .inline-label
+  margin: 0rem
   > .form-label.-transparent
     margin-bottom: 0
     font-size: 1em
@@ -593,7 +597,7 @@ input[readonly].-clickable
   // OR $inlinelabel-border
   border-radius:  2px
   padding:        0 $form-padding
-  margin-bottom:  0.5rem
+  margin-bottom:  0rem
   align-items:    center
   line-height:    1
 

--- a/app/assets/stylesheets/content/_legacy_actions.sass
+++ b/app/assets/stylesheets/content/_legacy_actions.sass
@@ -97,6 +97,7 @@ ul.legacy-actions-more
 
 .legacy-actions--inline-label
   @extend .inline-label
+  margin-bottom: 1rem
   height: 1.5em
 
   .form-label

--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -38,7 +38,7 @@ $filters--border-color: $gray !default
 
 .simple-filters--container
   @extend %filters--container
-  padding: 1rem 1rem 0
+  padding: 1rem 1rem 1rem 1rem
   margin: 0.6em 0
 
   .simple-filter--trailing-labels
@@ -70,6 +70,7 @@ $filters--border-color: $gray !default
   .simple-filters--filter,
     padding: 0
     display: flex
+    align-items: center
     @include breakpoint(large)
 
     .simple-filters--filter-name
@@ -83,9 +84,13 @@ $filters--border-color: $gray !default
 
   .simple-filters--controls
     padding: 0
-    align-self: flex-start
+    align-self: center
     @include breakpoint(large)
       flex: 1
+
+    button,
+    .button
+      margin-bottom: 0rem
 
 .simple-filters--filters.-columns-3
   justify-content: flex-start
@@ -100,4 +105,9 @@ $filters--border-color: $gray !default
   .simple-filters--filter,
   .simple-filters--controls
     padding: 0
+    align-self: center
     @include breakpoint(large)
+
+    button,
+    .button
+      margin-bottom: 0rem

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -142,14 +142,15 @@ table.generic-table
       overflow:  hidden
       text-overflow: ellipsis
       text-align: left
-      line-height: 34px
+      line-height: 2rem
       vertical-align: middle
 
       // Center input fields and select boxes vertically in tables
       .form--field
         margin: 0px
       @each $inputElement in $input-elements
-        #{$inputElement}
+        #{$inputElement},
+        #{$inputElement}~.form-label
           margin-top: 0.5rem
           margin-bottom: 0.5rem
 


### PR DESCRIPTION
This PR removes the `margin-bottom` - values from labels and input fields. Thus only the container element should contain a margin-bottom-value and elements shall be aligned more easily.

_Note_: Part of the ticket was the correct alignment of labels and input fields. Since I could not reproduce that there are no explicit changes for that. However since `vertical-align: middle` and the removed margin the elements should be correctly aligned.

https://community.openproject.org/work_packages/21592/activity
