### PR TITLE
[21707] Style danger zone for deleting a repository

### DIFF
--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -54,30 +54,32 @@ See doc/COPYRIGHT.rdoc for more details.
   </section>
 <% end %>
 <% else %>
-<%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
-  <section class="form--section">
-    <h3 class="form--section-title">
-      <%= l('repositories.destroy.title_not_managed', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>").html_safe %>
-    </h3>
-    <p>
-      <%= simple_format l('repositories.destroy.linked_text',
-                        project_name: @project.identifier, url: @repository.url) %>
-    </p>
-    <p class="danger-zone--warning">
-      <span class="icon icon-attention2"></span>
-      <span><%= l('repositories.destroy.info_not_managed') %></span>
-    </p>
-    <div class="danger-zone--verification">
-      <%= styled_button_tag project_repository_path(@project),
-        title: l(:button_delete),
-        method: :delete,
-        disabled: false,
-        class: '-highlight' do %>
+  <div class="notification-box -warning">
+    <div class="notification-box--content">
+      <p><strong><%= l('repositories.destroy.title_not_managed', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>").html_safe %></strong><br /></p>
+      <p>
+        <%= simple_format l('repositories.destroy.linked_text',
+                          project_name: @project.identifier, url: @repository.url) %>
+      </p>
+      <p>
+        <span><%= l('repositories.destroy.info_not_managed') %></span>
+      </p>
+      <p>
+        <%= link_to project_repository_path(@project),
+          title: l(:button_delete),
+          method: :delete,
+          class: 'button' do %>
           <i class="button--icon icon-delete"></i>
           <span class="button--text"><%= l(:button_delete) %></span>
-      <% end %>
+        <% end %>
+        <%= link_to settings_repository_tab_path,
+          title: l(:button_cancel),
+          class: 'button' do %>
+          <i class="button--icon icon-close"></i>
+          <span class="button--text"><%= l(:button_cancel) %></span>
+        <% end %>
+      </p>
     </div>
-  </section>
-<% end %>
+  </div>
 <% end %>
 

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -54,29 +54,30 @@ See doc/COPYRIGHT.rdoc for more details.
   </section>
 <% end %>
 <% else %>
-<div class="notification-box -warning">
-  <div class="notification-box--content">
-    <p><strong><%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %></strong><br /></p>
+<%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
+  <section class="form--section">
+    <h3 class="form--section-title">
+      <%= l('repositories.destroy.title_not_managed', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>").html_safe %>
+    </h3>
     <p>
       <%= simple_format l('repositories.destroy.linked_text',
                         project_name: @project.identifier, url: @repository.url) %>
     </p>
-    <p>
-      <%= link_to project_repository_path(@project),
+    <p class="danger-zone--warning">
+      <span class="icon icon-attention2"></span>
+      <span><%= l('repositories.destroy.info_not_managed') %></span>
+    </p>
+    <div class="danger-zone--verification">
+      <%= styled_button_tag project_repository_path(@project),
         title: l(:button_delete),
         method: :delete,
-        class: 'button' do %>
-        <i class="button--icon icon-delete"></i>
-        <span class="button--text"><%= l(:button_delete) %></span>
+        disabled: false,
+        class: '-highlight' do %>
+          <i class="button--icon icon-delete"></i>
+          <span class="button--text"><%= l(:button_delete) %></span>
       <% end %>
-      <%= link_to settings_repository_tab_path,
-        title: l(:button_cancel),
-        class: 'button' do %>
-        <i class="button--icon icon-close"></i>
-        <span class="button--text"><%= l(:button_cancel) %></span>
-      <% end %>
-    </p>
-  </div>
-</div>
+    </div>
+  </section>
+<% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1397,9 +1397,11 @@ en:
     destroy:
       confirmation: "If you continue, this will permanently delete the managed repository of %{project_name}."
       info: "Deleting the repository is an irreversible action."
-      linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}.\nNote: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
+      info_not_managed: "Note: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
+      linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}."
       managed_path_note: "The following directory will be erased: %{path}"
       title: "Do you really want to delete the %{repository_type} of the project %{project_name}?"
+      title_not_managed: "Do you really want to delete the linked %{repository_type}?"
     errors:
       build_failed: "Unable to create the repository with the selected configuration. %{reason}"
       managed_delete: "Unable to delete the managed repository."


### PR DESCRIPTION
This applies the danger zone styling for linked repositories. Further the title and destroy info text were updated.

https://community.openproject.org/work_packages/21707/activity
