### PR TITLE
Test fix for broken teatro

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,10 +1,10 @@
 stage:
   before:
-    - npm install -g npm
-    - cd frontend;
-      /usr/local/bin/npm install --unsafe-perm --ignore-scripts &&
+    - npm install npm
+    - pushd frontend;
+      npm install --unsafe-perm --ignore-scripts;
       bower install --allow-root;
-      cd ..
+      popd
     - cp config/configuration.yml.example config/configuration.yml
     - cp config/database.teatro.yml config/database.yml
     - bundle exec rake generate_secret_token


### PR DESCRIPTION
Teatro fails to prepare branches at the moment with the following output:

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'are-we-there-yet'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npmlog/log.js:2:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
