### PR TITLE
Fix chained rake commands

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -62,6 +62,15 @@ module OpenProject::Plugins
             config.paths['db/migrate'].expanded.each do |expanded_path|
               app.config.paths['db/migrate'] << expanded_path
             end
+
+            ##
+            # Manually inject these paths into various places
+            # in order to re-enable chained rake tasks
+            # finding all migrations.
+            # http://blog.pivotal.io/pivotal-labs/labs/leave-your-migrations-in-your-rails-engines
+            paths = app.config.paths['db/migrate'].to_a
+            ActiveRecord::Tasks::DatabaseTasks.migrations_paths |= paths
+            ActiveRecord::Migrator.migrations_paths |= paths
           end
         end
       end


### PR DESCRIPTION
In its current implementation, our plugins (Rails engines)
automatically append their migration paths to the root application
`config['db/migrate']`.

This procedure works fine unless using a chained rake command,
such as `db:create db:migrate db:seed` due to the migration paths
simply not being updated timely.

The following simple fix extends the OP engine class to
set the migration paths of both `ActiveRecord::Tasks::DatabaseTasks`
and `ActiveRecord::Migrator` to the union of the existing paths
and the root config after migration paths of a plugin were added.

This should effectively fix the chaining issue.
