### PR TITLE
[21786] Issues with danger zones

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -84,6 +84,9 @@
         <i class="button--icon icon-delete"></i>
         <span class="button--text">Delete</span>
       </button>
+      <a class="button -with-icon icon-cancel">
+       Cancel
+      </a>
     </div>
   </section>
 </form>

--- a/app/views/projects/destroy_info.html.erb
+++ b/app/views/projects/destroy_info.html.erb
@@ -54,6 +54,11 @@ See doc/COPYRIGHT.rdoc for more details.
            concat content_tag :i, '', class: 'button--icon icon-delete'
            concat content_tag :span, l(:button_delete), class: 'button--text'
            end %>
+      <%= link_to admin_projects_path,
+          title: l(:button_cancel),
+          class: 'button -with-icon icon-cancel' do %>
+            <%= l(:button_cancel) %>
+          <% end %>
     </div>
   </section>
 <% end %>

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -27,32 +27,36 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% if @repository.managed? %>
-<%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
-  <section class="form--section">
-    <h3 class="form--section-title">
-      <%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
-    </h3>
-    <p>
-      <%= l('repositories.destroy.confirmation', project_name: @project.identifier) %>
-      <br/>
-      <%= l('repositories.destroy.managed_path_note', path: @repository.root_url) %>
-    </p>
-    <p class="danger-zone--warning">
-      <span class="icon icon-attention2"></span>
-      <span><%= l('repositories.destroy.info') %></span>
-    </p>
-    <div class="danger-zone--verification">
-      <%= styled_button_tag project_repository_path(@project),
-        method: :delete,
-        title: l(:button_delete),
-        disabled: false,
-        class: '-highlight' do %>
-          <i class="button--icon icon-delete"></i>
-          <span class="button--text"><%= l(:button_delete) %></span>
-      <% end %>
-    </div>
-  </section>
-<% end %>
+  <%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
+    <section class="form--section">
+      <h3 class="form--section-title">
+        <%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
+      </h3>
+      <p>
+        <%= l('repositories.destroy.confirmation', project_name: @project.identifier) %>
+        <br/>
+        <%= l('repositories.destroy.managed_path_note', path: @repository.root_url) %>
+      </p>
+      <p class="danger-zone--warning">
+        <span class="icon icon-attention2"></span>
+        <span><%= l('repositories.destroy.info') %></span>
+      </p>
+      <p>
+        <%= l('repositories.destroy.repository_verification', identifier: "<em class=\"danger-zone--expected-value\">#{h(@project.identifier)}</em>").html_safe %>
+      </p>
+      <div class="danger-zone--verification">
+        <input type="text"></input>
+        <%= styled_button_tag project_repository_path(@project),
+          method: :delete,
+          title: l(:button_delete),
+          disabled: true,
+          class: '-highlight' do %>
+            <i class="button--icon icon-delete"></i>
+            <span class="button--text"><%= l(:button_delete) %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
 <% else %>
   <div class="notification-box -warning">
     <div class="notification-box--content">
@@ -69,8 +73,8 @@ See doc/COPYRIGHT.rdoc for more details.
           title: l(:button_delete),
           method: :delete,
           class: 'button' do %>
-          <i class="button--icon icon-delete"></i>
-          <span class="button--text"><%= l(:button_delete) %></span>
+          <i class="button--icon icon-remove"></i>
+          <span class="button--text"><%= l(:button_remove) %></span>
         <% end %>
         <%= link_to settings_repository_tab_path,
           title: l(:button_cancel),

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -55,6 +55,11 @@ See doc/COPYRIGHT.rdoc for more details.
             <i class="button--icon icon-delete"></i>
             <span class="button--text"><%= l(:button_delete) %></span>
         <% end %>
+        <%= link_to settings_repository_tab_path,
+          title: l(:button_cancel),
+          class: 'button -with-icon icon-cancel' do %>
+            <%= l(:button_cancel) %>
+        <% end %>
       </div>
     </section>
   <% end %>
@@ -81,9 +86,8 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
         <%= link_to settings_repository_tab_path,
           title: l(:button_cancel),
-          class: 'button' do %>
-          <i class="button--icon icon-close"></i>
-          <span class="button--text"><%= l(:button_cancel) %></span>
+          class: 'button -with-icon icon-cancel' do %>
+            <%= l(:button_cancel) %>
         <% end %>
       </p>
     </div>

--- a/app/views/repositories/destroy_info.html.erb
+++ b/app/views/repositories/destroy_info.html.erb
@@ -30,10 +30,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= styled_form_tag(project_repository_path(@project), method: :delete, class: 'danger-zone') do %>
     <section class="form--section">
       <h3 class="form--section-title">
-        <%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>", project_name: h(@project.identifier)).html_safe %>
+        <%= l('repositories.destroy.title', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>").html_safe %>
       </h3>
       <p>
-        <%= l('repositories.destroy.confirmation', project_name: @project.identifier) %>
+        <%= l('repositories.destroy.subtitle', repository_type: "#{h(@repository.repository_type)} - #{l(:project_module_repository)}", project_name: h(@project.identifier)).html_safe %> <br />
+        <%= l('repositories.destroy.confirmation') %>
         <br/>
         <%= l('repositories.destroy.managed_path_note', path: @repository.root_url) %>
       </p>
@@ -62,8 +63,10 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="notification-box--content">
       <p><strong><%= l('repositories.destroy.title_not_managed', repository_type: "<em>#{h(@repository.repository_type)} - #{l(:project_module_repository)}</em>").html_safe %></strong><br /></p>
       <p>
-        <%= simple_format l('repositories.destroy.linked_text',
-                          project_name: @project.identifier, url: @repository.url) %>
+        <%= l('repositories.destroy.subtitle_not_managed',
+            repository_type: "#{h(@repository.repository_type)} - #{l(:project_module_repository)}",
+            project_name: h(@project.identifier),
+            url: h(@repository.url)).html_safe %> <br />
       </p>
       <p>
         <span><%= l('repositories.destroy.info_not_managed') %></span>

--- a/app/views/repositories/settings/_vendor_attribute_groups.html.erb
+++ b/app/views/repositories/settings/_vendor_attribute_groups.html.erb
@@ -14,9 +14,15 @@
     <div class="attributes-group--header-control">
       <%= link_to l(:label_user_plural), committers_project_repository_path(repository.project),
             class: 'icon icon-user1' %>
-      <%= link_to l(:button_delete), destroy_info_project_repository_path(repository.project),
+      <% if type === 'managed' %>
+        <%= link_to l(:button_delete), destroy_info_project_repository_path(repository.project),
             method: :get,
             class:  'icon icon-delete' %>
+      <% else %>
+        <%= link_to l(:button_remove), destroy_info_project_repository_path(repository.project),
+            method: :get,
+            class:  'icon icon-remove' %>
+      <% end %>
     </div>
     <% end %>
   </div>

--- a/app/views/users/deletion_info.html.erb
+++ b/app/views/users/deletion_info.html.erb
@@ -54,6 +54,11 @@ See doc/COPYRIGHT.rdoc for more details.
           concat content_tag :i, '', class: 'button--icon icon-delete'
           concat content_tag :span, l(:button_delete), class: 'button--text'
           end %>
+        <%= link_to edit_user_path(@user),
+          title: l(:button_cancel),
+          class: 'button -with-icon icon-cancel' do %>
+            <%= l(:button_cancel) %>
+          <% end %>
       </div>
     </section>
   </div>

--- a/app/views/work_packages/bulk/destroy.html.erb
+++ b/app/views/work_packages/bulk/destroy.html.erb
@@ -81,6 +81,11 @@ See doc/COPYRIGHT.rdoc for more details.
             concat content_tag :i, '', class: 'button--icon icon-delete'
             concat content_tag :span, l(:button_delete), class: 'button--text'
             end %>
+      <%= link_to project_work_packages_path(@project),
+          title: l(:button_cancel),
+          class: 'button -with-icon icon-cancel' do %>
+            <%= l(:button_cancel) %>
+          <% end %>
   </section>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1400,6 +1400,7 @@ en:
       info_not_managed: "Note: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
       linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}."
       managed_path_note: "The following directory will be erased: %{path}"
+      repository_verification: "Enter the project's identifier %{identifier} to verify the deletion of its reopsitory."
       title: "Do you really want to delete the %{repository_type} of the project %{project_name}?"
       title_not_managed: "Do you really want to delete the linked %{repository_type}?"
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1348,7 +1348,7 @@ en:
       info: "Deleting the project is an irreversible action."
       project_verification: "Enter the project's name %{name} to verify the deletion."
       subprojects_confirmation: "Its subproject(s): %{value} will also be deleted."
-      title: "Do you really want to delete the project %{name}?"
+      title: "Delete the project %{name}"
 
   project_module_activity: "Activity"
   project_module_boards: "Forums"
@@ -1395,14 +1395,15 @@ en:
     create_successful: "The repository has been registered."
     delete_sucessful: "The repository has been deleted."
     destroy:
-      confirmation: "If you continue, this will permanently delete the managed repository of %{project_name}."
+      confirmation: "If you continue, this will permanently delete the managed repository."
       info: "Deleting the repository is an irreversible action."
       info_not_managed: "Note: This will NOT delete the contents of this repository, as it is not managed by OpenProject."
-      linked_text: "You're about to remove the linked repository %{url} from the project %{project_name}."
       managed_path_note: "The following directory will be erased: %{path}"
-      repository_verification: "Enter the project's identifier %{identifier} to verify the deletion of its reopsitory."
-      title: "Do you really want to delete the %{repository_type} of the project %{project_name}?"
-      title_not_managed: "Do you really want to delete the linked %{repository_type}?"
+      repository_verification: "Enter the project's identifier %{identifier} to verify the deletion of its repository."
+      subtitle: "Do you really want to delete the %{repository_type} of the project %{project_name}?"
+      subtitle_not_managed: "Do you really want to remove the linked %{repository_type} %{url} from the project %{project_name}?"
+      title: "Delete the %{repository_type}"
+      title_not_managed: "Remove the linked %{repository_type}?"
     errors:
       build_failed: "Unable to create the repository with the selected configuration. %{reason}"
       managed_delete: "Unable to delete the managed repository."
@@ -1913,7 +1914,7 @@ en:
         _Updated automatically by changing values within child work package %{child}_
     destroy:
       info: "Deleting the work package is an irreversible action."
-      title: "Do you really want to delete the work package?"
+      title: "Delete the work package"
 
   nothing_to_preview: "Nothing to preview"
 

--- a/features/work_packages/destroy.feature
+++ b/features/work_packages/destroy.feature
@@ -52,7 +52,7 @@ Feature: Deleting work packages
     When I go to the page of the work package "wp1"
     And I select "Delete" from the action menu
     And I confirm popups
-    Then I should see "DO YOU REALLY WANT TO DELETE THE WORK PACKAGE?"
+    Then I should see "DELETE THE WORK PACKAGE"
     When I choose "Reassign"
     And I fill in the id of work package "wp2" into "to_do_reassign_to_id"
     And I submit the form by the "Delete" button

--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -158,7 +158,7 @@ describe 'Create repository', type: :feature, js: true, selenium: true do
         expect(page).to have_selector('div.flash.notice',
                                       text: I18n.t('repositories.create_successful'))
         expect(page).to have_selector('button[type="submit"]', text: I18n.t(:button_save))
-        expect(page).to have_selector('a.icon-delete', text: I18n.t(:button_delete))
+        expect(page).to have_selector('a.icon-remove', text: I18n.t(:button_remove))
       end
     end
 

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -59,7 +59,7 @@ describe 'Repository Settings', type: :feature, js: true do
 
     it 'deletes the repository' do
       expect(Repository.exists?(repository.id)).to be true
-      find('a.icon-delete', text: I18n.t(:button_delete)).click
+      find('a.icon-remove', text: I18n.t(:button_remove)).click
 
       # Confirm the notification warning
       if type == 'managed'
@@ -67,7 +67,7 @@ describe 'Repository Settings', type: :feature, js: true do
         find('.danger-zone .button').click
       else
         expect(page).to have_selector('.notification-box.-warning')
-        find('a', text: I18n.t(:button_delete)).click
+        find('a', text: I18n.t(:button_remove)).click
       end
 
       vendor = find('select[name="scm_vendor"]')

--- a/spec/features/support/components/danger_zone.rb
+++ b/spec/features/support/components/danger_zone.rb
@@ -1,0 +1,70 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class DangerZone
+  include Capybara::DSL
+
+  attr_reader :page
+
+  def initialize(page)
+    @page = page
+  end
+
+  def container_selector
+    '.danger-zone--verification'
+  end
+
+  def confirmation_field
+    page.within container_selector do
+      find('input[type=text]')
+    end
+  end
+
+  def danger_button
+    page.within container_selector do
+      find('button.-highlight')
+    end
+  end
+
+  def cancel_button
+    page.within container_selector do
+      find('a.icon-cancel')
+    end
+  end
+
+  ##
+  # Set the confirmation field to the given value
+  def confirm_with(value)
+    confirmation_field.set value
+  end
+
+  ##
+  def disabled?
+    !!danger_button[:disabled]
+  end
+end


### PR DESCRIPTION
This PR deals with several issues with danger zones:
- [x] translation errors for german language
- [x] missing cancel button
- [x] missing confirm field in repositories danger zone
- [x] using 'remove' instead of 'delete' for not managed repositories
- [x] shorten the headline

For details see the WP: https://community.openproject.org/work_packages/21786/activity
