### PR TITLE
Load I18n::Backend::Fallbacks everytime

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -105,6 +105,9 @@ module OpenProject
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
 
+    # Fall back to default locale
+    config.i18n.fallbacks = true
+
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = 'utf-8'
 

--- a/config/initializers/30-redmine.rb
+++ b/config/initializers/30-redmine.rb
@@ -28,9 +28,14 @@
 #++
 
 # Adds fallback to default locale for untranslated strings
+I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+
+# As we enabled +config.i18n.fallbacks+, Rails will fall back
+# to the default locale.
+# When other locales are available, fall back to them.
 if Setting.table_exists? # don't want to prevent migrations
-  I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-  I18n.fallbacks.defaults = [I18n.default_locale] + Setting.available_languages.map(&:to_sym)
+  defaults = Set.new I18n.fallbacks.defaults + Setting.available_languages.map(&:to_sym)
+  I18n.fallbacks.defaults = defaults
 end
 
 require 'open_project'


### PR DESCRIPTION
This commit changes the redmine initializer to always require
`I18n::Backend::Fallbacks` to be loaded.

This should re-enable default Rails commands such as `rake db:setup`
and `rake db:reset`.

Relevant work package: https://community.openproject.org/work_packages/3782
