### PR TITLE
Fix/invite user with taken login

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -171,7 +171,7 @@ class MembersController < ApplicationController
   def suggest_invite_via_email?(user, query, principals)
     user.admin? && # only admins may add new users via email
       query =~ mail_regex &&
-      principals.none? { |p| p.mail == query } &&
+      principals.none? { |p| p.mail == query || p.login == query } &&
       query # finally return email
   end
 

--- a/app/workers/deliver_invitation_job.rb
+++ b/app/workers/deliver_invitation_job.rb
@@ -1,0 +1,50 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class DeliverInvitationJob
+  include OpenProject::BeforeDelayedJob
+
+  attr_reader :token_id
+
+  def initialize(token_id)
+    @token_id = token_id
+  end
+
+  def perform
+    if token
+      UserMailer.user_signed_up(token).deliver_now
+    else
+      Rails.logger.warn "Can't deliver invitation. The token is missing: #{token_id}"
+    end
+  end
+
+  def token
+    @token ||= Token.find_by(id: @token_id)
+  end
+end

--- a/config/initializers/user_invitation.rb
+++ b/config/initializers/user_invitation.rb
@@ -2,5 +2,5 @@
 # The default behaviour is to send the user a sign-up mail
 # when they were invited.
 OpenProject::Notifications.subscribe UserInvitation::EVENT_NAME do |token|
-  UserMailer.user_signed_up(token).deliver_now
+  Delayed::Job.enqueue DeliverInvitationJob.new(token.id)
 end

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -1,0 +1,110 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+feature 'invite user via email', type: :feature, js: true do
+  let!(:project) { FactoryGirl.create :project, name: 'Project 1', identifier: 'project1' }
+  let(:admin) { FactoryGirl.create :admin }
+  let!(:developer) { FactoryGirl.create :role, name: 'Developer' }
+
+  let(:members_page) { Pages::Members.new project.identifier }
+
+  before do
+    allow(User).to receive(:current).and_return admin
+  end
+
+  context 'with a new user' do
+    scenario 'adds the invited user to the project' do
+      members_page.visit!
+      click_on 'Add Member'
+
+      members_page.search_and_select_principal! 'finkelstein@openproject.com',
+                                                'Invite finkelstein@openproject.com'
+      members_page.select_role! 'Developer'
+      expect(members_page).to have_selected_new_principal('Invite finkelstein@openproject.com')
+
+      click_on 'Add'
+      expect(members_page).to have_added_user 'finkelstein@openproject.com (invited)'
+    end
+  end
+
+  context 'with a registered user' do
+    let!(:user) do
+      FactoryGirl.create :user, mail: 'hugo@openproject.com',
+                                login: 'hugo@openproject.com',
+                                firstname: 'Hugo',
+                                lastname: 'Hurried'
+    end
+
+    scenario 'user lookup by email' do
+      members_page.visit!
+      click_on 'Add Member'
+
+      members_page.search_and_select_principal! 'hugo@openproject.com',
+                                                'Hugo Hurried'
+      members_page.select_role! 'Developer'
+
+      click_on 'Add'
+      expect(members_page).to have_added_user 'Hugo Hurried'
+    end
+
+    context 'who is already a member' do
+      before do
+        project.add_member! user, [developer]
+      end
+
+      shared_examples 'no user to invite is found' do
+        scenario 'no matches found' do
+          members_page.visit!
+          click_on 'Add Member'
+
+          members_page.search_principal! 'hugo@openproject.com'
+          expect(members_page).to have_no_search_results
+        end
+      end
+
+      it_behaves_like 'no user to invite is found'
+
+      ##
+      # This is a edge case where the email address to be invited is free in principle
+      # but there is a user with that email address as their login. Due to this the email address
+      # cannot be used after all as the login is the same as the email address for new users
+      # which means the login for this invited user will already by taken.
+      # Accordingly it should not be offered to invite a user with that email address.
+      context 'with different email but email as login' do
+        before do
+          user.mail = 'foo@bar.de'
+          user.save!
+        end
+
+        it_behaves_like 'no user to invite is found'
+      end
+    end
+  end
+end

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -118,6 +118,37 @@ module Pages
       end
     end
 
+    ##
+    # Searches for a string in the 'New Member' dialogue's principal
+    # selection and selects the given entry.
+    #
+    # @param query What to search for in the user search field.
+    # @param selection The exact result to select.
+    def search_and_select_principal!(query, selection)
+      search_principal! query
+      select_search_result! selection
+    end
+
+    def search_principal!(query)
+      input = find '.select2-search-field input#s2id_autogen4'
+      input.set query
+    end
+
+    def select_search_result!(value)
+      find('.select2-results div', text: value).click
+    end
+
+    def has_no_search_results?
+      has_text?('No matches found')
+    end
+
+    ##
+    # Indicates whether the given principal has been selected as one
+    # of the users to be added to the project in the 'New member' dialogue.
+    def has_selected_new_principal?(name)
+      has_selector? '.select2-search-choice', text: name
+    end
+
     def select_role!(role_name)
       if !User.current.impaired?
         select2(role_name, css: '#s2id_member_role_ids')


### PR DESCRIPTION
WP [#21789](https://community.openproject.org/work_packages/21789/activity)

Yes, the whole 'delay the user invitation mail' business is not part of the bugfix but I didn't feel like opening another PR and having travis churn through another complete set of tests just for this.

The only actually relevant spec is [this](https://github.com/opf/openproject/pull/3650/files#diff-594ba91d43f70539ec514d2c71f4ccafR100). The rest is some extra feature specs for good measure.
