### PR TITLE
Fix occasional WebMock::NetConnectNotAllowedError

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,12 @@ RSpec.configure do |config|
   # Otherwise, all requests are being mocked by default.
   WebMock.disable!
 
+  # When we enable webmock, no connections other than stubbed ones are allowed.
+  # We will exempt local connections from this block, since selenium etc.
+  # uses localhost to communicate with the browser.
+  # Leaving this off will randomly fail some specs with WebMock::NetConnectNotAllowedError
+  WebMock.disable_net_connect!(allow_localhost: true)
+
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.


### PR DESCRIPTION
We're seeing ocassional webmock errors related to local requests to the
selenium server (cf. in the following example to `127.0.0.1:50133`).

These failures seem to stem from a connection being opened after the
context includes `webmock: true`.

We should be able to bypass these issues by allowing localhost
connections at all times, even when webmock is enabled.

That means:
- stubbed requests will always return stubbed responses
- localhost requests will call the original endpoint UNLESS stubbed
- Other connections will still raise the same error (as expected)

```
WebMock::NetConnectNotAllowedError:
Real HTTP connections are disabled. Unregistered request: GET http://127.0.0.1:50133/__identify__ with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}

You can stub this request with the following snippet:

stub_request(:get, "http://127.0.0.1:50133/__identify__").
  with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
  to_return(:status => 200, :body => "", :headers => {})
```
