### PR TITLE
Set migration_paths explicitly from config

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -69,8 +69,8 @@ module OpenProject::Plugins
             # finding all migrations.
             # http://blog.pivotal.io/pivotal-labs/labs/leave-your-migrations-in-your-rails-engines
             paths = app.config.paths['db/migrate'].to_a
-            ActiveRecord::Tasks::DatabaseTasks.migrations_paths |= paths
-            ActiveRecord::Migrator.migrations_paths |= paths
+            ActiveRecord::Tasks::DatabaseTasks.migrations_paths = paths
+            ActiveRecord::Migrator.migrations_paths = paths
           end
         end
       end


### PR DESCRIPTION
Turns out that `ActiveRecord::Migrator.migrations_paths` may contain
a relative path to the migrations under `db/migrate`, while
`app.config.paths['db/migrate']` contains an absolute one.

Let's set these paths from config explicitly.
