### PR TITLE
Simplify component handling

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -282,3 +282,6 @@ var requireTemplate = require.context('./templates', true, /\.html$/);
 requireTemplate.keys().forEach(requireTemplate);
 
 require('!ngtemplate?module=openproject.templates!html!angular-busy/angular-busy.html');
+
+var requireComponent = require.context('./components/', true, /\.(js|html)$/);
+requireComponent.keys().forEach(requireComponent);


### PR DESCRIPTION
The Intention is to refactor the way angular components are initialized and used by the build script.
Now it is possible to put the `.js` or `.html` files in any subdirectory under `frontend/app/components` without any extra configuration.
