### PR TITLE
Set accept_language in selenium fallback

### DIFF
--- a/spec/support/selenium_fallback.rb
+++ b/spec/support/selenium_fallback.rb
@@ -4,7 +4,10 @@ Capybara.register_driver :selenium do |app|
   Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] ||
     Selenium::WebDriver::Firefox::Binary.path
 
-  Capybara::Selenium::Driver.new(app, browser: :firefox)
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile['intl.accept_languages'] = 'en'
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile)
 end
 
 # RSpec.configure do |config|


### PR DESCRIPTION
In order to force the correct locale in local Firefox browsers,
ensure that the default accepted language is english.

Otherwise, anonymous users in a, e.g., german locale will
receive spec errors due to localized strings.

Note that this was already merged in https://github.com/opf/openproject/pull/3448, but got lost in the specs transition
