### PR TITLE
Fix/no self notified gets disabled

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -117,7 +117,7 @@ class MyController < ApplicationController
   # Configure user's mail notifications
   def mail_notifications
     @user = User.current
-    write_settings(redirect_to: :mail_notifications)
+    write_email_settings(redirect_to: :mail_notifications) if request.patch?
   end
 
   def first_login
@@ -251,16 +251,22 @@ class MyController < ApplicationController
     false
   end
 
+  def write_email_settings(redirect_to:)
+    update_service = UpdateUserEmailSettingsService.new(@user)
+    if update_service.call(mail_notification: permitted_params.user[:mail_notification],
+                           no_self_notified: params[:no_self_notified] == '1',
+                           notified_project_ids: params[:notified_project_ids])
+      flash[:notice] = l(:notice_account_updated)
+      redirect_to(action: redirect_to)
+    end
+  end
+
   def write_settings(redirect_to:)
     if request.patch?
       @user.attributes = permitted_params.user
       @user.pref.attributes = params[:pref] || {}
-      @user.pref[:no_self_notified] = (params[:no_self_notified] == '1')
       if @user.save
         @user.pref.save
-        @user.notified_project_ids =
-          (@user.mail_notification == 'selected' ? params[:notified_project_ids] : [])
-        set_language_if_valid @user.language
         flash[:notice] = l(:notice_account_updated)
         redirect_to(action: redirect_to)
       end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -254,7 +254,7 @@ class MyController < ApplicationController
   def write_email_settings(redirect_to:)
     update_service = UpdateUserEmailSettingsService.new(@user)
     if update_service.call(mail_notification: permitted_params.user[:mail_notification],
-                           no_self_notified: params[:no_self_notified] == '1',
+                           self_notified: params[:self_notified] == '1',
                            notified_project_ids: params[:notified_project_ids])
       flash[:notice] = l(:notice_account_updated)
       redirect_to(action: redirect_to)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -161,12 +161,15 @@ class UsersController < ApplicationController
     end
 
     if @user.save
-      # TODO: Similar to My#account
-      @user.pref.attributes = params[:pref] || {}
-      @user.pref[:no_self_notified] = (params[:no_self_notified] == '1')
-      @user.pref.save
+      pref_params = params[:pref] || {}
 
-      @user.notified_project_ids = (@user.mail_notification == 'selected' ? params[:notified_project_ids] : [])
+      update_email_service = UpdateUserEmailSettingsService.new(@user)
+      update_email_service.call(mail_notification: pref_params.delete(:mail_notification),
+                                no_self_notified: params[:no_self_notified] == '1',
+                                notified_project_ids: params[:notified_project_ids])
+
+      @user.pref.attributes = pref_params
+      @user.pref.save
 
       if !@user.password.blank? && @user.change_password_allowed?
         send_information = params[:send_information]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -165,7 +165,7 @@ class UsersController < ApplicationController
 
       update_email_service = UpdateUserEmailSettingsService.new(@user)
       update_email_service.call(mail_notification: pref_params.delete(:mail_notification),
-                                no_self_notified: params[:no_self_notified] == '1',
+                                self_notified: params[:self_notified] == '1',
                                 notified_project_ids: params[:notified_project_ids])
 
       @user.pref.attributes = pref_params

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -65,6 +65,14 @@ class UserPreference < ActiveRecord::Base
     comments_sorting == 'desc'
   end
 
+  def self_notified?
+    !others[:no_self_notified]
+  end
+
+  def self_notified=(value)
+    others[:no_self_notified] = !value
+  end
+
   def warn_on_leaving_unsaved?
     # Need to cast here as previous values were '0' / '1'
     to_boolean(others.fetch(:warn_on_leaving_unsaved) { true })

--- a/app/services/update_user_email_settings_service.rb
+++ b/app/services/update_user_email_settings_service.rb
@@ -1,0 +1,48 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class UpdateUserEmailSettingsService < Struct.new :user
+  def call(mail_notification: nil,
+           no_self_notified: nil,
+           notified_project_ids: [])
+
+    user.mail_notification = mail_notification unless mail_notification.nil?
+    user.pref[:no_self_notified] = no_self_notified unless no_self_notified.nil?
+
+    ret_value = false
+
+    user.transaction do
+      if (ret_value = user.save && user.pref.save) && user.mail_notification == 'selected'
+        user.notified_project_ids = notified_project_ids
+      end
+    end
+
+    ret_value
+  end
+end

--- a/app/services/update_user_email_settings_service.rb
+++ b/app/services/update_user_email_settings_service.rb
@@ -29,11 +29,11 @@
 
 class UpdateUserEmailSettingsService < Struct.new :user
   def call(mail_notification: nil,
-           no_self_notified: nil,
+           self_notified: nil,
            notified_project_ids: [])
 
     user.mail_notification = mail_notification unless mail_notification.nil?
-    user.pref[:no_self_notified] = no_self_notified unless no_self_notified.nil?
+    user.pref.self_notified = self_notified unless self_notified.nil?
 
     ret_value = false
 

--- a/app/services/update_user_email_settings_service.rb
+++ b/app/services/update_user_email_settings_service.rb
@@ -27,22 +27,36 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class UpdateUserEmailSettingsService < Struct.new :user
+UpdateUserEmailSettingsService = Struct.new(:user) do
   def call(mail_notification: nil,
            self_notified: nil,
            notified_project_ids: [])
 
-    user.mail_notification = mail_notification unless mail_notification.nil?
-    user.pref.self_notified = self_notified unless self_notified.nil?
+    set_mail_notification(mail_notification)
+    set_self_notified(self_notified)
 
     ret_value = false
 
     user.transaction do
-      if (ret_value = user.save && user.pref.save) && user.mail_notification == 'selected'
-        user.notified_project_ids = notified_project_ids
+      if (ret_value = user.save && user.pref.save)
+        set_notified_project_ids(notified_project_ids)
       end
     end
 
     ret_value
+  end
+
+  private
+
+  def set_mail_notification(mail_notification)
+    user.mail_notification = mail_notification unless mail_notification.nil?
+  end
+
+  def set_self_notified(self_notified)
+    user.pref.self_notified = self_notified unless self_notified.nil?
+  end
+
+  def set_notified_project_ids(notified_project_ids)
+    user.notified_project_ids = notified_project_ids if user.mail_notification == 'selected'
   end
 end

--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -59,8 +59,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="form--field">
   <div class="form--field-container">
     <label class="form--label-with-check-box">
-      <%= styled_check_box_tag 'no_self_notified', 1, @user.pref[:no_self_notified] %>
-      <%= l(:label_user_mail_no_self_notified) %>
+      <%= styled_check_box_tag 'self_notified', 1, @user.pref.self_notified? %>
+      <%= l(:label_user_mail_self_notified) %>
     </label>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1075,7 +1075,7 @@ en:
   label_used_by: "Used by"
   label_user_activity: "%{value}'s activity"
   label_user_anonymous: "Anonymous"
-  label_user_mail_no_self_notified: "I don't want to be notified of changes that I make myself"
+  label_user_mail_self_notified: "I want to be notified of changes that I make myself"
   label_user_mail_option_all: "For any event on all my projects"
   label_user_mail_option_none: "No events"
   label_user_mail_option_only_assigned: "Only for things I am assigned to"

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -144,4 +144,12 @@ describe UserPreference do
       expect(subject).not_to be_valid
     end
   end
+
+  describe 'self_notified getter/setter' do
+    it 'has a getter and a setter for self_notified' do
+      subject.self_notified = false
+      expect(subject.self_notified?).to be_falsey
+      expect(subject[:no_self_notified]).to be_truthy
+    end
+  end
 end

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -152,4 +152,23 @@ describe UserPreference do
       expect(subject[:no_self_notified]).to be_truthy
     end
   end
+
+  describe '[]=' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    context 'for attributes stored in "others"' do
+      it 'will save the values on sending "save"' do
+        subject.save
+
+        value = !subject[:no_self_notified]
+
+        subject[:no_self_notified] = value
+
+        subject.save
+        subject.reload
+
+        expect(subject[:no_self_notified]).to eql(value)
+      end
+    end
+  end
 end

--- a/spec/services/update_user_email_settings_service_spec.rb
+++ b/spec/services/update_user_email_settings_service_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe UpdateUserEmailSettingsService, type: :model do
+  let(:user) { stub_model(User) }
+  let(:service) { described_class.new(user) }
+
+  describe '#call' do
+    it 'returns true if saving is successful' do
+      allow(user).to receive(:save).and_return(true)
+      allow(user.pref).to receive(:save).and_return(true)
+
+      expect(service.call).to be_truthy
+    end
+
+    it 'returns false if saving of user is unsuccessful' do
+      allow(user).to receive(:save).and_return(false)
+      allow(user.pref).to receive(:save).and_return(true)
+
+      expect(service.call).to be_falsey
+    end
+
+    it 'returns false if saving of user preference is unsuccessful' do
+      allow(user).to receive(:save).and_return(true)
+      allow(user.pref).to receive(:save).and_return(false)
+
+      expect(service.call).to be_falsey
+    end
+
+    it 'sets the mail_notification if provided' do
+      expect(user).to receive(:mail_notification=).with(true)
+      service.call(mail_notification: true)
+    end
+
+    it 'does not alter mail_notification if not provided' do
+      expect(user).to_not receive(:mail_notification=)
+      service.call()
+    end
+
+    it 'sets the no_self_notified if provided' do
+      expect(user.pref).to receive(:[]=).with(:no_self_notified, true)
+      service.call(no_self_notified: true)
+    end
+
+    it 'does not alter no_self_notified if not provided' do
+      expect(user.pref).not_to receive(:[]=)
+      service.call()
+    end
+
+    it 'set the notified_project_ids on successful saving and mail_notifications is "selected"' do
+      allow(user).to receive(:mail_notification).and_return 'selected'
+      allow(user).to receive(:save).and_return true
+      allow(user.pref).to receive(:save).and_return true
+
+      expect(user).to receive(:notified_project_ids=).with([1,2,3])
+
+      service.call(notified_project_ids: [1,2,3])
+    end
+  end
+end

--- a/spec/services/update_user_email_settings_service_spec.rb
+++ b/spec/services/update_user_email_settings_service_spec.rb
@@ -64,9 +64,9 @@ describe UpdateUserEmailSettingsService, type: :model do
       service.call()
     end
 
-    it 'sets the no_self_notified if provided' do
-      expect(user.pref).to receive(:[]=).with(:no_self_notified, true)
-      service.call(no_self_notified: true)
+    it 'sets self_notified if provided' do
+      expect(user.pref).to receive(:self_notified=).with(true)
+      service.call(self_notified: true)
     end
 
     it 'does not alter no_self_notified if not provided' do


### PR DESCRIPTION
Fixes https://community.openproject.org/work_packages/21770 which was caused by always setting the no_self_notification option upon saving within the `account` and `settings` action.

With the PR, the email settings are only updated in the `mail_notification` action. A service is introduced in order to reduce complexity in the already overly complex `MyController`. That service was then used within the `UsersController` as well.

On top of the fix, there is a mini feature included in the PR. The setting "I don't want to be notified of changes that I make myself" was inverted. This change is pushed down into the model layer, by adding new accessors in the `UserPreference` model. The direct manipulation of via `[:no_self_notified]=` is still possible.
