### PR TITLE
Fix/meaningfull error message on type update

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -180,7 +180,8 @@ class ProjectsController < ApplicationController
     elsif @project.update_attributes(params[:project])
       flash[:notice] << l('notice_successful_update')
     else
-      flash[:error] = l('timelines.cannot_update_planning_element_types')
+      flash.delete :notice
+      flash[:error] = @project.errors.full_messages
     end
     redirect_to action: 'settings', tab: 'types'
   end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -153,6 +153,10 @@ class PermittedParams < Struct.new(:params, :current_user)
     params.require(:project_type).permit(*self.class.permitted_attributes[:project_type])
   end
 
+  def projects_type_ids
+    params.require(:project).require(:type_ids).map(&:to_i).select { |x| x > 0 }
+  end
+
   def project_type_move
     params.require(:project_type).permit(*self.class.permitted_attributes[:move_to])
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -555,6 +555,12 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def types_used_by_work_packages
+    ::Type.where(id: WorkPackage.where(project_id: project.id)
+                                .select(:type_id)
+                                .uniq)
+  end
+
   # Returns an array of the types used by the project and its active sub projects
   def rolled_up_types
     @rolled_up_types ||=

--- a/app/services/base_project_service.rb
+++ b/app/services/base_project_service.rb
@@ -27,33 +27,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class UpdateProjectsTypesService < BaseProjectService
-  def call(type_ids)
-    type_ids = [::Type.standard_type.id] if type_ids.nil? || type_ids.empty?
-
-    if types_missing?(type_ids)
-      project.errors.add(:type,
-                         :in_use_by_work_packages,
-                         types: missing_types(type_ids).map(&:name).join(', '))
-      false
-    else
-      project.type_ids = type_ids
-
-      true
-    end
+class BaseProjectService
+  def initialize(project)
+    self.project = project
   end
 
-  protected
+  private
 
-  def types_missing?(type_ids)
-    !missing_types(type_ids).empty?
-  end
-
-  def missing_types(type_ids)
-    types_used_by_work_packages.select { |t| !type_ids.include?(t.id) }
-  end
-
-  def types_used_by_work_packages
-    @types_used_by_work_packages ||= project.types_used_by_work_packages
-  end
+  attr_accessor :project
 end

--- a/app/services/update_projects_types_service.rb
+++ b/app/services/update_projects_types_service.rb
@@ -1,0 +1,59 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+UpdateProjectsTypesService = Struct.new :project do
+  def call(type_ids)
+    type_ids = [::Type.standard_type.id] if type_ids.nil? || type_ids.empty?
+
+    if types_missing?(type_ids)
+      project.errors.add(:type,
+                         :in_use_by_work_packages,
+                         types: missing_types(type_ids).map(&:name).join(', '))
+      false
+    else
+      project.type_ids = type_ids
+
+      true
+    end
+  end
+
+  protected
+
+  def types_missing?(type_ids)
+    !missing_types(type_ids).empty?
+  end
+
+  def missing_types(type_ids)
+    types_used_by_work_packages.select { |t| !type_ids.include?(t.id) }
+  end
+
+  def types_used_by_work_packages
+    @types_used_by_work_packages ||= project.types_used_by_work_packages
+  end
+end

--- a/app/views/projects/settings/_types.html.erb
+++ b/app/views/projects/settings/_types.html.erb
@@ -27,9 +27,6 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% extend TimelinesHelper %>
-
-
 <%= form_for @project,
              :url => { :action => 'types', :id => @project },
              :method => :patch,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,10 @@ en:
         before_or_equal_to: "must be before or equal to %{date}."
         could_not_be_copied: "could not be (fully) copied."
       models:
+        project:
+          attributes:
+            types:
+              in_use_by_work_packages: "still in use by work packages: %{types}"
         project_association:
           identical_projects: "Dependency cannot be created between one project and itself."
           project_association_not_allowed: "does not allow associations."
@@ -1251,7 +1255,6 @@ en:
   notice_automatic_set_of_standard_type: "Set standard type automatically."
   notice_logged_out: "You have been logged out."
   notice_wont_delete_auth_source: The authentication mode cannot be deleted as long as there are still users using it.
-  error_types_in_use_by_work_packages: "The following types are still referenced by work packages: %{types}"
   notice_project_cannot_update_custom_fields: "You cannot update the project's available custom fields."
 
   # Default format for numbers

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -83,6 +83,14 @@ describe PermittedParams, type: :model do
     end
   end
 
+  describe '#project_types' do
+    it 'should require type_ids within project' do
+      params = ActionController::Parameters.new(project: { type_ids: ['1', '', '2'] })
+
+      expect(PermittedParams.new(params, user).projects_type_ids).to eq([1, 2])
+    end
+  end
+
   describe '#color' do
     it 'should permit name' do
       params = ActionController::Parameters.new(color: { 'name' => 'blubs' })

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -248,4 +248,19 @@ describe Project, type: :model do
       it_behaves_like 'respecting group assignment settings'
     end
   end
+
+  describe '#types_used_by_work_packages' do
+    let(:project) { FactoryGirl.create(:project_with_types) }
+    let(:type) { project.types.first }
+    let(:other_type) { project.types.second }
+    let(:project_work_package) { FactoryGirl.create(:work_package, type: type, project: project) }
+    let(:other_project_work_package) { FactoryGirl.create(:work_package, type: other_type) }
+
+    it 'returns the type used by a work package of the project' do
+      project_work_package
+      other_project_work_package
+
+      expect(project.types_used_by_work_packages).to match_array [project_work_package.type]
+    end
+  end
 end

--- a/spec/services/update_projects_types_service.rb
+++ b/spec/services/update_projects_types_service.rb
@@ -1,0 +1,90 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe UpdateProjectsTypesService do
+  let(:project) { double(Project, types_used_by_work_packages: []) }
+  let(:type) { double(Type, id: 456, name: 'A type') }
+  let(:standard_type) { double('StandardType', id: 123) }
+  let(:instance) { described_class.new(project) }
+
+  before do
+    allow(Type).to receive(:standard_type).and_return standard_type
+  end
+
+  describe '.call' do
+    context 'with ids provided' do
+      let(:ids) { [1, 2, 3] }
+
+      it 'returns true and updates the ids' do
+        expect(project).to receive(:type_ids=).with(ids)
+
+        expect(instance.call(ids)).to be_truthy
+      end
+    end
+
+    context 'with no id passed' do
+      let(:ids) { [] }
+
+      it 'adds the id of the default type and returns true' do
+        expect(project).to receive(:type_ids=).with([standard_type.id])
+
+        expect(instance.call(ids)).to be_truthy
+      end
+    end
+
+    context 'with nil passed' do
+      let(:ids) { nil }
+
+      it 'adds the id of the default type and returns true' do
+        expect(project).to receive(:type_ids=).with([standard_type.id])
+
+        expect(instance.call(ids)).to be_truthy
+      end
+    end
+
+    context 'the id of a type in use is not provided' do
+      before do
+        allow(project).to receive(:types_used_by_work_packages).and_return([type])
+      end
+
+      it 'returns false and sets an error message' do
+        ids = [1]
+
+        errors = double('Errors')
+        expect(project).to receive(:errors).and_return(errors)
+        expect(errors).to receive(:add).with(:type, :in_use_by_work_packages, types: type.name)
+
+        expect(project).to_not receive(:type_ids=)
+
+        expect(instance.call(ids)).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://community.openproject.org/work_packages/21797 and refactors the settings#types. 

Because `project.type_ids=` is used to update the type_ids, it is no longer possible for an invalid state of the project (e.g. a required custom field not filled out) to block the update of the types.

With the introduction of the service, the controller now has way less clutter. I still dislike the heavy usage of flash messages within the controller, especially to transmit error messages, but refactoring that is to big an effort.
