### PR TITLE
[21829] Button alignment in filters wrong

### DIFF
--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -67,8 +67,8 @@ $filters--border-color: $gray !default
   // is 50% and two elements should be within a row and padding is anything but
   // 0. The elements will in sum take up more than 100% and thus the second
   // element will move to the next row.
-  .simple-filters--filter,
-    padding: 0
+  .simple-filters--filter
+    padding: 0 0 0 1rem
     display: flex
     align-items: center
     @include breakpoint(large)
@@ -85,7 +85,7 @@ $filters--border-color: $gray !default
       margin-right: 20px
 
   .simple-filters--controls
-    padding: 0
+    padding: 0 0 0 1rem
     align-self: center
     @include breakpoint(large)
       flex: 1
@@ -106,7 +106,7 @@ $filters--border-color: $gray !default
   // element will move to the next row.
   .simple-filters--filter,
   .simple-filters--controls
-    padding: 0
+    padding: 0 0 0 1rem
     align-self: center
     @include breakpoint(large)
 

--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -72,11 +72,12 @@ $filters--border-color: $gray !default
     display: flex
     align-items: center
     @include breakpoint(large)
-    margin-bottom: 1rem
+
+    @media only screen and (max-width: 1200px)
+      margin-bottom: 1rem
 
     .simple-filters--filter-name
       flex-basis: 15%
-      margin-top: 5px
     .simple-filters--filter-value
       flex-basis: 75%
 

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -54,7 +54,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <%= calendar_for('to') %>
       </div>
     </li>
-    <li>
+    <li class="simple-filters--controls">
       <%= styled_button_tag l(:button_apply), class: 'button -highlight -small' %>
       <%= link_to l(:button_clear), polymorphic_time_entries_path(@issue || @project), :class => 'button -small' %>
     </li>


### PR DESCRIPTION
This removes the `margin-bottom`of the filter components for the correct alignment with the buttons. The breakpoint takes care of certain margin when the site is small and the filters have to be shown under each other.

https://community.openproject.org/work_packages/21829/activity
