### PR TITLE
[21733] Misaligned text in details pane (safari)

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -39,7 +39,6 @@
       // important for IE
       display: inline-block
       max-width: 100%
-      vertical-align: top
   p
     word-wrap: break-word
 


### PR DESCRIPTION
This removes the `vertical-align: top` which has broken the layout under safari. 

https://community.openproject.org/work_packages/21733/activity
