### PR TITLE
Fix/number localization

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -44,9 +44,9 @@ require('angular-animate');
 require('angular-aria');
 require('angular-modal');
 
-if (I18n.locale === 'de') {
-  require('angular-i18n/angular-locale_de-de');
-}
+// depends on the html element having a 'lang' attribute
+var documentLang = angular.element('html').attr('lang');
+require('angular-i18n/angular-locale_' + documentLang + '.js');
 
 require('angular-ui-router');
 

--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -45,7 +45,7 @@ require('angular-aria');
 require('angular-modal');
 
 // depends on the html element having a 'lang' attribute
-var documentLang = angular.element('html').attr('lang');
+var documentLang = angular.element('html').attr('lang') || 'en';
 require('angular-i18n/angular-locale_' + documentLang + '.js');
 
 require('angular-ui-router');

--- a/frontend/app/work_packages/services/index.js
+++ b/frontend/app/work_packages/services/index.js
@@ -68,6 +68,7 @@ angular.module('openproject.workPackages.services')
     '$http',
     '$rootScope',
     '$timeout',
+    '$filter',
     'HookService',
     'NotificationsService',
     'EditableFieldsState',

--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -34,6 +34,7 @@ module.exports = function(
   $http,
   $rootScope,
   $timeout,
+  $filter,
   HookService,
   NotificationsService,
   EditableFieldsState
@@ -380,7 +381,8 @@ module.exports = function(
     if (schema.props[field]) {
       if (schema.props[field].type === 'Duration') {
         var hours = moment.duration(value).asHours();
-        return I18n.t('js.units.hour', { count: hours.toFixed(2) });
+        var formattedHours = $filter('number')(hours, 2);
+        return I18n.t('js.units.hour', { count: formattedHours });
       }
 
       if (schema.props[field].type === 'Boolean') {


### PR DESCRIPTION
Fixes https://community.openproject.org/work_packages/21799 by:
- Correctly initializing `$locale`: We used to check for `I18n.locale` to include the german localization file that would in turn set the locale in `$locale`. This was only defined for the german localization. With the introduction of openproject-translations, we can no longer restrict the check to only care for german. We are therefore requiring all the localization files by webpack. On top of that, the comparison against `I18n.locale` was not working because it always had a value of `en` this is because `en` is the default value and `I18n.locale` was only set afterwards in an script inline to the page, so after openproject-app.js had long been executed.
- Using an angular filter to format a duration. Because `$locale.id` has the right value now, the number is localized correctly.

The first fix would not have been necessary in the strictest sense. I could have used `I18n.l` to format the number. But after I identified the problem I deemed it worthy to fix to avoid others stumbling over it later on. 
