### PR TITLE
Fix/spec robustness

### DIFF
--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -51,7 +51,7 @@ class UserSearchService
   def ids_search(scope)
     ids = params[:ids].split(',')
 
-    scope.where(id: ids)
+    scope.not_builtin.where(id: ids)
   end
 
   def query_search(scope)

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -34,8 +34,8 @@ RSpec.feature 'Work package navigation', selenium: true do
   let(:work_package) { FactoryGirl.build(:work_package, project: project) }
 
   before do
-    work_package.save!
     login_as(user)
+    work_package.save!
   end
 
   scenario 'all different angular based work package views', js: true do

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -89,5 +89,8 @@ RSpec.feature 'Work package navigation', selenium: true do
 
     full_work_package.expect_subject
     full_work_package.expect_current_path
+
+    # Safeguard: ensure spec to have finished loading everything before proceeding to the next spec
+    full_work_package.ensure_page_loaded
   end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -26,8 +26,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'rack_session_access/capybara'
+
 module AuthenticationHelpers
-  def login_as user
+  def login_as(user)
+    if is_a? RSpec::Rails::FeatureExampleGroup
+      # If we want to mock having finished the login process
+      # we must set the user_id in rack.session accordingly
+      # Otherwise e.g. calls to Warden will behave unexpectantly
+      # as they will login AnonymousUser
+      page.set_rack_session(user_id: user.id)
+    end
+
     allow(User).to receive(:current).and_return(user)
   end
 end

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -30,7 +30,6 @@ require 'support/pages/page'
 
 module Pages
   class FullWorkPackage < Page
-
     attr_reader :work_package
 
     def initialize(work_package)
@@ -48,6 +47,11 @@ module Pages
       expect(current_path).to eql path
     end
 
+    def ensure_page_loaded
+      expect(page).to have_selector('.work-package-details-activities-activity-contents .user',
+                                    text: work_package.journals.last.user.name)
+    end
+
     private
 
     def container
@@ -55,7 +59,7 @@ module Pages
     end
 
     def path
-      work_package_path(work_package.id, "activity")
+      work_package_path(work_package.id, 'activity')
     end
   end
 end


### PR DESCRIPTION
Attempt to prevent test flickers ala: https://travis-ci.org/opf/openproject/jobs/86834279. The causes for this where:

1) The `UserSearchService` returning `AnonymousUser` altogether. AnonymousUser is an internal user and as such should not be found.
2) `spec/features/work_packages/navigation_spec.rb` leaving AnonymousUser in the DB. There is a race condition (albeit one leading to failures pretty consistently) that the backend process has already truncated the DB when the front end process tries to get some user information by calling `api/v3/users/:id`. Authentication will take place before the process is processed further. As there is no [user_id stored in `rack.session`](https://github.com/opf/openproject/blob/dev/lib/open_project/authentication/strategies/warden/session.rb#L15), User.anonymous is called which creates the AnonymousUser in the DB. The PR therefore ensures that rack_session is provisioned consistently with normal code execution. On top of that, it ensures (or tries to) that the front end process has made all the api requests before going to the next test.
