### PR TITLE
Allow to add attachments to a WP with permission to add WPs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1421,7 +1421,7 @@ en:
           tb: "TB"
 
   permission_add_work_package_notes: "Add notes"
-  permission_add_work_packages: "Add work packages"
+  permission_add_work_packages: "Add work packages (also allows to add attachments to all work packages)"
   permission_add_messages: "Post messages"
   permission_add_project: "Create project"
   permission_add_subprojects: "Create subprojects"

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -1029,7 +1029,7 @@ Instead the `fileName` inside the JSON of the metadata part will be used.
 
     Returned if the client does not have sufficient permissions.
 
-    **Required permission:** edit work package
+    **Required permission:** edit work package or add work package
 
     *Note that you will only receive this error, if you are at least allowed to see the work package.*
 

--- a/lib/api/v3/attachments/attachments_by_work_package_api.rb
+++ b/lib/api/v3/attachments/attachments_by_work_package_api.rb
@@ -59,7 +59,7 @@ module API
           end
 
           post do
-            authorize(:edit_work_packages, context: @work_package.project)
+            authorize_any [:edit_work_packages, :add_work_packages], projects: @work_package.project
 
             metadata = parse_metadata params[:metadata]
             file = params[:file]

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -124,7 +124,8 @@ module API
           {
             href: api_v3_paths.attachments_by_work_package(represented.id),
             method: :post
-          } if current_user_allowed_to(:edit_work_packages, context: represented.project)
+          } if current_user_allowed_to(:edit_work_packages, context: represented.project) ||
+               current_user_allowed_to(:add_work_packages, context: represented.project)
         end
 
         link :availableWatchers do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -458,6 +458,24 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         context 'user is not allowed to edit work packages' do
           let(:permissions) { all_permissions - [:edit_work_packages] }
 
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'addAttachment' }
+            let(:href) { api_v3_paths.attachments_by_work_package(work_package.id) }
+          end
+        end
+
+        context 'user is not allowed to add work packages' do
+          let(:permissions) { all_permissions - [:add_work_packages] }
+
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'addAttachment' }
+            let(:href) { api_v3_paths.attachments_by_work_package(work_package.id) }
+          end
+        end
+
+        context 'user is neither allowed to edit work packages nor to add them' do
+          let(:permissions) { all_permissions - [:edit_work_packages, :add_work_packages] }
+
           it_behaves_like 'has no link' do
             let(:link) { 'addAttachment' }
           end

--- a/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachments_by_work_package_resource_spec.rb
@@ -129,5 +129,19 @@ describe 'API v3 Attachments by work package resource', type: :request do
         let(:message) { "File #{expanded_localization}" }
       end
     end
+
+    context 'only allowed to add work packages, but no edit permission' do
+      let(:permissions) { [:view_work_packages, :add_work_packages] }
+
+      it 'should respond with HTTP Created' do
+        expect(subject.status).to eq(201)
+      end
+    end
+
+    context 'only allowed to view work packages' do
+      let(:permissions) { [:view_work_packages] }
+
+      it_behaves_like 'unauthorized access'
+    end
   end
 end


### PR DESCRIPTION
This is neccessary to allow adding attachments, after creating a new work package.

The undesired part is, that it also allows you to add attachments long after creating the WP.

https://community.openproject.org/work_packages/21612
