### PR TITLE
use close! to delete tmp file consistently

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -49,7 +49,7 @@ module FileUploader
         tmp = Tempfile.new 'op_uploaded_files'
         path = Pathname(tmp)
 
-        tmp.delete # delete temp file
+        tmp.close! # delete temp file
         path.mkdir # create temp directory
 
         path.to_s


### PR DESCRIPTION
Using `#delete` does not work on Windows. Thanks @scumie for pointing it out.
