### PR TITLE
Fix/boolearize bool custom values

### DIFF
--- a/app/models/queries/work_packages/available_filter_options.rb
+++ b/app/models/queries/work_packages/available_filter_options.rb
@@ -62,7 +62,10 @@ module Queries::WorkPackages::AvailableFilterOptions
       when 'date'
         options = { type: :date, order: 20 }
       when 'bool'
-        options = { type: :list, values: [[l(:general_text_yes), '1'], [l(:general_text_no), '0']], order: 20 }
+        options = { type: :list,
+                    values: [[l(:general_text_yes), ActiveRecord::Base.connection.unquoted_true],
+                             [l(:general_text_no), ActiveRecord::Base.connection.unquoted_false]],
+                    order: 20 }
       when 'user', 'version'
         next unless project
         options = { type: :list_optional, values: field.possible_values_options(project), order: 20 }

--- a/db/migrate/20151028063433_boolearlize_bool_custom_values.rb
+++ b/db/migrate/20151028063433_boolearlize_bool_custom_values.rb
@@ -1,0 +1,85 @@
+class BoolearlizeBoolCustomValues < ActiveRecord::Migration
+  def up
+    update_custom_values(fake_true, db_true, fake_false, db_false)
+    update_queries(fake_true, db_true_unquoted, fake_false, db_false_unquoted)
+  end
+
+  def down
+    update_custom_values(db_true, fake_true, db_false, fake_false)
+    update_queries(db_true_unquoted, fake_true, db_false_unquoted, fake_false)
+  end
+
+  private
+
+  def update_custom_values(old_true, new_true, old_false, new_false)
+    bool_custom_fields.each do |bool_custom_field|
+      alter(CustomValue, bool_custom_field, old_false, new_false)
+      alter(CustomValue, bool_custom_field, old_true, new_true)
+      alter(CustomizableJournal, bool_custom_field, old_false, new_false)
+      alter(CustomizableJournal, bool_custom_field, old_true, new_true)
+    end
+  end
+
+  def update_queries(old_true, new_true, old_false, new_false)
+    queries = Query.all
+
+    queries.each do |query|
+      query.filters.each do |filter|
+        update_filter(filter, old_true, new_true, old_false, new_false)
+      end
+      query.save
+    end
+  end
+
+  def update_filter(filter, old_true, new_true, old_false, new_false)
+    custom_field_match = filter.field.to_s.match(/\Acf_(\d+)\z/)
+
+    return unless custom_field_match
+
+    custom_field_id = custom_field_match[1].to_i
+
+    bool_custom_field = bool_custom_fields.find { |cf| cf.id == custom_field_id }
+
+    return unless bool_custom_field
+
+    filter
+      .values
+      .map! { |v| v == old_false ? new_false : v }
+      .map! { |v| v == old_true ? new_true : v }
+  end
+
+  def bool_custom_fields
+    @bool_custom_fields ||= CustomField.where(field_format: 'bool').all
+  end
+
+  def alter(scope, custom_field, old, new)
+    scope
+      .where(custom_field_id: custom_field.id,
+             value: old)
+      .update_all(value: new)
+  end
+
+  def db_false
+    ActiveRecord::Base.connection.quoted_false
+  end
+
+  def db_true
+    ActiveRecord::Base.connection.quoted_true
+  end
+
+  def db_false_unquoted
+    ActiveRecord::Base.connection.unquoted_false
+  end
+
+  def db_true_unquoted
+    ActiveRecord::Base.connection.unquoted_true
+  end
+
+  def fake_false
+    '0'
+  end
+
+  def fake_true
+    '1'
+  end
+end


### PR DESCRIPTION
With the changes in the way boolean custom values are stored ('0' -> 'f', '1' -> 'f') the queries can no longer compare the filter values to the old true/false representation. Therefore, the query filter is now initialized to have the correct AR true/false values.

However, as the change did not incorporate changing all the values already stored in the DB to the new representation, the PR also contains a migration which does that. It updates:
- `CustomValue`
- `CustomizableJournal`
- The filters on `Query` which belong to a `CustomField` of type `bool`

There is one limitation to the fix. Queries that are not stored in the DB but in some document (e.g. email, chat, ...) the user has outside of the system will still not work as said query will still contain '0' or '1' as the filter value. A fix for that is possible, but given the expected limited number of such cases and the complexity it would add to the code, I refrained from doing this.

https://community.openproject.org/work_packages/21746 
