### PR TITLE
fix protractor spec broken by 735b83c

### DIFF
--- a/frontend/tests/integration/specs/work-packages/details-pane/relations/parent-relations-handler-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/relations/parent-relations-handler-spec.js
@@ -35,7 +35,7 @@ describe('Details pane', function() {
       var parentsSlide;
       beforeEach(function () {
         detailsPaneHelper.loadPane(819, 'relations');
-        parentsSlide = element(by.css('[handler="wpParent"] [execute-on-enter]'));
+        parentsSlide = element(by.css('[handler="wpParent"] accessible-by-keyboard a'));
         parentsSlide.click();
         browser.waitForAngular();
       });
@@ -51,7 +51,7 @@ describe('Details pane', function() {
       var parentsSlide;
       beforeEach(function () {
         detailsPaneHelper.loadPane(822, 'relations');
-        parentsSlide = element(by.css('[handler="wpParent"] [execute-on-enter]'));
+        parentsSlide = element(by.css('[handler="wpParent"] accessible-by-keyboard a'));
         parentsSlide.click();
         browser.waitForAngular();
       });


### PR DESCRIPTION
The execute-on-enter directive was removed in 735b83c. The test should have been adapted then.
