### PR TITLE
allow new users independently from password config

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,8 +45,6 @@ class UsersController < ApplicationController
   before_filter :check_if_deletion_allowed, only: [:deletion_info,
                                                    :destroy]
 
-  before_filter :block_if_password_login_disabled, only: [:new, :create]
-
   accept_key_auth :index, :show, :create, :update, :destroy
 
   include SortHelper
@@ -340,10 +338,6 @@ class UsersController < ApplicationController
     else
       'admin'
     end
-  end
-
-  def block_if_password_login_disabled
-    render_404 if OpenProject::Configuration.disable_password_login?
   end
 
   def set_password?(params)

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -28,11 +28,9 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= toolbar title: l(:label_user_plural) do %>
-  <% unless OpenProject::Configuration.disable_password_login? %>
-    <%= link_to new_user_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i>
-      <span class="button--text"><%= l(:label_user_new) %></span>
-    <% end %>
+  <%= link_to new_user_path, class: 'button -alt-highlight' do %>
+    <i class="button--icon icon-add"></i>
+    <span class="button--text"><%= l(:label_user_new) %></span>
   <% end %>
   <%= call_hook(:user_admin_action_menu) %>
 <% end %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -247,40 +247,6 @@ describe UsersController, type: :controller do
   end
 
   describe 'index' do
-    describe 'new user button' do
-      render_views
-
-      context 'with password login enabled' do
-        before do
-          allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
-
-          as_logged_in_user admin do
-            get :index
-          end
-        end
-
-        it 'is shown' do
-          expect(response.body).to have_selector('a', text: I18n.t('label_user_new'))
-        end
-      end
-
-      context 'with password login disabled' do
-        before do
-          allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(true)
-
-          as_logged_in_user admin do
-            get :index
-          end
-        end
-
-        # you must not be able to create new users if password login is disabled
-        # as users are managed externally
-        it 'is hidden' do
-          expect(response.body).not_to have_selector('a', text: I18n.t('label_user_new'))
-        end
-      end
-    end
-
     describe 'with session lifetime' do
       # TODO move this section to a proper place because we test a
       # before_filter from the application controller
@@ -377,68 +343,6 @@ describe UsersController, type: :controller do
 
           it_should_behave_like 'index action with disabled session lifetime or inactivity not exceeded'
         end
-      end
-    end
-  end
-
-  describe '#new' do
-    context 'with password login enabled' do
-      before do
-        allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
-
-        as_logged_in_user admin do
-          get :new
-        end
-      end
-
-      it 'should return HTTP 200' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    context 'with password login disabled' do
-      before do
-        allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(true)
-
-        as_logged_in_user admin do
-          get :new
-        end
-      end
-
-      # you must not be able to create new users if password login is disabled
-      it 'should return HTTP 404' do
-        expect(response.status).to eq 404
-      end
-    end
-  end
-
-  describe '#create' do
-    context 'with password login enabled' do
-      before do
-        allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
-
-        as_logged_in_user admin do
-          post :create
-        end
-      end
-
-      it 'should return HTTP 400 due to missing parameters' do
-        expect(response.status).to eq 400
-      end
-    end
-
-    context 'with password login disabled' do
-      before do
-        allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(true)
-
-        as_logged_in_user admin do
-          post :create
-        end
-      end
-
-      # you must not be able to create new users if password login is disabled
-      it 'should return HTTP 404' do
-        expect(response.status).to eq 404
       end
     end
   end


### PR DESCRIPTION
The new user form has been simplified and decoupled from the
password/authentication choice previously. Accordingly we may,
nay, we must enable the user creation again even with the
password login disabled.

In such a case a user will have to use OmniAuth.
