### PR TITLE
Strip notify from frontend

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -441,10 +441,8 @@ en:
     inplace:
       button_edit: "%{attribute}: Edit"
       button_save: "%{attribute}: Save"
-      button_save_and_send: "%{attribute}: Save and send email"
       button_cancel: "%{attribute}: Cancel"
       button_save_all: "Save"
-      button_save_and_send_all: "Save and send email"
       button_cancel_all: "Cancel"
       link_formatting_help: "Text formatting"
       btn_preview_enable: "Preview"

--- a/frontend/app/services/activity-service.js
+++ b/frontend/app/services/activity-service.js
@@ -34,9 +34,9 @@ module.exports = function(
   NotificationsService
   ) {
   var ActivityService = {
-    createComment: function(workPackage, comment, notify) {
+    createComment: function(workPackage, comment) {
       return $http({
-        url: URI(workPackage.links.addComment.url()).addSearch('notify', notify).toString(),
+        url: workPackage.links.addComment.url(),
         method: 'POST',
         data: JSON.stringify({ comment: comment }),
         headers: { 'Content-Type': 'application/json; charset=UTF-8' }

--- a/frontend/app/services/work-package-service.js
+++ b/frontend/app/services/work-package-service.js
@@ -259,11 +259,10 @@ module.exports = function($http,
       return workPackage.links.updateImmediately.fetch(options);
     },
 
-    updateWorkPackage: function(workPackage, notify) {
+    updateWorkPackage: function(workPackage) {
       var options = { ajax: {
         method: workPackage.links.updateImmediately.props.method,
-        url: URI(workPackage.links.updateImmediately.props.href)
-            .addSearch('notify', notify).toString(),
+        url: workPackage.links.updateImmediately.props.href,
         headers: {
           Accept: 'application/hal+json'
         },

--- a/frontend/app/templates/work_packages.list.new.html
+++ b/frontend/app/templates/work_packages.list.new.html
@@ -60,11 +60,6 @@
     <i class="icon-yes"></i>
     <span class="button--text" ng-bind="::I18n.t('js.inplace.button_save_all')"></span>
   </button>
-  <button class="button" ng-click="vm.submit(true)">
-    <i class="icon-yes"></i>
-    <i class="icon-mail"></i>
-    <span class="button--text" ng-bind="::I18n.t('js.inplace.button_save_and_send_all')"></span>
-  </button>
   <button class="button" ng-click="vm.cancel()">
     <i class="icon-close"></i>
     <span class="button--text" ng-bind="::I18n.t('js.inplace.button_cancel_all')"></span>

--- a/frontend/app/templates/work_packages/comment_field.html
+++ b/frontend/app/templates/work_packages/comment_field.html
@@ -17,21 +17,16 @@
       </accessible-by-keyboard>
     </div>
     <div class="inplace-edit--write edit-strategy-comment" ng-show="fieldController.isEditing">
-      <form class="inplace-edit--form" ng-if="fieldController.isEditing" name="fieldController.editForm" ng-submit="fieldController.submit(false)" novalidate>
+      <form class="inplace-edit--form" ng-if="fieldController.isEditing" name="fieldController.editForm" ng-submit="fieldController.submit()" novalidate>
         <div class="inplace-edit--write-value" ng-include="'/templates/components/inplace_editor/editable/wiki_textarea.html'" ng-click="fieldController.markActive()" tabindex="-1">
         </div>
         <div class="inplace-edit--dashboard">
           <div class="inplace-edit--controls" ng-hide="fieldController.state.isBusy || !fieldController.isActive()">
-            <accessible-by-keyboard execute="fieldController.submit(false)"
+            <accessible-by-keyboard execute="fieldController.submit()"
                                     ng-disabled="fieldController.isEmpty()"
                                     class="inplace-edit--control inplace-edit--control--save">
               <icon-wrapper icon-name="yes" icon-title="{{ fieldController.saveTitle }}">
               </icon-wrapper>
-            </accessible-by-keyboard>
-            <accessible-by-keyboard execute="fieldController.submit(true)"
-                                    ng-disabled="fieldController.isEmpty()"
-                                    class="inplace-edit--control -icons-2 inplace-edit--control--send">
-             <icon-wrapper icon-name="send-mail" icon-title="{{ editPaneController.saveAndSendTitle }}"></icon-wrapper>
             </accessible-by-keyboard>
             <accessible-by-keyboard execute="fieldController.discardEditing()" class="inplace-edit--control inplace-edit--control--cancel">
               <icon-wrapper icon-name="close" icon-title="{{ fieldController.cancelTitle }}">

--- a/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
+++ b/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
@@ -1,10 +1,10 @@
 <div class="inplace-edit--write edit-strategy-{{ strategy }}" ng-show="fieldController.isEditing">
-  <form class="inplace-edit--form" ng-if="fieldController.isEditing" name="editPaneController.editForm" ng-submit="editPaneController.submit(false)" novalidate>
+  <form class="inplace-edit--form" ng-if="fieldController.isEditing" name="editPaneController.editForm" ng-submit="editPaneController.submit()" novalidate>
       <div class="inplace-edit--write-value" ng-include="templateUrl" ng-click="editPaneController.markActive()" tabindex="-1" ng-attr-role="{{ strategy == 'text' || 'wiki_textarea' ? 'textbox' : 'button' }}">
       </div>
     <div class="inplace-edit--dashboard">
       <div class="inplace-edit--controls" ng-hide="fieldController.state.isBusy || !editPaneController.isActive()">
-        <accessible-by-keyboard execute="editPaneController.submit(true)" class="inplace-edit--control inplace-edit--control--save">
+        <accessible-by-keyboard execute="editPaneController.submit()" class="inplace-edit--control inplace-edit--control--save">
           <icon-wrapper icon-name="yes" icon-title="{{ editPaneController.saveTitle }}">
           </icon-wrapper>
         </accessible-by-keyboard>

--- a/frontend/app/work_packages/controllers/work-package-new-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-new-controller.js
@@ -107,7 +107,7 @@ module.exports = function(
     });
   }
 
-  function submit(notify) {
+  function submit() {
     var field = angular.element('.work-packages--details--subject:first .inplace-edit--write')
                        .scope().editPaneController.submitField;
 
@@ -117,7 +117,7 @@ module.exports = function(
       prepend: true,
     };
 
-    WorkPackageFieldService.submitWorkPackageChanges(notify, function() {
+    WorkPackageFieldService.submitWorkPackageChanges(function() {
       $rootScope.$emit('workPackagesRefreshRequired');
     });
   }

--- a/frontend/app/work_packages/directives/inplace_editor/custom/editable/inplace-editor-date-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/custom/editable/inplace-editor-date-directive.js
@@ -52,7 +52,7 @@ module.exports = function(WorkPackageFieldService, EditableFieldsState,
           datepicker;
 
       scope.execute = function() {
-        form.scope().editPaneController.submit(false);
+        form.scope().editPaneController.submit();
       };
 
       if(scope.fieldController.writeValue) {

--- a/frontend/app/work_packages/directives/inplace_editor/custom/editable/inplace-editor-date-range-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/custom/editable/inplace-editor-date-range-directive.js
@@ -72,7 +72,7 @@ module.exports = function(TimezoneService, ConfigurationService,
       }
 
       scope.execute = function() {
-        form.scope().editPaneController.submit(false);
+        form.scope().editPaneController.submit();
       };
 
       startDatepicker = new Datepicker(divStart, inputStart, scope.startDate);

--- a/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/inplace-editor-edit-pane-directive.js
@@ -65,9 +65,8 @@ module.exports = function(
 
       // Propagate submission to all active fields
       // not contained in the workPackage.form (e.g., comment)
-      this.submit = function(notify) {
+      this.submit = function() {
         WorkPackageFieldService.submitWorkPackageChanges(
-          notify,
           function() {
             // Clears the location hash, as we're now
             // scrolling to somewhere else
@@ -79,7 +78,7 @@ module.exports = function(
         );
       };
 
-      this.submitField = function(notify) {
+      this.submitField = function() {
         var submit = $q.defer();
         var fieldController = $scope.fieldController;
         var pendingFormChanges = getPendingFormChanges();
@@ -112,10 +111,7 @@ module.exports = function(
             function(form) {
               EditableFieldsState.workPackage.form = form;
               if (_.isEmpty(form.embedded.validationErrors.props)) {
-                var result = WorkPackageService.updateWorkPackage(
-                  EditableFieldsState.workPackage,
-                  notify
-                );
+                var result = WorkPackageService.updateWorkPackage(EditableFieldsState.workPackage);
                 result.then(angular.bind(this, function(updatedWorkPackage) {
                   submit.resolve();
                   $scope.$emit('workPackageUpdatedInEditor', updatedWorkPackage);

--- a/frontend/app/work_packages/directives/inplace_editor/inplace-editor-main-pane-directive.js
+++ b/frontend/app/work_packages/directives/inplace_editor/inplace-editor-main-pane-directive.js
@@ -40,10 +40,6 @@ module.exports = function() {
           'js.inplace.button_save',
           { attribute: fieldController.field }
         );
-        this.saveAndSendTitle = I18n.t(
-          'js.inplace.button_save_and_send',
-          { attribute: fieldController.field }
-        );
         this.cancelTitle = I18n.t(
           'js.inplace.button_cancel',
           { attribute: fieldController.field }

--- a/frontend/app/work_packages/directives/work-package-comment-directive.js
+++ b/frontend/app/work_packages/directives/work-package-comment-directive.js
@@ -65,7 +65,7 @@ module.exports = function(
     };
 
     // Propagate submission to all active fields
-    ctrl.submit = function(notify) {
+    ctrl.submit = function() {
 
       // Avoid submitting empty comments
       if (ctrl.isEmpty()) {
@@ -74,7 +74,6 @@ module.exports = function(
 
       var nextActivity = ctrl.activities.length + 1;
       WorkPackageFieldService.submitWorkPackageChanges(
-        notify,
         function() {
           $location.hash('activity-' + (nextActivity));
         }
@@ -84,7 +83,7 @@ module.exports = function(
     /**
     * Returns a promise to submits this very comment field
     */
-    ctrl.submitField = function(notify) {
+    ctrl.submitField = function() {
       var submit = $q.defer();
 
       // Avoid submitting empty comments
@@ -96,8 +95,7 @@ module.exports = function(
       ctrl.state.isBusy = true;
       ActivityService.createComment(
         ctrl.workPackage,
-        ctrl.writeValue,
-        notify
+        ctrl.writeValue
       ).then(function() {
         ctrl.discardEditing();
         NotificationsService.addSuccess(I18n.t('js.work_packages.comment_added'));

--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -397,11 +397,11 @@ module.exports = function(
     return WorkPackagesHelper.formatValue(value, mappings[field]);
   }
 
-  function submitWorkPackageChanges(notify, callback) {
+  function submitWorkPackageChanges(callback) {
     // We have to ensure that some promises are executed earlier then others
     var promises = [];
     angular.forEach(EditableFieldsState.submissionPromises, function(field) {
-      var p = field.thePromise.call(this, notify);
+      var p = field.thePromise.call(this);
       if (field.prepend) {
         promises.unshift(p);
       } else {

--- a/frontend/tests/unit/tests/services/activity-service-test.js
+++ b/frontend/tests/unit/tests/services/activity-service-test.js
@@ -70,8 +70,7 @@ describe('ActivityService', function() {
 
       apiFetchResource = ActivityService.createComment(
         workPackage,
-        comment,
-        false
+        comment
       );
     }));
 

--- a/frontend/tests/unit/tests/work_packages/directives/work-package-comment-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/work-package-comment-directive-test.js
@@ -136,16 +136,13 @@ describe('workPackageCommentDirectiveTest', function() {
 
         it('does not allow sending comment with an empty message', function() {
           var saveButton = commentSection.find('.inplace-edit--control--save');
-          var sendButton = commentSection.find('.inplace-edit--control--send');
           var commentField = commentSection.find('textarea').click();
 
           expect(saveButton.attr('disabled')).to.eq('disabled');
-          expect(sendButton.attr('disabled')).to.eq('disabled');
 
           commentField.val('a useful comment');
           commentField.trigger('change');
           expect(saveButton.attr('disabled')).to.be.undefined;
-          expect(sendButton.attr('disabled')).to.be.undefined;
         });
       });
     });


### PR DESCRIPTION
The option to save and send mail for a work package attribute has been
removed in https://github.com/opf/openproject/pull/3689.

However, some pieces of that implementation remained:
1. The comment field still had the third notify button
   ![commentsave](https://cloud.githubusercontent.com/assets/459462/10812105/00f0058c-7e13-11e5-95d9-611703531856.png)
2. Several directives and the `WorkPackageService` processed the
   notification field.

**Note**: This currently also removes the save and send button from the new work package form.

![bildschirmfoto 2015-10-28 um 16 47 33](https://cloud.githubusercontent.com/assets/459462/10794651/34d28b5e-7d96-11e5-99bd-c296fcea30d9.png)

Relevant work package: https://community.openproject.org/work_packages/21871
