### PR TITLE
[21890] Design issues on status reporting

### DIFF
--- a/app/assets/stylesheets/content/_form_error_messages.sass
+++ b/app/assets/stylesheets/content/_form_error_messages.sass
@@ -30,6 +30,7 @@
 
 span.errorSpan
   font-weight: bold
+  width: 100%
 
   textarea, select, input
     &, &:hover, &:focus

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -496,7 +496,6 @@ input[readonly].-clickable
 
   &.select2-container
     // styles adapted to input fields to align them
-    margin-bottom: 0.5rem
     .select2-choice
       height: 2.15rem
 
@@ -598,6 +597,7 @@ input[readonly].-clickable
     font-size: 1em
     background: none
     border: none
+    line-height: 2
 
 .form--label-with-check-box
   display:     block

--- a/app/assets/stylesheets/content/_select2.scss
+++ b/app/assets/stylesheets/content/_select2.scss
@@ -122,9 +122,10 @@ $se2-theme-selectable-font-color-highlighted: $drop-down-selected-font-color;
 
 $se2-element-height: 33px;
 $se2-input-height: rem-calc(34px);
-$se2-line-height: 30px;
+$se2-line-height: $se2-element-height;
 $se2-button-width: 28px;
-$se2-arrow-button-width: 18px;
+$se2-arrow-button-height: 20px;
+$se2-arrow-button-width: 17px;
 $se2-results-max-height: 200px;
 
 $se-multiple-input-line-height: 19px;
@@ -141,7 +142,7 @@ $se2-width: 100%;
     box-shadow: none;
     background: none;
     height: $se2-element-height;
-    line-height: $se2-element-height;
+    line-height: $se2-line-height;
 
     .select2-chosen {
       line-height: $se2-line-height;
@@ -156,7 +157,7 @@ $se2-width: 100%;
 
       > b {
         display: inline-block;
-        height: $se2-arrow-button-width;
+        height: $se2-arrow-button-height;
         width: $se2-arrow-button-width;
       }
     }


### PR DESCRIPTION
This sets the 'line-height' for select2-boxes equally to the height for the correct vertical alignment. Further the width of the class "errorSpan" is set to avoid too small fields.

https://community.openproject.org/work_packages/21890/activity
