### PR TITLE
Fix status reporting cukes

### DIFF
--- a/features/reportings/reporting_administration.feature
+++ b/features/reportings/reporting_administration.feature
@@ -39,11 +39,14 @@ Feature: General Reporting administration
           | Name | World Domination                    |
     Given there is 1 project with the following:
           | Name | How to stay sane and drink lemonade |
+    And there is a timeline "Testline" for project "Santas Project"
+    And there is a timeline "Testline" for project "World Domination"
+    And there is a timeline "Testline" for project "How to stay sane and drink lemonade"
 
   @javascript
   Scenario: Creating a reporting
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
       And I click on "New reporting"
       And I should see "Reports to project"
@@ -59,7 +62,7 @@ Feature: General Reporting administration
           | Project        | Reporting To Project | Reported Project Status Comment |
           | Santas Project | World Domination     | Hallo Junge                     |
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
       And I click on "New reporting"
       And I should see "Reports to project"
@@ -75,7 +78,7 @@ Feature: General Reporting administration
           | Project        | Reporting To Project | Reported Project Status Comment |
           | Santas Project | World Domination     | Hallo Junge                     |
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
      Then I should see "World Domination"
       And I should see "Hallo Junge"
@@ -98,7 +101,7 @@ Feature: General Reporting administration
           | Santas Project | Careful Boy          | Don't be a-gamblin'             |
 
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
      Then I should see "World Domination"
       And I should see "Hallo Junge"
@@ -120,7 +123,7 @@ Feature: General Reporting administration
           | Project        | Reporting To Project | Reported Project Status Comment |
           | Santas Project | World Domination     | Hallo Junge                     |
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
      When I follow link "Delete" for report "World Domination"
       And I click on "Delete"
@@ -134,7 +137,7 @@ Feature: General Reporting administration
           | Project        | Reporting To Project | Reported Project Status Comment |
           | Santas Project | World Domination     | Hallo Junge                     |
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
       And I click on "Delete"
       And I click on "Cancel"

--- a/features/reportings/reporting_permissions.feature
+++ b/features/reportings/reporting_permissions.feature
@@ -95,12 +95,13 @@ Feature: Reporting Permissions
 
       And the user "privileged" is a "project admin"
       And the user "unprivileged" is a "random guy" in the project "Santas Project"
+      And there is a timeline "Testline" for project "Santas Project"
 
   @javascript
   Scenario: Creating a reporting by a privileged user
      When I am already logged in as "privileged"
       And I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
       And I click on "New reporting"
 
@@ -116,7 +117,7 @@ Feature: Reporting Permissions
           | Santas Project | World Domination     | Hallo Junge                     |
 
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
       And I follow link "Edit" for report "World Domination"
 
@@ -129,7 +130,7 @@ Feature: Reporting Permissions
     Given the user "observer" is a "view reportings" in the project "Santas Project"
       And I am already logged in as "observer"
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
      Then I should not see "New reporting"
 
@@ -141,7 +142,7 @@ Feature: Reporting Permissions
           | Santas Project | World Domination     | Hallo Junge                     |
       And I am already logged in as "editor"
      When I go to the page of the project called "Santas Project"
-      And I toggle the "Timelines" submenu
+      And I open the "Timelines" menu
       And I click on "Status reportings"
 
      Then I should see "New reporting"


### PR DESCRIPTION
https://github.com/opf/openproject/pull/3711 moved the status reportings
menu into the timeline module.

This in turn breaks some cukes that rely on clicking the status
reportings menu.

Also, we need to extend these cukes with an existing timeline, otherwise
a new timeline form is rendered (for which some of the cukes do not
account permissions for and again, fail).
