### PR TITLE
add priority to list of attributes inherited from children

### DIFF
--- a/lib/api/decorators/schema.rb
+++ b/lib/api/decorators/schema.rb
@@ -66,7 +66,7 @@ module API
                                      name_source: property,
                                      href_callback:,
                                      required: true,
-                                     writable: true,
+                                     writable: -> { represented.writable?(property) },
                                      show_if: true)
           raise ArgumentError if property.nil?
 
@@ -97,7 +97,7 @@ module API
                                            value_representer:,
                                            link_factory:,
                                            required: true,
-                                           writable: true,
+                                           writable: -> { represented.writable?(property) },
                                            show_if: true)
           raise ArgumentError unless property
 

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -67,7 +67,11 @@ module API
           end
 
           def writable?(property)
-            if [:percentage_done, :estimated_time, :start_date, :due_date].include? property
+            if [:percentage_done,
+                :estimated_time,
+                :start_date,
+                :due_date,
+                :priority].include? property
               return false unless @work_package.leaf?
             end
 

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -63,6 +63,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     before do
       allow(schema).to receive(:assignable_values).with(:version, anything).and_return(versions)
+      allow(schema).to receive(:writable?).and_return(true)
     end
 
     describe 'basic custom field' do

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -231,5 +231,17 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
         expect(subject.writable?(:due_date)).to be true
       end
     end
+
+    context 'priority' do
+      it 'is not writable when the work package is a parent' do
+        allow(work_package).to receive(:leaf?).and_return(false)
+        expect(subject.writable?(:priority)).to be false
+      end
+
+      it 'is writable when the work package is a leaf' do
+        allow(work_package).to receive(:leaf?).and_return(true)
+        expect(subject.writable?(:priority)).to be true
+      end
+    end
   end
 end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -435,6 +435,10 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'priorities' do
+      before do
+        allow(schema).to receive(:writable?).with(:priority).and_return true
+      end
+
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'priority' }
         let(:type) { 'Priority' }
@@ -447,6 +451,20 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:json_path) { 'priority' }
         let(:href_path) { 'priorities' }
         let(:factory) { :priority }
+      end
+
+      context 'not writable' do
+        before do
+          allow(schema).to receive(:writable?).with(:priority).and_return false
+        end
+
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'priority' }
+          let(:type) { 'Priority' }
+          let(:name) { I18n.t('activerecord.attributes.work_package.priority') }
+          let(:required) { true }
+          let(:writable) { false }
+        end
       end
     end
 


### PR DESCRIPTION
Priority is inherited from the children up to the parent. The API should reflect that and declare the priority to not be writable for work packages that have children. As the front end is aware of the relevance of the `writable` property, it will not show the priority as editable. 
