### PR TITLE
[21404] LocalStorage backed persistent notification toggle

### DIFF
--- a/app/assets/javascripts/repository_navigation.js
+++ b/app/assets/javascripts/repository_navigation.js
@@ -79,33 +79,6 @@
         sendForm();
       }
     });
-
-
-    /*
-    Close checkout instructions
-    */
-    var checkout = $('#repository--checkout-instructions'),
-        toggle = $('#repository--checkout-instructions-toggle');
-
-    if (checkout.length > 0) {
-      checkout.find('.notification-box--close').click(function(e){
-        e.preventDefault();
-        checkout.hide().prop('hidden', true);
-        toggle.removeClass('-pressed');
-      });
-
-      toggle.click(function(e) {
-        e.preventDefault();
-        if (checkout.prop('hidden')) {
-          checkout.prop('hidden', false);
-          checkout.slideDown();
-        } else {
-          checkout.slideUp(function() { checkout.prop('hidden', true); });
-        }
-
-        toggle.toggleClass('-pressed');
-      });
-    }
   });
 }(jQuery));
 

--- a/app/assets/stylesheets/open_project_global/_accessibility.sass
+++ b/app/assets/stylesheets/open_project_global/_accessibility.sass
@@ -33,3 +33,6 @@
   width: 1px
   height: 1px
   overflow: hidden
+
+[hidden]
+  display: none

--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -26,8 +26,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<div id="repository--checkout-instructions" class="notification-box -info">
-  <a href="javscript:" title="{{ ::I18n.t('js.close_popup_title') }}" class="notification-box--close icon-context icon-close"></a>
+<div id="repository--checkout-instructions"
+     class="notification-box -info persistent-toggle--notification"
+     hidden>
+  <a title="{{ ::I18n.t('js.close_popup_title') }}"
+     class="notification-box--close icon-context icon-close">
+  </a>
   <div class="notification-box--content">
     <p>
     <%= simple_format instructions.instructions %>

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :header_tags do %>
   <%= javascript_include_tag 'repository_navigation' %>
 <% end %>
+<persistent-toggle identifier="repository.checkout_instructions">
 <%= toolbar title: l('repositories.named_repository',
                      vendor_name: @repository.class.vendor_name) do %>
   <% if @instructions && @instructions.available? %>
@@ -51,7 +52,9 @@ See doc/COPYRIGHT.rdoc for more details.
     </button>
   </li>
   <li class="toolbar-item -icon-only">
-    <a id="repository--checkout-instructions-toggle" class="button -pressed" href="javascript:"
+    <a id="repository--checkout-instructions-toggle"
+       class="persistent-toggle--click-handler button"
+       ng-class="{ '-pressed': !isHidden }"
        title="<%= l('repositories.checkout.show_instructions') %>">
       <i class="button--icon icon-info"></i>
     </a>
@@ -82,5 +85,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render partial: 'checkout_instructions',
              locals: { repository: @repository, instructions: @instructions } %>
 <% end %>
+</persistent-toggle>
 
 

--- a/frontend/app/ui_components/index.js
+++ b/frontend/app/ui_components/index.js
@@ -67,6 +67,11 @@ angular.module('openproject.uiComponents')
   .directive('inaccessibleByTab', [require('./inaccessible-by-tab-directive')])
   .directive('modal', [require('./modal-directive')])
   .directive('modalLoading', ['I18n', require('./modal-loading-directive')])
+  .directive('persistentToggle', [
+    '$timeout',
+    'CacheService',
+    require('./persistent-toggle-directive')]
+  )
   .directive('progressBar', ['I18n', require('./progress-bar-directive')])
   .constant('LABEL_MAX_CHARS', 40)
   .constant('KEY_CODES', {

--- a/frontend/app/ui_components/persistent-toggle-directive.js
+++ b/frontend/app/ui_components/persistent-toggle-directive.js
@@ -1,0 +1,71 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+module.exports = function($timeout, CacheService) {
+  return {
+    restrict: 'EA',
+    link: function(scope, element, attributes) {
+      var clickHandler = element.find('.persistent-toggle--click-handler'),
+          targetNotification = element.find('.persistent-toggle--notification'),
+          cache = CacheService.localStorage();
+
+      scope.isHidden = cache.get(attributes.identifier);
+
+      function toggle(isNowHidden) {
+        cache.put(attributes.identifier, isNowHidden);
+
+        scope.$apply(function() {
+          scope.isHidden = isNowHidden;
+        });
+
+        if (isNowHidden) {
+          targetNotification.slideUp(function() {
+            // Set hidden only after animation completed
+            targetNotification.prop('hidden', true);
+          });
+        } else {
+          targetNotification.slideDown();
+          targetNotification.prop('hidden', false);
+        }
+      }
+
+      // Clicking the handler toggles the notification
+      clickHandler.bind('click', function() {
+        toggle(!scope.isHidden);
+      });
+
+      // Closing the notification remembers the decision
+      targetNotification.find('.notification-box--close').bind('click', function() {
+        toggle(true);
+      });
+
+      // Set initial state
+      targetNotification.prop('hidden', !!scope.isHidden);
+    }
+  };
+};

--- a/frontend/tests/unit/tests/ui_components/persistent-toggle-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/persistent-toggle-directive-test.js
@@ -1,0 +1,87 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+describe('persistentToggle Directive', function() {
+  var compile, element, scope, CacheService;
+  var mockStorage = {};
+
+  beforeEach(module('openproject.api'));
+  beforeEach(angular.mock.module('openproject.uiComponents', 'openproject.services'));
+  beforeEach(module('openproject.templates'));
+
+  beforeEach(inject(function($rootScope, $compile, _CacheService_) {
+    var html = '<persistent-toggle identifier="test.foobar">' +
+      '<a class="persistent-toggle--click-handler"></a>' +
+      '<div class="persistent-toggle--notification"></div>' +
+      '</persistent-toggle>';
+
+    element = angular.element(html);
+    scope = $rootScope.$new();
+    CacheService = _CacheService_;
+
+    compile = function() {
+      $compile(element)(scope);
+      scope.$digest();
+    };
+  }));
+
+  describe('toggle property', function() {
+    var button, notification, getItemStub, setItemStub;
+
+    beforeEach(inject(function($window) {
+      compile();
+
+      getItemStub = sinon.stub($window.localStorage, 'getItem', function(key) { return mockStorage[key] });
+      setItemStub = sinon.stub($window.localStorage, 'setItem', function(key,value) { mockStorage[key] = value.toString() });
+
+      button  = element.find('.persistent-toggle--click-handler');
+      notification  = element.find('.persistent-toggle--notification');
+    }));
+
+    afterEach(function() {
+      getItemStub.restore();
+      setItemStub.restore();
+    });
+
+    it('shows when no value is set', function() {
+      var value = CacheService.localStorage().get('test.foobar');
+      expect(value).to.not.be.ok;
+      expect(notification.prop('hidden')).to.be.false;
+    });
+
+    it('persists the notification status when clicked', function() {
+      button.click();
+
+      expect(notification.prop('hidden')).to.be.true;
+      var value = CacheService.localStorage().get('test.foobar');
+      expect(value).to.equal(true);
+    });
+  });
+});

--- a/spec/features/repositories/checkout_instructions_spec.rb
+++ b/spec/features/repositories/checkout_instructions_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Create repository', type: :feature, js: true do
+  let(:current_user) { FactoryGirl.create (:admin) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:enabled_scms) { %w[git] }
+
+  before do
+    allow(User).to receive(:current).and_return current_user
+    allow(Setting).to receive(:enabled_scm).and_return(enabled_scms)
+    allow(Setting).to receive(:repository_checkout_data).and_return(checkout_data)
+
+    allow(OpenProject::Configuration).to receive(:[]).and_call_original
+    allow(OpenProject::Configuration).to receive(:[]).with('scm').and_return(config)
+  end
+
+  context 'managed repositories' do
+    include_context 'with tmpdir'
+    let(:config) {
+      {
+        git: { manages: File.join(tmpdir, 'git') }
+      }
+    }
+    let(:checkout_data) {
+      { 'git' => { 'enabled' => '1', 'base_url' => 'http://localhost/git/' } }
+    }
+
+    let!(:repository) {
+      repo = FactoryGirl.build(:repository_git, scm_type: :managed)
+      repo.project = project
+      repo.configure(:managed, nil)
+      repo.save!
+
+      repo
+    }
+
+    it 'toggles checkout instructions' do
+      visit project_repository_path(project)
+
+      expect(page).to have_selector('#repository--checkout-instructions')
+      expect(page).to have_selector('#repository--checkout-instructions-toggle.-pressed')
+
+      button = find('#repository--checkout-instructions-toggle')
+      button.click
+
+      expect(page).not_to have_selector('#repository--checkout-instructions')
+      expect(page).not_to have_selector('#repository--checkout-instructions-toggle.-pressed')
+    end
+  end
+end


### PR DESCRIPTION
Introduces a directive for storing the visibility state of a notification (currently used for repository checkout instructions) in LocalStorage using the `CacheService`.

This should be suitable for the notification toggle in `/my/account` as well.

Related work package: https://community.openproject.org/work_packages/21404
