### PR TITLE
[21702] Unnecessary page reload after changing search term when filtering work packages by their subject

### DIFF
--- a/frontend/app/work_packages/controllers/work-packages-list-controller.js
+++ b/frontend/app/work_packages/controllers/work-packages-list-controller.js
@@ -215,10 +215,9 @@ module.exports = function($scope, $rootScope, $state, $stateParams, $location, l
   function updateResults() {
     $scope.$broadcast('openproject.workPackages.updateResults');
 
-    $scope.refreshWorkPackages = WorkPackageService.getWorkPackages($scope.projectIdentifier, $scope.query, PaginationService.getPaginationOptions())
+    WorkPackageService.getWorkPackages($scope.projectIdentifier,
+      $scope.query, PaginationService.getPaginationOptions())
       .then(setupWorkPackagesTable);
-
-    return $scope.refreshWorkPackages;
   }
 
   // More

--- a/frontend/app/work_packages/directives/query-filter-directive.js
+++ b/frontend/app/work_packages/directives/query-filter-directive.js
@@ -54,7 +54,9 @@ module.exports = function(
       scope.showValueOptionsAsSelect = !scope.filter.isSingleInputField();
 
       if (scope.showValueOptionsAsSelect) {
-        WorkPackageLoadingHelper.withLoading(scope, QueryService.getAvailableFilterValues, [scope.filter.name, scope.projectIdentifier])
+        WorkPackageLoadingHelper.withLoading(scope, QueryService.getAvailableFilterValues,
+          [scope.filter.name, scope.projectIdentifier])
+
           .then(buildOptions)
           .then(addStandardOptions)
           .then(function(options) {
@@ -71,12 +73,18 @@ module.exports = function(
       // Filter updates
 
       scope.$watch('filter.operator', function(operator) {
-        if(operator && scope.filter.requiresValues) scope.showValuesInput = scope.filter.requiresValues();
+        if(operator && scope.filter.requiresValues){
+          scope.showValuesInput = scope.filter.requiresValues();
+        }
       });
 
       scope.$watch('filter', function(filter, oldFilter) {
+        var isEmptyText = filter.type === 'text' && filter.textValue === undefined;
+
         if (filter !== oldFilter) {
-          if (filter.isConfigured() && (filterChanged(filter, oldFilter) || valueReset(filter, oldFilter))) {
+          if ((isEmptyText || filter.isConfigured())
+              && (filterChanged(filter, oldFilter) || valueReset(filter, oldFilter))) {
+
             PaginationService.resetPage();
             scope.$emit('queryStateChange');
             scope.$emit('workPackagesRefreshRequired');


### PR DESCRIPTION
Remove the loading overlay when filtering for text values.
If no text is given, the filter behaves as if it is not set.

https://community.openproject.org/work_packages/21702/activity
