### PR TITLE
[21771] Spent time section is shown even if there is no time logged

### DIFF
--- a/frontend/app/work_packages/services/work-package-field-service.js
+++ b/frontend/app/work_packages/services/work-package-field-service.js
@@ -218,8 +218,7 @@ module.exports = function(
       return true;
     }
 
-    // strategy pattern, guys
-    if (field === 'spentTime' && WorkPackageFieldService.getValue(workPackage, field) === 'PT0S') {
+    if (field === 'spentTime' && workPackage.props[field] === 'PT0S') {
       return true;
     }
 


### PR DESCRIPTION
Supersedes https://github.com/opf/openproject/pull/3730

If the spentTime field has the value "0 hours", hide it. Checks for `PT0S`, the empty ISO8601 duration returned [by the API](https://github.com/opf/openproject/blob/release/4.2/doc/apiv3-documentation.apib#L271).

https://community.openproject.org/work_packages/21771/activity
