### PR TITLE
Membership change not waiting for ajax

### DIFF
--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -68,4 +68,5 @@ When /^I edit membership to project "(.*?)" to contain the roles:$/ do |project,
     checkbox.click unless checkbox.checked?
   end
   steps %{ And I click "Change" within "#tab-content-memberships .memberships" }
+  steps %{ And I wait for AJAX }
 end


### PR DESCRIPTION
The membership edit cuke does not wait for ajax to complete,
thus the page reload may occur before the roles have actually been
updated.

This should fix the broken cuke http://ci/job/myproject-dev-test/2895/Db=postgresql,Node=0.10,Ruby=2.2.3,Tests=core-features,l=tests/testReport/(root)/User/Editing_membership_to_a_project/
