### PR TITLE
Prevent legacy tests from failing randomly

### DIFF
--- a/app/assets/javascripts/openproject.js
+++ b/app/assets/javascripts/openproject.js
@@ -69,8 +69,12 @@ window.OpenProject = (function ($) {
         project.hname   = OpenProject.Helpers.hname(project.name, project.level);
         project.parents = parents.slice(0, -1); // make sure to pass a clone
         project.tokens  = OpenProject.Helpers.Search.tokenize(project.name);
-        project.url     = openProject.getFullUrl('/projects/' + project.identifier) + "?jump=" +
-                            encodeURIComponent(jQuery('meta[name="current_menu_item"]').attr('content'));
+        project.url     = openProject.getFullUrl('/projects/' + project.identifier);
+
+        var currentMenuItem = jQuery('meta[name="current_menu_item"]').attr('content');
+        if (currentMenuItem) {
+          project.url += "?jump=" + encodeURIComponent(currentMenuItem);
+        }
 
         return project;
       });


### PR DESCRIPTION
If there is no content attribute for the given meta tag (see commit), no parameters are appended.
This prevents legacy tests from failing randomly.
