### PR TITLE
Fix/localized values

### DIFF
--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -365,12 +365,13 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
       return null;
     }
 
-    var mappings = {
+    var fieldMapping = {
       dueDate: 'date',
       startDate: 'date',
       createdAt: 'datetime',
       updatedAt: 'datetime'
-    };
+    }[field] || schema.props[field].type;
+
 
     if (schema.props[field] && schema.props[field]) {
       if (schema.props[field].type === 'Duration') {
@@ -386,9 +387,12 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
       if (workPackage.schema.props[field].type === 'Date') {
         return value;
       }
+      if (fieldMapping === 'Float') {
+        return $filter('number')(value);
+      }
     }
 
-    return WorkPackagesHelper.formatValue(value, mappings[field]);
+    return WorkPackagesHelper.formatValue(value, fieldMapping);
   }
 
   var WorkPackageFieldService = {

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -372,27 +372,20 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
       updatedAt: 'datetime'
     }[field] || schema.props[field].type;
 
-
-    if (schema.props[field] && schema.props[field]) {
-      if (schema.props[field].type === 'Duration') {
+    switch(fieldMapping) {
+      case('Duration'):
         var hours = moment.duration(value).asHours();
         var formattedHours = $filter('number')(hours, 2);
         return I18n.t('js.units.hour', { count: formattedHours });
-      }
-
-      if (schema.props[field].type === 'Boolean') {
+      case('Boolean'):
         return value ? I18n.t('js.general_text_yes') : I18n.t('js.general_text_no');
-      }
-
-      if (workPackage.schema.props[field].type === 'Date') {
+      case('Date'):
         return value;
-      }
-      if (fieldMapping === 'Float') {
+      case('Float'):
         return $filter('number')(value);
-      }
+      default:
+        return WorkPackagesHelper.formatValue(value, fieldMapping);
     }
-
-    return WorkPackagesHelper.formatValue(value, fieldMapping);
   }
 
   var WorkPackageFieldService = {

--- a/lib/redmine/custom_field_format.rb
+++ b/lib/redmine/custom_field_format.rb
@@ -30,6 +30,7 @@
 module Redmine
   class CustomFieldFormat
     include Redmine::I18n
+    include ActionView::Helpers::NumberHelper
 
     cattr_accessor :available
     @@available = {}
@@ -56,10 +57,14 @@ module Redmine
       l(is_true ? :general_text_Yes : :general_text_No)
     end
 
-    ['string', 'text', 'int', 'float', 'list'].each do |name|
+    ['string', 'text', 'int', 'list'].each do |name|
       define_method("format_as_#{name}") {|value|
         return value.to_s
       }
+    end
+
+    def format_as_float(value)
+      number_with_delimiter(value.to_s)
     end
 
     ['user', 'version'].each do |name|

--- a/spec/lib/redmine/custom_field_format_spec.rb
+++ b/spec/lib/redmine/custom_field_format_spec.rb
@@ -26,14 +26,16 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class JournalFormatter::Fraction < JournalFormatter::Attribute
-  include ActionView::Helpers::NumberHelper
+require 'spec_helper'
 
-  def format_values(values)
-    values.map do |v|
-      v.nil? ?
-        nil :
-        number_with_precision(v.to_f, precision: 2)
+describe Redmine::CustomFieldFormat do
+  let(:instance) { described_class.new 'test', label: 'blubs', order: '1' }
+
+  describe '#format_value' do
+    it 'returns a localized float' do
+      I18n.with_locale(:de) do
+        expect(instance.format_as_float('5.67')).to eql '5,67'
+      end
     end
   end
 end


### PR DESCRIPTION
Localizes values for custom fields of type float in the work package show page.

It does so by localizing the value returned from the API. For consistency sake, I also change the localization of the journals, so they should be in synch.

That should fix what https://community.openproject.org/work_packages/21799 mentioned.

I have however not been able to also change the localization in the work packages table. Because the two views do not share the same data structure and the information, whether the value is actually a float or just some string is not easily available in the work packages table, I see no way to extend the fix to that part of the application. We would need to change the data structure underlying the wp table first. 
