### PR TITLE
[21945] Let start and end date stay on the same line

### DIFF
--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -60,7 +60,6 @@ div[class*='work-packages--details--']
     span
       overflow: hidden
       text-overflow: ellipsis
-      display: block
 
       p
         overflow: inherit


### PR DESCRIPTION
https://github.com/opf/openproject/pull/3339 introduced `display: block` on all spans, along other things. I cannot see a difference for that single rule other than it causes the bug reported at https://community.openproject.org/work_packages/21945.
