### PR TITLE
[ci skip] Allow teatro to start up

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,6 +1,8 @@
+project:
+  after:
+    - npm install npm
 stage:
   before:
-    - npm install npm
     - pushd frontend;
       npm install --unsafe-perm --ignore-scripts;
       bower install --allow-root;
@@ -13,4 +15,5 @@ stage:
     - bundle exec rake db:create db:migrate
     - bundle exec rake db:seed RAILS_ENV=development
 
-  run: foreman start -f Procfile.dev
+  assets: bundle exec rake assets:webpack RAILS_ENV=development
+  run: foreman start -f Procfile.dev -c all=1,assets=0


### PR DESCRIPTION
Forcefully runs assets:webpack before running the application due to some strange bug in teatro that looks for a webpack-provided bundle that is yet in process of being bundled.

Also runs `npm install npm` on the project's container itself rather than in every step.
