### PR TITLE
[21896] Buttons too close on tables

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -58,7 +58,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
     y: auto
 
 .generic-table--action-buttons
-  margin-top: 3rem
+  margin-top: 2rem
 
 #generic-table
   tr.issue

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -124,11 +124,12 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <br>
-  <%= link_to new_custom_field_path(type: tab[:name]), class: 'button -alt-highlight' do %>
-    <i class="button--icon icon-add"></i>
-    <span class="button--text"><%= l(:label_custom_field_new) %></span>
-  <% end %>
+  <div class="generic-table--action-buttons">
+    <%= link_to new_custom_field_path(type: tab[:name]), class: 'button -alt-highlight' do %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_custom_field_new) %></span>
+    <% end %>
+  </div>
 <% else %>
   <%= no_results_box(action_url: new_custom_field_path(type: tab[:name]), display_action: true) %>
 <% end %>

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -102,5 +102,11 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
   <% end %>
-  <p><%= link_to l(:label_enumeration_new), { action: 'new', type: klass.name } %></p>
+  <div class="generic-table--action-buttons">
+    <%= link_to l(:label_enumeration_new), { action: 'new', type: klass.name , class: 'button -alt-highlight'} do %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= l(:label_enumeration_new) %></span>
+    <% end %>
+  </div>
+
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -56,7 +56,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if ((project.module_enabled?('work_package_tracking')) && render_types) %>
   <section class="form--section">
     <%= render partial: 'projects/form/types',
-               locals: { f: f, project: project } %>
+               locals: { f: f, project: project, withControlls: false} %>
   </section>
 <% end %>
 

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<fieldset class="form--fieldset -with-control" id="project_types">
+<fieldset class="form--fieldset" id="project_types">
   <legend class="form--fieldset-legend"><%=l(:label_enabled_project_activities)%></legend>
 
   <div class="generic-table--container">
@@ -107,4 +107,9 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="generic-table--header-background"></div>
     </div>
   </div>
+  <% if withControlls == true %>
+    <div class="generic-table--action-buttons">
+      <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+    </div>
+  <% end %>
 </fieldset>

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
                          id: "types_flash_notice",
                          class: "ignored-by-flash-activation" %>
 
-<fieldset class="form--fieldset -with-control" id="project_types">
+<fieldset class="form--fieldset" id="project_types">
   <legend class="form--fieldset-legend"><%=l(:label_enabled_project_types)%></legend>
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">
@@ -134,4 +134,9 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
+  <% if withControlls == true %>
+    <div class="generic-table--action-buttons">
+      <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+    </div>
+  <% end %>
 </fieldset>

--- a/app/views/projects/settings/_activities.html.erb
+++ b/app/views/projects/settings/_activities.html.erb
@@ -31,9 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 method: :put,
                 class: "tabular" do %>
 
-    <%= render partial: 'projects/form/activities', locals: { project: @project } %>
-
-    <p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %></p>
+    <%= render partial: 'projects/form/activities', locals: { project: @project, withControlls: true } %>
   <% end %>
 
   <br/>

--- a/app/views/projects/settings/_boards.html.erb
+++ b/app/views/projects/settings/_boards.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% if @project.boards.any? %>
-  <fieldset class="form--fieldset -with-control">
+  <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_boards) %>
     </legend>
@@ -104,15 +104,17 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="generic-table--header-background"></div>
       </div>
     </div>
+    <% if @project.boards.any? %>
+      <div class="generic-table--action-buttons">
+        <%= link_to_if_authorized({ controller: '/boards', action: 'new', project_id: @project },
+                                class: 'button -alt-highlight') do %>
+          <i class="button--icon icon-add"></i>
+          <span class="button--text"><%= l(:label_board_new) %></span>
+        <% end %>
+      </div>
+    <% end %>
   <% else %>
     <%= no_results_box(action_url: new_project_category_path(@project), display_action: authorize_for('categories', 'new')) %>
   <% end %>
 </fieldset>
 
-<% if @project.boards.any? %>
-  <p>
-    <%= link_to_if_authorized l(:label_board_new),
-                              { controller: '/boards', action: 'new', project_id: @project },
-                              class: 'button -alt-highlight' %>
-  </p>
-<% end %>

--- a/app/views/projects/settings/_categories.html.erb
+++ b/app/views/projects/settings/_categories.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% if @project.categories.any? %>
-  <fieldset class="form--fieldset -with-control">
+  <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_work_package_categories) %>
     </legend>
@@ -87,15 +87,16 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="generic-table--header-background"></div>
       </div>
     </div>
+    <% if @project.categories.any? %>
+      <div class="generic-table--action-buttons">
+        <%= link_to_if_authorized({ controller: '/categories', action: 'new', project_id: @project },
+                              class: 'button -alt-highlight') do %>
+          <i class="button--icon icon-add"></i>
+          <span class="button--text"><%= l(:label_work_package_category_new) %></span>
+        <% end %>
+      </div>
+    <% end %>
   <% else %>
     <%= no_results_box(action_url: new_project_category_path(@project), display_action: authorize_for('categories', 'new')) %>
   <% end %>
 </fieldset>
-
-<% if @project.categories.any? %>
-  <p>
-    <%= link_to_if_authorized l(:label_work_package_category_new),
-                              { controller: '/categories', action: 'new', project_id: @project },
-                              class: 'button -alt-highlight' %>
-  </p>
-<% end %>

--- a/app/views/projects/settings/_types.html.erb
+++ b/app/views/projects/settings/_types.html.erb
@@ -32,9 +32,8 @@ See doc/COPYRIGHT.rdoc for more details.
                url: { action: 'types', id: @project },
                method: :patch,
                html: {id: 'types-form'} do |f| %>
-    <%= render partial: 'projects/form/types', locals: { f: f, project: @project } %>
+    <%= render partial: 'projects/form/types', locals: { f: f, project: @project, withControlls: true } %>
 
-    <p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %></p>
   <% end %>
 
   <br/>

--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% if @project.shared_versions.any? %>
-  <fieldset class="form--fieldset -with-control">
+  <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_versions) %>
     </legend>
@@ -150,6 +150,15 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="generic-table--header-background"></div>
       </div>
     </div>
+    <% if @project.versions.any? %>
+      <div class="generic-table--action-buttons">
+        <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                              class: 'button -alt-highlight') do %>
+          <i class="button--icon icon-add"></i>
+          <span class="button--text"><%= l(:label_version_new) %></span>
+        <% end %>
+      </div>
+    <% end %>
   <% else %>
     <%= no_results_box(action_url: new_project_version_path(@project), display_action: authorize_for('messages', 'new')) %>
   <% end %>
@@ -161,10 +170,4 @@ See doc/COPYRIGHT.rdoc for more details.
                   close_completed_project_versions_path(@project),
                   method: :put %>
   </div>
-
-  <p>
-    <%= link_to_if_authorized l(:label_version_new),
-                              { controller: '/versions', action: 'new', project_id: @project },
-                              class: 'button -alt-highlight' %>
-  </p>
 <% end %>


### PR DESCRIPTION
This PR applies the class 'generic-table--action-buttons' for buttons below tables. The class adds a margin so that the buttons are not too close to the table. It was introduced in the scope of https://github.com/opf/openproject/pull/3637.

This applies the class for the tables Admin/Enumeration, Admin/CF, Settings

Further there are also tables in backlogs, costs and pdf-export plugin, which will be regarded in separate PRs.

https://community.openproject.org/work_packages/21896/activity
