### PR TITLE
[21904] Check box too close to button in work package share modal

### DIFF
--- a/frontend/app/templates/work_packages/modals/share.html
+++ b/frontend/app/templates/work_packages/modals/share.html
@@ -4,35 +4,37 @@
 
     <h3>{{ ::I18n.t('js.label_share') }}</h3>
 
-    <div>
-      <label class="checkbox-label">
-        <input type="checkbox"
+    <div class="form--field -wide-label">
+      <div class="form--field-container -vertical">
+        <label class="form--label-with-check-box">
+          <div class="form--check-box-container">
+            <input type="checkbox"
                name="is_public"
                ng-model="query.isPublic"
                ng-disabled="cannot('query', 'publicize') && cannot('query', 'depublicize')"
+               class="form--check-box"
                focus></input>
-        <div class="styled-checkbox"></div>
-        {{ ::I18n.t('js.label_visible_for_others') }}
-      </label>
-    </div>
-    <div>
-      <label class="checkbox-label">
-        <input type="checkbox"
+          </div>
+          {{ ::I18n.t('js.label_visible_for_others') }}
+        </label>
+        <label class="form--label-with-check-box">
+          <div class="form--check-box-container">
+            <input type="checkbox"
                name="show_in_menu"
                ng-model="shareSettings.starred"
-               ng-disabled="query.isGlobal() || cannot('query', 'star')"></input>
-        <div class="styled-checkbox"></div>
-        {{ ::I18n.t('js.label_show_in_menu') }}
-      </label>
-    </div>
-    <div>
-      <button class="button -highlight -with-icon icon-yes" ng-click="saveQuery()">
-        {{ ::I18n.t('js.modals.button_save') }}
-      </button>
-      <button class="button" ng-click="modal.closeMe()">
-        {{ ::I18n.t('js.modals.button_cancel') }}
-      </button>
+               ng-disabled="query.isGlobal() || cannot('query', 'star')"
+               class="form--check-box"></input>
+          </div>
+          {{ ::I18n.t('js.label_show_in_menu') }}
+        </label>
+      </div>
     </div>
 
+    <button class="button -highlight -with-icon icon-yes" ng-click="saveQuery()">
+      {{ ::I18n.t('js.modals.button_save') }}
+    </button>
+    <button class="button" ng-click="modal.closeMe()">
+      {{ ::I18n.t('js.modals.button_cancel') }}
+    </button>
   </div>
 </div>


### PR DESCRIPTION
This PR applies the class hierarchy as suggested in the LSG to the share modal view. Thus the checkboxes were correctly displayed.

https://community.openproject.org/work_packages/21904/activity
