### PR TITLE
[21964] Greater distance of buttons in wiki and repositories

### DIFF
--- a/app/assets/stylesheets/scm.css.sass
+++ b/app/assets/stylesheets/scm.css.sass
@@ -80,9 +80,6 @@ li.change
 .repository--checkout-instructions--url
   margin-top: 1rem
 
-button.repository--compare-button
-  margin-top: 1rem
-
 .repository-breadcrumbs
   font-size: 0.9rem
   margin: 15px 0

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -113,9 +113,11 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
   </div>
   <% if show_diff %>
-    <button type="submit" class="button repository--compare-button">
-      <i class="button--icon icon-compare"></i>
-      <span class="button--text"><%= l(:label_view_diff) %></span>
-    </button>
+    <div class="generic-table--action-buttons">
+      <button type="submit" class="button">
+        <i class="button--icon icon-compare"></i>
+        <span class="button--text"><%= l(:label_view_diff) %></span>
+      </button>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -114,6 +114,9 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <%= submit_tag l(:label_view_diff), class: 'button -highlight -small' if show_diff %>
+  <div class="generic-table--action-buttons">
+    <%= submit_tag l(:label_view_diff), class: 'button -highlight -small' if show_diff %>
+  </div>
+
   <%= pagination_links_full @versions %>
 <% end %>


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/3756 the class 'generic-table--action-buttons' is applied. Thereby the revision tables for wiki and repos were missing. This is done in this PR.

https://community.openproject.org/work_packages/21964/activity
