### PR TITLE
[21966] Broken layout of field affixes in tables

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -156,7 +156,6 @@ table.generic-table
       @each $inputElement in $input-elements
         #{$inputElement},
         #{$inputElement}~.form-label
-          display: inline-block
           vertical-align: middle
 
       input[type="checkbox"], input[type="radio"]


### PR DESCRIPTION
This removes the `display: inline-block` value for the correct alignment. The input and select fields are now displayed as block while the affix gets displayed as flex. This is defined in the LSG component.

https://community.openproject.org/work_packages/21966/activity
