### PR TITLE
Feature/limited notifictions

### DIFF
--- a/frontend/app/services/notifications-service.js
+++ b/frontend/app/services/notifications-service.js
@@ -61,12 +61,33 @@ module.exports = function(I18n, $rootScope) {
   },
   broadcast = function(event, data) {
     $rootScope.$broadcast(event, data);
+  },
+  currentNotifications = [],
+  notificationAdded = function(newNotification) {
+    var toRemove = currentNotifications.slice(0);
+    _.each(toRemove, function(existingNotification) {
+      if (newNotification.type === 'success' || newNotification.type === 'error') {
+        remove(existingNotification);
+      }
+    });
+
+    currentNotifications.push(newNotification);
+  },
+  notificationRemoved = function(removedNotification) {
+    _.remove(currentNotifications, function(element) {
+      return element === removedNotification;
+    });
   };
+
+  $rootScope.$on('notification.remove', function(_e, notification) {
+    notificationRemoved(notification);
+  });
 
   // public
   var add = function(message) {
     var notification = createNotification(message);
     broadcast('notification.add', notification);
+    notificationAdded(notification);
     return notification;
   },
   addError = function(message, errors) {
@@ -79,7 +100,7 @@ module.exports = function(I18n, $rootScope) {
     return add(createSuccessNotification(message));
   },
   addNotice = function(message) {
-    return add(createNoticeNotification(message))
+    return add(createNoticeNotification(message));
   },
   addWorkPackageUpload = function(message, uploads) {
     return add(createWorkPackageUploadNotification(message, uploads));
@@ -87,6 +108,7 @@ module.exports = function(I18n, $rootScope) {
   remove = function(notification) {
     broadcast('notification.remove', notification);
   };
+
 
   return {
     add: add,

--- a/frontend/app/work_packages/controllers/index.js
+++ b/frontend/app/work_packages/controllers/index.js
@@ -108,6 +108,8 @@ angular.module('openproject.workPackages.controllers')
     'WorkPackageService',
     'EditableFieldsState',
     'WorkPackagesDisplayHelper',
+    'NotificationsService',
+    'I18n',
     require('./work-package-new-controller')
   ])
   .controller('WorkPackageShowController', [

--- a/frontend/app/work_packages/controllers/work-package-new-controller.js
+++ b/frontend/app/work_packages/controllers/work-package-new-controller.js
@@ -38,7 +38,9 @@ module.exports = function(
            WorkPackageFieldService,
            WorkPackageService,
            EditableFieldsState,
-           WorkPackageDisplayHelper
+           WorkPackageDisplayHelper,
+           NotificationsService,
+           I18n
            ) {
 
   var vm = this;
@@ -120,6 +122,7 @@ module.exports = function(
 
     EditableFieldsState.save(function() {
       $rootScope.$emit('workPackagesRefreshRequired');
+      NotificationsService.addSuccess(I18n.t('js.notice_successful_create'));
     });
   }
 

--- a/frontend/app/work_packages/directives/work-package-comment-directive.js
+++ b/frontend/app/work_packages/directives/work-package-comment-directive.js
@@ -114,7 +114,7 @@ module.exports = function(
         ctrl.writeValue
       ).then(function() {
         ctrl.discardEditing();
-        NotificationsService.addSuccess(I18n.t('js.work_packages.comment_added'));
+        NotificationsService.addSuccess(I18n.t('js.notice_successful_update'));
         submit.resolve();
       }, function() {
         NotificationsService.addError(I18n.t('js.work_packages.comment_send_failed'));


### PR DESCRIPTION
All existing notifications get removed if a notification of type
- success
- error
  is added.

This is for now a very naive implementation but might prove enough to satisfy the requirements as formulated in https://community.openproject.org/work_packages/20248.

In addition, it adds a success notification after wp creation.
