### PR TITLE
Feature/limited notifictions

### DIFF
--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -199,7 +199,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   &.ng-enter.ng-enter-active
     opacity: 1
   &.ng-leave
-    +transition(opacity 0.5s ease)
+    +transition(opacity 2s ease)
     opacity: 1
   &.ng-leave.ng-leave-active
     opacity: 0

--- a/features/work_packages/update.feature
+++ b/features/work_packages/update.feature
@@ -129,7 +129,6 @@ Feature: Updating work packages
     And I fill in a comment with "human horn"
     And I preview the comment to be added and see "human horn"
     And I submit the form by the "Save" button
-    And I should see "The comment was successfully added."
     And I should see the comment "human horn"
 
   @javascript

--- a/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.js
+++ b/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.js
@@ -38,7 +38,8 @@ function editActionsBar() {
       'edit-actions-bar.directive.html',
 
     scope: {
-      onCancel: '&'
+      onCancel: '&',
+      onSave: '&'
     },
 
     bindToController: true,
@@ -52,9 +53,7 @@ function editActionsBar() {
         },
 
         save: function () {
-          EditableFieldsState.save().then(function() {
-            NotificationsService.addSuccess(I18n.t('js.notice_successful_create'));
-          });
+          EditableFieldsState.save().then(vm.onSave);
         },
 
         cancel: function () {

--- a/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.js
+++ b/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.js
@@ -43,7 +43,7 @@ function editActionsBar() {
 
     bindToController: true,
     controllerAs: 'vm',
-    controller:  function ($scope, I18n, EditableFieldsState) {
+    controller:  function ($scope, I18n, EditableFieldsState, NotificationsService) {
       var vm = this;
 
       angular.extend(vm, {
@@ -52,7 +52,9 @@ function editActionsBar() {
         },
 
         save: function () {
-          EditableFieldsState.save();
+          EditableFieldsState.save().then(function() {
+            NotificationsService.addSuccess(I18n.t('js.notice_successful_create'));
+          });
         },
 
         cancel: function () {

--- a/frontend/app/components/inplace-edit/services/editable-fields-state.service.js
+++ b/frontend/app/components/inplace-edit/services/editable-fields-state.service.js
@@ -49,7 +49,9 @@ function EditableFieldsState($q, $rootScope, $window) {
     },
 
     save: function () {
-      var promises = [];
+      var promises = [],
+          deferred = $q.defer();
+
       angular.forEach(this.submissionPromises, function(field) {
         var p = field.thePromise.call(this);
         promises[field.prepend ? 'unshift' : 'push' ](p);
@@ -61,7 +63,10 @@ function EditableFieldsState($q, $rootScope, $window) {
         this.submissionPromises = {};
         this.currentField = null;
         this.editAll.stop();
+        deferred.resolve();
       }));
+
+      return deferred.promise;
     },
 
     discard: function (fieldName) {

--- a/frontend/app/components/routes/controllers/work-package-new.controller.js
+++ b/frontend/app/components/routes/controllers/work-package-new.controller.js
@@ -32,7 +32,7 @@ angular
 
 function WorkPackageNewController($scope, $rootScope, $state, $stateParams, PathHelper,
     WorkPackagesOverviewService, WorkPackageFieldService, WorkPackageService, EditableFieldsState,
-    WorkPackagesDisplayHelper) {
+    WorkPackagesDisplayHelper, NotificationsService) {
 
   var vm = this;
 
@@ -53,6 +53,10 @@ function WorkPackageNewController($scope, $rootScope, $state, $stateParams, Path
   vm.isEditable = WorkPackagesDisplayHelper.isEditable;
   vm.hasNiceStar = WorkPackagesDisplayHelper.hasNiceStar;
   vm.showToggleButton = WorkPackagesDisplayHelper.showToggleButton;
+
+  vm.notifyCreation = function() {
+    NotificationsService.addSuccess(I18n.t('js.notice_successful_create'));
+  };
 
   activate();
 

--- a/frontend/app/components/routes/templates/work-package-new.route.html
+++ b/frontend/app/components/routes/templates/work-package-new.route.html
@@ -84,4 +84,6 @@
     <work-package-attachments work-package="vm.workPackage" data-ng-show="!vm.hideEmptyFields"></work-package-attachments>
   </div>
 </div>
-<edit-actions-bar on-cancel="vm.cancel()"></edit-actions-bar>
+<edit-actions-bar on-cancel="vm.cancel()"
+                  on-save="vm.notifyCreation()">
+</edit-actions-bar>

--- a/frontend/app/components/work-packages/directives/work-package-comment/work-package-comment.directive.js
+++ b/frontend/app/components/work-packages/directives/work-package-comment/work-package-comment.directive.js
@@ -109,7 +109,7 @@ function workPackageComment($timeout, $location, $q, EditableFieldsState,
         ctrl.writeValue
       ).then(function() {
         ctrl.discardEditing();
-        NotificationsService.addSuccess(I18n.t('js.work_packages.comment_added'));
+        NotificationsService.addSuccess(I18n.t('js.notice_successful_update'));
         submit.resolve();
       }, function() {
         NotificationsService.addError(I18n.t('js.work_packages.comment_send_failed'));

--- a/frontend/app/components/work-packages/directives/work-package-comment/work-package-comment.directive.js
+++ b/frontend/app/components/work-packages/directives/work-package-comment/work-package-comment.directive.js
@@ -109,7 +109,6 @@ function workPackageComment($timeout, $location, $q, EditableFieldsState,
         ctrl.writeValue
       ).then(function() {
         ctrl.discardEditing();
-        NotificationsService.addSuccess(I18n.t('js.notice_successful_update'));
         submit.resolve();
       }, function() {
         NotificationsService.addError(I18n.t('js.work_packages.comment_send_failed'));

--- a/frontend/app/services/notifications-service.js
+++ b/frontend/app/services/notifications-service.js
@@ -61,12 +61,33 @@ module.exports = function(I18n, $rootScope) {
   },
   broadcast = function(event, data) {
     $rootScope.$broadcast(event, data);
+  },
+  currentNotifications = [],
+  notificationAdded = function(newNotification) {
+    var toRemove = currentNotifications.slice(0);
+    _.each(toRemove, function(existingNotification) {
+      if (newNotification.type === 'success' || newNotification.type === 'error') {
+        remove(existingNotification);
+      }
+    });
+
+    currentNotifications.push(newNotification);
+  },
+  notificationRemoved = function(removedNotification) {
+    _.remove(currentNotifications, function(element) {
+      return element === removedNotification;
+    });
   };
+
+  $rootScope.$on('notification.remove', function(_e, notification) {
+    notificationRemoved(notification);
+  });
 
   // public
   var add = function(message) {
     var notification = createNotification(message);
     broadcast('notification.add', notification);
+    notificationAdded(notification);
     return notification;
   },
   addError = function(message, errors) {
@@ -79,7 +100,7 @@ module.exports = function(I18n, $rootScope) {
     return add(createSuccessNotification(message));
   },
   addNotice = function(message) {
-    return add(createNoticeNotification(message))
+    return add(createNoticeNotification(message));
   },
   addWorkPackageUpload = function(message, uploads) {
     return add(createWorkPackageUploadNotification(message, uploads));
@@ -87,6 +108,7 @@ module.exports = function(I18n, $rootScope) {
   remove = function(notification) {
     broadcast('notification.remove', notification);
   };
+
 
   return {
     add: add,

--- a/frontend/app/ui_components/notifications-directive.js
+++ b/frontend/app/ui_components/notifications-directive.js
@@ -32,7 +32,7 @@ module.exports = function() {
     scope.stack = [];
 
     scope.$on('notification.add', function(_e, notification) {
-      scope.stack.push(notification);
+      scope.stack.unshift(notification);
     });
 
     scope.$on('notification.remove', function(_e, notification) {

--- a/frontend/app/work_packages/controllers/index.js
+++ b/frontend/app/work_packages/controllers/index.js
@@ -95,23 +95,6 @@ angular.module('openproject.workPackages.controllers')
     'NotificationsService',
     require('./work-package-details-controller')
   ])
-  .controller('WorkPackageNewController', [
-    '$scope',
-    '$rootScope',
-    '$state',
-    '$stateParams',
-    '$timeout',
-    '$window',
-    'PathHelper',
-    'WorkPackagesOverviewService',
-    'WorkPackageFieldService',
-    'WorkPackageService',
-    'EditableFieldsState',
-    'WorkPackagesDisplayHelper',
-    'NotificationsService',
-    'I18n',
-    require('./work-package-new-controller')
-  ])
   .controller('WorkPackageShowController', [
     '$scope',
     '$rootScope',

--- a/frontend/app/work_packages/controllers/index.js
+++ b/frontend/app/work_packages/controllers/index.js
@@ -95,6 +95,23 @@ angular.module('openproject.workPackages.controllers')
     'NotificationsService',
     require('./work-package-details-controller')
   ])
+  .controller('WorkPackageNewController', [
+    '$scope',
+    '$rootScope',
+    '$state',
+    '$stateParams',
+    '$timeout',
+    '$window',
+    'PathHelper',
+    'WorkPackagesOverviewService',
+    'WorkPackageFieldService',
+    'WorkPackageService',
+    'EditableFieldsState',
+    'WorkPackagesDisplayHelper',
+    'NotificationsService',
+    'I18n',
+    require('./work-package-new-controller')
+  ])
   .controller('WorkPackageShowController', [
     '$scope',
     '$rootScope',


### PR DESCRIPTION
Supersedes https://github.com/opf/openproject/pull/3764
- Removes comment submission notification
- Re-orders notifications for marginally better animations (we'll have to discuss how the removal should actually look like)

---

Original description:

All existing notifications get removed if a notification of type
- success
- error is added.

This is for now a very naive implementation but might prove enough to satisfy the requirements as formulated in https://community.openproject.org/work_packages/20248.

In addition, it adds a success notification after wp creation.
