### PR TITLE
[21940] Allow type changes without validation errors

### DIFF
--- a/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
+++ b/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
@@ -173,7 +173,7 @@ function InplaceEditorEditPaneController($scope, $element, $location, $timeout,
   });
 
   $scope.$on('form.updateRequired', function() {
-    inplaceEditStorage.updateWorkPackageForm();
+    inplaceEditStorage.refreshWorkPackageForm();
   });
 
   $scope.$on('workPackageRefreshed', function() {


### PR DESCRIPTION
This separates updateWorkPackageForm into a refreshWorkPackageForm,
which does not check validations.

This is required for updating the form from the API for type changes,
thus allowing to receive the latest form for the given type while not
reciving any validation errors nor losing data for the intersection of
form fields.

Relevant work package: https://community.openproject.org/work_packages/21940/activity

This should be complete, but is waiting for https://github.com/opf/openproject/pull/3753 to be merged.
