### PR TITLE
[21970] Add definingProject as an optgroup to version dropdown

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
@@ -10,6 +10,6 @@
       title="{{ fieldController.editTitle }}"
       class="inplace-edit-select form--select"
       id="inplace-edit--write-value--{{::field.name}}"
-      ng-options="option as option.name for option in customEditorController.allowedValues track by option.hrefTracker">
+      ng-options="option.name group by customEditorController.optionGroup(option) for option in customEditorController.allowedValues track by option.hrefTracker">
   </select>
 </div>

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
@@ -10,6 +10,6 @@
       title="{{ fieldController.editTitle }}"
       class="inplace-edit-select form--select"
       id="inplace-edit--write-value--{{::field.name}}"
-      ng-options="option.name group by customEditorController.optionGroup(option) for option in customEditorController.allowedValues track by option.hrefTracker">
+      ng-options="option.name group by option.group for option in customEditorController.allowedValues track by option.hrefTracker">
   </select>
 </div>

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
@@ -92,6 +92,11 @@ function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfi
     });
   };
 
+  this.optionGroup = function(option) {
+   return WorkPackageFieldConfigurationService
+     .getDropDownOptionGroup($scope.field.name, option);
+  };
+
   var addEmptyOption = function(values) {
     var emptyOption = { props: { href: null,
                                  name: $scope.field.placeholder } };

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -140,12 +140,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
   function getEmbeddedAllowedValues(workPackage, field) {
     var options = [];
     var schema = getSchema(workPackage);
-    var allowedValues = schema.props[field]._embedded.allowedValues;
-    options = _.map(allowedValues, function(item) {
-      return _.extend({}, item, { name: item.name || item.title });
-    });
-
-    return options;
+    return schema.props[field]._embedded.allowedValues;
   }
 
   function getLinkedAllowedValues(workPackage, field) {
@@ -401,6 +396,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     getValue: getValue,
     getLabel: getLabel,
     getAllowedValues: getAllowedValues,
+    allowedValuesEmbedded: allowedValuesEmbedded,
     format: format,
     getInplaceEditStrategy: getInplaceEditStrategy,
     getInplaceDisplayStrategy: getInplaceDisplayStrategy

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -140,9 +140,9 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
   function getEmbeddedAllowedValues(workPackage, field) {
     var options = [];
     var schema = getSchema(workPackage);
-    var allowedValues = schema.props[field]._links.allowedValues;
+    var allowedValues = schema.props[field]._embedded.allowedValues;
     options = _.map(allowedValues, function(item) {
-      return _.extend({}, item, { name: item.title });
+      return _.extend({}, item, { name: item.name || item.title });
     });
 
     return options;

--- a/frontend/app/services/version-service.js
+++ b/frontend/app/services/version-service.js
@@ -30,6 +30,12 @@ module.exports = function($http, PathHelper) {
 
   var VersionService = {
 
+    getDefininingProject: function(resource) {
+      if (resource._links && resource._links.definingProject) {
+        return resource._links.definingProject.title;
+      }
+    },
+
     getVersions: function(projectIdentifier) {
       var url;
 

--- a/frontend/app/work_packages/services/index.js
+++ b/frontend/app/work_packages/services/index.js
@@ -51,8 +51,10 @@ angular.module('openproject.workPackages.services')
       attributes: []
     }
   ])
-  .factory('WorkPackageFieldConfigurationService',
-           require('./work-package-field-configuration-service'))
+  .factory('WorkPackageFieldConfigurationService', [
+    'VersionService',
+    require('./work-package-field-configuration-service')
+  ])
   .service('WorkPackagesOverviewService', [
     'WORK_PACKAGE_ATTRIBUTES',
     require('./work-packages-overview-service')

--- a/frontend/app/work_packages/services/work-package-field-configuration-service.js
+++ b/frontend/app/work_packages/services/work-package-field-configuration-service.js
@@ -26,14 +26,19 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function() {
+module.exports = function(VersionService) {
   function getDropdownSortingStrategy(field) {
     var sorting;
 
     switch(field) {
       case 'version':
-        sorting = function(field) {
-          return field.title.toLowerCase();
+        sorting = function(option) {
+          var definingProject = VersionService.getDefininingProject(option) || '';
+
+          // This is a hack to work around limited lodash multi-attribute
+          // sorting and works fine for string-based sorting in our case.
+          // TODO Possibly refactor when v3 hits
+          return definingProject + '_' + option.name.toLowerCase();
         };
         break;
       default:
@@ -42,7 +47,16 @@ module.exports = function() {
     return sorting;
   }
 
+  function getDropDownOptionGroup(field, option) {
+    switch(field) {
+      case 'version':
+        return VersionService.getDefininingProject(option);
+        break;
+    }
+  }
+
   return {
-    getDropdownSortingStrategy: getDropdownSortingStrategy
+    getDropdownSortingStrategy: getDropdownSortingStrategy,
+    getDropDownOptionGroup: getDropDownOptionGroup
   };
 };

--- a/frontend/tests/unit/tests/components/inplace-edit/directives/edit-drop-down.directive.test.js
+++ b/frontend/tests/unit/tests/components/inplace-edit/directives/edit-drop-down.directive.test.js
@@ -58,6 +58,7 @@ describe('Inplace editor drop-down directive', function() {
 
     scope.field = {
       getAllowedValues: sinon.stub().returns(allowedValuePromise),
+      allowedValuesEmbedded: sinon.stub().returns(false),
       format: sinon.stub().returns({ props: { name: allowedValues[0].name } }),
       isRequired: sinon.stub().returns(true),
       value: { props: { href: allowedValues[0].href } }

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'features/work_packages/details/inplace_editor/shared_examples'
+require 'features/work_packages/shared_contexts'
+require 'features/work_packages/details/inplace_editor/work_package_field'
+require 'features/work_packages/work_packages_page'
+
+describe 'subject inplace editor', js: true, selenium: true do
+  let(:project) { FactoryGirl.create :project_with_types, name: 'Root', is_public: true }
+  let(:subproject1) { FactoryGirl.create :project_with_types, name: 'Child', parent: project }
+  let(:subproject2) { FactoryGirl.create :project_with_types, name: 'Aunt', parent: project }
+
+  let!(:version) {
+    FactoryGirl.create(:version,
+                       status: 'open',
+                       sharing: 'tree',
+                       project: project)
+  }
+  let!(:version2) {
+    FactoryGirl.create(:version,
+                       status: 'open',
+                       sharing: 'tree',
+                       project: subproject1)
+  }
+  let!(:version3) {
+    FactoryGirl.create(:version,
+                       status: 'open',
+                       sharing: 'tree',
+                       project: subproject2)
+  }
+
+  let(:property_name) { :version }
+  let!(:work_package) { FactoryGirl.create :work_package, project: project }
+  let(:user) { FactoryGirl.create :admin }
+  let(:work_packages_page) { WorkPackagesPage.new(project) }
+  let(:field) { WorkPackageField.new page, property_name }
+
+  before do
+    login_as(user)
+    work_packages_page.visit_index(work_package)
+    within '.work-packages--details-content' do
+      click_on 'Show all'
+    end
+    field.activate_edition
+  end
+
+  it 'renders hierarchical versions' do
+    expect(page).to have_selector("#{field.field_selector} select")
+
+    options = page.all("#{field.field_selector} select option")
+    expect(options.map(&:text)).to eq(['-', version3.name, version2.name, version.name])
+
+    optgroups = page.all("#{field.field_selector} select optgroup", visible: false)
+      .map { |el| el[:label] }
+
+    expect(optgroups).to eq(%w(Aunt Child Root))
+
+
+    options[1].select_option
+    field.submit_by_click
+
+    field.expect_state_text(version3.name)
+
+  end
+end


### PR DESCRIPTION
Versions should be grouped by project in the inplace edit of versions.
This provides this functionality as an optgroup through the `definingProject` embedded property. 

Adding the same functionality for work package filters is out of scope for this PR.

Relevant work package: https://community.openproject.org/work_packages/21970/activity
