### PR TITLE
[21907] Avoid errors when missing standard type

### DIFF
--- a/app/services/update_projects_types_service.rb
+++ b/app/services/update_projects_types_service.rb
@@ -29,10 +29,10 @@
 
 class UpdateProjectsTypesService < BaseProjectService
   def call(type_ids)
-    type_ids = [::Type.standard_type.id] if type_ids.nil? || type_ids.empty?
+    type_ids = standard_types if type_ids.nil? || type_ids.empty?
 
     if types_missing?(type_ids)
-      project.errors.add(:type,
+      project.errors.add(:types,
                          :in_use_by_work_packages,
                          types: missing_types(type_ids).map(&:name).join(', '))
       false
@@ -44,6 +44,15 @@ class UpdateProjectsTypesService < BaseProjectService
   end
 
   protected
+
+  def standard_types
+    type = ::Type.standard_type
+    if type.nil?
+      []
+    else
+      [type.id]
+    end
+  end
 
   def types_missing?(type_ids)
     !missing_types(type_ids).empty?


### PR DESCRIPTION
Adds an extra check for a standard type that otherwise may throw an
error when the given `type_ids` array is empty, introduced in https://github.com/opf/openproject/pull/3667.

Previously, this behavior was avoided by the `params[:project]` check in
`ProjectsController`.

Relevant work package: https://community.openproject.org/work_packages/21907
