### PR TITLE
Automatically load disable(d)_specs.rb from plugins

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -161,7 +161,7 @@ end
 # (and other plugins' specs) keep working with this plugin in an OpenProject configuration
 # even if it changes things which would otherwise break existing specs.
 Rails.application.config.plugins_to_test_paths.each do |dir|
-  ['disable_specs.rb', 'config_spec_helper.rb'].each do |file_name|
+  ['disabled_specs.rb', 'disable_specs.rb', 'config_spec_helper.rb'].each do |file_name|
     file = File.join(dir, 'spec', file_name)
 
     if File.exists?(file)


### PR DESCRIPTION
As filenames differed we check for both filenames.
