### PR TITLE
Rename spec description

### DIFF
--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -126,7 +126,9 @@ describe WorkPackage, type: :model do
 
           subject { work_package.errors.full_messages.first }
 
-          it { is_expected.to eq("Database #{I18n.t('activerecord.errors.messages.inclusion')}") }
+          it 'matches' do
+            is_expected.to eq("Database #{I18n.t('activerecord.errors.messages.inclusion')}")
+          end
         end
       end
 


### PR DESCRIPTION
This is require so we can disable it within a plugin. Somehow rspec
example disabler has problems with quotes.
