### PR TITLE
prevent ui-routing on wp not found

### DIFF
--- a/frontend/app/openproject-app.js
+++ b/frontend/app/openproject-app.js
@@ -263,6 +263,13 @@ openprojectApp
         CacheService.disableCaching();
       }
 
+      $rootScope.$on('$stateChangeError',
+        function(event){
+            event.preventDefault();
+            // transitionTo() promise will be rejected with
+            // a 'transition prevented' error
+      });
+
       // at the moment of adding this code it was mostly used to
       // keep the previous state for the code to know where
       // to redirect the user on cancel new work package form

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -75,10 +75,6 @@ angular.module('openproject')
         workPackage: function(WorkPackageService, $stateParams) {
           var wsPromise = WorkPackageService.getWorkPackage($stateParams.workPackageId);
 
-          wsPromise.catch(function(){
-            location.href = '/projects';
-          });
-
           return wsPromise;
         },
         // TODO hack, get rid of latestTab in ShowController

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -35,10 +35,11 @@ RSpec.feature 'Work package navigation', selenium: true do
 
   before do
     login_as(user)
-    work_package.save!
   end
 
   scenario 'all different angular based work package views', js: true do
+    work_package.save!
+
     # deep link global work package index
     global_work_packages = Pages::WorkPackagesTable.new
     global_work_packages.visit!
@@ -92,5 +93,12 @@ RSpec.feature 'Work package navigation', selenium: true do
 
     # Safeguard: ensure spec to have finished loading everything before proceeding to the next spec
     full_work_package.ensure_page_loaded
+  end
+
+  scenario 'show 404 upon wrong url', js: true do
+    visit '/work_packages/0'
+
+    expect(page).to have_selector('.errorExplanation',
+                                  text: I18n.t('notice_file_not_found'))
   end
 end


### PR DESCRIPTION
As stated by
https://github.com/angular-ui/ui-router/wiki#state-change-events:

"$stateChangeError - fired when an error occurs during transition.
It's important to note that if you have any errors in your resolve
functions (javascript errors, non-existent services, etc) they will
not throw traditionally. You must listen for this $stateChangeError
event to catch ALL errors. Use event.preventDefault() to prevent the
$UrlRouter from reverting the URL to the previous valid location (in
case of a URL navigation)."

Fixes https://community.openproject.org/work_packages/21868 and might fix other weird redirects upon failures as well.
