### PR TITLE
[20248] Accessibility for Rails notifications

### DIFF
--- a/app/assets/javascripts/accessibility.js
+++ b/app/assets/javascripts/accessibility.js
@@ -29,5 +29,11 @@
 // If there is a flash message, give focus it.
 // This is necessary for screen readers.
 jQuery(function() {
-  jQuery('div.flash a').first().focus();
+  var flash = jQuery('.flash').first();
+
+  if (flash.hasClass('error')) {
+    flash.find('a').focus();
+  } else {
+    flash.find('.close-handler').focus();
+  }
 });

--- a/frontend/app/components/inplace-edit/services/inplace-edit-multi-storage.service.js
+++ b/frontend/app/components/inplace-edit/services/inplace-edit-multi-storage.service.js
@@ -42,9 +42,7 @@ function inplaceEditMultiStorage($rootScope, $q, inplaceEditStorage, EditableFie
   });
 
   $rootScope.$on('inplaceEditMultiStorage.save.comment', function (event, promise) {
-    promise.then(function() {
-      NotificationsService.addSuccess(I18n.t('js.work_packages.comment_added'));
-    }).catch(function() {
+    promise.catch(function() {
       NotificationsService.addError(I18n.t('js.work_packages.comment_send_failed'));
     });
   });

--- a/frontend/app/ui_components/focus-directive.js
+++ b/frontend/app/ui_components/focus-directive.js
@@ -27,7 +27,7 @@
 //++
 
 // TODO move to UI components
-module.exports = function(FocusHelper) {
+module.exports = function(FocusHelper, ConfigurationService) {
 
   function isSelect2Element(attrs) {
     var select2attributes = Object.keys(attrs).filter(function(attribute) {
@@ -55,7 +55,10 @@ module.exports = function(FocusHelper) {
 
   return {
     link: function(scope, element, attrs) {
-      updateFocus(scope, element, attrs);
+      // Set initial focus only when not on accessibility mode
+      if (!ConfigurationService.accessibilityModeEnabled()) {
+        updateFocus(scope, element, attrs);
+      }
 
       scope.$on('updateFocus', function() {
         updateFocus(scope, element, attrs);

--- a/frontend/app/ui_components/index.js
+++ b/frontend/app/ui_components/index.js
@@ -47,7 +47,11 @@ angular.module('openproject.uiComponents')
   .directive('emptyElement', [require('./empty-element-directive')])
   .constant('ENTER_KEY', 13)
   .directive('expandableSearch', ['ENTER_KEY', require('./expandable-search')])
-  .directive('focus', ['FocusHelper', require('./focus-directive')])
+  .directive('focus', [
+    'FocusHelper',
+    'ConfigurationService',
+    require('./focus-directive')
+  ])
   .constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex], select')
   .service('FocusHelper', ['$timeout', 'FOCUSABLE_SELECTOR', require(
     './focus-helper')])

--- a/frontend/tests/unit/tests/ui_components/focus-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/focus-directive-test.js
@@ -39,6 +39,15 @@ describe('focus Directive', function() {
   beforeEach(angular.mock.module('openproject.uiComponents'));
   beforeEach(module('openproject.templates'));
 
+  beforeEach(module('openproject.uiComponents', function($provide) {
+    var configurationService = {};
+
+    configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
+
+    $provide.constant('ConfigurationService', configurationService);
+  }));
+
   beforeEach(inject(function($compile, $rootScope, $document, $timeout) {
     doc = $document[0];
     rootScope = $rootScope;

--- a/frontend/tests/unit/tests/ui_components/selectable-title-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/selectable-title-directive-test.js
@@ -37,6 +37,15 @@ describe('selectableTitle Directive', function() {
     'openproject.templates',
     'truncate'));
 
+  beforeEach(module('openproject.uiComponents', function($provide) {
+    var configurationService = {};
+
+    configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
+
+    $provide.constant('ConfigurationService', configurationService);
+  }));
+
   beforeEach(inject(function($rootScope, $compile, _$timeout_) {
     var html;
     $timeout = _$timeout_;

--- a/frontend/tests/unit/tests/work_packages/column-context-menu-test.js
+++ b/frontend/tests/unit/tests/work_packages/column-context-menu-test.js
@@ -45,6 +45,7 @@ describe('columnContextMenu', function() {
     var configurationService = {};
 
     configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
 
     $provide.constant('$stateParams', stateParams);
     $provide.constant('ConfigurationService', configurationService);

--- a/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
@@ -36,10 +36,12 @@ describe('optionsDropdown Directive', function() {
                       'openproject.api',
                       'openproject.layout',
                       'openproject.services'));
+    
     beforeEach(module('openproject.templates', function($provide) {
       var configurationService = {};
 
       configurationService.isTimezoneSet = sinon.stub().returns(false);
+      configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
 
       $provide.constant('$stateParams', stateParams);
       $provide.constant('ConfigurationService', configurationService);

--- a/frontend/tests/unit/tests/work_packages/directives/query-filters-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/query-filters-directive-test.js
@@ -42,7 +42,11 @@ describe('queryFilters', function() {
                     'openproject.workPackages.filters'));
 
   beforeEach(module('openproject.templates', function($provide) {
-    $provide.constant('ConfigurationService', new Object());
+    var configurationService = {};
+
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
+
+    $provide.constant('ConfigurationService', configurationService);
   }));
 
   beforeEach(inject(function(

--- a/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
@@ -49,6 +49,8 @@ describe('workPackageDetailsToolbar', function() {
   beforeEach(module('openproject.templates', function($provide) {
     var configurationService = {};
 
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
+
     $provide.constant('$stateParams', stateParams);
     $provide.constant('ConfigurationService', configurationService);
   }));

--- a/frontend/tests/unit/tests/work_packages/directives/work-package-relations-directive-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/work-package-relations-directive-test.js
@@ -44,9 +44,10 @@ describe('Work Package Relations Directive', function() {
     var configurationService = {};
 
     configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
 
     $provide.constant('$stateParams', stateParams);
-    $provide.constant('ConfigurationService', function() { return configurationService; });
+    $provide.constant('ConfigurationService', configurationService);
   }));
 
   beforeEach(inject(function($rootScope,

--- a/frontend/tests/unit/tests/work_packages/work-package-context-menu-test.js
+++ b/frontend/tests/unit/tests/work_packages/work-package-context-menu-test.js
@@ -44,6 +44,7 @@ describe('workPackageContextMenu', function() {
     var configurationService = {};
 
     configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
 
     $provide.constant('ConfigurationService', configurationService);
     $provide.constant('$stateParams', stateParams);


### PR DESCRIPTION
This focuses on rails-based flashes for:
1. On the error text for error flashes
2. On the close icon otherwise

This requires a change in the focus directive, which by default sets focus on page load.
This behavior is now overridden in accessibility mode.

Also removes the comment success notification
Relevant work package https://community.openproject.org/work_packages/20248/activity

https://github.com/opf/openproject/pull/3533 would address these points however it is not ready yet.
