### PR TITLE
Fix double slash issue for all projects child states

### DIFF
--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -229,9 +229,7 @@ angular.module('openproject')
     });
 
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams){
-      var matchListState = toState.name.match(/work-packages\.list.*/);
-
-      if (matchListState && !toParams.projects && toParams.projectPath) {
+      if (toParams.projects === ''  && toParams.projectPath) {
         toParams.projects = 'projects';
         $state.go(toState, toParams);
       }

--- a/frontend/tests/unit/tests/work_packages/routing-test.js
+++ b/frontend/tests/unit/tests/work_packages/routing-test.js
@@ -46,7 +46,7 @@ describe('Routing', function () {
 
     beforeEach(function () {
       toState = { name: 'work-packages.list' };
-      toParams = { projectPath: 'my_project', projects: null };
+      toParams = { projectPath: 'my_project', projects: '' };
     });
 
     it('sets the projects path segment to "projects" ', function () {
@@ -58,21 +58,5 @@ describe('Routing', function () {
       broadcast();
       expect(spy.withArgs(toState, toParams).called).to.be.true;
     });
-
-    it('routes to child states of work-packages.list', function () {
-      var childStates = ['child', 'my.other.child'];
-
-      childStates.forEach(function (childState) {
-        toState.name = 'work-packages.list.' + childState;
-        broadcast();
-        expect(spy.withArgs(toState, toParams).calledOnce).to.be.true;
-      });
-    });
-
-    it('is ignored on other routes than work-packages.list', function () {
-      toState.name = 'work-packages.other.route';
-      broadcast();
-      expect(spy.withArgs(toState, toParams).called).to.be.false;
-    })
   });
 });


### PR DESCRIPTION
The previous fix was insufficient, as it applied only for `work-packages.list` states.
This fixes the double slash issue once and for all.
