### PR TITLE
[21737] Properly focus the notification to read out the content

### DIFF
--- a/frontend/app/templates/components/notification-box.html
+++ b/frontend/app/templates/components/notification-box.html
@@ -1,4 +1,4 @@
-<div class="notification-box{{' -' + content.type}}">
+<div class="notification-box{{' -' + content.type}}" tabindex="0" aria-atomic="true">
   <div class="notification-box--content">
     <p>{{content.message}}</p>
     <div data-ng-switch="content.type" data-ng-if="typeable()">

--- a/frontend/app/ui_components/notification-box-directive.js
+++ b/frontend/app/ui_components/notification-box-directive.js
@@ -52,8 +52,11 @@ module.exports = function(I18n, $timeout) {
     };
 
     $timeout(function() {
-      element.find('.notification-box--errors').attr('role', 'alert');
-      element.find('.notification-box--close').focus();
+      if (scope.content.type === 'error') {
+        element.focus();
+      } else {
+        element.find('.notification-box--close').focus();
+      }
     });
 
     scope.$on('upload.error', function() {


### PR DESCRIPTION
Despite `role="alert"` set, the notification wasn't properly read out to the user. Focussing it seems to fix that.
