### PR TITLE
Fix routing for projects sub routes

### DIFF
--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -229,7 +229,7 @@ angular.module('openproject')
     });
 
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams){
-      if (toParams.projects === ''  && toParams.projectPath) {
+      if (!toParams.projects && toParams.projectPath) {
         toParams.projects = 'projects';
         $state.go(toState, toParams);
       }

--- a/frontend/tests/unit/tests/work_packages/routing-test.js
+++ b/frontend/tests/unit/tests/work_packages/routing-test.js
@@ -46,7 +46,7 @@ describe('Routing', function () {
 
     beforeEach(function () {
       toState = { name: 'work-packages.list' };
-      toParams = { projectPath: 'my_project', projects: '' };
+      toParams = { projectPath: 'my_project', projects: null };
     });
 
     it('sets the projects path segment to "projects" ', function () {


### PR DESCRIPTION
As the previous fix assumed, the empty `projects` path segment would be an empty string, it did not apply for `null` values.
Now all falsy values are accepted.
