### PR TITLE
[21990,22000] Custom fields errors in split pane

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
@@ -63,7 +63,14 @@ inplaceEditorDropDown.$inject = ['EditableFieldsState', 'FocusHelper'];
 
 function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfigurationService) {
 
+  var customEditorController = this;
+
   this.allowedValues = [];
+  this.emptyOption = {
+    props: { href: null },
+    href: null,
+    name: $scope.field.placeholder
+  };
 
   function extractOptions(values) {
     var options = values;
@@ -83,7 +90,6 @@ function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfi
   }
 
   this.updateAllowedValues = function(field) {
-    var customEditorController = this;
 
     return $q(function(resolve) {
       $scope.field.getAllowedValues()
@@ -98,8 +104,15 @@ function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfi
 
           options = extractOptions(values);
 
-          if (!$scope.field.isRequired()) {
-            options = addEmptyOption(options);
+          var nullUsed = false;
+          if ($scope.field.value === null) {
+            nullUsed = true;
+            $scope.field.value = customEditorController.emptyOption;
+          }
+
+          if (nullUsed || !$scope.field.isRequired()) {
+            var arrayWithEmptyOption = [customEditorController.emptyOption];
+            options = arrayWithEmptyOption.concat(options);
           }
 
           addHrefTracker(options);
@@ -109,23 +122,6 @@ function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfi
           resolve();
         });
     });
-  };
-
-  var addEmptyOption = function(values) {
-    var emptyOption = { props: { href: null,
-                                 name: $scope.field.placeholder } };
-
-    if (!$scope.field.isRequired()) {
-      var arrayWithEmptyOption = [emptyOption.props];
-
-      values = arrayWithEmptyOption.concat(values);
-
-      if ($scope.field.value === null) {
-        $scope.field.value = emptyOption;
-      }
-    }
-
-    return values;
   };
 
   // We have to maintain a separate property just to track the object by

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
@@ -72,7 +72,7 @@ function InplaceEditorDropDownController($q, $scope, I18n, WorkPackageFieldConfi
     if ($scope.field.allowedValuesEmbedded()) {
        options = _.map(values, function(item) {
         return _.extend({}, item._links.self, {
-          name: item._links.self.title,
+          name: item._links.self.title || item.value,
           group: WorkPackageFieldConfigurationService
                    .getDropDownOptionGroup($scope.field.name, item)
         });

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -61,10 +61,9 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
 
     // not writable if no embedded allowed values
     if (schema.props[field]._links && allowedValuesEmbedded(workPackage, field)) {
-      if (getEmbeddedAllowedValues(workPackage, field).length === 0) {
-        return false;
-      }
+      isWritable = getEmbeddedAllowedValues(workPackage, field).length > 0;
     }
+
     return isWritable;
   }
 

--- a/frontend/app/templates/components/notification-box.html
+++ b/frontend/app/templates/components/notification-box.html
@@ -25,7 +25,7 @@
       </div>
       <div data-ng-switch-when="error">
         <ul class="notification-box--errors" role="alert">
-          <li data-ng-repeat="error in content.errors">{{error}}</li>
+          <li data-ng-repeat="error in content.errors track by $index">{{error}}</li>
         </ul>
         <!-- "continue editing" button -->
       </div>

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -175,6 +175,7 @@ module API
                                                   customized.assignable_values(:version,
                                                                                current_user)
                                                 },
+                                                writable: true,
                                                 value_representer: Versions::VersionRepresenter,
                                                 link_factory: -> (version) {
                                                   {
@@ -190,6 +191,7 @@ module API
 
           @class.schema_with_allowed_link property_name(custom_field.id),
                                           type: 'User',
+                                          writable: true,
                                           name_source: -> (*) { custom_field.name },
                                           required: custom_field.is_required,
                                           href_callback: -> (*) {
@@ -208,6 +210,7 @@ module API
                                                   custom_field.possible_values
                                                 },
                                                 value_representer: representer,
+                                                writable: true,
                                                 link_factory: -> (value) {
                                                   {
                                                     href: api_v3_paths.string_object(value),

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -63,7 +63,6 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     before do
       allow(schema).to receive(:assignable_values).with(:version, anything).and_return(versions)
-      allow(schema).to receive(:writable?).and_return(true)
     end
 
     describe 'basic custom field' do


### PR DESCRIPTION
This PR addresses two issues:
1. List, Version and User properties were not set as `writable` since https://github.com/opf/openproject/pull/3728. They were simply missed there and I 'fixed' the spec incorrectly, thus effectively hiding the missing property.
2. The drop-down has been altered to use embedded values where applicable in order to react to sortable lists (e.g., version, which have a `definingProject` property for grouping). This PR extends this directive to respect the values of custom fields as correct item names.

This should fix both
https://community.openproject.org/work_packages/21990
https://community.openproject.org/work_packages/22000
