### PR TITLE
fix bool values in customizable journals

### DIFF
--- a/db/migrate/20151116110245_fix_customizable_bool_values.rb
+++ b/db/migrate/20151116110245_fix_customizable_bool_values.rb
@@ -1,0 +1,45 @@
+class FixCustomizableBoolValues < ActiveRecord::Migration
+  def up
+    update_customizable_values(quoted_true, unquoted_true, quoted_false, unquoted_false)
+  end
+
+  def down
+    update_customizable_values(unquoted_true, quoted_true, unquoted_false, quoted_false)
+  end
+
+  private
+
+  def update_customizable_values(old_true, new_true, old_false, new_false)
+    bool_custom_fields.each do |bool_custom_field|
+      alter(CustomizableJournal, bool_custom_field, old_false, new_false)
+      alter(CustomizableJournal, bool_custom_field, old_true, new_true)
+    end
+  end
+
+  def bool_custom_fields
+    @bool_custom_fields ||= CustomField.where(field_format: 'bool').all
+  end
+
+  def alter(scope, custom_field, old, new)
+    scope
+      .where(custom_field_id: custom_field.id,
+             value: old)
+      .update_all(value: new)
+  end
+
+  def quoted_false
+    ActiveRecord::Base.connection.quoted_false
+  end
+
+  def quoted_true
+    ActiveRecord::Base.connection.quoted_true
+  end
+
+  def unquoted_false
+    ActiveRecord::Base.connection.unquoted_false
+  end
+
+  def unquoted_true
+    ActiveRecord::Base.connection.unquoted_true
+  end
+end


### PR DESCRIPTION
7621676460073a3b06be81dc2c6383173332a3f9 migrated the bool custom values stored in the db to real db values. Unfortunately, the values in the customizable_journals were all quoted which they should not have been.

https://community.openproject.org/work_packages/21928
