### PR TITLE
[22050] Allow responsible_id in projects settings

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -282,6 +282,7 @@ class PermittedParams
     whitelist = params.require(:project).permit(:name,
                                                 :description,
                                                 :is_public,
+                                                :responsible_id,
                                                 :identifier,
                                                 :project_type_id,
                                                 custom_fields: [],

--- a/app/views/projects/form/attributes/_responsible_id.html.erb
+++ b/app/views/projects/form/attributes/_responsible_id.html.erb
@@ -35,19 +35,16 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if User.current.impaired? %>
       <%= form.select :responsible_id, project.possible_responsibles.map {|m| [m.name, m.id]}, include_blank: true %>
     <% else %>
-      <% options = { :'data-ajaxURL' => url_for({controller: "/members",
+      <% responsible = project.responsible.nil? ? [t('label_none_parentheses'), -1] : [project.responsible.name, project.responsible.id]
+         options = { :'data-ajaxURL' => url_for({controller: "/members",
                                                action: "paginate_users" }),
-                   :'data-projectId' => project.id
-                 } %>
+                     :'data-projectId' => project.id,
+                     :'data-selected' => [responsible].to_json
+                   }
+      %>
       <%= javascript_include_tag "autocompleter.js" %>
       <%= javascript_include_tag "project/responsible_attribute.js" %>
-      <%= form.select(:responsible_id, options_for_select([]),
-        {},
-        project.responsible.nil? ? options : options.merge({ :'data-selected' =>
-                                                             [[project.responsible.name, project.
-                                                             responsible.id]].to_json
-                                                            }))
-     %>
+      <%= form.select(:responsible_id, options_for_select([]), {}, options) %>
     <% end %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1077,6 +1077,7 @@ en:
   label_nothing_display: "Nothing to display"
   label_nobody: "nobody"
   label_none: "none"
+  label_none_parentheses: "(none)"
   label_not_contains: "doesn't contain"
   label_not_equals: "is not"
   label_notify_member_plural: "Email updates"


### PR DESCRIPTION
This fixes two issues:
1. `responsible_id` was missing in allowed params for projects
   controller / settings.
2. When the value is not set from Rails, undefined is showing. There may
   be a workaround solely in the frontend, but for now I return (none) to
   the autocompletion as a responsible name instead of an empty string.

https://community.openproject.org/work_packages/22050
