### PR TITLE
Feature/seeded settings

### DIFF
--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -56,6 +56,10 @@ module DemoData
       end
     end
 
+    def applicable?
+      Project.count == 0
+    end
+
     def project_data_seeders(project)
       seeders = [
         DemoData::CustomFieldSeeder,


### PR DESCRIPTION
This has two parts:

1) a bug fix which allows to rerun `db:seed` without having the default project recreated.
2) a feature which seeds all settings to the db. This is necessary so that plugins can extend the settings as they are seeded to the db. However, this would also be beneficial on a general basis. Currently, the `settings.yml` has it's own way of lazy seeding which is parallel to what we have under 'db/seed'. It was not possible to remove that duplicity as the tests rely on the settings to be lazily created.

https://community.openproject.org/work_packages/22020/activity
