### PR TITLE
not writable overrules having a list of values

### DIFF
--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -60,7 +60,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     var isWritable = schema.props[field].writable;
 
     // not writable if no embedded allowed values
-    if (schema.props[field]._links && allowedValuesEmbedded(workPackage, field)) {
+    if (isWritable && schema.props[field]._links && allowedValuesEmbedded(workPackage, field)) {
       isWritable = getEmbeddedAllowedValues(workPackage, field).length > 0;
     }
 


### PR DESCRIPTION
Without the additional check, fields that have writable set to false will still be considered writable if they have a link list. The priority is an example where this occured. The API should IMO not have a list of available values when the field is not writable but that is a separate fix.
