### PR TITLE
Edit work package route and specs

### DIFF
--- a/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.html
+++ b/frontend/app/components/inplace-edit/directives/edit-actions-bar/edit-actions-bar.directive.html
@@ -1,9 +1,9 @@
 <div class="work-packages--edit-actions" ng-show="vm.visible()">
-  <button class="button -alt-highlight" accesskey="3" ng-click="vm.save()">
+  <button id="work-packages--edit-actions-save" class="button -alt-highlight" accesskey="3" ng-click="vm.save()">
     <i class="button--icon icon-yes"></i>
     <span class="button--text" ng-bind="::vm.text.save"></span>
   </button>
-  <button class="button" accesskey="7" ng-click="vm.cancel()">
+  <button id="work-packages--edit-actions-cancel" class="button" accesskey="7" ng-click="vm.cancel()">
     <i class="button--icon icon-close"></i>
     <span class="button--text" ng-bind="::vm.text.cancel"></span>
   </button>

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -73,6 +73,19 @@ angular.module('openproject')
       reloadOnSearch: false
     })
 
+    .state('work-packages.edit', {
+      url: '/{projects}/{projectPath}/work_packages/{workPackageId}/edit',
+      params: {
+        projectPath: { value: null, squash: true },
+        projects: { value: null, squash: true }
+      },
+
+      onEnter: function ($state, $stateParams, EditableFieldsState) {
+        EditableFieldsState.editAll.start();
+        $state.go('work-packages.list.details.overview', $stateParams);
+      }
+    })
+
     .state('work-packages.show', {
       url: '/work_packages/{workPackageId:[0-9]+}?query_props',
       templateUrl: '/components/routes/partials/work-packages.show.html',

--- a/frontend/app/work_packages/controllers/menus/index.js
+++ b/frontend/app/work_packages/controllers/menus/index.js
@@ -111,10 +111,12 @@ angular.module('openproject.workPackages')
   ])
   .controller('WorkPackageContextMenuController', [
     '$scope',
+    '$state',
     'WorkPackagesTableHelper',
     'WorkPackageContextMenuHelper',
     'WorkPackageService',
     'WorkPackagesTableService',
+    'EditableFieldsState',
     'I18n',
     '$window',
     'PERMITTED_CONTEXT_MENU_ACTIONS',

--- a/frontend/app/work_packages/controllers/menus/work-package-context-menu-controller.js
+++ b/frontend/app/work_packages/controllers/menus/work-package-context-menu-controller.js
@@ -26,7 +26,18 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function($scope, WorkPackagesTableHelper, WorkPackageContextMenuHelper, WorkPackageService, WorkPackagesTableService, I18n, $window, PERMITTED_CONTEXT_MENU_ACTIONS) {
+module.exports = function(
+  $scope,
+  $state,
+  WorkPackagesTableHelper,
+  WorkPackageContextMenuHelper,
+  WorkPackageService,
+  WorkPackagesTableService,
+  EditableFieldsState,
+  I18n,
+  $window,
+  PERMITTED_CONTEXT_MENU_ACTIONS
+) {
 
   $scope.I18n = I18n;
 
@@ -44,10 +55,23 @@ module.exports = function($scope, WorkPackagesTableHelper, WorkPackageContextMen
   };
 
   $scope.triggerContextMenuAction = function(action, link) {
-    if (action === 'delete') {
-      deleteSelectedWorkPackages();
-    } else {
-      $window.location.href = link;
+    switch(action) {
+
+      case 'delete':
+        deleteSelectedWorkPackages();
+        break;
+
+      case 'edit':
+        var params = {
+          workPackageId: getSelectedWorkPackageId()
+        }
+        EditableFieldsState.editAll.start();
+        $state.transitionTo('work-packages.list.details.overview', params);
+        break;
+
+      default:
+        $window.location.href = link;
+        break;
     }
   };
 
@@ -61,6 +85,11 @@ module.exports = function($scope, WorkPackagesTableHelper, WorkPackageContextMen
     var selectedRows = WorkPackagesTableHelper.getSelectedRows($scope.rows);
 
     return WorkPackagesTableHelper.getWorkPackagesFromRows(selectedRows);
+  }
+
+  function getSelectedWorkPackageId() {
+    var selected = getSelectedWorkPackages()[0];
+    return selected && selected.id;
   }
 
   function getSelectedWorkPackages() {

--- a/frontend/tests/integration/specs/work-packages/work-package-edit-spec.js
+++ b/frontend/tests/integration/specs/work-packages/work-package-edit-spec.js
@@ -159,4 +159,11 @@ describe('Work package edit', function() {
       });
     });
   });
+
+  describe('when visiting the work package edit routes', function () {
+    it('should should open the details view in edit mode', function () {
+      browser.get('/work_packages/' + page.wpId + '/edit');
+      expect(page.editableFields.isDisplayed()).to.eventually.be.ok;
+    });
+  })
 });

--- a/spec/features/work_packages/details/inplace_editor/work_package_field.rb
+++ b/spec/features/work_packages/details/inplace_editor/work_package_field.rb
@@ -82,7 +82,7 @@ class WorkPackageField
       extend ::Angular::DSL unless singleton_class.included_modules.include?(::Angular::DSL)
       ng_wait
 
-      expect(page).to have_selector('.work-packages--details-content')
+      expect(page).to have_selector('.work-packages--details--subject')
     end
   end
 end

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/work_package_field'
 require 'features/work_packages/work_packages_page'
+require 'features/page_objects/notification'
+
 
 describe 'new work package', js: true do
   let(:type_task) { FactoryGirl.create(:type_task) }
-  let(:types) { [type_task] }
+  let(:type_bug) { FactoryGirl.create(:type_bug) }
+  let(:types) { [type_task, type_bug] }
   let(:status) { FactoryGirl.build(:status, is_default: true) }
   let(:priority) { FactoryGirl.build(:priority, is_default: true) }
   let(:project) {
@@ -20,9 +23,12 @@ describe 'new work package', js: true do
   let(:subject_field) { WorkPackageField.new(page, :subject) }
   let(:description_field) { WorkPackageField.new(page, :description) }
 
+  let(:notification) { PageObjects::Notifications.new(page) }
+
   def disable_leaving_unsaved_warning
     FactoryGirl.create(:user_preference, user: user, others: { warn_on_leaving_unsaved: false })
   end
+
 
   before do
     status.save!
@@ -39,20 +45,119 @@ describe 'new work package', js: true do
     end
   end
 
-  it 'sucessfully creates a work package' do
-    # Safeguard to ensure the create form to be loaded
-    expect(page).to have_selector('.work-packages--details-content.-create-mode', wait: 10)
-
-    find('#work-package-subject input').set(subject)
-    find('#work-package-description textarea').set(description)
-
+  def save_work_package!(expect_success=true)
     within '.work-packages--edit-actions' do
       click_button 'Save'
     end
 
-    expect(page).to have_selector('.work-packages--details #tabs')
+    if expect_success
+      notification.expect_success('Successful creation.')
+    end
+  end
 
-    subject_field.expect_state_text(subject)
-    description_field.expect_state_text(description)
+  shared_examples 'work package creation workflow' do
+
+    context 'with missing values' do
+      it 'shows an error when subject is missing' do
+        find('#work-package-description textarea').set(description)
+        save_work_package!(false)
+        notification.expect_error("Subject can't be blank.")
+      end
+    end
+
+    context 'with subject set' do
+      before do
+        find('#work-package-subject input').set(subject)
+      end
+
+      it 'creates a basic work package' do
+        find('#work-package-description textarea').set(description)
+
+        save_work_package!
+        expect(page).to have_selector('#tabs')
+
+        subject_field.expect_state_text(subject)
+        description_field.expect_state_text(description)
+      end
+
+      it 'can switch types and keep attributes' do
+        find('#work-package-subject input').set(subject)
+        select 'Bug', from: 'inplace-edit--write-value--type'
+
+        save_work_package!
+        expect(page).to have_selector('#work-package-type', text: 'Bug')
+      end
+
+      context 'custom fields' do
+        let(:custom_fields) {
+          fields = [
+            FactoryGirl.create(
+              :work_package_custom_field,
+              field_format: 'string',
+              is_required: true,
+              is_for_all: true
+            ),
+            FactoryGirl.create(
+              :work_package_custom_field,
+              field_format: 'list',
+              possible_values: %w(foo bar xyz),
+              is_required: false,
+              is_for_all: true
+            )
+          ]
+
+          fields
+        }
+        let(:type_task) { FactoryGirl.create(:type_task, custom_fields: custom_fields) }
+        let(:project) {
+          FactoryGirl.create(:project,
+                             types: types,
+                             work_package_custom_fields: custom_fields)
+        }
+
+        it do
+          within '.panel-toggler' do
+            click_on 'Show all'
+          end
+
+          ids = custom_fields.map(&:id)
+          cf1 = find("input#inplace-edit--write-value--customField#{ids.first}")
+          expect(cf1).not_to be_nil
+          expect(page).to have_select("inplace-edit--write-value--customField#{ids.last}",
+                                      options: %w(- foo bar xyz))
+
+          select 'foo', from: "inplace-edit--write-value--customField#{ids.last}"
+
+          save_work_package!(false)
+          # Its a known bug that custom fields validation errors do not contain their names
+          notification.expect_error("can't be blank.")
+
+          cf1.set 'Custom field content'
+          save_work_package!(false)
+
+          expect(page).to have_selector("#work-package-customField#{ids.first}", 'Custom field content')
+          expect(page).to have_selector("#work-package-customField#{ids.last}", 'foo')
+        end
+      end
+    end
+  end
+
+  context 'split screen' do
+    before do
+      # Safeguard to ensure the create form to be loaded
+      expect(page).to have_selector('.work-packages--details-content.-create-mode', wait: 10)
+    end
+
+    it_behaves_like 'work package creation workflow'
+  end
+
+  context 'full screen' do
+    before do
+      find('#work-packages-show-view-button').click
+      # Safeguard to ensure the create form to be loaded
+      expect(page).to have_selector('.work-package--new-state', wait: 10)
+    end
+
+    it_behaves_like 'work package creation workflow'
   end
 end

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -313,5 +313,22 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
         let(:index) { 1 }
       end
     end
+
+    describe 'opening work package edit mode' do
+      before do
+        select_work_package_row(1, :right)
+        within '.dropdown-menu' do
+          click_on 'Edit'
+        end
+      end
+
+      it do
+        subject = page.find("#inplace-edit--write-value--subject")
+        expect(subject.value).to eq(work_package_3.subject)
+
+        # Cancel edit + move to index
+        find('#work-packages--edit-actions-cancel').click
+      end
+    end
   end
 end


### PR DESCRIPTION
Spin-off from https://github.com/opf/openproject/pull/3818 to only add the angular edit route handler, handle edit context menu and create feature specs.
