### PR TITLE
[21750] Remove unnecessary loading overlay in WP show route

### DIFF
--- a/frontend/app/components/routes/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routes/controllers/work-package-show.controller.js
@@ -127,7 +127,6 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
         $scope.$broadcast('workPackageRefreshed');
       });
   }
-  $scope.wpPromise = WorkPackageService.getWorkPackage($scope.workPackage.props.id);
 
   // Inform parent that work package is loaded so back url can be maintained
   $scope.$emit('workPackgeLoaded');

--- a/frontend/app/components/routes/partials/work-packages.show.html
+++ b/frontend/app/components/routes/partials/work-packages.show.html
@@ -98,7 +98,7 @@
   <back-url></back-url>
 
 
-  <div class="work-packages--split-view" cg-busy="wpPromise">
+  <div class="work-packages--split-view">
     <div class="work-packages--left-panel">
       <div class="work-packages--panel-inner">
         <div class="attributes-group">


### PR DESCRIPTION
Removing the loading overlay will make the work package seemingly load faster.
This does not resolve the actual performance problem though.

https://community.openproject.org/work_packages/21750/activity
