### PR TITLE
Correct cuke step used in impermanent memberships plugin

### DIFF
--- a/features/step_definitions/project_member_steps.rb
+++ b/features/step_definitions/project_member_steps.rb
@@ -83,10 +83,10 @@ def select_principal(principal)
 end
 
 def select_role(role)
-  if !User.current.impaired?
-    select2(role.name, css: '#s2id_member_role_ids')
-  else
+  if User.current.impaired?
     select_without_select2(role.name, 'form .roles')
+  else
+    select(role.name, from: 'member_role_ids')
   end
 end
 


### PR DESCRIPTION
This should fix

```
(::) failed steps (::)

Unable to find css "#s2id_member_role_ids" (Capybara::ElementNotFound)
./features/step_definitions/project_member_steps.rb:87:in `select_role'
./features/step_definitions/project_member_steps.rb:74:in `/^I select(?: the)? role "(.+)"$/'
./features/step_definitions/project_member_steps.rb:57:in `/^I add(?: the)? principal "(.+)" as(?: a)? "(.+)"$/'
/Users/oliver/finn/openproject/plugins/openproject-impermanent_memberships/features/project_settings_member.feature:32:in `When I add the principal "wurst" as "hotdog"'

Failing Scenarios:
cucumber /Users/oliver/finn/openproject/plugins/openproject-impermanent_memberships/features/project_settings_member.feature:30 # Scenario: Add member to project
```
