### PR TITLE
Fix/seed modules and default role

### DIFF
--- a/app/seeders/basic_data/setting_seeder.rb
+++ b/app/seeders/basic_data/setting_seeder.rb
@@ -47,9 +47,17 @@ module BasicData
     end
 
     def data
-      Setting.available_settings.each_with_object({}) do |(k, v), hash|
+      settings = Setting.available_settings.each_with_object({}) do |(k, v), hash|
         hash[k] = v['default'] || ''
       end
+
+      # deviate from the defaults specified in settings.yml here
+      # to set a default role. The role cannot be specified in the settings.yml as
+      # that would mean to know the ID upfront.
+      default_role_id = Role.find_by(name: I18n.t(:default_role_project_admin)).id
+      settings['new_project_user_role_id'] = default_role_id
+
+      settings
     end
 
     private

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -30,13 +30,11 @@ module DemoData
     # Careful: The seeding recreates the seeded project before it runs, so any changes
     # on the seeded project will be lost.
     def seed_data!
+      # We are relying on the default_projects_modules setting to set the desired project modules
       puts ' ↳ Creating demo project...'
 
       puts '   -Creating/Resetting Demo project'
       project = reset_demo_project
-
-      puts '   -Setting modules.'
-      set_modules(project)
 
       puts '   -Setting members.'
       set_members(project)
@@ -82,11 +80,6 @@ module DemoData
         description:  I18n.t('seeders.demo_data.project.description'),
         types:        Type.all
       )
-    end
-
-    def set_modules(project)
-      project.enabled_module_names += ['timelines']
-      project.enabled_module_names -= ['repository']
     end
 
     def set_members(project)

--- a/config/initializers/30-redmine.rb
+++ b/config/initializers/30-redmine.rb
@@ -36,11 +36,6 @@ I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 if Setting.table_exists? # don't want to prevent migrations
   defaults = Set.new I18n.fallbacks.defaults + Setting.available_languages.map(&:to_sym)
   I18n.fallbacks.defaults = defaults
-
-  if Setting.new_project_user_role_id.empty? && \
-      role_project_admin = Role.where(name: I18n.t(:default_role_project_admin)).first
-    Setting.new_project_user_role_id = role_project_admin.id
-  end
 end
 
 require 'open_project'

--- a/db/migrate/20130723092240_add_activity_module.rb
+++ b/db/migrate/20130723092240_add_activity_module.rb
@@ -35,7 +35,10 @@ class AddActivityModule < ActiveRecord::Migration
     end
 
     # add activity module from default settings
-    Setting['default_projects_modules'] = ['activity'] | Setting.default_projects_modules
+    # if the setting already exists
+    if Setting.find_by(name: 'default_projects_modules')
+      Setting['default_projects_modules'] = ['activity'] | Setting.default_projects_modules
+    end
   end
 
   def down
@@ -45,6 +48,9 @@ class AddActivityModule < ActiveRecord::Migration
     end
 
     # remove activity module from default settings
-    Setting['default_projects_modules'] = Setting.default_projects_modules - ['activity']
+    # if the setting already exists
+    if Setting.find_by(name: 'default_projects_modules')
+      Setting['default_projects_modules'] = Setting.default_projects_modules - ['activity']
+    end
   end
 end

--- a/db/migrate/20140203141127_rename_modulename_issue_tracking.rb
+++ b/db/migrate/20140203141127_rename_modulename_issue_tracking.rb
@@ -34,7 +34,14 @@ class RenameModulenameIssueTracking < ActiveRecord::Migration
       SET name = 'work_package_tracking'
       WHERE name = 'issue_tracking';
     SQL
-    Setting['default_projects_modules'] = Setting['default_projects_modules'].map { |m| m.gsub('issue_tracking', 'work_package_tracking') }
+
+    if Setting.find_by(name: 'default_projects_modules')
+      new_settings = Setting['default_projects_modules'].map { |m|
+        m.gsub('issue_tracking', 'work_package_tracking')
+      }
+
+      Setting['default_projects_modules'] = new_settings
+    end
   end
 
   def down
@@ -43,6 +50,13 @@ class RenameModulenameIssueTracking < ActiveRecord::Migration
       SET name = 'issue_tracking'
       WHERE name = 'work_package_tracking';
     SQL
-    Setting['default_projects_modules'] = Setting['default_projects_modules'].map { |m| m.gsub('work_package_tracking', 'issue_tracking') }
+
+    if Setting.find_by(name: 'default_projects_modules')
+      new_settings = Setting['default_projects_modules'].map { |m|
+        m.gsub('work_package_tracking', 'issue_tracking')
+      }
+
+      Setting['default_projects_modules'] = new_settings
+    end
   end
 end


### PR DESCRIPTION
Consists of two parts:

1) Fixes seeding the default_projects_modules on vestal installations. The migrations used to create the setting so that when seeding was issued after the migration, the setting was skipped as the setting already existed. This is still related to https://community.openproject.org/work_packages/22020. The seeding mechanism is also extended to the demo project where a duplication for the project modules has been removed so that less places exist for specifying the setting.
2) The default role for non admins in a project is now set via the `SettingSeeder` (idea by @oliverguenther). It is not possible to specify it in the settings.yml. This should fix the last part of https://community.openproject.org/work_packages/22019 
