### PR TITLE
copy over symbol in custom value to customizable

### DIFF
--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -103,6 +103,16 @@ module ActiveModel
                                                               message: message)
     end
 
+    # Need to do the house keeping along with AR::Errors
+    # so that the symbols are removed when a new validation round starts
+    def clear_with_storing_error_symbols
+      clear_without_storing_error_symbols
+
+      @error_symbols = Hash.new
+    end
+
+    alias_method_chain :clear, :storing_error_symbols
+
     private
 
     def error_symbols

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -125,8 +125,16 @@ module Redmine
 
         def validate_custom_values
           custom_field_values.reject(&:marked_for_destruction?).select(&:invalid?).each do |cv|
-            cv.errors.each do |_, message|
-              errors.add(cv.custom_field.accessor_name.to_sym, message)
+
+            cv.errors.each do |attribute, _|
+              # Relies on patch to AR::Errors in 10-patches.rb.
+              # We need to take the original symbol used to set the message to
+              # make the same symbol available on the customized object itself.
+              # This is important e.g. in the API v3 where the error messages are
+              # post processed.
+              cv.errors.symbols_for(attribute).each do |symbol|
+                errors.add(cv.custom_field.accessor_name.to_sym, symbol)
+              end
             end
           end
         end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -75,6 +75,8 @@ describe WorkPackage, type: :model do
       describe 'invalid custom field values' do
         context 'short error message' do
           shared_examples_for 'custom field with invalid value' do
+            let(:custom_field_key) { "custom_field_#{custom_field.id}".to_sym }
+
             before do
               change_custom_field_value(work_package, custom_field_value)
             end
@@ -82,11 +84,22 @@ describe WorkPackage, type: :model do
             describe 'error message' do
               before do work_package.save end
 
-              subject { work_package.errors["custom_field_#{custom_field.id}"] }
+              subject { work_package.errors[custom_field_key] }
 
               it {
                 is_expected.to include(I18n.translate("activerecord.errors.messages.#{error_key}"))
               }
+            end
+
+            describe 'symbols_for' do
+              before do
+                work_package.save
+              end
+
+              it 'stores the symbol' do
+                actual_symbols = work_package.errors.symbols_for(custom_field_key)
+                expect(actual_symbols).to match_array([error_key.to_sym])
+              end
             end
 
             describe 'work package attribute update' do


### PR DESCRIPTION
We need to have access to the original symbol so that the API v3 can
post process the errors on the custom fields just like it does every
other field. When only a string is provided, the symbol :unknown is
stored which will lead to the API rendering error messages like "can't
be blank" (without the erroneous field name).

Addresses the most pressing part of https://community.openproject.org/work_packages/21936
