### PR TITLE
Fix/always show required fields

### DIFF
--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -84,7 +84,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     if (inplaceEditErrors.errors && inplaceEditErrors.errors[field]) {
       return false;
     }
-    return isEmpty(workPackage, field);
+    return isEmpty(workPackage, field) && !isRequired(workPackage, field);
   }
 
   function isMilestone(workPackage) {

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -93,12 +93,14 @@ module API
                  type: 'Duration',
                  show_if: -> (_) do
                    current_user_allowed_to(:view_time_entries, context: represented.project)
-                 end
+                 end,
+                 required: false
 
           schema :percentage_done,
                  type: 'Integer',
                  name_source: :done_ratio,
-                 show_if: -> (*) { Setting.work_package_done_ratio != 'disabled' }
+                 show_if: -> (*) { Setting.work_package_done_ratio != 'disabled' },
+                 required: false
 
           schema :created_at,
                  type: 'DateTime'

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -275,7 +275,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:path) { 'spentTime' }
         let(:type) { 'Duration' }
         let(:name) { I18n.t('activerecord.attributes.work_package.spent_time') }
-        let(:required) { true }
+        let(:required) { false }
         let(:writable) { false }
       end
 
@@ -301,7 +301,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:path) { 'percentageDone' }
         let(:type) { 'Integer' }
         let(:name) { I18n.t('activerecord.attributes.work_package.done_ratio') }
-        let(:required) { true }
+        let(:required) { false }
         let(:writable) { true }
       end
 
@@ -314,7 +314,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:path) { 'percentageDone' }
           let(:type) { 'Integer' }
           let(:name) { I18n.t('activerecord.attributes.work_package.done_ratio') }
-          let(:required) { true }
+          let(:required) { false }
           let(:writable) { false }
         end
       end


### PR DESCRIPTION
Always show fields that are 'required' (as specified by the API). That way, non empty fields that are required are shown. When a work package is created before a required custom field is added, the fields are empty, but should be shown so that the user can spot the problem. 

https://community.openproject.org/work_packages/21936
