### PR TITLE
use waiting capybara methods

### DIFF
--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -30,10 +30,11 @@
 Then /^I should see membership to the project "(.+)" with the roles:$/ do |project, roles_table|
   project = Project.like(project).first
   steps %{ Then I should see "#{project.name}" within "#tab-content-memberships .memberships" }
+  tab = page.find('#tab-content-memberships .memberships')
 
-  found_roles = page.find(:css, '#tab-content-memberships .memberships').find(:xpath, "//tr[contains(.,'#{project.name}')]").find(:css, 'td.roles span').text.split(',').map(&:strip)
-
-  found_roles.should =~ roles_table.raw.flatten
+  roles_table.raw.flatten.each do |role_name|
+    expect(tab.find('tr', text: project.name)).to have_selector('td.roles span', text: role_name)
+  end
 end
 
 Then /^I should not see membership to the project "(.+)"$/ do |project|


### PR DESCRIPTION
This might fix the flickering cuke (`features/admin/user.feature:98`). The theory behind the fix is that the front end process is testing too fast and thus it will work on the not yet rerendered memberships.
