### PR TITLE
Define imagemagick dependency

### DIFF
--- a/doc/operation_guides/manual/installation-guide.md
+++ b/doc/operation_guides/manual/installation-guide.md
@@ -39,11 +39,12 @@ sudo passwd openproject #(enter desired password)
 
 ```bash
 [root@host] apt-get update -y
-[root@host] apt-get install -y zlib1g-dev build-essential \
-                    libssl-dev libreadline-dev            \
-                    libyaml-dev libgdbm-dev               \
-                    libncurses5-dev automake              \
-                    libtool bison libffi-dev git curl     \
+[root@host] apt-get install -y zlib1g-dev build-essential           \
+                    libssl-dev libreadline-dev                      \
+                    libyaml-dev libgdbm-dev                         \
+                    libncurses5-dev automake                        \
+                    imagemagick libmagickcore-dev libmagickwand-dev \
+                    libtool bison libffi-dev git curl               \
                     libxml2 libxml2-dev libxslt1-dev # nokogiri
 ```
 


### PR DESCRIPTION
Once the openproject-local_avatars plugin lands, its dependency on imagemagick (rather, rmagick) must be addressed.

https://github.com/rmagick/rmagick/wiki/Installing-on-Ubuntu

[ci skip]
