### PR TITLE
reliably get schema of dynamic attribute

### DIFF
--- a/frontend/app/components/inplace-edit/directives/display-pane/display-pane.directive.js
+++ b/frontend/app/components/inplace-edit/directives/display-pane/display-pane.directive.js
@@ -98,7 +98,7 @@ function InplaceEditorDisplayPaneController($scope, HookService) {
   // refactor to a service method the whole extraction
   this.getDynamicDirectiveName = function() {
     return HookService.call('workPackageOverviewAttributes', {
-      type: field.resource.schema.props[field.name].type,
+      type: field.getSchema(field.resource).props[field.name].type,
       field: field.name,
       workPackage: field.resource
     })[0];


### PR DESCRIPTION
This is very akward but quick.

Gets rid of:

![image](https://cloud.githubusercontent.com/assets/617519/11236160/9052585a-8dd7-11e5-9370-ea4e3a82902c.png)

For dynamic attributes like "budget".
