### PR TITLE
Feature/undefined checkout instructions

### DIFF
--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -90,6 +90,11 @@ class Scm::CheckoutInstructionsService
     checkout_settings['enabled'].to_i > 0
   end
 
+  def supported_but_not_enabled?
+    repository.supports_checkout_info? && !checkout_enabled?
+  end
+
+
   ##
   # Determines whether permissions for the given repository
   # are available.

--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </p>
   </div>
 </div>
-<% else %>
+<% elsif @instructions.supported_but_not_enabled? %>
 <div class="notification-box -warning">
   <a title="{{ ::I18n.t('js.close_popup_title') }}"
      class="notification-box--close icon-context icon-close">

--- a/app/views/repositories/_checkout_instructions.html.erb
+++ b/app/views/repositories/_checkout_instructions.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
+<% if @instructions.available? %>
 <div id="repository--checkout-instructions"
      class="notification-box -info persistent-toggle--notification"
      hidden>
@@ -43,3 +44,13 @@ See doc/COPYRIGHT.rdoc for more details.
     </p>
   </div>
 </div>
+<% else %>
+<div class="notification-box -warning">
+  <a title="{{ ::I18n.t('js.close_popup_title') }}"
+     class="notification-box--close icon-context icon-close">
+  </a>
+  <div class="notification-box--content">
+    <p><%= l('repositories.checkout.not_available') %></p>
+  </div>
+</div>
+<% end %>

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -81,7 +81,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 
-<% if @instructions && @instructions.available? %>
+<% if @instructions %>
   <%= render partial: 'checkout_instructions',
              locals: { repository: @repository, instructions: @instructions } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1543,7 +1543,7 @@ en:
       instructions: "Checkout instructions"
       show_instructions: "Display checkout instructions"
       text_instructions: "This text is displayed alongside the checkout URL for guidance on how to check out the repository."
-      not_available: "Checkout instructions are not available for this repository"
+      not_available: "Checkout instructions are not defined for this repository. Ask your administrator to enable them for this repository in the system settings."
     create_managed_delay: "Please note: The repository is managed, it is created asynchronously on the disk and will be available shortly."
     create_successful: "The repository has been registered."
     delete_sucessful: "The repository has been deleted."


### PR DESCRIPTION
We should show a warning when the checkout instructions have not been configured, but are supported by the SCM vendor.
