### PR TITLE
don't fail invitation on long email addresses

### DIFF
--- a/app/controllers/concerns/user_invitation.rb
+++ b/app/controllers/concerns/user_invitation.rb
@@ -48,15 +48,36 @@ module UserInvitation
   #         on the returned user will yield `false`. Check for validation errors
   #         in that case.
   def invite_new_user(email:, login: nil, first_name: nil, last_name: nil)
+    placeholder = placeholder_name(email)
+
     user = User.new login: login || email,
                     mail: email,
-                    firstname: first_name || email,
-                    lastname: last_name || '(invited)',
+                    firstname: first_name || placeholder.first,
+                    lastname: last_name || placeholder.last,
                     status: Principal::STATUSES[:invited]
 
     yield user if block_given?
 
     invite_user! user
+  end
+
+  ##
+  # Creates a placeholder name for the user based on their email address.
+  # For the unlikely case that the local or domain part of the email address
+  # are longer than 30 characters they will be trimmed to 27 characters and an
+  # elipsis will be appended.
+  def placeholder_name(email)
+    first, last = email.split('@').map { |name| trim_name(name) }
+
+    [first, '@' + last]
+  end
+
+  def trim_name(name)
+    if name.size > 30
+      name[0..26] + '...'
+    else
+      name
+    end
   end
 
   ##

--- a/spec/controllers/concerns/user_invitation_spec.rb
+++ b/spec/controllers/concerns/user_invitation_spec.rb
@@ -1,0 +1,49 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe UserInvitation do
+  describe '.placeholder_name' do
+    it 'given an email it uses the local part as first and the domain as the last name' do
+      email = 'xxxhunterxxx@openproject.com'
+      first, last = UserInvitation.placeholder_name email
+
+      expect(first).to eq 'xxxhunterxxx'
+      expect(last).to eq '@openproject.com'
+    end
+
+    it 'trims names if they are too long (> 30 characters)' do
+      email = 'hallowurstsalatgetraenkebuechse@veryopensuchproject.openproject.com'
+      first, last = UserInvitation.placeholder_name email
+
+      expect(first).to eq 'hallowurstsalatgetraenkebue...'
+      expect(last).to eq '@veryopensuchproject.openpro...'
+    end
+  end
+end

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -50,7 +50,7 @@ feature 'invite user via email', type: :feature, js: true do
       expect(members_page).to have_selected_new_principal('Invite finkelstein@openproject.com')
 
       click_on 'Add'
-      expect(members_page).to have_added_user 'finkelstein@openproject.com (invited)'
+      expect(members_page).to have_added_user 'finkelstein @openproject.com'
     end
   end
 


### PR DESCRIPTION
Issue: One cannot invite users with too long email addresses (longer than 30 characters).

Users will not be named `<email> (invited)` anymore but `local @domain` instead. As said before this is merely a temporary name to be able to recognize the invited user without clicking them. This is only relevant when inviting users directly via the project members view where no name is given but just an email address.
