### PR TITLE
Fix/redirect on unauthenticated wp access

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -175,7 +175,7 @@ class WorkPackagesController < ApplicationController
   end
 
   def not_found_unless_work_package
-    render_404 unless work_package
+    deny_access unless work_package
   end
 
   def protect_from_unauthorized_export

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -47,15 +47,15 @@ class WorkPackagesController < ApplicationController
   include OpenProject::Concerns::Preview
   include OpenProject::ClientPreferenceExtractor
 
-  accept_key_auth :index, :show, :create, :update
+  accept_key_auth :index, :show
 
   # before_filter :disable_api # TODO re-enable once API is used for any JSON request
   before_filter :not_found_unless_work_package,
                 :project,
-                :authorize, except: [:index, :preview, :column_data, :column_sums]
+                :authorize, only: :show
   before_filter :find_optional_project,
-                :protect_from_unauthorized_export, only: [:index, :all, :preview]
-  before_filter :load_query, only: :index
+                :protect_from_unauthorized_export,
+                :load_query, only: :index
 
   def show
     respond_to do |format|

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -44,7 +44,6 @@ class WorkPackagesController < ApplicationController
   include QueriesHelper
   include PaginationHelper
   include SortHelper
-  include OpenProject::Concerns::Preview
   include OpenProject::ClientPreferenceExtractor
 
   accept_key_auth :index, :show

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -50,9 +50,7 @@ class WorkPackagesController < ApplicationController
   accept_key_auth :index, :show
 
   # before_filter :disable_api # TODO re-enable once API is used for any JSON request
-  before_filter :not_found_unless_work_package,
-                :project,
-                :authorize, only: :show
+  before_filter :authorize_on_work_package, only: :show
   before_filter :find_optional_project,
                 :protect_from_unauthorized_export,
                 :load_query, only: :index
@@ -61,7 +59,7 @@ class WorkPackagesController < ApplicationController
     respond_to do |format|
       format.html do
         gon.settings = client_preferences
-        gon.settings[:enabled_modules] = @project ? @project.enabled_modules.collect(&:name) : []
+        gon.settings[:enabled_modules] = project ? project.enabled_modules.collect(&:name) : []
 
         render :show, locals: { work_package: work_package }, layout: 'angular'
       end
@@ -82,14 +80,6 @@ class WorkPackagesController < ApplicationController
                          journals: journals }
       end
     end
-  end
-
-  def journals
-    @journals ||= work_package.journals.changing
-                  .includes(:user)
-                  .order("#{Journal.table_name}.created_at ASC").to_a
-    @journals.reverse_order if current_user.wants_comments_in_reverse_order?
-    @journals
   end
 
   def index
@@ -134,47 +124,9 @@ class WorkPackagesController < ApplicationController
     render_404
   end
 
-  def project
-    @project ||= work_package.project
-  end
-
-  def time_entry
-    attributes = {}
-    permitted = {}
-
-    if params[:work_package]
-      permitted = permitted_params.update_work_package(project: project)
-    end
-
-    if permitted.has_key?('time_entry')
-      attributes = permitted['time_entry']
-    end
-
-    work_package.add_time_entry(attributes)
-  end
-
-  def work_package
-    if params[:id]
-      existing_work_package
-    end
-  end
-
   protected
 
-  def load_query
-    @query ||= retrieve_query
-  rescue ActiveRecord::RecordNotFound
-    render_404
-  end
-
-  def existing_work_package
-    @existing_work_package ||= begin
-      wp = WorkPackage.includes(:project).find_by(id: params[:id])
-      wp && wp.visible?(current_user) ? wp : nil
-    end
-  end
-
-  def not_found_unless_work_package
+  def authorize_on_work_package
     deny_access unless work_package
   end
 
@@ -187,8 +139,10 @@ class WorkPackagesController < ApplicationController
     end
   end
 
-  def send_notifications?
-    params[:send_notification] != '0'
+  def load_query
+    @query ||= retrieve_query
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def per_page_param
@@ -200,6 +154,22 @@ class WorkPackagesController < ApplicationController
     else
       super
     end
+  end
+
+  def project
+    @project ||= work_package.project
+  end
+
+  def work_package
+    @work_package ||= WorkPackage.visible(current_user).find_by(id: params[:id])
+  end
+
+  def journals
+    @journals ||= work_package.journals.changing
+                  .includes(:user)
+                  .order("#{Journal.table_name}.created_at ASC").to_a
+    @journals.reverse_order if current_user.wants_comments_in_reverse_order?
+    @journals
   end
 
   private

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -88,7 +88,7 @@ class WorkPackagesController < ApplicationController
     @journals ||= work_package.journals.changing
                   .includes(:user)
                   .order("#{Journal.table_name}.created_at ASC").to_a
-    @journals.reverse! if current_user.wants_comments_in_reverse_order?
+    @journals.reverse_order if current_user.wants_comments_in_reverse_order?
     @journals
   end
 

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -63,8 +63,7 @@ describe WorkPackagesController, type: :controller do
     describe 'w/ the permission to see the project
               w/ having the necessary permissions' do
       before do
-        allow(controller).to receive(:work_package).and_return(stub_work_package)
-        expect(controller).to receive(:authorize).and_return(true)
+        expect(WorkPackage).to receive_message_chain('visible.find_by').and_return(stub_work_package)
       end
 
       instance_eval(&block)
@@ -350,87 +349,4 @@ describe WorkPackagesController, type: :controller do
       end
     end
   end
-
-  describe '#work_package' do
-    describe 'when providing an id (wanting to see an existing wp)' do
-      describe 'when beeing allowed to see the work_package' do
-        become_member_with_view_planning_element_permissions
-
-        it 'should return the work_package' do
-          controller.params = { id: planning_element.id }
-
-          expect(controller.work_package).to eq(planning_element)
-        end
-
-        it 'should return nil for non existing work_packages' do
-          controller.params = { id: 0 }
-
-          expect(controller.work_package).to be_nil
-        end
-      end
-
-      describe 'when not beeing allowed to see the work_package' do
-        it 'should return nil' do
-          controller.params = { id: planning_element.id }
-
-          expect(controller.work_package).to be_nil
-        end
-      end
-    end
-
-    describe 'when providing a project_id (wanting to build a new wp)' do
-      let(:wp_params) { { wp_attribute: double('wp_attribute') } }
-      let(:params) { { project_id: stub_project.id } }
-
-      before do
-        allow(Project).to receive(:find_visible).and_return stub_project
-      end
-
-      describe 'if the project is not visible for the current_user' do
-        before do
-          projects = [stub_project]
-          allow(Project).to receive(:visible).and_return projects
-          allow(projects).to receive(:find_by).and_return(stub_project)
-        end
-
-        it 'should return nil' do
-          expect(controller.work_package).to be_nil
-        end
-      end
-    end
-
-    describe 'when providing neither id nor project_id (error)' do
-      it 'should return nil' do
-        controller.params = {}
-
-        expect(controller.work_package).to be_nil
-      end
-    end
-  end
-
-  describe '#project' do
-    it "should be the work_packages's project" do
-      allow(controller).to receive(:work_package).and_return(planning_element)
-
-      expect(controller.project).to eq(planning_element.project)
-    end
-  end
-
-  describe '#time_entry' do
-    before do
-      allow(controller).to receive(:work_package).and_return(stub_planning_element)
-    end
-
-    it 'should return a time entry' do
-      expected = double('time_entry')
-
-      allow(stub_planning_element).to receive(:add_time_entry).and_return(expected)
-
-      expect(controller.time_entry).to eq(expected)
-    end
-  end
-
-  let(:filename) { 'testfile.txt' }
-  let(:file) { File.open(Rails.root.join('spec/fixtures/files', filename)) }
-  let(:uploaded_file) { ActionDispatch::Http::UploadedFile.new(tempfile: file, type: 'text/plain', filename: filename) }
 end

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -55,8 +55,8 @@ describe WorkPackagesController, type: :controller do
         call_action
       end
 
-      it 'should render a 404' do
-        expect(response.response_code).to be === 404
+      it 'should render a 403' do
+        expect(response.response_code).to be === 403
       end
     end
 

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -99,6 +99,6 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     visit '/work_packages/0'
 
     expect(page).to have_selector('.errorExplanation',
-                                  text: I18n.t('notice_file_not_found'))
+                                  text: I18n.t('notice_not_authorized'))
   end
 end

--- a/spec_legacy/integration/application_spec.rb
+++ b/spec_legacy/integration/application_spec.rb
@@ -26,7 +26,7 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe 'Application' do
   include Redmine::I18n
@@ -44,8 +44,8 @@ describe 'Application' do
   end
 
   it 'set localization' do
-    Setting.available_languages = [:de, :en]
-    Setting.default_language = 'en'
+    allow(Setting).to receive(:available_languages).and_return [:de, :en]
+    allow(Setting).to receive(:default_language).and_return 'en'
 
     # a french user
     get '/projects', {},  'HTTP_ACCEPT_LANGUAGE' => 'de,de-de;q=0.8,en-us;q=0.5,en;q=0.3'
@@ -62,7 +62,7 @@ describe 'Application' do
   it 'token based access should not start session' do
     # work_packages of a private project
     get '/work_packages/4.atom'
-    assert_response 404
+    assert_response 302
 
     rss_key = User.find(2).rss_key
     get "/work_packages/4.atom?key=#{rss_key}"


### PR DESCRIPTION
This started of as a fix for the change in behaviour on unauthenticated access to a work package
https://community.openproject.org/work_packages/21868
which is done in ddfb0cc.

It additionally fixes a bug on reversing the journals which is equivalent to 03a3460.

It then reduced the complexity of the controller and it's spec as the complexity was only necessary for when the controller had more actions. As a side effect, only methods that are actions are visible (not private/protected) now which, given our catch all route is a good idea.
