### PR TITLE
Move dev to 5.1.0-alpha

### DIFF
--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -32,7 +32,7 @@ require 'rexml/document'
 module OpenProject
   module VERSION #:nodoc:
     MAJOR = 5
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
     TINY  = PATCH # Redmine compat
 
@@ -48,7 +48,7 @@ module OpenProject
     #
     #   2.0.0debian-2
     def self.special
-      '-beta'
+      '-alpha'
     end
 
     def self.revision


### PR DESCRIPTION
Now that release/5.0 is used with 5.0.1, we should move to 5.1 here.

[ci skip]
