### PR TITLE
Use proper server name in repoman configuration

### DIFF
--- a/app/workers/scm/create_remote_repository_job.rb
+++ b/app/workers/scm/create_remote_repository_job.rb
@@ -37,7 +37,7 @@
 # Until then, a synchronous process is more failsafe.
 class Scm::CreateRemoteRepositoryJob < Scm::RemoteRepositoryJob
   def perform
-    response = send(repository_request.merge(action: :create))
+    response = send_request(repository_request.merge(action: :create))
     repository.root_url = response['path']
     repository.url = response['url']
 

--- a/app/workers/scm/delete_remote_repository_job.rb
+++ b/app/workers/scm/delete_remote_repository_job.rb
@@ -36,6 +36,6 @@
 # Until then, a synchronous process is more failsafe.
 class Scm::DeleteRemoteRepositoryJob < Scm::RemoteRepositoryJob
   def perform
-    send(repository_request.merge(action: :delete))
+    send_request(repository_request.merge(action: :delete))
   end
 end

--- a/app/workers/scm/relocate_repository_job.rb
+++ b/app/workers/scm/relocate_repository_job.rb
@@ -43,7 +43,7 @@ class Scm::RelocateRepositoryJob < Scm::RemoteRepositoryJob
   ##
   # POST to the remote managed repository a request to relocate the repository
   def relocate_remote
-    response = send(repository_request.merge(
+    response = send_request(repository_request.merge(
            action: :relocate,
            old_repository: repository.root_url))
     repository.root_url = response['path']

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -233,6 +233,12 @@ default:
   #     - old_repository: The known path to the old repository (used during relocate, only)
   #
   #   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
+  #
+  # insecure:
+  #   Only applies when the manages: key is set to a URL
+  #   If the given URL uses SSL, certificate checking will be disabled.
+  #   This key is set for a packaged installation by default, since it communicates locally and
+  #   these installations may often include a snakeoil certificate.
   # mode:
   #   The octal file mode to set the repository folder to (defaults to 0700).
   # group:

--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -49,7 +49,11 @@ default:
   <% if ENV['SVN_REPOSITORIES'].present? %>
     subversion:
       # SVN uses Apache repository wrapper due to permission errors in multi-user operation
-      manages: <%= ENV['SERVER_PROTOCOL'] %>://<%= ENV['SERVER_HOSTNAME'] %>/repoman_svn
+      manages: http://127.0.0.1/repoman_svn
+      # Do noot verify SSL certificates when SERVER_PROTOCOL is 'https'.
+      # As we currently only support local repoman installations with packager,
+      # this option is set to true by default.
+      insecure: true
       access_token: <%= ENV['SVN_REPOMAN_TOKEN'] %>
   <% end %>
 <% end %>

--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -49,7 +49,7 @@ default:
   <% if ENV['SVN_REPOSITORIES'].present? %>
     subversion:
       # SVN uses Apache repository wrapper due to permission errors in multi-user operation
-      manages: http://localhost/repoman_svn
+      manages: <%= ENV['SERVER_PROTOCOL'] %>://<%= ENV['SERVER_HOSTNAME'] %>/repoman_svn
       access_token: <%= ENV['SVN_REPOMAN_TOKEN'] %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Repoman is not accessible from localhost in all configurations,
thus we instead use the proper servername configured in the wizard
to communicate with repoman for SVN repositories.

Adds an `insecure` option to the `configuration.yml`.

This option only applies when the manages: key is set to a URL.

If the given URL uses SSL, certificate checking will be disabled.
This key is set for a packaged installation by default, since it communicates locally and
these installations may often include a snakeoil certificate.

Related to https://github.com/finnlabs/addon-repositories/pull/5

/cc @crohr 
