### PR TITLE
Use SERVER_GROUP from addon-apache2

### DIFF
--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -44,7 +44,7 @@ default:
     git:
       manages: <%= ENV['GIT_REPOSITORIES'] %>
       mode: 0770
-      group: <%= ENV['SERVER_USER'] %>
+      group: <%= ENV['SERVER_GROUP'] %>
   <% end %>
   <% if ENV['SVN_REPOSITORIES'].present? %>
     subversion:


### PR DESCRIPTION
https://github.com/pkgr/addon-apache2/blob/master/bin/postinstall#L196
introduced a `SERVER_GROUP` variable to account for distributions where
the Apache user name is not identitical to the group (whyever one should
choose to do that).

[ci skip]
