### PR TITLE
Bump nokogiri to 1.6.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     non-stupid-digest-assets (1.0.4)
     object-daddy (1.1.1)


### PR DESCRIPTION
Nokogiri 1.6.6.4 addresses a number of CVEs in libxml2/libxslt.

https://bugzilla.gnome.org/show_bug.cgi?id=746048
https://hackerone.com/reports/57125
http://www.ubuntu.com/usn/usn-2812-1/

https://github.com/opf/openproject/pull/3887
