### PR TITLE
Revert "Adapt branch of OpenProject-Translations"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -230,7 +230,7 @@ platforms :jruby do
 end
 
 group :opf_plugins do
-  gem 'openproject-translations', git:'https://github.com/opf/openproject-translations.git', branch: 'release/5.0'
+  gem 'openproject-translations', git:'https://github.com/opf/openproject-translations.git', branch: 'dev'
 end
 
 # Load Gemfile.local, Gemfile.plugins and plugins' Gemfiles


### PR DESCRIPTION
This reverts commit f9210ae024e2f9ff76223124e288254f7719d452. I think this commit should only have been applied to the `release/5.0` branch
