### PR TITLE
Add rake task to allow setting checkout URL from packager

### DIFF
--- a/lib/tasks/scm.rake
+++ b/lib/tasks/scm.rake
@@ -101,6 +101,23 @@ To resolve these cases, you can either:
     end
   end
 
+  desc 'Setup a repository checkout base URL for the given vendor: rake scm:set_checkout_url[git=<url>, subversion=<url>]'
+  task set_checkout_url: :environment do |_t, args|
+
+    checkout_data = Setting.repository_checkout_data
+    args.extras.each do |tuple|
+      vendor, base_url = tuple.split('=')
+
+      unless OpenProject::Scm::Manager.enabled?(vendor.to_sym)
+        puts "Vendor #{vendor} is not enabled, skipping."
+        next
+      end
+
+      checkout_data[vendor] = { 'enabled' => 1, 'url' => base_url }
+    end
+    Setting.repository_checkout_data = checkout_data
+  end
+
   namespace :migrate do
     desc 'Migrate existing repositories to managed for a given URL prefix'
     task managed: :environment do |task, args|


### PR DESCRIPTION
This commit adds the rake task `scm:set_checkout_url` to configure
repository checkout URLs from outside, e.g., from packager without
knowledge of the checkout data structure.

With this task, we can instrument the packager postinstall to set the
checkout data automatically from the values it has been configured with.

Relevant work package: https://community.openproject.org/work_packages/21996/activity
See also: https://github.com/pkgr/addon-openproject/pull/6
