### PR TITLE
Fix/work package activity performance

### DIFF
--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -54,6 +54,13 @@ class TimeEntry < ActiveRecord::Base
   validate :validate_consistency_of_work_package_id
 
   scope :visible, -> (*args) {
+    # TODO: check whether the visibility should also be influenced by the work
+    # package the time entry is assigned to.  Currently a work package can
+    # switch projects. But as the time entry is still part of it's original
+    # project, it is unclear, whether the time entry is actually visible if the
+    # user lacks the view_work_packages permission in the moved to project.
+    #
+    # See WorkPackage#compute_spent_hours for an implementation of it.
     includes(:project)
       .merge(Project.allowed_to(args.first || User.current, :view_time_entries))
   }

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -938,9 +938,14 @@ class WorkPackage < ActiveRecord::Base
   end
 
   def compute_spent_hours(usr = User.current)
+    # The joins(:project) part witin
+    # self_and_descendants.joins(:project).visible(usr) is important! Without
+    # it, the visibility condition references the projects table joined by
+    # TimeEntry.visible. That is both semantically wrong and bad performance
+    # wise.
     spent_time = TimeEntry.visible(usr)
-                 .on_work_packages(self_and_descendants.visible(usr))
-                 .sum(:hours)
+                  .on_work_packages(self_and_descendants.joins(:project).visible(usr))
+                  .sum(:hours)
 
     spent_time || 0.0
   end

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -48,7 +48,12 @@ module API
           end
 
           get do
-            @activities = ::Journal::AggregatedJournal.aggregated_journals(journable: @work_package)
+            @activities = ::Journal::AggregatedJournal.aggregated_journals(journable: @work_package,
+                                                                           includes: [
+                                                                             :customizable_journals,
+                                                                             :attachable_journals,
+                                                                             :data]
+                                                                          )
             self_link = api_v3_paths.work_package_activities @work_package.id
             Activities::ActivityCollectionRepresenter.new(@activities,
                                                           self_link,

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -48,7 +48,7 @@ module API
 
         link :user do
           {
-            href: api_v3_paths.user(represented.user.id)
+            href: api_v3_paths.user(represented.user_id)
           }
         end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -316,7 +316,12 @@ module API
         end
 
         def activities
-          activities = ::Journal::AggregatedJournal.aggregated_journals(journable: represented)
+          activities = ::Journal::AggregatedJournal.aggregated_journals(journable: represented,
+                                                                        includes: [
+                                                                          :customizable_journals,
+                                                                          :attachable_journals,
+                                                                          :data]
+                                                                       )
           self_link = api_v3_paths.work_package_activities represented.id
           Activities::ActivityCollectionRepresenter.new(activities,
                                                         self_link,


### PR DESCRIPTION
Improves the performance of `api/v3/work_packages/:id`. In my tests the response time was cut down to one third.

There are two parts to this fix:
- Eager load the `customizable_journals`, `attachable_journals` and `<data>_journals` (e.g. `work_package_journals`) so that the n+1 queries are removed
- Optimize the computation for spent time. The query was actually wrong before as well. 

I tried to optimize this even further by introducing a self written object cache that would remove the necessity to even ask the AR query cache for results. The rational behind it was, that in the journals a lot of values are referenced and you often have changes like: Assigned to user A -> Assigned to user B -> Assigned to user A. In that case, user A would not have to be reinitialized. As my tests did not show a significant performance gain (about 50 ms) I deemed the potential havoc such a cache could produce to outweigh the performance gain.

The real performance gain however could be achieved by no longer embedding the activities in the response to work_packages#show. This is something the front end has to be able to cope with though, @furinvader. The front end could then show the work package faster and load the activities after an initial result is displayed to the user. Depending on the state the user wishes to see (e.g. relations), the activities would not have to be loaded at all.  
#### Todo
- [x] Apply eager loading to `work_packages/:id/activities` endpoint

https://community.openproject.org/work_packages/22097
