### PR TITLE
[22149] Fix multiple appeared wp save buttons

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -192,6 +192,7 @@
 
 .work-packages--edit-actions
   @extend .work-packages--details-toolbar
+  -webkit-transform: translate3d(0,0,0)
 
   .work-packages--left-panel &
     position: absolute


### PR DESCRIPTION
This bug occures only on chrome with high resolution monitors (such as retina displays).
https://community.openproject.org/work_packages/22149/activity
