### PR TITLE
Fix/work package form performance

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -595,6 +595,19 @@ class Project < ActiveRecord::Base
     end
   end
 
+  # Returns all versions a work package can be assigned to.  Opposed to
+  # #shared_versions this returns an array of Versions, not a scope.
+  #
+  # The main benefit is in scenarios where work packages' projects are eager
+  # loaded.  Because eager loading the project e.g. via
+  # WorkPackage.includes(:project).where(type: 5) will assign the same instance
+  # (same object_id) for every work package having the same project this will
+  # reduce the number of db queries when performing operations including the
+  # project's versions.
+  def assignable_versions
+    @all_shared_versions ||= shared_versions.open.to_a
+  end
+
   # Returns a hash of project users grouped by role
   def users_by_role
     members.includes(:user, :roles).inject({}) do |h, m|

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -113,7 +113,7 @@ class Project < ActiveRecord::Base
   has_one :repository, dependent: :destroy
   has_many :changesets, through: :repository
   has_one :wiki, dependent: :destroy
-  # Custom field for the project work units
+  # Custom field for the project's work_packages
   has_and_belongs_to_many :work_package_custom_fields, -> {
     order("#{CustomField.table_name}.position")
   }, class_name: 'WorkPackageCustomField',

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -373,7 +373,9 @@ class WorkPackage < ActiveRecord::Base
 
   def soonest_start
     @soonest_start ||= (
-      self_and_ancestors.map(&:relations_to)
+      self_and_ancestors.includes(relations_to: :from)
+                        .where(relations: { relation_type: Relation::TYPE_PRECEDES })
+                        .map(&:relations_to)
                         .flatten
                         .map(&:successor_soonest_start)
     ).compact.max

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -399,7 +399,10 @@ class WorkPackage < ActiveRecord::Base
   #   * the version it was already assigned to
   #     (to make sure, that you can still update closed tickets)
   def assignable_versions
-    @assignable_versions ||= (project.shared_versions.open + [(fixed_version_id_changed? ? Version.find_by(id: fixed_version_id_was) : fixed_version)]).compact.uniq.sort
+    @assignable_versions ||= begin
+      current_version = fixed_version_id_changed? ? Version.find_by(id: fixed_version_id_was) : fixed_version
+      (project.assignable_versions + [current_version]).compact.uniq.sort
+    end
   end
 
   def kind

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -399,7 +399,7 @@ class WorkPackage < ActiveRecord::Base
   #   * the version it was already assigned to
   #     (to make sure, that you can still update closed tickets)
   def assignable_versions
-    @assignable_versions ||= (project.shared_versions.open + [Version.find_by(id: fixed_version_id_was)]).compact.uniq.sort
+    @assignable_versions ||= (project.shared_versions.open + [(fixed_version_id_changed? ? Version.find_by(id: fixed_version_id_was) : fixed_version)]).compact.uniq.sort
   end
 
   def kind

--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -183,7 +183,7 @@ module WorkPackage::Validations
   end
 
   def status_exists?
-    status_id && Status.find_by(id: status_id)
+    status_id && Status.where(id: status_id).exists?
   end
 
   def status_transition_exists?

--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -163,11 +163,7 @@ module WorkPackage::Validations
       wp.parent = self if wp.parent_id == id
     end
 
-    invalid_descendants = all_descendants.select { |c|
-      !c.valid?(nil, skip_descendants_validation: true)
-    }
-
-    copy_descendants_errors(invalid_descendants)
+    copy_descendants_errors(all_descendants)
   end
 
   def validate_estimated_hours
@@ -190,8 +186,10 @@ module WorkPackage::Validations
     type.is_valid_transition?(status_id_was, status_id, User.current.roles(project))
   end
 
-  def copy_descendants_errors(invalid_descendants)
-    invalid_descendants.each do |descendant|
+  def copy_descendants_errors(all_descendants)
+    all_descendants.each do |descendant|
+      descendant.valid?(nil, skip_descendants_validation: true)
+
       descendant.errors.each do |attribute, message|
         full_message = descendant.errors.full_message(attribute, message)
         errors.add(:base, "#{I18n.t('label_child_element')} ##{descendant.id}: #{full_message}")

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -49,7 +49,9 @@ module API
             when :status
               assignable_statuses_for(current_user)
             when :type
-              project.try(:types)
+              if project.respond_to?(:types)
+                project.types.includes(:color)
+              end
             when :version
               @work_package.try(:assignable_versions)
             when :priority

--- a/lib/api/v3/work_packages/work_packages_shared_helpers.rb
+++ b/lib/api/v3/work_packages/work_packages_shared_helpers.rb
@@ -49,7 +49,9 @@ module API
             # In Pass 2 the representer is created with the new type info and will be able
             # to also parse custom fields successfully
             merge_hash_into_work_package!(request_body, work_package)
-            merge_hash_into_work_package!(request_body, work_package)
+            if work_package.type_id_changed?
+              merge_hash_into_work_package!(request_body, work_package)
+            end
           end
         end
 

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -127,7 +127,11 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
   end
 
   describe '#assignable_types' do
-    let(:result) { double }
+    let(:result) {
+      result = double
+      allow(result).to receive(:includes).and_return(result)
+      result
+    }
 
     it 'calls through to the project' do
       expect(project).to receive(:types).and_return(result)

--- a/spec_legacy/unit/issue_nested_set_spec.rb
+++ b/spec_legacy/unit/issue_nested_set_spec.rb
@@ -77,7 +77,7 @@ describe 'IssueNestedSet', type: :model do
     assert_equal [1, parent1.id, 5], [parent1.project_id, parent1.root_id, parent1.nested_set_span]
 
     # child can not be moved to Project 2 because its child is on a disabled type
-    service = MoveWorkPackageService.new(child, User.current)
+    service = MoveWorkPackageService.new(child, User.find(1))
     assert_equal false, service.call(Project.find(2))
     child.reload
     grandchild.reload

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -1074,8 +1074,8 @@ describe Project, type: :model do
 
       it 'should return 100 if the version has only closed issues' do
         v1 = FactoryGirl.create(:version, project: @project)
-        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v1)
         v2 = FactoryGirl.create(:version, project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v1)
         FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('Closed'), fixed_version: v2)
 
         assert_equal 100, @project.completed_percent
@@ -1083,8 +1083,8 @@ describe Project, type: :model do
 
       it 'should return the averaged completed percent of the versions (not weighted)' do
         v1 = FactoryGirl.create(:version, project: @project)
-        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v1)
         v2 = FactoryGirl.create(:version, project: @project)
+        FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v1)
         FactoryGirl.create(:work_package, project: @project, status: Status.find_by_name('New'), estimated_hours: 10, done_ratio: 50, fixed_version: v2)
 
         assert_equal 50, @project.completed_percent


### PR DESCRIPTION
Improves the performance of work_packages#form mainly by improving the performance of work_package#valid?

The most time consuming part of this is validating all the children. The performance improvements there stem from eager loading most of what the children require to be validated themselves.

Compared to that, the other improvements are negligleble but improve the performance a bit at least.

There are still too many queries issued upon work package validation. The most annoying one is checking for the start_date which has to be after the last_start/end_date of a relation of the type PRECEDES to any ancestor of the current work package. That one is highly specific to every work package and I couldn't find a way to optimize this further [apart from turning it into one query](https://github.com/opf/openproject/compare/release/5.0...ulferts:fix/work_package_form_performance?expand=1#diff-bf5b70b6182b3b115141f05cef932382R376.

The other one is the check for the assignable versions. This again is work package specific, or to be more precise the work package's project specific. So I could optimize this to at least [reuse the result of former computations for a project](https://github.com/opf/openproject/compare/release/5.0...ulferts:fix/work_package_form_performance?expand=1#diff-091778d5c1679dbdc51b6db971f68d22R608). But there is no eager loading taking place here and we still have an n+1 query of sorts here.

Be that as it may, the PR considerably improves the performance and IMO is good to be merged in.

Primarily addresses: https://community.openproject.org/work_packages/22100

Should also take care of: https://community.openproject.org/work_packages/22167
