### PR TITLE
Fix repository relocation on managed remote

### DIFF
--- a/app/workers/scm/relocate_repository_job.rb
+++ b/app/workers/scm/relocate_repository_job.rb
@@ -44,8 +44,8 @@ class Scm::RelocateRepositoryJob < Scm::RemoteRepositoryJob
   # POST to the remote managed repository a request to relocate the repository
   def relocate_remote
     response = send_request(repository_request.merge(
-           action: :relocate,
-           old_repository: repository.root_url))
+       action: :relocate,
+       old_identifier: File.basename(repository.root_url)))
     repository.root_url = response['path']
     repository.url = response['url']
 

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -230,7 +230,7 @@ default:
   #     - identifier: The repository identifier name
   #     - vendor: The SCM vendor of the repository to create
   #     - project: identifier, name and ID of the associated project
-  #     - old_repository: The known path to the old repository (used during relocate, only)
+  #     - old_identifier: The identifier to the old repository (used only during relocate)
   #
   #   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
   #

--- a/doc/operation_guides/manual/repository-integration.md
+++ b/doc/operation_guides/manual/repository-integration.md
@@ -37,7 +37,7 @@ The following is an excerpt of the configuration and contains all required infor
 	#     - identifier: The repository identifier name
 	#     - vendor: The SCM vendor of the repository to create
 	#     - project: identifier, name and ID of the associated project
-	#     - old_repository: The known path to the old repository (used during relocate, only)
+	#     - old_identifier: The identifier to the old repository (used only during relocate)
 	#
 	#   NOTE: Disabling :managed repositories using disabled_types takes precedence over this setting.
 	#

--- a/extra/Apache/OpenProjectRepoman.pm
+++ b/extra/Apache/OpenProjectRepoman.pm
@@ -5,6 +5,7 @@ use warnings FATAL => 'all', NONFATAL => 'redefine';
 
 use File::Path qw(rmtree);
 use File::Spec ();
+use File::Copy qw(move);
 
 use Apache2::Module;
 use Apache2::Module;
@@ -46,7 +47,7 @@ sub AccessSecret {
 ##
 # Creates an actual repository on disk for Subversion and Git.
 sub create_repository {
-  my ($r, $vendor, $repository) = @_;
+  my ($r, $vendor, $repository, $repository_root, $request) = @_;
 
   my $command = {
     git => "git init $repository --shared --bare",
@@ -60,8 +61,20 @@ sub create_repository {
 ##
 # Removes the repository with a given identifier on disk.
 sub delete_repository {
-  my ($r, $vendor, $repository) = @_;
+  my ($r, $vendor, $repository, $repository_root, $request) = @_;
   rmtree($repository) if -d $repository;
+}
+
+sub relocate_repository {
+  my ($r, $vendor, $repository, $repository_root, $request) = @_;
+
+  # Determine validity of the old repository identifier as a dir name
+  my $old_identifier = $request->{old_identifier};
+  die "Old repository identifier is empty") unless (length($old_identifier) > 0);
+  die "Old repository identifier is an invalid filename") if ($old_identifier =~ m{[\\/:*?"<>|]});
+
+  my $old_repository = File::Spec->catdir($repository_root, $old_identifier);
+  move($old_repository, $repository) if -d $old_repository;
 }
 
 ##
@@ -98,7 +111,7 @@ sub make_error {
 # Actual incoming request handler, that receives the JSON request
 # and determines the necessary local action from the request.
 sub _handle_request {
-    my $r = shift;
+  my $r = shift;
 
   # Parse JSON request
   my $request = parse_request($r);
@@ -143,12 +156,13 @@ sub _handle_request {
   my $target = File::Spec->catdir($repository_root, $repository_identifier);
   my %actions = (
     'create' => \&create_repository,
+    'relocate' => \&relocate_repository,
     'delete' => \&delete_repository
     );
 
   my $action = $actions{$request->{action}};
   die "Unknown action.\n"  unless defined($action);
-  $action->($r, $vendor, $target);
+  $action->($r, $vendor, $target, $repository_root, $request);
 
   return {
     success => JSON::PP::true,

--- a/spec/support/scm/relocate_repository.rb
+++ b/spec/support/scm/relocate_repository.rb
@@ -61,7 +61,7 @@ shared_examples_for 'repository can be relocated' do |vendor|
     end
 
     it 'sends a relocation request when project identifier is updated' do
-      current_path = repository.root_url
+      old_identifier = 'bar'
 
       # Rename the project
       project.identifier = 'somenewidentifier'
@@ -69,7 +69,7 @@ shared_examples_for 'repository can be relocated' do |vendor|
 
       expect(WebMock)
         .to have_requested(:post, url)
-        .with(body: hash_including(old_repository: current_path,
+        .with(body: hash_including(old_identifier: old_identifier,
                                    action: 'relocate'))
     end
   end


### PR DESCRIPTION
Repositories were not relocated when using a managed remote. While the API endpoint was made available in https://github.com/opf/openproject/pull/3697, it explicitly did not include the managed remote used by packager.

This PR provides the complete behavior for packaged remotes.

This also changes the request to use an old identifier instead of the
whole path. The managed remote will build the correct old path itself.
