### PR TITLE
[22200] Broken table layout in Admin/workflow

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -112,6 +112,9 @@ table
     thead
       .workflow-table--header
         text-align: right
+        display: flex
+        span
+          flex-basis: 50%
       .workflow-table--check-all
         font-size: 12px
         font-style: italic


### PR DESCRIPTION
This uses a flexbox for the header of the workflow table. Thus the two elements can be displayed in one line.

https://community.openproject.org/work_packages/22200/activity
