### PR TITLE
Typo in LegacyJournalMigrator

### DIFF
--- a/db/migrate/migration_utils/legacy_journal_migrator.rb
+++ b/db/migrate/migration_utils/legacy_journal_migrator.rb
@@ -274,7 +274,7 @@ module Migration
     def deserialize_changed_data(journal)
       changed_data = journal['changed_data']
       return Hash.new if changed_data.nil?
-      load_with_sych(changed_data)
+      load_with_syck(changed_data)
     end
 
     def deserialize_journal(journal)


### PR DESCRIPTION
There's a typo in `load_with_syck` that I seem to have missed in https://github.com/opf/openproject/pull/3431/files#diff-ce1587738d1777378536559f39d5ee1dR278.

Thanks @jakubbialas for your contribution!
