### PR TITLE
[21918] Add ngAnnotate

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1219,7 +1219,7 @@
       "version": "0.5.1"
     },
     "lodash": {
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "ng-annotate-loader": {
       "version": "0.0.10",

--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1221,6 +1221,81 @@
     "lodash": {
       "version": "2.4.1"
     },
+    "ng-annotate-loader": {
+      "version": "0.0.10",
+      "dependencies": {
+        "ng-annotate": {
+          "version": "1.0.2",
+          "dependencies": {
+            "acorn": {
+              "version": "2.1.0"
+            },
+            "alter": {
+              "version": "0.2.0"
+            },
+            "convert-source-map": {
+              "version": "1.0.0"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3"
+                },
+                "minimist": {
+                  "version": "0.0.10"
+                }
+              }
+            },
+            "ordered-ast-traverse": {
+              "version": "1.1.1",
+              "dependencies": {
+                "ordered-esprima-props": {
+                  "version": "1.1.0"
+                }
+              }
+            },
+            "simple-fmt": {
+              "version": "0.1.0"
+            },
+            "simple-is": {
+              "version": "0.2.0"
+            },
+            "stable": {
+              "version": "0.1.5"
+            },
+            "stringmap": {
+              "version": "0.2.2"
+            },
+            "stringset": {
+              "version": "0.2.1"
+            },
+            "tryor": {
+              "version": "0.1.2"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.2",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.12",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3"
+            },
+            "json5": {
+              "version": "0.4.0"
+            }
+          }
+        }
+      }
+    },
     "ngtemplate-loader": {
       "version": "0.1.3",
       "dependencies": {
@@ -1681,14 +1756,6 @@
                           "version": "2.0.1"
                         }
                       }
-                    }
-                  }
-                },
-                "fsevents": {
-                  "version": "0.3.6",
-                  "dependencies": {
-                    "nan": {
-                      "version": "1.8.4"
                     }
                   }
                 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "glob": "^4.5.3",
     "html-loader": "^0.2.3",
     "json-loader": "^0.5.1",
-    "lodash": "^2.4.2",
+    "lodash": "2.4.1",
     "ngtemplate-loader": "^0.1.2",
     "polyfill-function-prototype-bind": "0.0.1",
     "shelljs": "^0.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "glob": "^4.5.3",
     "html-loader": "^0.2.3",
     "json-loader": "^0.5.1",
-    "lodash": "2.4.1",
+    "lodash": "^2.4.2",
     "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^0.1.2",
     "polyfill-function-prototype-bind": "0.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "html-loader": "^0.2.3",
     "json-loader": "^0.5.1",
     "lodash": "2.4.1",
+    "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^0.1.2",
     "polyfill-function-prototype-bind": "0.0.1",
     "shelljs": "^0.3.0",

--- a/frontend/scripts/clean-shrinkwrap.js
+++ b/frontend/scripts/clean-shrinkwrap.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 //-- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -25,8 +27,6 @@
 //
 // See doc/COPYRIGHT.rdoc for more details.
 //++
-
-#!/usr/bin/env node
 
 /**
  * this script is just a temporary solution to deal with the issue of npm outputting the npm

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -66,7 +66,8 @@ var loaders = [
   { test: /\.png$/,                   loader: 'url-loader?limit=100000&mimetype=image/png' },
   { test: /\.gif$/,                   loader: 'file-loader' },
   { test: /\.jpg$/,                   loader: 'file-loader' },
-  { test: /js-[\w|-]{2,5}\.yml$/,     loader: 'json!yaml' }
+  { test: /js-[\w|-]{2,5}\.yml$/,     loader: 'json!yaml' },
+  { test: /[\/].*\.js$/,              loader: 'ng-annotate?map=true' }
 ];
 
 for (var k in pathConfig.pluginNamesPaths) {


### PR DESCRIPTION
This PR provides the following:
1. Cleans up the previous lodash dependency updated in https://github.com/opf/openproject/commit/e050d2d5cf26ad67e645d4757dc342ee89de95b1#diff-0a6694dd0d6b93a2aa14f32e3d873b4c
2. Moves the node env hashbang before the comment to be properly parseable by *sh
3. Adds ng-annotate as a dependency and shrinkwrap the last state. In the process, `fsevents` is removed from the shrinkwrap since it only makes sense for OSX installations and is not originating from the package.json. You'll be able to profit from better fs handling by manually installing it _globablly_ `npm i -g fsevents`.

Supersedes https://github.com/opf/openproject/pull/3930
https://community.openproject.org/work_packages/21918/activity
