### PR TITLE
Add required attribute to select HTML options

### DIFF
--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -72,6 +72,10 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   def select(field, choices, options = {}, html_options = {})
     html_options[:class] = Array(html_options[:class]) + %w(form--select)
 
+    if options[:required]
+      html_options[:required] = true
+    end
+
     label_for_field(field, options) + container_wrap_field(super, 'select', options)
   end
 


### PR DESCRIPTION
The required attribute set in `options` are passed to the label,
but are not properly applied to the actual select element.

https://community.openproject.org/work_packages/20450/activity
