### PR TITLE
Specs: Better selector for hovering the activity comment

### DIFF
--- a/spec/features/work_packages/details/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/activity_comments_spec.rb
@@ -134,7 +134,7 @@ describe 'activity comments', js: true, selenium: true do
                                         text: initial_comment)
 
           # Hover comment
-          page.find('.work-package-details-activities-activity-contents').hover
+          page.find('.user-comment > .message').hover
 
           # Quote this comment
           page.find('.comments-icons .icon-quote', visible: false).click


### PR DESCRIPTION
On travis, the following spec fails occasionally due to missing the quote icon, which is only visible on hovering the comment container.

`spec/features/work_packages/details/activity_comments_spec.rb`

This focuses on an inner element of the container to create a better hover trigger without using native browser events.
