### PR TITLE
Fix git warning in version.rb

### DIFF
--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -28,6 +28,7 @@
 #++
 
 require 'rexml/document'
+require 'open3'
 
 module OpenProject
   module VERSION #:nodoc:
@@ -52,7 +53,7 @@ module OpenProject
     end
 
     def self.revision
-      revision = `git rev-parse HEAD`
+      revision, = Open3.capture3('git', 'rev-parse', 'HEAD')
       if revision.present?
         revision.strip[0..8]
       end


### PR DESCRIPTION
This fixes the annoying Git warning in packager that is printed for everytime the environment is loaded (which happens quite often during the postinstall script).

fatal: Not a git repository (or any of the parent directories): .git
I'm not even sure why we do this in there, since there's a release plugin that may optionally add commit hash information to the repository.
