### PR TITLE
mark inherited attributes as writable for new work packages

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -451,6 +451,15 @@ class WorkPackage < ActiveRecord::Base
     type && type.is_milestone?
   end
 
+  # Overwriting awesome nested set here as it considers unpersisted work
+  # packages to not be leaves.
+  # https://github.com/collectiveidea/awesome_nested_set/blob/master/lib/awesome_nested_set/model.rb#L135
+  # The OP workflow however requires to first create a WP before children can
+  # be assigned to it. Unpersisted WPs are hence always leaves.
+  def leaf?
+    new_record? || super
+  end
+
   # Returns an array of status that user is able to apply
   def new_statuses_allowed_to(user, include_default = false)
     return [] if status.nil?

--- a/spec/models/work_package/work_package_nested_set_spec.rb
+++ b/spec/models/work_package/work_package_nested_set_spec.rb
@@ -36,211 +36,207 @@ describe WorkPackage, type: :model do
   let(:work_package2) { FactoryGirl.build(:work_package, project: project) }
   let(:work_package3) { FactoryGirl.build(:work_package, project: project) }
 
-  [:work_package].each do |subclass|
-    describe "(#{subclass})" do
-      let(:instance) { send(subclass) }
-      let(:parent) { send(:"#{subclass}2") }
-      let(:parent2) { send(:"#{subclass}3") }
+  let(:instance) { work_package }
+  let(:parent) { work_package2 }
+  let(:parent2) { work_package3 }
 
-      shared_examples_for 'root' do
-        it "should set root_id to the id of the #{subclass}" do
-          expect(instance.root_id).to eq(instance.id)
-        end
+  shared_examples_for 'root' do
+    it 'should set root_id to the id of the work_package' do
+      expect(instance.root_id).to eq(instance.id)
+    end
 
-        it 'should set lft to 1' do
-          expect(instance.lft).to eq(1)
-        end
+    it 'should set lft to 1' do
+      expect(instance.lft).to eq(1)
+    end
 
-        it 'should set rgt to 2' do
-          expect(instance.rgt).to eq(2)
-        end
-      end
+    it 'should set rgt to 2' do
+      expect(instance.rgt).to eq(2)
+    end
+  end
 
-      shared_examples_for 'first child' do
-        it "should set root_id to the id of the parent #{subclass}" do
-          expect(instance.root_id).to eq(parent.id)
-        end
+  shared_examples_for 'first child' do
+    it 'should set root_id to the id of the parent work_package' do
+      expect(instance.root_id).to eq(parent.id)
+    end
 
-        it 'should set lft to 2' do
-          expect(instance.lft).to eq(2)
-        end
+    it 'should set lft to 2' do
+      expect(instance.lft).to eq(2)
+    end
 
-        it 'should set rgt to 3' do
-          expect(instance.rgt).to eq(3)
-        end
-      end
+    it 'should set rgt to 3' do
+      expect(instance.rgt).to eq(3)
+    end
+  end
 
-      describe 'creating a new instance without a parent' do
-        before do
-          instance.save!
-        end
+  describe 'creating a new instance without a parent' do
+    before do
+      instance.save!
+    end
 
-        it_should_behave_like 'root'
-      end
+    it_should_behave_like 'root'
+  end
 
-      describe 'creating a new instance with a parent' do
-        before do
-          parent.save!
-          instance.parent = parent
+  describe 'creating a new instance with a parent' do
+    before do
+      parent.save!
+      instance.parent = parent
 
-          instance.save!
-        end
+      instance.save!
+    end
 
-        it_should_behave_like 'first child'
-      end
+    it_should_behave_like 'first child'
+  end
 
-      describe 'an existant instance receives a parent' do
-        before do
-          parent.save!
-          instance.save!
-          instance.parent = parent
-          instance.save!
-        end
+  describe 'an existant instance receives a parent' do
+    before do
+      parent.save!
+      instance.save!
+      instance.parent = parent
+      instance.save!
+    end
 
-        it_should_behave_like 'first child'
-      end
+    it_should_behave_like 'first child'
+  end
 
-      describe 'an existant instance becomes a root' do
-        before do
-          parent.save!
-          instance.parent = parent
-          instance.save!
-          instance.parent_id = nil
-          instance.save!
-        end
+  describe 'an existant instance becomes a root' do
+    before do
+      parent.save!
+      instance.parent = parent
+      instance.save!
+      instance.parent_id = nil
+      instance.save!
+    end
 
-        it_should_behave_like 'root'
+    it_should_behave_like 'root'
 
-        it 'should set parent_id to nil' do
-          expect(instance.parent_id).to eq(nil)
-        end
-      end
+    it 'should set parent_id to nil' do
+      expect(instance.parent_id).to eq(nil)
+    end
+  end
 
-      describe 'an existant instance receives a new parent (new tree)' do
-        before do
-          parent.save!
-          parent2.save!
-          instance.parent_id = parent2.id
-          instance.save!
+  describe 'an existant instance receives a new parent (new tree)' do
+    before do
+      parent.save!
+      parent2.save!
+      instance.parent_id = parent2.id
+      instance.save!
 
-          instance.parent = parent
-          instance.save!
-        end
+      instance.parent = parent
+      instance.save!
+    end
 
-        it_should_behave_like 'first child'
+    it_should_behave_like 'first child'
 
-        it 'should set parent_id to new parent' do
-          expect(instance.parent_id).to eq(parent.id)
-        end
-      end
+    it 'should set parent_id to new parent' do
+      expect(instance.parent_id).to eq(parent.id)
+    end
+  end
 
-      describe "an existant instance
-                with a right sibling receives a new parent" do
-        let(:other_child) { send(:"#{subclass}3") }
+  describe "an existant instance
+            with a right sibling receives a new parent" do
+    let(:other_child) { work_package3 }
 
-        before do
-          parent.save!
-          instance.parent = parent
-          instance.save!
-          other_child.parent = parent
-          other_child.save!
+    before do
+      parent.save!
+      instance.parent = parent
+      instance.save!
+      other_child.parent = parent
+      other_child.save!
 
-          instance.parent_id = nil
-          instance.save!
-        end
+      instance.parent_id = nil
+      instance.save!
+    end
 
-        it "former roots's root_id should be unchanged" do
-          parent.reload
-          expect(parent.root_id).to eq(parent.id)
-        end
+    it "former roots's root_id should be unchanged" do
+      parent.reload
+      expect(parent.root_id).to eq(parent.id)
+    end
 
-        it "former roots's lft should be 1" do
-          parent.reload
-          expect(parent.lft).to eq(1)
-        end
+    it "former roots's lft should be 1" do
+      parent.reload
+      expect(parent.lft).to eq(1)
+    end
 
-        it "former roots's rgt should be 4" do
-          parent.reload
-          expect(parent.rgt).to eq(4)
-        end
+    it "former roots's rgt should be 4" do
+      parent.reload
+      expect(parent.rgt).to eq(4)
+    end
 
-        it "former right siblings's root_id should be unchanged" do
-          other_child.reload
-          expect(other_child.root_id).to eq(parent.id)
-        end
+    it "former right siblings's root_id should be unchanged" do
+      other_child.reload
+      expect(other_child.root_id).to eq(parent.id)
+    end
 
-        it "former right siblings's left should be 2" do
-          other_child.reload
-          expect(other_child.lft).to eq(2)
-        end
+    it "former right siblings's left should be 2" do
+      other_child.reload
+      expect(other_child.lft).to eq(2)
+    end
 
-        it "former right siblings's rgt should be 3" do
-          other_child.reload
-          expect(other_child.rgt).to eq(3)
-        end
-      end
+    it "former right siblings's rgt should be 3" do
+      other_child.reload
+      expect(other_child.rgt).to eq(3)
+    end
+  end
 
-      describe 'an existant instance receives a new parent (same tree)' do
-        before do
-          parent.save!
-          parent2.save!
-          instance.parent_id = parent2.id
-          instance.save!
+  describe 'an existant instance receives a new parent (same tree)' do
+    before do
+      parent.save!
+      parent2.save!
+      instance.parent_id = parent2.id
+      instance.save!
 
-          instance.parent = parent
-          instance.save!
-        end
+      instance.parent = parent
+      instance.save!
+    end
 
-        it_should_behave_like 'first child'
-      end
+    it_should_behave_like 'first child'
+  end
 
-      describe 'an existant instance with children receives a new parent (itself)' do
-        let(:child) { send(:"#{subclass}3") }
+  describe 'an existant instance with children receives a new parent (itself)' do
+    let(:child) { work_package3 }
 
-        before do
-          parent.save!
-          instance.parent = parent
-          instance.save!
-          child.parent_id = instance.id
-          child.save!
+    before do
+      parent.save!
+      instance.parent = parent
+      instance.save!
+      child.parent_id = instance.id
+      child.save!
 
-          # reloading as instance's nested set attributes (lft, rgt) where
-          # updated by adding child to the set
-          instance.reload
-          instance.parent_id = nil
-          instance.save!
-        end
+      # reloading as instance's nested set attributes (lft, rgt) where
+      # updated by adding child to the set
+      instance.reload
+      instance.parent_id = nil
+      instance.save!
+    end
 
-        it "former parent's root_id should be unchanged" do
-          parent.reload
-          expect(parent.root_id).to eq(parent.id)
-        end
+    it "former parent's root_id should be unchanged" do
+      parent.reload
+      expect(parent.root_id).to eq(parent.id)
+    end
 
-        it "former parent's left should be 1" do
-          parent.reload
-          expect(parent.lft).to eq(1)
-        end
+    it "former parent's left should be 1" do
+      parent.reload
+      expect(parent.lft).to eq(1)
+    end
 
-        it "former parent's right should be 2" do
-          parent.reload
-          expect(parent.rgt).to eq(2)
-        end
+    it "former parent's right should be 2" do
+      parent.reload
+      expect(parent.rgt).to eq(2)
+    end
 
-        it "the child should have the root_id of the parent #{subclass}" do
-          child.reload
-          expect(child.root_id).to eq(instance.id)
-        end
+    it 'the child should have the root_id of the parent work_package' do
+      child.reload
+      expect(child.root_id).to eq(instance.id)
+    end
 
-        it 'the child should have a lft of 2' do
-          child.reload
-          expect(child.lft).to eq(2)
-        end
+    it 'the child should have a lft of 2' do
+      child.reload
+      expect(child.lft).to eq(2)
+    end
 
-        it 'the child should have a rgt of 3' do
-          child.reload
-          expect(child.rgt).to eq(3)
-        end
-      end
+    it 'the child should have a rgt of 3' do
+      child.reload
+      expect(child.rgt).to eq(3)
     end
   end
 end

--- a/spec/models/work_package/work_package_nested_set_spec.rb
+++ b/spec/models/work_package/work_package_nested_set_spec.rb
@@ -68,12 +68,22 @@ describe WorkPackage, type: :model do
     end
   end
 
+  describe 'instantiating a new instance' do
+    it 'is considered a leaf' do
+      expect(instance).to be_leaf
+    end
+  end
+
   describe 'creating a new instance without a parent' do
     before do
       instance.save!
     end
 
     it_should_behave_like 'root'
+
+    it 'is considered a leaf' do
+      expect(instance).to be_leaf
+    end
   end
 
   describe 'creating a new instance with a parent' do
@@ -85,6 +95,14 @@ describe WorkPackage, type: :model do
     end
 
     it_should_behave_like 'first child'
+
+    it 'is considered a leaf' do
+      expect(instance).to be_leaf
+    end
+
+    it 'the parent is not considered a leaf' do
+      expect(parent.reload).to_not be_leaf
+    end
   end
 
   describe 'an existant instance receives a parent' do


### PR DESCRIPTION
Because work packages only become parents after they are created the inherited attributes should be writable. Awesome nested set however considers non persisted objects to not be leafs.

https://community.openproject.org/work_packages/22157

For reviewing, please consider the second commit. The first one is only a refactoring.
