### PR TITLE
[22225] Fix concat scoping issue

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -545,11 +545,11 @@ module ApplicationHelper
     legend = options[:legend] || ''
 
     content_tag :span do
-      concat content_tag :span, class: 'progress-bar', style: "width: #{width}" do
+      progress = content_tag :span, class: 'progress-bar', style: "width: #{width}" do
         concat content_tag(:span, '', class: 'inner-progress closed', style: "width: #{closed}%")
         concat content_tag(:span, '', class: 'inner-progress done',   style: "width: #{done}%")
       end
-      concat content_tag(:span, "#{legend}% #{l(:total_progress)}", class: 'progress-bar-legend')
+      progress + content_tag(:span, "#{legend}% #{l(:total_progress)}", class: 'progress-bar-legend')
     end
   end
 


### PR DESCRIPTION
https://github.com/opf/openproject/commit/1f53f5472e9250a94167569c47e1f52d5b09d12a#diff-127a850b7d7b20173ad3fba88f8a25e3
introduced a refactor for code style improvements.

This included a switch from `(content_tag do .. end).<<` to `concat
content_tag ...`, which caused concat to receive the block instead of content_tag.

I believe this approach is clearer than using concat in this case.

Note that this issue occurs only on dev due to https://github.com/opf/openproject/pull/3907 being merged against it.
https://community.openproject.org/work_packages/22225/activity
