### PR TITLE
Squish date to avoid start-of-month bugs

### DIFF
--- a/spec/features/work_packages/tabs/activity_tab_spec.rb
+++ b/spec/features/work_packages/tabs/activity_tab_spec.rb
@@ -74,8 +74,10 @@ describe 'Activity tab', js: true, selenium: true do
       journals.each_with_index do |journal, idx|
         date_selector = ".work-package-details-activities-activity:nth-of-type(#{idx + 1}) " +
                         '.activity-date'
+        # .squish is required in order to match the date without double spaces
+        # on the first 9 days of the month
         expect(page).to have_selector(date_selector,
-                                      text: journal.created_at.to_date.to_s(:long))
+                                      text: journal.created_at.to_date.to_s(:long).squish)
 
         activity = page.find("#activity-#{idx + 1}")
         expect(activity).to have_selector('.user', text: journal.user.name)


### PR DESCRIPTION
The date output in the `activity_tab_spec` today is `"December  1, 2015"` (mind the extra space),
which no longer matches the result when the date is a single digit.
