### PR TITLE
[22250] Work package full screen icon missing

### DIFF
--- a/frontend/app/components/wp-buttons/wp-view-button/wp-view-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-view-button/wp-view-button.directive.html
@@ -9,5 +9,5 @@
         title="{{ label }}"
         ng-click="showWorkPackageShowView()"
         ng-class="{ '-active': isShowViewActive() }">
-  <i class="icon-fullscreen-view button--icon"></i>
+  <i class="icon-view-fullscreen button--icon"></i>
 </button>


### PR DESCRIPTION
This applies the correct class for the fullscreen icon. 

https://community.openproject.org/work_packages/22250/activity
