### PR TITLE
[22254] Unclear icons in Activity 

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -39,7 +39,9 @@ See doc/COPYRIGHT.rdoc for more details.
     <dl>
       <% @events_by_day[day].sort {|x,y| y.event_datetime <=> x.event_datetime }.each do |e| -%>
         <dt class="<%= e.event_type %> <%= User.current.logged? && e.respond_to?(:event_author) && User.current == e.event_author ? 'me' : nil %>">
-          <%= icon_wrapper("icon-context icon-#{e.event_type}", e.event_name) %>
+          <% event_type = e.event_type == 'meeting' ? 'meetings' : e.event_type %>
+          <% event_type = e.event_type == 'cost_object' ? 'budget' : event_type %>
+          <%= icon_wrapper("icon-context icon-#{event_type}", e.event_name) %>
           <%= avatar(e.event_author) if e.respond_to?(:event_author) %>
           <span class="time"><%= format_time(e.event_datetime.to_time, false) %></span>
           <%= content_tag('span', link_to(e.project.name, e.project), class: 'project') if (@project.nil? || @project != e.project) && e.project %>


### PR DESCRIPTION
This changes the icon name generation for the activity overview. Thus the correct icons were used. 

https://community.openproject.org/work_packages/22254/activity

**Note** in the plugins the unused icon definitions were removed:
- https://github.com/finnlabs/openproject-costs/pull/204
- https://github.com/finnlabs/openproject-meeting/pull/101
