### PR TITLE
[22253] Icon to expand / collapse work package groups missing

### DIFF
--- a/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.html
@@ -55,7 +55,7 @@
             <div ng-class="[
                     'expander',
                     'icon-context',
-                    'icon-' + (groupExpanded[currentGroup] && 'minus' || 'plus')
+                    'icon-' + (groupExpanded[currentGroup] && 'minus2' || 'plus')
                   ]"
                   ng-click="toggleCurrentGroup()">
               <span ng-class="{


### PR DESCRIPTION
This corrects the used icon name for the group expander in the WP table.

https://community.openproject.org/work_packages/22253/activity
