### PR TITLE
[22262] Project expand / collapse icon in timeline too far to the left

### DIFF
--- a/app/assets/stylesheets/timelines.css.sass
+++ b/app/assets/stylesheets/timelines.css.sass
@@ -215,23 +215,10 @@ a.tl-discreet-link:hover, input.icon:hover
   position: relative
   left: -16px
 
-#content table td
-  &.tl-indent-0
-    padding-left: 16px
-  &.tl-indent-1
-    padding-left: 28px
-  &.tl-indent-2
-    padding-left: 40px
-  &.tl-indent-3
-    padding-left: 52px
-  &.tl-indent-4
-    padding-left: 64px
-  &.tl-indent-5
-    padding-left: 76px
-  &.tl-indent-6
-    padding-left: 88px
-  &.tl-indent-7
-    padding-left: 100px
+#content table
+  @for $i from 0 through 7
+    td.tl-indent-#{$i}
+      padding-left: calc(20px + (12px * #{$i}))
 
 .tl-left-main
   border-right: 1px solid black


### PR DESCRIPTION
This increases the indentation of timeline entries. Further the the styling rules for the indentation where summed up in a loop.

https://community.openproject.org/work_packages/22262/activity
