### PR TITLE
[21729] Border misaligned in danger zone (IE)

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -68,6 +68,8 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
 
   &.danger-zone
     border: 1px solid $content-form-danger-zone-bg-color
+    // For correct display in IE
+    border-top: 0px
 
     .form--section
       padding-top: 0px


### PR DESCRIPTION
This removes the top border from the danger zone. Thus there can be no mismatch between the header and the border. The bug occurred only in IE on some zoom factors.

https://community.openproject.org/work_packages/21729/activity
