### PR TITLE
Fix jstoolbar icons

### DIFF
--- a/app/assets/javascripts/jstoolbar/jstoolbar.js
+++ b/app/assets/javascripts/jstoolbar/jstoolbar.js
@@ -172,7 +172,7 @@ jsToolBar.prototype = {
   button: function(toolName) {
     var tool = this.elements[toolName];
     if (typeof tool.fn[this.mode] != 'function') return null;
-    var b = new jsButton(tool.title, tool.fn[this.mode], this, 'jstb_'+toolName);
+    var b = new jsButton(tool.title, tool.fn[this.mode], this, 'icon-small jstb_'+toolName);
     if (tool.icon != undefined) b.icon = tool.icon;
     return b;
   },

--- a/app/assets/stylesheets/_jstoolbar.sass
+++ b/app/assets/stylesheets/_jstoolbar.sass
@@ -58,6 +58,7 @@ $jstoolbar--icon-active-background: #eee
   text-align: right
 
   button
+    @include icon-common
     padding: 0.25rem
     margin-left: 0.25rem
     height: 1.625rem
@@ -68,11 +69,7 @@ $jstoolbar--icon-active-background: #eee
     color: $body-font-color
     border-radius: 2px
     overflow-y: hidden
-    line-height: 1.3rem
     display: inline-block
-
-    &:before
-      @include icon-common
 
     &:hover
       border-color: $jstoolbar--icon-hover-border
@@ -107,47 +104,47 @@ $jstoolbar--icon-active-background: #eee
   font-size: 1px
   margin-right: 4px
 
-.jstb_strong:before
-  content: "\e042"
+.jstb_strong
+  @extend .icon-bold
 
-.jstb_em:before
-  content: "\e070"
+.jstb_em
+  @extend .icon-italic
 
-.jstb_ins:before
-  content: "\e0b3"
+.jstb_ins
+  @extend .icon-underline
 
-.jstb_del:before
-  content: "\e072"
+.jstb_del
+  @extend .icon-strike-through
 
-.jstb_code:before
-  content: "\e050"
+.jstb_code
+  @extend .icon-code-tag
 
-.jstb_h1:before
-  content: "\e0d6"
+.jstb_h1
+  @extend .icon-headline1
 
-.jstb_h2:before
-  content: "\e0d7"
+.jstb_h2
+  @extend .icon-headline2
 
-.jstb_h3:before
-  content: "\e0d8"
+.jstb_h3
+  @extend .icon-headline3
 
-.jstb_ul:before
-  content: "\e07b"
+.jstb_ul
+  @extend .icon-unordered-list
 
-.jstb_ol:before
-  content: "\e07d"
+.jstb_ol
+  @extend .icon-ordered-list
 
-.jstb_bq:before
-  content: "\e08d"
+.jstb_bq
+  @extend .icon-paragraph-right
 
-.jstb_unbq:before
-  content: "\e08e"
+.jstb_unbq
+  @extend .icon-paragraph-left
 
-.jstb_pre:before
-  content: "\e0d9"
+.jstb_pre
+  @extend .icon-pre
 
-.jstb_link:before
-  content: "\e013"
+.jstb_link
+  @extend .icon-link
 
-.jstb_img:before
-  content: "\e06c"
+.jstb_img
+  @extend .icon-image1

--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -105,7 +105,8 @@
     .jstb_ol,
     .jstb_preview,
     .jstb_help
-      display: inline-block
+      display: inline-flex
+      justify-content: center
 
 .inplace-edit--select
   .select2-display-none

--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -31,7 +31,7 @@ module.exports = function() {
                           '&quot;resizable=yes, location=no, width=600, height=640, ' +
                           'menubar=no, status=no, scrollbars=yes&quot;); return false;',
       HELP_LINK_HTML = jQuery('<button title="' + I18n.t('js.inplace.link_formatting_help') + '"' +
-                              ' class="jstb_help icon icon-help1" ' +
+                              ' class="jstb_help icon icon-help1 icon-small" ' +
                               ' type="button" ' +
                               'onclick="' + HELP_LINK_ONCLICK + '">' +
                               '<span class="hidden-for-sighted">' +
@@ -41,7 +41,7 @@ module.exports = function() {
       PREVIEW_DISABLE_TEXT = I18n.t('js.inplace.btn_preview_disable'),
       PREVIEW_BUTTON_CLASS = 'jstb_preview',
       PREVIEW_BUTTON_ATTRIBUTES = {
-        'class': PREVIEW_BUTTON_CLASS + ' icon-preview',
+        'class': PREVIEW_BUTTON_CLASS + ' icon-preview icon-small',
         type: 'button',
         title: PREVIEW_ENABLE_TEXT,
         text: ''


### PR DESCRIPTION
This fixes the references to JSToolbar icons, but there is still an issue with the size of the icons.

@HDinger as mentioned in the JF, you can probably fix this much faster than me.

![bildschirmfoto 2015-12-04 um 12 14 45](https://cloud.githubusercontent.com/assets/459462/11588515/8316c6a6-9a81-11e5-9cb7-20e81df4b30f.png)

https://community.openproject.org/work_packages/details/22271
