### PR TITLE
Fix inplace-edit label locales

### DIFF
--- a/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
+++ b/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
@@ -91,10 +91,11 @@ function InplaceEditorEditPaneController($scope, $element, $location, $timeout,
 
   var vm = this;
   var field = $scope.field;
+  var fieldLabel = field.getLabel();
   var wpStore = inplaceEditMultiStorage.stores.workPackage;
 
-  this.saveTitle = I18n.t('js.inplace.button_save', { attribute: field.name });
-  this.cancelTitle = I18n.t('js.inplace.button_cancel', { attribute: field.name });
+  this.saveTitle = I18n.t('js.inplace.button_save', { attribute: fieldLabel });
+  this.cancelTitle = I18n.t('js.inplace.button_cancel', { attribute: fieldLabel });
 
   this.submit = function() {
     var detectedViolations = [];


### PR DESCRIPTION
The inplace save/cancel label used the (internal) field name instead
of the localized label.

https://community.openproject.org/work_packages/22261

originated from change in:
https://community.openproject.org/work_packages/21741
