### PR TITLE
Remove empty href in new work package menu

### DIFF
--- a/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
+++ b/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
@@ -3,7 +3,9 @@
 
   <ul class="dropdown-menu">
     <li ng-repeat="type in vm.types">
-      <a href="" role="menuitem" focus="{{ !$index }}" ng-click="vm.createWorkPackage(type.id)">
+      <a ui-sref="{{ vm.stateName }}({ projectPath: vm.projectIdentifier, type: type.id })"
+         role="menuitem" focus="{{ !$index }}">
+
         {{ type.name }}
       </a>
     </li>

--- a/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.directive.js
+++ b/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.directive.js
@@ -58,13 +58,6 @@ function WorkPackageCreateButtonController($state, ProjectService) {
     return !inProjectContext || !canCreate || $state.includes('**.new') || !vm.types;
   };
 
-  vm.createWorkPackage = function (type) {
-    $state.go(vm.stateName, {
-      projectPath: vm.projectIdentifier,
-      type: type
-    })
-  };
-
   if (inProjectContext) {
     ProjectService.fetchProjectResource(vm.projectIdentifier).then(function(project) {
       canCreate = !!project.links.createWorkPackage;


### PR DESCRIPTION
This removes the href attribute from the menu items, since it causes
weird behavior depending on the subproject the user is in.

For the user, this should not have a drawback (rather, it improves
readability for screenreaders since they do not pronounce 'Link, visited' all the time).

The downside is that capybara's `click_link` does not match without a
link. We could do `href='#'` or `href='javascript:;'`, but I dislike
both. Alternatively, we should refactor these non-link items as a button
instead, because essentially, that's what they are.

I believe that this fixes  https://community.openproject.org/work_packages/22244, since deleting the href tag (in console) removes the issue for me on community.
