### PR TITLE
[22272] Incorrect button styling in activity and versions

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -98,7 +98,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% end %>
     <%= hidden_field_tag('user_id', params[:user_id]) unless params[:user_id].blank? %>
     <%= hidden_field_tag('apply', true) %>
-    <p><%= submit_tag l(:button_apply), class: 'button -tiny -round -highlight', name: nil %></p>
+    <p><%= submit_tag l(:button_apply), class: 'button -small -highlight', name: nil %></p>
   <% end %>
 <% end %>
 

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -57,18 +57,24 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :sidebar do %>
   <%= form_tag({}, method: :get) do %>
     <h3><%= l(:description_filter) %></h3>
-    <% @types.each do |type| %>
-      <label><%= check_box_tag "type_ids[]", type.id, (@selected_type_ids.include? type.id.to_s), id: nil %>
-        <%=h type.name %></label><br />
-    <% end %>
-    <br />
-    <label for="completed"><%= check_box_tag "completed", 1, params[:completed] %> <%= l(:label_show_completed_versions) %></label>
+    <p>
+      <% @types.each do |type| %>
+        <%= check_box_tag "type_ids[]", type.id, (@selected_type_ids.include? type.id.to_s), id: nil %>
+        <label><%=h type.name %></label><br />
+      <% end %>
+    </p>
+    <p>
+      <%= check_box_tag "completed", 1, params[:completed] %>
+      <label for="completed"> <%= l(:label_show_completed_versions) %></label>
+    </p>
     <% if @project.descendants.active.any? %>
       <%= hidden_field_tag 'with_subprojects', 0 %>
-      <br />
-      <label><%= check_box_tag 'with_subprojects', 1, @with_subprojects %> <%=l(:label_subproject_plural)%></label>
+      <p>
+        <%= check_box_tag 'with_subprojects', 1, @with_subprojects %>
+        <label><%=l(:label_subproject_plural)%></label>
+      </p>
     <% end %>
-    <p><%= submit_tag l(:button_apply), class: 'button -tiny -round -highlight', name: nil %></p>
+    <p><%= submit_tag l(:button_apply), class: 'button -small -highlight', name: nil %></p>
   <% end %>
   <h3><%= l(:label_version_plural) %></h3>
   <% @versions.each do |version| %>


### PR DESCRIPTION
This changes the styling classes of the buttons below the filter option in activity and version. Thus the buttons look more like they are defined in the LSG.
Further the filter styling of version was adapted to the one from activity.

https://community.openproject.org/work_packages/22272/activity
