### PR TITLE
[22273] Misaligned selection text in repositories

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -161,17 +161,10 @@
   padding: 0
 
   .select2-choice
-    height: 40px
     min-width: 150px
-
-    .select2-chosen
-      line-height: 40px
 
   .select2-arrow
     border-color: $toolbar-item--border-color
-
-  .select2-chosen
-    line-height: 40px
 
 .toolbar-input-group
   display: flex

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -67,7 +67,8 @@
   display: table
 
 .toolbar-items
-  > li,
+  > li
+  .toolbar-item,
   .toolbar-button-group > li
     float: left
     &.toolbar-item


### PR DESCRIPTION
This remove the `height`and `line-height` of select-boxes in the toolbar to 2.15rem. Thus the height of these select boxes doesn't get overwritten with now wrong values.

https://community.openproject.org/work_packages/22273/activity
