### PR TITLE
Embed ImageMagick for SLES11

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/pkgr/pkgr-buildpack-imagemagick.git
 https://github.com/heroku/heroku-buildpack-nodejs.git#v71
 https://github.com/pkgr/heroku-buildpack-ruby.git#universal

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -18,6 +18,9 @@ targets:
     <<: *redhat
     dependencies:
       - epel-release
+  sles-11:
+    env:
+      - EMBED_IMAGEMAGICK=true
   sles-12:
     build_dependencies:
       - ImageMagick-devel


### PR DESCRIPTION
ImageMagick is much too old on SLES11, and recent versions of rmagick don't like that.
rmagick is used by plugins included in the community edition, hence this change.

/cc @oliverguenther 
