### PR TITLE
Fix sort labels in admin/projects

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -317,14 +317,4 @@ module SortHelper
       l(:label_sort_by, "\"#{caption}\"") unless options[:title]
     end
   end
-
-  # Returns a table header tag similar to +sort_header_tag+, but
-  # according to the LSG table component.
-  def sort_header_tag_with_lsg(column, options = {})
-    caption = options.delete(:caption) || column.to_s.humanize
-    default_order = options.delete(:default_order) || 'asc'
-    lang = options.delete(:lang) || nil
-
-    sort_link(column, caption, default_order, lang: lang)
-  end
 end

--- a/app/views/admin/projects.html.erb
+++ b/app/views/admin/projects.html.erb
@@ -75,38 +75,10 @@ See doc/COPYRIGHT.rdoc for more details.
         </colgroup>
         <thead>
           <tr>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <%= sort_header_tag_with_lsg('name', caption: Project.model_name.human) %>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <%= sort_header_tag_with_lsg('is_public',
-                                               caption: Project.human_attribute_name(:is_public)) %>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <%= sort_header_tag_with_lsg('required_disk_space',
-                                               caption: I18n.t(:label_required_disk_storage)) %>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <%= sort_header_tag_with_lsg('created_on',
-                                               caption: Project.human_attribute_name(:created_on)) %>
-                </div>
-              </div>
-            </th>
+            <%= sort_header_tag('name', caption: Project.model_name.human) %>
+            <%= sort_header_tag('is_public', caption:Project.human_attribute_name(:is_public)) %>
+            <%= sort_header_tag('required_disk_space', caption: I18n.t(:label_required_disk_storage)) %>
+            <%= sort_header_tag('created_on', caption: Project.human_attribute_name(:created_on)) %>
             <th></th>
           </tr>
         </thead>


### PR DESCRIPTION
These seem to have been forgotten in the restyling of the tables.
