### PR TITLE
Use repoman URL provided by addon-repositories

### DIFF
--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -38,18 +38,20 @@ default:
   smtp_password: <%= ENV['SMTP_PASSWORD'] %>
   smtp_enable_starttls_auto: <%= ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO') { "false" } %>
   attachments_storage_path: <%= ENV.fetch('ATTACHMENTS_STORAGE_PATH') { "/var/db/_APP_NAME_/files" } %>
-<% if (ENV['GIT_REPOSITORIES'] || ENV['SVN_REPOSITORIES']).present? %>
+<% git_configured = ENV['GIT_REPOSITORIES'].present? %>
+<% svn_configured = ENV['SVN_REPOSITORIES'].present? %>
+<% if git_configured || svn_configured %>
   scm:
-  <% if ENV['GIT_REPOSITORIES'].present? %>
+  <% if git_configured %>
     git:
       manages: <%= ENV['GIT_REPOSITORIES'] %>
       mode: 0770
       group: <%= ENV['SERVER_GROUP'] %>
   <% end %>
-  <% if ENV['SVN_REPOSITORIES'].present? %>
+  <% if svn_configured %>
     subversion:
       # SVN uses Apache repository wrapper due to permission errors in multi-user operation
-      manages: http://127.0.0.1/repoman_svn
+      manages: <%= ENV['SVN_REPOMAN_URL'] %>
       # Do noot verify SSL certificates when SERVER_PROTOCOL is 'https'.
       # As we currently only support local repoman installations with packager,
       # this option is set to true by default.


### PR DESCRIPTION
This provides the necessary counterpart for relative-root installations provided by the following packager addon extensions:

**Apache2**: https://github.com/pkgr/addon-apache2/pull/2
- Adds a wizard entry to the addon, asking for a path prefix (may be skipped by keeping it empty)
- Writes all vhost configurations with the given prefix
- Defines an Alias from `/prefix` to the public directory in order for `/prefix/assets` to be matched automatically.

**OpenProject**: https://github.com/pkgr/addon-openproject/pull/7/files
- Runs `rake assets:precompile` whenever either
  1. A relative root installation has been found in the configuration
  2. An existing `RAILS_RELATIVE_URL_ROOT` has been set.
- Sets `RAILS_RELATIVE_URL_ROOT` to the configured value.

**Repositories**: https://github.com/finnlabs/addon-repositories/pull/11
- Installs to `/git/<prefix>` and `/svn/<prefix>` when a server prefix has been found (Using `/prefix/git` matches the Alias instead and we also need `/svn/pi` for Telekom).
- Outputs the correct `SVN_REPOMAN_URL` with or without prefix, depending on the configuration. This output is used by the configuration.yml.

/cc @crohr 

:exclamation: Merge only with the other PRs mentioned above :exclamation: 
Relevant work package: https://community.openproject.org/work_packages/22280/activity
