### PR TITLE
Feature/work package copy

### DIFF
--- a/frontend/app/components/routes/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routes/controllers/work-package-show.controller.js
@@ -57,35 +57,35 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
 
   // stuff copied from details toolbar directive...
   function getPermittedActions(authorization, permittedMoreMenuActions) {
-    var permittedActions = authorization.permittedActions(permittedMoreMenuActions);
+    var permittedActions = authorization.permittedActionsWithLinks(permittedMoreMenuActions);
     var augmentedActions = { };
 
-    angular.forEach(permittedActions, function(value, key) {
-      var css = ['icon-' + key];
+    angular.forEach(permittedActions, function(permission) {
+      var css = ['icon-' + permission.key];
 
-      this[key] = { link: value, css: css };
+      this[permission.key] = { link: permission.link, css: css };
     }, augmentedActions);
 
     return augmentedActions;
   }
-  function getPermittedPluginActions(authorization) {
-    var pluginActions = HookService
-                        .call('workPackageDetailsMoreMenu')
-                        .reduce(function(previousValue, currentValue) {
-                          return angular.extend(previousValue, currentValue);
-                        }, { });
 
-    var permittedPluginActions = authorization.permittedActions(Object.keys(pluginActions));
+  function getPermittedPluginActions(authorization) {
+    var pluginActions = [];
+    angular.forEach(HookService.call('workPackageDetailsMoreMenu'), function(action) {
+      pluginActions = pluginActions.concat(action);
+    });
+
+    var permittedPluginActions = authorization.permittedActionsWithLinks(pluginActions);
     var augmentedPluginActions = { };
 
-    angular.forEach(permittedPluginActions, function(value, key) {
-      var css = [].concat(pluginActions[key]);
+    angular.forEach(permittedPluginActions, function(action) {
+      var css = [].concat(action.css);
 
       if (css.length === 0) {
-        css = ['icon-' + key];
+        css = ["icon-" + action.key];
       }
 
-      this[key] = { link: value, css: css };
+      this[action.key] = { link: action.link, css: css };
     }, augmentedPluginActions);
 
     return augmentedPluginActions;

--- a/frontend/app/components/work-packages/controllers/wp-new.controller.js
+++ b/frontend/app/components/work-packages/controllers/wp-new.controller.js
@@ -79,59 +79,69 @@ function WorkPackageNewController($scope,
 
   $scope.I18n = I18n;
 
-  activate();
+  function activate(wp) {
+    vm.workPackage = wp;
+    WorkPackagesDisplayHelper.setFocus();
 
-  function activate() {
-    EditableFieldsState.forcedEditState = true;
-    EditableFieldsState.editAll.state = true;
-    var data = {};
+    $scope.$watchCollection('vm.workPackage.form', function() {
+      vm.groupedFields = WorkPackagesOverviewService.getGroupedWorkPackageOverviewAttributes();
+      var schema = WorkPackageFieldService.getSchema(vm.workPackage);
+      var otherGroup = _.find(vm.groupedFields, { groupName: 'other' });
+      otherGroup.attributes = [];
 
-    if (angular.isDefined($stateParams.type)) {
-      data = {
-        _links: {
-          type: {
-            href: PathHelper.apiV3TypePath($stateParams.type)
-          }
+      _.forEach(schema.props, function(prop, propName) {
+        if (propName.match(/^customField/)) {
+          otherGroup.attributes.push(propName);
         }
-      };
-    }
+      });
 
-    vm.loaderPromise = WorkPackageService.initializeWorkPackage($stateParams.projectPath, data)
-    .then(function(wp) {
-      vm.workPackage = wp;
-      WorkPackagesDisplayHelper.setFocus();
-
-      $scope.$watchCollection('vm.workPackage.form', function() {
-        vm.groupedFields = WorkPackagesOverviewService.getGroupedWorkPackageOverviewAttributes();
-        var schema = WorkPackageFieldService.getSchema(vm.workPackage);
-        var otherGroup = _.find(vm.groupedFields, { groupName: 'other' });
-        otherGroup.attributes = [];
-
-        _.forEach(schema.props, function(prop, propName) {
-          if (propName.match(/^customField/)) {
-            otherGroup.attributes.push(propName);
-          }
-        });
-
-        otherGroup.attributes.sort(function(a, b) {
-          var getLabel = function(field) {
-            return vm.getLabel(vm.workPackage, field);
-          };
-          var left = getLabel(a).toLowerCase(),
-              right = getLabel(b).toLowerCase();
-          return left.localeCompare(right);
-        });
+      otherGroup.attributes.sort(function(a, b) {
+        var getLabel = function(field) {
+          return vm.getLabel(vm.workPackage, field);
+        };
+        var left = getLabel(a).toLowerCase(),
+            right = getLabel(b).toLowerCase();
+        return left.localeCompare(right);
       });
     });
+  }
+
+  prepareInitialData().then(activate);
+
+  function prepareInitialData() {
+    EditableFieldsState.forcedEditState = true;
+    EditableFieldsState.editAll.state = true;
+
+    if ($stateParams.copiedFromWorkPackageId) {
+      vm.loaderPromise = WorkPackageService.getWorkPackage($stateParams.copiedFromWorkPackageId)
+        .then(function(workPackage) {
+          return WorkPackageService.initializeWorkPackageFromCopy(workPackage);
+        });
+    }
+    else {
+      if (angular.isDefined($stateParams.type)) {
+        vm.initialData = {
+          _links: {
+            type: {
+              href: PathHelper.apiV3TypePath($stateParams.type)
+            }
+          }
+        };
+      }
+      vm.loaderPromise =  WorkPackageService.initializeWorkPackage($stateParams.projectPath,
+                                                                   vm.initialData);
+    }
 
     loadingIndicator.on(vm.loaderPromise);
 
     $scope.$on('workPackageUpdatedInEditor', function(e, workPackage) {
       $state.go(vm.successState, { workPackageId: workPackage.props.id });
     });
-    
+
     $scope.$on('$stateChangeStart', function () {
       EditableFieldsState.editAll.stop();
     });
+
+    return vm.loaderPromise;
   }
 }

--- a/frontend/app/components/work-packages/services/work-package.service.js
+++ b/frontend/app/components/work-packages/services/work-package.service.js
@@ -108,6 +108,16 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
         });
     },
 
+    initializeWorkPackageFromCopy: function(workPackage) {
+      var projectIdentifier = workPackage.embedded.project.props.identifier;
+      var initialData = _.clone(workPackage.form.embedded.payload.props);
+
+      initialData._links = _.clone(workPackage.form.embedded.payload.links);
+      delete initialData.lockVersion;
+
+      return WorkPackageService.initializeWorkPackage(projectIdentifier, initialData);
+    },
+
     getWorkPackage: function(id) {
       var path = PathHelper.apiV3WorkPackagePath(id),
           resource = HALAPIResource.setup(path);

--- a/frontend/app/components/work-packages/services/work-package.service.js
+++ b/frontend/app/components/work-packages/services/work-package.service.js
@@ -106,7 +106,7 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
           inplaceEditErrors.errors = null;
 
           wp.props = _.clone(form.embedded.payload.props);
-          wp.links = _.extend(wp.links, _.clone(workPackage.form.embedded.payload.links));
+          wp.links = _.extend(wp.links, _.clone(form.embedded.payload.links));
 
           return wp;
         });

--- a/frontend/app/components/work-packages/services/work-package.service.js
+++ b/frontend/app/components/work-packages/services/work-package.service.js
@@ -104,6 +104,10 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
           wp.form = form;
           EditableFieldsState.workPackage = wp;
           inplaceEditErrors.errors = null;
+
+          wp.props = _.clone(form.embedded.payload.props);
+          wp.links = _.extend(wp.links, _.clone(workPackage.form.embedded.payload.links));
+
           return wp;
         });
     },

--- a/frontend/app/helpers/path-helper.js
+++ b/frontend/app/helpers/path-helper.js
@@ -105,6 +105,12 @@ module.exports = function() {
     workPackageDuplicatePath: function(projectId, workPackageId) {
       return '/projects/' + projectId + '/work_packages/new?copy_from=' + workPackageId;
     },
+    workPackageCopyPath: function(workPackageId) {
+      return '/work_packages/' + workPackageId + '/copy';
+    },
+    workPackageDetailsCopyPath: function(projectId, workPackageId) {
+      return '/projects/' + projectId + '/work_packages/details/' + workPackageId + '/copy';
+    },
     workPackageMovePath: function(id) {
       return PathHelper.workPackagePath(id) + '/move/new';
     },

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -189,6 +189,11 @@ angular.module('openproject')
       templateUrl: '/components/routes/partials/work-packages.list.new.html',
       reloadOnSearch: false
     })
+    .state('work-packages.list.copy', {
+      url: '/details/{copiedFromWorkPackageId:[0-9]+}/copy',
+      templateUrl: '/components/routes/partials/work-packages.list.new.html',
+      reloadOnSearch: false
+    })
     .state('work-packages.list.details', {
       url: '/details/{workPackageId:[0-9]+}',
       templateUrl: '/components/routes/partials/work-packages.list.details.html',

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -89,6 +89,11 @@ angular.module('openproject')
       reloadOnSearch: false
     })
 
+    .state('work-packages.copy', {
+      url: '/work_packages/{copiedFromWorkPackageId:[0-9]+}/copy',
+      templateUrl: '/components/routes/partials/work-packages.new.html'
+    })
+
     .state('work-packages.edit', {
       url: '/{projects}/{projectPath}/work_packages/{workPackageId}/edit',
       params: {

--- a/frontend/app/services/project-service.js
+++ b/frontend/app/services/project-service.js
@@ -52,6 +52,10 @@ module.exports = function($http, PathHelper, FiltersHelper, HALAPIResource) {
       return ProjectService.doQuery(url);
     },
 
+    getWorkPackageProject: function(workPackage) {
+      return ProjectService.doQuery(workPackage.links.project.props.href);
+    },
+
     doQuery: function(url, params) {
       return $http.get(url, { params: params })
         .then(function(response){

--- a/frontend/app/work_packages/directives/index.js
+++ b/frontend/app/work_packages/directives/index.js
@@ -55,9 +55,10 @@ angular.module('openproject.workPackages.directives')
     'I18n', require('./sort-header-directive')
   ])
   .constant('PERMITTED_MORE_MENU_ACTIONS', [
-    'log_time',
-    'move',
-    'delete'
+    { key: 'log_time', link: 'log_time', resource: 'workPackage' },
+    { key: 'move', link: 'move', resource: 'workPackage' },
+    { key: 'delete', link: 'delete', resource: 'workPackage' },
+    { key: 'copy', link: 'createWorkPackage', resource: 'project' }
   ])
   .directive('workPackageDetailsToolbar', [
     'PERMITTED_MORE_MENU_ACTIONS',

--- a/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
+++ b/frontend/app/work_packages/directives/work-package-details-toolbar-directive.js
@@ -37,34 +37,35 @@ module.exports = function(
     WorkPackageAuthorization) {
 
   function getPermittedActions(authorization, permittedMoreMenuActions) {
-    var permittedActions = authorization.permittedActions(permittedMoreMenuActions);
+    var permittedActions = authorization.permittedActionsWithLinks(permittedMoreMenuActions);
     var augmentedActions = { };
 
-    angular.forEach(permittedActions, function(value, key) {
-      var css = ["icon-" + key];
+    angular.forEach(permittedActions, function(permission) {
+      var css = ["icon-" + permission.key];
 
-      this[key] = { link: value, css: css };
+      this[permission.key] = { link: permission.link, css: css };
     }, augmentedActions);
 
     return augmentedActions;
   }
 
   function getPermittedPluginActions(authorization) {
-    var pluginActions = HookService.call('workPackageDetailsMoreMenu').reduce(function(previousValue, currentValue) {
-                          return angular.extend(previousValue, currentValue);
-                        }, { });
+    var pluginActions = [];
+    angular.forEach(HookService.call('workPackageDetailsMoreMenu'), function(action) {
+      pluginActions = pluginActions.concat(action);
+    });
 
-    var permittedPluginActions = authorization.permittedActions(Object.keys(pluginActions));
+    var permittedPluginActions = authorization.permittedActionsWithLinks(pluginActions);
     var augmentedPluginActions = { };
 
-    angular.forEach(permittedPluginActions, function(value, key) {
-      var css = [].concat(pluginActions[key]);
+    angular.forEach(permittedPluginActions, function(action) {
+      var css = [].concat(action.css);
 
-      if (css.length == 0) {
-        css = ["icon-" + key];
+      if (css.length === 0) {
+        css = ["icon-" + action.key];
       }
 
-      this[key] = { link: value, css: css };
+      this[action.key] = { link: action.link, css: css };
     }, augmentedPluginActions);
 
     return augmentedPluginActions;

--- a/frontend/app/work_packages/models/index.js
+++ b/frontend/app/work_packages/models/index.js
@@ -27,6 +27,6 @@
 //++
 
 angular.module('openproject.workPackages.models')
-  .factory('WorkPackageAuthorization', require('./work-package-authorization'))
-  .factory('Datepicker', ['TimezoneService', 'ConfigurationService', 
+  .factory('WorkPackageAuthorization', ['ProjectService', '$state', 'PathHelper', require('./work-package-authorization')])
+  .factory('Datepicker', ['TimezoneService', 'ConfigurationService',
                           '$timeout', require('./datepicker.js')]);

--- a/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
@@ -85,8 +85,14 @@ describe('workPackageDetailsToolbar', function() {
   });
 
   var pluginActions = {
-    plugin_action_1: { plugin_action_1: ['plugin_action_1_css_1', 'plugin_action_1_css_2'] },
-    plugin_action_2: { plugin_action_2: ['plugin_action_2_css_1'] }
+    plugin_action_1: { key: 'plugin_action_1',
+                       resource: 'workPackage',
+                       link: 'plugin_action_1',
+                       css: ['plugin_action_1_css_1', 'plugin_action_1_css_2'] },
+    plugin_action_2: { key: 'plugin_action_2',
+                       resource: 'workPackage',
+                       link: 'plugin_action_2',
+                       css: ['plugin_action_2_css_1'] }
   };
 
   beforeEach(function() {
@@ -98,6 +104,13 @@ describe('workPackageDetailsToolbar', function() {
         delete: { href: 'deleteMeLink' },
         plugin_action_1: { href: 'plugin_actionMeLink' },
         plugin_action_2: { href: 'plugin_actionMeLink' }
+      },
+      embedded: {
+        project: {
+          links: {
+            createWorkPackage: { href: 'createWorkPackageLink' }
+          }
+        }
       }
     };
 

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -1,0 +1,124 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.feature 'Work package copy', js: true, selenium: true do
+  let(:user) do
+    FactoryGirl.create(:user,
+                       member_in_project: project,
+                       member_through_role: create_role)
+  end
+  let(:work_flow) do
+    FactoryGirl.create(:workflow,
+                       role: create_role,
+                       type_id: original_work_package.type_id,
+                       old_status: original_work_package.status,
+                       new_status: FactoryGirl.create(:status))
+  end
+
+  let(:create_role) do
+    FactoryGirl.create(:role,
+                       permissions: [:view_work_packages,
+                                     :add_work_packages,
+                                     :edit_work_packages])
+  end
+  let(:project) { FactoryGirl.create(:project) }
+  let(:original_work_package) do
+    FactoryGirl.build(:work_package,
+                      project: project,
+                      assigned_to: assignee,
+                      responsible: responsible,
+                      fixed_version: version,
+                      author: author)
+  end
+  let(:role) { FactoryGirl.build(:role, permissions: [:view_work_packages]) }
+  let(:assignee) do
+    FactoryGirl.build(:user,
+                      firstname: 'An',
+                      lastname: 'assignee',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:responsible) do
+    FactoryGirl.build(:user,
+                      firstname: 'The',
+                      lastname: 'responsible',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:author) do
+    FactoryGirl.build(:user,
+                      firstname: 'The',
+                      lastname: 'author',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:version) do
+    FactoryGirl.build(:version,
+                      project: project)
+  end
+
+  before do
+    login_as(user)
+    original_work_package.save!
+    work_flow.save!
+  end
+
+  scenario 'on fullscreen page' do
+    original_work_package_page = Pages::FullWorkPackage.new(original_work_package)
+    to_copy_work_package_page = original_work_package_page.visit_copy!
+
+    to_copy_work_package_page.expect_current_path
+    to_copy_work_package_page.expect_fully_loaded
+
+    to_copy_work_package_page.update_attributes Description: 'Copied WP Description'
+    to_copy_work_package_page.save!
+
+    expect(page).to have_selector('.notification-box--content',
+                                  text: I18n.t('js.notice_successful_create'))
+
+    copied_work_package = WorkPackage.order(created_at: 'desc').first
+
+    expect(copied_work_package).to_not eql original_work_package
+
+    work_package_page = Pages::FullWorkPackage.new(copied_work_package)
+
+    work_package_page.ensure_page_loaded
+    work_package_page.expect_attributes Subject: original_work_package.subject,
+                                        Description: 'Copied WP Description',
+                                        Version: original_work_package.fixed_version,
+                                        Priority: original_work_package.priority,
+                                        Assignee: original_work_package.assigned_to,
+                                        Responsible: original_work_package.responsible,
+                                        Author: user
+
+    work_package_page.expect_activity user, number: 1
+    work_package_page.expect_current_path
+  end
+end

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -36,6 +36,10 @@ module Pages
       @work_package = work_package
     end
 
+    def visit_tab!(tab)
+      visit path(tab)
+    end
+
     def expect_subject
       within(container) do
         expect(page).to have_content(work_package.subject)

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -29,35 +29,47 @@
 require 'support/pages/page'
 
 module Pages
-  class SplitWorkPackage < Pages::AbstractWorkPackage
-    attr_reader :project
+  class AbstractWorkPackage < Page
+    attr_reader :work_package
 
-    def initialize(work_package, project = nil)
+    def initialize(work_package)
       @work_package = work_package
-      @project = project
     end
 
-    def visit_copy!
-      page = SplitWorkPackageCreate.new(project || work_package.project, work_package)
-      page.visit!
-
-      page
-    end
-
-    private
-
-    def details_container
-      find('.work-packages--details')
-    end
-
-    def path(tab='overview')
-      state = "#{work_package.id}/#{tab}"
-
-      if project
-        project_work_packages_path(project, "details/#{state}")
-      else
-        details_work_packages_path(state)
+    def expect_subject
+      within(container) do
+        expect(page).to have_content(work_package.subject)
       end
+    end
+
+    def ensure_page_loaded
+      expect(page).to have_selector('.work-package-details-activities-activity-contents .user',
+                                    text: work_package.journals.last.user.name)
+    end
+
+    def expect_attributes(attribute_expectations)
+      attribute_expectations.each do |label_name, value|
+        label = label_name.to_s
+
+        if label == 'Subject'
+          expect(page).to have_selector('.attribute-subject', text: value)
+        elsif label == 'Description'
+          expect(page).to have_selector('.attribute-description', text: value)
+        else
+          expect(page).to have_selector('.attributes-key-value--key', text: label)
+
+          dl_element = page.find('.attributes-key-value--key', text: label).parent
+
+          expect(dl_element).to have_selector('.attributes-key-value--value-container', text: value)
+        end
+      end
+    end
+
+    def expect_activity(user, number: nil)
+      container = '#work-package-activites-container'
+      container += " #activity-#{number}" if number
+
+      expect(page).to have_selector(container + ' .user', text: user.name)
     end
   end
 end

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -72,10 +72,6 @@ module Pages
       expect(page).to have_selector(container + ' .user', text: user.name)
     end
 
-    def visit_tab!(tab)
-      visit path(tab)
-    end
-
     def visit_copy!
       page = FullWorkPackageCreate.new(work_package)
       page.visit!

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -42,11 +42,6 @@ module Pages
       end
     end
 
-    def expect_current_path
-      current_path = URI.parse(current_url).path
-      expect(current_path).to eql path
-    end
-
     def ensure_page_loaded
       expect(page).to have_selector('.work-package-details-activities-activity-contents .user',
                                     text: work_package.journals.last.user.name)
@@ -54,16 +49,36 @@ module Pages
 
     def expect_attributes(attribute_expectations)
       attribute_expectations.each do |label_name, value|
-        expect(page).to have_selector('.attributes-key-value--key', text: label_name.to_s)
+        label = label_name.to_s
 
-        dl_element = page.find('.attributes-key-value--key', text: label_name.to_s).parent
+        if label == 'Subject'
+          expect(page).to have_selector('.attribute-subject', text: value)
+        elsif label == 'Description'
+          expect(page).to have_selector('.attribute-description', text: value)
+        else
+          expect(page).to have_selector('.attributes-key-value--key', text: label)
 
-        expect(dl_element).to have_selector('.attributes-key-value--value-container', text: value)
+          dl_element = page.find('.attributes-key-value--key', text: label).parent
+
+          expect(dl_element).to have_selector('.attributes-key-value--value-container', text: value)
+        end
       end
+    end
+
+    def expect_activity(user, number: nil)
+      container = '#work-package-activites-container'
+      container += " #activity-#{number}" if number
+
+      expect(page).to have_selector(container + ' .user', text: user.name)
     end
 
     def visit_tab!(tab)
       visit path(tab)
+    end
+
+    def visit_copy!
+      visit work_package_path(work_package) + '/copy'
+      FullWorkPackageCreate.new(work_package)
     end
 
     private

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -29,7 +29,7 @@
 require 'support/pages/page'
 
 module Pages
-  class FullWorkPackage < Page
+  class FullWorkPackage < Pages::AbstractWorkPackage
     attr_reader :work_package
 
     def initialize(work_package)
@@ -77,8 +77,10 @@ module Pages
     end
 
     def visit_copy!
-      visit work_package_path(work_package) + '/copy'
-      FullWorkPackageCreate.new(work_package)
+      page = FullWorkPackageCreate.new(work_package)
+      page.visit!
+
+      page
     end
 
     private

--- a/spec/support/pages/full_work_package_create.rb
+++ b/spec/support/pages/full_work_package_create.rb
@@ -26,61 +26,40 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'support/pages/page'
+
 module Pages
-  class Page
-    include Capybara::DSL
-    include RSpec::Matchers
-    include OpenProject::StaticRouting::UrlHelpers
+  class FullWorkPackageCreate < Page
+    attr_reader :work_package
 
-    def current_page?
-      URI.parse(current_url).path == path
+    def initialize(work_package = nil)
+      # in case of copy, the original work package can be provided
+      @work_package = work_package
     end
 
-    def visit!
-      raise 'No path defined' unless path
-
-      visit path
-
-      self
+    def expect_fully_loaded
+      expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
     end
 
-    def accept_alert_dialog!
-      alert_dialog.accept if selenium_driver?
-    end
-
-    def dismiss_alert_dialog!
-      alert_dialog.dismiss if selenium_driver?
-    end
-
-    def alert_dialog
-      page.driver.browser.switch_to.alert
-    end
-
-    def has_alert_dialog?
-      if selenium_driver?
-        begin
-          page.driver.browser.switch_to.alert
-        rescue Selenium::WebDriver::Error::NoAlertPresentError
-          false
-        end
+    def update_attributes(attribute_map)
+      # Only designed for text fields for now
+      attribute_map.each do |label, value|
+        fill_in(label, with: value)
       end
     end
 
-    def selenium_driver?
-      Capybara.current_driver.to_s.include?('selenium')
+    def save!
+      click_button I18n.t('js.button_save')
     end
 
-    def set_items_per_page!(n)
-      Setting.per_page_options = "#{n}, 50, 100"
-    end
+    private
 
-    def expect_current_path
-      current_path = URI.parse(current_url).path
-      expect(current_path).to eql path
+    def container
+      find('.work-packages--show-view')
     end
 
     def path
-      nil
+      work_package_path(work_package) + '/copy' if work_package
     end
   end
 end

--- a/spec/support/pages/split_work_package.rb
+++ b/spec/support/pages/split_work_package.rb
@@ -46,7 +46,7 @@ module Pages
 
     private
 
-    def details_container
+    def container
       find('.work-packages--details')
     end
 

--- a/spec/support/pages/split_work_package_create.rb
+++ b/spec/support/pages/split_work_package_create.rb
@@ -29,34 +29,38 @@
 require 'support/pages/page'
 
 module Pages
-  class SplitWorkPackage < Pages::AbstractWorkPackage
-    attr_reader :project
+  class SplitWorkPackageCreate < Page
+    attr_reader :work_package,
+                :project
 
-    def initialize(work_package, project = nil)
+    def initialize(project, work_package = nil)
+      # in case of copy, the original work package can be provided
       @work_package = work_package
       @project = project
     end
 
-    def visit_copy!
-      page = SplitWorkPackageCreate.new(project || work_package.project, work_package)
-      page.visit!
+    def expect_fully_loaded
+      expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
+    end
 
-      page
+    def update_attributes(attribute_map)
+      # Only designed for text fields for now
+      attribute_map.each do |label, value|
+        fill_in(label, with: value)
+      end
+    end
+
+    def save!
+      click_button I18n.t('js.button_save')
     end
 
     private
 
-    def details_container
-      find('.work-packages--details')
-    end
-
-    def path(tab='overview')
-      state = "#{work_package.id}/#{tab}"
-
-      if project
-        project_work_packages_path(project, "details/#{state}")
+    def path
+      if work_package
+        project_work_packages_path(project) + "/details/#{work_package.id}/copy"
       else
-        details_work_packages_path(state)
+        project_work_packages_path(project) + '/create_new'
       end
     end
   end


### PR DESCRIPTION
Recreates the copy functionality for work packages both on the details pane as well as on full screen. By that it almost satisfies:

https://community.openproject.org/work_packages/21666

The limitation is that watchers of the original work package are not copied. Another limitation is the suboptimal performance which one might want to improve later on. Currently, when switching from the existing work package to the copy form, the whole page is reloaded. This is due to the current implementation of the menu. 

:warning: please merge https://github.com/finnlabs/openproject-costs/issues/205 together with this pr :warning:
