### PR TITLE
limit joined members

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -51,36 +51,47 @@ class Project < ActiveRecord::Base
       .where("#{Principal.table_name}.type='User' AND #{User.table_name}.status=#{Principal::STATUSES[:active]}")
       .references(:users, :roles)
   }
+
   has_many :possible_assignee_members, -> {
     includes(:principal, :roles)
       .where(Project.possible_principles_condition)
       .references(:principals, :roles)
   }, class_name: 'Member'
   # Read only
-  has_many :possible_assignees, -> {
-      # Have to reference it again although possible_assignee_members does already specify it
-      # to be able to use the Project.possible_principles_condition there
-      includes(members: :roles)
+  has_many :possible_assignees, -> (object){
+    # Have to reference members and roles again although
+    # possible_assignee_members does already specify it to be able to use the
+    # Project.possible_principles_condition there
+    #
+    # The .where(members_users: { project_id: object.id })
+    # part is an optimization preventing to have all the members joined
+    includes(members: :roles)
+      .where(members_users: { project_id: object.id })
       .references(:roles)
       .merge(Principal.order_by_name)
-    },
-    through: :possible_assignee_members,
-    source: :principal
+  },
+  through: :possible_assignee_members,
+  source: :principal
   has_many :possible_responsible_members, -> {
     includes(:principal, :roles)
       .where(Project.possible_principles_condition)
       .references(:principals, :roles)
   }, class_name: 'Member'
   # Read only
-  has_many :possible_responsibles, -> {
-      # Have to reference it again although possible_assignee_members does already specify it
-      # to be able to use the Project.possible_principles_condition there
-      includes(members: :roles)
+  has_many :possible_responsibles, -> (object){
+    # Have to reference members and roles again although
+    # possible_responsible_members does already specify it to be able to use
+    # the Project.possible_principles_condition there
+    #
+    # The .where(members_users: { project_id: object.id })
+    # part is an optimization preventing to have all the members joined
+    includes(members: :roles)
+      .where(members_users: { project_id: object.id })
       .references(:roles)
       .merge(Principal.order_by_name)
-    },
-    through: :possible_responsible_members,
-    source: :principal
+  },
+  through: :possible_responsible_members,
+  source: :principal
   has_many :memberships, class_name: 'Member'
   has_many :member_principals, -> {
     includes(:principal)


### PR DESCRIPTION
Prevents to have all the user's members joined on a query for a
project's available_assignees and available_responsibles. Not only the
memberships the query is interested in (the one of the project) was
joined but all the memberships the user had. So the more memberships the
users have, the slower the query did become.

https://community.openproject.org/work_packages/22275/activity
