### PR TITLE
[22245] Fix invalid params on category edit

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -65,10 +65,6 @@ class CategoriesController < ApplicationController
     end
   end
 
-  def edit
-    @category.attributes = permitted_params.category
-  end
-
   def update
     @category.attributes = permitted_params.category
     if @category.save

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -88,6 +88,31 @@ describe CategoriesController, type: :controller do
   end
 
   describe '#edit' do
+    let(:category) {
+      FactoryGirl.create(:category,
+                         project: project)
+    }
+
+    subject { response }
+    before do
+      get :edit,
+           id: category_id
+    end
+
+
+    context 'valid category' do
+      let(:category_id) { category.id }
+      it { is_expected.to be_success }
+      it { is_expected.to render_template('edit') }
+    end
+
+    context 'invalid category' do
+      let(:category_id) { 404 }
+      it { is_expected.to be_not_found }
+    end
+  end
+
+  describe '#update' do
     let(:name) { 'Testing' }
 
     context 'valid category' do


### PR DESCRIPTION
The edit route wrongly assigned parameters to the category,
although it should only render the edit form.

This only became apparent when strong params where requiring the
`:category` param hash.

https://community.openproject.org/work_packages/22245/activity
