### PR TITLE
Feature/child work packages

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -365,6 +365,7 @@ en:
       message_successful_bulk_delete: Successfully deleted work packages.
       create:
         header: 'New Work Package'
+        header_with_parent: 'New work package (Child of %{type} #%{id})'
       no_results:
         title: No work packages to display
         description_html: |

--- a/frontend/app/components/work-packages/controllers/wp-new.controller.js
+++ b/frontend/app/components/work-packages/controllers/wp-new.controller.js
@@ -63,6 +63,17 @@ function WorkPackageNewController($scope,
   vm.notifyCreation = function() {
     NotificationsService.addSuccess(I18n.t('js.notice_successful_create'));
   };
+  vm.getHeading = function() {
+    if (vm.parentWorkPackage !== undefined) {
+      return I18n.t('js.work_packages.create.header_with_parent',
+                    { type: vm.parentWorkPackage.embedded.type.props.name,
+                      id: vm.parentWorkPackage.props.id });
+    }
+    else {
+       return I18n.t('js.work_packages.create.header');
+    }
+  };
+
   vm.goBack = function() {
     var args = ['^'],
         prevState = $rootScope.previousState;
@@ -112,7 +123,14 @@ function WorkPackageNewController($scope,
     EditableFieldsState.forcedEditState = true;
     EditableFieldsState.editAll.state = true;
 
-    if ($stateParams.copiedFromWorkPackageId) {
+    if ($stateParams.parent_id) {
+      vm.loaderPromise = WorkPackageService.getWorkPackage($stateParams.parent_id)
+        .then(function(workPackage) {
+          vm.parentWorkPackage = workPackage;
+          return WorkPackageService.initializeWorkPackageWithParent(workPackage);
+        });
+    }
+    else if ($stateParams.copiedFromWorkPackageId) {
       vm.loaderPromise = WorkPackageService.getWorkPackage($stateParams.copiedFromWorkPackageId)
         .then(function(workPackage) {
           return WorkPackageService.initializeWorkPackageFromCopy(workPackage);

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
@@ -1,6 +1,6 @@
 <div cg-busy="vm.loaderPromise" class="work-packages--details-content -create-mode">
   <div ng-if="vm.workPackage">
-    <h2>{{ ::I18n.t('js.work_packages.create.header') }}</h2>
+    <h2>{{ vm.getHeading() }}</h2>
 
     <div class="work-packages--create--title">
       <work-package-field field-name="'subject'" tabindex="0"></work-package-field>

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
@@ -30,7 +30,7 @@
 
 <div cg-busy="vm.loaderPromise">
   <div ng-if="vm.workPackage">
-    <h2>{{ ::I18n.t('js.work_packages.create.header') }}</h2>
+    <h2>{{ vm.getHeading() }}</h2>
 
     <div class="work-packages--create--title">
       <work-package-field field-name="'subject'" tabindex="0"></work-package-field>

--- a/frontend/app/components/work-packages/services/work-package.service.js
+++ b/frontend/app/components/work-packages/services/work-package.service.js
@@ -100,7 +100,6 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
 
       return wp.links.update.fetch(options)
         .then(function(form) {
-          form.pendingChanges = changes;
           wp.form = form;
           EditableFieldsState.workPackage = wp;
           inplaceEditErrors.errors = null;
@@ -126,7 +125,11 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
       var projectIdentifier = parentWorkPackage.embedded.project.props.identifier;
 
       var initialData = {
-        parentId: String(parentWorkPackage.props.id)
+        _links: {
+          parent: {
+            href: PathHelper.apiV3WorkPackagePath(parentWorkPackage.props.id)
+          }
+        }
       };
 
       return WorkPackageService.initializeWorkPackage(projectIdentifier, initialData);

--- a/frontend/app/components/work-packages/services/work-package.service.js
+++ b/frontend/app/components/work-packages/services/work-package.service.js
@@ -122,6 +122,17 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
       return WorkPackageService.initializeWorkPackage(projectIdentifier, initialData);
     },
 
+    initializeWorkPackageWithParent: function(parentWorkPackage) {
+      var projectIdentifier = parentWorkPackage.embedded.project.props.identifier;
+
+      var initialData = {
+        parentId: String(parentWorkPackage.props.id)
+      };
+
+      return WorkPackageService.initializeWorkPackage(projectIdentifier, initialData);
+    },
+
+
     getWorkPackage: function(id) {
       var path = PathHelper.apiV3WorkPackagePath(id),
           resource = HALAPIResource.setup(path);

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -185,7 +185,7 @@ angular.module('openproject')
       }
     })
     .state('work-packages.list.new', {
-      url: '/create_new?type',
+      url: '/create_new?type&parent_id',
       templateUrl: '/components/routes/partials/work-packages.list.new.html',
       reloadOnSearch: false
     })

--- a/frontend/app/routing.js
+++ b/frontend/app/routing.js
@@ -83,7 +83,7 @@ angular.module('openproject')
     })
 
     .state('work-packages.new', {
-      url: '/{projects}/{projectPath}/work_packages/new?type',
+      url: '/{projects}/{projectPath}/work_packages/new?type&parent_id',
       templateUrl: '/components/routes/partials/work-packages.new.html',
       controllerAs: 'vm',
       reloadOnSearch: false

--- a/frontend/app/work_packages/view_models/children-relations-handler.js
+++ b/frontend/app/work_packages/view_models/children-relations-handler.js
@@ -29,7 +29,8 @@
 module.exports = function(
     CommonRelationsHandler,
     WorkPackageService,
-    ApiNotificationsService
+    ApiNotificationsService,
+    $state
   ) {
   function ChildrenRelationsHandler(workPackage, children) {
       var handler = new CommonRelationsHandler(workPackage, children, undefined);
@@ -42,7 +43,14 @@ module.exports = function(
         return !!this.workPackage.links.update;
       };
       handler.addRelation = function() {
-        window.location = this.workPackage.links.addChild.href;
+        var params = { parent_id: this.workPackage.props.id,
+                       projectPath: this.workPackage.embedded.project.props.identifier };
+        if ($state.includes('work-packages.show')) {
+          $state.go('work-packages.new', params);
+        }
+        else {
+          $state.go('work-packages.list.new', params);
+        }
       };
       handler.getRelatedWorkPackage = function(workPackage, relation) { return relation.fetch(); };
       handler.removeRelation = function(scope) {

--- a/frontend/app/work_packages/view_models/index.js
+++ b/frontend/app/work_packages/view_models/index.js
@@ -44,5 +44,6 @@ angular.module('openproject.viewModels')
     'CommonRelationsHandler',
     'WorkPackageService',
     'ApiNotificationsService',
+    'PathHelper',
     require('./parent-relations-handler')
   ]);

--- a/frontend/app/work_packages/view_models/index.js
+++ b/frontend/app/work_packages/view_models/index.js
@@ -37,6 +37,7 @@ angular.module('openproject.viewModels')
     'CommonRelationsHandler',
     'WorkPackageService',
     'ApiNotificationsService',
+    '$state',
     require('./children-relations-handler')
   ])
   .factory('ParentRelationsHandler', [

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -119,6 +119,16 @@ module API
                  required: false,
                  writable: true
 
+          # TODO:
+          # * remove parent_id above in favor of only having :parent
+          # * create an available_work_package_parent resource
+          # * turn :parent into a schema_with_allowed_link
+
+          schema :parent,
+                 type: 'WorkPackage',
+                 required: false,
+                 writable: true
+
           schema_with_allowed_link :assignee,
                                    type: 'User',
                                    required: false,

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -114,6 +114,11 @@ module API
           schema :project,
                  type: 'Project'
 
+          schema :parent_id,
+                 type: 'Integer',
+                 required: false,
+                 writable: true
+
           schema_with_allowed_link :assignee,
                                    type: 'User',
                                    required: false,

--- a/lib/api/v3/work_packages/work_package_attribute_links_representer.rb
+++ b/lib/api/v3/work_packages/work_package_attribute_links_representer.rb
@@ -93,6 +93,9 @@ module API
         linked_property :version,
                         association: :fixed_version_id
         linked_property :priority
+        linked_property :parent,
+                        path: :work_package,
+                        namespace: :work_packages
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -182,7 +182,7 @@ module API
         link :addChild do
           {
             href: new_project_work_packages_path(represented.project,
-                                                work_package: { parent_id: represented }),
+                                                 parent_id: represented),
             type: 'text/html',
             title: "Add child of #{represented.subject}"
           } if current_user_allowed_to(:add_work_packages, context: represented.project)

--- a/spec/factories/issue_priority_factory.rb
+++ b/spec/factories/issue_priority_factory.rb
@@ -30,4 +30,8 @@ FactoryGirl.define do
   factory :issue_priority do
     sequence(:name) { |n| "IssuePriority #{n}" }
   end
+
+  factory :default_priority, parent: :issue_priority do
+    is_default true
+  end
 end

--- a/spec/features/work_packages/create_child_spec.rb
+++ b/spec/features/work_packages/create_child_spec.rb
@@ -1,0 +1,129 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.feature 'Work package create children', js: true, selenium: true do
+  let(:user) do
+    FactoryGirl.create(:user,
+                       member_in_project: project,
+                       member_through_role: create_role)
+  end
+  let(:work_flow) do
+    FactoryGirl.create(:workflow,
+                       role: create_role,
+                       type_id: original_work_package.type_id,
+                       old_status: original_work_package.status,
+                       new_status: FactoryGirl.create(:status))
+  end
+
+  let(:create_role) do
+    FactoryGirl.create(:role,
+                       permissions: [:view_work_packages,
+                                     :add_work_packages,
+                                     :edit_work_packages,
+                                     :manage_subtasks])
+  end
+  let(:project) { FactoryGirl.create(:project) }
+  let(:original_work_package) do
+    FactoryGirl.build(:work_package,
+                      project: project,
+                      assigned_to: assignee,
+                      responsible: responsible,
+                      fixed_version: version,
+                      priority: default_priority,
+                      author: author,
+                      status: default_status)
+  end
+  let(:default_priority) do
+    FactoryGirl.build(:default_priority)
+  end
+  let(:default_status) do
+    FactoryGirl.build(:default_status)
+  end
+  let(:role) { FactoryGirl.build(:role, permissions: [:view_work_packages]) }
+  let(:assignee) do
+    FactoryGirl.build(:user,
+                      firstname: 'An',
+                      lastname: 'assignee',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:responsible) do
+    FactoryGirl.build(:user,
+                      firstname: 'The',
+                      lastname: 'responsible',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:author) do
+    FactoryGirl.build(:user,
+                      firstname: 'The',
+                      lastname: 'author',
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:version) do
+    FactoryGirl.build(:version,
+                      project: project)
+  end
+
+  before do
+    login_as(user)
+    allow(user.pref).to receive(:warn_on_leaving_unsaved?).and_return(false)
+    original_work_package.save!
+    work_flow.save!
+  end
+
+  scenario 'on fullscreen page' do
+    original_work_package_page = Pages::FullWorkPackage.new(original_work_package)
+
+    child_work_package_page = original_work_package_page.add_child
+
+    child_work_package_page.expect_current_path
+    child_work_package_page.expect_heading
+
+    child_work_package_page.update_attributes Subject: 'Child work package'
+
+    child_work_package_page.save!
+
+    expect(page).to have_selector('.notification-box--content',
+                                  text: I18n.t('js.notice_successful_create'))
+
+    child_work_package = WorkPackage.order(created_at: 'desc').first
+
+    expect(child_work_package).to_not eql original_work_package
+
+    child_work_package_page = Pages::FullWorkPackage.new(child_work_package)
+
+    child_work_package_page.expect_subject
+    child_work_package_page.expect_current_path
+
+    child_work_package_page.expect_parent(original_work_package)
+  end
+end

--- a/spec/features/work_packages/create_child_spec.rb
+++ b/spec/features/work_packages/create_child_spec.rb
@@ -105,8 +105,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
 
     child_work_package_page = original_work_package_page.add_child
 
-    child_work_package_page.expect_current_path
     child_work_package_page.expect_heading
+    child_work_package_page.expect_current_path
 
     child_work_package_page.update_attributes Subject: 'Child work package'
 
@@ -121,6 +121,35 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
 
     child_work_package_page = Pages::FullWorkPackage.new(child_work_package)
 
+    child_work_package_page.ensure_page_loaded
+    child_work_package_page.expect_subject
+    child_work_package_page.expect_current_path
+
+    child_work_package_page.expect_parent(original_work_package)
+  end
+
+  scenario 'on split screen page' do
+    original_work_package_page = Pages::SplitWorkPackage.new(original_work_package, project)
+
+    child_work_package_page = original_work_package_page.add_child
+
+    child_work_package_page.expect_heading
+    child_work_package_page.expect_current_path
+
+    child_work_package_page.update_attributes Subject: 'Child work package'
+
+    child_work_package_page.save!
+
+    expect(page).to have_selector('.notification-box--content',
+                                  text: I18n.t('js.notice_successful_create'))
+
+    child_work_package = WorkPackage.order(created_at: 'desc').first
+
+    expect(child_work_package).to_not eql original_work_package
+
+    child_work_package_page = Pages::SplitWorkPackage.new(child_work_package, project)
+
+    child_work_package_page.ensure_page_loaded
     child_work_package_page.expect_subject
     child_work_package_page.expect_current_path
 

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -370,6 +370,16 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
 
+    describe 'parentId' do
+      it_behaves_like 'has basic schema properties' do
+        let(:path) { 'parentId' }
+        let(:type) { 'Integer' }
+        let(:name) { I18n.t('activerecord.attributes.work_package.parent') }
+        let(:required) { false }
+        let(:writable) { true }
+      end
+    end
+
     describe 'type' do
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'type' }

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -380,6 +380,16 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
 
+    describe 'parent' do
+      it_behaves_like 'has basic schema properties' do
+        let(:path) { 'parent' }
+        let(:type) { 'WorkPackage' }
+        let(:name) { I18n.t('activerecord.attributes.work_package.parent') }
+        let(:required) { false }
+        let(:writable) { true }
+      end
+    end
+
     describe 'type' do
       it_behaves_like 'has basic schema properties' do
         let(:path) { 'type' }

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -204,6 +204,17 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:link) { "/api/v3/priorities/#{priority.id}" }
         end
       end
+
+      describe 'parent' do
+        let(:parent) { FactoryGirl.build_stubbed(:work_package) }
+
+        before do work_package.parent = parent end
+
+        it_behaves_like 'linked property' do
+          let(:property) { 'parent' }
+          let(:link) { "/api/v3/work_packages/#{parent.id}" }
+        end
+      end
     end
 
     describe 'custom fields' do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -591,7 +591,8 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
       context 'when the user has the permission to add work packages' do
         it 'should have a link to add child' do
-          expect(subject).to have_json_path('_links/addChild/href')
+          expect(subject).to be_json_eql(new_project_work_packages_path(project, parent_id: work_package.id).to_json)
+            .at_path('_links/addChild/href')
         end
       end
 

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -75,5 +75,39 @@ module Pages
 
       expect(page).to have_selector(container + ' .user', text: user.name)
     end
+
+    def expect_parent(parent = nil)
+      parent ||= work_package.parent
+
+      expect(parent).to_not be_nil
+
+      visit_tab!('relations')
+
+      expect(page).to have_selector(".relation[title=#{I18n.t('js.relation_labels.parent')}] a",
+                                    text: "##{parent.id} #{parent.subject}")
+    end
+
+    def add_child
+      visit_tab!('relations')
+
+      page.find('.relation a', text: I18n.t('js.relation_labels.children')).click
+
+      click_button I18n.t('js.relation_buttons.add_child')
+
+      create_page(parent_work_package: work_package)
+    end
+
+    def visit_copy!
+      page = create_page(original_work_package: work_package)
+      page.visit!
+
+      page
+    end
+
+    private
+
+    def create_page(_args)
+      raise NotImplementedError
+    end
   end
 end

--- a/spec/support/pages/abstract_work_package_create.rb
+++ b/spec/support/pages/abstract_work_package_create.rb
@@ -29,33 +29,39 @@
 require 'support/pages/page'
 
 module Pages
-  class SplitWorkPackage < Pages::AbstractWorkPackage
-    attr_reader :project
+  class AbstractWorkPackageCreate < Page
+    attr_reader :original_work_package,
+                :parent_work_package
 
-    def initialize(work_package, project = nil)
-      super work_package
-      @project = project
+    def initialize(original_work_package: nil, parent_work_package: nil)
+      # in case of copy, the original work package can be provided
+      @original_work_package = original_work_package
+      @parent_work_package = parent_work_package
     end
 
-    private
-
-    def container
-      find('.work-packages--details')
-    end
-
-    def path(tab = 'overview')
-      state = "#{work_package.id}/#{tab}"
-
-      if project
-        project_work_packages_path(project, "details/#{state}")
+    def expect_heading
+      if parent_work_package
+        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header_with_parent',
+                                                         type: parent_work_package.type,
+                                                         id: parent_work_package.id))
       else
-        details_work_packages_path(state)
+        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header'))
       end
     end
 
-    def create_page(args)
-      args.merge!(project: project || work_package.project)
-      SplitWorkPackageCreate.new(args)
+    def update_attributes(attribute_map)
+      # Only designed for text fields for now
+      attribute_map.each do |label, value|
+        fill_in(label, with: value)
+      end
+    end
+
+    def expect_fully_loaded
+      expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
+    end
+
+    def save!
+      click_button I18n.t('js.button_save')
     end
   end
 end

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -30,75 +30,6 @@ require 'support/pages/page'
 
 module Pages
   class FullWorkPackage < Pages::AbstractWorkPackage
-    attr_reader :work_package
-
-    def initialize(work_package)
-      @work_package = work_package
-    end
-
-    def expect_subject
-      within(container) do
-        expect(page).to have_content(work_package.subject)
-      end
-    end
-
-    def ensure_page_loaded
-      expect(page).to have_selector('.work-package-details-activities-activity-contents .user',
-                                    text: work_package.journals.last.user.name)
-    end
-
-    def expect_attributes(attribute_expectations)
-      attribute_expectations.each do |label_name, value|
-        label = label_name.to_s
-
-        if label == 'Subject'
-          expect(page).to have_selector('.attribute-subject', text: value)
-        elsif label == 'Description'
-          expect(page).to have_selector('.attribute-description', text: value)
-        else
-          expect(page).to have_selector('.attributes-key-value--key', text: label)
-
-          dl_element = page.find('.attributes-key-value--key', text: label).parent
-
-          expect(dl_element).to have_selector('.attributes-key-value--value-container', text: value)
-        end
-      end
-    end
-
-    def expect_activity(user, number: nil)
-      container = '#work-package-activites-container'
-      container += " #activity-#{number}" if number
-
-      expect(page).to have_selector(container + ' .user', text: user.name)
-    end
-
-    def expect_parent(parent = nil)
-      parent ||= work_package.parent
-
-      expect(parent).to_not be_nil
-
-      visit_tab!('relations')
-
-      expect(page).to have_selector(".relation[title=#{I18n.t('js.relation_labels.parent')}] a",
-                                    text: "##{parent.id} #{parent.subject}")
-    end
-
-    def add_child
-      visit_tab!('relations')
-
-      page.find('.relation a', text: I18n.t('js.relation_labels.children')).click
-
-      click_button I18n.t('js.relation_buttons.add_child')
-
-      Pages::FullWorkPackageCreate.new(parent_work_package: work_package)
-    end
-
-    def visit_copy!
-      page = FullWorkPackageCreate.new(original_work_package: work_package)
-      page.visit!
-
-      page
-    end
 
     private
 
@@ -108,6 +39,10 @@ module Pages
 
     def path(tab = 'activity')
       work_package_path(work_package.id, tab)
+    end
+
+    def create_page(args)
+      Pages::FullWorkPackageCreate.new(args)
     end
   end
 end

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -72,8 +72,29 @@ module Pages
       expect(page).to have_selector(container + ' .user', text: user.name)
     end
 
+    def expect_parent(parent = nil)
+      parent ||= work_package.parent
+
+      expect(parent).to_not be_nil
+
+      visit_tab!('relations')
+
+      expect(page).to have_selector(".relation[title=#{I18n.t('js.relation_labels.parent')}] a",
+                                    text: "##{parent.id} #{parent.subject}")
+    end
+
+    def add_child
+      visit_tab!('relations')
+
+      page.find('.relation a', text: I18n.t('js.relation_labels.children')).click
+
+      click_button I18n.t('js.relation_buttons.add_child')
+
+      Pages::FullWorkPackageCreate.new(parent_work_package: work_package)
+    end
+
     def visit_copy!
-      page = FullWorkPackageCreate.new(work_package)
+      page = FullWorkPackageCreate.new(original_work_package: work_package)
       page.visit!
 
       page
@@ -85,7 +106,7 @@ module Pages
       find('.work-packages--show-view')
     end
 
-    def path(tab='activity')
+    def path(tab = 'activity')
       work_package_path(work_package.id, tab)
     end
   end

--- a/spec/support/pages/full_work_package_create.rb
+++ b/spec/support/pages/full_work_package_create.rb
@@ -30,15 +30,27 @@ require 'support/pages/page'
 
 module Pages
   class FullWorkPackageCreate < Page
-    attr_reader :work_package
+    attr_reader :original_work_package,
+                :parent_work_package
 
-    def initialize(work_package = nil)
+    def initialize(original_work_package: nil, parent_work_package: nil)
       # in case of copy, the original work package can be provided
-      @work_package = work_package
+      @original_work_package = original_work_package
+      @parent_work_package = parent_work_package
     end
 
     def expect_fully_loaded
       expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
+    end
+
+    def expect_heading
+      if parent_work_package
+        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header_with_parent',
+                                                         type: parent_work_package.type,
+                                                         id: parent_work_package.id))
+      else
+        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header'))
+      end
     end
 
     def update_attributes(attribute_map)
@@ -59,7 +71,11 @@ module Pages
     end
 
     def path
-      work_package_path(work_package) + '/copy' if work_package
+      if original_work_package
+        work_package_path(work_package) + '/copy'
+      elsif parent_work_package
+        new_project_work_packages_path(parent_work_package.project.identifier)
+      end
     end
   end
 end

--- a/spec/support/pages/full_work_package_create.rb
+++ b/spec/support/pages/full_work_package_create.rb
@@ -29,41 +29,7 @@
 require 'support/pages/page'
 
 module Pages
-  class FullWorkPackageCreate < Page
-    attr_reader :original_work_package,
-                :parent_work_package
-
-    def initialize(original_work_package: nil, parent_work_package: nil)
-      # in case of copy, the original work package can be provided
-      @original_work_package = original_work_package
-      @parent_work_package = parent_work_package
-    end
-
-    def expect_fully_loaded
-      expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
-    end
-
-    def expect_heading
-      if parent_work_package
-        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header_with_parent',
-                                                         type: parent_work_package.type,
-                                                         id: parent_work_package.id))
-      else
-        expect(page).to have_selector('h2', text: I18n.t('js.work_packages.create.header'))
-      end
-    end
-
-    def update_attributes(attribute_map)
-      # Only designed for text fields for now
-      attribute_map.each do |label, value|
-        fill_in(label, with: value)
-      end
-    end
-
-    def save!
-      click_button I18n.t('js.button_save')
-    end
-
+  class FullWorkPackageCreate < AbstractWorkPackageCreate
     private
 
     def container
@@ -72,9 +38,10 @@ module Pages
 
     def path
       if original_work_package
-        work_package_path(work_package) + '/copy'
+        work_package_path(original_work_package) + '/copy'
       elsif parent_work_package
-        new_project_work_packages_path(parent_work_package.project.identifier)
+        new_project_work_packages_path(parent_work_package.project.identifier,
+                                       parent_id: parent_work_package.id)
       end
     end
   end

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -75,8 +75,11 @@ module Pages
     end
 
     def expect_current_path
-      current_path = URI.parse(current_url).path
-      expect(current_path).to eql path
+      uri = URI.parse(current_url)
+      expected_path = uri.path
+      expected_path += '?' + uri.query if uri.query
+
+      expect(expected_path).to eql path
     end
 
     def path

--- a/spec/support/pages/split_work_package_create.rb
+++ b/spec/support/pages/split_work_package_create.rb
@@ -29,38 +29,26 @@
 require 'support/pages/page'
 
 module Pages
-  class SplitWorkPackageCreate < Page
-    attr_reader :work_package,
-                :project
+  class SplitWorkPackageCreate < AbstractWorkPackageCreate
+    attr_reader :project
 
-    def initialize(project, work_package = nil)
-      # in case of copy, the original work package can be provided
-      @work_package = work_package
+    def initialize(project:, original_work_package: nil, parent_work_package: nil)
       @project = project
-    end
 
-    def expect_fully_loaded
-      expect(page).to have_field(I18n.t('js.work_packages.properties.subject'))
-    end
-
-    def update_attributes(attribute_map)
-      # Only designed for text fields for now
-      attribute_map.each do |label, value|
-        fill_in(label, with: value)
-      end
-    end
-
-    def save!
-      click_button I18n.t('js.button_save')
+      super(original_work_package: original_work_package,
+            parent_work_package: parent_work_package)
     end
 
     private
 
     def path
-      if work_package
-        project_work_packages_path(project) + "/details/#{work_package.id}/copy"
+      if original_work_package
+        project_work_packages_path(project) + "/details/#{original_work_package.id}/copy"
       else
-        project_work_packages_path(project) + '/create_new'
+        path = project_work_packages_path(project) + '/create_new'
+        path += "?parent_id=#{parent_work_package.id}" if parent_work_package
+
+        path
       end
     end
   end


### PR DESCRIPTION
Implements creation of child work packages from each work package's relation tab as specified by:

https://community.openproject.org/work_packages/22178/activity

The functionality makes use of the `parent_id` field that is defined on the work package resource. IMO this field violates the API design. I have changed the front end application to only use the linked `parent` resource but did not remove the `parent_id` field as I don't think that it would be good practice to do that in a patch level release. The field should be removed on dev though.
