### PR TITLE
Remove embedded users in Projects#show

### DIFF
--- a/app/views/api/experimental/projects/show.api.rabl
+++ b/app/views/api/experimental/projects/show.api.rabl
@@ -35,8 +35,6 @@ attributes :id,
 
 node(:embedded) do |project|
   {
-    possible_assignees:    project.possible_assignees,
-    possible_responsibles: project.possible_responsibles,
     types:                 project.types
   }
 end

--- a/spec/views/api/experimental/projects/index_api_json_spec.rb
+++ b/spec/views/api/experimental/projects/index_api_json_spec.rb
@@ -57,8 +57,6 @@ describe 'api/experimental/projects/index.api.rabl', type: :view do
 
     it { is_expected.to have_json_type(Object).at_path('projects/1')  }
     it { is_expected.to have_json_path('projects/1/name')             }
-    it { is_expected.to have_json_path('projects/1/embedded/possible_responsibles') }
-    it { is_expected.to have_json_path('projects/1/embedded/possible_assignees')    }
     it { is_expected.to have_json_path('projects/1/embedded/types')   }
   end
 end

--- a/spec/views/api/experimental/projects/show_api_json_spec.rb
+++ b/spec/views/api/experimental/projects/show_api_json_spec.rb
@@ -29,13 +29,10 @@
 require File.expand_path('../../../../../spec_helper', __FILE__)
 
 describe 'api/experimental/projects/show.api.rabl', type: :view do
-  let(:principals) { FactoryGirl.build_list(:principal, 3) }
   let(:types)     { FactoryGirl.build_list(:type,   2) }
 
   let(:project)   {
     FactoryGirl.build(:project,
-                      possible_responsibles: principals,
-                      possible_assignees:    principals,
                       types:                 types
                      )
   }
@@ -52,10 +49,5 @@ describe 'api/experimental/projects/show.api.rabl', type: :view do
   it { is_expected.to have_json_path('project') }
   it { is_expected.to have_json_path('project/name') }
 
-  it { is_expected.to have_json_path('project/embedded/possible_responsibles') }
-  it { is_expected.to have_json_path('project/embedded/possible_assignees')    }
-
-  it { is_expected.to have_json_size(3).at_path('project/embedded/possible_responsibles') }
-  it { is_expected.to have_json_size(3).at_path('project/embedded/possible_assignees') }
   it { is_expected.to have_json_size(2).at_path('project/embedded/types') }
 end


### PR DESCRIPTION
I believe its no longer in use by the frontend. If that's really the case, it should scrape off a few seconds of load time on the ITE data set.
