### PR TITLE
[22300] Arrow icons for WP costs columns not displayed in same line

### DIFF
--- a/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
@@ -5,7 +5,7 @@
        ng-class="[currentSortDirection && 'sort', currentSortDirection]"
        lang-attribute
        lang="{{locale}}">{{headerTitle}}</a>
-    <span ng-if="!sortable">{{headerTitle}}</span>
+    <a ng-if="!sortable">{{headerTitle}}</a>
     <icon-wrapper css-class="dropdown-indicator icon-small"
                   icon-name="pulldown"
                   title="{{I18n.t('js.label_open_menu')}}"></icon-wrapper>


### PR DESCRIPTION
This changes the tag from 'span' to 'a' for non sortable columns. Thus the same styling rules can be applied for them.

https://community.openproject.org/work_packages/22300/activity
