### PR TITLE
[22305] Checkboxes are not properly aligned in WP sort columns

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -94,6 +94,7 @@ $ng-modal-image-width:   $ng-modal-image-height
     .select2-container
       float: left
       margin-right: 20px
+      margin-bottom: 0px
       @media(min-width: 1801px)
         width: 300px
       @media(max-width: 1800px)
@@ -107,6 +108,8 @@ $ng-modal-image-width:   $ng-modal-image-height
     label.option-label
       float: left
       margin-right: 20px
+      input
+        margin-top: 0px
 
   .columns-modal-content
     margin-bottom: 15px


### PR DESCRIPTION
This removes the 'margin'-values inside the modal sorting box. Thus the items are automatically aligned.

https://community.openproject.org/work_packages/22305/activity
