### PR TITLE
[22306] Missing icons in export modal

### DIFF
--- a/frontend/app/templates/work_packages/modals/export.html
+++ b/frontend/app/templates/work_packages/modals/export.html
@@ -7,7 +7,7 @@
     <ul class="export-options">
       <li ng-repeat="option in modal.exportOptions">
         <a ng-href="{{ ::option.url }}" focus="$first">
-          <i class="icon-page-{{ ::option.identifier }} icon-big"></i>
+          <i class="icon-export-{{ ::option.identifier }} icon-big"></i>
           <span class="export-label">{{ ::option.label }}</span>
         </a>
       </li>


### PR DESCRIPTION
This changes the generated class names for the export icons in modal view.

https://community.openproject.org/work_packages/22306/activity
