### PR TITLE
[22308] Missing icon in search result list

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -89,6 +89,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <dt class="<%= e.event_type %>">
         <% event_type = e.event_type == 'meeting' ? 'meetings' : e.event_type %>
         <% event_type = e.event_type == 'cost_object' ? 'budget' : event_type %>
+        <% event_type = e.event_type == 'reply' ? 'forums' : event_type %>
         <%= icon_wrapper("icon-context icon-#{event_type}", e.event_name) %>
         <% if e.project != @project %>
           <span class="project"><%= e.project %></span>


### PR DESCRIPTION
This changes the icon class from 'reply' to 'forums' since reply doesn't exist any more.

https://community.openproject.org/work_packages/22308/activity
