### PR TITLE
fix setting custom values on version

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -325,16 +325,19 @@ class PermittedParams
     # `version_settings_attributes` is from a plugin. Unfortunately as it stands
     # now it is less work to do it this way than have the plugin override this
     # method. We hopefully will change this in the future.
-    params.fetch(:version, {}).permit(:name,
-                                    :description,
-                                    :effective_date,
-                                    :due_date,
-                                    :start_date,
-                                    :wiki_page_title,
-                                    :status,
-                                    :sharing,
-                                    :custom_field_value,
-                                    version_settings_attributes: [:id, :display, :project_id])
+    permitted_params = params.fetch(:version, {}).permit(:name,
+                                                         :description,
+                                                         :effective_date,
+                                                         :due_date,
+                                                         :start_date,
+                                                         :wiki_page_title,
+                                                         :status,
+                                                         :sharing,
+                                                         version_settings_attributes: [:id,
+                                                                                       :display,
+                                                                                       :project_id])
+
+    permitted_params.merge(custom_field_values(:version, required: false))
   end
 
   def comment

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -251,8 +251,7 @@ describe PermittedParams, type: :model do
   describe '#version' do
     it 'should permit its whitelisted params' do
       acceptable_params = [:name, :description, :effective_date, :due_date,
-                           :start_date, :wiki_page_title, :status, :sharing,
-                           :custom_field_value]
+                           :start_date, :wiki_page_title, :status, :sharing]
 
       acceptable_params_with_data = HashWithIndifferentAccess[acceptable_params.map {|x| [x, 'value']}]
 
@@ -268,6 +267,14 @@ describe PermittedParams, type: :model do
     it 'allows an empty params hash' do
       params = ActionController::Parameters.new
       expect(PermittedParams.new(params, user).time_entry).to eq({})
+    end
+
+    it 'should permit custom field values' do
+      hash = { 'custom_field_values' => { '1' => '5' } }
+
+      params = ActionController::Parameters.new(version: hash)
+
+      expect(PermittedParams.new(params, user).version).to eq(hash)
     end
   end
 


### PR DESCRIPTION
The permitted params for custom values on versions where incorrect:
1) Added the `custom_field_values` to the list of permitted params
2) removed `custom_field_value` from the list of permitted params because it was just wrong.

https://community.openproject.org/work_packages/22226/activity
