### PR TITLE
[22312] Missing icon on overview page

### DIFF
--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -1,5 +1,5 @@
 <h3 class="widget-box--header">
-  <span class="icon-context openproject"></span>
+  <span class="icon-context icon-openproject"></span>
   <span class="widget-box--header-title"><%= l('homescreen.blocks.community') %></span>
 </h3>
 


### PR DESCRIPTION
This corrects the class name of the openproject icon. Thus it is correctly displayed.

https://community.openproject.org/work_packages/22312/activity
