### PR TITLE
Only set Setting.new_project_user_role_id when possible

### DIFF
--- a/app/seeders/basic_data/setting_seeder.rb
+++ b/app/seeders/basic_data/setting_seeder.rb
@@ -54,8 +54,10 @@ module BasicData
       # deviate from the defaults specified in settings.yml here
       # to set a default role. The role cannot be specified in the settings.yml as
       # that would mean to know the ID upfront.
-      default_role_id = Role.find_by(name: I18n.t(:default_role_project_admin)).id
-      settings['new_project_user_role_id'] = default_role_id
+      if settings_in_db.include?('new_project_user_role_id')
+        default_role_id = Role.find_by(name: I18n.t(:default_role_project_admin)).try(:id)
+        settings['new_project_user_role_id'] = default_role_id if default_role_id
+      end
 
       settings
     end
@@ -63,7 +65,7 @@ module BasicData
     private
 
     def settings_in_db
-      Setting.all.pluck(:name)
+      @settings_in_db ||= Setting.all.pluck(:name)
     end
 
     def settings_not_in_db


### PR DESCRIPTION
Fixes BUG #22213 ( https://community.openproject.org/work_packages/22213/activity )

Only sets Setting.new_project_user_role_id when
(a) it's not already set, and
(b) it can be automatically determined (i.e. the role still has its default name)

(incorporated @ulferts notes from pull request #4006 and based on release/5.0)
