### PR TITLE
Fix/autocompleter performance

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-wiki-textarea/edit-wiki-textarea.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-wiki-textarea/edit-wiki-textarea.directive.js
@@ -40,7 +40,7 @@ function inplaceEditorWikiTextarea(AutoCompleteHelper, $timeout) {
 
     controller: InplaceEditorWikiTextareaController,
     controllerAs: 'customEditorController',
-    
+
     link: function(scope, element) {
       $timeout(function() {
         AutoCompleteHelper.enableTextareaAutoCompletion(element.find('textarea'));
@@ -80,7 +80,6 @@ function InplaceEditorWikiTextareaController($scope, $sce, TextileService, Edita
 
   this.isPreview = false;
   this.previewHtml = '';
-  this.autocompletePath = '/work_packages/auto_complete.json';
 
   this.togglePreview = function() {
     this.isPreview = !this.isPreview;

--- a/frontend/app/helpers/auto-complete-helper.js
+++ b/frontend/app/helpers/auto-complete-helper.js
@@ -27,13 +27,14 @@
 //++
 
 module.exports = function($http, PathHelper) {
-  var getAtWhoParameters = function(url) {
+  var getAtWhoParameters = function(url, textarea) {
     return {
       at: '#',
       start_with_space: false,
       search_key: 'id_subject',
       tpl: '<li data-value="${atwho-at}${id}">${to_s}</li>',
       limit: 10,
+      textarea: textarea,
       callbacks: {
         remote_filter: function(query, callback) {
           if (query.length > 0) {
@@ -43,7 +44,15 @@ module.exports = function($http, PathHelper) {
                 for (var i = data.length - 1; i >= 0; i--) {
                   data[i]['id_subject'] = data[i]['id'].toString() + ' ' + data[i]['subject'];
                 }
-                callback(data);
+
+                if (angular.element(textarea).is(':visible')) {
+                  callback(data);
+                }
+                else {
+                  // discard the results if the textarea is no longer visible,
+                  // i.e. nobody cares for the results
+                  callback([]);
+                }
               });
           }
         },
@@ -60,7 +69,7 @@ module.exports = function($http, PathHelper) {
         var url = PathHelper.workPackageJsonAutoCompletePath();
 
         if (url !== undefined && url.length > 0) {
-          angular.element(textarea).atwho(getAtWhoParameters(url));
+          angular.element(textarea).atwho(getAtWhoParameters(url, textarea));
         }
       });
     }


### PR DESCRIPTION
Consists of two parts in order to satisfy https://community.openproject.org/work_packages/22274/activity:
- improves the performance of the sql queries on mysql by providing the index to use via a db hint. This improves the performance dramatically for short search terms, e.g. "34". For longer search terms however, when the required number of results (10 at the moment) is not to be found easily, the db query is still slow. This is because the db has to look through all the work packages if it cannot find enough work packages matching the string. So a query which does not match any work packages is the worst case. There are some additional improvements made in the PR (optimize the columns to use based on the search query characteristics) but the query might still take some time.
- The second part is therefore to not show the results if the user has decided to no longer be interested in the results by closing the inplace edit. The results used to be displayed in the upper left corner in such scenarios. Now, the results are discarded.

It would have been beneficial to show some kind of loading animation while the request is still in progress, but the lib used does not provide a mechanism to do so.
