### PR TITLE
Fix/remove ui select from modal

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -64,6 +64,11 @@ en:
     description_subwork_package: "Sub work package of"
     filter:
       noneElement: "(none)"
+      sorting:
+        criteria:
+          one: "First sorting criteria"
+          two: "Second sorting criteria"
+          three: "Third sorting criteria"
     general_text_no: "no"
     general_text_yes: "yes"
     general_text_No: "No"
@@ -360,7 +365,6 @@ en:
       label_filter_add: "Add filter"
       label_options: "Options"
       label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
-      label_column_select: "Status - Combined dropdown field: Selection with auto-completion."
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       create:

--- a/frontend/app/templates/work_packages/modals/group_by.html
+++ b/frontend/app/templates/work_packages/modals/group_by.html
@@ -4,28 +4,36 @@
 
     <h3>{{ ::I18n.t('js.label_group_by') }}</h3>
 
-    <div class="select2-modal-content">
-      <ui-select ng-model="vm.selectedColumnName" theme="select2" focus id="selected_columns_new" aria-labelledby="column_select_description">
-        <ui-select-match>{{$select.selected.title}}</ui-select-match>
-        <ui-select-choices repeat="column.name as column in vm.groupableColumns | filter: { title: $select.search } | orderBy:'title'">
-          <div ng-bind-html="column.title | highlight: $select.search"></div>
-        </ui-select-choices>
-      </ui-select>
-      <span class="tooltip--right -multiline" tabindex="0" data-tooltip="{{ ::I18n.t('js.work_packages.label_column_select') }}" aria-labelledby="column_select_description">
-        <i class="icon icon-help2"></i>
-      </span>
-      <div id="column_select_description" class="hidden-for-sighted">
-        {{ ::I18n.t('js.work_packages.label_column_select') }}
+    <form>
+      <div class="form--field -full-width">
+        <label
+          for="selected_columns_new"
+          class="form--label hidden-for-sighted">
+          {{ ::I18n.t('js.label_group_by') }}
+        </label>
+        <div class="form--field-container">
+          <div class="form--select-container">
+            <select
+                ng-model="vm.selectedColumnName"
+                focus
+                title="{{ fieldController.editTitle }}"
+                id="selected_columns_new"
+                class="form--select"
+                ng-options="column.name as column.title for column in vm.groupableColumns | orderBy: 'title'">
+            </select>
+          </div>
+        </div>
       </div>
-    </div>
-    <div>
-      <button class="button -highlight" ng-click="updateGroupBy()">
-        {{ ::I18n.t('js.modals.button_apply') }}
-      </button>
-      <button class="button" ng-click="modal.closeMe()">
-        {{ ::I18n.t('js.modals.button_cancel') }}
-      </button>
-    </div>
+
+      <div>
+        <button class="button -highlight" ng-click="updateGroupBy()">
+          {{ ::I18n.t('js.modals.button_apply') }}
+        </button>
+        <button class="button" ng-click="modal.closeMe()">
+          {{ ::I18n.t('js.modals.button_cancel') }}
+        </button>
+      </div>
+    </form>
 
   </div>
 </div>

--- a/frontend/app/templates/work_packages/modals/sorting.html
+++ b/frontend/app/templates/work_packages/modals/sorting.html
@@ -8,17 +8,20 @@
       <div id="modal-sorting" class="modal-content-container" cg-busy="promise">
         <div class="form--row" ng-repeat="element in sortElements">
           <div class="form--field -full-width">
+            <label
+               for="modal-sorting-attribute-{{$index}}"
+               class="form--label hidden-for-sighted">
+              {{ I18n.t('js.filter.sorting.criteria.' + { 1: 'one', 2: 'two', 3: 'three'}[$index + 1]) }}
+            </label>
             <div class="form--field-container">
-              <ui-select ng-model="element[0]" theme="select2" focus="!$index" aria-labelledby="sorting_select_description">
-                <ui-select-match>{{$select.selected.label}}</ui-select-match>
-                <ui-select-choices repeat="column as column in getRemainingAvailableColumnsData() | filter: { label: $select.search } | orderBy:'label'">
-                  <div ng-bind-html="column.label | highlight: $select.search"></div>
-                </ui-select-choices>
-              </ui-select>
-              <div class="form--tooltip-container">
-                <span class="tooltip--right -multiline" tabindex="0" data-tooltip="{{ ::I18n.t('js.work_packages.label_column_select') }}" aria-labelledby="sorting_select_description">
-                  <i class="icon icon-help2"></i>
-                </span>
+              <div class="form--select-container">
+                <select
+                   id="modal-sorting-attribute-{{$index}}"
+                   ng-model="element[0]"
+                   focus="!$index"
+                   class="form--select"
+                   ng-options="column.label for column in getRemainingAvailableColumnsData(element[0]) track by column.id">
+                </select>
               </div>
             </div>
           </div>
@@ -44,9 +47,6 @@
               </label>
             </div>
           </div>
-        </div>
-        <div id="sorting_select_description" class="hidden-for-sighted">
-          {{ ::I18n.t('js.work_packages.label_column_select') }}
         </div>
       </div>
       <button class="button -highlight"

--- a/frontend/tests/integration/specs/work-packages/work-packages-modal-focus-spec.js
+++ b/frontend/tests/integration/specs/work-packages/work-packages-modal-focus-spec.js
@@ -61,7 +61,7 @@ describe('OpenProject', function() {
     element(by.css('#work-packages-settings-button')).click();
     element(by.css('[ng-click="showGroupingModal($event)"]')).click();
     browser.driver.switchTo().activeElement().getAttribute('id').then(function (elementId) {
-      expect(element(by.css('.ng-modal-window .select2-container input.ui-select-focusser')).getAttribute('id'))
+      expect(element(by.css('.ng-modal-window #selected_columns_new')).getAttribute('id'))
         .to.eventually.equal(elementId);
     });
   });

--- a/frontend/tests/integration/specs/work-packages/work-packages-modal-focus-spec.js
+++ b/frontend/tests/integration/specs/work-packages/work-packages-modal-focus-spec.js
@@ -52,7 +52,7 @@ describe('OpenProject', function() {
     browser.driver.switchTo().activeElement().getAttribute('id');
     browser.driver.switchTo().activeElement().getAttribute('id').then(function (elementId) {
       browser.waitForAngular();
-      expect(element(by.css('.ng-modal-window .form--row:first-child input.ui-select-focusser')).getAttribute('id'))
+      expect(element(by.css('.ng-modal-window #modal-sorting-attribute-0')).getAttribute('id'))
         .to.eventually.equal(elementId);
     });
   });

--- a/frontend/tests/unit/tests/work_packages/controllers/dialogs/sorting-modal-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/dialogs/sorting-modal-test.js
@@ -76,15 +76,11 @@ describe('sortingModal', function() {
       buildController();
     });
 
-    it('formats the columns for select2', function() {
-      var columnData = scope.availableColumnsData[1];
+    it('formats the columns for select', function() {
+      var columnData = scope.availableColumnsData[0];
 
       expect(columnData).to.have.property('id', 'parent');
       expect(columnData).to.have.property('label', 'Parent');
-    });
-
-    it('includes a blank option as the first option', function() {
-      expect(scope.availableColumnsData[0]).to.deep.equal({ id: null, label: ' ', other: null });
     });
   });
 

--- a/spec/features/support/work_package_table.rb
+++ b/spec/features/support/work_package_table.rb
@@ -48,9 +48,8 @@ shared_context 'work package table helpers' do
     # Ensure the modal is opened before calling the non waiting 'all' function.
     find('.ng-modal-window', text: 'Sorting')
 
-    within '#modal-sorting' do
-      first_sort_criteria = first('.select2-container')
-      ui_select_choose(first_sort_criteria, column_name)
+    within '#modal-sorting .form--row:first-of-type' do
+      select column_name, from: I18n.t('js.filter.sorting.criteria.one')
 
       order_name = order == :desc ? 'Descending' : 'Ascending'
       choose(order_name)


### PR DESCRIPTION
Creates accessibility be replacing ui-select in the modals
- sort
- group by

The columns modal is still employing ui-select as there is no concept as of now with which ui the existing ui-multiselect is to be replaced.

https://community.openproject.org/work_packages/20140/activity
