### PR TITLE
remove method=put from preview request

### DIFF
--- a/frontend/app/ui_components/has-preview-directive.js
+++ b/frontend/app/ui_components/has-preview-directive.js
@@ -39,8 +39,7 @@ module.exports = function() {
           url: href,
           type: 'POST',
           data: angular.element('#' + id.replace(/(-preview)/g, '')).serialize()
-            .replace(
-              '_method=patch&', ''),
+            .replace(/_method=(patch|put)&/, ''),
           success: function(data) {
             angular.element(target).html(data);
             angular.element('html, body').animate({


### PR DESCRIPTION
Fix previewing wiki - the has-preview directive was only filtering out `method=patch` but not `method=put` so the verb used was not matching a route.

https://community.openproject.org/work_packages/22328/activity
https://community.openproject.org/work_packages/22322/activity

Thanks to _Guillaume Ferry_ for reporting the problem.
