### PR TITLE
add missing class on work package attachments

### DIFF
--- a/frontend/app/templates/work_packages/attachments-edit.html
+++ b/frontend/app/templates/work_packages/attachments-edit.html
@@ -1,4 +1,4 @@
-<div class="work-packages--attachments">
+<div class="work-packages--attachments attributes-group">
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
       <h3 class="attributes-group--header-text">

--- a/frontend/app/templates/work_packages/attachments.html
+++ b/frontend/app/templates/work_packages/attachments.html
@@ -1,4 +1,4 @@
-<div class="work-packages--attachments">
+<div class="work-packages--attachments attributes-group">
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
       <h3 class="attributes-group--header-text">


### PR DESCRIPTION
All other attribute groups (e.g. people, files) have that class. Without the class, the files section lacks an margin-top
