### PR TITLE
Fix/hide empty group

### DIFF
--- a/frontend/app/components/routes/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routes/controllers/work-package-show.controller.js
@@ -263,6 +263,7 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
   vm.workPackage = $scope.workPackage;
 
   vm.isGroupHideable = WorkPackagesDisplayHelper.isGroupHideable;
+  vm.isGroupEmpty = WorkPackagesDisplayHelper.isGroupEmpty;
   vm.isFieldHideable = WorkPackagesDisplayHelper.isFieldHideable;
   vm.getLabel = WorkPackagesDisplayHelper.getLabel;
   vm.isSpecified = WorkPackagesDisplayHelper.isSpecified;

--- a/frontend/app/components/routes/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routes/controllers/work-package-show.controller.js
@@ -262,8 +262,12 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
   vm.hideEmptyFields = true;
   vm.workPackage = $scope.workPackage;
 
-  vm.isGroupHideable = WorkPackagesDisplayHelper.isGroupHideable;
-  vm.isGroupEmpty = WorkPackagesDisplayHelper.isGroupEmpty;
+  vm.shouldHideGroup = function(group) {
+    return WorkPackagesDisplayHelper.shouldHideGroup(vm.hideEmptyFields,
+                                                     vm.groupedFields,
+                                                     group,
+                                                     vm.workPackage);
+  };
   vm.isFieldHideable = WorkPackagesDisplayHelper.isFieldHideable;
   vm.getLabel = WorkPackagesDisplayHelper.getLabel;
   vm.isSpecified = WorkPackagesDisplayHelper.isSpecified;

--- a/frontend/app/components/routes/partials/work-packages.show.html
+++ b/frontend/app/components/routes/partials/work-packages.show.html
@@ -108,7 +108,7 @@
           </div>
         </div>
 
-        <div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage)" class="attributes-group">
+        <div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)" class="attributes-group">
 
           <div class="attributes-group--header">
             <div class="attributes-group--header-container">

--- a/frontend/app/components/routes/partials/work-packages.show.html
+++ b/frontend/app/components/routes/partials/work-packages.show.html
@@ -108,7 +108,7 @@
           </div>
         </div>
 
-        <div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)" class="attributes-group">
+        <div ng-repeat="group in vm.groupedFields" ng-hide="vm.shouldHideGroup(group.groupName)" class="attributes-group">
 
           <div class="attributes-group--header">
             <div class="attributes-group--header-container">

--- a/frontend/app/components/work-packages/controllers/wp-new.controller.js
+++ b/frontend/app/components/work-packages/controllers/wp-new.controller.js
@@ -54,6 +54,7 @@ function WorkPackageNewController($scope,
   vm.isGroupHideable = function(groups, group, wp) {
     return WorkPackagesDisplayHelper.isGroupHideable(groups, group, wp, vm.isFieldHideable);
   };
+  vm.isGroupEmpty = WorkPackagesDisplayHelper.isGroupEmpty;
   vm.getLabel = WorkPackagesDisplayHelper.getLabel;
   vm.isSpecified = WorkPackagesDisplayHelper.isSpecified;
   vm.isEditable = WorkPackagesDisplayHelper.isEditable;

--- a/frontend/app/components/work-packages/controllers/wp-new.controller.js
+++ b/frontend/app/components/work-packages/controllers/wp-new.controller.js
@@ -51,10 +51,14 @@ function WorkPackageNewController($scope,
   vm.loaderPromise = null;
 
   vm.isFieldHideable = WorkPackagesDisplayHelper.isFieldHideableOnCreate;
-  vm.isGroupHideable = function(groups, group, wp) {
-    return WorkPackagesDisplayHelper.isGroupHideable(groups, group, wp, vm.isFieldHideable);
+  vm.shouldHideGroup = function(group) {
+    return WorkPackagesDisplayHelper.shouldHideGroup(vm.hideEmptyFields,
+                                                     vm.groupedFields,
+                                                     group,
+                                                     vm.workPackage,
+                                                     vm.isFieldHideable);
   };
-  vm.isGroupEmpty = WorkPackagesDisplayHelper.isGroupEmpty;
+
   vm.getLabel = WorkPackagesDisplayHelper.getLabel;
   vm.isSpecified = WorkPackagesDisplayHelper.isSpecified;
   vm.isEditable = WorkPackagesDisplayHelper.isEditable;

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
@@ -19,7 +19,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)"
+         ng-hide="vm.shouldHideGroup(group.groupName)"
          class="attributes-group">
 
       <div class="attributes-group--header">

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-create-form.directive.html
@@ -19,7 +19,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage)"
+         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)"
          class="attributes-group">
 
       <div class="attributes-group--header">

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
@@ -49,7 +49,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage)"
+         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)"
          class="attributes-group">
 
       <div class="attributes-group--header">

--- a/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
+++ b/frontend/app/components/work-packages/directives/wp-create-form/wp-full-create-form.directive.html
@@ -49,7 +49,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)"
+         ng-hide="vm.shouldHideGroup(group.groupName)"
          class="attributes-group">
 
       <div class="attributes-group--header">

--- a/frontend/app/templates/work_packages/tabs/overview.html
+++ b/frontend/app/templates/work_packages/tabs/overview.html
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)" class="attributes-group">
+<div ng-repeat="group in vm.groupedFields" ng-hide="vm.shouldHideGroup(group.groupName)" class="attributes-group">
 
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">

--- a/frontend/app/templates/work_packages/tabs/overview.html
+++ b/frontend/app/templates/work_packages/tabs/overview.html
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage)" class="attributes-group">
+<div ng-repeat="group in vm.groupedFields" ng-hide="vm.hideEmptyFields && vm.isGroupHideable(vm.groupedFields, group.groupName, vm.workPackage) || !vm.hideEmptyFields && vm.isGroupEmpty(vm.groupedFields, group.groupName)" class="attributes-group">
 
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -42,6 +42,7 @@ module.exports = function(
   vm.workPackage = $scope.workPackage;
 
   vm.isGroupHideable = WorkPackageDisplayHelper.isGroupHideable;
+  vm.isGroupEmpty = WorkPackageDisplayHelper.isGroupEmpty;
   vm.isFieldHideable = WorkPackageDisplayHelper.isFieldHideable;
   vm.getLabel = WorkPackageDisplayHelper.getLabel;
   vm.isSpecified = WorkPackageDisplayHelper.isSpecified;

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -41,8 +41,12 @@ module.exports = function(
   vm.hideEmptyFields = true;
   vm.workPackage = $scope.workPackage;
 
-  vm.isGroupHideable = WorkPackageDisplayHelper.isGroupHideable;
-  vm.isGroupEmpty = WorkPackageDisplayHelper.isGroupEmpty;
+  vm.shouldHideGroup = function(group) {
+    return WorkPackageDisplayHelper.shouldHideGroup(vm.hideEmptyFields,
+                                                    vm.groupedFields,
+                                                    group,
+                                                    vm.workPackage);
+  };
   vm.isFieldHideable = WorkPackageDisplayHelper.isFieldHideable;
   vm.getLabel = WorkPackageDisplayHelper.getLabel;
   vm.isSpecified = WorkPackageDisplayHelper.isSpecified;

--- a/frontend/app/work_packages/helpers/work-package-display-helper.js
+++ b/frontend/app/work_packages/helpers/work-package-display-helper.js
@@ -52,7 +52,11 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
       isGroupEmpty = function (groupedFields, groupName) {
         var group = _.find(groupedFields, {groupName: groupName});
 
-        return group.attributes.length === 0
+        return group.attributes.length === 0;
+      },
+      shouldHideGroup = function(hideEmptyActive, groupedFields, groupName, workPackage, cb) {
+        return hideEmptyActive && isGroupHideable(groupedFields, groupName, workPackage, cb) ||
+          !hideEmptyActive && isGroupEmpty(groupedFields, groupName);
       },
       isFieldHideable = function (workPackage, field) {
         if (!workPackage) {
@@ -122,6 +126,7 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
   return {
     isGroupHideable: isGroupHideable,
     isGroupEmpty: isGroupEmpty,
+    shouldHideGroup: shouldHideGroup,
     isFieldHideable: isFieldHideable,
     isFieldHideableOnCreate: isFieldHideableOnCreate,
     isSpecified: isSpecified,

--- a/frontend/app/work_packages/helpers/work-package-display-helper.js
+++ b/frontend/app/work_packages/helpers/work-package-display-helper.js
@@ -45,9 +45,14 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
         }
         var group = _.find(groupedFields, {groupName: groupName});
         var isHideable = typeof cb === 'undefined' ? isFieldHideable : cb;
-        return _.every(group.attributes, function(field) {
+        return group.attributes.length === 0 || _.every(group.attributes, function(field) {
           return isHideable(workPackage, field);
         });
+      },
+      isGroupEmpty = function (groupedFields, groupName) {
+        var group = _.find(groupedFields, {groupName: groupName});
+
+        return group.attributes.length === 0
       },
       isFieldHideable = function (workPackage, field) {
         if (!workPackage) {
@@ -116,6 +121,7 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
 
   return {
     isGroupHideable: isGroupHideable,
+    isGroupEmpty: isGroupEmpty,
     isFieldHideable: isFieldHideable,
     isFieldHideableOnCreate: isFieldHideableOnCreate,
     isSpecified: isSpecified,


### PR DESCRIPTION
Hides attribute groups on the work packages pages if they the group does not contain an attribute (e.g. custom field section empty)

https://community.openproject.org/work_packages/22003/activity 
