### PR TITLE
[22338] Long names are not abbreviated in WP overview

### DIFF
--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -171,3 +171,5 @@ $work-package-details--tab-height: 40px
   .assigned_to a
     display: block
     min-height: 22px
+    overflow: hidden
+    text-overflow: ellipsis


### PR DESCRIPTION
This adds styling rules for too long assignees. Thus these names get abbreviated if too long.

https://community.openproject.org/work_packages/22338/activity
