### PR TITLE
Configure testing with Karma and TypeScript

### DIFF
--- a/frontend/app/components/example/example.service.test.ts
+++ b/frontend/app/components/example/example.service.test.ts
@@ -1,0 +1,37 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {ExampleService} from './example.service'
+
+var expect = chai.expect;
+
+describe.only('Example', () => {
+  it('is just an example', () => {
+    expect(true).to.be.true;
+  })
+});

--- a/frontend/app/components/example/example.service.ts
+++ b/frontend/app/components/example/example.service.ts
@@ -1,0 +1,37 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+export class ExampleService {
+
+}
+
+angular.module('openproject.example', []);
+
+angular
+  .module('openproject.example')
+  .service(ExampleService);

--- a/frontend/app/components/routing/routing.configuration.test.ts
+++ b/frontend/app/components/routing/routing.configuration.test.ts
@@ -29,22 +29,29 @@
 var expect = chai.expect;
 
 describe('Routing', () => {
-  var $rootScope, $state, mockState = {
+  var $rootScope: ng.IRootScopeService;
+  var $state: ng.ui.IStateService;
+  var mockState = {
     go: () => {}
   };
 
-  beforeEach(angular.mock.module('openproject', ($provide) => {
+  beforeEach(angular.mock.module('openproject', ($provide: ng.auto.IProvideService) => {
     $provide.value('$state', mockState);
   }));
 
-  beforeEach(inject((_$rootScope_) => {
+  beforeEach(angular.mock.inject((_$rootScope_: ng.IRootScopeService) => {
     $rootScope = _$rootScope_;
   }));
 
   describe('when the project id is set', () => {
-    var toState, toParams,
-      spy = sinon.spy(mockState, 'go'),
-      broadcast = () => {
+    interface CustomStateParams extends ng.ui.IStateParamsService {
+      projects: string
+    }
+
+    var toState: Object;
+    var toParams: CustomStateParams;
+    var spy = sinon.spy(mockState, 'go');
+    var broadcast = () => {
         $rootScope.$broadcast('$stateChangeStart', toState, toParams);
       };
 

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -101,13 +101,12 @@ module.exports = function(config) {
         sourceMap: false,
         target: 'ES5',
         module: 'commonjs',
-        noImplicitAny: false,
+        noImplicitAny: true,
         noResolve: true,
         removeComments: true,
         concatenateOutput: false
       },
       typings: [
-        'typings/tsd.d.ts',
         'typings/**/*.d.ts'
       ]
     },

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -99,20 +99,15 @@ module.exports = function(config) {
       options: {
         sourceMap: false,
         target: 'ES5',
-        module: 'amd',
+        module: 'commonjs',
         noImplicitAny: false,
-        noResolve: true,
+        noResolve: false,
         removeComments: true,
         concatenateOutput: false
       },
       typings: [
         'typings/tsd.d.ts',
-        'typings/angularjs/angular.d.ts',
-        'typings/sinon/sinon.d.ts',
-        'typings/jquery/jquery.d.ts',
-        'typings/mocha/mocha.d.ts',
-        'typings/chai/chai.d.ts',
-        'typings/angularjs/angular-mocks.d.ts'
+        'typings/**/*.d.ts'
       ],
       transformPath: function(path) {
         return path.replace(/\.ts$/, '.js');

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -102,17 +102,14 @@ module.exports = function(config) {
         target: 'ES5',
         module: 'commonjs',
         noImplicitAny: false,
-        noResolve: false,
+        noResolve: true,
         removeComments: true,
         concatenateOutput: false
       },
       typings: [
         'typings/tsd.d.ts',
         'typings/**/*.d.ts'
-      ],
-      transformPath: function(path) {
-        return path.replace(/\.ts$/, '.js');
-      }
+      ]
     },
 
 

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -74,6 +74,7 @@ module.exports = function(config) {
       'tests/unit/tests/legacy-tests.js',
 
       'app/components/**/*.test.js',
+
       'app/components/**/*.test.ts'
     ],
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "noEmitOnError": false,
     "noImplicitAny": false,
-    "removeComments": false,
+    "removeComments": true,
     "preserveConstEnums": true,
     "sourceMap": true
   },


### PR DESCRIPTION
Currently there are `.js` files generated and not cleaned by the `karma-typescript-preprocessor` package.
Goal of this PR is to remove those files and get the testing configuration right.
