### PR TITLE
[22318] Remove double escaping

### DIFF
--- a/lib/open_project/scm/adapters/local_client.rb
+++ b/lib/open_project/scm/adapters/local_client.rb
@@ -121,10 +121,6 @@ module OpenProject
           ((client_version <=> v) >= 0) || (client_version.empty? && options[:unknown])
         end
 
-        def shell_quote(str)
-          Shellwords.escape(str)
-        end
-
         def supports_cat?
           true
         end
@@ -135,7 +131,7 @@ module OpenProject
 
         def target(path = '')
           base = path.match(/\A\//) ? root_url : url
-          shell_quote("#{base}/#{path}".gsub(/[?<>\*]/, ''))
+          "#{base}/#{path}".gsub(/[?<>\*]/, '')
         end
 
         ##

--- a/lib/open_project/scm/adapters/subversion.rb
+++ b/lib/open_project/scm/adapters/subversion.rb
@@ -222,8 +222,8 @@ module OpenProject
         # --non-interactive         avoid prompts
         def build_svn_cmd(args)
           if @login.present?
-            args.push('--username', shell_quote(@login))
-            args.push('--password', shell_quote(@password)) if @password.present?
+            args.push('--username', @login)
+            args.push('--password', @password) if @password.present?
           end
 
           args.push('--no-auth-cache', '--non-interactive')
@@ -299,13 +299,6 @@ module OpenProject
           xml_capture(cmd, force_encoding: true) do |doc|
             doc.xpath('/log/logentry').each &block
           end
-        end
-
-        def target(path = '')
-          base = path.match(/\A\//) ? root_url : url
-          uri = "#{base}/#{path}"
-          URI.escape(URI.escape(uri), '[]')
-          # shell_quote(uri.gsub(/[?<>\*]/, ''))
         end
 
         ##

--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -121,8 +121,7 @@ describe OpenProject::Scm::Adapters::Subversion do
 
         idx = svn_cmd.index('--password')
         expect(idx).not_to be_nil
-        expect(svn_cmd[idx + 1])
-          .to eq("VG\\%\\'\\;rm\\ -rf\\ /\\;\\},Y\\<lo\\>\\^m\\\\\\+DuE,vJP/9")
+        expect(password)
       end
     end
   end


### PR DESCRIPTION
With OpenProject 5.0, we moved to Open3 pseudo-shell, which no longer
requires escaping separate arguments (unless the whole command is passed
as a single string, which will result in a new shell with `Process.spawn`).

The `shell_quote` functionality was still used though and causes issues
with remote subversion passwords, which will be improperly escaped.

Relevant work package:
https://community.openproject.org/work_packages/22318
