### PR TITLE
[22373] Avoid rendering as link when id is null

### DIFF
--- a/frontend/app/components/wp-table/directives/wp-column/wp-column.directive.js
+++ b/frontend/app/components/wp-table/directives/wp-column/wp-column.directive.js
@@ -80,7 +80,10 @@ function WorkPackageColumnController($scope, PathHelper, WorkPackagesHelper) {
     setDisplayText(getFormattedColumnValue());
 
     if (vm.column.meta_data.link.display) {
-      displayDataAsLink(WorkPackagesHelper.getColumnDataId(vm.workPackage, vm.column));
+      var id = WorkPackagesHelper.getColumnDataId(vm.workPackage, vm.column)
+      if (id) {
+        displayDataAsLink(id);
+      }
     } else {
       setCustomDisplayType();
     }


### PR DESCRIPTION
The `assigned_to` column was renders with a link to the resource `/users/null`
when no assignee is set.

https://community.openproject.org/work_packages/22373/activity
