### PR TITLE
[22377] Disable date picker when accessibility mode is enabled

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -90,6 +90,7 @@ en:
     label_board_sticky: "Sticky"
     label_create_work_package: "Create new work package"
     label_date: "Date"
+    label_date_with_format: "Enter the %{date_attribute} using the following format: %{format}"
     label_deactivate: "Deactivate"
     label_descending: "Descending"
     label_description: "Description"

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-date-range/edit-date-range.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-date-range/edit-date-range.directive.html
@@ -8,6 +8,9 @@
          class="inplace-edit--date-range-start-date"
          id="inplace-edit--write-value--{{::field.name}}-start"
          ng-change="onStartEdit()"
+         title="{{::startDateTitle}}"
+         aria-label="{{::startDateLabel}}"
+         placeholder="{{::dateFormat}}"
          ng-model="startDate" ng-class="{'inplace-edit--highlight': startDateIsChanged}" />
   <div class="inplace-edit--date-range-start-date-picker"></div>
   <span class="delimeter">-</span>
@@ -19,6 +22,9 @@
   <input type="text"
          class="inplace-edit--date-range-end-date"
          id="inplace-edit--write-value--{{::field.name}}-end"
+         title="{{::startDateTitle}}"
+         aria-label="{{::startDateLabel}}"
+         placeholder="{{::dateFormat}}"
          ng-change="onEndEdit()"
          ng-model="endDate" ng-class="{'inplace-edit--highlight': endDateIsChanged}" />
   <div class="inplace-edit--date-range-end-date-picker"></div>

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-date/edit-date.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-date/edit-date.directive.html
@@ -8,6 +8,8 @@
          ng-change="onEdit()"
          ng-click="showDatepicker()"
          title="{{ fieldController.editTitle }}"
+         placeholder="-"
+         aria-label="{{::dateLabel}}"
          class="inplace-edit--date"
          id="inplace-edit--write-value--{{::field.name}}"
          type="text" />

--- a/frontend/tests/integration/specs/work-packages/details-pane/date-range-picker-spec.js
+++ b/frontend/tests/integration/specs/work-packages/details-pane/date-range-picker-spec.js
@@ -33,12 +33,57 @@ var expect = require('../../../spec_helper.js').expect,
     datepicker = detailsPaneHelper.datepicker,
     elements = detailsPaneHelper.elements;
 
-describe('details pane', function() {
+describe.only('details pane', function() {
   var dateRangePicker;
 
   var normalizeString = function(string) {
     return string.replace(/\r?\n|\r/g, "").replace(/  /g, " ")
   };
+
+  describe('when accessibility mode is enabled', function () {
+    var startDate, endDate,
+      startDateDatepicker, endDateDatepicker;
+
+    before(function () {
+      browser.addMockModule('openproject.config', function () {
+        angular.module('openproject.config', []).value('ConfigurationService', {
+          accessibilityModeEnabled: function () {
+            return true;
+          },
+
+          timeFormatPresent: angular.noop,
+          dateFormatPresent: angular.noop,
+          dateFormat: angular.noop,
+          startOfWeekPresent: angular.noop
+        });
+      });
+    });
+
+    after(function () {
+      browser.removeMockModule('openproject.config');
+    });
+
+    beforeEach(function() {
+      detailsPaneHelper.loadPane(819, 'activity');
+      dateRangePicker = $('.inplace-edit.attribute-date');
+      dateRangePicker.$('.inplace-edit--read-value').click();
+
+      startDate = dateRangePicker.$('.inplace-edit--date-range-start-date');
+      endDate = dateRangePicker.$('.inplace-edit--date-range-end-date');
+      startDateDatepicker = dateRangePicker.$('.inplace-edit--date-range-start-date-picker');
+      endDateDatepicker = dateRangePicker.$('.inplace-edit--date-range-end-date-picker');
+    });
+
+    it('startDatePicker should not appear as a calendar', function () {
+      startDate.click();
+      expect(startDateDatepicker.isDisplayed()).to.eventually.be.false;
+    });
+
+    it('endDatePicker should not appear as a calendar', function () {
+      endDate.click();
+      expect(endDateDatepicker.isDisplayed()).to.eventually.be.false;
+    });
+  });
 
   describe('date range picker', function() {
     beforeEach(function() {


### PR DESCRIPTION
The date picker has some drastic restrictions with regards to accessibility. As it's unfeasible to make the date picker component fully accessible, we instead:
1. Avoid showing the date picker in accessibility mode
2. Provide an extensive label on date fields with regards to its format and type.
3. Use API-provided error handling instead of the implicit fixes the date picker provides (such as invalid format, wrong start/end dates).

https://community.openproject.org/work_packages/22377/activity
