### PR TITLE
Remove role="grid" from tables

### DIFF
--- a/app/assets/stylesheets/content/_table.lsg
+++ b/app/assets/stylesheets/content/_table.lsg
@@ -6,7 +6,7 @@
 ```
 <div class="generic-table--container">
   <div class="generic-table--results-container" style="max-height: 340px;">
-    <table role="grid" class="generic-table" interactive-table>
+    <table class="generic-table" interactive-table>
       <colgroup>
         <col highlight-col>
         <col highlight-col>
@@ -113,7 +113,7 @@
 
 <div class="generic-table--container -with-footer">
   <div class="generic-table--results-container" style="max-height: 340px;">
-    <table role="grid" class="generic-table" interactive-table>
+    <table class="generic-table" interactive-table>
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/admin/plugins.html.erb
+++ b/app/views/admin/plugins.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @plugins.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table plugins">
+      <table interactive-table class="generic-table plugins">
         <colgroup>
           <col>
           <col>

--- a/app/views/admin/projects.html.erb
+++ b/app/views/admin/projects.html.erb
@@ -65,7 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @projects.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -40,7 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @auth_sources.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_board_plural) %>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table boards">
+    <table interactive-table class="generic-table boards">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -70,7 +70,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @topics.any? %>
     <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table role="grid" class="generic-table">
+          <table interactive-table class="generic-table">
             <colgroup>
               <col highlight-col>
               <col highlight-col>

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if (@custom_fields_by_type[tab[:name]] || []).any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if enumerations.any? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if @group.memberships.any? %>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table role="grid" class="generic-table memberships">
+          <table interactive-table class="generic-table memberships">
             <colgroup>
               <col highlight-col>
               <col highlight-col>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if @group.users.any? %>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table role="grid" class="generic-table users">
+          <table interactive-table class="generic-table users">
             <colgroup>
               <col highlight-col>
               <col>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -39,7 +39,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @groups.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% authorized = authorize_for('members', 'update') %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/my/access_token.html.erb
+++ b/app/views/my/access_token.html.erb
@@ -37,7 +37,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if has_tokens? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container" style="max-height: 340px;">
-        <table id="access-token-table" role="grid" class="generic-table" interactive-table>
+        <table id="access-token-table" class="generic-table" interactive-table>
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -51,7 +51,7 @@ entries_by_day = entries.group_by(&:spent_on)
 <% if entries.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table time-entries">
+      <table interactive-table class="generic-table time-entries">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/planning_element_type_colors/index.html.erb
+++ b/app/views/planning_element_type_colors/index.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @colors.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/project_associations/index.html.erb
+++ b/app/views/project_associations/index.html.erb
@@ -52,7 +52,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </h3>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table role="grid" class="generic-table timelines-project_associations">
+          <table interactive-table class="generic-table timelines-project_associations">
             <colgroup>
               <col highlight-col>
               <col highlight-col>

--- a/app/views/project_types/index.html.erb
+++ b/app/views/project_types/index.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @project_types.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table types" id="types-form">
+      <table interactive-table class="generic-table types" id="types-form">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/projects/settings/_boards.html.erb
+++ b/app/views/projects/settings/_boards.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/projects/settings/_categories.html.erb
+++ b/app/views/projects/settings/_categories.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/reportings/index.html.erb
+++ b/app/views/reportings/index.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @reportings.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/repositories/_dir_list.html.erb
+++ b/app/views/repositories/_dir_list.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table entries" id="browser">
+    <table interactive-table class="generic-table entries" id="browser">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= form_tag({controller: '/repositories', action: 'diff', project_id: @project, path: to_path_param(path)}, method: :get) do %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table changesets">
+      <table interactive-table class="generic-table changesets">
         <colgroup>
           <col highlight-col>
           <col>

--- a/app/views/repositories/committers.html.erb
+++ b/app/views/repositories/committers.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag({}) do %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= render partial: 'layouts/action_menu_specific' %>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table">
+    <table interactive-table class="generic-table">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="autoscroll">
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -48,7 +48,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @statuses.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <% if WorkPackage.use_status_for_done_ratio? %>

--- a/app/views/time_entries/reports/show.html.erb
+++ b/app/views/time_entries/reports/show.html.erb
@@ -84,7 +84,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% unless @hours.empty? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table" id="time-report">
+        <table interactive-table class="generic-table" id="time-report">
           <colgroup>
             <% @criterias.each do |criteria| %>
               <col highlight-col>

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table">
+    <table interactive-table class="generic-table">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -40,7 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @types.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col>

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @user.memberships.any? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table memberships">
+        <table interactive-table class="generic-table memberships">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -72,7 +72,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table">
+    <table interactive-table class="generic-table">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= form_tag({action: "diff"}, method: :get) do %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table wiki-page-versions">
+      <table interactive-table class="generic-table wiki-page-versions">
         <colgroup>
           <col highlight-col>
           <col>

--- a/app/views/work_packages/_list_simple.html.erb
+++ b/app/views/work_packages/_list_simple.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag({}) do %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table work_packages">
+        <table interactive-table class="generic-table work_packages">
           <colgroup>
             <col highlight-col>
             <col highlight-col>

--- a/app/views/work_packages/reports/_report.html.erb
+++ b/app/views/work_packages/reports/_report.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% column_names = report.statuses.map(&:name) + [l(:label_open_work_packages), l(:label_closed_work_packages), l(:label_total)] %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table">
+      <table interactive-table class="generic-table">
         <colgroup>
          <% column_names.each do |name| %>
             <col highlight-col>

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div id="workflow_form_<%= name %>" class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table workflow-table transitions-<%= name %>">
+    <table interactive-table class="generic-table workflow-table transitions-<%= name %>">
       <colgroup>
         <col>
         <col>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="autoscroll">
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table role="grid" class="generic-table">
+        <table interactive-table class="generic-table">
           <colgroup>
             <col>
             <col highlight-col>


### PR DESCRIPTION
As described in https://community.openproject.org/work_packages/20429/activity#activity-19,
the role 'grid' effectively blocks impaired users from detecting input elements in
cells of those tables.

https://community.openproject.org/work_packages/20429/activity

Further references:
https://www.paciellogroup.com/blog/2014/10/notes-on-fixing-incorrect-table-structure-using-aria/
http://webaim.org/blog/jaws-ate-my-tables/

Please also merge the related PRs.
