### PR TITLE
Implement better TypeScript-Karma test configuration

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,4 +5,5 @@
 /npm-debug.log
 /public/**/*
 /tests/unit/reports
+/tests/unit/tests/typescript
 /tmp

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -40,6 +40,7 @@ var gulpFilter = require('gulp-filter');
 var replace = require('gulp-replace');
 var tsproject = require('tsproject');
 var karma = require('karma');
+var fs = require('fs');
 
 var protractor = require('gulp-protractor').protractor,
   webdriverStandalone = require('gulp-protractor').webdriver_standalone,
@@ -54,6 +55,23 @@ var paths = {
   ],
   fonts: '../app/assets/fonts/**/*',
   styleguide: '../app/assets/stylesheets/styleguide.html.lsg'
+};
+
+var deleteFolderRecursive = function(path) {
+  if( fs.existsSync(path) ) {
+    fs.readdirSync(path).forEach(function(file){
+      var curPath = path + "/" + file;
+
+      if(fs.lstatSync(curPath).isDirectory()) {
+        deleteFolderRecursive(curPath);
+
+      } else {
+        fs.unlinkSync(curPath);
+      }
+    });
+
+    fs.rmdirSync(path);
+  }
 };
 
 gulp.task('lint', function() {
@@ -173,12 +191,22 @@ gulp.task('watch', function() {
   gulp.watch('../app/assets/stylesheets/**/*.lsg',  ['styleguide']);
 });
 
+
+var tsOutDir = __dirname + '/tests/unit/tests/typescript';
+
 gulp.task('typescript-tests', function () {
-  return tsproject.src('./tsconfig.test.json').pipe(gulp.dest('.'));
+  return tsproject.src('./tsconfig.test.json', {
+    compilerOptions: {
+      outDir: tsOutDir
+    }
+  }).pipe(gulp.dest('.'));
 });
 
 gulp.task('tests:karma', ['typescript-tests'], function () {
   karma.server.start({
     configFile: __dirname + '/karma.conf.js'
+
+  }, function () {
+    deleteFolderRecursive(tsOutDir)
   });
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -38,6 +38,7 @@ var autoprefixer = require('gulp-autoprefixer');
 var livingstyleguide = require('gulp-livingstyleguide');
 var gulpFilter = require('gulp-filter');
 var replace = require('gulp-replace');
+var tsproject = require('tsproject');
 
 var protractor = require('gulp-protractor').protractor,
   webdriverStandalone = require('gulp-protractor').webdriver_standalone,
@@ -60,7 +61,7 @@ gulp.task('lint', function() {
     .pipe(jshint.reporter('jshint-stylish'));
 });
 
-gulp.task('webpack', function() {
+gulp.task('webpack', ['tests:typescript'], function() {
   return gulp.src('app/openproject-app.js')
     .pipe(gulpWebpack(config))
     .pipe(gulp.dest('../app/assets/javascripts/bundles'));
@@ -169,4 +170,13 @@ gulp.task('watch', function() {
   gulp.watch('../app/assets/stylesheets/**/*.scss', ['sass', 'styleguide']);
   gulp.watch('../app/assets/stylesheets/**/*.sass', ['sass', 'styleguide']);
   gulp.watch('../app/assets/stylesheets/**/*.lsg',  ['styleguide']);
+});
+
+gulp.task('tests:typescript', function () {
+  return tsproject.src('./tsconfig.test.json', {
+    logLevel: 1,
+    compilerOptions: {
+      outDir: './tests/unit/tests/typescript'
+    }
+  }).pipe(gulp.dest('.'));
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -39,6 +39,7 @@ var livingstyleguide = require('gulp-livingstyleguide');
 var gulpFilter = require('gulp-filter');
 var replace = require('gulp-replace');
 var tsproject = require('tsproject');
+var karma = require('karma');
 
 var protractor = require('gulp-protractor').protractor,
   webdriverStandalone = require('gulp-protractor').webdriver_standalone,
@@ -172,6 +173,12 @@ gulp.task('watch', function() {
   gulp.watch('../app/assets/stylesheets/**/*.lsg',  ['styleguide']);
 });
 
-gulp.task('tests:typescript', function () {
+gulp.task('typescript-tests', function () {
   return tsproject.src('./tsconfig.test.json').pipe(gulp.dest('.'));
+});
+
+gulp.task('tests:karma', ['typescript-tests'], function () {
+  karma.server.start({
+    configFile: __dirname + '/karma.conf.js'
+  });
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -195,6 +195,8 @@ gulp.task('watch', function() {
 var tsOutDir = __dirname + '/tests/unit/tests/typescript';
 
 gulp.task('typescript-tests', function () {
+  deleteFolderRecursive(tsOutDir);
+
   return tsproject.src('./tsconfig.test.json', {
     compilerOptions: {
       outDir: tsOutDir

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -206,7 +206,12 @@ gulp.task('tests:karma', ['typescript-tests'], function () {
   karma.server.start({
     configFile: __dirname + '/karma.conf.js'
 
-  }, function () {
-    deleteFolderRecursive(tsOutDir)
+  }, function (exitCode) {
+    if(exitCode === 0) {
+      console.log('No error occurred. Temporary test files are deleted.');
+      deleteFolderRecursive(tsOutDir);
+    } else {
+      console.log('An error occurred. Temporary test files can be found in ' + tsOutDir);
+    }
   });
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task('lint', function() {
     .pipe(jshint.reporter('jshint-stylish'));
 });
 
-gulp.task('webpack', ['tests:typescript'], function() {
+gulp.task('webpack', function() {
   return gulp.src('app/openproject-app.js')
     .pipe(gulpWebpack(config))
     .pipe(gulp.dest('../app/assets/javascripts/bundles'));
@@ -173,11 +173,5 @@ gulp.task('watch', function() {
 });
 
 gulp.task('tests:typescript', function () {
-  return tsproject.src('./tsconfig.test.json', {
-    logLevel: 1,
-    compilerOptions: {
-      outDir: './tests/unit/tests/typescript',
-      sourceMap: false
-    }
-  }).pipe(gulp.dest('.'));
+  return tsproject.src('./tsconfig.test.json').pipe(gulp.dest('.'));
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -176,7 +176,8 @@ gulp.task('tests:typescript', function () {
   return tsproject.src('./tsconfig.test.json', {
     logLevel: 1,
     compilerOptions: {
-      outDir: './tests/unit/tests/typescript'
+      outDir: './tests/unit/tests/typescript',
+      sourceMap: false
     }
   }).pipe(gulp.dest('.'));
 });

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -120,12 +120,12 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'Firefox'],
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    singleRun: true,
 
 
 

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -73,9 +73,7 @@ module.exports = function(config) {
       'tests/unit/tests/**/*test.js',
       'tests/unit/tests/legacy-tests.js',
 
-      'app/components/**/*.test.js',
-
-      'app/components/**/*.test.ts'
+      'app/components/**/*.test.js'
     ],
 
 
@@ -90,27 +88,11 @@ module.exports = function(config) {
     preprocessors: {
       '/templates/**/*.html': ['ng-html2js'],
       '../app/assets/javascripts/*.js': ['coverage'],
-      'app/**/*.js': ['webpack'],
-      'app/components/**/*.test.ts': ['typescript']
+      'app/**/*.js': ['webpack']
     },
     ngHtml2JsPreprocessor: {
       module: 'openproject.templates'
     },
-    typescriptPreprocessor: {
-      options: {
-        sourceMap: false,
-        target: 'ES5',
-        module: 'commonjs',
-        noImplicitAny: false,
-        noResolve: true,
-        removeComments: true,
-        concatenateOutput: false
-      },
-      typings: [
-        'typings/**/*.d.ts'
-      ]
-    },
-
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -88,7 +88,8 @@ module.exports = function(config) {
     preprocessors: {
       '/templates/**/*.html': ['ng-html2js'],
       '../app/assets/javascripts/*.js': ['coverage'],
-      'app/**/*.js': ['webpack']
+      'app/**/*.js': ['webpack'],
+      'tests/unit/tests/typescript/**/*.js': ['webpack']
     },
     ngHtml2JsPreprocessor: {
       module: 'openproject.templates'

--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1522,7 +1522,7 @@
       }
     },
     "typescript": {
-      "version": "1.7.3"
+      "version": "1.6.2"
     },
     "url-loader": {
       "version": "0.5.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "sinon": "~1.9.1",
     "sinon-chai": "~2.5.0",
     "sorted-object": "^1.0.0",
+    "tsproject": "^1.0.5",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "test": "npm run karma && npm run protractor",
     "karma": "./node_modules/.bin/gulp tests:karma",
-    "protractor": "./node_modules/gulp/bin/gulp.js tests:protractor",
-    "postinstall": "./node_modules/bower/bin/bower install --config.interactive=false"
+    "protractor": "./node_modules/.bin/gulp tests:protractor",
+    "postinstall": "./node_modules/.bin/bower install --config.interactive=false"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "karma-mocha": "~0.1.3",
     "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-phantomjs-launcher": "~0.1.4",
-    "karma-typescript-preprocessor": "0.0.21",
     "karma-webpack": "^1.5.0",
     "mocha": "~1.18.2",
     "mocha-jenkins-reporter": "^0.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "test": "npm run karma && npm run protractor",
-    "karma": "./node_modules/karma/bin/karma start --single-run --browsers Firefox,PhantomJS",
+    "karma": "./node_modules/karma/bin/karma start",
     "protractor": "./node_modules/gulp/bin/gulp.js tests:protractor",
     "postinstall": "./node_modules/bower/bin/bower install --config.interactive=false"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "shelljs": "^0.3.0",
     "style-loader": "^0.8.2",
     "ts-loader": "^0.7.2",
-    "typescript": "^1.7.3",
+    "typescript": "^1.6.2",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.3",
     "yaml-loader": "^0.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "test": "npm run karma && npm run protractor",
-    "karma": "./node_modules/karma/bin/karma start",
+    "karma": "./node_modules/.bin/gulp tests:karma",
     "protractor": "./node_modules/gulp/bin/gulp.js tests:protractor",
     "postinstall": "./node_modules/bower/bin/bower install --config.interactive=false"
   }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -6,8 +6,6 @@
     "noImplicitAny": false,
     "preserveConstEnums": true,
     "sourceMap": false,
-    "outDir": "./tests/unit/tests/typescript",
-    "outFile": "./tests/unit/tests/typescript/typescript.test.js",
     "removeComments": true
   },
   "files": [

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -4,23 +4,14 @@
     "module": "commonjs",
     "noEmitOnError": false,
     "noImplicitAny": false,
-    "removeComments": true,
     "preserveConstEnums": true,
-    "sourceMap": true
+    "sourceMap": false,
+    "outDir": "./tests/unit/tests/typescript",
+    "outFile": "./tests/unit/tests/typescript/typescript.test.js",
+    "removeComments": true
   },
   "files": [
     "app/components/**/*.test.ts",
     "typings/tsd.d.ts"
-  ],
-  "bundles": {
-    "typescript.test": {
-      "files": [
-        "app/components/**/*.test.ts",
-        "typings/tsd.d.ts"
-      ],
-      "config": {
-        "outDir": "./tests/unit/tests/typescript"
-      }
-    }
-  }
+  ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "noEmitOnError": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "sourceMap": true
+  },
+  "files": [
+    "app/components/**/*.test.ts",
+    "typings/tsd.d.ts"
+  ],
+  "bundles": {
+    "typescript.test": {
+      "files": [
+        "app/components/**/*.test.ts",
+        "typings/tsd.d.ts"
+      ],
+      "config": {
+        "outDir": "./tests/unit/tests/typescript"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Now modules and classes (and any other exported TS objects) can be imported into the test files.
This resolves some thrown errors as well as makes it finally possible to test i.e. controller classes directly.

As there is an issue with the newer TS versions (above 1.6.2) and `tsproject`, a downgrade to 1.6.2 was necessary. I couldn't find a better fix for that issue for now.
Also, the features of `typescript` 1.7.x are not needed in OpenProject as of yet.

**Caution**
Before the PR is merged, please make sure that all the karma tests were run by travis.
There should be 1024 tests in total.
