### PR TITLE
Unescape titles coming from route params

### DIFF
--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -115,7 +115,7 @@ class WikiMenuItemsController < ApplicationController
   end
 
   def get_data_from_params(params)
-    @page_title = params[:id]
+    @page_title = CGI.unescape(params[:id])
     wiki_id = @project.wiki.id
 
     @page = WikiPage.find_by(title: @page_title, wiki_id: wiki_id)

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -16,8 +16,7 @@ module ToolbarHelper
 
   def dom_title(title)
     content_tag :div, class: 'title-container' do
-      title_attribute = decode title
-      content_tag(:h2, title.html_safe, title: title_attribute)
+      content_tag(:h2, title, title: title)
     end
   end
 


### PR DESCRIPTION
The route parameters used for titles were not always properly unescaped in order to find utf8-based titles. This also removes escaping toolbar titles, since that's not safe input.

https://community.openproject.org/work_packages/22384/activity
