### PR TITLE
[21338] Special Icons for added/deleted folders in Repository/Revision view

### DIFF
--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -91,6 +91,26 @@ module RepositoriesHelper
     render_changes_tree(tree[:s])
   end
 
+  # This calculates whether a folder was added, deleted or modified. It is based on the assumption that
+  # a folder was added/deleted when all content was added/deleted since the folder changes were not tracked.
+  def calculate_folder_action(tree)
+    folderAction = ''
+    unified_actions_in_same_iteration = true
+    tree.keys.sort.each do |changedFile|
+      if c = tree[changedFile][:c]
+        if c.action == 'A' && unified_actions_in_same_iteration && folderAction != 'D'
+          folderAction = 'A'
+        elsif c.action == 'D' && unified_actions_in_same_iteration && folderAction != 'A'
+          folderAction = 'D'
+        else
+          folderAction = ''
+          unified_actions_in_same_iteration = false
+        end
+      end
+    end
+    return folderAction
+  end
+
   def render_changes_tree(tree)
     return '' if tree.nil?
 
@@ -108,7 +128,17 @@ module RepositoriesHelper
                        project_id: @project,
                        path: path_param,
                        rev: @changeset.identifier)
-        output << "<li class='#{style} icon icon-folder-open'>#{text}</li>"
+
+        folderAction = calculate_folder_action(s)
+        case folderAction
+        when 'A'
+          output << "<li class='#{style} icon icon-folder-add'>#{text}</li>"
+        when 'D'
+          output << "<li class='#{style} icon icon-folder-remove'>#{text}</li>"
+        else
+          output << "<li class='#{style} icon icon-folder-open'>#{text}</li>"
+        end
+
         output << render_changes_tree(s)
       elsif c = tree[file][:c]
         style << " change-#{c.action}"

--- a/lib/redmine/unified_diff.rb
+++ b/lib/redmine/unified_diff.rb
@@ -236,7 +236,7 @@ module Redmine
 
     def html_line_left
       if offsets
-        line_left.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>').html_safe
+        line_left.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>')
       else
         line_left
       end
@@ -244,7 +244,7 @@ module Redmine
 
     def html_line_right
       if offsets
-        line_right.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>').html_safe
+        line_right.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>')
       else
         line_right
       end
@@ -252,7 +252,7 @@ module Redmine
 
     def html_line
       if offsets
-        line.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>').html_safe
+        line.dup.insert(offsets.first, '<span>').insert(offsets.last, '</span>')
       else
         line
       end


### PR DESCRIPTION
This estimates the folder action of a repository revision for the use of special icons. Since the folder action is not directly tracked, it is now based on it's content. A folder was added/deleted when all its content was added/deleted.

https://community.openproject.org/work_packages/21338/activity
