### PR TITLE
Style issues in Admin/CustomFields

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -382,6 +382,9 @@ fieldset.form--fieldset
     @include grid-size(shrink)
     max-width: none
 
+  .destroy_locale
+    display: flex
+
 .form--field-inline-action
   @include grid-content(shrink)
   padding: 0 0 0 0.2rem
@@ -418,6 +421,11 @@ fieldset.form--fieldset
 .form--field-extra-actions
   @extend %form--field-after-container
   @include grid-visible-overflow
+
+  &.add_locale.icon
+    margin-top: 5px
+    &:before
+    padding-left: 0px
 
 %form--field-element-container
   display: block

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -282,7 +282,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def add_localization_link
-    @template.content_tag :a, l(:button_add), href: '#', class: 'form--field-extra-actions add_locale'
+    @template.content_tag :a, l(:button_add), href: '#', class: 'form--field-extra-actions add_locale icon icon-add'
   end
 
   def localized_options(options, locale = :en)


### PR DESCRIPTION
This fixes styling issues in admin/customFields. The delete icons were correctly aligned and an icon for the add-language-functionality was added.

https://community.openproject.org/work_packages/22394/activity
