### PR TITLE
[22395] Consistent icon color for watcher buttons

### DIFF
--- a/app/assets/stylesheets/content/_buttons.sass
+++ b/app/assets/stylesheets/content/_buttons.sass
@@ -131,14 +131,6 @@ a.button
   @extend .icon-small
   @extend .icon-pulldown
 
-// hack around the old watchers_link implementation
-a.watcher_link
-  color: $button--font-color
-  text-decoration: none
-
-  &:before
-    margin-right: $button--text-icon-spacing
-
 // hack around the old markup (icon class applied on <a>)
 // which is used for toolbar-items to add space after icons inside buttons
 .toolbar-item

--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -43,7 +43,7 @@ module WatchersHelper
     path = send(:"#{(watched ? 'unwatch' : 'watch')}_path", object_type: object.class.to_s.underscore.pluralize,
                                                             object_id: object.id,
                                                             replace: options.delete('replace'))
-    html_options[:class] = html_options[:class].to_s + (watched ? ' icon icon-watched' : ' icon icon-unwatched')
+    html_options[:class] = html_options[:class].to_s + (watched ? ' icon-context icon-watched' : ' icon-context icon-unwatched')
 
     method = watched ?
       :delete :


### PR DESCRIPTION
This changes the used icon-class so that the watcher buttons will look like in WP and like the other buttons in the toolbar.

https://community.openproject.org/work_packages/22395/activity
