### PR TITLE
Update tsproject and typescript

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1522,7 +1522,7 @@
       }
     },
     "typescript": {
-      "version": "1.6.2"
+      "version": "1.7.5"
     },
     "url-loader": {
       "version": "0.5.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "shelljs": "^0.3.0",
     "style-loader": "^0.8.2",
     "ts-loader": "^0.7.2",
-    "typescript": "^1.6.2",
+    "typescript": "^1.7.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.3",
     "yaml-loader": "^0.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "sinon": "~1.9.1",
     "sinon-chai": "~2.5.0",
     "sorted-object": "^1.0.0",
-    "tsproject": "^1.0.5",
+    "tsproject": "^1.1.0-rc.2",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {


### PR DESCRIPTION
Fix the failing karma tests due to the usage of the soon-to-be deprecated `tsproject` v1.0.5.
