### PR TITLE
[22454] Fix improperly escaped toolbars

### DIFF
--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -16,7 +16,7 @@ module ToolbarHelper
 
   def dom_title(title)
     content_tag :div, class: 'title-container' do
-      content_tag(:h2, title, title: title)
+      content_tag(:h2, title)
     end
   end
 
@@ -25,9 +25,5 @@ module ToolbarHelper
     content_tag :ul, class: 'toolbar-items' do
       yield
     end
-  end
-
-  def decode(string)
-    raw(strip_tags(string)).strip
   end
 end

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -1,5 +1,6 @@
 module ToolbarHelper
   include ERB::Util
+  include ActionView::Helpers::OutputSafetyHelper
 
   def toolbar(title:, subtitle: '', link_to: nil, html: {})
     classes = ['toolbar-container', html[:class]].compact.join(' ')
@@ -14,15 +15,23 @@ module ToolbarHelper
     end
   end
 
+  def breadcrumb_toolbar(*elements, subtitle: '', html: {}, &block)
+    toolbar(title: safe_join(elements, ' &raquo '.html_safe), subtitle: subtitle, html: html, &block)
+  end
+
   protected
 
-  def dom_title(title, link_to = nil)
+  def dom_title(raw_title, link_to = nil)
+    title = ''.html_safe
+    title << raw_title
+
+    if link_to.present?
+      title << ': '
+      title << link_to
+    end
+
     content_tag :div, class: 'title-container' do
-      if link_to.present?
-        content_tag(:h2, "#{h(title)}: #{link_to}".html_safe)
-      else
-        content_tag(:h2, title)
-      end
+      content_tag(:h2, title)
     end
   end
 

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -1,9 +1,11 @@
 module ToolbarHelper
-  def toolbar(title:, subtitle: '', html: {})
+  include ERB::Util
+
+  def toolbar(title:, subtitle: '', link_to: nil, html: {})
     classes = ['toolbar-container', html[:class]].compact.join(' ')
     content_tag :div, class: classes do
       toolbar = content_tag :div, class: 'toolbar' do
-        dom_title(title) + dom_toolbar {
+        dom_title(title, link_to) + dom_toolbar {
           yield if block_given?
         }
       end
@@ -14,9 +16,13 @@ module ToolbarHelper
 
   protected
 
-  def dom_title(title)
+  def dom_title(title, link_to = nil)
     content_tag :div, class: 'title-container' do
-      content_tag(:h2, title)
+      if link_to.present?
+        content_tag(:h2, "#{h(title)}: #{link_to}".html_safe)
+      else
+        content_tag(:h2, title)
+      end
     end
   end
 

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= call_hook :activity_index_head %>
 
-<%= toolbar title: (@author.nil? ? l(:label_activity) : l(:label_user_activity, link_to_user(@author)).html_safe),
+<%= toolbar title: (@author.nil? ? l(:label_activity) : l(:label_user_activity, link_to_user(@author))).html_safe,
             subtitle: l(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to-1))
 %>
 

--- a/app/views/auth_sources/edit.html.erb
+++ b/app/views/auth_sources/edit.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{l(:label_auth_source)} #{@auth_source.name}" %>
-<%= toolbar title: "#{l(:label_auth_source)} (#{h @auth_source.auth_method_name})" %>
+<%= toolbar title: "#{l(:label_auth_source)} (#{@auth_source.auth_method_name})" %>
 
 <%= labelled_tabular_form_for @auth_source, as: :auth_source do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/auth_sources/new.html.erb
+++ b/app/views/auth_sources/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_auth_source_new) %>
-<%= toolbar title: "#{l(:label_auth_source_new)} (#{h @auth_source.auth_method_name})" %>
+<%= toolbar title: "#{l(:label_auth_source_new)} (#{@auth_source.auth_method_name})" %>
 
 <%= labelled_tabular_form_for @auth_source, as: :auth_source do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/categories/destroy.html.erb
+++ b/app/views/categories/destroy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{Category.model_name.human} #{h @category.name}" %>
+<%= toolbar title: "#{Category.model_name.human} #{@category.name}" %>
 <%= form_tag({}, {method: :delete}) do %>
   <div class="box">
     <p><strong><%= l(:text_work_package_category_destroy_question, @issue_count) %></strong></p>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -29,10 +29,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{CustomField.model_name.human} #{h @custom_field.name}" %>
 
-<%= toolbar title: %{#{link_to l(:label_custom_field_plural), custom_fields_path}
-    &raquo; #{link_to l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)}
-    &raquo; #{h @custom_field.name}
-  }.squish.html_safe
+<%= breadcrumb_toolbar link_to(l(:label_custom_field_plural), custom_fields_path),
+                       link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+                       @custom_field.name
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -31,8 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: %{#{link_to l(:label_custom_field_plural), custom_fields_path}
     &raquo; #{link_to l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)}
-    &raquo; #{@custom_field.name}
-  }.squish
+    &raquo; #{h @custom_field.name}
+  }.squish.html_safe
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -28,10 +28,9 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_custom_field_new) %>
-<%= toolbar title: %{#{link_to l(:label_custom_field_plural), custom_fields_path}
-    &raquo; #{link_to l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)}
-    &raquo; #{l(:label_custom_field_new)}
-  }.squish.html_safe
+<%= breadcrumb_toolbar link_to(l(:label_custom_field_plural), custom_fields_path),
+                       link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+                       l(:label_custom_field_new)
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: %{#{link_to l(:label_custom_field_plural), custom_fields_path}
     &raquo; #{link_to l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)}
     &raquo; #{l(:label_custom_field_new)}
-  }.squish
+  }.squish.html_safe
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/enumerations/destroy.html.erb
+++ b/app/views/enumerations/destroy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(@enumeration.option_name), enumerations_path}, @enumeration %>
 <%= styled_form_tag({}, method: :delete) do %>
   <section class="form--section">
     <p><strong><%= l(:text_enumeration_destroy_question, @enumeration.objects_count) %></strong></p>

--- a/app/views/enumerations/destroy.html.erb
+++ b/app/views/enumerations/destroy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}" %>
+<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}".html_safe %>
 <%= styled_form_tag({}, method: :delete) do %>
   <section class="form--section">
     <p><strong><%= l(:text_enumeration_destroy_question, @enumeration.objects_count) %></strong></p>

--- a/app/views/enumerations/edit.html.erb
+++ b/app/views/enumerations/edit.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Enumeration.model_name.human} #{h @enumeration.name}" %>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}" %>
+<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}".html_safe %>
 
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/enumerations/edit.html.erb
+++ b/app/views/enumerations/edit.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Enumeration.model_name.human} #{h @enumeration.name}" %>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{h @enumeration}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(@enumeration.option_name), enumerations_path), @enumeration %>
 
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/enumerations/new.html.erb
+++ b/app/views/enumerations/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_enumeration_new) %>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{l(:label_enumeration_new)}" %>
+<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{l(:label_enumeration_new)}".html_safe %>
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= styled_button_tag l(:button_create), class: '-highlight -with-icon icon-checkmark' %>

--- a/app/views/enumerations/new.html.erb
+++ b/app/views/enumerations/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_enumeration_new) %>
-<%= toolbar title: "#{link_to l(@enumeration.option_name), enumerations_path} &raquo; #{l(:label_enumeration_new)}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(@enumeration.option_name), enumerations_path), l(:label_enumeration_new) %>
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= styled_button_tag l(:button_create), class: '-highlight -with-icon icon-checkmark' %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -28,5 +28,5 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Group.model_name.human} #{h @group.name}" %>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{@group.name}" %>
+<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{@group.name}".html_safe %>
 <%= render_tabs group_settings_tabs %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -28,5 +28,5 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Group.model_name.human} #{h @group.name}" %>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{@group.name}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), @group.name %>
 <%= render_tabs group_settings_tabs %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l("label_group_new") %>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{l(:label_group_new)}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), l(:label_group_new) %>
 
 <%= labelled_tabular_form_for(@group) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l("label_group_new") %>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{l(:label_group_new)}" %>
+<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{l(:label_group_new)}".html_safe %>
 
 <%= labelled_tabular_form_for(@group) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{h @group.name}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), @group.name %>
 <ul>
   <% @group.users.each do |user| %>
     <li><%=h user %></li>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{h @group.name}" %>
+<%= toolbar title: "#{link_to l(:label_group_plural), groups_path} &raquo; #{h @group.name}".html_safe %>
 <ul>
   <% @group.users.each do |user| %>
     <li><%=h user %></li>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: "#{avatar(@news.author)}  #{h @news.title}" do %>
+<%= toolbar title: "#{avatar(@news.author)}  #{h @news.title}".html_safe do %>
   <% if User.current.allowed_to?(:manage_news, @project) %>
     <li class="toolbar-item">
       <%= link_to(edit_news_path(@news),

--- a/app/views/planning_element_type_colors/confirm_destroy.html.erb
+++ b/app/views/planning_element_type_colors/confirm_destroy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: h(@color.name) %>
+<%= toolbar title: @color.name %>
 <%= labelled_tabular_form_for @color,
             url: color_url(@color),
             html: {method: 'delete'},

--- a/app/views/project_types/confirm_destroy.html.erb
+++ b/app/views/project_types/confirm_destroy.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: h(@project_type.name) %>
+<%= toolbar title: @project_type.name %>
 <%= labelled_tabular_form_for(@project_type,
             url: project_type_path(@project_type),
             html: {method: 'delete'}) do |f| %>

--- a/app/views/project_types/edit.html.erb
+++ b/app/views/project_types/edit.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{l("timelines.admin_menu.project_type")} #{h @project_type.name}" %>
-<%= toolbar title: "#{l(:label_edit)} #{l("timelines.admin_menu.project_type")} #{h @project_type.name}" %>
+<%= toolbar title: "#{l(:label_edit)} #{l("timelines.admin_menu.project_type")} #{@project_type.name}" %>
 <%= labelled_tabular_form_for(@project_type,
              url: project_type_path(@project_type),
              html: {method: 'put'}) do |f| %>

--- a/app/views/repositories/diff.html.erb
+++ b/app/views/repositories/diff.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: "#{l(:label_revision)} #{@diff_format_revisions} #{h @path}" do %>
+<%= toolbar title: "#{l(:label_revision)} #{@diff_format_revisions} #{@path}" do %>
   <li class="toolbar-item">
     <%= form_tag({path: to_path_param(@path)}, method: :get) do %>
       <%= hidden_field_tag('rev', params[:rev]) if params[:rev] %>

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Role.model_name.human} #{h @role.name}" %>
 
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{@role.name}" %>
+<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{@role.name}".html_safe %>
 
 
 <%= labelled_tabular_form_for @role, html: { id: 'role_form' }, as: :role do |f| %>

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Role.model_name.human} #{h @role.name}" %>
 
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{@role.name}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_role_plural), roles_path), @role.name %>
 
 
 <%= labelled_tabular_form_for @role, html: { id: 'role_form' }, as: :role do |f| %>

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), l("label_group_new") %>
 
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_role_new)}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_role_plural), roles_path), l(:label_role_new) %>
 
 <%= labelled_tabular_form_for @role, html: {id: 'role_form'}, as: :role do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), l("label_group_new") %>
 
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_role_new)}" %>
+<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_role_new)}".html_safe %>
 
 <%= labelled_tabular_form_for @role, html: {id: 'role_form'}, as: :role do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_permissions_report)}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_role_plural), roles_path), l(:label_permissions_report) %>
 <%= form_tag(roles_path, method: :put, id: 'permissions_form') do %>
   <%= hidden_field_tag 'permissions[0]', '', id: nil %>
   <div class="autoscroll">

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_permissions_report)}" %>
+<%= toolbar title: "#{link_to(l(:label_role_plural), roles_path)} &raquo; #{l(:label_permissions_report)}".html_safe %>
 <%= form_tag(roles_path, method: :put, id: 'permissions_form') do %>
   <%= hidden_field_tag 'permissions[0]', '', id: nil %>
   <div class="autoscroll">

--- a/app/views/settings/plugin.html.erb
+++ b/app/views/settings/plugin.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{l(:label_settings)}: #{h @plugin.name}" %>
+<%= toolbar title: "#{l(:label_settings)}: #{@plugin.name}" %>
 <div id="settings">
   <%= styled_form_tag({action: 'plugin'}) do %>
     <div class="box">

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Status.model_name.human} #{h @status.name}" %>
-<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{h @status.name}"%>
+<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{h @status.name}".html_safe %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Status.model_name.human} #{h @status.name}" %>
-<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{h @status.name}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_work_package_status_plural), new_status_path), @status.name %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_work_package_status_new) %>
-<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{l(:label_work_package_status_new)}".html_safe %>
+<%= breadcrumb_toolbar link_to(l(:label_work_package_status_plural), new_status_path), l(:label_work_package_status_new) %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_work_package_status_new) %>
-<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{l(:label_work_package_status_new)}"%>
+<%= toolbar title: "#{link_to l(:label_work_package_status_plural), new_status_path} &raquo; #{l(:label_work_package_status_new)}".html_safe %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/timelines/confirm_destroy.html.erb
+++ b/app/views/timelines/confirm_destroy.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title I18n.t("timelines.delete_timeline", timeline: @timeline.name) %>
-<%= toolbar title: h(@timeline.name) %>
+<%= toolbar title: @timeline.name %>
 <%= labelled_tabular_form_for @timeline,
             url: project_timeline_path(@project, @timeline),
             html: {method: 'delete'} do |f| %>

--- a/app/views/timelines/edit.html.erb
+++ b/app/views/timelines/edit.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% html_title I18n.t("timelines.edit_timeline", timeline: h(@timeline.name)) %>
-<%= toolbar title: I18n.t("timelines.edit_timeline", timeline: h(@timeline.name)) %>
+<%= toolbar title: I18n.t("timelines.edit_timeline", timeline: @timeline.name) %>
 
 <%= labelled_tabular_form_for(@timeline,
             url: project_timeline_path(@project, @timeline),

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title "#{l('timelines.project_menu.timelines')}: #{h @timeline.name}" %>
-<%= toolbar title: h(@timeline.name) do %>
+<%= toolbar title: @timeline.name do %>
   <% if timeline_action_authorized?(:new) %>
     <li class="toolbar-item">
       <%= new_timeline_link @project do %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Type.model_name.human} #{h @type.name}" %>
 
-<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{h @type.name}".html_safe %>
+<%= breadcrumb_toolbar link_to(t(:label_type_plural), types_path), @type.name %>
 
 <%= form_for @type, builder: TabularFormBuilder, lang: current_language do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Type.model_name.human} #{h @type.name}" %>
 
-<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{h @type.name}" %>
+<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{h @type.name}".html_safe %>
 
 <%= form_for @type, builder: TabularFormBuilder, lang: current_language do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/types/new.html.erb
+++ b/app/views/types/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_type_new) %>
-<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{t(:label_type_new)}" %>
+<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{t(:label_type_new)}".html_safe %>
 
 <%= form_for controller.type, builder: TabularFormBuilder, lang: current_language  do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/types/new.html.erb
+++ b/app/views/types/new.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_type_new) %>
-<%= toolbar title: "#{link_to t(:label_type_plural), types_path} &raquo; #{t(:label_type_new)}".html_safe %>
+<%= breadcrumb_toolbar link_to(t(:label_type_plural), types_path), t(:label_type_new) %>
 
 <%= form_for controller.type, builder: TabularFormBuilder, lang: current_language  do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/users/_toolbar.html
+++ b/app/views/users/_toolbar.html
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar(title: "#{link_to l(:label_user_plural), users_path} &raquo; #{@user.new_record? ? l(:label_user_new) : h(@user.name)}".html_safe) do %>
+<%= breadcrumb_toolbar(link_to(l(:label_user_plural), users_path), @user.new_record? ? l(:label_user_new) : @user.name) do %>
   <% unless @user.new_record? %>
     <li class="toolbar-item">
       <%= link_to user_path(@user), class: 'button' do %>

--- a/app/views/users/_toolbar.html
+++ b/app/views/users/_toolbar.html
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar(title: "#{link_to l(:label_user_plural), users_path} &raquo; #{@user.new_record? ? l(:label_user_new) : h(@user.name)}") do %>
+<%= toolbar(title: "#{link_to l(:label_user_plural), users_path} &raquo; #{@user.new_record? ? l(:label_user_new) : h(@user.name)}".html_safe) do %>
   <% unless @user.new_record? %>
     <li class="toolbar-item">
       <%= link_to user_path(@user), class: 'button' do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= call_hook :users_show_head %>
 <% end %>
 
-<%= toolbar title: "#{avatar @user} #{h(@user.name)}" do %>
+<%= toolbar title: "#{avatar @user} #{h(@user.name)}".html_safe do %>
   <% if User.current.admin? %>
     <li class="toolbar-item">
       <%= link_to edit_user_path(@user), class: 'button', accesskey: accesskey(:edit) do %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: h(@version.name) do %>
+<%= toolbar title: @version.name do %>
  <% if authorize_for(:versions, :edit) %>
     <li class="toolbar-item">
       <%= link_to(edit_version_path(@version), class: 'button') do %>

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{h(@page.pretty_title)}" %>
+<%= toolbar title: @page.pretty_title %>
 <%= form_tag({}, method: :delete) do %>
   <div class="box">
     <p><strong><%= l(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{h(@page.pretty_title)}" %>
+<%= toolbar title: @page.pretty_title %>
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: "#{t(:button_change_parent_page)}: #{h(@page.title)}" %>
+<%= toolbar title: "#{t(:button_change_parent_page)}: #{@page.title}" %>
 
 <%= error_messages_for 'page' %>
 

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{h(@page.pretty_title)}" %>
+<%= toolbar title: @page.pretty_title %>
 <h3><%= l(:label_history) %></h3>
 <%= form_tag({action: "diff"}, method: :get) do %>
   <div class="generic-table--container">

--- a/app/views/wiki/rename.html.erb
+++ b/app/views/wiki/rename.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: "#{l(:button_rename)} #{h(@original_title)}" %>
+<%= toolbar title: "#{l(:button_rename)} #{@original_title}" %>
 
 <%= error_messages_for 'page' %>
 

--- a/app/views/work_packages/calendars/index.html.erb
+++ b/app/views/work_packages/calendars/index.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: (@query.new_record? ? l(:label_calendar) : h(@query.name)) %>
+<%= toolbar title: (@query.new_record? ? l(:label_calendar) : @query.name) %>
 <%= form_tag(work_packages_calendar_index_path, method: :get, id: 'query_form') do %>
   <%= hidden_field_tag('project_id', @project.to_param) if @project%>
   <fieldset id="filters" class="form--fieldset -collapsible collapsed" >

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -37,7 +37,7 @@ describe ToolbarHelper, type: :helper do
         <div class="toolbar-container">
           <div class="toolbar">
             <div class="title-container">
-              <h2 title="Title">Title</h2>
+              <h2>Title</h2>
             </div>
             <ul class="toolbar-items"></ul>
           </div>
@@ -51,11 +51,39 @@ describe ToolbarHelper, type: :helper do
         <div class="toolbar-container">
           <div class="toolbar">
             <div class="title-container">
-              <h2 title="Title">Title</h2>
+              <h2>Title</h2>
             </div>
             <ul class="toolbar-items"></ul>
           </div>
           <p class="subtitle">lorem</p>
+        </div>
+      }
+    end
+
+    it 'should be able to add a link_to' do
+      result = toolbar title: 'Title', link_to: link_to('foobar', user_path('1234'))
+      expect(result).to be_html_eql %{
+        <div class="toolbar-container">
+          <div class="toolbar">
+            <div class="title-container">
+              <h2>Title: <a href="/users/1234">foobar</a></h2>
+            </div>
+            <ul class="toolbar-items"></ul>
+          </div>
+        </div>
+      }
+    end
+
+    it 'should escape the title' do
+      result = toolbar title: '</h2><script>alert("foobar!");</script>'
+      expect(result).to be_html_eql %{
+        <div class="toolbar-container">
+          <div class="toolbar">
+            <div class="title-container">
+              <h2>&lt;/h2&gt;&lt;script&gt;alert(&quot;foobar!&quot;);&lt;/script&gt;</h2>
+            </div>
+            <ul class="toolbar-items"></ul>
+          </div>
         </div>
       }
     end
@@ -70,7 +98,7 @@ describe ToolbarHelper, type: :helper do
         <div class="toolbar-container">
           <div class="toolbar">
             <div class="title-container">
-              <h2 title="Title">Title</h2>
+              <h2>Title</h2>
             </div>
             <ul class="toolbar-items">
               <li>

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -110,4 +110,21 @@ describe ToolbarHelper, type: :helper do
       }
     end
   end
+  describe '.breadcrumb_toolbar' do
+    it 'should escape properly' do
+      result = breadcrumb_toolbar '</h2><script>alert("foobar!");</script>',
+                                  link_to('foobar', user_path('1234'))
+
+      expect(result).to be_html_eql %{
+        <div class="toolbar-container">
+          <div class="toolbar">
+            <div class="title-container">
+              <h2>&lt;/h2&gt;&lt;script&gt;alert(&quot;foobar!&quot;);&lt;/script&gt; &raquo; <a href="/users/1234">foobar</a></h2>
+            </div>
+            <ul class="toolbar-items"></ul>
+          </div>
+        </div>
+      }
+    end
+  end
 end


### PR DESCRIPTION
The user link of `/admin/users/new` was improperly escaped, as was several other toolbars due to the change in https://github.com/opf/openproject/pull/4052. This PR also
- provides a `breadcrumb_toolbar` for the `foo >> bar` style toolbars
- removes the title attribute of a toolbar, since I argue it does not make sense within h2.
