### PR TITLE
[20421] Add title to sort link itself

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -275,7 +275,7 @@ module SortHelper
     options[:title] = sort_header_title(column, options)
 
     within_sort_header_tag_hierarchy(options, sort_class(column)) do
-      sort_link(column, caption, default_order, lang: lang)
+      sort_link(column, caption, default_order, lang: lang, title: options[:title])
     end
   end
 

--- a/spec/helpers/sort_helper_spec.rb
+++ b/spec/helpers/sort_helper_spec.rb
@@ -54,7 +54,8 @@ describe SortHelper, type: :helper do
           <div class="generic-table--sort-header-outer">
             <div class="generic-table--sort-header">
               <span>
-                <a href="/work_packages?sort=sort_criteria_params">Id</a>
+                <a href="/work_packages?sort=sort_criteria_params"
+                   title="Sort by &quot;Id&quot;">Id</a>
               </span>
             </div>
           </div>
@@ -71,7 +72,8 @@ describe SortHelper, type: :helper do
             <div class="generic-table--sort-header-outer">
               <div class="generic-table--sort-header">
                 <span class="sort asc">
-                  <a href="/work_packages?sort=sort_criteria_params">Id</a>
+                  <a href="/work_packages?sort=sort_criteria_params"
+                     title="Ascending sorted by &quot;Id&quot;">Id</a>
                 </span>
               </div>
             </div>
@@ -90,7 +92,8 @@ describe SortHelper, type: :helper do
             <div class="generic-table--sort-header-outer">
               <div class="generic-table--sort-header">
                 <span class="sort desc">
-                  <a href="/work_packages?sort=sort_criteria_params">Id</a>
+                  <a href="/work_packages?sort=sort_criteria_params"
+                     title="Descending sorted by &quot;Id&quot;">Id</a>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
The sort link was added to the table header, but not the sort link
itself. This way, it was not accessible.

Should be sufficient to fix https://community.openproject.org/work_packages/20421/activity
