### PR TITLE
improve performance of projects table

### DIFF
--- a/app/models/project/storage.rb
+++ b/app/models/project/storage.rb
@@ -89,9 +89,9 @@ module Project::Storage
       <<-SQL
       SELECT wiki.project_id, SUM(wiki_attached.filesize) AS filesize
       FROM #{Wiki.table_name} wiki
-      LEFT JOIN #{WikiPage.table_name} pages
+      JOIN #{WikiPage.table_name} pages
         ON pages.wiki_id = wiki.id
-      LEFT JOIN #{Attachment.table_name} wiki_attached
+      JOIN #{Attachment.table_name} wiki_attached
         ON (wiki_attached.container_id = pages.id AND wiki_attached.container_type = 'WikiPage')
       GROUP BY wiki.project_id
       SQL
@@ -101,7 +101,7 @@ module Project::Storage
       <<-SQL
       SELECT wp.project_id, SUM(wp_attached.filesize) AS filesize
       FROM #{WorkPackage.table_name} wp
-      LEFT JOIN #{Attachment.table_name} wp_attached
+      JOIN #{Attachment.table_name} wp_attached
         ON (wp_attached.container_id = wp.id AND wp_attached.container_type = 'WorkPackage')
       GROUP BY wp.project_id
       SQL


### PR DESCRIPTION
The purpose of the subqueries is for the results to be factored into a sum.
Therefore rows that are null and filtered out rows count the same - 0.
But performance wise it makes a lot of difference if the row needs to be
kept in the query or if it is removed early on. This commit changes the
query to no longer keep rows for which no attachment exists by turing
the LEFT JOIN into a JOIN. By that, all containers without an attachment
are ruled out very fast. If a LEFT JOIN is used, all rows for work
packages and wiki/wiki_pages are returned even if they have no
attachment.

https://community.openproject.org/work_packages/22379/activity
