### PR TITLE
Fix/updating former work package

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -190,7 +190,6 @@ en:
     label_rejected_files_reason: "These files cannot be uploaded as their size is greater than %{maximumFilesize}"
     label_wait: "Please wait for configuration..."
     label_upload_counter: "%{done} of %{count} files finished"
-    label_successful_update: 'Successful update'
     label_validation_error: "The work package could not be saved due to the following errors:"
 
     placeholders:

--- a/frontend/app/components/routing/controllers/work-package-details.controller.js
+++ b/frontend/app/components/routing/controllers/work-package-details.controller.js
@@ -39,9 +39,10 @@ function WorkPackageDetailsController($scope, $state, latestTab, workPackage, I1
     latestTab.registerState(toState.name);
   });
 
-  $rootScope.$on('workPackageRefreshRequired', function(e) {
+  var refreshRequiredFunction = $rootScope.$on('workPackageRefreshRequired', function() {
     refreshWorkPackage();
   });
+  $scope.$on('$destroy', refreshRequiredFunction);
 
   // initialization
   setWorkPackageScopeProperties(workPackage);

--- a/frontend/app/components/routing/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routing/controllers/work-package-show.controller.js
@@ -47,9 +47,10 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
 
   // Listen to the event globally, as listeners are not necessarily
   // in the child scope
-  $rootScope.$on('workPackageRefreshRequired', function() {
+  var refreshRequiredFunction = $rootScope.$on('workPackageRefreshRequired', function() {
     refreshWorkPackage();
   });
+  $scope.$on('$destroy', refreshRequiredFunction);
 
   AuthorisationService.initModelAuth('work_package', workPackage.links);
 

--- a/frontend/app/components/routing/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routing/controllers/work-package-show.controller.js
@@ -299,7 +299,7 @@ function WorkPackageShowController($scope, $rootScope, $state, latestTab, workPa
       });
     });
     $scope.$on('workPackageUpdatedInEditor', function() {
-      NotificationsService.addSuccess(I18n.t('js.label_successful_update'));
+      NotificationsService.addSuccess(I18n.t('js.notice_successful_update'));
     });
   }
 }

--- a/frontend/app/work_packages/controllers/details-tab-overview-controller.js
+++ b/frontend/app/work_packages/controllers/details-tab-overview-controller.js
@@ -87,7 +87,7 @@ module.exports = function(
       });
     });
     $scope.$on('workPackageUpdatedInEditor', function() {
-      NotificationsService.addSuccess(I18n.t('js.label_successful_update'));
+      NotificationsService.addSuccess(I18n.t('js.notice_successful_update'));
     });
   }
 };


### PR DESCRIPTION
Removes the listener on rootScope upon controller destruction. Without that the listener will exist as long as the rootScope does, so until the user leaves the application's domain. This results in:
1) A memory leak accumulating listeners for every work package that is displayed
2) incomprehensible behaviour in cases the user makes updates to a work package when having viewed a different work package before that. In such a case, the formerly viewed work package is updated: https://community.openproject.org/work_packages/22363/activity

The bug 2) was supported by the `WorkPackageService`'s `getWorkPackage` method having an unexpected side effect. It sets the workPackage on `EditableFieldState` [to the fetched work package](https://github.com/opf/openproject/blob/dev/frontend/app/components/work-packages/services/work-package.service.js#L151). This IMO will cause further problems as the `getWorkPackage` might get used in other scenarios (e.g. to get a parent or otherwise related work package). I didn't touch it but would like to hear @furinvader`s opinion on it. 
