### PR TITLE
Fix missing label for password confirmation

### DIFF
--- a/app/views/account/password_recovery.html.erb
+++ b/app/views/account/password_recovery.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
     <div class="form--field -required">
       <%= styled_label_tag 'new_password_confirmation',
-            User.human_attribute_name(:new_password_confirmation) %>
+            User.human_attribute_name(:password_confirmation) %>
       <div class="form--field-container">
         <%= styled_password_field_tag 'new_password_confirmation', nil, size: 25, container_class: '-middle' %>
       </div>


### PR DESCRIPTION
This replace the new password confirmation humanize (which has no actual label associated) with the default password confirmation field:

https://community.openproject.org/work_packages/22490/activity
