### PR TITLE
[22433] Dark Theme: "Sort By" fields are almost not visible

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -252,6 +252,9 @@ $toggler-width: 40px
   a:hover
     text-decoration: underline
 
+  label
+    color: $main-menu-sidebar-font-color
+
   ul
     border: none
     overflow-x: hidden


### PR DESCRIPTION
This sets the default color of sidebar menu labels for all color schemes.

https://community.openproject.org/work_packages/22433/activity
