### PR TITLE
[22378] Fix build-up of class attributes

### DIFF
--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -41,7 +41,7 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
     @condition = options[:if]
     @param = options[:param] || :id
     @caption = options[:caption]
-    @html_options = options[:html] || {}
+    @html_options = options[:html].nil? ? {} : options[:html].dup
     # Adds a unique class to each menu item based on its name
     @html_options[:class] = [
       @html_options[:class], "#{@name.to_s.dasherize}-menu-item", 'ellipsis'


### PR DESCRIPTION
Due to an error in the parameter handling of `MenuManager::MenuItem`,
every request lead to an additional three class attributes in plugin
project menu items.

After some extensive debugging with @ulferts, we found this to be the definite cause of the crashing Mobile Safari.
