### PR TITLE
Improve accessibility on Rails forms

### DIFF
--- a/app/assets/stylesheets/content/_form_error_messages.sass
+++ b/app/assets/stylesheets/content/_form_error_messages.sass
@@ -34,4 +34,4 @@ span.errorSpan
 
   textarea, select, input
     &, &:hover, &:focus
-      border: 2px solid $content-form-danger-zone-bg-color
+      border: 2px solid $content-form-error-color

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -342,6 +342,17 @@ fieldset.form--fieldset
     @include grid-size(shrink)
     max-width: none
 
+  &.-error
+    @extend .icon-error
+    color: $content-form-danger-zone-bg-color
+    font-weight: bold
+    &::before
+      @include icon-common
+      display: inline-block
+      line-height:  $base-line-height
+      padding-right: 0.325rem
+
+
   &.-required,
   .form--field.-required > &
     &::after

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -351,21 +351,14 @@ fieldset.form--fieldset
       display: inline-block
       line-height:  $base-line-height
       padding-right: 0.325rem
-    &.-required,
-    .form--field.-required > &
-      &::after
-        color: $content-form-error-color
 
+.form--label-required
+  @include default-transition
+  color:   $primary-color-dark
+  padding: 0 0.325rem
 
-  &.-required,
-  .form--field.-required > &
-    &::after
-      @include default-transition
-      content:  '*'
-      color:    $primary-color-dark
-      padding:  0 0.325rem
-    &:hover::after
-      color:    $primary-color
+  .form--label.-error &
+    color: $content-form-error-color
 
 .form--field-container
   @include grid-content(10)

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -344,13 +344,17 @@ fieldset.form--fieldset
 
   &.-error
     @extend .icon-error
-    color: $content-form-danger-zone-bg-color
+    color: $content-form-error-color
     font-weight: bold
     &::before
       @include icon-common
       display: inline-block
       line-height:  $base-line-height
       padding-right: 0.325rem
+    &.-required,
+    .form--field.-required > &
+      &::after
+        color: $content-form-error-color
 
 
   &.-required,

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -152,6 +152,8 @@ $content-from-input-width:                      300px !default
 $content-form-input-border:                     1px solid #CACACA !default
 $content-form-input-hover-border:               1px solid #888888 !default
 
+$content-form-error-color:                      #9E2A1C !default
+
 $content-form-separator-color:                  #DDDDDD !default
 
 $content-form-danger-zone-bg-color:             #CA3F3F !default

--- a/app/views/common/_error_base.html.erb
+++ b/app/views/common/_error_base.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<div class="errorExplanation" id="errorExplanation" role="alert">
+<div class="errorExplanation" id="errorExplanation" tabindex="0" role="alert">
   <% if content_for?(:error_details) %>
     <h2><%= error_message %></h2>
     <%= content_for :error_details %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,7 +453,7 @@ en:
 
   errors:
     header_invalid_fields: "There were problems with the following fields:"
-    field_erroneous_label: "This field is invalid: %{full_errors}\nPlease enter a valid value"
+    field_erroneous_label: "This field is invalid: %{full_errors}\nPlease enter a valid value."
 
   activity:
     created: "Created: %{title}"
@@ -963,6 +963,7 @@ en:
   label_feeds_access_key: "RSS access key"
   label_feeds_access_key_created_on: "RSS access key created %{value} ago"
   label_feeds_access_key_type: "RSS"
+  label_field_is_required: 'This field is required.'
   label_file_added: "File added"
   label_file_plural: "Files"
   label_filter_add: "Add filter"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,6 +453,7 @@ en:
 
   errors:
     header_invalid_fields: "There were problems with the following fields:"
+    field_erroneous_label: "This field is invalid: %{full_errors}\nPlease enter a valid value"
 
   activity:
     created: "Created: %{title}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -963,7 +963,6 @@ en:
   label_feeds_access_key: "RSS access key"
   label_feeds_access_key_created_on: "RSS access key created %{value} ago"
   label_feeds_access_key_type: "RSS"
-  label_field_is_required: 'This field is required.'
   label_file_added: "File added"
   label_file_plural: "Files"
   label_filter_add: "Add filter"

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -206,10 +206,21 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       label_options[:class] << ' -error'
       error_label = I18n.t('errors.field_erroneous_label',
                            full_errors: @object.errors.full_messages_for(field).join(' '))
-       content << content_tag('span', error_label, class: 'hidden-for-sighted')
+       content << content_tag('p', error_label, class: 'hidden-for-sighted')
     end
 
-    label_options[:class] << ' -required' if options.delete(:required)
+    if options.delete(:required)
+      label_options[:class] << ' -required'
+      content << content_tag('span',
+                             '*',
+                             class: 'form--label-required',
+                             'aria-hidden': true)
+
+      content << content_tag('p',
+                             I18n.t(:label_field_is_required),
+                             class: 'hidden-for-sighted')
+    end
+
     label_options[:for] = if options[:for]
                             options[:for]
                           elsif options[:multi_locale] && id

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -198,9 +198,10 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
     id = element_id(translation_form) if translation_form
 
-    # FIXME: reenable the error handling
-    label_options[:class] << 'error' if false && @object && @object.respond_to?(:errors) && @object.errors[field] # FIXME
     label_options[:class] << 'form--label'
+
+    has_errors = @object.try(:errors) && @object.errors.include?(field)
+    label_options[:class] << ' -error' if has_errors
     label_options[:class] << ' -required' if options.delete(:required)
     label_options[:for] = if options[:for]
                             options[:for]

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -200,8 +200,15 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
     label_options[:class] << 'form--label'
 
-    has_errors = @object.try(:errors) && @object.errors.include?(field)
-    label_options[:class] << ' -error' if has_errors
+
+    content = h(text)
+    if @object.try(:errors) && @object.errors.include?(field)
+      label_options[:class] << ' -error'
+      error_label = I18n.t('errors.field_erroneous_label',
+                           full_errors: @object.errors.full_messages_for(field).join(' '))
+       content << content_tag('span', error_label, class: 'hidden-for-sighted')
+    end
+
     label_options[:class] << ' -required' if options.delete(:required)
     label_options[:for] = if options[:for]
                             options[:for]
@@ -211,7 +218,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     label_options[:lang] = options[:lang]
     label_options.reject! do |_k, v| v.nil? end
 
-    @template.label(@object_name, field, h(text), label_options)
+    @template.label(@object_name, field, content, label_options)
   end
 
   def element_id(translation_form)

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -40,6 +40,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
         localize_field(field, options, __method__)
       else
         options[:class] = Array(options[:class]) + [field_css_class(selector)]
+        merge_required_attributes(options[:required], options)
 
         input_options, label_options = extract_from options
 
@@ -72,10 +73,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   def select(field, choices, options = {}, html_options = {})
     html_options[:class] = Array(html_options[:class]) + %w(form--select)
 
-    if options[:required]
-      html_options[:required] = true
-    end
-
+    merge_required_attributes(options[:required], html_options)
     label_for_field(field, options) + container_wrap_field(super, 'select', options)
   end
 
@@ -126,6 +124,12 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     ret.concat content_tag(:span, suffix.html_safe, class: 'form--field-affix') if suffix
 
     field_container_wrap_field(ret, options)
+  end
+
+  def merge_required_attributes(required, options=nil)
+    if required
+      options.merge!({ required: true, 'aria-required': 'required' })
+    end
   end
 
   def field_container_wrap_field(field_html, options = {})
@@ -183,19 +187,8 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     options = options.dup
     return ''.html_safe if options.delete(:no_label)
 
-    text = if options[:label].is_a?(Symbol)
-             l(options[:label])
-           elsif options[:label]
-             options[:label]
-           elsif @object.is_a?(ActiveRecord::Base)
-             @object.class.human_attribute_name(field)
-           else
-             l(field)
-           end
-
-    label_options = { class: '',
-                      title: text }
-
+    text = get_localized_field(field, options[:label])
+    label_options = { class: '', title: text }
     id = element_id(translation_form) if translation_form
 
     label_options[:class] << 'form--label'
@@ -215,10 +208,6 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
                              '*',
                              class: 'form--label-required',
                              'aria-hidden': true)
-
-      content << content_tag('p',
-                             I18n.t(:label_field_is_required),
-                             class: 'hidden-for-sighted')
     end
 
     label_options[:for] = if options[:for]
@@ -230,6 +219,18 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     label_options.reject! do |_k, v| v.nil? end
 
     @template.label(@object_name, field, content, label_options)
+  end
+
+  def get_localized_field(field, label)
+    if label.is_a?(Symbol)
+      l(label)
+    elsif label
+      label
+    elsif @object.is_a?(ActiveRecord::Base)
+      @object.class.human_attribute_name(field)
+    else
+      l(field)
+    end
   end
 
   def element_id(translation_form)

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -557,7 +557,6 @@ JJ Abrams</textarea>
                  title="#{expected_title}">
             #{expected_title}
             <span class="form--label-required" aria-hidden="true">*</span>
-            <p class="hidden-for-sighted">This field is required.</span>
           </label>
         }).at_path('label')
       end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -550,6 +550,19 @@ JJ Abrams</textarea>
         }).at_path('label')
       end
 
+      def expected_required_label_like(expected_title, expected_classes = 'form--label')
+        expect(output).to be_html_eql(%{
+          <label class="#{expected_classes}"
+                 for="user_name"
+                 title="#{expected_title}">
+            #{expected_title}
+            <span class="form--label-required" aria-hidden="true">*</span>
+            <p class="hidden-for-sighted">This field is required.</span>
+          </label>
+        }).at_path('label')
+      end
+
+
       context 'with a label specified as string' do
         let(:text) { 'My own label' }
 
@@ -609,7 +622,7 @@ JJ Abrams</textarea>
           end
 
           it 'contains a specific error as a hidden sub-label' do
-            expect(output).to have_selector 'label.-error span',
+            expect(output).to have_selector 'label.-error p',
                                             count: 1,
                                             text: 'This field is invalid: Name is invalid. ' \
                                                   'Name is not set to one of the allowed values.'
@@ -626,7 +639,7 @@ JJ Abrams</textarea>
         end
 
         it 'uses the label' do
-          expected_label_like(I18n.t(:name), 'form--label -required')
+          expected_required_label_like(I18n.t(:name), 'form--label -required')
         end
       end
     end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -599,12 +599,20 @@ JJ Abrams</textarea>
         context 'with erroneous field' do
           before do
             resource.errors.add(:name, :invalid)
+            resource.errors.add(:name, :inclusion)
           end
 
           it 'shows an appropriate error label' do
             expect(output).to have_selector 'label.-error',
                                             count: 1,
-                                            text: User.human_attribute_name(:name)
+                                            text: 'Name'
+          end
+
+          it 'contains a specific error as a hidden sub-label' do
+            expect(output).to have_selector 'label.-error span',
+                                            count: 1,
+                                            text: 'This field is invalid: Name is invalid. ' \
+                                                  'Name is not set to one of the allowed values.'
           end
         end
       end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -582,7 +582,7 @@ JJ Abrams</textarea>
         end
       end
 
-      context 'with ActiveModel and withouth specified label' do
+      context 'with ActiveModel and without specified label' do
         let(:resource) {
           FactoryGirl.build_stubbed(:user,
                                     firstname:  'JJ',
@@ -594,6 +594,18 @@ JJ Abrams</textarea>
 
         it 'uses the human attibute name' do
           expected_label_like(User.human_attribute_name(:name))
+        end
+
+        context 'with erroneous field' do
+          before do
+            resource.errors.add(:name, :invalid)
+          end
+
+          it 'shows an appropriate error label' do
+            expect(output).to have_selector 'label.-error',
+                                            count: 1,
+                                            text: User.human_attribute_name(:name)
+          end
         end
       end
 


### PR DESCRIPTION
This PR tries to improve accessibility in Rails forms through a number of ways.
1. Use a separate error color for form borders (and label errors) with WCAG compliant color contrast.
2. Replace the \* required pseudo content with a separate span that contains an asterisk by default, and is replaced with an explicit span for impaired users.
3. Make field-specific error messages accessible to users by using a separate span within the label.

Should fix:
https://community.openproject.org/work_packages/20446
https://community.openproject.org/work_packages/20449
https://community.openproject.org/work_packages/20447

![demo_project_-_openproject](https://cloud.githubusercontent.com/assets/459462/12484345/3e630340-c05a-11e5-8095-36e8f755e43e.png)

Followup of https://github.com/opf/openproject/pull/3934 on release/5.0
