### PR TITLE
[22386] Avoid outputting paths in user_mailer format_text calls

### DIFF
--- a/app/views/user_mailer/message_posted.html.erb
+++ b/app/views/user_mailer/message_posted.html.erb
@@ -32,4 +32,4 @@ See doc/COPYRIGHT.rdoc for more details.
 </h1>
 <em><%= @message.author %></em>
 
-<%= format_text @message.content %>
+<%= format_text @message.content, only_path: false  %>

--- a/app/views/user_mailer/news_added.html.erb
+++ b/app/views/user_mailer/news_added.html.erb
@@ -30,4 +30,4 @@ See doc/COPYRIGHT.rdoc for more details.
 <h1><%= link_to @news.title, news_url(@news) %></h1>
 <em><%= @news.author.name if @news.author %></em>
 
-<%= format_text @news.description %>
+<%= format_text @news.description, only_path: false  %>

--- a/app/views/user_mailer/news_comment_added.html.erb
+++ b/app/views/user_mailer/news_comment_added.html.erb
@@ -31,4 +31,4 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p><%= t(:text_user_wrote, value: @comment.author) %></p>
 
-<%= format_text @comment.text %>
+<%= format_text @comment.text, only_path: false  %>


### PR DESCRIPTION
`:only_path` must be set to false explicitly to avoid output relative
paths, which results in invalid URLs in the user mailer.

https://community.openproject.org/work_packages/22386/activity
