### PR TITLE
Fix/set empty value if invalid dropdown

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.html
@@ -6,7 +6,7 @@
   </label>
   <select
       ng-disabled="fieldController.state.isBusy"
-      ng-model="field.value.props"
+      ng-model="field.value"
       title="{{ fieldController.editTitle }}"
       class="focus-input inplace-edit-select form--select"
       id="inplace-edit--write-value--{{::field.name}}"

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
@@ -57,7 +57,7 @@ function inplaceEditorDropDown(EditableFieldsState, FocusHelper, inplaceEditAll)
         }
       });
 
-      scope.$watch('field.value.props', function(value) {
+      scope.$watch('field.value', function(value) {
         if (value === undefined) {
           scope.field.value = scope.customEditorController.emptyOption;
         }
@@ -86,7 +86,8 @@ function InplaceEditorDropDownController($q, $scope, WorkPackageFieldConfigurati
         return _.extend({}, item._links.self, {
           name: item._links.self.title || item.value,
           group: WorkPackageFieldConfigurationService
-                   .getDropDownOptionGroup($scope.field.name, item)
+                   .getDropDownOptionGroup($scope.field.name, item),
+          props: { href: item._links.self.href }
         });
       });
     }
@@ -96,7 +97,7 @@ function InplaceEditorDropDownController($q, $scope, WorkPackageFieldConfigurati
 
   this.hasNullOption = function() {
     return !$scope.field.isRequired() ||
-      $scope.field.value.props.href === customEditorController.emptyOption.props.href;
+      $scope.field.value.href === customEditorController.emptyOption.href;
   };
 
   this.updateAllowedValues = function(field) {
@@ -115,7 +116,7 @@ function InplaceEditorDropDownController($q, $scope, WorkPackageFieldConfigurati
           options = extractOptions(values);
 
           if ($scope.field.value === null ||
-              _.find(options, { props: { href: $scope.field.value.href } }) === undefined) {
+              _.find(options, { href: $scope.field.value.href }) === undefined) {
             $scope.field.value = customEditorController.emptyOption;
           }
 

--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-drop-down/edit-drop-down.directive.js
@@ -96,7 +96,7 @@ function InplaceEditorDropDownController($q, $scope, WorkPackageFieldConfigurati
 
   this.hasNullOption = function() {
     return !$scope.field.isRequired() ||
-      $scope.field.value.href === customEditorController.emptyOption.href;
+      $scope.field.value.props.href === customEditorController.emptyOption.props.href;
   };
 
   this.updateAllowedValues = function(field) {
@@ -114,9 +114,8 @@ function InplaceEditorDropDownController($q, $scope, WorkPackageFieldConfigurati
 
           options = extractOptions(values);
 
-          var nullUsed = false;
-          if ($scope.field.value === null) {
-            nullUsed = true;
+          if ($scope.field.value === null ||
+              _.find(options, { props: { href: $scope.field.value.href } }) === undefined) {
             $scope.field.value = customEditorController.emptyOption;
           }
 

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -148,7 +148,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     return $http.get(href).then(function(r) {
       var options = [];
       options = _.map(r.data._embedded.elements, function(item) {
-        return _.extend({}, item._links.self, { name: item.name });
+        return _.extend({}, item._links.self, { name: item.name, props: { href: item._links.self.href } });
       });
       return options;
     });

--- a/frontend/tests/unit/tests/components/inplace-edit/directives/edit-drop-down.directive.test.js
+++ b/frontend/tests/unit/tests/components/inplace-edit/directives/edit-drop-down.directive.test.js
@@ -47,9 +47,9 @@ describe('Inplace editor drop-down directive', function() {
     scope = $rootScope.$new();
 
     allowedValues = [
-      { href: '/1', name: 'zzzzzz'},
-      { href: '/2', name: 'mmmmmm'},
-      { href: '/3', name: 'aaaaaa'}
+      { props: { href: '/1' }, href: '/1', name: 'zzzzzz'},
+      { props: { href: '/2' }, href: '/2', name: 'mmmmmm'},
+      { props: { href: '/3' }, href: '/3', name: 'aaaaaa'}
     ];
 
     var allowedValuePromise = $q(function(resolve) {
@@ -59,9 +59,8 @@ describe('Inplace editor drop-down directive', function() {
     scope.field = {
       getAllowedValues: sinon.stub().returns(allowedValuePromise),
       allowedValuesEmbedded: sinon.stub().returns(false),
-      format: sinon.stub().returns({ props: { name: allowedValues[0].name } }),
       isRequired: sinon.stub().returns(true),
-      value: { props: { href: allowedValues[0].href } }
+      value: allowedValues[0]
     };
 
     // severing dependency from the work package field directive as described by
@@ -73,24 +72,43 @@ describe('Inplace editor drop-down directive', function() {
     element.data('$workPackageFieldController', workPackageFieldController);
 
     workPackageFieldConfigurationService.getDropdownSortingStrategy = sinon.stub().returns(null);
-
-    angularCompile(element)(scope);
-    scope.$digest();
   }));
 
-  it('has options to choose from', function () {
-    var amount = element.find('.inplace-edit-select > option').length;
-    expect(amount).to.equal(allowedValues.length);
-  });
+  describe('with a current value', function() {
+    beforeEach(function() {
+      angularCompile(element)(scope);
+      scope.$apply();
+    });
 
-  it('prints the allowedValues as options', function() {
-    element.find('.inplace-edit-select > option').each(function(index) {
-      expect(angular.element(this).text()).to.equal(allowedValues[index].name);
+    it('has options to choose from', function () {
+      var amount = element.find('.inplace-edit-select > option').length;
+      expect(amount).to.equal(allowedValues.length);
+    });
+
+    it('prints the allowedValues as options', function() {
+      element.find('.inplace-edit-select > option').each(function(index) {
+        expect(angular.element(this).text()).to.equal(allowedValues[index].name);
+      });
+    });
+
+    it('preselects a value', function() {
+      var selectedText = element.find('.inplace-edit-select > option:selected').text();
+      expect(selectedText).to.equal(allowedValues[0].name);
     });
   });
 
-  it('preselects a value', function() {
-    var selectedText = element.find('.inplace-edit-select > option:selected').text();
-    expect(selectedText).to.equal(allowedValues[0].name);
+  describe('with an invalid current value', function() {
+    beforeEach(function() {
+      scope.field.value =  { props: { href: 'invalid/invalid' },
+                             href: 'invalid/invalid',
+                             name: 'invalid'};
+
+      angularCompile(element)(scope);
+      scope.$digest();
+    });
+
+    it('peselects the empty value', function() {
+      expect(scope.field.value.props.href).to.equal(null);
+    });
   });
 });


### PR DESCRIPTION
Allows setting empty values if the value is no longer valid. The problem becomes apparent when a work package's assignee/responsible is removed from the project.

https://community.openproject.org/work_packages/22544/activity
