### PR TITLE
Fix n+1 query in project tree select option helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,27 +222,29 @@ module ApplicationHelper
     end
   end
 
-  def project_tree_options_for_select(projects, options = {}, &_block)
-    Project.project_level_list(projects).map { |element|
+  def project_tree_options_for_select(projects, selected: nil, disabled: {}, &_block)
+    options = ''.html_safe
+    Project.project_level_list(projects).each do |element|
+      identifier = element[:project].id
       tag_options = {
-        value: h(element[:project].id),
+        value: h(identifier),
         title: h(element[:project].name),
       }
 
-      if options[:selected] == element[:project] ||
-         (options[:selected].respond_to?(:include?) &&
-          options[:selected].include?(element[:project]))
-
-        tag_options[:selected] = 'selected'
+      if !selected.nil? && selected.id == identifier
+        tag_options[:selected] = true
       end
 
-      level_prefix = ''
-      level_prefix = ('&nbsp;' * 3 * element[:level] + '&#187; ').html_safe if element[:level] > 0
+      tag_options[:disabled] = true if disabled.include? identifier
 
-      tag_options.merge!(yield(element[:project])) if block_given?
+      content = ''.html_safe
+      content << ('&nbsp;' * 3 * element[:level] + '&#187; ').html_safe if element[:level] > 0
+      content << element[:project].name
 
-      content_tag('option', level_prefix + h(element[:project].name), tag_options)
-    }.join('').html_safe
+      options << content_tag('option', content, tag_options)
+    end
+
+    options
   end
 
   # Yields the given block for each project with its level in the tree

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -126,12 +126,11 @@ module UsersHelper
   end
 
   # Options for the new membership projects combo-box
+  #
+  # Disables projects the user is already member in
   def options_for_membership_project_select(user, projects)
-    options = content_tag('option', "--- #{l(:actionview_instancetag_blank_option)} ---")
-    options << project_tree_options_for_select(projects) { |p|
-      { disabled: (user.projects.include?(p)) }
-    }
-    options
+    options = project_tree_options_for_select(projects, disabled: user.projects.ids.to_set)
+    content_tag('option', "--- #{l(:actionview_instancetag_blank_option)} ---") + options
   end
 
   def user_mail_notification_options(user)


### PR DESCRIPTION
Refactors the Project tree select option helper to load the identifiers
of a user's projects before mapping over it.

Unearthed while fixing https://community.openproject.org/work_packages/22205/activity
