### PR TITLE
[22562] Button too close in news block (overview page)

### DIFF
--- a/app/assets/stylesheets/content/_news.sass
+++ b/app/assets/stylesheets/content/_news.sass
@@ -27,6 +27,8 @@
 //++
 
 .news
+  &:last-of-type
+    margin-bottom: 1.25rem
   &.box > p
     margin-top: -15px
 

--- a/app/assets/stylesheets/content/_news.sass
+++ b/app/assets/stylesheets/content/_news.sass
@@ -27,8 +27,8 @@
 //++
 
 .news
-  &:last-of-type
-    margin-bottom: 1.25rem
+  margin-bottom: 3rem
+
   &.box > p
     margin-top: -15px
 
@@ -39,14 +39,12 @@
   .additional-information
     font-size: 11px
 
-h4.overview
-  margin-bottom: 0
-  border: 0
+  .news--comment
+    font-size: 11px
 
 .summary
   font-style: italic
+  font-size: 1rem
 
 p.author
   font-style: italic
-  /* to accomodate the .profile-wrap class
-  height: 42px

--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -28,12 +28,12 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div class="news">
   <%= link_to_project(news.project) + ': ' unless @project %>
-  <h4 class='overview'><%= link_to h(news.title), news_path(news) %></h4>
+  <h3 class='overview'><%= link_to h(news.title), news_path(news) %></h3>
   <p class="author additional-information"><%= authoring news.created_on, news.author %></p>
-  <div>
-    <%= "(#{l(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %>
+  <div class="news--comment">
     <% unless news.summary.blank? %>
       <div class="summary"><%=h news.summary %></div>
     <% end %>
+    <%= "(#{l(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %>
   </div>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -65,12 +65,12 @@ See doc/COPYRIGHT.rdoc for more details.
             </li>
           <% end %>
         </ul>
-        <p>
+        <div>
           <%= link_to l(:label_work_package_view_all), {controller: :work_packages, action: :index, project_id: @project}, class: 'button -highlight' %>
           <% if User.current.allowed_to?(:view_calendar, @project, global: true) %>
             <%= link_to(l(:label_calendar), {controller: '/work_packages/calendars', action: 'index', project_id: @project}, class: 'button -highlight') %>
           <% end %>
-        </p>
+        </div>
       </div>
     <% end %>
     <%= call_hook(:view_projects_show_left, project: @project) %>
@@ -86,7 +86,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <span class="widget-box--header-title"><%=l(:label_news_latest)%></span>
         </h3>
         <%= render partial: 'news/news', collection: @news %>
-        <p><%= link_to l(:label_news_view_all), {controller: '/news', action: 'index', project_id: @project}, class: 'button -highlight' %></p>
+        <div><%= link_to l(:label_news_view_all), {controller: '/news', action: 'index', project_id: @project}, class: 'button -highlight' %></div>
       </div>
     <% end %>
     <%= call_hook(:view_projects_show_right, project: @project) %>


### PR DESCRIPTION
This adds a distance to the button after the last element in news block on the overview page.

https://community.openproject.org/work_packages/22562/activity
