### PR TITLE
[22564] Label overlaps fields on small screens when copying a WP

### DIFF
--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -29,13 +29,13 @@ See doc/COPYRIGHT.rdoc for more details.
 <h2><%= l(:label_bulk_edit_selected_work_packages) %></h2>
 <ul><%= @work_packages.collect {|i| content_tag('li', link_to(h("#{i.type} ##{i.id}"), work_package_path(i)) + h(": #{i.subject}")) }.join("\n").html_safe %></ul>
 <%= styled_form_tag(url_for(controller: '/work_packages/bulk', action: :update),
-             method: :put) do %>
+             method: :put, class: '-wide-labels') do %>
   <%= @work_packages.collect {|i| hidden_field_tag('ids[]', i.id)}.join.html_safe %>
   <section class="form--section">
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= l(:label_change_properties) %></legend>
       <div class="grid-block">
-        <div class="grid-content">
+        <div class="grid-content medium-6">
           <div class="form--field">
             <label class="form--label" for="work_package_type_id"><%= WorkPackage.human_attribute_name(:type) %></label>
             <div class="form--field-container">
@@ -103,7 +103,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
           <%= call_hook(:view_work_packages_bulk_edit_details_bottom, { work_packages: @work_packages }) %>
         </div>
-        <div class="grid-content">
+        <div class="grid-content medium-6">
           <% if @project && User.current.allowed_to?(:manage_subtasks, @project) %>
             <div class="form--field">
               <label class="form--label" for='work_package_parent_id'><%= WorkPackage.human_attribute_name(:parent) %></label>

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -33,13 +33,13 @@ See doc/COPYRIGHT.rdoc for more details.
     <li><%= link_to_work_package work_package %></li>
   <% end -%>
 </ul>
-<%= styled_form_tag({action: 'create'}, id: 'move_form') do %>
+<%= styled_form_tag({action: 'create'}, id: 'move_form', class: '-wide-labels') do %>
   <%= @work_packages.collect {|i| hidden_field_tag('ids[]', i.id)}.join.html_safe %>
   <section class="form--section">
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= l(:label_change_properties) %></legend>
       <div class="grid-block">
-        <div class="grid-content">
+        <div class="grid-content medium-6">
           <div class="form--field">
             <label class="form--label" for="new_project_id"><%= WorkPackage.human_attribute_name(:project) %>:</label>
             <div class="form--field-container">
@@ -94,7 +94,7 @@ See doc/COPYRIGHT.rdoc for more details.
             </div>
           </div>
         </div>
-        <div class="grid-content">
+        <div class="grid-content medium-6">
           <div class="form--field">
             <label class="form--label" for='start_date'><%= WorkPackage.human_attribute_name(:start_date) %></label>
             <div class="form--field-container">


### PR DESCRIPTION
This sets the `-wide-labels` class to avoid that the forms overlap their labels on small screens. Since it does not only apply for copying a WP, but for build editing too, it is done there too.

https://community.openproject.org/work_packages/22564/activity
