### PR TITLE
[22498] Long WP names shall a appear on hover

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-display/display-user/display-user.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-display/display-user/display-user.directive.html
@@ -9,11 +9,13 @@
       <a ng-if="!user.isGroup"
          ng-href="{{user.href}}"
          class="user-field-user-link"
-         aria-label="{{field.getKeyValue()}}">
+         aria-label="{{field.getKeyValue()}}"
+         title="{{ user.name }}">
         {{user.name}}
       </a>
       <span ng-if="user.isGroup"
-            class="user-field-user-link">
+            class="user-field-user-link"
+            title="{{ user.name }}">
         {{user.name}}
       </span>
     </span>
@@ -22,7 +24,8 @@
       {{ field.placeholder }}
     </span>
     <span class="user-avatar--role"
-          ng-if="user.role">
+          ng-if="user.role"
+          title="{{ user.role }}">
       {{user.role}}
     </span>
   </span>

--- a/frontend/app/components/inplace-edit/directives/field-display/display-version/display-version.directive.html
+++ b/frontend/app/components/inplace-edit/directives/field-display/display-version/display-version.directive.html
@@ -5,12 +5,14 @@
     </span>
     <span ng-if="field.text && customEditorController.isVersionLinkViewable()">
       <a ng-href="{{ customEditorController.getVersionLink() }}"
-         aria-label="{{ field.getKeyValue() }}">
+         aria-label="{{ field.getKeyValue() }}"
+         title="{{ field.text.props.name }}">
         {{field.text.props.name}}
       </a>
     </span>
     <span ng-if="field.text && !customEditorController.isVersionLinkViewable()"
-          wp-accessible-attribute="field">
+          wp-accessible-attribute="field"
+          title="{{ field.text.props.name }}">
       {{field.text.props.name}}
     </span>
 </div>

--- a/frontend/app/templates/inplace-edit/display/fields/embedded.html
+++ b/frontend/app/templates/inplace-edit/display/fields/embedded.html
@@ -1,2 +1,3 @@
 <span wp-accessible-attribute="field"
-      ng-bind="field.text.props.name || field.text.props.value || field.placeholder"></span>
+      ng-bind="field.text.props.name || field.text.props.value || field.placeholder"
+      title="{{ field.text.props.name || field.text.props.value || field.placeholder }}"></span>

--- a/frontend/app/templates/inplace-edit/display/fields/text.html
+++ b/frontend/app/templates/inplace-edit/display/fields/text.html
@@ -3,4 +3,5 @@
       wp-accessible-attribute="field"></span>
 <span ng-if="!field.isEmpty()"
       ng-bind="field.text"
-      wp-accessible-attribute="field"></span>
+      wp-accessible-attribute="field"
+      title="{{ field.text }}"></span>


### PR DESCRIPTION
This adds a title to the elements on WP page depending on their content. Thus when hovering for example over the title the whole title is shown. Before the user had to click and scroll to see the whole time.
The only exception are the wiki-text-areas since there a title depending on the content doesn't make sense.

https://community.openproject.org/work_packages/22498/activity
