### PR TITLE
[12136] Custom fields are not sorted alphabetically as timelines filter

### DIFF
--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -288,7 +288,7 @@ class Timeline < ActiveRecord::Base
   end
 
   def get_custom_fields
-    project.all_work_package_custom_fields
+    project.all_work_package_custom_fields.sort_by{ |n| n[:name].downcase }
   end
 
   def selected_planning_element_assignee


### PR DESCRIPTION
This sorts the returned custom fields of work packages alphabetically. Thus they are correctly displayed when used as filter in timelines.

https://community.openproject.org/work_packages/12136/activity
