### PR TITLE
[22570] Misaligned filters in timeline filters option

### DIFF
--- a/app/views/timelines/_custom_fields.html.erb
+++ b/app/views/timelines/_custom_fields.html.erb
@@ -46,17 +46,21 @@ custom_fields.each do |custom_field|
                                 [l('timelines.filter.noneElement'), '-1'],
                                 [l('general_text_Yes'), '1'],
                                 [l('general_text_No'), '0']
-                              ], timeline.custom_fields_filter[custom_field.id.to_s]),
-                              class: "cf_boolean_select"
+                              ],
+                              timeline.custom_fields_filter[custom_field.id.to_s]),
+                              class: "cf_boolean_select",
+                              container_class: '-wide'
       %>
     <% elsif custom_field.field_format == 'list' %>
-      <%= hidden_field_tag("timeline[options][custom_fields][#{custom_field.id.to_s}][]",
-            timeline.custom_field_list_value(custom_field.id.to_s),
-            {
-              :"data-values" => list_to_select_object_with_none(custom_field.possible_values).to_json,
-              class: "cf_list_select"
-            }
-          ) %>
+      <span class="form--select-container -wide">
+        <%= hidden_field_tag("timeline[options][custom_fields][#{custom_field.id.to_s}][]",
+              timeline.custom_field_list_value(custom_field.id.to_s),
+              {
+                :"data-values" => list_to_select_object_with_none(custom_field.possible_values).to_json,
+                class: "cf_list_select"
+              }
+            ) %>
+      </span>
     <% end %>
   </div>
   <%


### PR DESCRIPTION
This changes the style of the CF filters in timeline options by applying the same structure/classes like the other filters.

https://community.openproject.org/work_packages/22570/activity
