### PR TITLE
add index on member_roles inherited_from

### DIFF
--- a/db/migrate/20160125143638_index_member_roles_inherited_from.rb
+++ b/db/migrate/20160125143638_index_member_roles_inherited_from.rb
@@ -1,0 +1,36 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class IndexMemberRolesInheritedFrom < ActiveRecord::Migration
+  def change
+    # The index is required for member/member_role deletion when a user
+    # leaves a group.
+    add_index :member_roles, :inherited_from
+  end
+end


### PR DESCRIPTION
Tremendously improves the performance when removing a user from a group and by that fixes:

https://community.openproject.org/work_packages/21533/activity

There are still a whole lot of n+1 queries in the vicinity of the user#show and user#update actions. Tackling that will take a lot of time. But now the one query for inherited member roles which can take up to 1 sec each will perform way faster. In my tests, which are based on a lot of generated data, this is fast enough.
