### PR TITLE
[22571] Checkboxes misaligned when creating a custom field

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -659,11 +659,15 @@ input[readonly].-clickable
   display:     block
   clear:       both
   line-height: $base-line-height
+  padding:  0 2rem 0 0
 
   & > .form--check-box-container
     display:  block
     float:    left
-    padding:  0.125rem 0.5rem 0 0
+    padding-right: 0.5rem
+
+    input[type="checkbox"]
+      vertical-align: middle
 
 .form--field-affix
   flex:           0 0 auto

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -100,14 +100,22 @@ See doc/COPYRIGHT.rdoc for more details.
      when "WorkPackageCustomField" %>
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%=l(:label_type_plural)%></legend>
-      <% for type in @types %>
-        <%= check_box_tag "custom_field[type_ids][]", type.id, (@custom_field.types.include? type),
-              id: "custom_field_type_ids_#{type.id}",
-              class: 'form--checkbox' %>
-        <%= content_tag :label, (type.is_standard) ? l(:label_custom_field_default_type) : h(type),
-              class: "no-css",
-              for: "custom_field_type_ids_#{type.id}" %>
-      <% end %>
+      <div class="form--field">
+        <div class="form--field-container">
+          <% for type in @types %>
+            <%= content_tag :label, '',
+                  class: "form--label-with-check-box",
+                  for: "custom_field_type_ids_#{type.id}" do %>
+              <div class="form--check-box-container">
+                <%= check_box_tag "custom_field[type_ids][]", type.id, (@custom_field.types.include? type),
+                      id: "custom_field_type_ids_#{type.id}",
+                      class: 'form--check-box' %>
+              </div>
+              <%= (type.is_standard) ? l(:label_custom_field_default_type) : h(type) %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
       <%= hidden_field_tag "custom_field[type_ids][]", '' %>
     </fieldset>
     &nbsp;


### PR DESCRIPTION
This changes the structure of the checkboxes used when creating a CF. Further the style was adapted so that the boxes were correctly aligned.

https://community.openproject.org/work_packages/22571/activity
