### PR TITLE
always show new version button

### DIFF
--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -150,15 +150,13 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="generic-table--header-background"></div>
       </div>
     </div>
-    <% if @project.versions.any? %>
-      <div class="generic-table--action-buttons">
-        <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
-                              class: 'button -alt-highlight') do %>
-          <i class="button--icon icon-add"></i>
-          <span class="button--text"><%= l(:label_version_new) %></span>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="generic-table--action-buttons">
+      <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                            class: 'button -alt-highlight') do %>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= l(:label_version_new) %></span>
+      <% end %>
+    </div>
   <% else %>
     <%= no_results_box(action_url: new_project_version_path(@project), display_action: authorize_for('versions', 'new')) %>
   <% end %>


### PR DESCRIPTION
The authorization is done on the link and the link will only be displayed if there are versions already.

Fixes: https://community.openproject.org/work_packages/22584/activity

:warning: requires merging of finnlabs/openproject-backlogs#205 :warning:
