### PR TITLE
Do not fail to start if OpenProject does not have git available

### DIFF
--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -57,6 +57,8 @@ module OpenProject
       if revision.present?
         revision.strip[0..8]
       end
+    rescue
+      nil
     end
 
     REVISION = self.revision


### PR DESCRIPTION
With the packaged install, users that choose to skip the apache addon will also skip the repositories addon, which means `git` won't be automatically installed on the system.

The quick fix is to return nil if we fail to fetch the revision, or we could also add `git` as a dependency for all distributions.

/cc @og
