### PR TITLE
[22601] Add separate regex-based delimiter for incoming mails

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -413,6 +413,13 @@ class MailHandler < ActionMailer::Base
       regex = Regexp.new("^[> ]*(#{delimiters.join('|')})\s*[\r\n].*", Regexp::MULTILINE)
       body = body.gsub(regex, '')
     end
+
+    regex_delimiter = Setting.mail_handler_body_delimiter_regex
+    if regex_delimiter.present?
+      regex = Regexp.new(regex_delimiter, Regexp::MULTILINE)
+      body = body.gsub(regex, '')
+    end
+
     body.strip
   end
 

--- a/app/views/settings/_mail_handler.html.erb
+++ b/app/views/settings/_mail_handler.html.erb
@@ -32,6 +32,9 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= setting_text_area :mail_handler_body_delimiters, rows: 5 %>
       <div class="form--field-instructions"><%= l(:text_line_separated) %></div>
     </div>
+    <div class="form--field">
+      <%= setting_text_field :mail_handler_body_delimiter_regex %>
+      <div class="form--field-instructions"><%= l(:text_regexp_multiline) %></div>
   </section>
   <section class="form--section">
     <div class="form--field"><%= setting_check_box :mail_handler_api_enabled,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1675,6 +1675,7 @@ en:
   setting_mail_handler_api_description: "The email web handler enables OpenProject to receive emails containing specific commands as an instrumentation mechanism (e.g., to create and update work packages)."
   setting_mail_handler_api_key: "API key"
   setting_mail_handler_body_delimiters: "Truncate emails after one of these lines"
+  setting_mail_handler_body_delimiter_regex: "Truncate emails matching this regex"
   setting_new_project_user_role_id: "Role given to a non-admin user who creates a project"
   setting_password_active_rules: "Active character classes"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"
@@ -1789,6 +1790,7 @@ en:
   text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter."
   text_reassign: "Reassign to work package:"
   text_regexp_info: "eg. ^[A-Z0-9]+$"
+  text_regexp_multiline: 'The regex is applied in a multi-line mode. e.g., ^---\s+'
   text_repository_usernames_mapping: "Select or update the OpenProject user mapped to each username found in the repository log.\nUsers with the same OpenProject and repository username or email are automatically mapped."
   text_select_mail_notifications: "Select actions for which email notifications should be sent."
   text_status_changed_by_changeset: "Applied in changeset %{value}."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -194,6 +194,8 @@ notified_events:
   - wiki_content_updated
 mail_handler_body_delimiters:
   default: ''
+mail_handler_body_delimiter_regex:
+  default: ''
 mail_handler_api_enabled:
   default: 0
 mail_handler_api_key:

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -74,6 +74,24 @@ describe MailHandler, type: :model do
     }.to change(User, :count).by(1)
   end
 
+  describe '#cleanup_body' do
+    let(:input) { "Subject:foo\nDescription:bar\n" \
+                  ">>> myserver.example.org 2016-01-27 15:56 >>>\n... (Email-Body) ..." }
+    let(:handler) { MailHandler.send :new }
+
+    context 'with regex delimiter' do
+      before do
+        allow(Setting).to receive(:mail_handler_body_delimiter_regex).and_return('>>>.+?>>>.*')
+        allow(handler).to receive(:plain_text_body).and_return(input)
+        expect(handler).to receive(:cleaned_up_text_body).and_call_original
+      end
+
+      it 'removes the irrelevant lines' do
+        expect(handler.send(:cleaned_up_text_body)).to eq("Subject:foo\nDescription:bar")
+      end
+    end
+  end
+
   private
 
   FIXTURES_PATH = File.dirname(__FILE__) + '/../fixtures/mail_handler'


### PR DESCRIPTION
This adds a simple additional field to let the input body of mails be
delimited by a regex provided by the user, since all other delimiters
are escaped before being used by regex.

Since we don't want to force existing user of the feature to change
their settings, simply removing the regex escape is not a viable option.

https://community.openproject.org/work_packages/22601
