### PR TITLE
[22485] Pass proper ids array to legacy bulk delete controller

### DIFF
--- a/frontend/app/components/common/path-heleper/path-helper.service.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.js
@@ -104,9 +104,6 @@ function PathHelper() {
     workPackageDetailsCopyPath: function(projectId, workPackageId) {
       return '/projects/' + projectId + '/work_packages/details/' + workPackageId + '/copy';
     },
-    workPackageDeletePath: function(ids) {
-      return PathHelper.workPackagesBulkDeletePath() + '?ids=' + (Array.isArray(ids) ? ids.join() : ids);
-    },
     usersPath: function() {
       return PathHelper.staticBase + '/users';
     },

--- a/frontend/app/components/work-packages/work-package.service.js
+++ b/frontend/app/components/work-packages/work-package.service.js
@@ -31,7 +31,7 @@ angular
   .module('openproject.services')
   .factory('WorkPackageService', WorkPackageService);
 
-function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResource,
+function WorkPackageService($http, PathHelper, UrlParamsHelper, WorkPackagesHelper, HALAPIResource,
     DEFAULT_FILTER_PARAMS, DEFAULT_PAGINATION_OPTIONS, $rootScope, $window, $q, $cacheFactory,
     AuthorisationService, EditableFieldsState, WorkPackageFieldService, NotificationsService,
     inplaceEditErrors) {
@@ -353,7 +353,8 @@ function WorkPackageService($http, PathHelper, WorkPackagesHelper, HALAPIResourc
               .error(function(data, status) {
                 // FIXME catch this kind of failover in angular instead of redirecting
                 // to a rails-based legacy view
-                window.location = PathHelper.workPackageDeletePath(ids);
+                params = UrlParamsHelper.buildQueryString(params);
+                window.location = PathHelper.workPackagesBulkDeletePath() + '?' + params;
 
                 // TODO wire up to API and processs API response
                 // NotificationsService.addError(


### PR DESCRIPTION
When associations have to be removed, the frontend can't directly remove
work packages but instead redirects to the legacy Rails view.

If multiple ids are passed, they are passed comma-separated, while Rails
expects them to be params arrays (as in the moves/copy controller).

https://community.openproject.org/work_packages/22485/activity
