### PR TITLE
[21680] Use pre-generated error message from custom field

### DIFF
--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -58,11 +58,12 @@ module ActiveModel
     # dependent on specific errors (which we use in the APIv3).
     # We therefore add a second information store containing pairs of [symbol, translated_message].
     def add_with_storing_error_symbols(attribute, message = :invalid, options = {})
+      error_symbol = options.fetch(:error_symbol) { message }
       add_without_storing_error_symbols(attribute, message, options)
 
       if store_new_symbols?
-        if message.is_a?(Symbol)
-          symbol = message
+        if error_symbol.is_a?(Symbol)
+          symbol = error_symbol
           partial_message = normalize_message(attribute, message, options)
           full_message = full_message(attribute, partial_message)
         else

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -71,7 +71,7 @@ module ActiveModel
           full_message = message
         end
 
-        writable_symbols_and_messages_for(attribute) << [symbol, full_message]
+        writable_symbols_and_messages_for(attribute) << [symbol, full_message, partial_message]
       end
     end
 
@@ -143,8 +143,8 @@ class Reform::Contract::Errors
     @store_new_symbols = true
 
     errors.keys.each do |attribute|
-      errors.symbols_and_messages_for(attribute).each do |symbol, message|
-        writable_symbols_and_messages_for(attribute) << [symbol, message]
+      errors.symbols_and_messages_for(attribute).each do |symbol, full_message, partial_message|
+        writable_symbols_and_messages_for(attribute) << [symbol, full_message, partial_message]
       end
     end
   end

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -77,7 +77,7 @@ module API
 
           errors.keys.each do |attribute|
             api_attribute_name = ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
-            errors.symbols_and_messages_for(attribute).each do |symbol, full_message|
+            errors.symbols_and_messages_for(attribute).each do |symbol, full_message, _|
               if symbol == :error_readonly
                 api_errors << ::API::Errors::UnwritableProperty.new(api_attribute_name)
               else

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -133,10 +133,10 @@ module Redmine
               # This is important e.g. in the API v3 where the error messages are
               # post processed.
               name = cv.custom_field.accessor_name.to_sym
-              cv.errors.symbols_and_messages_for(attribute).each do |symbol, message|
+              cv.errors.symbols_and_messages_for(attribute).each do |symbol, _, partial_message|
                 # Use the generated message by the custom field
                 # as it may contain specific parameters (e.g., :too_long requires :count)
-                errors.add(name, message, error_symbol: symbol)
+                errors.add(name, partial_message, error_symbol: symbol)
               end
             end
           end

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -132,8 +132,11 @@ module Redmine
               # make the same symbol available on the customized object itself.
               # This is important e.g. in the API v3 where the error messages are
               # post processed.
-              cv.errors.symbols_for(attribute).each do |symbol|
-                errors.add(cv.custom_field.accessor_name.to_sym, symbol)
+              name = cv.custom_field.accessor_name.to_sym
+              cv.errors.symbols_and_messages_for(attribute).each do |symbol, message|
+                # Use the generated message by the custom field
+                # as it may contain specific parameters (e.g., :too_long requires :count)
+                errors.add(name, message, error_symbol: symbol)
               end
             end
           end


### PR DESCRIPTION
Instead of generating a new error message when applying custom field
errors on the customizable model, simply copy the already existing error
message from the custom field, and save the symbol for later API
processing.

This saves both time and avoids errors when CFs require additional
attributes for humanizing the error messages.

https://community.openproject.org/work_packages/21680
