### PR TITLE
[22497] Comment icons not visible on Dark Theme

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_activities_tab.sass
@@ -114,7 +114,7 @@
     a:hover
       text-decoration: none
   .action-icon
-    color: $main-menu-font-color
+    color: $content-icon-link-color
     &::before
       padding: 0 0 0 0.3em
 


### PR DESCRIPTION
This changes the used icon color for a better visibility in all styles.

https://community.openproject.org/work_packages/22497/activity
