### PR TITLE
Fix static paths of Frontend PathHelper

### DIFF
--- a/frontend/app/components/common/path-heleper/path-helper.service.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.js
@@ -31,78 +31,75 @@ angular
   .factory('PathHelper', PathHelper);
 
 function PathHelper() {
-  var PathHelper;
+  var PathHelper,
+      appBasePath = window.appBasePath ? window.appBasePath : '';
 
   return PathHelper = {
-    apiV2: '/api/v2',
-    apiExperimental: '/api/experimental',
-    apiV3: '/api/v3',
-
-    appBasePath:  window.appBasePath ? window.appBasePath : '',
     staticBase:   appBasePath,
 
-    activityFromPath: function(projectIdentifier, from) {
-      var link = '/activity';
+    apiV2: appBasePath + '/api/v2',
+    apiExperimental: appBasePath + '/api/experimental',
+    apiV3: appBasePath + '/api/v3',
 
-      if (projectIdentifier) {
-        link = PathHelper.staticBase + PathHelper.projectPath(projectIdentifier) + link;
-      }
-
-      if (from) {
-        link += '?from=' + from;
-      }
-
-      return link;
-    },
-    boardsPath: function(projectIdentifier) {
-      return PathHelper.projectPath(projectIdentifier) + '/boards';
+    activityPath: function() {
+      return PathHelper.staticBase + '/activity';
     },
     boardPath: function(projectIdentifier, boardIdentifier) {
-      return PathHelper.boardsPath(projectIdentifier) + '/' + boardIdentifier;
+      return PathHelper.projectBoardsPath(projectIdentifier) + '/' + boardIdentifier;
+    },
+    keyboardShortcutsHelpPath: function() {
+      return PathHelper.staticBase + '/help/keyboard_shortcuts';
     },
     messagePath: function(messageIdentifier) {
       return PathHelper.staticBase + '/topics/' + messageIdentifier;
     },
+    myPagePath: function() {
+      return PathHelper.staticBase + '/my/page';
+    },
     projectsPath: function() {
-      return '/projects';
+      return PathHelper.staticBase + '/projects';
     },
     projectPath: function(projectIdentifier) {
       return PathHelper.projectsPath() + '/' + projectIdentifier;
     },
+    projectActivityPath: function(projectIdentifier) {
+      return PathHelper.projectPath(projectIdentifier) + '/activity';
+    },
+    projectBoardsPath: function(projectIdentifier) {
+      return PathHelper.projectPath(projectIdentifier) + '/boards';
+    },
+    projectCalendarPath: function(projectId) {
+      return PathHelper.projectPath(projectId) + '/work_packages/calendar';
+    },
+    projectNewsPath: function(projectId) {
+      return PathHelper.projectPath(projectId) + '/news';
+    },
+    projectTimelinesPath: function(projectId) {
+      return PathHelper.projectPath(projectId) + '/timelines';
+    },
+    projectTimeEntriesPath: function(projectIdentifier) {
+      return PathHelper.projectPath(projectIdentifier) + '/time_entries';
+    },
+    projectWikiPath: function(projectId) {
+      return PathHelper.projectPath(projectId) + '/wiki';
+    },
     projectWorkPackagesPath: function(projectId) {
-      return PathHelper.projectPath(projectId) + PathHelper.workPackagesPath();
+      return PathHelper.projectPath(projectId) + '/work_packages';
+    },
+    projectWorkPackageNewPath: function(projectId) {
+      return PathHelper.projectWorkPackagesPath(projectId) + '/new';
     },
     queryPath: function(queryIdentifier) {
-      return '/queries/' + queryIdentifier;
+      return PathHelper.staticBase + '/queries/' + queryIdentifier;
     },
-    timeEntriesPath: function(projectIdentifier, workPackageIdentifier) {
-      var path = '/time_entries';
-
-      if (workPackageIdentifier) {
-        return PathHelper.workPackagePath(workPackageIdentifier) + path;
-      } else if (projectIdentifier) {
-        return PathHelper.projectPath(projectIdentifier) + path;
-      }
-
-      return path;
+    timeEntriesPath: function(workPackageId) {
+      return PathHelper.workPackagePath(workPackageId) + '/time_entries';
     },
     timeEntryPath: function(timeEntryIdentifier) {
       return PathHelper.staticBase + '/time_entries/' + timeEntryIdentifier;
     },
     timeEntryEditPath: function(timeEntryIdentifier) {
       return PathHelper.timeEntryPath(timeEntryIdentifier) + '/edit';
-    },
-    workPackagesPath: function() {
-      return '/work_packages';
-    },
-    workPackagePath: function(id) {
-      return PathHelper.staticBase + '/work_packages/' + id;
-    },
-    workPackageCopyPath: function(workPackageId) {
-      return PathHelper.staticBase + '/work_packages/' + workPackageId + '/copy';
-    },
-    workPackageDetailsCopyPath: function(projectId, workPackageId) {
-      return PathHelper.staticBase + '/projects/' + projectId + '/work_packages/details/' + workPackageId + '/copy';
     },
     usersPath: function() {
       return PathHelper.staticBase + '/users';
@@ -111,25 +108,30 @@ function PathHelper() {
       return PathHelper.usersPath() + '/' + id;
     },
     versionsPath: function() {
-      return '/versions';
+      return PathHelper.staticBase + '/versions';
     },
     versionPath: function(versionId) {
       return PathHelper.versionsPath() + '/' + versionId;
     },
-    subProjectsPath: function() {
-      return '/sub_projects';
+    workPackagesPath: function() {
+      return PathHelper.staticBase + '/work_packages';
+    },
+    workPackagePath: function(id) {
+      return PathHelper.staticBase + '/work_packages/' + id;
+    },
+    workPackageCopyPath: function(workPackageId) {
+      return PathHelper.workPackagePath(workPackageId) + '/copy';
+    },
+    workPackageDetailsCopyPath: function(projectIdentifier, workPackageId) {
+      return PathHelper.projectWorkPackagesPath(projectIdentifier) + '/details/' + workPackageId + '/copy';
     },
     workPackagesBulkDeletePath: function() {
       return PathHelper.workPackagesPath() + '/bulk';
     },
-    workPackageJsonAutoCompletePath: function() {
-      return '/work_packages/auto_complete.json';
-    },
-    workPackageNewWithParameterPath: function(projectId, parameters) {
-      var path = '/projects/' + projectId + '/work_packages/new?';
-
-      for (var parameter in parameters) {
-        path += 'work_package[' + parameter + ']=' + parameters[parameter] + ';';
+    workPackageJsonAutoCompletePath: function(projectId) {
+      var path = PathHelper.workPackagesPath() + '/auto_complete.json';
+      if (projectId) {
+        path += '?project_id=' + projectId
       }
 
       return path;
@@ -158,34 +160,34 @@ function PathHelper() {
       return PathHelper.apiProjectPath(projectIdentifier) + '/queries/grouped';
     },
     apiProjectPath: function(projectIdentifier) {
-      return PathHelper.apiExperimental + PathHelper.projectPath(projectIdentifier);
+      return PathHelper.apiExperimental + '/projects/' + projectIdentifier;
     },
     apiProjectQueriesPath: function(projectIdentifier) {
       return PathHelper.apiProjectPath(projectIdentifier) + '/queries';
     },
     apiProjectQueryPath: function(projectIdentifier, queryIdentifier) {
-      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.queryPath(queryIdentifier);
+      return PathHelper.apiProjectPath(projectIdentifier) + '/queries/' + queryIdentifier;
     },
     apiProjectsPath: function(){
-      return PathHelper.apiExperimental + PathHelper.projectsPath();
+      return PathHelper.apiExperimental + '/projects';
     },
     apiProjectSubProjectsPath: function(projectIdentifier) {
-      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.subProjectsPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + '/sub_projects';
     },
     apiProjectUsersPath: function(projectIdentifier) {
       return PathHelper.apiProjectPath(projectIdentifier) + '/users';
     },
     apiVersionsPath: function(projectIdentifier) {
-      return PathHelper.apiExperimental + PathHelper.versionsPath();
+      return PathHelper.apiExperimental + '/versions';
     },
     apiProjectVersionsPath: function(projectIdentifier) {
-      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.versionsPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + '/versions';
     },
     apiProjectWorkPackagesPath: function(projectIdentifier) {
-      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.workPackagesPath();
+      return PathHelper.apiProjectPath(projectIdentifier) + '/work_packages';
     },
     apiProjectWorkPackagesSumsPath: function(projectIdentifier) {
-      return PathHelper.apiProjectPath(projectIdentifier) + PathHelper.workPackagesPath() + '/column_sums';
+      return PathHelper.apiProjectWorkPackagesPath(projectIdentifier) + '/column_sums';
     },
     apiQueriesPath: function() {
       return PathHelper.apiExperimental + '/queries';
@@ -211,11 +213,8 @@ function PathHelper() {
     },
 
     // API V3
-    apiV3BasePath: function() {
-      return PathHelper.staticBase + PathHelper.apiV3;
-    },
     apiConfigurationPath: function() {
-      return PathHelper.apiV3BasePath() + '/configuration';
+      return PathHelper.apiV3 + '/configuration';
     },
     apiQueryStarPath: function(queryId) {
       return PathHelper.apiV3QueryPath(queryId) + '/star';
@@ -224,83 +223,41 @@ function PathHelper() {
       return PathHelper.apiV3QueryPath(queryId) + '/unstar';
     },
     apiV3QueryPath: function(queryId) {
-      return PathHelper.apiV3BasePath() + PathHelper.queryPath(queryId);
+      return PathHelper.apiV3 + '/queries/' + queryId;
     },
     apiV3WorkPackagePath: function(workPackageId) {
-      return PathHelper.apiV3BasePath() + '/work_packages/' + workPackageId;
+      return PathHelper.apiV3 + '/work_packages/' + workPackageId;
     },
     apiV3WorkPackageFormPath: function(projectIdentifier) {
       return PathHelper.apiv3ProjectWorkPackagesPath(projectIdentifier) + '/form';
     },
     apiPrioritiesPath: function() {
-      return PathHelper.apiV3BasePath() + '/priorities';
+      return PathHelper.apiV3 + '/priorities';
     },
-    apiV3ProjectsPath: function(projectIdentifier) {
-      return PathHelper.apiV3BasePath() + PathHelper.projectsPath() + '/' + projectIdentifier;
+    apiV3ProjectPath: function(projectIdentifier) {
+      return PathHelper.apiV3 + '/projects/' + projectIdentifier;
     },
     apiv3ProjectWorkPackagesPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/work_packages';
+      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/work_packages';
     },
     apiV3ProjectCategoriesPath: function(projectIdentifier) {
-      return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/categories';
+      return PathHelper.apiV3ProjectPath(projectIdentifier) + '/categories';
     },
     apiV3TypePath: function(typeId) {
-      return PathHelper.apiV3BasePath() + '/types/' + typeId;
+      return PathHelper.apiV3 + '/types/' + typeId;
     },
     apiV3UserPath: function(userId) {
-      return PathHelper.apiV3BasePath() + '/users/' + userId;
+      return PathHelper.apiV3 + '/users/' + userId;
     },
     apiStatusesPath: function() {
-      return PathHelper.apiV3BasePath() + '/statuses';
+      return PathHelper.apiV3 + '/statuses';
     },
     apiProjectWorkPackageTypesPath: function(projectIdentifier) {
       return PathHelper.apiV3ProjectsPath(projectIdentifier) + '/types';
     },
     apiWorkPackageTypesPath: function() {
-      return PathHelper.apiV3BasePath() + '/types';
+      return PathHelper.apiV3 + '/types';
     },
-    // Static
-    staticUserPath: function(userId) {
-      return PathHelper.userPath(userId);
-    },
-    staticWorkPackagePath: function(workPackageId) {
-      return PathHelper.workPackagePath(workPackageId);
-    },
-    staticProjectPath: function(projectIdentifier) {
-      return PathHelper.staticBase + PathHelper.projectPath(projectIdentifier);
-    },
-    staticVersionPath: function(versionId) {
-      return PathHelper.staticBase + PathHelper.versionPath(versionId);
-    },
-    staticProjectWorkPackagesPath: function(projectId) {
-      return PathHelper.staticBase + PathHelper.projectWorkPackagesPath(projectId);
-    },
-    staticWorkPackagesPath: function() {
-      return PathHelper.staticBase + PathHelper.workPackagesPath();
-    },
-    staticWorkPackageNewWithParametersPath: function(projectId, parameters) {
-      return PathHelper.staticBase + PathHelper.workPackageNewWithParameterPath(projectId, parameters);
-    },
-    staticWorkPackagesAutocompletePath: function(projectId) {
-      return PathHelper.staticBase + '/work_packages/auto_complete.json?project_id=' + projectId;
-    },
-    staticProjectWikiPath: function(projectId) {
-      return PathHelper.staticProjectPath(projectId) + '/wiki';
-    },
-    staticProjectCalendarPath: function(projectId) {
-      return PathHelper.staticProjectPath(projectId) + '/work_packages/calendar';
-    },
-    staticProjectNewsPath: function(projectId) {
-      return PathHelper.staticProjectPath(projectId) + '/news';
-    },
-    staticProjectTimelinesPath: function(projectId) {
-      return PathHelper.staticProjectPath(projectId) + '/timelines';
-    },
-    staticMyPagePath: function() {
-      return PathHelper.staticBase + '/my/page';
-    },
-    staticKeyboardShortcutsHelpPath: function() {
-      return PathHelper.staticBase + '/help/keyboard_shortcuts';
-    }
+
   };
 }

--- a/frontend/app/components/common/path-heleper/path-helper.service.test.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.test.js
@@ -38,7 +38,7 @@ describe('PathHelper', function() {
     var projectIdentifier = 'majora';
 
     it('should provide the project\'s path', function() {
-      expect(PathHelper.apiV3ProjectsPath(projectIdentifier)).to.equal('/api/v3/projects/majora');
+      expect(PathHelper.apiV3ProjectPath(projectIdentifier)).to.equal('/api/v3/projects/majora');
     });
 
     it('should provide a path to the project\'s categories', function() {

--- a/frontend/app/components/inplace-edit/directives/field-display/display-user/display-user.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-display/display-user/display-user.directive.js
@@ -66,7 +66,7 @@ function InplaceDisplayUserController($scope, PathHelper) {
   var getHref = function(user) {
     var id = user.props.id;
 
-    return PathHelper.staticUserPath(id);
+    return PathHelper.userPath(id);
   };
 
   var getAvatar = function(user) {

--- a/frontend/app/components/inplace-edit/directives/field-display/display-version/display-version.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-display/display-version/display-version.directive.js
@@ -51,7 +51,7 @@ function InplaceDisplayVersionController($scope, PathHelper) {
     return version.links.definingProject && version.links.definingProject.href;
   };
   this.getVersionLink = function() {
-    return field.text && PathHelper.staticVersionPath(field.text.props.id);
+    return field.text && PathHelper.versionPath(field.text.props.id);
   };
 }
 InplaceDisplayVersionController.$inject = ['$scope', 'PathHelper'];

--- a/frontend/app/components/routing/controllers/work-package-details.controller.js
+++ b/frontend/app/components/routing/controllers/work-package-details.controller.js
@@ -84,14 +84,14 @@ function WorkPackageDetailsController($scope, $state, workPackage, I18n, RELATIO
       $scope.watchers = workPackage.embedded.watchers.embedded.elements;
     }
 
-    $scope.showStaticPagePath = PathHelper.staticWorkPackagePath($scope.workPackage.props.id);
+    $scope.showStaticPagePath = PathHelper.workPackagePath($scope.workPackage.props.id);
 
     // Type
     $scope.type = workPackage.embedded.type;
 
     // Author
     $scope.author = workPackage.embedded.author;
-    $scope.authorPath = PathHelper.staticUserPath($scope.author.props.id);
+    $scope.authorPath = PathHelper.userPath($scope.author.props.id);
     $scope.authorActive = UsersHelper.isActive($scope.author);
 
     // Attachments

--- a/frontend/app/components/routing/controllers/work-package-show.controller.js
+++ b/frontend/app/components/routing/controllers/work-package-show.controller.js
@@ -155,14 +155,14 @@ function WorkPackageShowController($scope, $rootScope, $state, workPackage, I18n
       $scope.watchers = workPackage.embedded.watchers.embedded.elements;
     }
 
-    $scope.showStaticPagePath = PathHelper.staticWorkPackagePath($scope.workPackage.props.id);
+    $scope.showStaticPagePath = PathHelper.workPackagePath($scope.workPackage.props.id);
 
     // Type
     $scope.type = workPackage.embedded.type;
 
     // Author
     $scope.author = workPackage.embedded.author;
-    $scope.authorPath = PathHelper.staticUserPath($scope.author.props.id);
+    $scope.authorPath = PathHelper.userPath($scope.author.props.id);
     $scope.authorActive = UsersHelper.isActive($scope.author);
 
     // Attachments

--- a/frontend/app/components/wp-activity/activity-entry.directive.js
+++ b/frontend/app/components/wp-activity/activity-entry.directive.js
@@ -46,7 +46,7 @@ function activityEntry(PathHelper) {
 
     link: function(scope) {
       var projectId = scope.workPackage.embedded.project.props.id;
-      scope.autocompletePath = PathHelper.staticWorkPackagesAutocompletePath(projectId);
+      scope.autocompletePath = PathHelper.workPackageJsonAutoCompletePath(projectId);
 
       scope.activityType = scope.activity.props._type;
       scope.activityLabel = I18n.t('js.label_activity_no', { activityNo: scope.activityNo });

--- a/frontend/app/components/wp-table/directives/wp-column/wp-column.directive.js
+++ b/frontend/app/components/wp-table/directives/wp-column/wp-column.directive.js
@@ -137,15 +137,15 @@ function WorkPackageColumnController($scope, PathHelper, WorkPackagesHelper) {
           return '';
         }
 
-        return PathHelper.staticUserPath(id);
+        return PathHelper.userPath(id);
       },
 
       get version() {
-        return PathHelper.staticVersionPath(id);
+        return PathHelper.versionPath(id);
       },
 
       get project() {
-        return PathHelper.staticProjectPath(id);
+        return PathHelper.projectPath(id);
       }
     };
 

--- a/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.js
@@ -55,7 +55,7 @@ function wpTable(WorkPackagesTableService, $window, featureFlags, PathHelper){
       var activeSelectionBorderIndex;
 
       scope.workPackagesTableData = WorkPackagesTableService.getWorkPackagesTableData();
-      scope.workPackagePath = PathHelper.staticWorkPackagePath;
+      scope.workPackagePath = PathHelper.workPackagePath;
 
       var topMenuHeight = angular.element('#top-menu').prop('offsetHeight') || 0;
       scope.adaptVerticalPosition = function(event) {

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -149,9 +149,9 @@ module.exports = function(I18n, PaginationService, PathHelper) {
       var relativeUrl;
 
       if (query.project_id) {
-        relativeUrl = PathHelper.staticProjectWorkPackagesPath(query.project_id);
+        relativeUrl = PathHelper.projectWorkPackagesPath(query.project_id);
       } else {
-        relativeUrl = PathHelper.staticWorkPackagesPath();
+        relativeUrl = PathHelper.workPackagesPath();
       }
 
       return query.exportFormats.map(function(format){

--- a/frontend/app/services/keyboard-shortcut-service.js
+++ b/frontend/app/services/keyboard-shortcut-service.js
@@ -47,15 +47,15 @@ module.exports = function($window, $rootScope, $timeout, PathHelper) {
   var shortcuts = {
     '?': showHelpModal,
     'up up down down left right left right b a enter': showHelpModal,
-    'g m': 'staticMyPagePath',
-    'g o': projectScoped('staticProjectPath'),
-    'g w p': projectScoped('staticProjectWorkPackagesPath'),
-    'g w i': projectScoped('staticProjectWikiPath'),
+    'g m': 'myPagePath',
+    'g o': projectScoped('projectPath'),
+    'g w p': projectScoped('projectWorkPackagesPath'),
+    'g w i': projectScoped('projectWikiPath'),
     'g a': projectScoped('activityFromPath'),
-    'g c': projectScoped('staticProjectCalendarPath'),
-    'g n': projectScoped('staticProjectNewsPath'),
-    'g t': projectScoped('staticProjectTimelinesPath'),
-    'n w p': projectScoped('staticWorkPackageNewWithParametersPath'),
+    'g c': projectScoped('projectCalendarPath'),
+    'g n': projectScoped('projectNewsPath'),
+    'g t': projectScoped('projectTimelinesPath'),
+    'n w p': projectScoped('projectWorkPackageNewPath'),
 
     'g e': accessKey('edit'),
     'g p': accessKey('preview'),
@@ -116,7 +116,7 @@ module.exports = function($window, $rootScope, $timeout, PathHelper) {
   }
 
   function showHelpModal() {
-    modalHelperInstance.createModal(PathHelper.staticKeyboardShortcutsHelpPath());
+    modalHelperInstance.createModal(PathHelper.keyboardShortcutsHelpPath());
   }
 
   // this could be extracted into a separate component if it grows

--- a/frontend/app/services/query-service.js
+++ b/frontend/app/services/query-service.js
@@ -395,9 +395,9 @@ module.exports = function(
 
     getQueryPath: function(query) {
       if (query.project_id) {
-        return PathHelper.staticProjectWorkPackagesPath(query.project_id) + '?query_id=' + query.id;
+        return PathHelper.projectWorkPackagesPath(query.project_id) + '?query_id=' + query.id;
       } else {
-        return PathHelper.staticWorkPackagesPath() + '?query_id=' + query.id;
+        return PathHelper.workPackagesPath() + '?query_id=' + query.id;
       }
     },
 

--- a/frontend/app/time_entries/controllers/time-entries-controller.js
+++ b/frontend/app/time_entries/controllers/time-entries-controller.js
@@ -35,6 +35,14 @@ module.exports = function($scope, $http, PathHelper, SortService, PaginationServ
   SortService.setColumn(gon.sort_column);
   SortService.setDirection(gon.sort_direction);
 
+  function timeEntriesPath(projectId, workPackageId) {
+    if (workPackageIdentifier) {
+      return PathHelper.timeEntriesPath(workPackageId);
+    } else if (projectIdentifier) {
+      return PathHelper.projectTimeEntriesPath(projectIdentifier);
+    }
+  }
+
   $scope.loadTimeEntries = function() {
     $scope.isLoading = true;
 

--- a/frontend/app/timelines/models/project.js
+++ b/frontend/app/timelines/models/project.js
@@ -415,7 +415,7 @@ module.exports = function(PathHelper) {
       return this.getParent();
     },
     getUrl: function() {
-      var url = PathHelper.staticProjectPath(this.identifier);
+      var url = PathHelper.projectPath(this.identifier);
 
       url += "/timelines";
 

--- a/frontend/app/ui_components/authoring-directive.js
+++ b/frontend/app/ui_components/authoring-directive.js
@@ -40,11 +40,21 @@ module.exports = function(I18n, PathHelper, TimezoneService) {
       var timeago = createdOn.fromNow();
       var time = createdOn.format('LLL');
 
+      function activityFromPath(project, from) {
+        var path = PathHelper.projectActivityPath(project);
+
+        if (from) {
+          path += '?from=' + from;
+        }
+
+        return path;
+      }
+
       scope.I18n = I18n;
       scope.authorLink = '<a href="'+ PathHelper.userPath(scope.author.id) + '">' + scope.author.name + '</a>';
 
       if (scope.activity) {
-        scope.timestamp = '<a title="' + time + '" href="' + PathHelper.activityFromPath(scope.project, createdOn.format('YYYY-MM-DD')) + '">' + timeago + '</a>';
+        scope.timestamp = '<a title="' + time + '" href="' + activityFromPath(scope.project, createdOn.format('YYYY-MM-DD')) + '">' + timeago + '</a>';
       } else {
         scope.timestamp = '<span class="timestamp" title="' + time + '">' + timeago + '</span>';
       }

--- a/frontend/app/ui_components/user-field-directive.js
+++ b/frontend/app/ui_components/user-field-directive.js
@@ -39,7 +39,7 @@ module.exports = function(PathHelper) {
         }
       });
 
-      scope.userPath = PathHelper.staticUserPath;
+      scope.userPath = PathHelper.userPath;
     }
   };
 };

--- a/frontend/app/work_packages/activities/revision-activity-directive.js
+++ b/frontend/app/work_packages/activities/revision-activity-directive.js
@@ -47,7 +47,7 @@ module.exports = function($compile,
       if (scope.activity.links.author === undefined) {
         scope.userName = scope.activity.props.authorName;
       } else {
-        scope.userPath = PathHelper.staticUserPath;
+        scope.userPath = PathHelper.userPath;
         scope.activity.links.author.fetch().then(function(user) {
           scope.userId = user.props.id;
           scope.userName = user.props.name;

--- a/frontend/app/work_packages/activities/user-activity-directive.js
+++ b/frontend/app/work_packages/activities/user-activity-directive.js
@@ -69,7 +69,7 @@ module.exports = function($uiViewScroll,
       });
 
       scope.I18n = I18n;
-      scope.userPath = PathHelper.staticUserPath;
+      scope.userPath = PathHelper.userPath;
       scope.inEdit = false;
       scope.inPreview = false;
       scope.userCanEdit = !!scope.activity.links.update;

--- a/frontend/app/work_packages/tabs/related-work-package-table-row-directive.js
+++ b/frontend/app/work_packages/tabs/related-work-package-table-row-directive.js
@@ -32,8 +32,8 @@ module.exports = function(I18n, PathHelper, WorkPackagesHelper) {
     restrict: 'A',
     link: function(scope) {
       scope.I18n = I18n;
-      scope.workPackagePath = PathHelper.staticWorkPackagePath;
-      scope.userPath = PathHelper.staticUserPath;
+      scope.workPackagePath = PathHelper.workPackagePath;
+      scope.userPath = PathHelper.userPath;
 
       scope.handler.getRelatedWorkPackage(scope.workPackage, scope.relation).then(function(relatedWorkPackage){
         scope.relatedWorkPackage = relatedWorkPackage;


### PR DESCRIPTION
_Reopened against dev_

This PR strives to end the madness that lives in the PathHelper service by no longer discerning between generic, static, and API paths.

Paths either have a prefix for API (experimental or V3) or are static paths compatible with relative root installations.

Will require a rebase after https://github.com/opf/openproject/pull/4129 is merged.
