### PR TITLE
[22614] Wrongly labeled button on project settings

### DIFF
--- a/app/views/projects/_edit.html.erb
+++ b/app/views/projects/_edit.html.erb
@@ -36,5 +36,5 @@ See doc/COPYRIGHT.rdoc for more details.
                                 render_custom_fields: false
                               } %>
 
-  <%= f.button l(:button_update), class: 'button -highlight -with-icon icon-checkmark' %>
+  <%= f.button l(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
 <% end %>

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -92,7 +92,7 @@ Feature: Project Settings
     When I am already admin
     And  I go to the settings page of the project "project1"
     And  I select "project2" from "Subproject of"
-    And  I click on "Update" within "#content"
+    And  I click on "Save" within "#content"
     And  I follow "Copy" within "#content"
     And  I fill in "Name" with "Copied Project"
     And  I fill in "Identifier" with "cp"


### PR DESCRIPTION
This changes the button text from 'update' to 'save'.

https://community.openproject.org/work_packages/22614/activity
