### PR TITLE
[22616] Missing asterix when creating custom field

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -110,8 +110,8 @@
         Write anything you like.
       </div>
     </div>
-    <div class="form--field">
-      <label class="form--label -required">Email:</label>
+    <div class="form--field -required">
+      <label class="form--label">Email:</label>
       <div class="form--field-container">
         <div class="form--text-field-container">
           <input type="email" class="form--text-field" placeholder="a valid email">

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -31,7 +31,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <section class="form--section" id="custom_field_form">
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name,
-                     multi_locale: true %>
+                     multi_locale: true,
+                     required: true %>
   </div>
   <div class="form--field">
     <%= f.select :field_format,

--- a/app/views/projects/form/attributes/_name.html.erb
+++ b/app/views/projects/form/attributes/_name.html.erb
@@ -28,5 +28,5 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="form--field -required">
-  <%= form.text_field :name %>
+  <%= form.text_field :name, required: true %>
 </div>


### PR DESCRIPTION
This sets the form-fields to required, in order to the the star when creating a new Costume Field or Project.

https://community.openproject.org/work_packages/22616/activity
