### PR TITLE
[21910] Watch button on news page cannot be focused / triggered by keyboard

### DIFF
--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -43,7 +43,7 @@ module WatchersHelper
     path = send(:"#{(watched ? 'unwatch' : 'watch')}_path", object_type: object.class.to_s.underscore.pluralize,
                                                             object_id: object.id,
                                                             replace: options.delete('replace'))
-    html_options[:class] = html_options[:class].to_s + (watched ? ' icon-context icon-watched' : ' icon-context icon-unwatched')
+    html_options[:class] = html_options[:class].to_s + ' button'
 
     method = watched ?
       :delete :
@@ -53,9 +53,11 @@ module WatchersHelper
       l(:button_unwatch) :
       l(:button_watch)
 
-    content_tag :div, class: 'button' do
-      link_to(label, path, html_options.merge(remote: true, method: method))
-    end
+    link_to(content_tag(:i,'', class: watched ? 'button--icon icon-watched' : ' button--icon icon-unwatched') +
+      content_tag(:span, label, class: 'button--text'), path, html_options.merge(remote: true, method: method))
+
+
+
   end
 
   # Returns HTML for a list of users watching the given object


### PR DESCRIPTION
This changes the structure of `watcher_link` constructor so that it is accessible by keyboard now.

https://community.openproject.org/work_packages/21910/activity
