### PR TITLE
[22330] Use back_url for bulk move, copy, and edit

### DIFF
--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -78,7 +78,7 @@ class WorkPackages::MovesController < ApplicationController
         redirect_to project_work_packages_path(@target_project || @project)
       end
     else
-      redirect_to project_work_packages_path(@project)
+      redirect_back_or_default(project_work_packages_path(@project))
     end
   end
 

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -31,6 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= styled_form_tag(url_for(controller: '/work_packages/bulk', action: :update),
              method: :put, class: '-wide-labels') do %>
   <%= @work_packages.collect {|i| hidden_field_tag('ids[]', i.id)}.join.html_safe %>
+  <%= back_url_hidden_field_tag %>
   <section class="form--section">
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= l(:label_change_properties) %></legend>

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -35,6 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 </ul>
 <%= styled_form_tag({action: 'create'}, id: 'move_form', class: '-wide-labels') do %>
   <%= @work_packages.collect {|i| hidden_field_tag('ids[]', i.id)}.join.html_safe %>
+  <%= back_url_hidden_field_tag %>
   <section class="form--section">
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= l(:label_change_properties) %></legend>


### PR DESCRIPTION
This sets the back_url to wherever the bulk request originated from,
allowing users to be redirected to their old work package, query, or
table.

Note that this does not simply work for bulk destroy, since users may
use that functionality from split/full view and will in this case be redirected
to a non-existing resource.
We might pass a query_id in this case (to at least redirect back to queries), however it would be better if the
frontend decided what path the user should be redirected to in this
case.

https://community.openproject.org/work_packages/22330/activity
