### PR TITLE
Pass project to custom field context in bulk mode

### DIFF
--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -111,7 +111,7 @@ module CustomFieldsHelper
     custom_field_label_tag(name, custom_value) + custom_field_tag(name, custom_value)
   end
 
-  def custom_field_tag_for_bulk_edit(name, custom_field)
+  def custom_field_tag_for_bulk_edit(name, custom_field, project=nil)
     field_name = "#{name}[custom_field_values][#{custom_field.id}]"
     field_id = "#{name}_custom_field_values_#{custom_field.id}"
     field_format = Redmine::CustomFieldFormat.find_by_name(custom_field.field_format)
@@ -126,7 +126,7 @@ module CustomFieldsHelper
                                                         [l(:general_text_yes), '1'],
                                                         [l(:general_text_no), '0']]), id: field_id)
     when 'list'
-      styled_select_tag(field_name, options_for_select([[l(:label_no_change_option), '']] + custom_field.possible_values_options), id: field_id)
+      styled_select_tag(field_name, options_for_select([[l(:label_no_change_option), '']] + custom_field.possible_values_options(project)), id: field_id)
     else
       styled_text_field_tag(field_name, '', id: field_id)
     end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -118,13 +118,10 @@ class CustomField < ActiveRecord::Base
   def possible_values_options(obj = nil)
     case field_format
     when 'user', 'version'
-      if obj.respond_to?(:project) && obj.project
-        case field_format
-        when 'user'
-          obj.project.users.sort.map { |u| [u.to_s, u.id.to_s] }
-        when 'version'
-          obj.project.versions.sort.map { |u| [u.to_s, u.id.to_s] }
-        end
+      if obj.is_a?(Project)
+        possible_values_options_in_project(obj)
+      elsif obj.try(:project)
+        possible_values_options_in_project(obj.project)
       else
         []
       end
@@ -132,6 +129,17 @@ class CustomField < ActiveRecord::Base
       locale = obj if obj.is_a?(String) || obj.is_a?(Symbol)
       attribute = possible_values(locale: locale)
       attribute
+    end
+  end
+
+  def possible_values_options_in_project(project)
+    case field_format
+    when 'user'
+      project.users.sort.map { |u| [u.to_s, u.id.to_s] }
+    when 'version'
+      project.versions.sort.map { |u| [u.to_s, u.id.to_s] }
+    else
+      []
     end
   end
 

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -98,7 +98,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <div class="form--field">
               <%= blank_custom_field_label_tag('work_package', custom_field) %>
               <div class="form--field-container">
-                <%= custom_field_tag_for_bulk_edit('work_package', custom_field) %>
+                <%= custom_field_tag_for_bulk_edit('work_package', custom_field, @project) %>
               </div>
             </div>
           <% end %>

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -38,10 +38,11 @@ describe WorkPackages::BulkController, type: :controller do
                        is_for_all: true)
   }
   let(:custom_field_2) { FactoryGirl.create(:work_package_custom_field) }
+  let(:custom_field_user) { FactoryGirl.create(:user_issue_custom_field) }
   let(:status) { FactoryGirl.create(:status) }
   let(:type) {
     FactoryGirl.create(:type_standard,
-                       custom_fields: [custom_field_1, custom_field_2])
+                       custom_fields: [custom_field_1, custom_field_2, custom_field_user])
   }
   let(:project_1) {
     FactoryGirl.create(:project,
@@ -145,6 +146,10 @@ describe WorkPackages::BulkController, type: :controller do
 
           describe '#project' do
             it { assert_select 'select', attributes: { name: "work_package[custom_field_values][#{custom_field_2.id}]" } }
+          end
+
+          describe '#user' do
+            it { assert_select 'select', attributes: { name: "work_package[custom_field_values][#{custom_field_user.id}]" } }
           end
         end
       end


### PR DESCRIPTION
List custom fields such as `user` uses the project to identify potential
options for the custom field selection.

In bulk mode, that context was not passed to the cf helper.

Related to https://community.openproject.org/work_packages/22494/activity
