### PR TITLE
[22654] Searched text is invisible in dark theme

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -151,7 +151,7 @@
     float: none
 
   span.filter-selection
-    @include query-select-dropdown-filter-select($main-menu-font-color)
+    @include query-select-dropdown-filter-select($primary-color)
 
   .dropdown-scrollable
     overflow-y: auto


### PR DESCRIPTION
This changes the font of highlighted search results. Thus it is readable in all themes.

https://community.openproject.org/work_packages/22654/activity
