### PR TITLE
[21680 ] Add frontend validation for integer custom fields

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -477,6 +477,8 @@ en:
       errors:
         required: '%{field} cannot be empty'
         number: '%{field} is not a valid number'
+        maxlength: '%{field} cannot contain more than %{maxLength} digit(s)'
+        minlength: '%{field} cannot contain less than %{minLength} digit(s)'
 
     error_could_not_resolve_version_name: "Couldn't resolve version name"
     error_could_not_resolve_user_name: "Couldn't resolve user name"

--- a/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
+++ b/frontend/app/components/inplace-edit/directives/edit-pane/edit-pane.directive.js
@@ -42,6 +42,7 @@ function inplaceEditorEditPane($timeout, EditableFieldsState, FocusHelper, inpla
     link: function(scope, element, attrs, fieldController) {
       var field = scope.field;
 
+      scope.fieldSchema = field.getFieldSchema();
       scope.fieldController = fieldController;
       scope.editableFieldsState = EditableFieldsState;
 
@@ -103,9 +104,8 @@ function InplaceEditorEditPaneController($scope, $element, $location, $timeout,
       Object.keys(vm.editForm.$error).forEach(function(error) {
 
         if (vm.editForm.$error[error]) {
-          detectedViolations.push(I18n.t('js.inplace.errors.' + error, {
-            field: field.getLabel()
-          }));
+          var localizationArgs = _.extend({ field: field.getLabel() }, field.getFieldSchema());
+          detectedViolations.push(I18n.t('js.inplace.errors.' + error, localizationArgs));
         }
       });
     }

--- a/frontend/app/components/inplace-edit/services/work-package-field.service.js
+++ b/frontend/app/components/inplace-edit/services/work-package-field.service.js
@@ -41,6 +41,11 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     }
   }
 
+  function getFieldSchema(workPackage, field) {
+    var schema = getSchema(workPackage);
+    return schema.props[field];
+  }
+
   function isEditable(workPackage, field) {
     // no form - no editing
     if (!workPackage.form) {
@@ -413,6 +418,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
 
   var WorkPackageFieldService = {
     getSchema: getSchema,
+    getFieldSchema: getFieldSchema,
     isEditable: isEditable,
     isRequired: isRequired,
     isSpecified: isSpecified,

--- a/frontend/app/templates/inplace-edit/edit/fields/integer.html
+++ b/frontend/app/templates/inplace-edit/edit/fields/integer.html
@@ -8,6 +8,8 @@
          id="inplace-edit--write-value--{{::field.name}}"
          name="value"
          type="number"
+         ng-minlength="{{ fieldSchema.minLength }}"
+         ng-maxlength="{{ fieldSchema.maxLength }}"
          ng-disabled="fieldController.state.isBusy"
          ng-required="fieldController.isRequired"
          title="{{ fieldController.editTitle }}"

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -92,6 +92,11 @@ FactoryGirl.define do
         field_format 'text'
         sequence(:name) { |n| "TextWorkPackageCustomField #{n}" }
       end
+
+      factory :integer_issue_custom_field do
+        field_format 'int'
+        sequence(:name) { |n| "IntegerWorkPackageCustomField #{n}" }
+      end
     end
 
     factory :time_entry_custom_field, class: TimeEntryCustomField do

--- a/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'features/work_packages/details/inplace_editor/work_package_field'
+require 'features/work_packages/work_packages_page'
+
+describe 'custom field inplace editor', js: true, selenium: true do
+  let(:user) { FactoryGirl.create :admin }
+  let(:type) { FactoryGirl.create(:type_standard, custom_fields: [custom_field]) }
+  let(:project) {
+    FactoryGirl.create :project,
+                       types: [type],
+                       work_package_custom_fields: [custom_field]
+  }
+
+  let(:work_package) {
+    FactoryGirl.create :work_package,
+                       type: type,
+                       project: project,
+                       custom_values: { custom_field.id => 123 }
+  }
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
+
+  let(:property_name) { :customField1 }
+  let(:work_packages_page) { WorkPackagesPage.new(project) }
+  let(:field) { WorkPackageField.new page, property_name }
+
+  before do
+    login_as(user)
+
+    wp_page.visit!
+    wp_page.ensure_page_loaded
+
+    wp_page.view_all_attributes
+
+    field.activate_edition
+    expect(page).to have_selector("#{field.field_selector} input")
+  end
+
+  def expect_update(value, update_args)
+    field.input_element.set value
+    field.submit_by_click
+    wp_page.expect_notification(update_args)
+  end
+
+  describe 'integer type' do
+    let(:custom_field) {
+      FactoryGirl.create(:integer_issue_custom_field, args.merge(name: 'MyNumber'))
+    }
+
+    context 'with length restrictions' do
+      let(:args) {
+        { min_length: 2, max_length: 5 }
+      }
+
+      it 'renders errors for invalid entries' do
+        # Invalid input (non-digit)
+        expect_update 'certainly no digit',
+                      type: :error,
+                      message: 'MyNumber is not a valid number'
+
+        # exceeding max length
+        expect_update '123456',
+                      type: :error,
+                      message: 'MyNumber cannot contain more than 5 digit(s)'
+
+        # below min length
+        expect_update '1',
+                      type: :error,
+                      message: 'MyNumber cannot contain less than 2 digit(s)'
+
+        # Correct value
+        expect_update '9999',
+                      message: I18n.t('js.notice_successful_update')
+        wp_page.expect_attributes MyNumber: '9999'
+      end
+    end
+
+    context 'no restrictions' do
+      let(:args) { {} }
+      it 'renders errors for invalid entries' do
+        # Invalid input (non-digit)
+        expect_update 'certainly no digit',
+                      type: :error,
+                      message: 'MyNumber is not a valid number'
+
+        # Invalid input (non-digit)
+        expect_update '9999999999',
+                      message: I18n.t('js.notice_successful_update')
+        wp_page.expect_attributes MyNumber: '9999999999'
+
+        # Remove value
+        field.activate_edition
+        expect_update '',
+                      message: I18n.t('js.notice_successful_update')
+        wp_page.expect_attributes MyNumber: '-'
+      end
+    end
+
+    context 'required' do
+      let(:args) { { is_required: true } }
+
+      it 'renders errors for invalid entries' do
+        # Invalid input (non-digit)
+        expect_update '',
+                      type: :error,
+                      message: "MyNumber can't be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Validation for max/minLength on integer custom fields
had to be performed on the API, even though the work package schema
allows the frontend to do that on its own.

This adds min/maxLength from integer custom Fields and fulfills the 'ideal' solution of https://community.openproject.org/work_packages/21680/activity
