### PR TITLE
[11611] Personalize this page: Consistent Wording of the same functionality

### DIFF
--- a/app/views/my/page_layout.html.erb
+++ b/app/views/my/page_layout.html.erb
@@ -80,7 +80,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <li class="toolbar-item">
       <%= link_to({action: 'page'}, class: 'button') do %>
         <i class="button--icon icon-cancel"></i>
-        <span class="button--text"><%= l(:button_back) %></span>
+        <span class="button--text"><%= l(:button_save_back) %></span>
       <% end %>
     </li>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,6 +552,7 @@ en:
   button_reset: "Reset"
   button_rollback: "Rollback to this version"
   button_save: "Save"
+  button_save_back: "Save and back"
   button_show: "Show"
   button_sort: "Sort"
   button_submit: "Submit"


### PR DESCRIPTION
This changes the labeling of the button to 'Save and back' in the personalize my page section.

The PR for the 'my project page' plugin can be found here: https://github.com/finnlabs/openproject-my_project_page/pull/76

https://community.openproject.org/work_packages/11611/activity
