### PR TITLE
[22005] Allow queries to be changed by enter

### DIFF
--- a/frontend/app/components/routing/controllers/work-packages-list.controller.js
+++ b/frontend/app/components/routing/controllers/work-packages-list.controller.js
@@ -216,7 +216,9 @@ function WorkPackagesListController($scope, $rootScope, $state, $stateParams, $l
   $scope.loadQuery = function(queryId) {
     // Clear unsaved changes to current query
     clearUrlQueryParams();
-    loadingIndicator.mainPage = $state.go('work-packages.list', { 'query_id': queryId });
+    loadingIndicator.mainPage = $state.go('work-packages.list',
+                                          { 'query_id': queryId },
+                                          { reload: true });
   };
 
   function updateResults() {

--- a/frontend/app/templates/work_packages/menus/query_select_dropdown_menu.html
+++ b/frontend/app/templates/work_packages/menus/query_select_dropdown_menu.html
@@ -15,10 +15,8 @@
         <div class="title-group-header">{{ group.name }}</div>
         <li ng-repeat="model in group.models"
             ng-class="{'selected': model.highlighted }">
-          <a href=""
+          <a ng-click="switchToSelectedQuery(model.id)"
              title="{{ model.label }}"
-             ui-sref="work-packages.list({ query_id: model.id, query_props: undefined })"
-             ui-sref-opts="{ reload: true }"
              ng-bind-html="model.labelHtml">
           </a>
         </li>

--- a/frontend/app/work_packages/controllers/menus/query-select-dropdown-menu-controller.js
+++ b/frontend/app/work_packages/controllers/menus/query-select-dropdown-menu-controller.js
@@ -89,10 +89,6 @@ module.exports = function($scope, $sce, LABEL_MAX_CHARS, KEY_CODES) {
     }).indexOf(scope.selectedId);
   }
 
-  function performSelect() {
-    scope.transitionMethod(scope.selectedId);
-  }
-
   function nextNonEmptyGroup(groups, currentGroupIndex) {
     currentGroupIndex = (currentGroupIndex === undefined) ? -1 : currentGroupIndex;
     while (currentGroupIndex < groups.length - 1) {
@@ -184,7 +180,7 @@ module.exports = function($scope, $sce, LABEL_MAX_CHARS, KEY_CODES) {
   scope.handleSelection = function(event) {
     switch(event.which) {
       case KEY_CODES.enter:
-        performSelect();
+        scope.switchToSelectedQuery(scope.selectedId);
         preventDefault(event);
         break;
       case KEY_CODES.down:
@@ -199,6 +195,10 @@ module.exports = function($scope, $sce, LABEL_MAX_CHARS, KEY_CODES) {
         break;
     }
   };
+
+  scope.switchToSelectedQuery = function(queryId) {
+    scope.transitionMethod(queryId);
+  }
 
   scope.reload = function(modelId, newTitle) {
     scope.selectedTitle = newTitle;


### PR DESCRIPTION
While each query item had `ui-sref` set, the keyboard event was handled
by `handleSelection` which passed the request on to `WorkPackagesListController#loadQuery`.

This fixes the double handling of events by using the same path as
`handleSelection`.

https://community.openproject.org/work_packages/22005/activity
