### PR TITLE
Format dates according to the user's timezone

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -39,7 +39,7 @@ class ActivitiesController < ApplicationController
       begin; @date_to = params[:from].to_date + 1; rescue; end
     end
 
-    @date_to ||= Date.today + 1
+    @date_to ||= User.current.today + 1
     @date_from = @date_to - @days
     @with_subprojects = params[:with_subprojects].nil? ? Setting.display_subprojects_work_packages? : (params[:with_subprojects] == '1')
     @author = (params[:user_id].blank? ? nil : User.active.find(params[:user_id]))
@@ -56,7 +56,7 @@ class ActivitiesController < ApplicationController
     if events.empty? || stale?(etag: [@activity.scope, @date_to, @date_from, @with_subprojects, @author, events.first, User.current, current_language])
       respond_to do |format|
         format.html do
-          @events_by_day = events.group_by { |e| e.event_datetime.to_date }
+          @events_by_day = events.group_by { |e| e.event_datetime.in_time_zone(User.current.time_zone).to_date }
           render layout: false if request.xhr?
         end
         format.atom do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,7 +123,7 @@ module ApplicationHelper
   end
 
   def format_activity_day(date)
-    date == Date.today ? l(:label_today).titleize : format_date(date)
+    date == User.current.today ? l(:label_today).titleize : format_date(date)
   end
 
   def format_activity_description(text)


### PR DESCRIPTION
By default, the date headlines of activities will be output with UTC+0,
which may incorrectly group activities under a single date when working in different timezones.

By using the current user's timezone, these dates should be grouped correctly.

https://community.openproject.org/work_packages/22641/activity
