### PR TITLE
[21902] Error message for macros cut off when little content

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -176,6 +176,10 @@
   .user-field-user-link
     display: inline
 
+  .macro-unavailable.permanent
+    position: relative
+    top: 0
+
 .inplace-edit--preview
   border: 1px solid $inplace-edit--border-color
   padding: 0.375rem


### PR DESCRIPTION
This sets error message to `position: relative` so that it contributes to the height of the container and is not cut off.

https://community.openproject.org/work_packages/21902/activity
