### PR TITLE
Fix/n+1 queries on query menu items

### DIFF
--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -87,7 +87,10 @@ module Redmine::MenuManager::MenuHelper
   end
 
   def build_work_packages_menu(_project)
-    query_menu_items = visible_queries.map(&:query_menu_item).compact
+    query_menu_items = visible_queries
+                       .includes(:query_menu_item)
+                       .map(&:query_menu_item)
+                       .compact
 
     Redmine::MenuManager.loose :project_menu do |menu|
       query_menu_items.each do |query_menu_item|


### PR DESCRIPTION
Prevent n*2 additional queries for n `QueryMenuItem`s on every request that has a project menu. This saves about 10-20 ms on a whole lot of requests.

The first optimization is pretty straight forward by eager loading the models used in a #map right afterwards.

The second optimization tries to keep the change to a minium by memoizing the existence of a project. However, it might be smarter to actually drop all that custom memoization as the project association does already have memoization built in by rails. 
