### PR TITLE
enable Rack::Deflater

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,6 +74,14 @@ module OpenProject
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Use Rack::Deflater to gzip/deflate all the responses if the
+    # HTTP_ACCEPT_ENCODING header is set appropriately. As Rack::ETag as
+    # Rack::Deflater adds a timestamp to the content which would result in a
+    # different ETag on every request, Rack::Deflater has to be in the chain of
+    # middlewares after Rack::ETag.  #insert_before is used because on
+    # responses, the middleware stack is processed from top to bottom.
+    config.middleware.insert_before 'Rack::ETag', 'Rack::Deflater'
+
     config.middleware.swap ActionDispatch::ParamsParser,
                            'ParamsParserWithExclusion',
                            exclude: -> (env) {

--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -91,6 +91,12 @@ For the future we plan to add authentication modes based on OAuth2 and OpenID Co
 - `PATCH` - Update a resource
 - `DELETE` - Delete a resource
 
+# Compression
+
+Responses are compressed if requested by the client. Currently [gzip](http://www.gzip.org/) and [deflate](https://tools.ietf.org/html/rfc1951)
+are supported. The client signals the desired compression by setting the [`Accept-Encoding` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3).
+If no `Accept-Encoding` header is send, `Accept-Encoding: identity` is assumed which will result in the API responding uncompressed.
+
 # Group Basic Objects
 
 # Links

--- a/spec/requests/api/v3/rack_deflater_spec.rb
+++ b/spec/requests/api/v3/rack_deflater_spec.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Rack::Deflater, type: :request do
+  include API::V3::Utilities::PathHelper
+
+  let(:text) { 'text' }
+
+  it 'produces an identical eTag whether content is deflated or not' do
+    # Using the api_v3_paths.configuaration because of the endpoint's simplicity.
+    # It could be any endpoint really.
+    get api_v3_paths.configuration
+
+    expect(response.headers['Content-Encoding']).to be_nil
+
+    etag = response.headers['Etag']
+    content_length = response.headers['Content-Length'].to_i
+
+    get api_v3_paths.configuration,
+        {},
+        'HTTP_ACCEPT_ENCODING' => 'gzip'
+
+    expect(response.headers['Etag']).to eql etag
+    expect(response.headers['Content-Length'].to_i).to_not eql content_length
+    expect(response.headers['Content-Encoding']).to eql 'gzip'
+  end
+end


### PR DESCRIPTION
Rack::Deflater will compress every response served by the Rack stack if the appropriate ACCEPT_ENCODING header is set (e.g. HTML, JSON, ...). Assets would be compressed too if they would be served by the application directly.

As the ACCEPT_ENCODING header suggests compressing (e.g. "gzip, deflate") by default on all browsers I looked into, there is nothing to do on the client side of the application. This is also true for the XHR requests.

Does address https://community.openproject.org/work_packages/22669/activity but should also speed up the whole of the application.
