### PR TITLE
Allow Repository.disabled_types to be strings

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -109,7 +109,13 @@ class Repository < ActiveRecord::Base
   # Retrieves the :disabled_types setting from `configuration.yml
   # To avoid wrong set operations for string-based configuration, force them to symbols.
   def self.disabled_types
-    (scm_config[:disabled_types] || []).map(&:to_sym)
+    disabled = scm_config[:disabled_types]
+
+    if disabled.is_a?(String)
+      disabled.split(',')
+    else
+      (disabled || [])
+    end.map(&:to_sym)
   end
 
   def vendor

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -253,7 +253,8 @@ default:
   # disabled_types:
   #   Disable specific repository types for this particular vendor. This allows
   #   to restrict the available choices a project administrator has for creating repositories
-  #   See the example below for available types.
+  #   May be set as a YAML list of types or several types, separated by comma.
+  #    See the example below for available types.
   #
   #   Available types for git:
   #     - :local (Local repositories, registered using a local path)

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -96,6 +96,16 @@ describe Repository::Git, type: :model do
         end
       end
 
+      context 'with string disabled types' do
+        let(:config) { { disabled_types: 'managed,local' } }
+
+        it 'is no longer manageable' do
+          expect(instance.class.available_types).to eq([])
+          expect(instance.class.disabled_types).to eq([:managed, :local])
+          expect(instance.manageable?).to be false
+        end
+      end
+
       context 'and associated project' do
         before do
           instance.project = project

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -72,6 +72,16 @@ describe Repository::Subversion, type: :model do
         expect(instance.class.available_types).to be_empty
       end
     end
+
+    context 'with string disabled types' do
+      let(:config) { { disabled_types: 'managed,unknowntype' } }
+
+      it 'is no longer manageable' do
+        expect(instance.class.available_types).to eq([:existing])
+        expect(instance.class.disabled_types).to eq([:managed, :unknowntype])
+        expect(instance.manageable?).to be false
+      end
+    end
   end
 
   describe 'managed Subversion' do


### PR DESCRIPTION
When passing configuration settings through ENV (e.g., packager), we
can't pass arrays as configuration settings.

This PR allows `Repository.disabled_types` to be set as a String in ENV,
e.g., through
`OPENPROJECT_SCM_SUBVERSION_DISABLED__TYPES='existing,foobar'`.
