### PR TITLE
Fix/abbreviate overflowing pdf table header

### DIFF
--- a/app/models/work_package/pdf_export/ifpdf.rb
+++ b/app/models/work_package/pdf_export/ifpdf.rb
@@ -1,0 +1,105 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'rfpdf/fpdf'
+
+class WorkPackage::PdfExport::IFPDF < FPDF
+  include Redmine::I18n
+  include Helpers
+  attr_accessor :footer_date
+
+  def initialize(lang)
+    super()
+    set_language_if_valid lang
+
+    @font_for_content = 'Arial'
+    @font_for_footer  = 'Helvetica'
+
+    SetCreator(OpenProject::Info.app_name)
+    SetFont(@font_for_content)
+  end
+
+  def SetFontStyle(style, size)
+    SetFont(@font_for_content, style, size)
+  end
+
+  def SetTitle(txt)
+    txt = begin
+      utf16txt = txt.to_s.encode('UTF-16BE', 'UTF-8')
+      hextxt = '<FEFF'  # FEFF is BOM
+      hextxt << utf16txt.unpack('C*').map { |x| sprintf('%02X', x) }.join
+      hextxt << '>'
+    rescue
+      txt
+    end || ''
+    super(txt)
+  end
+
+  def textstring(s)
+    # Format a text string
+    if s =~ /\A</  # This means the string is hex-dumped.
+      return s
+    else
+      return '(' + escape(s) + ')'
+    end
+  end
+
+  def fix_text_encoding(txt)
+    # these quotation marks are not correctly rendered in the pdf
+    txt = txt.gsub(/[â€œâ€�]/, '"') if txt
+    txt = begin
+      # 0x5c char handling
+      txtar = txt.split('\\')
+      txtar << '' if txt[-1] == ?\\
+      txtar.map { |x| x.encode(l(:general_pdf_encoding), 'UTF-8') }.join('\\').gsub(/\\/, '\\\\\\\\')
+    rescue
+      txt
+    end || ''
+    txt
+  end
+
+  def RDMCell(w, h = 0, txt = '', border = 0, ln = 0, align = '', fill = 0, link = '')
+    Cell(w, h, fix_text_encoding(txt), border, ln, align, fill, link)
+  end
+
+  def RDMMultiCell(w, h = 0, txt = '', border = 0, align = '', fill = 0)
+    MultiCell(w, h, fix_text_encoding(txt), border, align, fill)
+  end
+
+  def Footer
+    SetFont(@font_for_footer, 'I', 8)
+    SetY(-15)
+    SetX(15)
+    RDMCell(0, 5, @footer_date, 0, 0, 'L')
+    SetY(-15)
+    SetX(-30)
+    RDMCell(0, 5, PageNo().to_s + '/{nb}', 0, 0, 'C')
+  end
+  alias alias_nb_pages AliasNbPages
+end

--- a/app/models/work_package/pdf_export/to_pdf_helper.rb
+++ b/app/models/work_package/pdf_export/to_pdf_helper.rb
@@ -27,22 +27,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module WorkPackage::PdfExporter
-  # Returns a PDF string of a list of work_packages
-  def pdf(work_packages, project, query, results, options = {})
-    ::WorkPackage::PdfExport::WorkPackageListToPdf
-      .new(work_packages,
-           project,
-           query,
-           results,
-           options)
-      .to_pdf
-  end
-
-  # Returns a PDF string of a single work_package
-  def work_package_to_pdf(work_package)
-    ::WorkPackage::PdfExport::WorkPackageToPdf
-      .new(work_package)
-      .to_pdf
+module WorkPackage::PdfExport::ToPdfHelper
+  def get_pdf(language)
+    if ['ko', 'ja', 'zh', 'zh-tw', 'th'].include? language.to_s.downcase
+      IFPDF.new(current_language)
+    else
+      ITCPDF.new(current_language)
+    end
   end
 end

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -1,0 +1,261 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class WorkPackage::PdfExport::WorkPackageListToPdf
+  include Redmine::I18n
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::NumberHelper
+  include CustomFieldsHelper
+  include ToPdfHelper
+
+  attr_accessor :work_packages,
+                :pdf,
+                :project,
+                :query,
+                :results,
+                :options
+
+  def initialize(work_packages, project, query, results, options = {})
+    self.work_packages = work_packages
+    self.project = project
+    self.query = query
+    self.results = results
+    self.options = options
+
+    self.pdf = get_pdf(current_language)
+  end
+
+  def to_pdf
+    pdf.alias_nb_pages
+    pdf.SetAutoPageBreak(false)
+    pdf.footer_date = format_date(Date.today)
+
+    pdf.AddPage('L')
+
+    write_title
+
+    write_headers
+
+    write_rows
+
+    write_tbc
+
+    pdf.Output
+  end
+
+  private
+
+  def write_title
+    title = query.new_record? ? l(:label_work_package_plural) : query.name
+    title = "#{project} - #{title}" if project
+    pdf.SetTitle(title)
+
+    pdf.SetFontStyle('B', 11)
+    pdf.RDMCell(190, 10, title)
+    pdf.Ln
+  end
+
+  def write_headers
+    # headers
+    pdf.SetFontStyle('B', 8)
+    pdf.SetFillColor(230, 230, 230)
+    column_contents = query.columns.map(&:caption)
+
+    max_height = calculate_max_height(column_contents, col_width)
+
+    pdf.RDMCell Page.table_width, max_height, '', 1, 1, 'L', 1
+    pdf.SetXY(base_x, base_y)
+
+    write_cells(column_contents, col_width, Page.row_height)
+    draw_borders(base_x, base_y, base_y + max_height, col_width)
+
+    pdf.SetY(base_y + max_height)
+  end
+
+  def write_rows
+    # rows
+    pdf.SetFontStyle('', 8)
+    pdf.SetFillColor(255, 255, 255)
+    previous_group = false
+    work_packages.each do |work_package|
+      if query.grouped? && (group = query.group_by_column.value(work_package)) != previous_group
+        pdf.SetFontStyle('B', 9)
+        pdf.RDMCell(277, Page.row_height,
+                    (group.blank? ? 'None' : group.to_s) + " (#{results.work_package_count_for(group)})",
+                    1, 1, 'L')
+        pdf.SetFontStyle('', 8)
+        previous_group = group
+      end
+
+      # fetch all the row values
+      col_values = query.columns.map { |column|
+        s = if column.is_a?(QueryCustomFieldColumn)
+              cv = work_package.custom_values.detect { |v| v.custom_field_id == column.custom_field.id }
+              show_value(cv)
+            else
+              value = work_package.send(column.name)
+              if value.is_a?(Date)
+                format_date(value)
+              elsif value.is_a?(Time)
+                format_time(value)
+              else
+                value
+              end
+            end
+        s.to_s
+      }
+
+      max_height = calculate_max_height(column_contents, col_width)
+      description_height = if options[:show_descriptions]
+                             calculate_max_height([work_package.description.to_s],
+                                                  [Page.table_width / 2])
+                           else
+                             0
+                           end
+
+      # make new page if it doesn't fit on the current one
+      space_left = Page.height - base_y - Page.bottom_margin
+      if max_height + description_height > space_left
+        pdf.AddPage('L')
+        base_x = pdf.GetX
+        base_y = pdf.GetY
+      end
+
+      # write the cells on page
+      write_cells(col_values, col_width, Page.row_height)
+      draw_borders(base_x, base_y, base_y + max_height, col_width)
+
+      # description
+      if options[:show_descriptions]
+        pdf.SetXY(base_x, base_y + max_height)
+        write_cells([work_package.description.to_s],
+                    [Page.table_width / 2],
+                    Page.row_height)
+        draw_borders(base_x,
+                     base_y + max_height,
+                     base_y + max_height + description_height,
+                     [Page.table_width])
+        pdf.SetY(base_y + max_height + description_height)
+      else
+        pdf.SetY(base_y + max_height)
+      end
+    end
+  end
+
+  def write_tbc
+    if work_packages.size == Setting.work_packages_export_limit.to_i
+      pdf.SetFontStyle('B', 10)
+      pdf.RDMCell(0, Page.row_height, '...')
+    end
+  end
+
+  def col_width
+    @col_width ||= begin
+      if query.columns.empty?
+        []
+      else
+        col_width = query.columns.map { |c|
+          if c.name == :subject ||
+             (c.is_a?(QueryCustomFieldColumn) &&
+              ['string', 'text'].include?(c.custom_field.field_format))
+            4.0
+          else
+            1.0
+          end
+        }
+        ratio = Page.table_width / col_width.reduce(:+)
+
+        col_width.map { |w| w * ratio }
+      end
+    end
+  end
+
+  # Renders MultiCells and returns the maximum height used
+  def write_cells(col_values, col_widths, row_height)
+    base_y = pdf.get_y
+    max_height = row_height
+    col_values.each_with_index do |_column, i|
+      col_x = pdf.get_x
+      pdf.RDMMultiCell(col_widths[i], row_height, col_values[i], 'T', 'L', 1)
+      max_height = (pdf.get_y - base_y) if (pdf.get_y - base_y) > max_height
+      pdf.SetXY(col_x + col_widths[i], base_y)
+    end
+    max_height
+  end
+
+  # Draw lines to close the row (MultiCell border drawing in not uniform)
+  def draw_borders(top_x, top_y, lower_y, col_widths)
+    col_x = top_x
+    pdf.Line(col_x, top_y, col_x, lower_y)    # id right border
+    col_widths.each do |width|
+      col_x += width
+      pdf.Line(col_x, top_y, col_x, lower_y)  # columns right border
+    end
+    pdf.Line(top_x, top_y, top_x, lower_y)    # left border
+    pdf.Line(top_x, lower_y, col_x, lower_y)  # bottom border
+  end
+
+  def calculate_max_height(column_contents, col_widths)
+    # render it off-page to find the max height used
+    base_x = pdf.GetX
+    base_y = pdf.GetY
+    pdf.SetY(2 * Page.height)
+    max_height = write_cells(column_contents, col_widths, Page.row_height)
+    pdf.SetXY(base_x, base_y)
+
+    max_height
+  end
+
+  class Page
+    # Landscape A4 = 210 x 297 mm
+    def self.height
+      210
+    end
+
+    def self.width
+      297
+    end
+
+    def self.right_margin
+      10
+    end
+
+    def self.bottom_margin
+      20
+    end
+
+    def self.row_height
+      5
+    end
+
+    def self.table_width
+      width - right_margin - 10  # fixed left margin
+    end
+  end
+end

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -1,0 +1,166 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class WorkPackage::PdfExport::WorkPackageToPdf
+  include Redmine::I18n
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::NumberHelper
+  include CustomFieldsHelper
+  include ToPdfHelper
+
+  attr_accessor :work_package,
+                :pdf
+
+  def initialize(work_package)
+    self.work_package = work_package
+
+    self.pdf = get_pdf(current_language)
+  end
+
+  def to_pdf
+    pdf.SetTitle("#{work_package.project} - ##{work_package.type} #{work_package.id}")
+    pdf.alias_nb_pages
+    pdf.footer_date = format_date(Date.today)
+    pdf.AddPage
+
+    pdf.SetFontStyle('B', 11)
+    pdf.RDMMultiCell(190, 5, "#{work_package.project} - #{work_package.type} # #{work_package.id}: #{work_package.subject}")
+    pdf.Ln
+
+    y0 = pdf.GetY
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:status) + ':', 'LT')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, work_package.status.to_s, 'RT')
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:priority) + ':', 'LT')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, work_package.priority.to_s, 'RT')
+    pdf.Ln
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:author) + ':', 'L')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, work_package.author.to_s, 'R')
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:category) + ':', 'L')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, work_package.category.to_s, 'R')
+    pdf.Ln
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:created_at) + ':', 'L')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, format_date(work_package.created_at), 'R')
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:assigned_to) + ':', 'L')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, work_package.assigned_to.to_s, 'R')
+    pdf.Ln
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:updated_at) + ':', 'LB')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, format_date(work_package.updated_at), 'RB')
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:due_date) + ':', 'LB')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMCell(60, 5, format_date(work_package.due_date), 'RB')
+    pdf.Ln
+
+    for custom_value in work_package.custom_field_values
+      pdf.SetFontStyle('B', 9)
+      pdf.RDMCell(35, 5, custom_value.custom_field.name + ':', 'L')
+      pdf.SetFontStyle('', 9)
+      pdf.RDMMultiCell(155, 5, (show_value custom_value), 'R')
+    end
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(35, 5, WorkPackage.human_attribute_name(:description) + ':')
+    pdf.SetFontStyle('', 9)
+    pdf.RDMMultiCell(155, 5, work_package.description.to_s, 'BR')
+
+    pdf.Line(pdf.GetX, y0, pdf.GetX, pdf.GetY)
+    pdf.Line(pdf.GetX, pdf.GetY, pdf.GetX + 190, pdf.GetY)
+    pdf.Ln
+
+    if work_package.changesets.any? && User.current.allowed_to?(:view_changesets, work_package.project)
+      pdf.SetFontStyle('B', 9)
+      pdf.RDMCell(190, 5, l(:label_associated_revisions), 'B')
+      pdf.Ln
+      for changeset in work_package.changesets
+        pdf.SetFontStyle('B', 8)
+        pdf.RDMCell(190, 5, format_time(changeset.committed_on) + ' - ' + changeset.author.to_s)
+        pdf.Ln
+        unless changeset.comments.blank?
+          pdf.SetFontStyle('', 8)
+          pdf.RDMMultiCell(190, 5, changeset.comments.to_s)
+        end
+        pdf.Ln
+      end
+    end
+
+    pdf.SetFontStyle('B', 9)
+    pdf.RDMCell(190, 5, l(:label_history), 'B')
+    pdf.Ln
+    for journal in work_package.journals.includes(:user).order("#{Journal.table_name}.created_at ASC")
+      next if journal.initial?
+      pdf.SetFontStyle('B', 8)
+      pdf.RDMCell(190, 5, format_time(journal.created_at) + ' - ' + journal.user.name)
+      pdf.Ln
+      pdf.SetFontStyle('I', 8)
+      for detail in journal.details
+        pdf.RDMMultiCell(190, 5, '- ' + journal.render_detail(detail, no_html: true, only_path: false))
+        pdf.Ln
+      end
+      if journal.notes?
+        pdf.Ln unless journal.details.empty?
+        pdf.SetFontStyle('', 8)
+        pdf.RDMMultiCell(190, 5, journal.notes.to_s)
+      end
+      pdf.Ln
+    end
+
+    if work_package.attachments.any?
+      pdf.SetFontStyle('B', 9)
+      pdf.RDMCell(190, 5, l(:label_attachment_plural), 'B')
+      pdf.Ln
+      for attachment in work_package.attachments
+        pdf.SetFontStyle('', 8)
+        pdf.RDMCell(80, 5, attachment.filename)
+        pdf.RDMCell(20, 5, number_to_human_size(attachment.filesize), 0, 0, 'R')
+        pdf.RDMCell(25, 5, format_date(attachment.created_on), 0, 0, 'R')
+        pdf.RDMCell(65, 5, attachment.author.name, 0, 0, 'R')
+        pdf.Ln
+      end
+    end
+    pdf.Output
+  end
+end

--- a/app/models/work_package/pdf_exporter.rb
+++ b/app/models/work_package/pdf_exporter.rb
@@ -76,10 +76,22 @@ module WorkPackage::PdfExporter
     # headers
     pdf.SetFontStyle('B', 8)
     pdf.SetFillColor(230, 230, 230)
-    query.columns.each_with_index do |column, i|
-      pdf.RDMCell(col_width[i], row_height, column.caption, 1, 0, 'L', 1)
-    end
-    pdf.Ln
+
+    # render it off-page to find the max height used
+    base_x = pdf.GetX
+    base_y = pdf.GetY
+    pdf.SetY(2 * page_height)
+    max_height = pdf_write_cells(pdf, query.columns.map(&:caption), col_width, row_height)
+    pdf.SetXY(base_x, base_y)
+
+    pdf.RDMCell table_width, max_height, '', 1, 1, 'L', 1
+
+    pdf.SetXY(base_x, base_y)
+
+    pdf_write_cells(pdf, query.columns.map(&:caption), col_width, row_height)
+    pdf_draw_borders(pdf, base_x, base_y, base_y + max_height, col_width)
+
+    pdf.SetY(base_y + max_height)
 
     # rows
     pdf.SetFontStyle('', 8)


### PR DESCRIPTION
Consists of two parts:
1) draws the header on multiple lines if the header text requires more space than fits into a single line (bcc5165) which fixes https://community.openproject.org/work_packages/20020/activity
2) Splits up the pdf export into separate files and refactors some more.
