### PR TITLE
Bump dalli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,8 +106,8 @@ gem 'transactional_lock', git: 'https://github.com/finnlabs/transactional_lock.g
 group :production do
   # we use dalli as standard memcache client
   # requires memcached 1.4+
-  # see https://github.com/mperham/dalli
-  gem 'dalli', '~> 2.7.2'
+  # see https://github.clientom/mperham/dalli
+  gem 'dalli', '~> 2.7.6'
 end
 
 gem 'sprockets',        '~> 2.12.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     daemons (1.2.2)
-    dalli (2.7.4)
+    dalli (2.7.6)
     database_cleaner (1.4.1)
     date_validator (0.7.1)
       activemodel
@@ -573,7 +573,7 @@ DEPENDENCIES
   color-tools (~> 1.3.0)
   cucumber-rails (~> 1.4.2)
   daemons
-  dalli (~> 2.7.2)
+  dalli (~> 2.7.6)
   database_cleaner (~> 1.4.1)
   date_validator (~> 0.7.1)
   delayed_job_active_record (~> 4.0.2)


### PR DESCRIPTION
This clarifies a warning/error message on production servers using
Unicorn with `preload_app` set ( which was recently introduced here ).

`127.0.0.1:11211 failed (count: 0) RuntimeError: Cannot share client between multiple processes`.

Related to https://github.com/petergoldstein/dalli/pull/556
