### PR TITLE
Revert "less magic on default query columns"

### DIFF
--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -65,7 +65,7 @@ module QueriesHelper
         end
         @query.group_by = params[:group_by]
         @query.display_sums = params[:display_sums].present? && params[:display_sums] == 'true'
-        @query.column_names = retrieve_query_column_names if retrieve_query_column_names
+        @query.column_names = params[:c] || (params[:query] && params[:query][:column_names])
         session[:query] = { project_id: @query.project_id, filters: @query.filters, group_by: @query.group_by, display_sums: @query.display_sums, column_names: @query.column_names }
       else
         @query = Query.find_by(id: session[:query][:id]) if session[:query][:id]
@@ -88,9 +88,5 @@ module QueriesHelper
                          .select(:id, :name, :is_public, :project_id)
     end
     @visible_queries
-  end
-
-  def retrieve_query_column_names
-    params[:c] || (params[:query] && params[:query][:column_names])
   end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -135,7 +135,6 @@ class Query < ActiveRecord::Base
   def initialize(attributes = nil, options = {})
     super
     add_default_filter if options[:initialize_with_default_filter]
-    self.column_names ||= Setting.work_package_list_default_columns
   end
 
   def add_default_filter
@@ -262,7 +261,7 @@ class Query < ActiveRecord::Base
     if has_default_columns?
       available_columns.select do |c|
         # Adds the project column by default for cross-project lists
-        (c.name == :project && project.nil?)
+        Setting.work_package_list_default_columns.include?(c.name.to_s) || (c.name == :project && project.nil?)
       end
     else
       # preserve the column_names order
@@ -275,6 +274,10 @@ class Query < ActiveRecord::Base
       names = names.inject([]) { |out, e| out += e.to_s.split(',') }
       names = names.select { |n| n.is_a?(Symbol) || !n.blank? }
       names = names.map { |n| n.is_a?(Symbol) ? n : n.to_sym }
+      # Set column_names to nil if default columns
+      if names.map(&:to_s) == Setting.work_package_list_default_columns
+        names = nil
+      end
     end
     write_attribute(:column_names, names)
   end

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -33,7 +33,7 @@ module API
         extend Grape::API::Helpers
 
         def work_packages_by_params(project: nil)
-          query = Query.new(name: '_', project: project, column_names: [])
+          query = Query.new(name: '_', project: project)
           query_params = {}
 
           begin

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -31,24 +31,6 @@ require 'spec_helper'
 describe Query, type: :model do
   let(:query) { FactoryGirl.build(:query) }
 
-  describe '#column_names' do
-    it 'is set to whatever the settings say on initialization' do
-      allow(Setting)
-        .to receive(:work_package_list_default_columns)
-        .and_return(['id', 'subject'])
-
-      new_query = Query.new
-
-      expect(new_query.column_names).to eql([:id, :subject])
-    end
-
-    it 'is set to whatever is provided on initialization' do
-      new_query = Query.new(column_names: [])
-
-      expect(new_query.column_names).to eql([])
-    end
-  end
-
   describe 'available_columns' do
     context 'with work_package_done_ratio NOT disabled' do
       it 'should include the done_ratio column' do


### PR DESCRIPTION
This reverts commit 2293c3735b6a98c2b75e8423ad270b7f1a93bc9a.

The original commit improved the performance significantly on the api v3 work_packages#index by reducing the number of fields selected by the query when all that is required is the id.

However the drawback of the commit is that queries who only use the default columns and as such have no columns to display stored, will show no columns at all.

Thus the commit should be reverted until a working patch is found.

https://community.openproject.org/work_packages/22707/activity
