### PR TITLE
Allow the configuration to disable APIv2 basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
       if (key = api_key_from_request) && accept_key_auth_actions.include?(params[:action])
         # Use API key
         User.find_by_api_key(key)
-      else
+      elsif OpenProject::Configuration.apiv2_enable_basic_auth?
         # HTTP Basic, either username/password or API key/random
         authenticate_with_http_basic do |username, password|
           User.try_to_login(username, password) || User.find_by_api_key(username)

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -324,6 +324,11 @@ default:
   #     user: admin
   #     password: admin
 
+
+  # By default, the legacy APIv2 allows authentication through basic auth.
+  # Uncomment the following line to restrict APIv2 access to API tokens
+  # apiv2_enable_basic_auth: false
+
 # specific configuration options for production environment
 # that overrides the default ones
 # production:

--- a/doc/apiv2-documentation.md
+++ b/doc/apiv2-documentation.md
@@ -9,6 +9,8 @@ __Be aware:__ The API v2 is marked as deprecated. Please read this [news article
 The API supports both *basic auth* and authentication via an *API access key*. The latter is transmitted either as one of the parameters, named `key`, for a request or in the request header `X-OpenProject-API-Key`.
 You can find a user's API key on their account page (/my/account).
 
+Authentication by basic auth is enabled by default, but can be disabled in the configuration (Set apiv2_enable_basic_auth to false)
+
 Example request:
 
 _GET_ `/api/v2/projects.xml?key=gh3g4h124grr871r8g`

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -320,6 +320,11 @@ module OpenProject
             define_method setting do
               self[setting]
             end
+
+            define_method "#{setting}?" do
+              ['true', true, '1'].include? self[setting]
+            end
+
           end unless respond_to? setting
         end
       end

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -80,7 +80,9 @@ module OpenProject
 
       'disabled_modules' => [], # allow to disable default modules
       'hidden_menu_items' => {},
-      'blacklisted_routes' => []
+      'blacklisted_routes' => [],
+
+      'apiv2_enable_basic_auth' => true,
     }
 
     @config = nil

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -33,19 +33,6 @@ module OpenProject
     # To be included into OpenProject::Configuration in order to provide
     # helper methods for easier access to certain configuration options.
     module Helpers
-      ##
-      # Activating this leaves omniauth as the only way to authenticate.
-      def disable_password_login?
-        true? self['disable_password_login']
-      end
-
-      ##
-      # If this is true a user's password cannot be chosen when editing a user.
-      # The only way to change the password is to generate a random one which is sent
-      # to the user who then has to change it immediately.
-      def disable_password_choice?
-        true? self['disable_password_choice']
-      end
 
       ##
       # Carrierwave storage type. Possible values are, among others, :file and :fog.
@@ -105,10 +92,6 @@ module OpenProject
         else
           Array(value)
         end
-      end
-
-      def true?(value)
-        ['true', true].include? value # check string to accommodate ENV override
       end
     end
   end


### PR DESCRIPTION
It should be possible for installation to disable basic auth authentication against APIv2 and only allow token-based authentication, as it is with APIv3.

https://community.openproject.org/work_packages/22694/activity
