### PR TITLE
Updated Documentation for Manual Install.

### DIFF
--- a/doc/operation_guides/manual/installation-guide.md
+++ b/doc/operation_guides/manual/installation-guide.md
@@ -95,9 +95,9 @@ use [rbenv](http://rbenv.org/).
 [openproject@host] source ~/.profile
 [openproject@host] git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
 
-[openproject@host] rbenv install 2.1.7
+[openproject@host] rbenv install 2.3.0
 [openproject@host] rbenv rehash
-[openproject@host] rbenv global 2.1.7
+[openproject@host] rbenv global 2.3.0
 ```
 
 To check our Ruby installation we run `ruby --version`. It should output

--- a/doc/operation_guides/manual/installation-guide.md
+++ b/doc/operation_guides/manual/installation-guide.md
@@ -85,7 +85,8 @@ mysql> QUIT
 ## Installation of Ruby
 
 The are several possibilities to install Ruby on your machine. We will
-use [rbenv](http://rbenv.org/).
+use [rbenv](http://rbenv.org/). Please be aware that the actual installation of a specific Ruby version takes some
+time to finsih.
 
 ```bash
 [root@host] su openproject --login
@@ -104,7 +105,7 @@ To check our Ruby installation we run `ruby --version`. It should output
 something very similar to:
 
 ```
-ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-linux]
+ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]
 ```
 
 ## Installation of Node
@@ -123,16 +124,16 @@ time to finsih.
 [openproject@host] source ~/.profile
 [openproject@host] git clone git://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
 
-[openproject@host] nodenv install 0.12.7
+[openproject@host] nodenv install 5.6.0
 [openproject@host] nodenv rehash
-[openproject@host] nodenv global 0.12.7
+[openproject@host] nodenv global 5.6.0
 ```
 
 To check our Node installation we run `node --version`. It should output
 something very similar to:
 
 ```
-v0.12.7
+v5.6.0
 ```
 
 ## Installation of OpenProject
@@ -271,6 +272,8 @@ Now, the Passenger gem is installed and integrated into apache.
 [openproject@ubuntu] gem install passenger
 [openproject@ubuntu] passenger-install-apache2-module
 ```
+
+If you are running on a Private Virtual Server (such as DigitalOcean) you need to make sure you have atleast 1024mb of RAM before running the `passenger-install-apache2-module`.
 
 Follow the instructions passenger provides.
 The passenger installer will ask you the question in "Which languages are you


### PR DESCRIPTION
### What's Changed:
### Ruby

Ruby > 2.3.0 [ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]]
- The new Ruby is required for `gem install passenger` and `passenger-install-appache2-module` to install. The required version is 2.2.2 so 2.3.0 allows this to install.
### Node

Node > 5.6.0 [v5.6.0]
- The new Node is required for the `npm install` to complete successfully. 
### Warnings

Added the `passenger-install-apache2-module` RAM warning.
