### PR TITLE
[22705] Text box very small when editing forum comment

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -46,6 +46,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 <div class="form--field -required">
   <%= f.text_area :content, required: true, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' } %>
-  <%= wikitoolbar_for(replying ? 'reply_content' : 'message_content') %>
+  <%= wikitoolbar_for('message_content') %>
 </div>
 <%= render partial: 'attachments/form' %>


### PR DESCRIPTION
This changes the correlation for the wiki-toolbar and the text-area. The error occurred since the wrong class was assigned.

https://community.openproject.org/work_packages/22705/activity
