### PR TITLE
[22716] 2 arrows displayed for table of content

### DIFF
--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -431,7 +431,7 @@ module OpenProject
           out << "<legend class='form--fieldset-legend' title='" +
             l(:description_toc_toggle) +
             "' onclick='toggleFieldset(this);'>
-            <a class='icon-context icon-pulldown' href='javascript:'>
+            <a href='javascript:'>
               #{l(:label_table_of_contents)}
             </a>
             </legend><div>"

--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -99,7 +99,7 @@ module Redmine
         text.gsub!(MACROS_RE) do
           esc = $1
           all = $2
-          macro = $3.downcase
+          macro = $3
           args = ($5 || '').split(',').each(&:strip!)
           if esc.nil?
             begin

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -587,7 +587,7 @@ WIKI_TEXT
         expect(html).to be_html_eql(%{
           <fieldset class='form--fieldset -collapsible'>
             <legend class='form--fieldset-legend' title='Show/Hide table of contents' onclick='toggleFieldset(this);'>
-              <a class="icon-context icon-pulldown" href='javascript:'>Table of Contents</a>
+              <a href='javascript:'>Table of Contents</a>
             </legend>
             <div>
               <ul class="toc">
@@ -626,7 +626,7 @@ WIKI_TEXT
         expect(html).to be_html_eql(%{
           <fieldset class='form--fieldset -collapsible'>
             <legend class='form--fieldset-legend' title='Show/Hide table of contents' onclick='toggleFieldset(this);'>
-              <a class="icon-context icon-pulldown" href='javascript:'>Table of Contents</a>
+              <a href='javascript:'>Table of Contents</a>
             </legend>
             <div>
               <ul class="toc">


### PR DESCRIPTION
This removes the icon class for the arrow. It is not needed since the fields provides its own arrow who also switches direction on click.

https://community.openproject.org/work_packages/22716/activity
