### PR TITLE
[21902] Error message for macros cut off when little content (2)

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -180,6 +180,13 @@
     position: relative
     top: 0
 
+// When user is not allowed to edit the field
+span:not(.inplace-editing--container)
+  .inplace-edit--read-value span
+    width: 100%
+    .macro-unavailable.permanent
+      width: 50%
+
 .inplace-edit--preview
   border: 1px solid $inplace-edit--border-color
   padding: 0.375rem

--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -105,7 +105,7 @@ module Redmine
             begin
               macros_runner.call(macro, args)
             rescue => e
-              "<span class=\"flash error permanent\">\
+              "<span class=\"flash error macro-unavailable permanent\">\
               #{::I18n.t(:macro_execution_error, macro_name: macro)} (#{e})\
               </span>".squish
             rescue NotImplementedError


### PR DESCRIPTION
This fixes the layout when a macro error message is shown. There are two cases handled: The demanded macro doesn't exist or the user has not the right to see the macro.

https://community.openproject.org/work_packages/21902/activity
