### PR TITLE
[22717] Headline styling overlaps toolbar

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+$toolbar-width: 300px
+
 div.wiki
   font-size: $wiki-default-font-size
   $wiki-max-heading-font-size: 24px
@@ -172,3 +174,4 @@ blockquote
 
 .toolbar-container + .wiki-content
   margin-top: -64px
+  width: calc(100% - #{$toolbar-width})

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$toolbar-width: 300px
+$toolbar-width: 400px
 
 div.wiki
   font-size: $wiki-default-font-size
@@ -174,4 +174,5 @@ blockquote
 
 .toolbar-container + .wiki-content
   margin-top: -64px
+  // Attention: When more buttons are added to the toolbar this might has to be changed
   width: calc(100% - #{$toolbar-width})


### PR DESCRIPTION
This reduces the width of the wiki if a toolbar is shown. Thus collisions are avoided.

https://community.openproject.org/work_packages/22717/activity
