### PR TITLE
Require login by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,7 +56,8 @@ log_requesting_user:
   default: 0
   format: int
 login_required:
-  default: 0
+  default: 1
+  format: boolean
 self_registration:
   default: '2'
 lost_password:


### PR DESCRIPTION
APIv3 authentication for users is depending on this settings, leaving it
off by default causes user data to be exposed in a new installation.

https://community.openproject.org/work_packages/22718
