### PR TITLE
Disable CSRF for add-in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.5'
 gem 'actionpack-action_caching'
+gem 'actionpack-xml_parser'
 gem 'activerecord-session_store'
 gem 'rails-observers'
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     actionpack-action_caching (1.1.1)
       actionpack (>= 4.0.0, < 5.0)
+    actionpack-xml_parser (1.0.2)
+      actionpack (>= 4.0.0, < 5)
     actionview (4.2.5.1)
       activesupport (= 4.2.5.1)
       builder (~> 3.1)
@@ -553,6 +555,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-action_caching
+  actionpack-xml_parser
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter
   activerecord-session_store

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -34,7 +34,7 @@ module Api
         def included(base)
           base.class_eval do
             if (respond_to? :skip_before_filter) && (respond_to? :prepend_before_filter)
-              # disable CSRF protection since the task connector doesn't support it
+              # disable CSRF protection since the V2 doesn't handle it
               skip_before_filter :verify_authenticity_token
               
               skip_before_filter :disable_api

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -34,6 +34,9 @@ module Api
         def included(base)
           base.class_eval do
             if (respond_to? :skip_before_filter) && (respond_to? :prepend_before_filter)
+              # disable CSRF protection since the task connector doesn't support it
+              skip_before_filter :verify_authenticity_token
+              
               skip_before_filter :disable_api
               prepend_before_filter :disable_everything_except_api
             end

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,11 @@ module OpenProject
 
     config.middleware.use Rack::Attack
 
+    ##
+    # Support XML requests as params for APIv2
+    # TODO: Remove this and 'actionpack-xml_parser' dependency when removing V2
+    config.middleware.insert_after 'ParamsParserWithExclusion', ActionDispatch::XmlParamsParser
+
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
     config.autoload_paths << Rails.root.join('lib')


### PR DESCRIPTION
The TaskConnector add-in doesn't handle CSRF tokens.

https://community.openproject.org/work_packages/22390/activity
