### PR TITLE
Basic extraction of lists / hashes in ENV configuration values

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -109,13 +109,7 @@ class Repository < ActiveRecord::Base
   # Retrieves the :disabled_types setting from `configuration.yml
   # To avoid wrong set operations for string-based configuration, force them to symbols.
   def self.disabled_types
-    disabled = scm_config[:disabled_types]
-
-    if disabled.is_a?(String)
-      disabled.split(',')
-    else
-      (disabled || [])
-    end.map(&:to_sym)
+    (scm_config[:disabled_types] || []).map(&:to_sym)
   end
 
   def vendor

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -88,6 +88,22 @@ storage config above like this:
 * [`blacklisted_routes`](#blacklisted-routes) (default: [])
 * [`global_basic_auth`](#global-basic-auth)
 
+## Passing data structures
+
+The configuration uses YAML to parse overrides from ENV. Using YAML inline syntax, you can:
+
+1. Pass a symbol as an override using `OPENPROJECT_SESSION_STORE=":active_record_store"`
+
+1. Pass arrays by wrapping values in brackets (e.g., `[val1, val2, val3]`).
+
+2. Pass hashes with `{key: foo, key2: bar}`.
+
+To pass symbol arrays or hashes with symbol keys, use the YAML `!ruby/symbol` notiation.
+Example: `{!ruby/symbol key: !ruby/symbol value}` will be parsed as `{ key: :value }`.
+
+Please note: The Configuration is a HashWithIndifferentAccess and thus it should be irrelevant for hashes to use symbol keys.
+
+
 ### disable password login
 
 *default: false*

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -92,10 +92,17 @@ describe OpenProject::Configuration do
     let(:config) {
       {
         'somesetting' => 'foo',
+        'some_list_entry' => nil,
         'nested' => {
           'key' => 'value',
+          'hash' => 'somethingelse',
           'deeply_nested' => {
             'key' => nil
+          }
+        },
+        'foo' => {
+          'bar' => {
+            'hash_with_symbols': 1234
           }
         }
       }
@@ -104,8 +111,11 @@ describe OpenProject::Configuration do
     let(:env_vars) {
       {
         'SOMESETTING' => 'bar',
+        'OPTEST_SOME__LIST__ENTRY' => '[foo, bar , xyz, whut wat]',
         'OPTEST_NESTED_KEY' => 'baz',
-        'OPTEST_NESTED_DEEPLY__NESTED_KEY' => '42'
+        'OPTEST_NESTED_DEEPLY__NESTED_KEY' => '42',
+        'OPTEST_NESTED_HASH' => '{ foo: bar, xyz: bla }',
+        'OPTEST_FOO_BAR_HASH__WITH__SYMBOLS' => '{ foo: !ruby/symbol foobar }'
       }
     }
 
@@ -124,7 +134,20 @@ describe OpenProject::Configuration do
     end
 
     it 'should override values nested several levels deep' do
-      expect(config['nested']['deeply_nested']['key']).to eq('42')
+      expect(config['nested']['deeply_nested']['key']).to eq(42)
+    end
+
+    it 'should parse simple comma-separated lists' do
+      expect(config['some_list_entry']).to eq(['foo', 'bar', 'xyz', 'whut wat'])
+    end
+
+    it 'should parse simple hashes' do
+      expect(config['nested']['hash']).to eq('foo' => 'bar', 'xyz' => 'bla')
+    end
+
+    it 'should parse hashes with symbols and non-string values' do
+      expect(config['foo']['bar']['hash_with_symbols']).to eq('foo' => :foobar)
+      expect(config['foo']['bar']['hash_with_symbols'][:foo]).to eq(:foobar)
     end
   end
 

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -97,7 +97,13 @@ describe Repository::Git, type: :model do
       end
 
       context 'with string disabled types' do
-        let(:config) { { disabled_types: 'managed,local' } }
+        before do
+          allow(OpenProject::Configuration).to receive(:default_override_source)
+            .and_return('OPENPROJECT_SCM_GIT_DISABLED__TYPES' => '[managed,local]')
+
+          OpenProject::Configuration.load
+          allow(adapter.class).to receive(:config).and_call_original
+        end
 
         it 'is no longer manageable' do
           expect(instance.class.available_types).to eq([])

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -74,7 +74,13 @@ describe Repository::Subversion, type: :model do
     end
 
     context 'with string disabled types' do
-      let(:config) { { disabled_types: 'managed,unknowntype' } }
+      before do
+        allow(OpenProject::Configuration).to receive(:default_override_source)
+          .and_return('OPENPROJECT_SCM_SUBVERSION_DISABLED__TYPES' => '[managed,unknowntype]')
+
+        OpenProject::Configuration.load
+        allow(instance.class).to receive(:scm_config).and_call_original
+      end
 
       it 'is no longer manageable' do
         expect(instance.class.available_types).to eq([:existing])


### PR DESCRIPTION
Allows users to pass arrays or hashes via `[foo,bar]` and `{ foo: bar }`
notation. **It doesn't escape commas and strips all whitespaces for keys, values.**

_Needed for some of our products._
