### PR TITLE
Fix committers array access

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -91,7 +91,7 @@ class RepositoriesController < ApplicationController
 
   def committers
     @committers = @repository.committers
-    @users = @project.users
+    @users = @project.users.to_a
     additional_user_ids = @committers.map(&:last).map(&:to_i) - @users.map(&:id)
     @users += User.where(id: additional_user_ids) unless additional_user_ids.empty?
     @users.compact!

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -240,7 +240,7 @@ class Repository < ActiveRecord::Base
 
   # Returns an array of committers usernames and associated user_id
   def committers
-    @committers ||= Changeset.connection.select_rows("SELECT DISTINCT committer, user_id FROM #{Changeset.table_name} WHERE repository_id = #{id}")
+    @committers ||= Changeset.where(repository_id: id).distinct.pluck(:committer, :user_id)
   end
 
   # Maps committers username to a user ids


### PR DESCRIPTION
When adding a new committer to a repository, the user collection was
`compact!`ed, which no longer exists on relations with Rails 4+.

Thanks to @gehasia for spotting and proposing a fix for the bug.

https://community.openproject.org/work_packages/22755/activity
