### PR TITLE
Fix message mail formatting

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -46,6 +46,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 <div class="form--field -required">
   <%= f.text_area :content, required: true, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' } %>
-  <%= wikitoolbar_for('message_content') %>
+  <%= wikitoolbar_for("#{f.object_name}_content") %>
 </div>
 <%= render partial: 'attachments/form' %>

--- a/app/views/user_mailer/message_posted.html.erb
+++ b/app/views/user_mailer/message_posted.html.erb
@@ -32,4 +32,4 @@ See doc/COPYRIGHT.rdoc for more details.
 </h1>
 <em><%= @message.author %></em>
 
-<%= format_text @message.content, only_path: false  %>
+<%= format_text @message.content, object: @message, only_path: false  %>


### PR DESCRIPTION
This restores the highlighting of  `##:id` and `###:id` links.

Also fixes a small display issue where the message textarea in forums
would not be displayed as a wiki toolbar.

https://community.openproject.org/work_packages/22728/activity
