### PR TITLE
Move UserPasswords to scrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,8 @@ gem 'nokogiri', '~> 1.6.7'
 gem 'carrierwave', '~> 0.10.0'
 gem 'fog', '~> 1.23.0', require: 'fog/aws/storage'
 
+gem 'scrypt', '~> 2.0.0', require: false
+
 group :test do
   gem 'rack-test', '~> 0.6.2'
   gem 'shoulda-context', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,9 @@ GEM
     faker (1.4.3)
       i18n (~> 0.5)
     ffi (1.9.10)
+    ffi-compiler (0.1.3)
+      ffi (>= 1.0.0)
+      rake
     fog (1.23.0)
       fog-brightbox
       fog-core (~> 1.23)
@@ -483,6 +486,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    scrypt (2.0.2)
+      ffi-compiler (>= 0.0.2)
+      rake
     selenium-webdriver (2.47.1)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
@@ -646,6 +652,7 @@ DEPENDENCIES
   rubytree (~> 0.8.3)
   sass (~> 3.4.12)
   sass-rails (~> 5.0.3)
+  scrypt (~> 2.0.0)
   selenium-webdriver (~> 2.47.1)
   shoulda-context (~> 1.2)
   shoulda-matchers (~> 2.8)

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -95,7 +95,7 @@ class MyController < ApplicationController
     @user = User.current  # required by "my" layout
     @username = @user.login
     return if redirect_if_password_change_not_allowed_for(@user)
-    if @user.check_password?(params[:password])
+    if @user.check_password?(params[:password], update_legacy: false)
       @user.password = params[:new_password]
       @user.password_confirmation = params[:new_password_confirmation]
       @user.force_password_change = false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,7 @@ class User < Principal
   # create new password if password was set
   def update_password
     if password && auth_source_id.blank?
-      new_password = passwords.build
+      new_password = passwords.build(type: UserPassword.active_type.to_s)
       new_password.plain_password = password
       new_password.save
 
@@ -365,12 +365,14 @@ class User < Principal
   end
 
   # Returns true if +clear_password+ is the correct user's password, otherwise false
-  def check_password?(clear_password)
+  # If +update_legacy+ is set, will automatically save legacy passwords using the current
+  # format.
+  def check_password?(clear_password, update_legacy: true)
     if auth_source_id.present?
       auth_source.authenticate(login, clear_password)
     else
       return false if current_password.nil?
-      current_password.same_as_plain_password?(clear_password)
+      current_password.matches_plaintext?(clear_password, update_legacy: update_legacy)
     end
   end
 
@@ -803,7 +805,7 @@ class User < Principal
     ban_count = Setting[:password_count_former_banned].to_i
     # make reducing the number of banned former passwords immediately effective
     # by only checking this number of former passwords
-    passwords[0, ban_count].any? { |f| f.same_as_plain_password?(password) }
+    passwords[0, ban_count].any? { |f| f.matches_plaintext?(password) }
   end
 
   def clean_up_former_passwords
@@ -902,7 +904,7 @@ class User < Principal
   end
 
   def self.default_admin_account_changed?
-    !User.active.find_by_login('admin').try(:current_password).try(:same_as_plain_password?, 'admin')
+    !User.active.find_by_login('admin').try(:current_password).try(:matches_plaintext?, 'admin')
   end
 end
 

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -35,11 +35,42 @@ class UserPassword < ActiveRecord::Base
 
   attr_accessor :plain_password
 
-  # Checks whether the stored password is the same as a given plaintext password
-  def same_as_plain_password?(plain_password)
-    UserPassword.secure_equals?(UserPassword.hash_with_salt(plain_password,
-                                                            salt),
-                                hashed_password)
+  ##
+  # Fixes the active UserPassword Type to use.
+  # This could allow for an entrypoint for plugins or customization
+  def self.active_type
+    UserPassword::Scrypt
+  end
+
+  ##
+  # Determines whether the hashed value of +plain+ matches the stored password hash.
+  def matches_plaintext?(plain, update_legacy: true)
+    if hash_matches?(plain)
+
+      # Update hash if necessary
+      if update_legacy
+        rehash_as_active(plain)
+      end
+
+      return true
+    end
+
+    false
+  end
+
+  ##
+  # Rehash the password using the currently active strategy.
+  # This replaces the password and keeps expiry date identical.
+  def rehash_as_active(plain)
+    active_class = UserPassword.active_type
+
+    unless is_a?(active_class)
+      becomes!(active_class)
+      self.hashed_password = derive_password!(plain)
+      save!
+    end
+  rescue => e
+    Rails.logger.error("Unable to re-hash UserPassword for #{user.login}: #{e.message}")
   end
 
   def expired?
@@ -48,39 +79,25 @@ class UserPassword < ActiveRecord::Base
     created_at < (Time.now - days_valid)
   end
 
-  # Returns a 128bits random salt as a hex string (32 chars long)
-  def self.generate_salt
-    SecureRandom.hex(16)
-  end
+  protected
 
-  # Return password digest
-  def self.hash_password(plain_password)
-    Digest::SHA1.hexdigest(plain_password)
-  end
-
-  # Hash a plaintext password with a given salt
-  # The hashed password has following form: SHA1(salt + SHA1(password))
-  def self.hash_with_salt(plain_password, salt)
-    # We should really use a standard key-derivation function like bcrypt here
-    hash_password("#{salt}#{hash_password plain_password}")
-  end
-
-  # constant-time comparison algorithm to prevent timing attacks
-  def self.secure_equals?(a, b)
-    return false if a.blank? || b.blank? || a.bytesize != b.bytesize
-    l = a.unpack "C#{a.bytesize}"
-
-    res = 0
-    b.each_byte do |byte| res |= byte ^ l.shift end
-    res == 0
-  end
-
-  private
-
+  # Save hashed_password from the initially passed plain password
+  # if it is is set.
   def salt_and_hash_password!
     return if plain_password.nil?
-    self.salt = UserPassword.generate_salt
-    self.hashed_password = UserPassword.hash_with_salt(plain_password,
-                                                       salt)
+    self.hashed_password = derive_password!(plain_password)
+  end
+
+  # Require the implementation to provide a secure comparisation
+  def hash_matches?(_plain)
+    raise NotImplementedError, 'Must be overridden by subclass'
+  end
+
+  def generate_salt
+    raise NotImplementedError, 'Must be overridden by subclass'
+  end
+
+  def derive_password!(_input)
+    raise NotImplementedError, 'Must be overridden by subclass'
   end
 end

--- a/app/models/user_password/scrypt.rb
+++ b/app/models/user_password/scrypt.rb
@@ -1,3 +1,4 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -26,28 +27,21 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-FactoryGirl.define do
-  factory :user_password, class: UserPassword.active_type do
-    association :user
-    plain_password 'adminADMIN!'
+##
+# Password hashing method using scrypt
+require 'scrypt'
+class UserPassword::Scrypt < UserPassword
+  protected
 
-    factory :old_user_password do
-      created_at 1.year.ago
-      updated_at 1.year.ago
-    end
+  ##
+  # Determines whether the hashed value of +plain+ matches the stored password hash.
+  def hash_matches?(plain)
+    # scrypt gem provides its own safe comparison operator
+    # against plain texts
+    SCrypt::Password.new(hashed_password) == plain
   end
 
-  factory :legacy_sha1_password, class: UserPassword::SHA1 do
-    association :user
-    type 'UserPassword::SHA1'
-    plain_password 'mylegacypassword!'
-
-    # Avoid going through the after_save hook
-    # As it's no longer possible for Sha1 passwords
-    after(:build) do |obj|
-      obj.salt = SecureRandom.hex(16)
-      obj.hashed_password = obj.send(:derive_password!, obj.plain_password)
-      obj.plain_password = nil
-    end
+  def derive_password!(input)
+    SCrypt::Password.create(input)
   end
 end

--- a/db/migrate/20160217225633_introduce_scrypt_passwords.rb
+++ b/db/migrate/20160217225633_introduce_scrypt_passwords.rb
@@ -1,0 +1,25 @@
+class IntroduceScryptPasswords < ActiveRecord::Migration
+  def up
+    # Introduce type to UserPassword
+    add_column :user_passwords, :type, :string, null: true
+
+    # Increase hash limit due to scrypt embedded salt
+    change_column :user_passwords, :hashed_password, :string, limit: 128, null: false
+
+    # All current passwords are assumed to be SHA-1 salted.
+    UserPassword.update_all(type: 'UserPassword::SHA1')
+
+    # Make type non-optional
+    change_column :user_passwords, :type, :string, null: false
+
+    # Make salt explicitly optional
+    change_column_null :user_passwords, :salt, true
+  end
+
+  def down
+    UserPassword.where(type: 'UserPassword::Scrypt').destroy_all
+    remove_column :user_passwords, :type
+    change_column :user_passwords, :hashed_password, :string, limit: 40
+    # Salt was (implictly) optional
+  end
+end

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -29,26 +29,57 @@
 require 'spec_helper'
 
 describe UserPassword, type: :model do
-  let(:old_password) { FactoryGirl.create(:old_user_password) }
-  let(:password) { FactoryGirl.create(:user_password) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:password) { FactoryGirl.create(:user_password, user: user, plain_password: 'adminAdmin!') }
 
-  describe '#expired?' do
-    it 'should be true for an old password when password expiry is activated' do
-      with_settings password_days_valid: 30 do
-        expect(old_password.expired?).to be_truthy
-      end
+  describe '#matches_plaintext?' do
+    it 'still matches the password' do
+      expect(password).to be_a(UserPassword.active_type)
+      expect(password.matches_plaintext?('adminAdmin!')).to be_truthy
+    end
+  end
+
+  describe '#rehash_as_active' do
+    let(:password) {
+      pass = FactoryGirl.build(:legacy_sha1_password, user: user, plain_password: 'adminAdmin!')
+      expect(pass).to receive(:salt_and_hash_password!).and_return nil
+
+      pass.save!
+      pass
+    }
+
+    before do
+      password
+      user.reload
     end
 
-    it 'should be false when password expiry is enabled and the password was changed recently' do
-      with_settings password_days_valid: 30 do
-        expect(password.expired?).to be_falsey
-      end
+    it 'rehashed the password when correct' do
+      expect(user.current_password).to be_a(UserPassword::SHA1)
+      expect {
+        password.matches_plaintext?('adminAdmin!')
+      }.to_not change { user.passwords.count }
+
+      expect(user.current_password).to be_a(UserPassword.active_type)
     end
 
-    it 'should be false for an old password when password expiry is disabled' do
-      with_settings password_days_valid: 0 do
-        expect(old_password.expired?).to be_falsey
-      end
+    it 'does not alter the password when invalid' do
+      expect(password.matches_plaintext?('wat')).to be false
+      expect(password).to be_a(UserPassword::SHA1)
+    end
+
+    it 'does not alter the password when disabled' do
+      expect(password.matches_plaintext?('adminAdmin!', update_legacy: false)).to be true
+      expect(user.current_password).to be_a(UserPassword::SHA1)
+    end
+  end
+
+  describe '#save' do
+    let(:password) { FactoryGirl.build(:user_password) }
+
+    it 'saves correctly' do
+      expect(password).to receive(:salt_and_hash_password!).and_call_original
+      expect { password.save! }.not_to raise_error
+      expect(password).not_to be_expired
     end
   end
 end

--- a/spec_legacy/fixtures/user_passwords.yml
+++ b/spec_legacy/fixtures/user_passwords.yml
@@ -30,6 +30,7 @@
 user_passwords_004:
   created_at: 2006-07-19 19:34:07 +02:00
   # password = foo
+  type: UserPassword::SHA1
   salt: 3126f764c3c5ac61cbfc103f25f934cf
   hashed_password: 9e4dd7eeb172c12a0691a6d9d3a269f7e9fe671b
   updated_at: 2006-07-19 19:34:07 +02:00
@@ -38,6 +39,7 @@ user_passwords_004:
 user_passwords_001:
   created_at: 2006-07-19 19:12:21 +02:00
   # password = adminADMIN!
+  type: UserPassword::SHA1
   salt: a19f9743f4b7b043a2fd07b8eb13a1df
   hashed_password: b4596ce83c0e154e5ce9d3dd5636fde4d6f38b75
   updated_at: 2006-07-19 22:57:52 +02:00
@@ -46,6 +48,7 @@ user_passwords_001:
 user_passwords_002:
   created_at: 2006-07-19 19:32:09 +02:00
   # password = jsmith
+  type: UserPassword::SHA1
   salt: 67eb4732624d5a7753dcea7ce0bb7d7d
   hashed_password: bfbe06043353a677d0215b26a5800d128d5413bc
   updated_at: 2006-07-19 22:42:15 +02:00
@@ -54,6 +57,7 @@ user_passwords_002:
 user_passwords_003:
   created_at: 2006-07-19 19:33:19 +02:00
   # password = foo
+  type: UserPassword::SHA1
   salt: 7599f9963ec07b5a3b55b354407120c0
   hashed_password: 8f659c8d7c072f189374edacfa90d6abbc26d8ed
   updated_at: 2006-07-19 19:33:19 +02:00
@@ -63,28 +67,34 @@ user_passwords_005:
   id: 5
   user_id: 5
   created_at: 2006-07-19 19:33:19 +02:00
+  type: UserPassword::SHA1
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_006:
   id: 6
   user_id: 6
   created_at: 2006-07-19 19:33:19 +02:00
+  type: UserPassword::SHA1
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_007:
   id: 7
   user_id: 7
+  type: UserPassword::SHA1
+  hashed_password: 1
   created_at: 2006-07-19 19:33:19 +02:00
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_008:
   id: 8
   user_id: 8
+  type: UserPassword::SHA1
   created_at: 2006-07-19 19:33:19 +02:00
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_009:
   id: 9
   user_id: 9
+  type: UserPassword::SHA1
   created_at: 2006-07-19 19:33:19 +02:00
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00


### PR DESCRIPTION
This PR:
1. Makes scrypt the default password storing function. The scrypt gem has sane defaults with 16MB memory requirements per default, so we don't have to re-configure it.
2. Make `UserPassword::SHA1` available only for existing passswords. They will still be valid, however as soon as a user logs in, the password is re-hashed as scrypt. This allows us to keep the expiration time the same.
3. `UserPassword::SHA1` no longer has the functionality to create/save new passwords.

Warning :exclamation: The introduced migration has to delete passwords when migrating down since otherwise, using the application will croak for scrypt passwords. I don't think we should easily remove the passwords in the down migration, so If you have a better solution, let me know.

https://community.openproject.org/projects/openproject/22769
