### PR TITLE
[22732] Author name on split screen not on one line

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -181,11 +181,12 @@
     top: 0
 
 // When user is not allowed to edit the field
-span:not(.inplace-editing--container)
-  .inplace-edit--read-value span
-    width: 100%
-    .macro-unavailable.permanent
-      width: 50%
+#work-package-description
+  span:not(.inplace-editing--container)
+    .inplace-edit--read-value span
+      width: 100%
+      .macro-unavailable.permanent
+        width: 50%
 
 .inplace-edit--preview
   border: 1px solid $inplace-edit--border-color


### PR DESCRIPTION
This uses a more specific the styling rule for macros in WP descriptions. The change there was the reason for the incorrect aligned author name.

https://community.openproject.org/work_packages/22732/activity
