### PR TITLE
Existing SVN repositories: Add option to accept ssl certificates

### DIFF
--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -274,6 +274,7 @@ default:
   #     manages: /opt/repositories/git
   #   subversion:
   #     client_command: /usr/local/bin/svn
+  #     trustedssl: true
   #     disabled_types:
   #       - :existing
   #     manages: /opt/repositories/svn

--- a/lib/open_project/scm/adapters/subversion.rb
+++ b/lib/open_project/scm/adapters/subversion.rb
@@ -102,8 +102,10 @@ module OpenProject
 
             return if doc.at_xpath('/info/entry/repository/uuid')
 
-            raise Exceptions::ScmUnauthorized.new if io_include?(stderr,
-                                                                 'E215004: Authentication failed')
+            stderr.each_line do |l|
+              Rails.logger.error("SVN access error: #{l}") if l =~ /E\d+:/
+              raise Exceptions::ScmUnauthorized.new if l.include?('E215004: Authentication failed')
+            end
           end
 
           raise Exceptions::ScmUnavailable
@@ -224,6 +226,10 @@ module OpenProject
           if @login.present?
             args.push('--username', @login)
             args.push('--password', @password) if @password.present?
+          end
+
+          if self.class.config[:trustedssl]
+            args.push('--trust-server-cert')
           end
 
           args.push('--no-auth-cache', '--non-interactive')


### PR DESCRIPTION
This provides a configuration option to add `--trust-server-cert` to the
SVN calls made by OpenProject.

Either add the `trustedssl` key to the Subversion scm configuration or
set the ENV `OPENPROJECT_SCM_SUBVERSION_TRUSTEDSSL=true`.

https://community.openproject.org/work_packages/4197
