### PR TITLE
[21902] Error message for macros cut off when little content (3)

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -346,6 +346,11 @@ a.inplace-editing--trigger-link,
 .inplace-edit--highlight
   border-color: $inplace-edit--color-highlight !important
 
+.work-packages--details
+  .inplace-edit--read-value .macro-unavailable.permanent
+    width: 75%
+    margin-left: -10rem
+
 .work-package--details--long-field
   margin-top: 10px
 


### PR DESCRIPTION
This adds styling rules for macro errors in the WP description for the split screen.

https://community.openproject.org/work_packages/21902/activity
