### PR TITLE
[22639] Use first type from position ordering

### DIFF
--- a/app/services/create_work_package_service.rb
+++ b/app/services/create_work_package_service.rb
@@ -41,7 +41,7 @@ class CreateWorkPackageService
     hash = {
       project: project,
       author: user,
-      type: project.types.where(is_default: true).first || project.types.first
+      type: project.types.first
     }
     project.add_work_package(hash)
   end


### PR DESCRIPTION
New work packages through the services are created with default types
first (e.g., when children wps are created).

For regular work packages, the default sorting order (position) is used.

https://community.openproject.org/work_packages/22639/activity
