### PR TITLE
Fix lost query_id param when switching to full view

### DIFF
--- a/frontend/app/components/routing/routing.configuration.ts
+++ b/frontend/app/components/routing/routing.configuration.ts
@@ -96,7 +96,7 @@ angular
       })
 
       .state('work-packages.show', {
-        url: '/work_packages/{workPackageId:[0-9]+}?query_props',
+        url: '/work_packages/{workPackageId:[0-9]+}?query_id&query_props',
         templateUrl: '/components/routing/views/work-packages.show.html',
         controller: 'WorkPackageShowController',
         controllerAs: 'vm',


### PR DESCRIPTION
This keeps the `query_id` URL param active that was already correctly passed to `$stateParams` but lost due to angular-router removing it since the query was fixed.

https://community.openproject.org/work_packages/22699
