### PR TITLE
[22746] Change styling of "show all / hide empty" attributes button

### DIFF
--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -61,7 +61,7 @@
   overflow-y: hidden
 
   .button
-    margin: 0 0 1px 0
+    margin: 0 0 5px 0
 
 // HACK. TODO: Remove H3 element rules in various places.
 .attributes-group--header-text,

--- a/frontend/app/templates/work_packages/tabs/_panel_expander.html
+++ b/frontend/app/templates/work_packages/tabs/_panel_expander.html
@@ -1,6 +1,6 @@
 <div class="panel-toggler"
      tabindex="-1">
-  <accessible-by-keyboard link-class="button -small -transparent {{ !collapsed ? '-active' : '' }}" data-execute="toggle()">
+  <accessible-by-keyboard link-class="icon-context icon-small button {{ !collapsed ? 'icon-arrow-up1' : 'icon-arrow-down1' }}" data-execute="toggle()">
     <span ng-if="!collapsed">
       <span ng-bind="collapseText"/>
     </span>


### PR DESCRIPTION
This changes the styling of the hide empty/show all button in WP overview.

https://community.openproject.org/work_packages/22746/activity
