### PR TITLE
[22752] Change behavior of "show all / hide empty" attributes button

### DIFF
--- a/frontend/app/components/work-packages/wp-create-form/wp-create-form.directive.html
+++ b/frontend/app/components/work-packages/wp-create-form/wp-create-form.directive.html
@@ -19,7 +19,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.shouldHideGroup(group.groupName)"
+         ng-hide="vm.shouldHideGroup(group.groupName) && vm.showAllFields"
          class="attributes-group">
 
       <div class="attributes-group--header">
@@ -29,7 +29,7 @@
         </div>
         <div class="attributes-group--header-toggle">
           <panel-expander tabindex="-1" ng-if="vm.showToggleButton() && $first"
-                          collapsed="vm.hideEmptyFields"
+                          collapsed="vm.showAllFields"
                           expand-text="{{ ::I18n.t('js.label_show_attributes') }}"
                           collapse-text="{{ ::I18n.t('js.label_hide_attributes') }}">
           </panel-expander>
@@ -38,14 +38,14 @@
 
       <div class="attributes-key-value">
         <div
-            ng-hide="vm.hideEmptyFields && vm.isFieldHideable(vm.workPackage, field)"
+            ng-hide="vm.showAllFields && vm.isFieldHideable(vm.workPackage, field)"
             ng-if="vm.isSpecified(vm.workPackage, field) && vm.isEditable(vm.workPackage, field)"
             ng-repeat-start="field in group.attributes" class="attributes-key-value--key">
           {{vm.getLabel(vm.workPackage, field)}}
           <span class="required" ng-if="vm.hasNiceStar(vm.workPackage, field)"> *</span>
         </div>
         <div
-            ng-hide="vm.hideEmptyFields && vm.isFieldHideable(vm.workPackage, field)"
+            ng-hide="vm.showAllFields && vm.isFieldHideable(vm.workPackage, field)"
             ng-if="vm.isSpecified(vm.workPackage, field) && vm.isEditable(vm.workPackage, field)"
             ng-repeat-end
             class="attributes-key-value--value-container">
@@ -53,7 +53,7 @@
         </div>
       </div>
     </div>
-    <work-package-attachments work-package="vm.workPackage" data-ng-show="!vm.hideEmptyFields"></work-package-attachments>
+    <work-package-attachments work-package="vm.workPackage" data-ng-show="vm.hideEmptyFields"></work-package-attachments>
   </div>
 </div>
 

--- a/frontend/app/components/work-packages/wp-create-form/wp-full-create-form.directive.html
+++ b/frontend/app/components/work-packages/wp-create-form/wp-full-create-form.directive.html
@@ -49,7 +49,7 @@
     </div>
 
     <div ng-repeat="group in vm.groupedFields"
-         ng-hide="vm.shouldHideGroup(group.groupName)"
+         ng-hide="vm.shouldHideGroup(group.groupName) && vm.showAllFields"
          class="attributes-group">
 
       <div class="attributes-group--header">
@@ -59,7 +59,7 @@
         </div>
         <div class="attributes-group--header-toggle">
           <panel-expander tabindex="-1" ng-if="vm.showToggleButton() && $first"
-                          collapsed="vm.hideEmptyFields"
+                          collapsed="vm.showAllFields"
                           expand-text="{{ ::I18n.t('js.label_show_attributes') }}"
                           collapse-text="{{ ::I18n.t('js.label_hide_attributes') }}">
           </panel-expander>
@@ -68,14 +68,14 @@
 
       <div class="attributes-key-value">
         <div
-            ng-hide="vm.hideEmptyFields && vm.isFieldHideable(vm.workPackage, field)"
+            ng-hide="vm.showAllFields && vm.isFieldHideable(vm.workPackage, field)"
             ng-if="vm.isSpecified(vm.workPackage, field) && vm.isEditable(vm.workPackage, field)"
             ng-repeat-start="field in group.attributes" class="attributes-key-value--key">
           {{vm.getLabel(vm.workPackage, field)}}
           <span class="required" ng-if="vm.hasNiceStar(vm.workPackage, field)"> *</span>
         </div>
         <div
-            ng-hide="vm.hideEmptyFields && vm.isFieldHideable(vm.workPackage, field)"
+            ng-hide="vm.showAllFields && vm.isFieldHideable(vm.workPackage, field)"
             ng-if="vm.isSpecified(vm.workPackage, field) && vm.isEditable(vm.workPackage, field)"
             ng-repeat-end
             class="attributes-key-value--value-container">
@@ -83,7 +83,7 @@
         </div>
       </div>
     </div>
-    <work-package-attachments work-package="vm.workPackage" data-ng-show="!vm.hideEmptyFields"></work-package-attachments>
+    <work-package-attachments work-package="vm.workPackage" data-ng-show="vm.hideEmptyFields"></work-package-attachments>
   </div>
 </div>
 

--- a/frontend/app/components/work-packages/wp-new.controller.js
+++ b/frontend/app/components/work-packages/wp-new.controller.js
@@ -47,6 +47,7 @@ function WorkPackageNewController($scope,
 
   vm.groupedFields = [];
   vm.hideEmptyFields = true;
+  vm.showAllFields = false;
 
   vm.loaderPromise = null;
 

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -131,10 +131,6 @@ describe 'new work package', js: true do
         }
 
         it do
-          within '.panel-toggler' do
-            find('a', text: 'Show all attributes').click
-          end
-
           ids = custom_fields.map(&:id)
           cf1 = find("input#inplace-edit--write-value--customField#{ids.first}")
           expect(cf1).not_to be_nil


### PR DESCRIPTION
This changes the behavior of the show all /hide empty button. When creating and editing a WP all fields are shown by default.

https://community.openproject.org/work_packages/22752/activity
