### PR TITLE
Use :warn as production default log level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ OpenProject::Application.configure do
   config.force_ssl = OpenProject::Configuration['rails_force_ssl']
 
   # Set to :debug to see everything in the log.
-  config.log_level = :info
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
I suggest to raise the default logging level to warn on production systems
for performance reasons.

[ci skip]
