### PR TITLE
[22259] Feature/svn path checkout

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -310,12 +310,12 @@ class RepositoriesController < ApplicationController
 
     # Prepare checkout instructions
     # available on all pages (even empty!)
-    @instructions = ::Scm::CheckoutInstructionsService.new(@repository)
+    @path = params[:path] || ''
+    @instructions = ::Scm::CheckoutInstructionsService.new(@repository, path: @path)
 
     # Asserts repository availability, or renders an appropriate error
     @repository.scm.check_availability!
 
-    @path = params[:path] || ''
     @rev = params[:rev].blank? ? @repository.default_branch : params[:rev].to_s.strip
     @rev_to = params[:rev_to]
 

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -30,18 +30,21 @@
 ##
 # Implements a repository service for building checkout instructions if supported
 class Scm::CheckoutInstructionsService
-  attr_reader :repository, :user
+  attr_reader :repository, :user, :path
 
-  def initialize(repository, user: User.current)
+  def initialize(repository, path: nil, user: User.current)
     @repository = repository
     @user = user
+    @path = path
   end
 
   ##
   # Retrieve the checkout URL using the repository vendor information
   # It may additionally set a path parameter, if the repository supports subtree checkout
-  def checkout_url(path = nil)
-    repository.scm.checkout_url(repository, checkout_base_url, path)
+  def checkout_url(with_path = false)
+    repository.scm.checkout_url(repository,
+                                checkout_base_url,
+                                with_path ? @path : nil)
   end
 
   ##

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -40,7 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
     <input id="repository-checkout-url"
            type="text" class="-clickable" size="40"
-           value="<%= @instructions.checkout_url %>"
+           value="<%= @instructions.checkout_url(true) %>"
            onclick="this.focus(); this.select();"
            readonly>
     <button class="toolbar-input--affix toolbar-input-group--affix -append"

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -251,6 +251,33 @@ describe RepositoriesController, type: :controller do
           end
         end
       end
+
+      describe 'checkout path' do
+        render_views
+
+        let(:role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
+        let(:checkout_hash) {
+          {
+            'subversion' => { 'enabled' => '1',
+                              'text' => 'foo',
+                              'base_url' => 'http://localhost'
+            }
+          }
+        }
+
+        before do
+          allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
+          get :show, project_id: project.identifier, path: 'subversion_test'
+        end
+
+        it 'renders an empty warning view' do
+          expected_path = "http://localhost/#{project.identifier}/subversion_test"
+
+          expect(response.code).to eq('200')
+          expect(response).to render_template partial: 'repositories/_checkout_instructions'
+          expect(response.body).to have_selector("#repository-checkout-url[value='#{expected_path}']")
+        end
+      end
     end
   end
 end

--- a/spec/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/services/scm/checkout_instructions_service_spec.rb
@@ -40,6 +40,7 @@ describe Scm::CheckoutInstructionsService do
   }
 
   let(:base_url) { 'http://example.org/svn/' }
+  let(:path) { nil }
   let(:text) { 'foo' }
   let(:checkout_hash) {
     {
@@ -51,7 +52,7 @@ describe Scm::CheckoutInstructionsService do
     }
   }
 
-  subject(:service) { Scm::CheckoutInstructionsService.new(repository, user: user) }
+  subject(:service) { Scm::CheckoutInstructionsService.new(repository, user: user, path: path) }
 
   before do
     allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
@@ -64,9 +65,12 @@ describe Scm::CheckoutInstructionsService do
           .to eq(URI("http://example.org/svn/#{project.identifier}"))
       end
 
-      it 'builds a subpath' do
-        expect(service.checkout_url('foo/bar'))
-          .to eq(URI("http://example.org/svn/#{project.identifier}/foo/bar"))
+      context 'with a subpath' do
+        let(:path) { 'foo/bar' }
+        it do
+          expect(service.checkout_url('foo/bar'))
+            .to eq(URI("http://example.org/svn/#{project.identifier}/foo/bar"))
+        end
       end
     end
 


### PR DESCRIPTION
With 5.0, the checkout instructions in the core did not have path-based checkout for Subversion by default. This PR restores that behavior.

https://community.openproject.org/work_packages/22259/activity
