### PR TITLE
Docker: Fix permission of bundle directory after running gem install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x6
 # We don't want to pollute any locally-mounted directory
 RUN useradd -d /home/app -m app
 RUN mkdir -p /usr/src/app
-RUN chown -R app /usr/src/app /usr/local/bundle
 RUN gem install bundler --version "${BUNDLER_VERSION}"
+RUN chown -R app:app /usr/src/app /usr/local/bundle
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
I get this error while running docker build:

```
Step 16 : RUN bundle install --jobs 8 --retry 3
 ---> Running in fe99d582cb41
Fetching gem metadata from https://rubygems.org/.......
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Fetching git://github.com/finnlabs/awesome_nested_set.git
There was an error while trying to write to
`/usr/local/bundle/cache/bundler/git`. It is likely that you need to grant write
permissions for that path.
The command '/bin/sh -c bundle install --jobs 8 --retry 3' returned a non-zero code: 23
```

This PR fixes it :)
