### PR TITLE
Use separate jobs for karma and protractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ env:
     - COVERAGE=true
 
   matrix:
-    - "TEST_SUITE=npm"
+    - "TEST_SUITE=karma"
+    - "TEST_SUITE=protractor"
 
     - "TEST_SUITE=spec_legacy       DB=mysql     GROUP_SIZE=2  GROUP=1"
     - "TEST_SUITE=spec_legacy       DB=mysql     GROUP_SIZE=2  GROUP=2"

--- a/script/ci_runner.sh
+++ b/script/ci_runner.sh
@@ -59,8 +59,10 @@ else
   GROUPING=''
 fi
 
-if [ $1 = "npm" ]; then
-  run "npm test"
+if [ $1 = "karma" ]; then
+  run "npm run karma"
+elif [ $1 = "protractor" ]; then
+  run "npm run protractor"
 else
   run "bundle exec rake parallel:$1 GROUP_SIZE=$2 GROUP=$3"
 fi


### PR DESCRIPTION
The combined npm suite is starting to get unwieldy and produces quite a
lot of output, so it might be best to split these two into separate
jobs.

/cc @ulferts 
