### PR TITLE
[22559] Allow plugins to receive field classes

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
@@ -69,7 +69,11 @@ export class FieldFactory {
     return new fieldClass(workPackage, fieldName, schema);
   }
 
-  protected static getType(type:string):string {
+  public static getClassFor(fieldName:string):typeof Field {
+    return this.classes[fieldName];
+  }
+
+  public static getType(type:string):string {
     let fields = FieldFactory.fields;
     let defaultType = FieldFactory.defaultType;
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
@@ -41,11 +41,16 @@ export class WorkPackageEditFieldService {
     return FieldFactory.create(resource, fieldName, schema);
   }
 
-  public addFieldType(fieldClass, displayType:string, fields:string[]) {
+  public addFieldType(fieldClass:typeof Field, displayType:string, fields:string[]) {
     fieldClass.type = displayType;
     fieldClass.$injector = this.$injector;
     FieldFactory.register(fieldClass, fields);
     return this;
+  }
+
+  public extendFieldType(displayType:string, fields:string[]) {
+    var fieldClass = FieldFactory.getClassFor(displayType);
+    return this.addFieldType(fieldClass, displayType, fields);
   }
 }
 


### PR DESCRIPTION
Costs cannot directly import, e.g., the SelectField, so we want the
service to be able to return the registered classes in order for Costs
to register the SelectField for a new type (costObject).
