### PR TITLE
Explitly require json5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "glob": "^4.5.3",
     "html-loader": "^0.2.3",
     "json-loader": "^0.5.1",
+    "json5": "^0.4.0",
     "lodash": "^2.4.2",
     "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^0.1.2",


### PR DESCRIPTION
Should fix package build errors that occasionally fail to build npm
dependencies such as https://packager.io/gh/opf/openproject-ce/build_runs/112
