### PR TITLE
Feature/add wp edit custom fields

### DIFF
--- a/app/assets/stylesheets/content/_datepicker.sass
+++ b/app/assets/stylesheets/content/_datepicker.sass
@@ -139,6 +139,11 @@ $dp-shadow-box-opacity: 1
       padding-bottom: $dp-week-padding-bottom
       @include set-table-cells-width($dp-table-width, $dp-number-of-columns)
 
+      // Cancel out effect of min-width css in generic-table in cases where the
+      // date picker is included inside a table.
+      table.generic-table &
+        min-width: 0px
+
     td
       padding: 0
       color: $dp-days-text-color
@@ -155,6 +160,11 @@ $dp-shadow-box-opacity: 1
           margin: $dp-day-margin-hover
           border: $dp-border
           border-radius: $dp-cell-corner-radius
+
+      // Cancel out effect of min-width css in generic-table in cases where the
+      // date picker is included inside a table.
+      table.generic-table &
+        min-width: 0px
 
     .ui-datepicker-week-col
       color: $dp-week-text-color
@@ -174,3 +184,6 @@ $dp-shadow-box-opacity: 1
     opacity: 1
     filter: Alpha(Opacity = 100)
     font-weight: bold
+
+.ui-datepicker--container
+  position: absolute

--- a/frontend/app/components/wp-edit/op-date-picker.directive.html
+++ b/frontend/app/components/wp-edit/op-date-picker.directive.html
@@ -1,0 +1,7 @@
+<div>
+  <ng-transclude></ng-transclude>
+  <!-- This input is there to be used by the datepicker.
+    That way, we don't force the usage of an input element on directives that transclude us -->
+  <input class="hidden-date-picker-input" type="hidden">
+  <div class="ui-datepicker--container"></div>
+</div>

--- a/frontend/app/components/wp-edit/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker.directive.ts
@@ -1,0 +1,167 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+interface opDatePickerScope extends ng.IScope {
+  onDeactivate:Function,
+  onChange:Function
+}
+
+function opDatePickerLink(scope: opDatePickerScope, element: ng.IAugmentedJQuery, attrs, ngModel) {
+  // we don't want the date picker in the accessibility mode
+  if (this.ConfigurationService.accessibilityModeEnabled()) {
+    return;
+  }
+
+  let input = element.find('.hidden-date-picker-input');
+  let datePickerContainer = element.find('.ui-datepicker--container');
+  let datePickerInstance;
+  let DatePicker = this.Datepicker;
+  let onDeactivate = scope.onDeactivate;
+  let onChange = scope.onChange;
+  let onClickCallback;
+
+  let unbindNgModelInitializationWatch = scope.$watch(() => ngModel.$viewValue !== NaN, () => {
+    showDatePicker();
+    unbindNgModelInitializationWatch();
+  });
+
+  function hide() {
+    datePickerInstance.hide();
+    unregisterClickCallback();
+  };
+
+  function registerClickCallback() {
+    // HACK: we need to bind to 'mousedown' because the wp-edit-field.directive
+    // binds to 'click' and stops the event propagation
+    onClickCallback = angular.element('body').bind('mousedown', function(e) {
+      var target = angular.element(e.target);
+      if(!target.is(input) &&
+        target.parents(datePickerContainer.attr('class')).length <= 0 &&
+        target.parents('.ui-datepicker-header').length <= 0) {
+
+        hide();
+        onDeactivate();
+      }
+    });
+  }
+
+  function unregisterClickCallback() {
+    angular.element('body').unbind('click', onClickCallback);
+  }
+
+  function showDatePicker() {
+    datePickerInstance = new DatePicker(datePickerContainer, input, ngModel.$viewValue);
+    ensureDatePickerVisible();
+
+    datePickerInstance.onChange = function(date) {
+      ngModel.$setViewValue(date);
+      onChange();
+    };
+
+    datePickerInstance.onDone = function() {
+      onChange();
+    };
+
+    registerClickCallback();
+  };
+
+  function ensureDatePickerVisible() {
+    let visibilityContainer = datePickerContainer.offsetParent();
+    let templateContainer = element.children('div');
+    // typescript compiler does not like it if we simply use
+    // containerBoundaries = visibilityContainer.offset()
+    let containerBoundaries = { top: visibilityContainer.offset().top,
+                                left: visibilityContainer.offset().left,
+                                right: visibilityContainer.offset().left + visibilityContainer.width(),
+                                bottom: visibilityContainer.offset().top + visibilityContainer.height() };
+
+    let positions = [
+      {
+        check: ((templateContainer.offset().top + templateContainer.height() + datePickerContainer.height() <= containerBoundaries.bottom) &&
+               (templateContainer.offset().left + datePickerContainer.width() <= containerBoundaries.right)),
+        css: {} //no change
+      },
+      {
+        check: ((templateContainer.offset().top + templateContainer.height() + datePickerContainer.height() <= containerBoundaries.bottom) &&
+               (templateContainer.offset().left + datePickerContainer.width() >= containerBoundaries.right)),
+        css: { marginLeft: templateContainer[0].offsetWidth - datePickerContainer.width() }
+      },
+      {
+        check: ((templateContainer.offset().top - datePickerContainer.height() >= containerBoundaries.top) &&
+               (templateContainer.offset().left + datePickerContainer.width() <= containerBoundaries.right)),
+        css: { marginTop: -templateContainer[0].offsetHeight - datePickerContainer.height() + 'px' }
+      },
+      {
+        check: ((templateContainer.offset().top - datePickerContainer.height() >= containerBoundaries.top) &&
+               (templateContainer.offset().left + datePickerContainer.width() >= containerBoundaries.right)),
+        css: { marginTop: -templateContainer[0].offsetHeight - datePickerContainer.height() + 'px',
+               marginLeft: templateContainer[0].offsetWidth - datePickerContainer.width() }
+      },
+      {
+        check: templateContainer.offset().left + templateContainer.width() + datePickerContainer.width() <= containerBoundaries.right,
+        css: { marginTop: -templateContainer[0].offsetHeight/2 - datePickerContainer.height()/2 + 'px',
+               marginLeft: templateContainer[0].offsetWidth }
+      },
+      {
+        check: true,
+        css: { marginTop: -templateContainer[0].offsetHeight/2 - datePickerContainer.height()/2 + 'px',
+               marginLeft: -datePickerContainer[0].offsetWidth }
+      }
+    ]
+
+    // use _.some to limit the checks to the first truthy position
+    _.some(positions, (position) => {
+      if (position.check) {
+        datePickerContainer.css(position.css);
+        return true;
+      }
+    });
+  };
+}
+
+function opDatePicker(ConfigurationService, Datepicker) {
+  let dependencies = { ConfigurationService: ConfigurationService,
+                       Datepicker: Datepicker };
+
+  return {
+    restrict: 'E',
+    transclude: true,
+    templateUrl: '/components/wp-edit/op-date-picker.directive.html',
+    //  by curtesy of http://stackoverflow.com/a/33614939/3206935
+    link: angular.bind(dependencies, opDatePickerLink),
+    require: 'ngModel',
+    scope: {
+      onChange: "&",
+      onDeactivate: "&"
+    }
+  };
+}
+
+angular
+  .module('openproject')
+  .directive('opDatePicker', opDatePicker);

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.directive.html
@@ -1,0 +1,5 @@
+<input type="checkbox"
+       wp-edit-field-requirements="vm.field.schema"
+       ng-model="vm.workPackage[vm.fieldName]"
+       ng-change="vm.submit()"
+       ng-blur="vm.deactivate()"/>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.directive.html
@@ -2,4 +2,5 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-change="vm.submit()"
-       ng-blur="vm.deactivate()"/>
+       ng-blur="vm.deactivate()"
+       focus />

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-boolean-field.module.ts
@@ -28,31 +28,6 @@
 
 import {Field} from "./wp-edit-field.module";
 
-export class SelectField extends Field {
-  public options:any[];
-  public placeholder:string = '-';
-  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html'
-
-  constructor(workPackage, fieldName, schema) {
-    super(workPackage, fieldName, schema);
-
-    if (angular.isArray(this.schema.allowedValues)) {
-      this.options = angular.copy(this.schema.allowedValues);
-      this.addEmptyOption();
-    } else {
-      this.schema.allowedValues.$load().then((values) => {
-        this.options = angular.copy(values.elements);
-        this.addEmptyOption();
-      });
-    }
-  }
-
-  private addEmptyOption() {
-    if (!this.schema.required) {
-      this.options.unshift({
-        href: "null",
-        name: this.placeholder,
-      });
-    }
-  }
+export class BooleanField extends Field {
+  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-boolean-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.directive.html
@@ -1,0 +1,8 @@
+<op-date-picker
+  on-change="vm.submit()"
+  ng-model="vm.workPackage[vm.fieldName]">
+
+  <input ng-model="vm.workPackage[vm.fieldName]"
+         type="text"/>
+
+</op-date-picker>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.directive.html
@@ -1,8 +1,10 @@
 <op-date-picker
   on-change="vm.submit()"
+  on-deactivate="vm.deactivate()"
   ng-model="vm.workPackage[vm.fieldName]">
 
   <input ng-model="vm.workPackage[vm.fieldName]"
-         type="text"/>
+         type="text"
+         focus/>
 
 </op-date-picker>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-date-field.module.ts
@@ -1,0 +1,33 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {Field} from "./wp-edit-field.module";
+
+export class DateField extends Field {
+  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-date-field.directive.html'
+}

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
@@ -27,24 +27,17 @@
 // ++
 
 import {Field} from "./wp-edit-field.module";
-import {WorkPackageEditFieldService} from "./wp-edit-field.service";
 import {TextField} from "./wp-edit-text-field.module";
 import {SelectField} from "./wp-edit-select-field.module";
+import {FloatField} from "./wp-edit-float-field.module";
+import {IntegerField} from "./wp-edit-integer-field.module";
+import {BooleanField} from "./wp-edit-boolean-field.module";
 
 //TODO: Implement
 class DateField extends Field {}
 
 //TODO: Implement
 class DateRangeField extends Field {}
-
-//TODO: Implement
-class IntegerField extends Field {}
-
-//TODO: Implement
-class FloatField extends Field {}
-
-//TODO: Implement
-class BooleanField extends Field {}
 
 //TODO: Implement
 class DurationField extends Field {}
@@ -65,5 +58,8 @@ angular
                                             'Type',
                                             'User',
                                             'Version',
-                                            'Category']);
+                                            'Category'])
+      .addFieldType(FloatField, 'float', ['Float'])
+      .addFieldType(IntegerField, 'integer', ['Integer'])
+      .addFieldType(BooleanField, 'boolean', ['Boolean']);
   });

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
@@ -26,15 +26,14 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {WorkPackageEditFieldService} from "./wp-edit-field.service";
 import {Field} from "./wp-edit-field.module";
 import {TextField} from "./wp-edit-text-field.module";
 import {SelectField} from "./wp-edit-select-field.module";
 import {FloatField} from "./wp-edit-float-field.module";
 import {IntegerField} from "./wp-edit-integer-field.module";
 import {BooleanField} from "./wp-edit-boolean-field.module";
-
-//TODO: Implement
-class DateField extends Field {}
+import {DateField} from "./wp-edit-date-field.module";
 
 //TODO: Implement
 class DateRangeField extends Field {}
@@ -62,5 +61,6 @@ angular
                                             'StringObject'])
       .addFieldType(FloatField, 'float', ['Float'])
       .addFieldType(IntegerField, 'integer', ['Integer'])
-      .addFieldType(BooleanField, 'boolean', ['Boolean']);
+      .addFieldType(BooleanField, 'boolean', ['Boolean'])
+      .addFieldType(DateField, 'date', ['Date']);
   });

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
@@ -58,7 +58,8 @@ angular
                                             'Type',
                                             'User',
                                             'Version',
-                                            'Category'])
+                                            'Category',
+                                            'StringObject'])
       .addFieldType(FloatField, 'float', ['Float'])
       .addFieldType(IntegerField, 'integer', ['Integer'])
       .addFieldType(BooleanField, 'boolean', ['Boolean']);

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -1,6 +1,5 @@
 <div ng-click="vm.isEditable && vm.activate()" class="wp-edit-field">
-  <form ng-show="vm.active"
-        ng-if="vm.workPackage"
+  <form ng-if="vm.workPackage && vm.active"
         ng-submit="vm.submit()">
 
     <ng-include src="vm.field.template"></ng-include>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -62,7 +62,7 @@ export class WorkPackageEditFieldController {
   }
 
   public get isEditable():boolean {
-    return this.isSupportedField && this.workPackage.isEditable;
+    return this.workPackage.isEditable;
   }
 
   public deactivate():boolean {
@@ -74,20 +74,6 @@ export class WorkPackageEditFieldController {
       this.field = this.wpEditField.getField(
         this.workPackage, this.fieldName, schema[this.fieldName]);
     });
-  }
-
-  // This method is temporarily needed to control which fields
-  // we support for inline editing. Once all fields are supported,
-  // the method is to be removed.
-  private get isSupportedField():boolean {
-    return ['subject',
-            'priority',
-            'type',
-            'status',
-            'assignee',
-            'responsible',
-            'version',
-            'category'].indexOf(this.fieldName) !== -1
   }
 }
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.directive.html
@@ -2,4 +2,5 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-blur="vm.deactivate()"
-       float-value />
+       float-value
+       focus />

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.directive.html
@@ -1,0 +1,5 @@
+<input type="text"
+       wp-edit-field-requirements="vm.field.schema"
+       ng-model="vm.workPackage[vm.fieldName]"
+       ng-blur="vm.deactivate()"
+       float-value />

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-float-field.module.ts
@@ -1,4 +1,3 @@
-// -- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 //
@@ -28,31 +27,6 @@
 
 import {Field} from "./wp-edit-field.module";
 
-export class SelectField extends Field {
-  public options:any[];
-  public placeholder:string = '-';
-  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html'
-
-  constructor(workPackage, fieldName, schema) {
-    super(workPackage, fieldName, schema);
-
-    if (angular.isArray(this.schema.allowedValues)) {
-      this.options = angular.copy(this.schema.allowedValues);
-      this.addEmptyOption();
-    } else {
-      this.schema.allowedValues.$load().then((values) => {
-        this.options = angular.copy(values.elements);
-        this.addEmptyOption();
-      });
-    }
-  }
-
-  private addEmptyOption() {
-    if (!this.schema.required) {
-      this.options.unshift({
-        href: "null",
-        name: this.placeholder,
-      });
-    }
-  }
+export class FloatField extends Field {
+  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-float-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.directive.html
@@ -1,0 +1,4 @@
+<input type="number"
+       wp-edit-field-requirements="vm.field.schema"
+       ng-model="vm.workPackage[vm.fieldName]"
+       ng-blur="vm.deactivate()">

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.directive.html
@@ -1,4 +1,5 @@
 <input type="number"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
-       ng-blur="vm.deactivate()">
+       ng-blur="vm.deactivate()"
+       focus>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-integer-field.module.ts
@@ -28,31 +28,6 @@
 
 import {Field} from "./wp-edit-field.module";
 
-export class SelectField extends Field {
-  public options:any[];
-  public placeholder:string = '-';
-  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html'
-
-  constructor(workPackage, fieldName, schema) {
-    super(workPackage, fieldName, schema);
-
-    if (angular.isArray(this.schema.allowedValues)) {
-      this.options = angular.copy(this.schema.allowedValues);
-      this.addEmptyOption();
-    } else {
-      this.schema.allowedValues.$load().then((values) => {
-        this.options = angular.copy(values.elements);
-        this.addEmptyOption();
-      });
-    }
-  }
-
-  private addEmptyOption() {
-    if (!this.schema.required) {
-      this.options.unshift({
-        href: "null",
-        name: this.placeholder,
-      });
-    }
-  }
+export class IntegerField extends Field {
+  public template:string = '/components/wp-edit/wp-edit-field/wp-edit-integer-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html
@@ -2,6 +2,7 @@
         wp-edit-field-requirements="vm.field.schema"
         ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
         ng-change="vm.submit()"
-        ng-blur="vm.deactivate()">
+        ng-blur="vm.deactivate()"
+        focus>
   <option value="" ng-if="false"></option>
 </select>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-select-field.directive.html
@@ -1,6 +1,6 @@
 <select ng-model="vm.workPackage[vm.fieldName]"
         wp-edit-field-requirements="vm.field.schema"
-        ng-options="value as value.name for value in vm.field.options track by value.href"
+        ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
         ng-change="vm.submit()"
         ng-blur="vm.deactivate()">
   <option value="" ng-if="false"></option>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-text-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-text-field.directive.html
@@ -1,4 +1,5 @@
 <input type="text"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
-       ng-blur="vm.deactivate()">
+       ng-blur="vm.deactivate()"
+       focus>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-text-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-text-field.module.ts
@@ -27,7 +27,6 @@
 // ++
 
 import {Field} from "./wp-edit-field.module";
-import {WorkPackageEditFieldService} from "./wp-edit-field.service";
 
 export class TextField extends Field {
   public template:string = '/components/wp-edit/wp-edit-field/wp-edit-text-field.directive.html'

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.js
@@ -49,6 +49,7 @@ function wpTd(){
 
 function WorkPackageTdController($scope, I18n, PathHelper, WorkPackagesHelper) {
   var vm = this;
+      vm.displayText = I18n.t('js.work_packages.placeholders.default');
 
   function updateAttribute() {
     if (!vm.schema[vm.attribute]) {


### PR DESCRIPTION
Adds inplace-edit directives for:
- `Integer`
- `Boolean`
- `Date`
- `Float`

That way, all custom fields are covered (Version and User already work via selects). 

Most of the new directives are very easy with the exception of the directive for `Date`. The directive itself is deliberately kept easy at the expense of having to create a new directive for the date picker. That way, the responsibilities are separated nicely. 

The PR additionally fixes the focus behaviour on the existing inplace edit directives. Once the user has activated an inline edit, the focus will be switched to the activated field. Doing that makes editing way easier and allows to actually make user of `ng-blur`.

Because the inplace edit directive for `Date` is employed within the work packages table and the date picker contains a table element itself, the styling of the work packages table is applied to the datepicker which is undesirable. I expect @HDinger to make short work of that problem :smile:
- https://community.openproject.org/work_packages/22558/activity
- https://community.openproject.org/work_packages/22554/activity
