### PR TITLE
Make escape cancel edition and restore pristine value

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -1,6 +1,7 @@
 <div ng-click="vm.isEditable && vm.activate()" class="wp-edit-field -small"
      ng-class="{ '-error': vm.errorenous, '-active': vm.active }">
   <form ng-if="vm.workPackage && vm.active"
+        name="vm.wpEditForm"
         ng-submit="vm.submit()">
 
     <ng-include src="vm.field.template"></ng-include>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -58,6 +58,10 @@ export class WorkPackageEditFieldController {
   }
 
   public activate() {
+    if (this._active) {
+      return;
+    }
+
     this.pristineValue = angular.copy(this.workPackage[this.fieldName]);
     this.setupField().then(() => {
       this._active = this.field.schema.writable;
@@ -96,8 +100,7 @@ function wpEditFieldLink(
   scope,
   element,
   attrs,
-  controllers: [WorkPackageEditFormController, WorkPackageEditFieldController],
-  $timeout) {
+  controllers: [WorkPackageEditFormController, WorkPackageEditFieldController]) {
 
   controllers[1].formCtrl = controllers[0];
   controllers[1].formCtrl.fields[scope.vm.fieldName] = scope.vm;
@@ -117,7 +120,7 @@ function wpEditFieldLink(
   element.addClass(scope.vm.fieldName);
   element.keyup(event => {
     if (event.keyCode === 27) {
-      $timeout(_ => scope.vm.reset());
+      scope.$evalAsync(_ => scope.vm.reset());
     }
   })
 }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -32,10 +32,12 @@ import {Field} from "./wp-edit-field.module";
 
 
 export class WorkPackageEditFieldController {
-  public formCtrl:WorkPackageEditFormController;
+  public formCtrl: WorkPackageEditFormController;
+  public wpEditForm:ng.IFormController;
   public fieldName:string;
   public field:Field;
   public errorenous:boolean;
+  protected pristineValue:any;
 
   protected _active:boolean = false;
 
@@ -56,6 +58,7 @@ export class WorkPackageEditFieldController {
   }
 
   public activate() {
+    this.pristineValue = angular.copy(this.workPackage[this.fieldName]);
     this.setupField().then(() => {
       this._active = this.field.schema.writable;
     });
@@ -74,6 +77,13 @@ export class WorkPackageEditFieldController {
     this.$element.toggleClass('-error', error)
   }
 
+  public reset() {
+    this.workPackage[this.fieldName] = this.pristineValue;
+    this.wpEditForm.$setPristine();
+    this.deactivate();
+    this.pristineValue = null;
+  }
+
   protected setupField():ng.IPromise<any> {
     return this.formCtrl.loadSchema().then(schema => {
       this.field = this.wpEditField.getField(
@@ -82,7 +92,12 @@ export class WorkPackageEditFieldController {
   }
 }
 
-function wpEditFieldLink(scope, element, attrs, controllers:[WorkPackageEditFormController, WorkPackageEditFieldController]) {
+function wpEditFieldLink(
+  scope,
+  element,
+  attrs,
+  controllers: [WorkPackageEditFormController, WorkPackageEditFieldController],
+  $timeout) {
 
   controllers[1].formCtrl = controllers[0];
   controllers[1].formCtrl.fields[scope.vm.fieldName] = scope.vm;
@@ -100,6 +115,11 @@ function wpEditFieldLink(scope, element, attrs, controllers:[WorkPackageEditForm
   })
 
   element.addClass(scope.vm.fieldName);
+  element.keyup(event => {
+    if (event.keyCode === 27) {
+      $timeout(_ => scope.vm.reset());
+    }
+  })
 }
 
 function wpEditField() {


### PR DESCRIPTION
This lets escape while in edit mode cancel the edition and restore the value using a pristine copy of the value.

I was trying to use the pristine values from `form.payload`, however they aren't `$load`ed , and thus are not complete values. I argue its easier to copy the value when starting to edit the field.
