### PR TITLE
[22846] Remove required attribute of empty translated fields

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -985,7 +985,9 @@ var I18nForms = (function ($) {
           new_translation.hide();
           new_translation.find('.destroy_flag').val('1')
                                                .attr('disabled', false);
-          new_translation.find('input, textarea').val('');
+          new_translation.find('input, textarea').val('')
+                                                 .removeAttr('aria-required')
+                                                 .removeAttr('required');
           new_translation.find('.locale_selector').val(locale);
           new_translation.insertAfter(translations.first());
 


### PR DESCRIPTION
Translations for `:multi_locale` fields are set to '', which is a
problem when they're set to `required="true"` since Chrome will try to
focus that element, which is invisible and cause a horrible `An invalid form control with name='...' is not focusable` error.

https://community.openproject.org/work_packages/22846/activity
