### PR TITLE
[21808] Make wp view mode buttons accessible 

### DIFF
--- a/frontend/app/components/wp-buttons/wp-button.template.html
+++ b/frontend/app/components/wp-buttons/wp-button.template.html
@@ -8,7 +8,7 @@
         class="button"
         title="{{ vm.label }}"
         ng-click="vm.performAction()"
-        ng-disabled="vm.disabled"
+        ng-disabled="vm.disabled || vm.isActive()"
         ng-class="{ '-active': vm.isActive() }">
   <i class="{{ ::vm.iconClass }} button--icon"></i>
   <span class="hidden-for-sighted">{{ vm.label }}</span>


### PR DESCRIPTION
This changes the `disabled` implementation of the WP view buttons. Now the selected button gets disabled. Thus the screen readers do not read it.

https://community.openproject.org/work_packages/21808/activity
