### PR TITLE
[19689] In details pane in relations tab, the focus is not set correctly on input field when expanding field

### DIFF
--- a/frontend/app/templates/work_packages/tabs/_add_work_package_relation.html
+++ b/frontend/app/templates/work_packages/tabs/_add_work_package_relation.html
@@ -7,8 +7,9 @@
         ng-model="$parent.relationToAddId"
         title="{{ I18n.t('js.field_value_enter_prompt', { field: I18n.t('js.relation_labels.' + handler.relationsId) }) }}"
         required
-        theme="select2">
-        <ui-select-match>{{$select.selected.to_s}}</ui-select-match>
+        theme="select2"
+        tabindex="0">
+        <ui-select-match tabindex="-1">{{$select.selected.to_s}}</ui-select-match>
         <ui-select-choices
           refresh-delay="100"
           refresh="autocompleteWorkPackages($select.search)"


### PR DESCRIPTION
This sets the tab index for the ui-select to avoid multiple tabbing for one field.

https://community.openproject.org/work_packages/19689/activity
