### PR TITLE
[22887] Design issues on wiki page

### DIFF
--- a/app/assets/stylesheets/_jstoolbar.sass
+++ b/app/assets/stylesheets/_jstoolbar.sass
@@ -83,6 +83,9 @@ $jstoolbar--icon-active-background: #eee
       box-shadow: inset 0px 0px 3px $jstoolbar--icon-active-border
       background: $jstoolbar--icon-active-background
 
+    &:before
+      display: block
+
     span
       display: none
 

--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -571,6 +571,7 @@ div.indent
   select#parent_wiki_menu_item
     margin-left: 7px
     margin-top: -1px
+    line-height: normal
   #item-name
     float: left
     padding-left: 3px

--- a/app/assets/stylesheets/content/_legacy_actions.sass
+++ b/app/assets/stylesheets/content/_legacy_actions.sass
@@ -49,7 +49,7 @@ ul.legacy-actions-main
 
 ul.legacy-actions-specific,
 .nosidebar ul.legacy-actions-specific
-  @include legacy-actions-defaults(-34px)
+  @include legacy-actions-defaults(-7px)
 
 p.subtitle + ul.legacy-actions-specific
   @include legacy-actions-defaults(-57px)

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -193,28 +193,10 @@ blockquote
     right: 15px
     padding: 0 0 0 0
 
-.toolbar-container + .wiki-content
+.toolbar-container ~ .wiki-content
   margin-top: -64px
 
-
 @include breakpoint(680px down)
-  .toolbar-container .toolbar-items
-    background: #fff
-    display: flex
-    margin-bottom: 20px
-    width: calc(100% + 5px)
+  .toolbar-container ~ .wiki-content
+    margin-top: 0
 
-    > li
-      -webkit-flex: 1 0 0
-      flex: 1 0 0
-
-      &:first-child
-        -webkit-flex: 3 0 0
-        flex: 3 0 0
-
-      .button
-        width: 100%
-        margin-top: 0
-
-  .wiki-title
-    margin-top: 4rem

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -26,8 +26,6 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$toolbar-width: 400px
-
 div.wiki
   font-size: $wiki-default-font-size
   $wiki-max-heading-font-size: 24px
@@ -163,6 +161,29 @@ h1:hover, h2:hover, h3:hover
     font-weight: bold
     font-size: $wiki-default-font-size
 
+  .wiki-title
+    max-width: 100%
+    overflow: hidden
+    text-overflow: ellipsis
+
+#wiki_form .attributes-group
+  .attributes-group--header-text
+    color: lighten($body-font-color, 10)
+  .form--label
+    display: none
+
+  .form--field-container
+    max-width: 100%
+
+    .form--text-area-container
+      margin-top: -46px
+
+      .jstElements
+        margin-bottom: 18px
+
+#wiki_page_parent_id
+  overflow: auto
+
 blockquote
   font-style: italic
   &.icon:before
@@ -174,5 +195,26 @@ blockquote
 
 .toolbar-container + .wiki-content
   margin-top: -64px
-  // Attention: When more buttons are added to the toolbar this might has to be changed
-  width: calc(100% - #{$toolbar-width})
+
+
+@include breakpoint(680px down)
+  .toolbar-container .toolbar-items
+    background: #fff
+    display: flex
+    margin-bottom: 20px
+    width: calc(100% + 5px)
+
+    > li
+      -webkit-flex: 1 0 0
+      flex: 1 0 0
+
+      &:first-child
+        -webkit-flex: 3 0 0
+        flex: 3 0 0
+
+      .button
+        width: 100%
+        margin-top: 0
+
+  .wiki-title
+    margin-top: 4rem

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -271,3 +271,23 @@
 .toolbar
   *
     outline: none
+
+@include breakpoint(680px down)
+  .toolbar-container .toolbar-items
+    background: #fff
+    display: flex
+    margin-bottom: 20px
+    width: calc(100% + 5px)
+
+    > li
+      -webkit-flex: 1 0 0
+      flex: 1 0 0
+
+      &:first-child
+        -webkit-flex: 3 0 0
+        flex: 3 0 0
+
+      .button
+        width: 100%
+        margin-top: 0
+        white-space: nowrap

--- a/app/views/wiki/_content.html.erb
+++ b/app/views/wiki/_content.html.erb
@@ -28,5 +28,6 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="wiki wiki-content">
+  <h1 class="wiki-title"><%= content.page.pretty_title %></h1>
   <%= format_text content, :text, attachments: content.page.attachments %>
 </div>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -30,11 +30,16 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>
-  <div class="form--field -required -vertical">
-    <%= f.text_area :text, cols: 100, rows: 25, class: 'wiki-edit', accesskey: accesskey(:edit),
-                  value: format_text(@content, :text, attachments: @content.page.attachments, edit: true),
-                  :'ng-non-bindable' => '' %>
+
+  <div class="attributes-group">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container">
+        <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
+       </div>
+     </div>
+    <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %>
   </div>
+
   <div class="form--field">
     <%= f.text_field :comments, size: 120 %>
   </div>

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -38,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
             "<option value=''></option>".html_safe + wiki_page_options_for_select(@parent_pages,
                                                                                   @page.parent),
             {label: WikiPage.human_attribute_name(:parent_title) },
-            {size: "#{@parent_pages.size + 1}", class: "parent-select"} %>
+            {size: "#{@parent_pages.size + 2}", class: "parent-select"} %>
     </p>
 
     <%= javascript_tag do -%>

--- a/app/views/wiki/index.html.erb
+++ b/app/views/wiki/index.html.erb
@@ -34,14 +34,16 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% content_for :action_menu_specific do %>
-  <%= watcher_link(@wiki, User.current) %>
+  <%= content_tag(:li, watcher_link(@wiki, User.current), class: 'toolbar-item') %>
 <% end %>
 
 <% html_title l(:label_wiki_toc) %>
 
-<h2 class="legacy-heading"><%= l(:label_index_by_title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
+<div class="wiki-content">
+<h2 class="legacy-heading"><%= l(:label_index_by_title) %></h2>
 <%= render_page_hierarchy(@pages_by_parent_id, nil, timestamp: true) %>
+</div>
 
 <% content_for :sidebar do %>
   <%= render partial: 'sidebar' %>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -30,11 +30,10 @@ See doc/COPYRIGHT.rdoc for more details.
 <h2 class="legacy-heading">
   <% if @page.parent %>
     <% breadcrumb_for_page(@page.parent, l("create_new_page")) %>
-    <%= l("create_child_page_for", title: @page.parent.pretty_title) %>
   <% else %>
     <% breadcrumb_paths(l("create_new_page")) %>
-    <%= l("create_new_page") %>
   <% end %>
+  <%= l("create_new_page") %>
 </h2>
 
 <%= labelled_tabular_form_for @content, as: :content, url: wiki_create_path(project_id: @project), html: {method: :post, multipart: true, id: 'wiki_form'} do |f| %>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -47,9 +47,24 @@ See doc/COPYRIGHT.rdoc for more details.
         <%= page_fields.text_field :title, size: 120 %>
       <% end %>
     </div>
-    <div class="form--field -required -vertical">
-      <%= f.text_area :text, cols: 100, rows: 25, class: 'wiki-edit', accesskey: accesskey(:edit),
-                      :'ng-non-bindable' => '' %>
+    <% if @page.parent %>
+      <div class="form--field -required">
+        <%= f.fields_for :page, @page do |page_fields| %>
+          <%= page_fields.select :parent_id,
+                "<option value=''></option>".html_safe + wiki_page_options_for_select(@wiki.pages,
+                                                                                      @page.parent),
+                {label: WikiPage.human_attribute_name(:parent_title)},
+                {class: "parent-select form--select"} %>
+        <% end%>
+      </div>
+    <% end %>
+    <div class="attributes-group">
+      <div class="attributes-group--header">
+        <div class="attributes-group--header-container">
+          <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
+         </div>
+       </div>
+      <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %>
     </div>
 
     <div class="form--field">

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @editable %>
     <% if User.current.allowed_to? :edit_wiki_pages, @project %>
       <% if @page %>
-        <%= content_tag(:li, link_to(l(:create_child_page), wiki_new_child_path(id: @page, project_id: @project), class: 'button icon-add -alt-highlight'), class: 'toolbar-item') %>
+        <%= content_tag(:li, link_to(l(:create_new_page), wiki_new_child_path(id: @page, project_id: @project), class: 'button icon-add -alt-highlight'), class: 'toolbar-item') %>
       <% end %>
     <% end %>
     <%= li_unless_nil(link_to_if_authorized(l(:button_edit), {action: 'edit', id: @page}, class: 'button icon-edit', accesskey: accesskey(:edit)), class: 'toolbar-item') if @content.version == @page.content.version %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -30,6 +30,11 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= call_hook :wiki_navigation %>
 <% content_for :action_menu_main do %>
   <% if @editable %>
+    <% if User.current.allowed_to? :edit_wiki_pages, @project %>
+      <% if @page %>
+        <%= content_tag(:li, link_to(l(:create_child_page), wiki_new_child_path(id: @page, project_id: @project), class: 'button icon-add -alt-highlight'), class: 'toolbar-item') %>
+      <% end %>
+    <% end %>
     <%= li_unless_nil(link_to_if_authorized(l(:button_edit), {action: 'edit', id: @page}, class: 'button icon-edit', accesskey: accesskey(:edit)), class: 'toolbar-item') if @content.version == @page.content.version %>
     <%= li_unless_nil(watcher_link(@page, User.current), class: 'toolbar-item') if Setting.notified_events.include?("wiki_content_added") or Setting.notified_events.include?("wiki_content_updated") %>
   <% end %>
@@ -38,11 +43,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @editable %>
     <%= li_unless_nil(link_to_if_authorized(l(:button_lock), {action: 'protect', id: @page, protected: 1}, method: :post, class: 'icon-context icon-locked')) if !@page.protected? %>
     <%= li_unless_nil(link_to_if_authorized(l(:button_unlock), {action: 'protect', id: @page, protected: 0}, method: :post, class: 'icon-context icon-unlocked')) if @page.protected? %>
-    <% if User.current.allowed_to? :edit_wiki_pages, @project %>
-      <% if @page %>
-        <%= content_tag(:li, link_to(l(:create_child_page), wiki_new_child_path(id: @page, project_id: @project), class: 'icon-context icon-duplicate')) %>
-      <% end %>
-    <% end %>
     <% if @content.version == @page.content.version %>
       <%= li_unless_nil(link_to_if_authorized(t(:button_rename),
                                               {action: 'rename', id: @page},
@@ -56,6 +56,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% end %>
   <%= li_unless_nil(link_to_if_authorized(l(:label_history), {action: 'history', id: @page}, class: 'icon-context icon-wiki')) %>
   <%= li_unless_nil(link_to_if_authorized(l(:button_manage_menu_entry), {controller: '/wiki_menu_items', action: 'edit', project_id: @project.identifier, id: @page}, class: 'icon-context icon-settings')) %>
+  <%= li_unless_nil(link_to_if_authorized(l(:label_table_of_contents), {controller: '/wiki', action: 'index', project_id: @project.identifier, id: @page}, class: 'icon-context icon-view-list')) %>
 <% end %>
 <% breadcrumb_paths(*(@page.ancestors.reverse.collect {|parent| link_to h(parent.breadcrumb_title), {id: parent, project_id: parent.project}} + [h(@page.breadcrumb_title)])) %>
 <% if @content.version != @page.content.version %>

--- a/app/views/wiki_menu_items/edit.html.erb
+++ b/app/views/wiki_menu_items/edit.html.erb
@@ -52,15 +52,6 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= form.radio_button 'setting', :main_item %>
     <%= form.label 'setting_main_item', l(:label_wiki_show_menu_item) %>
   </p>
-  <p class="wiki_menu_item_optional_links">
-    <%= form.check_box 'new_wiki_page' %>
-    <%= form.label 'new_wiki_page', l(:label_wiki_show_new_page_link) %>
-
-    <br>
-
-    <%= form.check_box 'index_page' %>
-    <%= form.label 'index_page', l(:label_wiki_show_index_page_link) %>
-  </p>
   <p>
     <% disabled = @parent_menu_item_options.empty? %>
     <%= form.radio_button 'setting', :sub_item, disabled: disabled %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -578,9 +578,7 @@ en:
       failed: "Could not copy project \"%{source_project_name}\" to project \"%{target_project_name}\"."
       succeeded: "Copied project \"%{source_project_name}\" to \"%{target_project_name}\"."
 
-  create_child_page: "Create new child page"
-  create_child_page_for: "Create new child page: \"%{title}\""
-  create_new_page: "Create new page"
+  create_new_page: "Create wiki page"
 
   date:
     abbr_day_names: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]

--- a/features/menu_items/wiki_menu_items.feature
+++ b/features/menu_items/wiki_menu_items.feature
@@ -63,24 +63,16 @@ Feature: Wiki menu items
     And I click on "Configure menu item"
     And I fill in "Avocado Wuaärst" for "menu_items_wiki_menu_item_name"
     And I choose "Show as menu item in project navigation"
-    And I check "Show submenu item 'Create new child page'"
-    And I check "Show submenu item 'Table of Contents'"
     And I press "Save"
     When I go to the wiki page "AwesomePage" for the project called "Awesome Project"
     Then I should see "Avocado Wuaärst" within "#main-menu"
-    Then I should see "Table of Contents" within "#main-menu"
-    Then I should see "Create new child page" within "#main-menu"
 
   @javascript @selenium
   Scenario: Change existing entry
     When I go to the wiki page "Wiki" for the project called "Awesome Project"
-    Then I should see "Table of Contents" within "#main-menu"
-    Then I should see "Create new child page" within "#main-menu"
     When I click on "More"
     And I click on "Configure menu item"
     And I fill in "Wikikiki" for "menu_items_wiki_menu_item_name"
-    And I uncheck "Show submenu item 'Table of Contents'"
-    And I uncheck "Show submenu item 'Create new child page'"
     And I press "Save"
     When I go to the wiki page "Wiki" for the project called "Awesome Project"
     Then I should see "Wikikiki" within "#main-menu"
@@ -90,8 +82,6 @@ Feature: Wiki menu items
   @javascript
   Scenario: Do not change existing entry, but saving nonetheless
     When I go to the wiki page "Wiki" for the project called "Awesome Project"
-    Then I should see "Table of Contents" within "#main-menu"
-    Then I should see "Create new child page" within "#main-menu"
     When I click on "More"
     And I click on "Configure menu item"
     And I press "Save"

--- a/features/menu_items/wiki_menu_items.feature
+++ b/features/menu_items/wiki_menu_items.feature
@@ -76,8 +76,6 @@ Feature: Wiki menu items
     And I press "Save"
     When I go to the wiki page "Wiki" for the project called "Awesome Project"
     Then I should see "Wikikiki" within "#main-menu"
-    Then I should not see "Table of Contents" within "#main-menu"
-    Then I should not see "Create new child page" within "#main-menu"
 
   @javascript
   Scenario: Do not change existing entry, but saving nonetheless

--- a/features/wiki/wiki_create_child.feature
+++ b/features/wiki/wiki_create_child.feature
@@ -49,7 +49,7 @@ Feature: Creating a wiki child page
       | title | Wikiparentpage |
     Given I go to the wiki index page of the project called "project1"
       And I click "Wikiparentpage"
-      And I click "Create new child page"
+      And I click "Create wiki page"
       And I fill in "content_page_title" with "Todd's wiki"
       And I press "Save"
     When I go to the wiki index page of the project called "project1"
@@ -63,7 +63,7 @@ Feature: Creating a wiki child page
       | title         | ParentWikiPage |
       | new_wiki_page | true           |
     When I go to the wiki page "ParentWikiPage" of the project called "project1"
-    And I click "Create new child page"
+    And I click "Create wiki page"
     And I fill in "content_page_title" with "Child Page !@#{$%^&*()_},./<>?;':"
     And I click "Save"
     Then I should see "Successful creation."

--- a/features/wiki/wiki_create_child.feature
+++ b/features/wiki/wiki_create_child.feature
@@ -49,7 +49,6 @@ Feature: Creating a wiki child page
       | title | Wikiparentpage |
     Given I go to the wiki index page of the project called "project1"
       And I click "Wikiparentpage"
-      And I follow "More" within "#content"
       And I click "Create new child page"
       And I fill in "content_page_title" with "Todd's wiki"
       And I press "Save"
@@ -63,7 +62,7 @@ Feature: Creating a wiki child page
     And the project "project1" has 1 wiki menu item with the following:
       | title         | ParentWikiPage |
       | new_wiki_page | true           |
-    When I go to the wiki new child page below the "ParentWikiPage" page of the project called "project1"
+    When I go to the wiki page "ParentWikiPage" of the project called "project1"
     And I click "Create new child page"
     And I fill in "content_page_title" with "Child Page !@#{$%^&*()_},./<>?;':"
     And I click "Save"

--- a/features/wiki/wiki_index.feature
+++ b/features/wiki/wiki_index.feature
@@ -49,12 +49,8 @@ Feature: Viewing the wiki index page
   Scenario: Visiting the wiki index page with a related page that has the index page option enabled on it's menu item should show the page and select the toc menu entry within the wiki menu item
     Given the project "project1" has 1 wiki page with the following:
       | title | ParentWikiPage |
-    And the project "project1" has 1 wiki menu item with the following:
-      | title      | ParentWikiPage |
-      | index_page | true           |
-    When I go to the wiki page "ParentWikiPage" of the project called "project1"
+    And I go to the wiki index page of the project called "project1"
     Then I should see "Index by title" within "#content"
-    And the table of contents wiki menu item inside the "ParentWikiPage" menu item should be selected
 
   Scenario: Visiting the wiki index page with a related page that has the index page option disabled on it's menu item should show the page and select no menu item
     Given the project "project1" has 1 wiki page with the following:

--- a/features/wiki/wiki_index.feature
+++ b/features/wiki/wiki_index.feature
@@ -52,7 +52,7 @@ Feature: Viewing the wiki index page
     And the project "project1" has 1 wiki menu item with the following:
       | title      | ParentWikiPage |
       | index_page | true           |
-    When I go to the wiki index page below the "ParentWikiPage" page of the project called "project1"
+    When I go to the wiki page "ParentWikiPage" of the project called "project1"
     Then I should see "Index by title" within "#content"
     And the table of contents wiki menu item inside the "ParentWikiPage" menu item should be selected
 

--- a/features/wiki/wiki_new_child.feature
+++ b/features/wiki/wiki_new_child.feature
@@ -48,9 +48,8 @@ Feature: Viewing the wiki new child page
     And the project "project1" has 1 wiki menu item with the following:
       | title         | ParentWikiPage |
       | new_wiki_page | true           |
-    When I go to the wiki new child page below the "ParentWikiPage" page of the project called "project1"
-    Then I should see "Create new child page" within "#content"
-    And the child page wiki menu item inside the "ParentWikiPage" menu item should be selected
+    When I go to the wiki page "ParentWikiPage" of the project called "project1"
+    Then I should see "Create wiki page" within "#content"
 
   Scenario: Visiting the wiki new child page with a related page that has the new child page option disabled on it's menu item should show the page and select no menu item
     Given the project "project1" has 1 wiki page with the following:
@@ -58,7 +57,7 @@ Feature: Viewing the wiki new child page
     And the project "project1" has 1 wiki menu item with the following:
       | title      | ParentWikiPage |
     When I go to the wiki new child page below the "ParentWikiPage" page of the project called "project1"
-    Then I should see "Create new child page" within "#content"
+    Then I should see "Create wiki page" within "#content"
     And there should be no menu item selected
 
   Scenario: Visiting the wiki new child page with an invalid parent page

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -58,21 +58,6 @@ module Redmine::MenuManager::MenuHelper
                   after: :repository,
                   html: { class: 'icon2 icon-wiki' }
 
-        menu.push :"#{main_item.item_class}_new_page",
-                  { action: 'new_child', controller: '/wiki', id: CGI.escape(main_item.title) },
-                  param:   :project_id,
-                  caption: :create_child_page,
-                  html:    { class: 'icon2 icon-add' },
-                  parent:  "#{main_item.item_class}".to_sym if main_item.new_wiki_page and
-                                                               WikiPage.find_by(wiki_id: project_wiki.id, title: main_item.title)
-
-        menu.push :"#{main_item.item_class}_toc",
-                  { action: 'index', controller: '/wiki', id: CGI.escape(main_item.title) },
-                  param:   :project_id,
-                  caption: :label_table_of_contents,
-                  html:    { class: 'icon2 icon-view-list' },
-                  parent:  "#{main_item.item_class}".to_sym if main_item.index_page
-
         main_item.children.each do |child|
           menu.push "#{child.item_class}".to_sym,
                     { controller: '/wiki', action: 'show', id: CGI.escape(child.title) },

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -408,7 +408,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select '#content a', text: 'Create new child page', count: 0
+              assert_select '#content a', text: 'Create wiki page', count: 0
             end
           end
 
@@ -422,7 +422,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select '#content a', text: 'Create new child page', count: 0
+              assert_select '#content a', text: 'Create wiki page', count: 0
             end
           end
         end
@@ -435,7 +435,7 @@ describe WikiController, type: :controller do
 
                 expect(response).to be_success
 
-                assert_select "#content a[href='#{wiki_new_child_path(project_id: @project, id: @page_with_content.title)}']", 'Create new child page'
+                assert_select "#content a[href='#{wiki_new_child_path(project_id: @project, id: @page_with_content.title)}']", 'Create wiki page'
               end
             end
 
@@ -446,7 +446,7 @@ describe WikiController, type: :controller do
                 expect(response).to be_success
 
                 assert_select "#content a[href='#{wiki_new_child_path(project_id: @project, id: 'i-am-a-ghostpage')}']",
-                              text: 'Create new child page', count: 0
+                              text: 'Create wiki page', count: 0
               end
             end
           end
@@ -461,21 +461,21 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select '#content a', text: 'Create new child page', count: 0
+              assert_select '#content a', text: 'Create wiki page', count: 0
             end
           end
         end
       end
 
       describe 'new page link' do
-        describe 'on an index page' do
+        describe 'on a show page' do
           describe 'being authorized to edit wiki pages' do
             it 'is visible' do
-              get 'index', project_id: @project.id
+              get 'show', project_id: @project.id
 
               expect(response).to be_success
 
-              assert_select ".toolbar a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
+              assert_select ".toolbar-items a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create wiki page'
             end
           end
 
@@ -485,37 +485,11 @@ describe WikiController, type: :controller do
             end
 
             it 'is invisible' do
-              get 'index', project_id: @project.id
+              get 'show', project_id: @project.id
 
               expect(response).to be_success
 
-              assert_select '.toolbar a', text: 'Create new child page', count: 0
-            end
-          end
-        end
-
-        describe 'on a wiki page' do
-          describe 'being authorized to edit wiki pages' do
-            it 'is visible' do
-              get 'show', id: @page_with_content.title, project_id: @project.identifier
-
-              expect(response).to be_success
-
-              assert_select ".toobar a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
-            end
-          end
-
-          describe 'being unauthorized to edit wiki pages' do
-            before do
-              allow(User).to receive(:current).and_return @anon
-            end
-
-            it 'is invisible' do
-              get 'show', id: @page_with_content.title, project_id: @project.identifier
-
-              expect(response).to be_success
-
-              assert_select '.toolbar a', text: 'Create new child page', count: 0
+              assert_select '.toolbar-items a', text: 'Create wiki page', count: 0
             end
           end
         end

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -475,7 +475,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select ".menu_root a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
+              assert_select ".toolbar a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
             end
           end
 
@@ -489,7 +489,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select '.menu_root a', text: 'Create new child page', count: 0
+              assert_select '.toolbar a', text: 'Create new child page', count: 0
             end
           end
         end
@@ -501,7 +501,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select ".menu_root a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
+              assert_select ".toobar a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Create new child page'
             end
           end
 
@@ -515,7 +515,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select '.menu_root a', text: 'Create new child page', count: 0
+              assert_select '.toolbar a', text: 'Create new child page', count: 0
             end
           end
         end


### PR DESCRIPTION
This changes the styling and structure of wiki pages. 

Requirements:
- [x] The title is shown on the first place of each wiki page.
- [x] Too long titles are truncated.
- [x] On very small screens the toolbar is placed above the headline, like in WP full screen view.
- [x] There is be a green button in the toolbar to add a new child page.
- [x] The link to the TOC is in the toolbar menu.
- [x] The sub menus are removed from the sidebar.
- [x] When creating a new child there is a field to select the parent element. The default is the page before.
- [x] When editing a page the headline "text" shall be recognizable, like in WP full screen view.

https://community.openproject.org/work_packages/22887/activity
