### PR TITLE
[20140] modals: fixes for accessibility of modals by keyboard

### DIFF
--- a/frontend/app/components/modals/columns-modal/columns-modal.template.html
+++ b/frontend/app/components/modals/columns-modal/columns-modal.template.html
@@ -1,7 +1,7 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
     <div class="modal-header">
-      <i class="icon-close" ng-click="vm.closeMe()" title="{{ ::vm.text.closePopup }}"></i>
+      <a><i class="icon-close" ng-click="vm.closeMe()" title="{{ ::vm.text.closePopup }}"></i></a>
     </div>
 
     <h3>{{ ::vm.text.columnsLabel }}</h3>

--- a/frontend/app/templates/work_packages/modals/export.html
+++ b/frontend/app/templates/work_packages/modals/export.html
@@ -1,6 +1,6 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header"><a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.label_export') }}</h3>
 

--- a/frontend/app/templates/work_packages/modals/group_by.html
+++ b/frontend/app/templates/work_packages/modals/group_by.html
@@ -1,6 +1,6 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header"><a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.label_group_by') }}</h3>
 
@@ -15,7 +15,7 @@
           <div class="form--select-container">
             <select
                 ng-model="vm.selectedColumnName"
-                focus
+                focus="true"
                 title="{{ fieldController.editTitle }}"
                 id="selected_columns_new"
                 class="form--select"

--- a/frontend/app/templates/work_packages/modals/save.html
+++ b/frontend/app/templates/work_packages/modals/save.html
@@ -1,6 +1,6 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header"><a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.label_save_as') }}</h3>
 

--- a/frontend/app/templates/work_packages/modals/settings.html
+++ b/frontend/app/templates/work_packages/modals/settings.html
@@ -1,6 +1,6 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header"><a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.modals.label_settings') }}</h3>
 

--- a/frontend/app/templates/work_packages/modals/share.html
+++ b/frontend/app/templates/work_packages/modals/share.html
@@ -1,6 +1,6 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header"><a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.label_share') }}</h3>
 

--- a/frontend/app/templates/work_packages/modals/sorting.html
+++ b/frontend/app/templates/work_packages/modals/sorting.html
@@ -1,6 +1,7 @@
 <div class="ng-modal-window">
   <div class="ng-modal-inner modal-content">
-    <div class="modal-header"><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></div>
+    <div class="modal-header">
+      <a><i class="icon-close" ng-click="modal.closeMe()" title="{{ ::I18n.t('js.close_popup_title') }}"></i></a></div>
 
     <h3>{{ ::I18n.t('js.label_sorting') }}</h3>
 


### PR DESCRIPTION
related to [https://community.openproject.org/work_packages/20140/activity](url)

The close button of modals should now work when triggered by the enter key.
Initial focus should be on the modal in Firefox as well. 

Needs some final cross browser compatibility testing.
