### PR TITLE
[18404] Styling inline edit: Change cursor and line height

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -383,19 +383,20 @@ td.-editable
 .inplace-edit.-small .inplace-edit--read,
 .inplace-edit.-small .inplace-edit--write,
 .wp-edit-field.-small
-  height: 30px
-  padding-bottom: 3px
-  padding-top: 3px
+  height: 24px
+  padding-bottom: 0px
+  padding-top: 0px
 
   .inplace-edit--read-value
     padding-top: 0
     padding-bottom: 0
 
   select, input
-    height: 28px
+    height: 24px
     padding-top: 0
     padding-bottom: 0
     line-height: normal
+    font-size: 14px
 
 .inplace-edit.-small
   margin-top: 3px

--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -44,11 +44,8 @@
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
-.wp-table--cell
-  cursor: not-allowed
-
-  &.-editable
-    cursor: pointer
+.wp-table--cell.-editable
+  cursor: text
 
 .work-package-table--container .generic-table tbody
   td

--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -44,8 +44,13 @@
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
-.wp-table--cell.-editable
-  cursor: text
+.wp-table--cell
+  cursor: not-allowed
+
+  &.id
+    cursor: pointer
+  &.-editable
+    cursor: text
 
 .work-package-table--container .generic-table tbody
   td


### PR DESCRIPTION
- Changes the used cursor in inline edit fields.
- Reduce line height of the wp table.
