### PR TITLE
[22259] Fix URI escaping of svn checkout paths

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -310,7 +310,7 @@ class RepositoriesController < ApplicationController
 
     # Prepare checkout instructions
     # available on all pages (even empty!)
-    @path = params[:path] || ''
+    @path = CGI.unescape(params[:path] || '')
     @instructions = ::Scm::CheckoutInstructionsService.new(@repository, path: @path)
 
     # Asserts repository availability, or renders an appropriate error

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -346,7 +346,7 @@ module ApplicationHelper
   end
 
   def to_path_param(path)
-    path.to_s
+    CGI.escape(path.to_s)
   end
 
   def reorder_links(name, url, options = {})

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -44,7 +44,7 @@ class Scm::CheckoutInstructionsService
   def checkout_url(with_path = false)
     repository.scm.checkout_url(repository,
                                 checkout_base_url,
-                                with_path ? @path : nil)
+                                with_path ? URI.escape(@path) : nil)
   end
 
   ##

--- a/lib/open_project/scm/adapters/local_client.rb
+++ b/lib/open_project/scm/adapters/local_client.rb
@@ -131,7 +131,7 @@ module OpenProject
 
         def target(path = '')
           base = path.match(/\A\//) ? root_url : url
-          "#{base}/#{path}".gsub(/[?<>\*]/, '')
+          "#{base}/#{path}"
         end
 
         ##

--- a/spec/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/services/scm/checkout_instructions_service_spec.rb
@@ -65,19 +65,27 @@ describe Scm::CheckoutInstructionsService do
           .to eq(URI("http://example.org/svn/#{project.identifier}"))
       end
 
-      context 'with a subpath' do
-        let(:path) { 'foo/bar' }
+      shared_examples 'valid checkout URL' do
         it do
-          expect(service.checkout_url('foo/bar'))
-            .to eq(URI("http://example.org/svn/#{project.identifier}/foo/bar"))
+          expect(service.checkout_url(path))
+            .to eq(URI("http://example.org/svn/#{project.identifier}/#{expected_path}"))
         end
       end
-    end
 
-    it_behaves_like 'builds the correct URL'
+      it_behaves_like 'valid checkout URL' do
+        let(:path) { 'foo/bar' }
+        let(:expected_path) { path }
+      end
 
-    context 'with missing trailing slash' do
-      it_behaves_like 'builds the correct URL'
+      it_behaves_like 'valid checkout URL' do
+        let(:path) { 'foo/bar with spaces' }
+        let(:expected_path) { 'foo/bar%20with%20spaces' }
+      end
+
+      it_behaves_like 'valid checkout URL' do
+        let(:path) { 'foo/bar with §\"!??```' }
+        let(:expected_path) { 'foo/%C2%A7%22!??%60%60%60' }
+      end
     end
   end
 


### PR DESCRIPTION
The paths weren't properly escaped for URLs. This fix allows any
subdirectory of arbitrary chars to be displayed as a checkout URL.

This also fixes an escaping issue in the adapter that prohibits checking
folder with special characters which SVN doesn't care about.

This is a followup for https://community.openproject.org/work_packages/22259/activity
