### PR TITLE
fix contract path in op_engine

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -213,7 +213,7 @@ module OpenProject::Plugins
           model_name = on.to_s.camelize
           namespace = model_name.pluralize
           Array(writable_for).each do |action|
-            contract_class = "::API::V3::#{namespace}::#{action.to_s.camelize}Contract".constantize
+            contract_class = "::#{namespace}::#{action.to_s.camelize}Contract".constantize
             contract_class.attribute ar_name, &block
           end
 


### PR DESCRIPTION
The contracts now reside in 

`app/contracts` 

and are thus no longer namespaced within `API::V3`
