### PR TITLE
[22829] Fix empty float/duration values

### DIFF
--- a/frontend/app/components/inplace-edit/directives/field-edit/edit-duration/edit-duration.directive.js
+++ b/frontend/app/components/inplace-edit/directives/field-edit/edit-duration/edit-duration.directive.js
@@ -61,7 +61,7 @@ function inplaceEditorDuration() {
       // The indirection fixes it but it might break two-way-binding. If someone where to change
       // field.value from the outside, this would not be reflected by numberValue.
       scope.$watch('numberValue', function(newValue) {
-        if(newValue) {
+        if(!isNaN(newValue)) {
           var minutes = Number(moment.duration(newValue, 'hours').asMinutes().toFixed(2));
 
           field.value = moment.duration(minutes, 'minutes');

--- a/frontend/app/ui_components/float-directive.js
+++ b/frontend/app/ui_components/float-directive.js
@@ -32,7 +32,9 @@ module.exports = function($filter) {
     require: 'ngModel',
     link: function(scope, element, attrs, ngModelController) {
       ngModelController.$parsers.push(function(data) {
-        return $filter('external2internalFloat')(data);
+        if (data != '') {
+          return $filter('external2internalFloat')(data);
+        }
       });
 
       ngModelController.$formatters.push(function(data) {


### PR DESCRIPTION
This fixes skipping input zeros to duration fields, as well
as outputting 'NaN' in the float-value directive when the parser
receives an empty input (which results in '').

https://community.openproject.com/work_packages/22829/activity
