### PR TITLE
[22829] Fix duration parsing in inline-edit

### DIFF
--- a/frontend/app/ui_components/duration-directive.js
+++ b/frontend/app/ui_components/duration-directive.js
@@ -32,7 +32,7 @@ module.exports = function($filter, TimezoneService) {
     require: 'ngModel',
     link: function(scope, element, attrs, ngModelController) {
       ngModelController.$parsers.push(function(value) {
-        if (value) {
+        if (!isNaN(value)) {
           var minutes = Number(moment.duration(value, 'hours').asMinutes().toFixed(2));
           return moment.duration(minutes, 'minutes');
         }


### PR DESCRIPTION
Empty / Zero values for duration fields were not properly parsed due to the invalid condition.
