### PR TITLE
Feature/project independent work package create

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -47,12 +47,16 @@ module WorkPackages
     end
 
     attribute :assigned_to_id do
+      next unless model.project
+
       validate_people_visible :assignee,
                               'assigned_to_id',
                               model.project.possible_assignee_members
     end
 
     attribute :responsible_id do
+      next unless model.project
+
       validate_people_visible :responsible,
                               'responsible_id',
                               model.project.possible_responsible_members
@@ -96,6 +100,9 @@ module WorkPackages
     end
 
     private
+
+    attr_reader :user,
+                :can
 
     def validate_people_visible(attribute, id_attribute, list)
       id = model[id_attribute]

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'model_contract'
+
 module WorkPackages
   class BaseContract < ::ModelContract
     attribute :subject

--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -29,17 +29,18 @@
 
 module WorkPackages
   class CreateContract < BaseContract
-    # These attributes need to be set during creation and cannot be modified via representer.
-    # Hence making them writable here is unproblematic.
-    attribute :project_id
-    attribute :author_id
+    attribute :author_id do
+      errors.add :author_id, :invalid if model.author != user
+    end
 
     validate :user_allowed_to_add
 
     private
 
     def user_allowed_to_add
-      unless @user.allowed_to?(:add_work_packages, model.project)
+      if (model.project && !@user.allowed_to?(:add_work_packages, model.project)) ||
+         !@user.allowed_to?(:add_work_packages, nil, global: true)
+
         errors.add :base, :error_unauthorized
       end
     end

--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'work_packages/base_contract'
+
 module WorkPackages
   class CreateContract < BaseContract
     attribute :author_id do

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'work_packages/base_contract'
+
 module WorkPackages
   class UpdateContract < BaseContract
     attribute :lock_version do

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -865,32 +865,6 @@ class Project < ActiveRecord::Base
     list
   end
 
-  def add_issue(attributes = {})
-    ActiveSupport::Deprecation.warn 'Project.add_issue is deprecated. Use Project.add_work_package instead.'
-    add_work_package attributes
-  end
-
-  def add_work_package(attributes = {})
-    WorkPackage.new do |i|
-      i.project = self
-
-      type    = attributes.delete(:type)
-      type_id = if type && type.respond_to?(:id)
-                  type.id
-                else
-                  attributes.delete(:type_id)
-                end
-
-      i.type = if type_id
-                 project.types.find(type_id)
-               else
-                 project.types.first
-               end
-
-      i.attributes = attributes
-    end
-  end
-
   def allowed_permissions
     @allowed_permissions ||= begin
       names = enabled_modules.loaded? ? enabled_module_names : enabled_modules.pluck(:name)

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -101,7 +101,7 @@ class ::Type < ActiveRecord::Base
     PlanningElementTypeColor.all
   end
 
-  def is_valid_transition?(status_id_a, status_id_b, roles)
+  def valid_transition?(status_id_a, status_id_b, roles)
     transition_exists?(status_id_a, status_id_b, roles.map(&:id))
   end
 

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -88,6 +88,10 @@ class ::Type < ActiveRecord::Base
     ::Type.where(is_default: true)
   end
 
+  def self.enabled_in(project)
+    ::Type.includes(:projects).where(projects: { id: project })
+  end
+
   def statuses
     return [] if new_record?
     @statuses ||= ::Type.statuses([id])

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -659,6 +659,12 @@ class WorkPackage < ActiveRecord::Base
     Project.where(Project.allowed_to_condition(user, :move_work_packages))
   end
 
+  # Returns a scope for the projects
+  # the user is create a work package in
+  def self.allowed_target_projects_on_create(user)
+    Project.where(Project.allowed_to_condition(user, :add_work_packages))
+  end
+
   # Do not redefine alias chain on reload (see #4838)
   alias_method_chain(:attributes=,
                      :type_first) unless method_defined?(:attributes_without_type_first=)

--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -183,7 +183,7 @@ module WorkPackage::Validations
   end
 
   def status_transition_exists?
-    type.is_valid_transition?(status_id_was, status_id, User.current.roles(project))
+    type.valid_transition?(status_id_was, status_id, User.current.roles(project))
   end
 
   def copy_descendants_errors(all_descendants)

--- a/app/services/add_work_package_note_service.rb
+++ b/app/services/add_work_package_note_service.rb
@@ -53,7 +53,8 @@ class AddWorkPackageNoteService
 
       result, errors = validate_and_save
 
-      ServiceResult.new(result, errors)
+      ServiceResult.new(success: result,
+                        errors: errors)
     end
   end
 

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -1,0 +1,52 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Concerns::Contracted
+  extend ActiveSupport::Concern
+
+  included do
+    class << self
+      attr_accessor :contract
+    end
+
+    private
+
+    attr_accessor :contract
+
+    def validate_and_save(object)
+      if !contract.validate
+        return false, contract.errors
+      elsif !object.save
+        return false, object.errors
+      else
+        return true, object.errors
+      end
+    end
+  end
+end

--- a/app/services/create_work_package_service.rb
+++ b/app/services/create_work_package_service.rb
@@ -28,25 +28,46 @@
 #++
 
 class CreateWorkPackageService
-  attr_reader :user, :project
+  include Concerns::Contracted
 
-  def initialize(user:, project:, send_notifications: true)
+  self.contract = WorkPackages::CreateContract
+
+  attr_reader :user
+
+  def initialize(user:)
     @user = user
-    @project = project
-
-    JournalManager.send_notification = send_notifications
   end
 
-  def create
-    hash = {
-      project: project,
-      author: user,
-      type: project.types.first
-    }
-    project.add_work_package(hash)
+  def call(attributes:, send_notifications: true)
+    User.execute_as user do
+      JournalManager.with_send_notifications send_notifications do
+        create(attributes)
+      end
+    end
   end
 
-  def save(work_package)
-    work_package.save
+  private
+
+  def create(attributes)
+    work_package = WorkPackage.new
+
+    initialize_contract(work_package)
+    assign_defaults(work_package, attributes)
+    assign_provided(work_package, attributes)
+    result, errors = validate_and_save(work_package)
+
+    ServiceResult.new(result, errors, result: work_package)
+  end
+
+  def assign_provided(work_package, attributes)
+    work_package.attributes = attributes
+  end
+
+  def assign_defaults(work_package, attributes)
+    work_package.author = user unless attributes[:author_id]
+  end
+
+  def initialize_contract(work_package)
+    self.contract = self.class.contract.new(work_package, user)
   end
 end

--- a/app/services/create_work_package_service.rb
+++ b/app/services/create_work_package_service.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'work_packages/create_contract'
+
 class CreateWorkPackageService
   include Concerns::Contracted
 

--- a/app/services/create_work_package_service.rb
+++ b/app/services/create_work_package_service.rb
@@ -56,7 +56,9 @@ class CreateWorkPackageService
     assign_provided(work_package, attributes)
     result, errors = validate_and_save(work_package)
 
-    ServiceResult.new(result, errors, result: work_package)
+    ServiceResult.new(success: result,
+                      errors: errors,
+                      result: work_package)
   end
 
   def assign_provided(work_package, attributes)

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -32,8 +32,8 @@ class ServiceResult
                 :errors,
                 :result
 
-  def initialize(success = false,
-                 errors = ActiveModel::Errors.new(self),
+  def initialize(success: false,
+                 errors: ActiveModel::Errors.new(self),
                  result: nil)
     self.success = success
     self.errors = errors

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -28,12 +28,16 @@
 #++
 
 class ServiceResult
-  attr_accessor :success, :errors
+  attr_accessor :success,
+                :errors,
+                :result
 
   def initialize(success = false,
-                 errors = ActiveModel::Errors.new(self))
+                 errors = ActiveModel::Errors.new(self),
+                 result: nil)
     self.success = success
     self.errors = errors
+    self.result = result
   end
 
   alias success? :success

--- a/app/services/update_work_package_service.rb
+++ b/app/services/update_work_package_service.rb
@@ -28,11 +28,9 @@
 #++
 
 class UpdateWorkPackageService
-  attr_accessor :user, :work_package
+  include Concerns::Contracted
 
-  class << self
-    attr_accessor :contract
-  end
+  attr_accessor :user, :work_package
 
   self.contract = WorkPackages::UpdateContract
 
@@ -53,13 +51,11 @@ class UpdateWorkPackageService
 
   private
 
-  attr_accessor :contract
-
   def update(attributes)
     set_attributes(attributes)
 
     changed_attributes = work_package.changes.dup
-    save_result, save_errors = validate_and_save
+    save_result, save_errors = validate_and_save(work_package)
 
     if save_result
       cleanup_result, cleanup_errors = cleanup(changed_attributes)
@@ -72,16 +68,6 @@ class UpdateWorkPackageService
 
   def set_attributes(attributes)
     work_package.attributes = attributes
-  end
-
-  def validate_and_save
-    if !contract.validate
-      return false, contract.errors
-    elsif !work_package.save
-      return false, work_package.errors
-    else
-      return true, work_package.errors
-    end
   end
 
   def cleanup(attributes)

--- a/app/services/update_work_package_service.rb
+++ b/app/services/update_work_package_service.rb
@@ -60,9 +60,11 @@ class UpdateWorkPackageService
     if save_result
       cleanup_result, cleanup_errors = cleanup(changed_attributes)
 
-      ServiceResult.new(cleanup_result, cleanup_errors)
+      ServiceResult.new(success: cleanup_result,
+                        errors: cleanup_errors)
     else
-      ServiceResult.new(save_result, save_errors)
+      ServiceResult.new(success: save_result,
+                        errors: save_errors)
     end
   end
 

--- a/lib/api/decorators/link_object.rb
+++ b/lib/api/decorators/link_object.rb
@@ -50,7 +50,7 @@ module API
                getter: -> (*) {
                  id = represented.send(@getter) if represented
 
-                 return nil unless id
+                 return nil if id.nil? || id == 0
 
                  api_v3_paths.send(@path, id)
                },

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -38,7 +38,7 @@ module API
 
         link :createWorkPackage do
           {
-            href: api_v3_paths.create_work_package_form(represented.id),
+            href: api_v3_paths.create_project_work_package_form(represented.id),
             method: :post
           } if current_user_allowed_to(:add_work_packages, context: represented)
         end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -79,6 +79,10 @@ module API
             "#{work_package(work_package_id)}/available_projects"
           end
 
+          def self.available_projects_on_create
+            "#{work_packages}/available_projects"
+          end
+
           def self.categories(project_id)
             "#{project(project_id)}/categories"
           end
@@ -89,6 +93,10 @@ module API
 
           def self.configuration
             "#{root}/configuration"
+          end
+
+          def self.create_work_package_form
+            "#{work_packages}/form"
           end
 
           def self.create_project_work_package_form(project_id)

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -91,7 +91,7 @@ module API
             "#{root}/configuration"
           end
 
-          def self.create_work_package_form(project_id)
+          def self.create_project_work_package_form(project_id)
             "#{work_packages_by_project(project_id)}/form"
           end
 

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -26,22 +26,23 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'api/v3/work_packages/work_packages_shared_helpers'
-require 'create_work_package_service'
-require 'work_packages/create_contract'
+require 'api/v3/projects/project_collection_representer'
 
 module API
   module V3
     module WorkPackages
-      class CreateProjectFormAPI < ::API::OpenProjectAPI
-        resource :form do
-          helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
+      class AvailableProjectsOnCreateAPI < ::API::OpenProjectAPI
+        resource :available_projects do
+          before do
+            authorize(:add_work_packages, global: true)
+          end
 
-          post do
-            create_work_package_form(WorkPackage.new(project: @project),
-                                     contract_class: ::WorkPackages::CreateContract,
-                                     form_class: CreateProjectFormRepresenter,
-                                     action: :create)
+          get do
+            available_projects = WorkPackage.allowed_target_projects_on_create(current_user)
+            self_link = api_v3_paths.available_projects_on_create
+            Projects::ProjectCollectionRepresenter.new(available_projects,
+                                                       self_link,
+                                                       current_user: current_user)
           end
         end
       end

--- a/lib/api/v3/work_packages/create_form_api.rb
+++ b/lib/api/v3/work_packages/create_form_api.rb
@@ -33,14 +33,14 @@ require 'work_packages/create_contract'
 module API
   module V3
     module WorkPackages
-      class CreateProjectFormAPI < ::API::OpenProjectAPI
+      class CreateFormAPI < ::API::OpenProjectAPI
         resource :form do
           helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
           post do
-            create_work_package_form(WorkPackage.new(project: @project),
+            create_work_package_form(WorkPackage.new(author: current_user),
                                      contract_class: ::WorkPackages::CreateContract,
-                                     form_class: CreateProjectFormRepresenter,
+                                     form_class: CreateFormRepresenter,
                                      action: :create)
           end
         end

--- a/lib/api/v3/work_packages/create_form_api.rb
+++ b/lib/api/v3/work_packages/create_form_api.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'api/v3/work_packages/work_packages_shared_helpers'
+require 'create_work_package_service'
 require 'work_packages/create_contract'
 
 module API
@@ -37,9 +38,8 @@ module API
           helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
           post do
-            create_contract = ::WorkPackages::CreateContract
             create_work_package_form(WorkPackage.new(project: @project),
-                                     contract_class: create_contract,
+                                     contract_class: ::WorkPackages::CreateContract,
                                      form_class: CreateFormRepresenter)
           end
         end

--- a/lib/api/v3/work_packages/create_form_api.rb
+++ b/lib/api/v3/work_packages/create_form_api.rb
@@ -38,7 +38,7 @@ module API
 
           post do
             create_contract = ::WorkPackages::CreateContract
-            create_work_package_form(create_service.create,
+            create_work_package_form(WorkPackage.new(project: @project),
                                      contract_class: create_contract,
                                      form_class: CreateFormRepresenter)
           end

--- a/lib/api/v3/work_packages/create_form_representer.rb
+++ b/lib/api/v3/work_packages/create_form_representer.rb
@@ -1,3 +1,4 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -26,23 +27,38 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'api/v3/work_packages/work_packages_shared_helpers'
-require 'create_work_package_service'
-require 'work_packages/create_contract'
-
 module API
   module V3
     module WorkPackages
-      class CreateProjectFormAPI < ::API::OpenProjectAPI
-        resource :form do
-          helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
+      class CreateFormRepresenter < FormRepresenter
+        link :self do
+          {
+            href: api_v3_paths.create_work_package_form,
+            method: :post
+          }
+        end
 
-          post do
-            create_work_package_form(WorkPackage.new(project: @project),
-                                     contract_class: ::WorkPackages::CreateContract,
-                                     form_class: CreateProjectFormRepresenter,
-                                     action: :create)
-          end
+        link :validate do
+          {
+            href: api_v3_paths.create_work_package_form,
+            method: :post
+          }
+        end
+
+        link :previewMarkup do
+          {
+            href: api_v3_paths.render_markup(link: api_v3_paths.project(represented.project_id)),
+            method: :post
+          } if represented.project
+        end
+
+        link :commit do
+          {
+            href: api_v3_paths.work_packages,
+            method: :post
+          } if represented.project &&
+               current_user.allowed_to?(:edit_work_packages, represented.project) &&
+               @errors.empty?
         end
       end
     end

--- a/lib/api/v3/work_packages/create_project_form_api.rb
+++ b/lib/api/v3/work_packages/create_project_form_api.rb
@@ -38,7 +38,12 @@ module API
           helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
           post do
-            create_work_package_form(WorkPackage.new(project: @project),
+            work_package = WorkPackage.new(
+              author: current_user,
+              type: @project.types.first,
+              project: @project
+            )
+            create_work_package_form(work_package,
                                      contract_class: ::WorkPackages::CreateContract,
                                      form_class: CreateProjectFormRepresenter,
                                      action: :create)

--- a/lib/api/v3/work_packages/create_project_form_api.rb
+++ b/lib/api/v3/work_packages/create_project_form_api.rb
@@ -33,14 +33,14 @@ require 'work_packages/create_contract'
 module API
   module V3
     module WorkPackages
-      class CreateFormAPI < ::API::OpenProjectAPI
+      class CreateProjectFormAPI < ::API::OpenProjectAPI
         resource :form do
           helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
           post do
             create_work_package_form(WorkPackage.new(project: @project),
                                      contract_class: ::WorkPackages::CreateContract,
-                                     form_class: CreateFormRepresenter)
+                                     form_class: CreateProjectFormRepresenter)
           end
         end
       end

--- a/lib/api/v3/work_packages/create_project_form_representer.rb
+++ b/lib/api/v3/work_packages/create_project_form_representer.rb
@@ -25,30 +25,41 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See doc/COPYRIGHT.rdoc for more details.
+#++
 
-require 'spec_helper'
-require 'rack/test'
+module API
+  module V3
+    module WorkPackages
+      class CreateProjectFormRepresenter < FormRepresenter
+        link :self do
+          {
+            href: api_v3_paths.create_project_work_package_form(represented.project_id),
+            method: :post
+          }
+        end
 
-describe ::API::V3::WorkPackages::CreateFormAPI do
-  include Rack::Test::Methods
-  include API::V3::Utilities::PathHelper
+        link :validate do
+          {
+            href: api_v3_paths.create_project_work_package_form(represented.project_id),
+            method: :post
+          }
+        end
 
-  let(:project) { FactoryGirl.create(:project, id: 5) }
-  let(:post_path) { api_v3_paths.create_work_package_form(project.id) }
-  let(:user) { FactoryGirl.build(:admin) }
+        link :previewMarkup do
+          {
+            href: api_v3_paths.render_markup(link: api_v3_paths.project(represented.project_id)),
+            method: :post
+          }
+        end
 
-  before do
-    login_as(user)
-    post post_path
-  end
-
-  subject(:response) { last_response }
-
-  it 'should return 200(OK)' do
-    expect(response.status).to eq(200)
-  end
-
-  it 'should be of type form' do
-    expect(response.body).to be_json_eql('Form'.to_json).at_path('_type')
+        link :commit do
+          {
+            href: api_v3_paths.work_packages_by_project(represented.project_id),
+            method: :post
+          } if current_user.allowed_to?(:edit_work_packages, represented.project) &&
+               @errors.empty?
+        end
+      end
+    end
   end
 end

--- a/lib/api/v3/work_packages/create_work_packages.rb
+++ b/lib/api/v3/work_packages/create_work_packages.rb
@@ -61,7 +61,7 @@ module API
         end
 
         def get_create_attributes(request_body)
-          write_work_package_attributes(WorkPackage.new, request_body)
+          write_work_package_attributes(WorkPackage.new, request_body || {})
             .changes.each_with_object({}) { |(k, v), h| h[k] = v.last }
         end
 

--- a/lib/api/v3/work_packages/create_work_packages.rb
+++ b/lib/api/v3/work_packages/create_work_packages.rb
@@ -1,0 +1,77 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'api/v3/work_packages/work_package_representer'
+require 'create_work_package_service'
+
+module API
+  module V3
+    module WorkPackages
+      module CreateWorkPackages
+        include ::API::V3::WorkPackages::WorkPackagesSharedHelpers
+
+        def create_work_packages(request_body, current_user)
+          attributes = get_create_attributes(request_body)
+
+          yield(attributes) if block_given?
+
+          result = create_work_package(current_user,
+                                       attributes,
+                                       notify_according_to_params)
+
+          represent_create_result(result, current_user)
+        end
+
+        private
+
+        def represent_create_result(result, current_user)
+          if result.success?
+            work_package = result.result
+            WorkPackages::WorkPackageRepresenter.create(work_package.reload,
+                                                        current_user: current_user,
+                                                        embed_links: true)
+          else
+            fail ::API::Errors::ErrorBase.create_and_merge_errors(result.errors)
+          end
+        end
+
+        def get_create_attributes(request_body)
+          write_work_package_attributes(WorkPackage.new, request_body)
+            .changes.each_with_object({}) { |(k, v), h| h[k] = v.last }
+        end
+
+        def create_work_package(current_user, attributes, send_notification)
+          create_service = CreateWorkPackageService.new(user: current_user)
+
+          create_service.call(attributes: attributes,
+                              send_notifications: send_notification)
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -31,8 +31,9 @@ module API
   module V3
     module WorkPackages
       class FormRepresenter < ::API::Decorators::Single
-        def initialize(model, current_user: nil, errors: [])
-          @errors = errors
+        def initialize(model, current_user: nil, errors: [], action: :update)
+          self.errors = errors
+          self.action = action
 
           super(model, current_user: current_user)
         end
@@ -50,16 +51,22 @@ module API
                    schema = Schema::SpecificWorkPackageSchema.new(work_package: represented)
                    Schema::WorkPackageSchemaRepresenter.create(schema,
                                                                form_embedded: true,
-                                                               current_user: current_user)
+                                                               current_user: current_user,
+                                                               action: action)
                  }
         property :validation_errors, embedded: true, exec_context: :decorator
+
+        private
+
+        attr_accessor :action,
+                      :errors
 
         def _type
           'Form'
         end
 
         def validation_errors
-          @errors.group_by(&:property).inject({}) do |hash, (property, errors)|
+          errors.group_by(&:property).inject({}) do |hash, (property, errors)|
             error = ::API::Errors::MultipleErrors.create_if_many(errors)
             hash[property] = ::API::V3::Errors::ErrorRepresenter.new(error)
             hash

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -56,8 +56,6 @@ module API
                  }
         property :validation_errors, embedded: true, exec_context: :decorator
 
-        private
-
         attr_accessor :action,
                       :errors
 

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -36,7 +36,8 @@ module API
             @work_package = work_package
           end
 
-          delegate :project,
+          delegate :project_id,
+                   :project,
                    :type,
                    :id,
                    to: :@work_package
@@ -50,11 +51,11 @@ module API
                 project.types.includes(:color)
               end
             when :version
-              @work_package.try(:assignable_versions)
+              @work_package.try(:assignable_versions) if project
             when :priority
               IssuePriority.active
             when :category
-              project.categories
+              project.categories if project.respond_to?(:categories)
             end
           end
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -54,6 +54,7 @@ module API
           def initialize(schema, context)
             @self_link = context.delete(:self_link) || nil
             @show_lock_version = !context.delete(:hide_lock_version)
+            @action = context.delete(:action) || :update
             super(schema, context)
           end
 
@@ -115,7 +116,11 @@ module API
                                    type: 'Project',
                                    required: true,
                                    href_callback: -> (*) {
-                                     api_v3_paths.available_projects_on_edit(represented.id)
+                                     if @action == :create
+                                       api_v3_paths.available_projects_on_create
+                                     else
+                                       api_v3_paths.available_projects_on_edit(represented.id)
+                                     end
                                    }
 
           schema :parent_id,
@@ -137,14 +142,18 @@ module API
                                    type: 'User',
                                    required: false,
                                    href_callback: -> (*) {
-                                     api_v3_paths.available_assignees(represented.project.id)
+                                     if represented.project
+                                       api_v3_paths.available_assignees(represented.project_id)
+                                     end
                                    }
 
           schema_with_allowed_link :responsible,
                                    type: 'User',
                                    required: false,
                                    href_callback: -> (*) {
-                                     api_v3_paths.available_responsibles(represented.project.id)
+                                     if represented.project
+                                       api_v3_paths.available_responsibles(represented.project_id)
+                                     end
                                    }
 
           schema_with_allowed_collection :type,

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -63,6 +63,20 @@ module API
           } if total_sums || groups && groups.any?(&:has_sums?)
         end
 
+        link :createWorkPackage do
+          {
+            href: api_v3_paths.create_work_package_form,
+            method: :post
+          } if current_user.allowed_to?(:add_work_packages, nil, global: true)
+        end
+
+        link :createWorkPackageImmediate do
+          {
+            href: api_v3_paths.work_packages,
+            method: :post
+          } if current_user.allowed_to?(:add_work_packages, nil, global: true)
+        end
+
         collection :elements,
                    getter: -> (*) {
                      work_packages = eager_loaded_work_packages

--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -67,7 +67,11 @@ module API
                    representer.from_json(value.to_json)
                  }
 
-        property :lock_version
+        property :lock_version,
+                 render_nil: true,
+                 getter: -> (*) {
+                   lock_version.to_i
+                 }
         property :subject, render_nil: true
         property :done_ratio,
                  as: :percentageDone,

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'api/v3/work_packages/work_package_representer'
+require 'api/v3/work_packages/create_work_packages'
 
 module API
   module V3
@@ -34,10 +35,15 @@ module API
       class WorkPackagesAPI < ::API::OpenProjectAPI
         resources :work_packages do
           helpers ::API::V3::WorkPackages::WorkPackageListHelpers
+          helpers ::API::V3::WorkPackages::CreateWorkPackages
 
           get do
             authorize(:view_work_packages, global: true)
             work_packages_by_params
+          end
+
+          post do
+            create_work_packages(request_body, current_user)
           end
 
           params do

--- a/lib/api/v3/work_packages/work_packages_by_project_api.rb
+++ b/lib/api/v3/work_packages/work_packages_by_project_api.rb
@@ -49,7 +49,7 @@ module API
           end
 
           mount ::API::V3::Projects::WorkPackageColumnsAPI
-          mount ::API::V3::WorkPackages::CreateFormAPI
+          mount ::API::V3::WorkPackages::CreateProjectFormAPI
         end
       end
     end

--- a/lib/api/v3/work_packages/work_packages_shared_helpers.rb
+++ b/lib/api/v3/work_packages/work_packages_shared_helpers.rb
@@ -58,7 +58,7 @@ module API
           end
         end
 
-        def create_work_package_form(work_package, contract_class:, form_class:)
+        def create_work_package_form(work_package, contract_class:, form_class:, action: :update)
           write_work_package_attributes(work_package, request_body, reset_lock_version: true)
           contract = contract_class.new(work_package, current_user)
           contract.validate
@@ -68,7 +68,10 @@ module API
           # errors for invalid data (e.g. validation errors) are handled inside the form
           if only_validation_errors(api_errors)
             status 200
-            form_class.new(work_package, current_user: current_user, errors: api_errors)
+            form_class.new(work_package,
+                           current_user: current_user,
+                           errors: api_errors,
+                           action: action)
           else
             fail ::API::Errors::MultipleErrors.create_if_many(api_errors)
           end

--- a/lib/api/v3/work_packages/work_packages_shared_helpers.rb
+++ b/lib/api/v3/work_packages/work_packages_shared_helpers.rb
@@ -48,11 +48,13 @@ module API
             # After Pass 1 the correct type/project information is merged into the WP
             # In Pass 2 the representer is created with the new type/project info and will be able
             # to also parse custom fields successfully
-            merge_hash_into_work_package!(request_body, work_package)
+            work_package = merge_hash_into_work_package!(request_body, work_package)
 
             if custom_field_context_changed?(work_package)
-              merge_hash_into_work_package!(request_body, work_package)
+              work_package = merge_hash_into_work_package!(request_body, work_package)
             end
+
+            work_package
           end
         end
 
@@ -81,6 +83,10 @@ module API
 
         def only_validation_errors(errors)
           errors.all? { |error| error.code == 422 }
+        end
+
+        def notify_according_to_params
+          !(params[:notify] == 'false')
         end
       end
     end

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -1,0 +1,134 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'contracts/work_packages/shared_base_contract'
+
+describe WorkPackages::CreateContract do
+  let(:work_package) { WorkPackage.new }
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+
+  subject(:contract) { described_class.new(work_package, user) }
+  let(:validated_contract) {
+    contract = subject
+    contract.validate
+    contract
+  }
+
+  it_behaves_like 'work package contract'
+
+  describe 'authorization' do
+    def add_work_packages_allowed(in_project: true, in_global: true)
+      allow(user)
+        .to receive(:allowed_to?)
+        .with(:add_work_packages, project)
+        .and_return(in_project)
+
+      allow(user)
+        .to receive(:allowed_to?)
+        .with(:add_work_packages, nil, global: true)
+        .and_return(in_global)
+    end
+
+    context 'user allowed in project and project specified' do
+      before do
+        add_work_packages_allowed(in_project: true, in_global: true)
+
+        work_package.project = project
+      end
+
+      it 'has no authorization error' do
+        expect(validated_contract.errors[:base]).to be_empty
+      end
+    end
+
+    context 'user not allowed in project and project specified' do
+      before do
+        add_work_packages_allowed(in_project: false, in_global: true)
+
+        work_package.project = project
+      end
+
+      it 'is not authorized' do
+        expect(validated_contract.errors.symbols_for(:base))
+          .to match_array [:error_unauthorized]
+      end
+    end
+
+    context 'user allowed in a project and no project specified' do
+      before do
+        add_work_packages_allowed(in_project: true, in_global: true)
+      end
+
+      it 'has no authorization error' do
+        expect(validated_contract.errors[:base]).to be_empty
+      end
+    end
+
+    context 'user not allowed in any project and no project specified' do
+      before do
+        add_work_packages_allowed(in_project: false, in_global: false)
+      end
+
+      it 'is not authorized' do
+        expect(validated_contract.errors.symbols_for(:base))
+          .to match_array [:error_unauthorized]
+      end
+    end
+
+    context 'user not allowed in any project and project specified' do
+      before do
+        add_work_packages_allowed(in_project: false, in_global: false)
+
+        work_package.project = project
+      end
+
+      it 'is not authorized' do
+        expect(validated_contract.errors.symbols_for(:base))
+          .to match_array [:error_unauthorized]
+      end
+    end
+  end
+
+  describe 'author_id' do
+    it 'is valid if the user is the user is the user the contract is evaluated for' do
+      work_package.author = user
+
+      expect(validated_contract.errors[:author_id]).to be_empty
+    end
+
+    it 'is invalid if the user is different from the user the contract is evaluated for' do
+      work_package.author = FactoryGirl.build_stubbed(:user)
+
+      expect(validated_contract.errors.symbols_for(:author_id))
+        .to match_array [:invalid]
+    end
+  end
+end

--- a/spec/contracts/work_packages/shared_base_contract.rb
+++ b/spec/contracts/work_packages/shared_base_contract.rb
@@ -1,0 +1,155 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+shared_examples_for 'work package contract' do
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:other_user) { FactoryGirl.build_stubbed(:user) }
+  let(:policy) { double(WorkPackagePolicy, allowed?: true) }
+
+  subject(:contract) { described_class.new(work_package, user) }
+
+  let(:validated_contract) {
+    contract = subject
+    contract.validate
+    contract
+  }
+
+  before do
+    allow(WorkPackagePolicy)
+      .to receive(:new)
+      .and_return(policy)
+  end
+
+  shared_examples_for 'has no error on' do |property|
+    it property do
+      expect(validated_contract.errors[property]).to be_empty
+    end
+  end
+
+  describe 'assigned_to_id' do
+    let(:assignee_members) { double('assignee_members') }
+
+    before do
+      allow(work_package)
+        .to receive(:project)
+        .and_return(project)
+
+      allow(project)
+        .to receive(:possible_assignee_members)
+        .and_return(assignee_members)
+
+      allow(assignee_members)
+        .to receive(:exists?)
+        .with(user_id: other_user.id)
+        .and_return true
+
+      work_package.assigned_to = other_user
+    end
+
+    context 'if the assigned user is a possible assignee' do
+      it_behaves_like 'has no error on', :assignee
+    end
+
+    context 'if the assigned user is not a possible assignee' do
+      before do
+        allow(assignee_members)
+          .to receive(:exists?)
+          .with(user_id: other_user.id)
+          .and_return false
+      end
+
+      it 'is not a valid assignee' do
+        error = I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
+                       property: I18n.t('attributes.assignee'))
+        expect(validated_contract.errors[:assignee]).to match_array [error]
+      end
+    end
+
+    context 'if the project is not set' do
+      before do
+        allow(work_package)
+          .to receive(:project)
+          .and_return(nil)
+      end
+
+      it_behaves_like 'has no error on', :assignee
+    end
+  end
+
+  describe 'responsible_id' do
+    let(:responsible_members) { double('responsible_members') }
+
+    before do
+      allow(work_package)
+        .to receive(:project)
+        .and_return(project)
+
+      allow(project)
+        .to receive(:possible_responsible_members)
+        .and_return(responsible_members)
+
+      allow(responsible_members)
+        .to receive(:exists?)
+        .with(user_id: other_user.id)
+        .and_return true
+
+      work_package.responsible = other_user
+    end
+
+    context 'if the responsible user is a possible responsible' do
+      it_behaves_like 'has no error on', :responsible
+    end
+
+    context 'if the assigned user is not a possible responsible' do
+      before do
+        allow(responsible_members)
+          .to receive(:exists?)
+          .with(user_id: other_user.id)
+          .and_return false
+      end
+
+      it 'is not a valid responsible' do
+        error = I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
+                       property: I18n.t('attributes.responsible'))
+        expect(validated_contract.errors[:responsible]).to match_array [error]
+      end
+    end
+
+    context 'if the project is not set' do
+      before do
+        allow(work_package)
+          .to receive(:project)
+          .and_return(nil)
+      end
+
+      it_behaves_like 'has no error on', :responsible
+    end
+  end
+end

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -27,6 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 
 require 'spec_helper'
+require 'contracts/work_packages/shared_base_contract'
 
 describe WorkPackages::UpdateContract do
   let(:project) { FactoryGirl.create(:project, is_public: false) }
@@ -36,6 +37,10 @@ describe WorkPackages::UpdateContract do
   let(:permissions) { [:view_work_packages, :edit_work_packages] }
 
   subject(:contract) { described_class.new(work_package, user) }
+
+  it_behaves_like 'work package contract' do
+    let(:work_package) { FactoryGirl.build_stubbed(:work_package) }
+  end
 
   describe 'lock_version' do
     context 'no lock_version present' do

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -75,7 +75,7 @@ describe ::API::V3::Projects::ProjectRepresenter do
       describe 'create work packages' do
         context 'user allowed to create work packages' do
           it 'has the correct path for a create form' do
-            is_expected.to be_json_eql(api_v3_paths.create_work_package_form(project.id).to_json)
+            is_expected.to be_json_eql(api_v3_paths.create_project_work_package_form(project.id).to_json)
               .at_path('_links/createWorkPackage/href')
           end
 

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -75,7 +75,8 @@ describe ::API::V3::Projects::ProjectRepresenter do
       describe 'create work packages' do
         context 'user allowed to create work packages' do
           it 'has the correct path for a create form' do
-            is_expected.to be_json_eql(api_v3_paths.create_project_work_package_form(project.id).to_json)
+            is_expected
+              .to be_json_eql(api_v3_paths.create_project_work_package_form(project.id).to_json)
               .at_path('_links/createWorkPackage/href')
           end
 

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -106,10 +106,16 @@ describe ::API::V3::Utilities::PathHelper do
     it_behaves_like 'api v3 path', '/work_packages/42/available_watchers'
   end
 
-  describe '#available_projects' do
+  describe '#available_projects_on_edit' do
     subject { helper.available_projects_on_edit 42 }
 
     it_behaves_like 'api v3 path', '/work_packages/42/available_projects'
+  end
+
+  describe '#available_projects_on_create' do
+    subject { helper.available_projects_on_create }
+
+    it_behaves_like 'api v3 path', '/work_packages/available_projects'
   end
 
   describe '#categories' do
@@ -128,6 +134,12 @@ describe ::API::V3::Utilities::PathHelper do
     subject { helper.configuration }
 
     it_behaves_like 'api v3 path', '/configuration'
+  end
+
+  describe '#create_work_package_form' do
+    subject { helper.create_work_package_form }
+
+    it_behaves_like 'api v3 path', '/work_packages/form'
   end
 
   describe '#create_project_work_package_form' do

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -130,8 +130,8 @@ describe ::API::V3::Utilities::PathHelper do
     it_behaves_like 'api v3 path', '/configuration'
   end
 
-  describe '#create_work_package_form' do
-    subject { helper.create_work_package_form 42 }
+  describe '#create_project_work_package_form' do
+    subject { helper.create_project_work_package_form 42 }
 
     it_behaves_like 'api v3 path', '/projects/42/work_packages/form'
   end

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -1,0 +1,153 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++require 'rspec'
+
+require 'spec_helper'
+
+describe ::API::V3::WorkPackages::CreateFormRepresenter do
+  include API::V3::Utilities::PathHelper
+
+  let(:errors) { [] }
+  let(:project) {
+    FactoryGirl.build_stubbed(:project)
+  }
+  let(:work_package) do
+    wp = FactoryGirl.build_stubbed(:work_package, project: project)
+    allow(wp).to receive(:assignable_versions).and_return []
+    wp
+  end
+  let(:current_user) {
+    FactoryGirl.build_stubbed(:user)
+  }
+  let(:representer) {
+    described_class.new(work_package, current_user: current_user, errors: errors)
+  }
+
+  context 'generation' do
+    subject(:generated) { representer.to_json }
+
+    describe '_links' do
+      it 'links to the create form api' do
+        is_expected
+          .to be_json_eql(api_v3_paths.create_work_package_form.to_json)
+          .at_path('_links/self/href')
+      end
+
+      it 'is a post' do
+        is_expected
+          .to be_json_eql(:post.to_json)
+          .at_path('_links/self/method')
+      end
+
+      describe 'validate' do
+        it 'links to the create form api' do
+          is_expected
+            .to be_json_eql(api_v3_paths.create_work_package_form.to_json)
+            .at_path('_links/validate/href')
+        end
+
+        it 'is a post' do
+          is_expected
+            .to be_json_eql(:post.to_json)
+            .at_path('_links/validate/method')
+        end
+      end
+
+      describe 'preview markup' do
+        it 'links to the markup api' do
+          path = api_v3_paths.render_markup(link: api_v3_paths.project(work_package.project_id))
+          is_expected
+            .to be_json_eql(path.to_json)
+            .at_path('_links/previewMarkup/href')
+        end
+
+        it 'is a post' do
+          is_expected
+            .to be_json_eql(:post.to_json)
+            .at_path('_links/previewMarkup/method')
+        end
+
+        it 'contains link to work package' do
+          expected_preview_link =
+            api_v3_paths.render_markup(format: 'textile',
+                                       link: "/api/v3/projects/#{work_package.project_id}")
+          expect(subject)
+            .to be_json_eql(expected_preview_link.to_json)
+            .at_path('_links/previewMarkup/href')
+        end
+      end
+
+      describe 'commit' do
+        before do
+          allow(current_user)
+            .to receive(:allowed_to?)
+            .and_return(false)
+          allow(current_user)
+            .to receive(:allowed_to?)
+            .with(:edit_work_packages, project)
+            .and_return(true)
+        end
+
+        context 'valid work package' do
+          it 'links to the work package create api' do
+            is_expected
+              .to be_json_eql(api_v3_paths.work_packages.to_json)
+              .at_path('_links/commit/href')
+          end
+
+          it 'is a post' do
+            is_expected
+              .to be_json_eql(:post.to_json)
+              .at_path('_links/commit/method')
+          end
+        end
+
+        context 'invalid work package' do
+          let(:errors) { [::API::Errors::Validation.new(:subject, 'it is broken')] }
+
+          it 'has no link' do
+            is_expected.not_to have_json_path('_links/commit/href')
+          end
+        end
+
+        context 'user with insufficient permissions' do
+          before do
+            allow(current_user)
+              .to receive(:allowed_to?)
+              .with(:edit_work_packages, project)
+              .and_return(false)
+          end
+
+          it 'has no link' do
+            is_expected.not_to have_json_path('_links/commit/href')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -29,7 +29,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::WorkPackages::CreateFormRepresenter do
+describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:errors) { [] }
@@ -52,7 +52,7 @@ describe ::API::V3::WorkPackages::CreateFormRepresenter do
     describe '_links' do
       it do
         is_expected.to be_json_eql(
-          api_v3_paths.create_work_package_form(work_package.project_id).to_json)
+          api_v3_paths.create_project_work_package_form(work_package.project_id).to_json)
           .at_path('_links/self/href')
       end
 
@@ -61,7 +61,7 @@ describe ::API::V3::WorkPackages::CreateFormRepresenter do
       describe 'validate' do
         it do
           is_expected.to be_json_eql(
-            api_v3_paths.create_work_package_form(work_package.project_id).to_json)
+            api_v3_paths.create_project_work_package_form(work_package.project_id).to_json)
             .at_path('_links/validate/href')
         end
 

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -56,7 +56,9 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
           .at_path('_links/self/href')
       end
 
-      it { is_expected.to be_json_eql(:post.to_json).at_path('_links/self/method') }
+      it do
+        is_expected.to be_json_eql(:post.to_json).at_path('_links/self/method')
+      end
 
       describe 'validate' do
         it do
@@ -65,7 +67,9 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
             .at_path('_links/validate/href')
         end
 
-        it { is_expected.to be_json_eql(:post.to_json).at_path('_links/validate/method') }
+        it do
+          is_expected.to be_json_eql(:post.to_json).at_path('_links/validate/method')
+        end
       end
 
       describe 'preview markup' do
@@ -76,7 +80,9 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
             .at_path('_links/previewMarkup/href')
         end
 
-        it { is_expected.to be_json_eql(:post.to_json).at_path('_links/previewMarkup/method') }
+        it do
+          is_expected.to be_json_eql(:post.to_json).at_path('_links/previewMarkup/method')
+        end
 
         it 'contains link to work package' do
           expected_preview_link =
@@ -95,13 +101,17 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
               .at_path('_links/commit/href')
           end
 
-          it { is_expected.to be_json_eql(:post.to_json).at_path('_links/commit/method') }
+          it do
+            is_expected.to be_json_eql(:post.to_json).at_path('_links/commit/method')
+          end
         end
 
         context 'invalid work package' do
           let(:errors) { [::API::Errors::Validation.new(:subject, 'it is broken')] }
 
-          it { is_expected.not_to have_json_path('_links/commit/href') }
+          it do
+            is_expected.not_to have_json_path('_links/commit/href')
+          end
         end
 
         context 'user with insufficient permissions' do
@@ -112,7 +122,9 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
                               member_through_role: role)
           }
 
-          it { is_expected.not_to have_json_path('_links/commit/href') }
+          it do
+            is_expected.not_to have_json_path('_links/commit/href')
+          end
         end
       end
     end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -41,11 +41,13 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   }
   let(:self_link) { '/a/self/link' }
   let(:embedded) { true }
+  let(:action) { :update }
   let(:representer) {
     described_class.create(schema,
                            form_embedded: embedded,
                            self_link: self_link,
-                           current_user: current_user)
+                           current_user: current_user,
+                           action: action)
   }
 
   before do
@@ -369,9 +371,20 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:writable) { true }
       end
 
-      it_behaves_like 'links to allowed values via collection link' do
-        let(:path) { 'project' }
-        let(:href) { "/api/v3/work_packages/#{work_package.id}/available_projects" }
+      context 'when updating' do
+        it_behaves_like 'links to allowed values via collection link' do
+          let(:path) { 'project' }
+          let(:href) { api_v3_paths.available_projects_on_edit(work_package.id) }
+        end
+      end
+
+      context 'when creating' do
+        let(:action) { :create }
+
+        it_behaves_like 'links to allowed values via collection link' do
+          let(:path) { 'project' }
+          let(:href) { api_v3_paths.available_projects_on_create }
+        end
       end
 
       context 'when not embedded' do
@@ -525,6 +538,16 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
             let(:path) { 'assignee' }
           end
         end
+
+        context 'when not having a project (yet)' do
+          before do
+            work_package.project = nil
+          end
+
+          it_behaves_like 'does not link to allowed values' do
+            let(:path) { 'assignee' }
+          end
+        end
       end
 
       describe 'responsible' do
@@ -543,6 +566,16 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
         context 'when not embedded' do
           let(:embedded) { false }
+
+          it_behaves_like 'does not link to allowed values' do
+            let(:path) { 'responsible' }
+          end
+        end
+
+        context 'when not having a project (yet)' do
+          before do
+            work_package.project = nil
+          end
 
           it_behaves_like 'does not link to allowed values' do
             let(:path) { 'responsible' }

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -72,6 +72,61 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
       is_expected.not_to have_json_path('totalSums')
     end
 
+    context 'when the user has the add_work_package permission in any project' do
+      before do
+        allow(user)
+          .to receive(:allowed_to?)
+          .and_return(false)
+
+        allow(user)
+          .to receive(:allowed_to?)
+          .with(:add_work_packages, nil, global: true)
+          .and_return(true)
+      end
+
+      it 'has a link to create work_packages' do
+        is_expected
+          .to be_json_eql(api_v3_paths.create_work_package_form.to_json)
+          .at_path('_links/createWorkPackage/href')
+      end
+
+      it 'declares to use POST to create work_packages' do
+        is_expected
+          .to be_json_eql(:post.to_json)
+          .at_path('_links/createWorkPackage/method')
+      end
+
+      it 'has a link to create work_packages immediately' do
+        is_expected
+          .to be_json_eql(api_v3_paths.work_packages.to_json)
+          .at_path('_links/createWorkPackageImmediate/href')
+      end
+
+      it 'declares to use POST to create work_packages immediately' do
+        is_expected
+          .to be_json_eql(:post.to_json)
+          .at_path('_links/createWorkPackageImmediate/method')
+      end
+    end
+
+    context 'when the user lacks the add_work_package permission' do
+      before do
+        allow(user)
+          .to receive(:allowed_to?)
+          .and_return(false)
+      end
+
+      it 'has no link to create work_packages' do
+        is_expected
+          .to_not have_json_path('_links/createWorkPackage')
+      end
+
+      it 'has no link to create work_packages immediately' do
+        is_expected
+          .to_not have_json_path('_links/createWorkPackageImmediate')
+      end
+    end
+
     context 'limited page size' do
       let(:page_size_parameter) { 2 }
 

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -40,7 +40,9 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
   end
   let(:representer) { described_class.create(work_package) }
 
-  before do allow(work_package).to receive(:lock_version).and_return(1) end
+  before do
+    allow(work_package).to receive(:lock_version).and_return(1)
+  end
 
   context 'generation' do
     subject(:generated) { representer.to_json }
@@ -60,6 +62,20 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
         it { is_expected.to have_json_type(Integer).at_path('lockVersion') }
 
         it { is_expected.to be_json_eql(work_package.lock_version.to_json).at_path('lockVersion') }
+
+        context 'with a lock version of nil (new work package)' do
+          before do
+            allow(work_package)
+              .to receive(:lock_version)
+              .and_return(nil)
+          end
+
+          it 'has a lockVersion of 0' do
+            is_expected
+              .to be_json_eql(0)
+              .at_path('lockVersion')
+          end
+        end
       end
 
       describe 'estimated hours' do
@@ -142,6 +158,19 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
         it { expect(subject).to be_json_eql(link.to_json).at_path(path) }
       end
 
+      shared_examples_for 'linked property with 0 value' do |attribute, association = attribute|
+        context "with a 0 for #{attribute}_id" do
+          before do
+            work_package.send("#{association}_id=", 0)
+          end
+
+          it_behaves_like 'linked property' do
+            let(:property) { attribute }
+            let(:link) { nil }
+          end
+        end
+      end
+
       describe 'status' do
         let(:status) { FactoryGirl.build_stubbed(:status) }
 
@@ -151,6 +180,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:property) { 'status' }
           let(:link) { "/api/v3/statuses/#{status.id}" }
         end
+
+        it_behaves_like 'linked property with 0 value', :status
       end
 
       describe 'assignee and responsible' do
@@ -163,6 +194,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           it_behaves_like 'linked property' do
             let(:property) { 'assignee' }
           end
+
+          it_behaves_like 'linked property with 0 value', :assignee, :assigned_to
         end
 
         describe 'responsible' do
@@ -171,6 +204,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           it_behaves_like 'linked property' do
             let(:property) { 'responsible' }
           end
+
+          it_behaves_like 'linked property with 0 value', :responsible
         end
       end
 
@@ -183,6 +218,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:property) { 'version' }
           let(:link) { "/api/v3/versions/#{version.id}" }
         end
+
+        it_behaves_like 'linked property with 0 value', :version, :fixed_version
       end
 
       describe 'category' do
@@ -194,6 +231,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:property) { 'category' }
           let(:link) { "/api/v3/categories/#{category.id}" }
         end
+
+        it_behaves_like 'linked property with 0 value', :category
       end
 
       describe 'priority' do
@@ -205,6 +244,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:property) { 'priority' }
           let(:link) { "/api/v3/priorities/#{priority.id}" }
         end
+
+        it_behaves_like 'linked property with 0 value', :priority
       end
 
       describe 'parent' do
@@ -216,6 +257,8 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           let(:property) { 'parent' }
           let(:link) { "/api/v3/work_packages/#{parent.id}" }
         end
+
+        it_behaves_like 'linked property with 0 value', :parent
       end
     end
 

--- a/spec/lib/api/v3/work_packages/work_packages_shared_helpers_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_packages_shared_helpers_spec.rb
@@ -67,12 +67,12 @@ describe ::API::V3::WorkPackages::WorkPackagesSharedHelpers do
     subject do
       helper.create_work_package_form(work_package,
                                       contract_class: ::WorkPackages::CreateContract,
-                                      form_class: ::API::V3::WorkPackages::CreateFormRepresenter)
+                                      form_class: ::API::V3::WorkPackages::CreateProjectFormRepresenter)
     end
 
     context 'valid parameters' do
       it 'should return a form' do
-        expect(subject).to be_a(::API::V3::WorkPackages::CreateFormRepresenter)
+        expect(subject).to be_a(::API::V3::WorkPackages::CreateProjectFormRepresenter)
       end
 
       it 'should pass the request body into the form' do

--- a/spec/lib/api/v3/work_packages/work_packages_shared_helpers_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_packages_shared_helpers_spec.rb
@@ -65,9 +65,11 @@ describe ::API::V3::WorkPackages::WorkPackagesSharedHelpers do
 
   describe '#create_work_package_form' do
     subject do
-      helper.create_work_package_form(work_package,
-                                      contract_class: ::WorkPackages::CreateContract,
-                                      form_class: ::API::V3::WorkPackages::CreateProjectFormRepresenter)
+      helper.create_work_package_form(
+        work_package,
+        contract_class: ::WorkPackages::CreateContract,
+        form_class: ::API::V3::WorkPackages::CreateProjectFormRepresenter
+      )
     end
 
     context 'valid parameters' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -75,59 +75,6 @@ describe Project, type: :model do
     end
   end
 
-  describe 'add_work_package' do
-    let(:project) { FactoryGirl.create(:project_with_types) }
-
-    it 'should return a new work_package' do
-      expect(project.add_work_package).to be_a(WorkPackage)
-    end
-
-    it 'should not be saved' do
-      expect(project.add_work_package).to be_new_record
-    end
-
-    it 'returned work_package should have project set to self' do
-      expect(project.add_work_package.project).to eq(project)
-    end
-
-    it "returned work_package should have type set to project's first type" do
-      expect(project.add_work_package.type).to eq(project.types.first)
-    end
-
-    it 'returned work_package should have type set to provided type' do
-      specific_type = FactoryGirl.build(:type)
-      project.types << specific_type
-
-      expect(project.add_work_package(type: specific_type).type).to eq(specific_type)
-    end
-
-    it "should raise an error if the provided type is not one of the project's types" do
-      # Load project first so that the new type is not automatically included
-      project
-      specific_type = FactoryGirl.create(:type)
-
-      expect { project.add_work_package(type: specific_type) }.to raise_error ActiveRecord::RecordNotFound
-    end
-
-    it 'returned work_package should have type set to provided type_id' do
-      specific_type = FactoryGirl.build(:type)
-      project.types << specific_type
-
-      expect(project.add_work_package(type_id: specific_type.id).type).to eq(specific_type)
-    end
-
-    it 'should set all the other attributes' do
-      attributes = { blubs: double('blubs') }
-
-      new_work_package = FactoryGirl.build_stubbed(:work_package)
-      expect(new_work_package).to receive(:attributes=).with(attributes)
-
-      allow(WorkPackage).to receive(:new).and_yield(new_work_package)
-
-      project.add_work_package(attributes)
-    end
-  end
-
   describe '#find_visible' do
     it 'should find the project by id if the user is project member' do
       become_member_with_permissions(project, user, :view_work_packages)

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -1,0 +1,49 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::Type, type: :model do
+  let(:type) { FactoryGirl.build(:type) }
+  let(:type2) { FactoryGirl.build(:type) }
+  let(:project) { FactoryGirl.build(:project) }
+
+  describe '.enabled_in(project)' do
+    before do
+      type.projects << project
+      type.save
+
+      type2.save
+    end
+
+    it 'returns the types enabled in the provided project' do
+      expect(Type.enabled_in(project)).to match_array([type])
+    end
+  end
+end

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -36,39 +36,11 @@ describe 'API v3 Work package resource', type: :request do
 
   let(:closed_status) { FactoryGirl.create(:closed_status) }
 
-  let!(:timeline)    { FactoryGirl.create(:timeline,     project_id: project.id) }
-  let!(:other_wp)    {
-    FactoryGirl.create(:work_package, project_id: project.id,
-                                      status: closed_status)
-  }
   let(:work_package) {
     FactoryGirl.create(:work_package, project_id: project.id,
-                                      description: description
+                                      description: 'lorem ipsum'
                       )
   }
-  let(:description) {
-    %{
-{{>toc}}
-
-h1. OpenProject Masterplan for 2015
-
-h2. three point plan
-
-# One ###{other_wp.id}
-# Two
-# Three
-
-h3. random thoughts
-
-h4. things we like
-
-* Pointed
-* Relaxed
-* Debonaire
-
-{{timeline(#{timeline.id})}}
-  }}
-
   let(:project) do
     FactoryGirl.create(:project, identifier: 'test_project', is_public: false)
   end
@@ -103,6 +75,7 @@ h4. things we like
     subject { last_response }
 
     before(:each) do
+      work_package.save!
       get api_v3_paths.work_packages
     end
 
@@ -160,6 +133,38 @@ h4. things we like
 
       describe 'response body' do
         subject(:parsed_response) { JSON.parse(last_response.body) }
+        let!(:timeline)    { FactoryGirl.create(:timeline,     project_id: project.id) }
+        let!(:other_wp)    {
+          FactoryGirl.create(:work_package, project_id: project.id,
+                                            status: closed_status)
+        }
+        let(:work_package) {
+          FactoryGirl.create(:work_package, project_id: project.id,
+                                            description: description
+                            )
+        }
+        let(:description) {
+          %{
+      {{>toc}}
+
+      h1. OpenProject Masterplan for 2015
+
+      h2. three point plan
+
+      # One ###{other_wp.id}
+      # Two
+      # Three
+
+      h3. random thoughts
+
+      h4. things we like
+
+      * Pointed
+      * Relaxed
+      * Debonaire
+
+      {{timeline(#{timeline.id})}}
+        }}
 
         it 'should respond with work package in HAL+JSON format' do
           expect(parsed_response['id']).to eq(work_package.id)
@@ -1026,6 +1031,155 @@ h4. things we like
 
       it 'does not delete the work package' do
         expect(WorkPackage.exists?(work_package.id)).to be_truthy
+      end
+    end
+  end
+
+  describe '#post' do
+    let(:path) { api_v3_paths.work_packages }
+    let(:permissions) { [:add_work_packages, :view_project] }
+    let(:status) { FactoryGirl.build(:status, is_default: true) }
+    let(:priority) { FactoryGirl.build(:priority, is_default: true) }
+    let(:type) { project.types.first }
+    let(:parameters) do
+      {
+        subject: 'new work packages',
+        _links: {
+          type: {
+            href: api_v3_paths.type(type.id)
+          },
+          project: {
+            href: api_v3_paths.project(project.id)
+          }
+        }
+      }
+    end
+
+    before do
+      status.save!
+      priority.save!
+
+      FactoryGirl.create(:user_preference, user: current_user, others: { no_self_notified: false })
+      post path, parameters.to_json, 'CONTENT_TYPE' => 'application/json'
+    end
+
+    context 'notifications' do
+      let(:permissions) { [:add_work_packages, :view_project, :view_work_packages] }
+
+      it 'sends a mail by default' do
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+
+      context 'without notifications' do
+        let(:path) { "#{api_v3_paths.work_packages}?notify=false" }
+
+        it 'should not send a mail' do
+          expect(ActionMailer::Base.deliveries.count).to eq(0)
+        end
+      end
+
+      context 'with notifications' do
+        let(:path) { "#{api_v3_paths.work_packages}?notify=true" }
+
+        it 'should send a mail' do
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
+    end
+
+    it 'should return Created(201)' do
+      expect(last_response.status).to eq(201)
+    end
+
+    it 'should create a work package' do
+      expect(WorkPackage.all.count).to eq(1)
+    end
+
+    it 'should use the given parameters' do
+      expect(WorkPackage.first.subject).to eq(parameters[:subject])
+    end
+
+    it 'should be associated with the provided project' do
+      expect(WorkPackage.first.project).to eq(project)
+    end
+
+    it 'should be associated with the provided type' do
+      expect(WorkPackage.first.type).to eq(type)
+    end
+
+    context 'no permissions' do
+      let(:current_user) { FactoryGirl.create(:user) }
+
+      it 'should hide the endpoint' do
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    context 'view_project permission' do
+      # Note that this just removes the add_work_packages permission
+      # view_project is actually provided by being a member of the project
+      let(:permissions) { [:view_project] }
+
+      it 'should point out the missing permission' do
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    context 'empty parameters' do
+      let(:parameters) { {} }
+
+      it_behaves_like 'multiple errors', 422
+
+      it 'should not create a work package' do
+        expect(WorkPackage.all.count).to eq(0)
+      end
+    end
+
+    context 'bogus parameters' do
+      let(:parameters) do
+        {
+          bogus: 'bogus',
+          _links: {
+            type: {
+              href: api_v3_paths.type(project.types.first.id)
+            },
+            project: {
+              href: api_v3_paths.project(project.id)
+            }
+          }
+        }
+      end
+
+      it_behaves_like 'constraint violation' do
+        let(:message) { "Subject can't be blank" }
+      end
+
+      it 'should not create a work package' do
+        expect(WorkPackage.all.count).to eq(0)
+      end
+    end
+
+    context 'invalid value' do
+      let(:parameters) do
+        {
+          subject: nil,
+          _links: {
+            type: {
+              href: api_v3_paths.type(project.types.first.id)
+            },
+            project: {
+              href: api_v3_paths.project(project.id)
+            }
+          }
+        }
+      end
+
+      it_behaves_like 'constraint violation' do
+        let(:message) { "Subject can't be blank" }
+      end
+
+      it 'should not create a work package' do
+        expect(WorkPackage.all.count).to eq(0)
       end
     end
   end

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -1,0 +1,104 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+require 'rack/test'
+
+describe ::API::V3::WorkPackages::CreateProjectFormAPI do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:path) { api_v3_paths.create_work_package_form }
+  let(:status) { FactoryGirl.create(:default_status) }
+  let(:priority) { FactoryGirl.create(:default_priority) }
+  let(:user) { FactoryGirl.build(:admin) }
+  let(:parameters) { {} }
+
+  before do
+    status
+    priority
+    login_as(user)
+    post path, parameters.to_json, 'CONTENT_TYPE' => 'application/json'
+  end
+
+  subject(:response) { last_response }
+
+  it 'should return 200(OK)' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'should be of type form' do
+    expect(response.body).to be_json_eql('Form'.to_json).at_path('_type')
+  end
+
+  it 'has the available_projects link for creation in the schema' do
+    expect(response.body)
+      .to be_json_eql(api_v3_paths.available_projects_on_create.to_json)
+      .at_path('_embedded/schema/project/_links/allowedValues/href')
+  end
+
+  describe 'with empty parameters' do
+    it 'has 3 validation errors' do
+      expect(subject.body).to have_json_size(3).at_path('_embedded/validationErrors')
+    end
+
+    it 'has a validation error on subject' do
+      expect(subject.body).to have_json_path('_embedded/validationErrors/subject')
+    end
+
+    it 'has a validation error on type' do
+      expect(subject.body).to have_json_path('_embedded/validationErrors/type')
+    end
+
+    it 'has a validation error on project' do
+      expect(subject.body).to have_json_path('_embedded/validationErrors/project')
+    end
+  end
+
+  describe 'with all minimum parameters' do
+    let(:project) { FactoryGirl.create(:project_with_types) }
+    let(:type) { project.types.first }
+    let(:parameters) {
+      {
+        _links: {
+          type: {
+            href: "/api/v3/types/#{type.id}"
+          },
+          project: {
+            href: "/api/v3/projects/#{project.id}"
+          }
+        },
+        subject: 'lorem ipsum'
+      }
+    }
+
+    it 'has 0 validation errors' do
+      expect(subject.body).to have_json_size(0).at_path('_embedded/validationErrors')
+    end
+  end
+end

--- a/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
@@ -25,41 +25,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See doc/COPYRIGHT.rdoc for more details.
-#++
 
-module API
-  module V3
-    module WorkPackages
-      class CreateFormRepresenter < FormRepresenter
-        link :self do
-          {
-            href: api_v3_paths.create_work_package_form(represented.project_id),
-            method: :post
-          }
-        end
+require 'spec_helper'
+require 'rack/test'
 
-        link :validate do
-          {
-            href: api_v3_paths.create_work_package_form(represented.project_id),
-            method: :post
-          }
-        end
+describe ::API::V3::WorkPackages::CreateProjectFormAPI do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
 
-        link :previewMarkup do
-          {
-            href: api_v3_paths.render_markup(link: api_v3_paths.project(represented.project_id)),
-            method: :post
-          }
-        end
+  let(:project) { FactoryGirl.create(:project, id: 5) }
+  let(:post_path) { api_v3_paths.create_project_work_package_form(project.id) }
+  let(:user) { FactoryGirl.build(:admin) }
 
-        link :commit do
-          {
-            href: api_v3_paths.work_packages_by_project(represented.project_id),
-            method: :post
-          } if current_user.allowed_to?(:edit_work_packages, represented.project) &&
-               @errors.empty?
-        end
-      end
-    end
+  before do
+    login_as(user)
+    post post_path
+  end
+
+  subject(:response) { last_response }
+
+  it 'should return 200(OK)' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'should be of type form' do
+    expect(response.body).to be_json_eql('Form'.to_json).at_path('_type')
   end
 end

--- a/spec/requests/api/v3/work_packages/work_packages_by_project_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_by_project_resource_spec.rb
@@ -240,7 +240,16 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request do
     let(:permissions) { [:add_work_packages, :view_project] }
     let(:status) { FactoryGirl.build(:status, is_default: true) }
     let(:priority) { FactoryGirl.build(:priority, is_default: true) }
-    let(:parameters) { { subject: 'new work packages' } }
+    let(:parameters) do
+      {
+        subject: 'new work packages',
+        _links: {
+          type: {
+            href: api_v3_paths.type(project.types.first.id)
+          }
+        }
+      }
+    end
 
     before do
       status.save!
@@ -307,9 +316,7 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request do
     context 'empty parameters' do
       let(:parameters) { {} }
 
-      it_behaves_like 'constraint violation' do
-        let(:message) { "Subject can't be blank" }
-      end
+      it_behaves_like 'multiple errors', 422
 
       it 'should not create a work package' do
         expect(WorkPackage.all.count).to eq(0)
@@ -317,7 +324,16 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request do
     end
 
     context 'bogus parameters' do
-      let(:parameters) { { bogus: nil } }
+      let(:parameters) do
+        {
+          bogus: 'bogus',
+          _links: {
+            type: {
+              href: api_v3_paths.type(project.types.first.id)
+            }
+          }
+        }
+      end
 
       it_behaves_like 'constraint violation' do
         let(:message) { "Subject can't be blank" }
@@ -329,7 +345,16 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request do
     end
 
     context 'invalid value' do
-      let(:parameters) { { subject: nil } }
+      let(:parameters) do
+        {
+          subject: nil,
+          _links: {
+            type: {
+              href: api_v3_paths.type(project.types.first.id)
+            }
+          }
+        }
+      end
 
       it_behaves_like 'constraint violation' do
         let(:message) { "Subject can't be blank" }

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -82,4 +82,26 @@ describe ServiceResult, type: :model do
       expect(instance.errors).to be_a ActiveModel::Errors
     end
   end
+
+  describe 'result' do
+    let(:result) { double('result') }
+
+    it 'is what the object is initialized with' do
+      instance = ServiceResult.new false, [], result: result
+
+      expect(instance.result).to eql result
+    end
+
+    it 'is what has been provided' do
+      instance.result = result
+
+      expect(instance.result).to eql result
+    end
+
+    it 'is nil by default' do
+      instance = ServiceResult.new
+
+      expect(instance.result).to be_nil
+    end
+  end
 end

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -34,12 +34,12 @@ describe ServiceResult, type: :model do
 
   describe 'success' do
     it 'is what the service is initialized with' do
-      instance = ServiceResult.new true
+      instance = ServiceResult.new success: true
 
       expect(instance.success).to be_truthy
       expect(instance.success?).to be_truthy
 
-      instance = ServiceResult.new false
+      instance = ServiceResult.new success: false
 
       expect(instance.success).to be_falsey
       expect(instance.success?).to be_falsey
@@ -73,7 +73,7 @@ describe ServiceResult, type: :model do
     end
 
     it 'is what the object is initialized with' do
-      instance = ServiceResult.new false, errors
+      instance = ServiceResult.new errors: errors
 
       expect(instance.errors).to eql errors
     end
@@ -87,7 +87,7 @@ describe ServiceResult, type: :model do
     let(:result) { double('result') }
 
     it 'is what the object is initialized with' do
-      instance = ServiceResult.new false, [], result: result
+      instance = ServiceResult.new result: result
 
       expect(instance.result).to eql result
     end


### PR DESCRIPTION
Adds the project independent work package creation resource.

It adapts the schema, form and collection to reflect the added endpoint.

Also adds an available_projects endpoint to query for projects in which work packages can be created.
- [x] New endpoint and it's auxillary endpoint is documented in the api v3 documentation. Created by https://github.com/opf/openproject/pull/4267

https://community.openproject.com/work_packages/22847/activity
