### PR TITLE
[22898] Inline edit: Add tooltip when form not editable

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -359,6 +359,7 @@ en:
       description_options_hide: "Hide options"
       description_options_show: "Show options"
       error: "An error has occured."
+      error_edit_prohibited: "Editing %{attribute} is blocked for this work package. Either this attribute is derived from relations (e.g, children) or otherwise not configurable."
       error_update_failed: "The work package could not be updated."
       edit_attribute: "%{attribute} - Edit"
       key_value: "%{key}: %{value}"

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -41,7 +41,11 @@ export class WorkPackageEditFieldController {
 
   protected _active:boolean = false;
 
-  constructor(protected wpEditField:WorkPackageEditFieldService, protected $element) {
+  constructor(
+    protected wpEditField:WorkPackageEditFieldService,
+    protected $element,
+    protected NotificationsService,
+    protected I18n) {
   }
 
   public get workPackage() {
@@ -65,6 +69,15 @@ export class WorkPackageEditFieldController {
     this.pristineValue = angular.copy(this.workPackage[this.fieldName]);
     this.setupField().then(() => {
       this._active = this.field.schema.writable;
+
+      // Display a generic error if the field turns out not to be editable,
+      // despite the field being editable.
+      if (this.isEditable && !this._active) {
+        this.NotificationsService.addError(this.I18n.t(
+          'js.work_packages.error_edit_prohibited',
+          { attribute: this.field.schema.name }
+        ));
+      }
     });
   }
 


### PR DESCRIPTION
This adds a toolbar to attributes which are writable from their schemas,
but are no longer writable when their form is loaded.

This may happen for, e.g., priority of parent work packages, but also
other magic constraints.

While we work on reducing the magic in the constraints, a generic tooltip
offers the fastest user-friendly way of informing the user of
constraints.

https://community.openproject.com/work_packages/22898/activity
