### PR TITLE
[20499] [Accessibility] Some error messages cannot be perceived with the screen reader (Core)

### DIFF
--- a/app/assets/stylesheets/accessibility.css
+++ b/app/assets/stylesheets/accessibility.css
@@ -35,3 +35,8 @@ button:focus,
 *:focus {
   outline: 3px solid darkblue;
 }
+
+.form--field-container input:out-of-range,
+.form--field-container input:invalid {
+  border: 2px solid #9E2A1C;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1762,6 +1762,7 @@ en:
   text_file_repository_writable: "Attachments directory writable"
   text_git_repo_example: "a bare and local repository (e.g. /gitrepo, c:\\gitrepo)"
   text_hint_disable_with_0: "Note: Disable with 0"
+  text_hours_between: "Between %{min} and %{max} hours."
   text_work_package_added: "Work package %{id} has been reported by %{author}."
   text_work_package_category_destroy_assignments: "Remove category assignments"
   text_work_package_category_destroy_question: "Some work packages (%{count}) are assigned to this category. What do you want to do?"

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -128,7 +128,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
   def merge_required_attributes(required, options=nil)
     if required
-      options.merge!({ required: true, :'aria-required' => 'required' })
+      options.merge!({ required: true, :'aria-required' => 'true' })
     end
   end
 


### PR DESCRIPTION
This makes changes for a better accessibility. 
- `aria-required` was set to `true`. Thus the screen reader reads a field as required.
- All invalid fields are marked red in accessibility mode.
- Since the PR was made together with https://github.com/finnlabs/openproject-meeting/pull/114 there was an additional text entry necessary.  

https://community.openproject.com/work_packages/20449/activity
