### PR TITLE
Remove parse error when opening details view

### DIFF
--- a/frontend/app/components/api/api-v3/api-v3-cache.config.ts
+++ b/frontend/app/components/api/api-v3/api-v3-cache.config.ts
@@ -27,26 +27,23 @@
 // ++
 
 function apiV3CacheConfig($provide) {
-
   // Add caching wrapper around $http using angular-cache
-  $provide.decorator('$http', function($delegate, CacheService) {
+  $provide.decorator('$http', ($delegate:ng.IHttpService, CacheService:op.CacheService) => {
     var $http = $delegate;
     var wrapper = function() {
-      var params = arguments;
-      var request = arguments[0];
-      var requestable = () => $http.apply($http, params);
-      var useCaching = request.cache || true;
-      var cacheOptions;
+      var args = arguments;
+      var request = args[0];
+      var requestable = () => $http.apply($http, args);
+      var useCaching = request.cache;
 
       // Override cache values from headers
       if (request.headers && request.headers.caching) {
-        cacheOptions = request.headers.caching;
+        let cacheOptions = request.headers.caching;
         useCaching = cacheOptions.enabled;
         delete request.headers.caching;
       }
 
-
-      // Do not cache anything but GET coming from Restangualr
+      // Do not cache anything but GET coming from Restangular
       if (!useCaching || (request.method && request.method !== 'GET')) {
         request.cache = false;
         return requestable();
@@ -57,20 +54,16 @@ function apiV3CacheConfig($provide) {
       }
     };
 
-    Object.keys($http).forEach(function(key) {
-      // Decorate all fns with our cached wrapper
-      if (typeof $http[key] === 'function') {
-        wrapper[key] = function() {
-          return $http[key].apply($http, arguments);
-        };
-      } else {
-        wrapper[key] = $http[key];
-      }
+    // Decorate all fns with our cached wrapper
+    Object.keys($http).forEach(key => {
+      let prop = $http[key];
+      let fn = function() { return prop.apply($http, arguments) };
+
+      wrapper[key] = angular.isFunction(prop) ? fn : prop;
     });
 
     return wrapper;
   });
-
 }
 
 angular

--- a/frontend/app/components/caching/cache-service.service.ts
+++ b/frontend/app/components/caching/cache-service.service.ts
@@ -137,7 +137,7 @@ function CacheService($q, CacheFactory) {
   };
 
   return CacheService;
-};
+}
 
 
 angular

--- a/frontend/app/typings/open-project.typings.ts
+++ b/frontend/app/typings/open-project.typings.ts
@@ -144,22 +144,6 @@ declare namespace api {
       meta:Meta;
       work_packages;
     }
-
-    interface ColumnsMeta {
-      group_sums;
-      total_sums;
-    }
-
-    interface JsonQueryParams {
-      c?; //columns
-      s?; //displaySums
-      p?; //projectId
-      g?:string; //groupBy
-      f?; //filters
-      t?; //sortCriteria
-      pa?:number; //page
-      pp?:number; //perPage
-    }
   }
 }
 
@@ -191,6 +175,18 @@ declare namespace op {
 
   interface I18n {
     t(translateId:string, parameters?:any):string;
+  }
+
+  interface CacheService {
+    temporaryCache();
+    localStorage();
+    memoryStorage();
+    customCache(identifier, params);
+    isCacheDisabled();
+    enableCaching();
+    disableCaching();
+    cachedPromise(promiseFn, key, options?);
+    loadResource(resource, force);
   }
 
   /**


### PR DESCRIPTION
A little refactoring also took place to satisfy the IDE - adding type definitions.
The distinction between arrow and ordinary functions clarifies, where the arguments object is needed and where it is not.

The useCaching variable always returned a true value, because of the `... || true` at the end. After removing it, the application startet to function normally.
