### PR TITLE
[Inline Edit] Remove underline form split view icon in WP table

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -39,6 +39,8 @@
       &:before
         color: $body-font-color
         padding: 0 0 0 0.25rem
+  &:hover
+    text-decoration: none
 
 table.generic-table tbody tr.issue .checkbox
   overflow: visible


### PR DESCRIPTION
This removes the line below the icon for split screen in WP table. The line occurs because of the `a-tag` and is now overwritten. 
