### PR TITLE
[20405] [Accessibility] Some interactive elements don't have a meaningful label

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -469,7 +469,7 @@ en:
       button_cancel: "%{attribute}: Cancel"
       button_save_all: "Save"
       button_cancel_all: "Cancel"
-      link_formatting_help: "Text formatting"
+      link_formatting_help: "Text formatting help"
       btn_preview_enable: "Preview"
       btn_preview_disable: "Disable preview"
       null_value_label: "No value"

--- a/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
+++ b/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
@@ -4,7 +4,7 @@
   <ul class="dropdown-menu">
     <li ng-repeat="type in vm.types">
       <a ui-sref="{{ vm.stateName }}({ projectPath: vm.projectIdentifier, type: type.id })"
-         role="menuitem" focus="{{ !$index }}">
+         role="menuitem" class="menu-item">
 
         {{ type.name }}
       </a>

--- a/frontend/app/components/modals/columns-modal/columns-modal.template.html
+++ b/frontend/app/components/modals/columns-modal/columns-modal.template.html
@@ -11,7 +11,7 @@
 
       <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2"
                  id="selected_columns" focus-on="columnsModalOpened"
-                 aria-labelledby="column_multiselect_description">
+                 aria-labelledby="column_multiselect_description" title="{{ ::vm.text.columnsLabel }}">
 
         <ui-select-match>{{ $item.title }}</ui-select-match>
 

--- a/frontend/app/components/routing/views/work-packages.list.html
+++ b/frontend/app/components/routing/views/work-packages.list.html
@@ -51,7 +51,8 @@
                 class="button last work-packages-settings-button"
                 has-dropdown-menu
                 target="SettingsDropdownMenu"
-                locals="query">
+                locals="query"
+                onclick="setTimeout(function(){ $(document).getElementsByClassName('menu-item')[0].focus(); }, 100);">
           <i class="button--icon icon-show-more"></i>
         </button>
       </li>

--- a/frontend/app/components/work-packages/wp-create-button/wp-create-button.directive.html
+++ b/frontend/app/components/work-packages/wp-create-button/wp-create-button.directive.html
@@ -1,7 +1,8 @@
 <div class="wp-create-button">
   <button class="button -alt-highlight add-work-package" has-dropdown-menu
           target="typesDropDownMenu" locals="vm" ng-disabled="vm.isDisabled()"
-          aria-label="{{ ::vm.text.create }}" aria-haspopup="true">
+          aria-label="{{ ::vm.text.create }}" aria-haspopup="true"
+          onclick="setTimeout(function(){ $(document).getElementsByClassName('menu-item')[0].focus(); }, 100);">
 
     <i class="button--icon icon-add"></i>
     <span class="button--text" ng-bind="::vm.text.button" aria-hidden="true"></span>

--- a/frontend/app/templates/components/selectable_title.html
+++ b/frontend/app/templates/components/selectable_title.html
@@ -1,6 +1,6 @@
 <div class="title-container">
   <div class="text">
-    <h2 title="{{ I18n.t('js.toolbar.search_query_title') }}">
+    <h2 title="{{ I18n.t('js.toolbar.search_query_title') }}" role="link">
       <span has-dropdown-menu target="QuerySelectDropdownMenu"
         locals="selectedTitle,groups,transitionMethod">
         <accessible-by-keyboard>

--- a/frontend/app/templates/work_packages/menus/settings_dropdown_menu.html
+++ b/frontend/app/templates/work_packages/menus/settings_dropdown_menu.html
@@ -3,12 +3,12 @@
   properly. Thus, don't remove the hrefs or the empty URLs! -->
   <ul class="dropdown-menu">
     <li>
-      <a role="menuitem" focus="" href="" ng-click="showColumnsModal($event)"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a>
+      <a role="menuitem" class="menu-item" href="" ng-click="showColumnsModal($event)"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a>
     </li>
-    <li><a href="" ng-click="showSortingModal($event)"><i class="icon-action-menu icon-sort-by"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>
-    <li><a href="" ng-click="showGroupingModal($event)"><i class="icon-action-menu icon-group-by"></i>{{ I18n.t('js.toolbar.settings.group_by') }}</a></li>
+    <li><a class="menu-item" href="" ng-click="showSortingModal($event)"><i class="icon-action-menu icon-sort-by"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>
+    <li><a class="menu-item" href="" ng-click="showGroupingModal($event)"><i class="icon-action-menu icon-group-by"></i>{{ I18n.t('js.toolbar.settings.group_by') }}</a></li>
     <li>
-      <a role="menuitem" role="menuitem" href="" ng-click="toggleDisplaySums($event)">
+      <a role="menuitem" class="menu-item" href="" ng-click="toggleDisplaySums($event)">
         <i ng-if="query.displaySums" class="icon-action-menu icon-checkmark"></i><i ng-if="!query.displaySums" class="icon-action-menu no-icon"></i>
         <accessible-element visible-text="I18n.t('js.toolbar.settings.display_sums')"
                             readable-text="displaySumsLabel">
@@ -16,32 +16,32 @@
       </a>
     </li>
     <li class="dropdown-divider"></li>
-    <li><a role="menuitem" href="" ng-click="saveQuery($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="saveQuery($event)"
            inaccessible-by-tab="saveQueryInvalid()"
            ng-class="{'inactive': saveQueryInvalid()}">
         <i class="icon-action-menu icon-save"></i>{{ I18n.t('js.toolbar.settings.save') }}</a>
     </li>
-    <li><a role="menuitem" href="" ng-click="showSaveAsModal($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="showSaveAsModal($event)"
            inaccessible-by-tab="showSaveModalInvalid()"
            ng-class="{'inactive': showSaveModalInvalid()}">
       <i class="icon-action-menu icon-save"></i>{{ I18n.t('js.toolbar.settings.save_as') }}</a>
     </li>
-    <li><a role="menuitem" href="" ng-click="deleteQuery($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="deleteQuery($event)"
            inaccessible-by-tab="deleteQueryInvalid()"
            ng-class="{'inactive': deleteQueryInvalid()}">
       <i class="icon-action-menu icon-delete"></i>{{ I18n.t('js.toolbar.settings.delete') }}</a>
     </li>
-    <li><a role="menuitem" href="" ng-click="showExportModal($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="showExportModal($event)"
            inaccessible-by-tab="showExportModalInvalid()"
            ng-class="{'inactive': showExportModalInvalid()}">
       <i class="icon-action-menu icon-export"></i>{{ I18n.t('js.toolbar.settings.export') }}</a>
     </li>
-    <li><a role="menuitem" href="" ng-click="showShareModal($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="showShareModal($event)"
            inaccessible-by-tab="showShareModalInvalid()"
            ng-class="{'inactive': showShareModalInvalid()}">
       <i class="icon-action-menu icon-publish"></i>{{ I18n.t('js.toolbar.settings.share') }}</a>
     </li>
-    <li><a role="menuitem" href="" ng-click="showSettingsModal($event)"
+    <li><a role="menuitem" class="menu-item" href="" ng-click="showSettingsModal($event)"
            inaccessible-by-tab="showSettingsModalInvalid()"
            ng-class="{'inactive': showSettingsModalInvalid()}">
       <i class="icon-action-menu icon-settings"></i>{{ I18n.t('js.toolbar.settings.page_settings') }}</a>


### PR DESCRIPTION
This PR fixes some accessibility issues on WP view:
- [x] the modal window for columns should have a better description for the select box. Instead of 'select box' it is now 'columns'
- [x] On wiki elements the toolbar button for help is read as 'text formatting'. This has been changed to a bit more meaningful label 'text formatting help'.
- [x] When opening the 'settings' menu or 'new work package' menu on WP view the focus shall be set to the first element to make clear that there is a submenu.
- [x] The headline 'work packages' shall be marked as link to make clear that something happens when clicking on it. 

https://community.openproject.com/work_packages/20405/activity
