### PR TITLE
Alternate docker-compose reusing the official Dockerfile

### DIFF
--- a/config/database.docker.yml
+++ b/config/database.docker.yml
@@ -1,0 +1,42 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+development: &mysql
+  adapter: mysql2
+  database: openproject_development
+  host: db
+  username: root
+  password:
+  encoding: utf8
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *mysql
+  database: openproject_test

--- a/doc/QUICK_START.md
+++ b/doc/QUICK_START.md
@@ -34,7 +34,40 @@ Detailed installation instructions for different platforms are located on the [O
 
 You can find information on configuring OpenProject in [`config/CONFIGURATION.md`](CONFIGURATION.md).
 
-## Fast install
+## Fast install (Docker version)
+
+### Prerequisites
+
+* Git
+* [Docker Engine](https://docs.docker.com/engine/installation/)
+* [Docker Compose](https://docs.docker.com/compose/)
+
+### Building and running
+
+1. Build the image (this will take some time)
+
+        docker-compose build
+
+2. Start and setup the database
+
+        docker-compose up -d db
+        docker-compose run db rake db:create db:migrate db:seed
+
+3. Start the other processes
+
+        docker-compose up
+
+Assets should be automatically recompiled anytime you make a change, and your
+ruby code should also be reloaded when you change a file locally.
+
+You can run arbitrary commands in the context of the application by using
+`docker-compose run`. For instance:
+
+    docker-compose run web rake db:migrate
+    docker-compose run web rails c
+    ...
+
+## Fast install (manual)
 
 These are generic (and condensed) installation instructions for the **current dev** branch *without plugins*, and optimised for a development environment. Refer to the OpenProject website for instructions for the **stable** branch, OpenProject configurations with plugins, as well as platform-specific guides.
 

--- a/doc/QUICK_START.md
+++ b/doc/QUICK_START.md
@@ -51,7 +51,8 @@ You can find information on configuring OpenProject in [`config/CONFIGURATION.md
 2. Start and setup the database
 
         docker-compose up -d db
-        docker-compose run db rake db:create db:migrate db:seed
+        cp config/database.docker.yml config/database.yml
+        docker-compose run web rake db:create db:migrate db:seed
 
 3. Start the other processes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+db:
+  image: mysql
+  volumes:
+    - ~/.docker-volumes/openproject/db:/var/lib/mysql
+  expose:
+    - "3306"
+  environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=true
+
+worker: &ruby
+  build: .
+  volumes:
+    - .:/usr/src/app
+  links:
+    - db
+  environment:
+    - "DATABASE_URL=mysql2://root@db/openproject_development?encoding=utf8"
+    - "RAILS_CACHE_STORE=file_store"
+  command: "./docker/worker"
+
+web:
+  <<: *ruby
+  ports:
+    - "8080:8080"
+  command: "./docker/web"
+
+frontend:
+  build: .
+  volumes:
+    - .:/usr/src/app
+  command: "./docker/webpack-watch"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ worker: &ruby
   links:
     - db
   environment:
-    - "DATABASE_URL=mysql2://root@db/openproject_development?encoding=utf8"
     - "RAILS_CACHE_STORE=file_store"
   command: "./docker/worker"
 

--- a/docker/webpack-watch
+++ b/docker/webpack-watch
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+npm install
+cd frontend
+
+exec $(npm bin)/webpack --colors --watch --progress


### PR DESCRIPTION
This is an alternative to #4264, which reuses the existing Dockerfile, and adds another process to automatically recompile assets.
