### PR TITLE
Fix current broken specs

### DIFF
--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable/routes.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable/routes.rb
@@ -46,13 +46,10 @@ module OpenProject
         end
 
         def self.watchable_object?(object)
-          if Object.const_defined? object.to_s.classify
-            klass = object.to_s.classify.constantize
-
-            klass.included_modules.include? Redmine::Acts::Watchable
-          else
-            false
-          end
+          klass = object.to_s.classify.constantize
+          klass.included_modules.include? Redmine::Acts::Watchable
+        rescue
+          false
         end
       end
     end

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -434,7 +434,7 @@ describe WikiController, type: :controller do
 
                 expect(response).to be_success
 
-                assert_select "#content a[href='#{wiki_new_child_path(project_id: @project, id: @page_with_content.title)}']", 'Wiki page'
+                assert_select "#content a[href='#{new_child_project_wiki_path(project_id: @project, id: @page_with_content.title)}']", 'Wiki page'
               end
             end
 
@@ -444,7 +444,7 @@ describe WikiController, type: :controller do
 
                 expect(response).to be_success
 
-                assert_select "#content a[href='#{wiki_new_child_path(project_id: @project, id: 'i-am-a-ghostpage')}']",
+                assert_select "#content a[href='#{new_child_project_wiki_path(project_id: @project, id: 'i-am-a-ghostpage')}']",
                               text: 'Wiki page', count: 0
               end
             end
@@ -474,7 +474,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select ".toolbar-items a[href='#{wiki_new_child_path(project_id: @project, id: 'Wiki')}']", 'Wiki page'
+              assert_select ".toolbar-items a[href='#{new_child_project_wiki_path(project_id: @project, id: 'Wiki')}']", 'Wiki page'
             end
           end
 

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -62,7 +62,12 @@ class WorkPackagesPage
   end
 
   def click_toolbar_button(button)
-    find('.toolbar-container').click_button button
+    close_notifications
+    find('.toolbar-container', wait: 5).click_button button
+  end
+
+  def close_notifications
+    page.all(:css, '.notification-box--close').each(&:click)
   end
 
   def select_query(query)


### PR DESCRIPTION
Specs were broken after release/5.0 was merged into dev due to parallel changes to the wiki module on dev, which leads to an invalid path.

/cc @opf/developers 
