### PR TITLE
[22376] [Accessibility] Focus not set on column context menu on trigger

### DIFF
--- a/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
+++ b/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
@@ -4,49 +4,49 @@
      ng-class="{'dropdown-anchor-right': column && column.name !== 'id'}">
   <ul class="dropdown-menu">
     <li ng-if="canSort()" role="menuitem">
-      <a role="menuitem" focus href="" ng-click="sortAscending(column.name)">
+      <a role="menuitem" class="menu-item" focus href="" ng-click="sortAscending(column.name)">
         <i class="icon-action-menu icon-sort-ascending"></i>
         <span ng-bind="I18n.t('js.work_packages.query.sort_ascending')"/>
       </a>
     </li>
 
     <li ng-if="canSort()">
-      <a role="menuitem" href="" ng-click="sortDescending(column.name)">
+      <a role="menuitem" class="menu-item" href="" ng-click="sortDescending(column.name)">
         <i class="icon-action-menu icon-sort-descending"></i>
         <span ng-bind="I18n.t('js.work_packages.query.sort_descending')"/>
       </a>
     </li>
 
     <li ng-if="isGroupable">
-      <a role="menuitem" focus="focusFeature('group')" href="" ng-click="groupBy(column.name)">
+      <a role="menuitem" class="menu-item" focus="focusFeature('group')" href="" ng-click="groupBy(column.name)">
         <i class="icon-action-menu icon-group-by"></i>
         <span ng-bind="I18n.t('js.work_packages.query.group')"/>
       </a>
     </li>
 
     <li ng-if="canMoveLeft()">
-      <a role="menuitem" focus="focusFeature('moveLeft')" href="" ng-click="moveLeft(column.name)">
+      <a role="menuitem" class="menu-item" focus="focusFeature('moveLeft')" href="" ng-click="moveLeft(column.name)">
         <i class="icon-action-menu icon-column-left"></i>
         <span ng-bind="I18n.t('js.work_packages.query.move_column_left')"/>
       </a>
     </li>
 
     <li ng-if="canMoveRight()">
-      <a role="menuitem" focus="focusFeature('moveRight')" href="" ng-click="moveRight(column.name)">
+      <a role="menuitem" class="menu-item" focus="focusFeature('moveRight')" href="" ng-click="moveRight(column.name)">
         <i class="icon-action-menu icon-column-right"></i>
         <span ng-bind="I18n.t('js.work_packages.query.move_column_right')"/>
       </a>
     </li>
 
     <li ng-if="canBeHidden()">
-      <a role="menuitem" focus="focusFeature('hide')" href="" ng-click="hideColumn(column.name)">
+      <a role="menuitem" class="menu-item" focus="focusFeature('hide')" href="" ng-click="hideColumn(column.name)">
         <i class="icon-action-menu icon-delete"></i>
         <span ng-bind="I18n.t('js.work_packages.query.hide_column')"/>
       </a>
     </li>
 
     <li>
-      <a role="menuitem" focus="focusFeature('insert')" href="" ng-click="insertColumns()">
+      <a role="menuitem" class="menu-item" focus="focusFeature('insert')" href="" ng-click="insertColumns()">
         <i class="icon-action-menu icon-columns"></i>
         <span ng-bind="I18n.t('js.work_packages.query.insert_columns')"/>
       </a>

--- a/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
@@ -5,7 +5,8 @@
        ng-class="[currentSortDirection && 'sort', currentSortDirection]"
        lang-attribute
        lang="{{locale}}"
-       id="{{ headerTitle }}">{{headerTitle}}</a>
+       id="{{ headerTitle }}"
+       onclick="setTimeout(function(){ $(document).getElementsByClassName('menu-item')[0].focus(); }, 100);">{{headerTitle}}</a>
     <a ng-if="!sortable">{{headerTitle}}</a>
     <label class="hidden-for-sighted" for="{{ headerTitle }}"> {{ fullTitle }} </label>
     <icon-wrapper css-class="dropdown-indicator icon-small"


### PR DESCRIPTION
Similar to #4271 this PR sets the focus on the first element of the menu opened on click on the wp table headers.

https://community.openproject.com/work_packages/22376/activity
