### PR TITLE
[20538] [Accessibility] Differences in versions cannot be perceived with the screen reader

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,7 +325,11 @@ en:
         reported_project_status: Project status
         created_at: Created
       work_package:
+        begin_insertion: "Begin of the insertion"
+        begin_deletion: "Begin of the deletion"
         done_ratio: "Progress (%)"
+        end_insertion: "End of the insertion"
+        end_deletion: "End of the deletion"
         fixed_version: "Version"
         parent: "Parent"
         parent_issue: "Parent"

--- a/lib/redmine/helpers/diff.rb
+++ b/lib/redmine/helpers/diff.rb
@@ -67,11 +67,16 @@ module Redmine
             end
           end
           if add_at
-            words[add_at] = '<ins class="diffmod">'.html_safe + words[add_at]
-            words[add_to] = words[add_to] + '</ins>'.html_safe
+            words[add_at] = ('<label class="hidden-for-sighted">' + WorkPackage.human_attribute_name(:begin_insertion) + '</label><ins class="diffmod">').html_safe + words[add_at]
+            words[add_to] = words[add_to] + ('</ins><label class="hidden-for-sighted">' + WorkPackage.human_attribute_name(:end_insertion) + '</label>').html_safe
+
           end
           if del_at
-            words.insert del_at - del_off + dels + words_add, '<del class="diffmod">'.html_safe + deleted + '</del>'.html_safe
+            words.insert del_at - del_off + dels + words_add, ('<label class="hidden-for-sighted">' +
+                                                                WorkPackage.human_attribute_name(:begin_deletion) +
+                                                                '</label><del class="diffmod">').html_safe + deleted +
+                                                                ('</del><label class="hidden-for-sighted">' +
+                                                                WorkPackage.human_attribute_name(:end_deletion) + '</label>').html_safe
             dels += 1
             del_off += words_del
             words_del = 0

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -71,7 +71,7 @@ describe JournalsController, type: :controller do
       end
 
       it 'should present the diff correctly' do
-        expect(response.body.strip).to eq("<div class=\"text-diff\">\n  <ins class=\"diffmod\">description</ins>\n</div>")
+        expect(response.body.strip).to eq("<div class=\"text-diff\">\n  <label class=\"hidden-for-sighted\">Begin of the insertion</label><ins class=\"diffmod\">description</ins><label class=\"hidden-for-sighted\">End of the insertion</label>\n</div>")
       end
     end
 


### PR DESCRIPTION
This adds hidden labels for the versions of wp descriptions. Changes are introduced by the screenreader with "Begin/End of the insertion/deletion".

https://community.openproject.com/work_packages/20538/activity
