### PR TITLE
[20452] [Accessibility] For some forms the focus order does not equal the optical order

### DIFF
--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -58,11 +58,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="login-options-container">
     <div class="login-links">
       <% if Setting.lost_password? %>
-        <%= link_to l(:label_password_lost), controller: '/account', action: 'lost_password' %>
+        <%= link_to l(:label_password_lost), { controller: '/account', action: 'lost_password' }, tabindex: "4" %>
         <br>
       <% end %>
       <% if Setting.self_registration? %>
-        <%= link_to l(:label_register), { controller: '/account', action: 'register' } %>
+        <%= link_to l(:label_register), { controller: '/account', action: 'register' }, tabindex: "5" %>
       <% end %>
     </div>
   </div>

--- a/app/views/hooks/login/_auth_provider.html.erb
+++ b/app/views/hooks/login/_auth_provider.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% unless Rails.env.production? %>
-  <a href="<%= url_for controller: '/auth', action: 'developer' %>" class="auth-provider auth-provider-developer">
+  <a tabindex="6" href="<%= url_for controller: '/auth', action: 'developer' %>" class="auth-provider auth-provider-developer">
     <span class="auth-provider-name">Omniauth Developer</span>
   </a>
 <% end %>


### PR DESCRIPTION
This adds a `tabindex` for the login form elements. Thus the correct tabbing order is granted. 

https://community.openproject.com/work_packages/20452/activity
