### PR TITLE
[20432] [Accessibility] Some form elements are pronounced with a wrong label

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -253,6 +253,9 @@ fieldset.form--fieldset
     .form--fieldset.-collapsible.collapsed  > &
       @extend .icon-arrow-down1:before
 
+#sidebar .form--fieldset-legend
+  color: $main-menu-sidebar-font-color
+
 .form--fieldset-control
   float:          right
   margin-top:     -2.8rem

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -86,7 +86,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :sidebar do %>
   <%= form_tag({}, method: :get) do %>
-    <h3><%= l(:description_filter) %></h3>
+    <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend"><%= l(:description_filter) %></legend>
     <p>
       <% @activity.event_types.each do |t| %>
         <%= check_box_tag "show_#{t}", 1, @activity.scope.include?(t) %>
@@ -101,6 +102,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= hidden_field_tag('user_id', params[:user_id]) unless params[:user_id].blank? %>
     <%= hidden_field_tag('apply', true) %>
     <p><%= submit_tag l(:button_apply), class: 'button -small -highlight', name: nil %></p>
+    </fieldset>
   <% end %>
 <% end %>
 

--- a/app/views/my/settings.erb
+++ b/app/views/my/settings.erb
@@ -36,13 +36,10 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for @user, as: :user, url: { action: 'settings' },
                               lang: current_language,
                               html: { id: 'my_account_form', class: 'form -wide-labels' } do |f| %>
-  <section class="form--section">
-    <section class="form--section">
+  <fieldset class="form--fieldset">
       <div class="form--field"><%= f.select :language, lang_options_for_select,  container_class: '-middle' %></div>
       <%= render partial: 'users/preferences', locals: { input_size: :middle } %>
-    </section>
-
-    <%= call_hook(:view_my_settings, user: @user, form: f) %>
-  </section>
+  </fieldset>
+  <%= call_hook(:view_my_settings, user: @user, form: f) %>
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/timelines/_comparison.html.erb
+++ b/app/views/timelines/_comparison.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <%= ff.radio_button :comparison, "relative", label:  l('timelines.filter.comparison.relative') %>
       </div>
       <div class="form--grouping">
-        <div id="timeline--form--project-filter-timeframe"
+        <div id="timeline--form---comparison-timeframe"
              class="form--grouping-label">
            <span class="hidden-for-sighted">
              <%= l('timelines.filter.comparison.relative') %>
@@ -72,7 +72,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
 
       <div class="form--grouping">
-        <div id="timeline--form--project-filter-timeframe"
+        <div id="timeline--form--comparison-timeframe"
              class="form--grouping-label">
           <span class="hidden-for-sighted">
             <%= l('timelines.filter.comparison.absolute') %>


### PR DESCRIPTION
This adds `fieldsets` and their legends for a better accessibility with screenreader:
In detail the following things were changed:
- [x] In timelines there was an ID given twice. Thus the screenreader read the wrong things. 
- [x] In MyAccount/Settings `sections` were replaced by `fieldsets` so that the screenreader reads the association. The backlogs part was done in: https://github.com/finnlabs/openproject-backlogs/pull/212
- [x] Filters in the sidebar were not read as such. Now under Activity is also a fieldset used. https://github.com/opf/openproject-documents/pull/59 does the same thing for the document sidebar filter

https://community.openproject.com/work_packages/20432/activity
