### PR TITLE
[20396][Accessibility] [3a][Accessibility] Navigating through subordinate input fields changes the selection of radio buttons

### DIFF
--- a/app/assets/javascripts/date-range.js
+++ b/app/assets/javascripts/date-range.js
@@ -46,8 +46,7 @@
       };
     };
 
-
-    intervalInputs.on('click focus', activateRadiobutton(periodOptionInterval));
-    period.on('click focus', activateRadiobutton(periodOptionList));
+    intervalInputs.on('click', activateRadiobutton(periodOptionInterval));
+    period.on('click', activateRadiobutton(periodOptionList));
   });
 }(jQuery));


### PR DESCRIPTION
This removes functionality that the radio button is checked on focus in time entries overview. Thus it is now selectable like every other radio button set by arrows.

https://community.openproject.com/work_packages/20396/activity
