### PR TITLE
[20364] [Accessibility] Some radio buttons cannot be used as usual

### DIFF
--- a/frontend/app/templates/work_packages/modals/sorting.html
+++ b/frontend/app/templates/work_packages/modals/sorting.html
@@ -29,20 +29,20 @@
             <div class="form--field-container">
               <label class="option-label">
                 <input type="radio"
-                       tabindex="0"
                        ng-model="element[1]"
                        ng-required="element[0].id"
                        ng-disabled="!element[0].id"
-                       ng-value="availableDirectionsData[1]">
+                       ng-value="availableDirectionsData[1]"
+                       name="modal-sorting-attribute-{{$index}}--sort-direction">
                 {{availableDirectionsData[1].label}}
               </label>
               <label class="option-label">
                 <input type="radio"
-                       tabindex="0"
                        ng-model="element[1]"
                        ng-required="element[0].id"
                        ng-disabled="!element[0].id"
-                       ng-value="availableDirectionsData[0]">
+                       ng-value="availableDirectionsData[0]"
+                       name="modal-sorting-attribute-{{$index}}--sort-direction">
                 {{availableDirectionsData[0].label}}
               </label>
             </div>


### PR DESCRIPTION
This sets a `name` for the radio buttons group in WP sort modal window. Thus the radio buttons are accessible by arrow keys. 

https://community.openproject.com/work_packages/20364/activity
