### PR TITLE
[22945]  Login button on responsive page missing

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -58,7 +58,8 @@
     > li
       display: none
 
-      &.drop-down
+      &.drop-down,
+      &:last-child
         display: block
 
         > a
@@ -77,6 +78,7 @@
             text-indent: 0
             top: 16px
             z-index: 1000
+            @include icon-common
 
           + ul
             width: 100vw


### PR DESCRIPTION
This PR adds the styling for the login button when there is no dropdown menu on small screens. Before the button was not displayed and users could not log in.

https://community.openproject.com/work_packages/22945/activity
