### PR TITLE
[21808] [Accessibility] Make wp view mode buttons accessible

### DIFF
--- a/frontend/app/components/routing/views/work-packages.list.html
+++ b/frontend/app/components/routing/views/work-packages.list.html
@@ -29,7 +29,7 @@
       <li class="toolbar-item hidden-for-mobile" feature-flag="detailsView">
         <ul id="work-packages-view-mode-selection" class="toolbar-button-group">
           <li>
-            <wp-list-view-button disabled="editAll.state"
+            <wp-list-view-button ng-disabled="!!editAll.state"
                                  project-identifier="projectIdentifier"></wp-list-view-button>
           </li>
           <li feature-flag="detailsView">

--- a/frontend/app/components/routing/views/work-packages.list.html
+++ b/frontend/app/components/routing/views/work-packages.list.html
@@ -29,7 +29,7 @@
       <li class="toolbar-item hidden-for-mobile" feature-flag="detailsView">
         <ul id="work-packages-view-mode-selection" class="toolbar-button-group">
           <li>
-            <wp-list-view-button ng-disabled="!!editAll.state"
+            <wp-list-view-button edit-all="editAll"
                                  project-identifier="projectIdentifier"></wp-list-view-button>
           </li>
           <li feature-flag="detailsView">

--- a/frontend/app/components/routing/views/work-packages.show.html
+++ b/frontend/app/components/routing/views/work-packages.show.html
@@ -22,8 +22,8 @@
         <li class="toolbar-item hidden-for-mobile" feature-flag="detailsView">
           <ul id="work-packages-view-mode-selection" class="toolbar-button-group">
             <li>
-              <wp-list-view-button ng-disabled="!!editAll.state"
-                                   project-identifier="projectIdentifier"></wp-list-view-button>
+            <wp-list-view-button edit-all="editAll"
+                                 project-identifier="projectIdentifier"></wp-list-view-button>
             </li>
             <li feature-flag="detailsView">
               <wp-details-view-button project-identifier="projectIdentifier"></wp-details-view-button>

--- a/frontend/app/components/routing/views/work-packages.show.html
+++ b/frontend/app/components/routing/views/work-packages.show.html
@@ -22,7 +22,7 @@
         <li class="toolbar-item hidden-for-mobile" feature-flag="detailsView">
           <ul id="work-packages-view-mode-selection" class="toolbar-button-group">
             <li>
-              <wp-list-view-button disabled="editAll.state"
+              <wp-list-view-button ng-disabled="!!editAll.state"
                                    project-identifier="projectIdentifier"></wp-list-view-button>
             </li>
             <li feature-flag="detailsView">

--- a/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.test.ts
+++ b/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.test.ts
@@ -39,7 +39,7 @@ describe('wpListViewButton directive', () => {
   ));
 
   beforeEach(angular.mock.inject(($compile, $rootScope, _$state_) => {
-    var html = '<wp-list-view-button disabled="disabled"' +
+    var html = '<wp-list-view-button edit-all="editAll"' +
           ' projectIdentifier="projectIdentifier"></wp-list-view-button>';
 
     var element = angular.element(html);
@@ -47,6 +47,8 @@ describe('wpListViewButton directive', () => {
     $state = _$state_;
 
     scope = $rootScope.$new();
+
+    scope.editAll = { state: false };
 
     $compile(element)(scope);
     scope.$digest();

--- a/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.ts
+++ b/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.ts
@@ -30,6 +30,7 @@ import {WorkPackageNavigationButtonController, wpButtonDirective} from '../wp-bu
 
 export class WorkPackageListViewButtonController extends WorkPackageNavigationButtonController {
   public projectIdentifier:number;
+  public editAll:any;
 
   public accessKey:number = 8;
   public activeState:string = 'work-packages.list';
@@ -45,6 +46,10 @@ export class WorkPackageListViewButtonController extends WorkPackageNavigationBu
 
   public isActive() {
     return this.$state.is(this.activeState);
+  }
+
+  public get disabled() {
+    return !!this.editAll.state;
   }
 
   public performAction() {
@@ -64,7 +69,8 @@ export class WorkPackageListViewButtonController extends WorkPackageNavigationBu
 function wpListViewButton(): ng.IDirective {
   return wpButtonDirective({
     scope: {
-      projectIdentifier: '='
+      projectIdentifier: '=',
+      editAll: '='
     },
 
     controller: WorkPackageListViewButtonController,


### PR DESCRIPTION
The list view button on WP overview was not focusable by keyboard, since it was disabled. I removed this since the other two buttons were not disabled neither and the button is thus focusable again.

https://community.openproject.com/work_packages/21808/activity
