### PR TITLE
[20405] [Accessibility] Wiki help button does not have a meaningful label

### DIFF
--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -41,8 +41,8 @@ module Redmine
                                     type: 'button',
                                     class: 'jstb_help',
                                     onclick: open_help,
-                                    :'aria-label' => l(:setting_text_formatting),
-                                    title: l(:setting_text_formatting)
+                                    :'aria-label' => ::I18n.t('js.inplace.link_formatting_help'),
+                                    title: ::I18n.t('js.inplace.link_formatting_help')
 
           javascript_tag(<<-EOF)
             var wikiToolbar = new jsToolBar($('#{field_id}'));


### PR DESCRIPTION
This changes the title and label of the help button in the wiki toolbar. Thus the label read by a screen reader is more meaningful.

https://community.openproject.com/work_packages/20405/activity
