### PR TITLE
[22916] Inline edit only on attribute text, double click to fullscreen

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -224,7 +224,6 @@ a.inplace-edit--icon-wrapper
 // the default class will win
 a.inplace-editing--trigger-link,
 .inplace-editing--trigger-link,
-td.-editable
   @include grid-block
   color: $body-font-color
   font-weight: inherit
@@ -253,7 +252,6 @@ td.-editable
     display: block
 
 .inplace-editing--container,
-.wp-edit-field
   @include grid-block
   border-color: transparent
   border-style: solid

--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -35,7 +35,7 @@
 
     .icon
       position: relative
-      left: 0.5rem
+      left: 0.25rem
       &:before
         color: $body-font-color
         padding: 0 0 0 0.25rem
@@ -44,3 +44,4 @@
 
 table.generic-table tbody tr.issue .checkbox
   overflow: visible
+  padding-left: 5px

--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -26,8 +26,20 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-.-editable
+.work-package-table--container table.generic-table tbody td
+  padding-left: 0
+  line-height: 24px
+
+// Styles for inline editable attributes
+.work-package-table--container td.-editable
+  padding-top: 0
+  padding-bottom: 0
+  display: table-cell
+  width: auto
+
   .wp-edit-field
+    padding-left: 0
+
     &.-active
       padding: 0
 
@@ -41,27 +53,38 @@
     form
       width: 100%
 
+    .-hidden-overflow
+      overflow: hidden
+      text-overflow: ellipsis
+
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
-.wp-table--cell
+  // Editable fields cursor
+  .wp-table--cell-span
+    padding: 0 25px 0 2px
+    cursor: text
+    border-color: transparent
+    border-style: solid
+    border-radius: 2px
+    border-width: 1px
+    overflow: visible
+    display: inline-block
+    line-height: 1.6
+
+
+    &:hover,
+    &:focus
+      border-color: $inplace-edit--border-color
+
+
+
+// Default cursor on non-editable and id fields
+.wp-table--cell-span
   cursor: not-allowed
 
   &.id
     cursor: pointer
-  &.-editable
-    cursor: text
-
-.work-package-table--container .generic-table tbody
-  td
-    .wp-edit-field .-hidden-overflow
-      overflow: hidden
-      text-overflow: ellipsis
-    &.-editable
-      padding-top: 0
-      padding-bottom: 0
-      display: table-cell
-      width: auto
 
 // Animations on leaving work packages
 .wp--row.ng-leave

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -241,9 +241,9 @@ function WorkPackagesListController($scope,
 
   $scope.nextAvailableWorkPackage = nextAvailableWorkPackage;
 
-  $scope.showWorkPackageDetails = function (id, force) {
+  $scope.openWorkPackageInFullView = function (id, force) {
     if (force || $state.current.url != "") {
-      loadingIndicator.mainPage = $state.go(keepTab.currentDetailsTab, {
+      loadingIndicator.mainPage = $state.go('work-packages.show', {
         workPackageId: id,
         query_props: $state.params.query_props
       });

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -81,7 +81,7 @@
                            group-by-column="groupByColumn"
                            display-sums="query.displaySums"
                            resource ="resource"
-                           activation-callback="showWorkPackageDetails(id, force)">
+                           activation-callback="openWorkPackageInFullView(id, force)">
       </wp-table>
     </div>
     <div class="work-packages--list-pagination-area">

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -1,4 +1,4 @@
-<div ng-click="vm.isEditable && vm.activate()" class="wp-edit-field -small"
+<div class="wp-edit-field -small"
      ng-class="{ '-error': vm.errorenous, '-active': vm.active }">
   <form ng-if="vm.workPackage && vm.active"
         name="vm.wpEditForm"

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -128,10 +128,6 @@ function wpEditFieldLink(
   controllers[1].formCtrl = controllers[0];
   controllers[1].formCtrl.fields[scope.vm.fieldName] = scope.vm;
 
-  element.click(event => {
-    event.stopImmediatePropagation();
-  });
-
   // Mark the td field if it is inline-editable
   // We're resolving the non-form schema here since its loaded anyway for the table
   scope.vm.workPackage.schema.$load().then(schema => {
@@ -143,6 +139,14 @@ function wpEditFieldLink(
     if (event.keyCode === 27) {
       scope.$evalAsync(_ => scope.vm.reset());
     }
+  });
+
+  // Find inline edit cells to handle click on
+  element.find('.wp-table--cell-span').click(event => {
+    if (scope.vm.isEditable) {
+      scope.vm.activate();
+    }
+    event.stopImmediatePropagation();
   });
 }
 

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -89,7 +89,7 @@
             locals="rows,row"
             after-focus-on=".id :focusable"
             single-click="selectWorkPackage(row, $event)"
-            ng-dblclick="showWorkPackageDetails(row)"
+            ng-dblclick="openWorkPackageInFullView(row)"
             ng-class="[
               'issue',
               'hascontextmenu',

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -30,7 +30,7 @@ angular
   .module('openproject.workPackages.directives')
   .directive('wpTable', wpTable);
 
-function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages){
+function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages, $state){
   return {
     restrict: 'E',
     replace: true,
@@ -187,13 +187,13 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages)
         }
       };
 
-      scope.showWorkPackageDetails = function(row) {
+      scope.openWorkPackageInFullView = function(row) {
         clearSelection();
 
         scope.setCheckedStateForAllRows(false);
 
         setRowSelectionState(row, true);
-
+        
         scope.activationCallback({ id: row.object.id, force: true });
       };
     }

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -179,7 +179,7 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages)
           if ($event.shiftKey) {
             clearSelection();
             activeSelectionBorderIndex = WorkPackagesTableService.selectRowRange(scope.rows, row, activeSelectionBorderIndex);
-          } else if($event.ctrlKey){
+          } else if($event.ctrlKey || $event.metaKey){
             setRowSelectionState(row, multipleChecked ? true : !currentRowCheckState);
           } else {
             setRowSelectionState(row, multipleChecked ? true : !currentRowCheckState);

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.js
@@ -33,6 +33,7 @@ angular
 function wpTd(){
   return {
     restrict: 'E',
+    replace: true,
     templateUrl: '/components/wp-table/wp-td/wp-td.directive.html',
 
     scope: {

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.test.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.test.js
@@ -56,7 +56,7 @@ describe('wpTd Directive', function() {
   }));
 
   var getInnermostSpan = function(start) {
-    return start.find('span :not(:has("*"))').first();
+    return start.find('span').last();
   };
 
   describe('element', function() {

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -223,10 +223,10 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
 
     context 'focus' do
       let(:first_link_selector) do
-        'table.keyboard-accessible-list tbody tr:first-child td.id div'
+        'table.keyboard-accessible-list tbody tr:first-child td.id a'
       end
       let(:second_link_selector) do
-        'table.keyboard-accessible-list tbody tr:nth-child(2) td.id div'
+        'table.keyboard-accessible-list tbody tr:nth-child(2) td.id a'
       end
 
       it 'navigates with J' do
@@ -283,14 +283,14 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
     describe 'work package context menu', js: true do
       it_behaves_like 'context menu' do
         let(:target_link) { '#work-package-context-menu li.detailsViewMenuItem a' }
-        let(:source_link) { '.work-package-table--container tr.issue td.id div' }
+        let(:source_link) { '.work-package-table--container tr.issue td.id a' }
         let(:keys) { [:shift, :alt, :f10] }
         let(:sets_focus) { true }
       end
 
       it_behaves_like 'context menu' do
         let(:target_link) { '#work-package-context-menu li.openFullScreenView a' }
-        let(:source_link) { '.work-package-table--container tr.issue td.id div' }
+        let(:source_link) { '.work-package-table--container tr.issue td.id a' }
         let(:keys) { [:shift, :alt, :f10] }
         let(:sets_focus) { false }
       end

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -53,9 +53,8 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     split_work_package.expect_subject
     split_work_package.expect_current_path
 
-    # open work package full screen
-
-    full_work_package = global_work_packages.open_full_screen(work_package)
+    # Go to full screen by double click
+    full_work_package = global_work_packages.open_full_screen_by_doubleclick(work_package)
 
     full_work_package.expect_subject
     full_work_package.expect_current_path
@@ -84,9 +83,8 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     split_project_work_package.expect_subject
     split_project_work_package.expect_current_path
 
-    # open work package full screen
-
-    full_work_package = project_work_packages.open_full_screen(work_package)
+    # open work package full screen by button
+    full_work_package = project_work_packages.open_full_screen_by_button(work_package)
 
     full_work_package.expect_subject
     full_work_package.expect_current_path

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -51,7 +51,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
 
   describe 'Work package row selection', js: true do
     def select_work_package_row(number, mouse_button_behavior = :left)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}).issue td.checkbox")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
       loading_indicator_saveguard
       case mouse_button_behavior
       when :double
@@ -64,7 +64,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
     end
 
     def select_work_package_row_with_shift(number)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}).issue td.checkbox")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
       loading_indicator_saveguard
 
       page.driver.browser.action.key_down(:shift)
@@ -74,7 +74,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
     end
 
     def select_work_package_row_with_ctrl(number)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}).issue td.checkbox")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
       loading_indicator_saveguard
 
       page.driver.browser.action.key_down(:control)
@@ -307,13 +307,13 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
       end
     end
 
-    describe 'opening work package details' do
+    describe 'opening work package full screen view' do
       before do
         select_work_package_row(1, :double)
       end
 
-      it_behaves_like 'work package row selected' do
-        let(:index) { 1 }
+      it do
+        expect(page).to have_selector('#work-package-subject', text: work_package_3.subject)
       end
     end
 

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -44,17 +44,30 @@ module Pages
     end
 
     def open_split_view(work_package)
+
+      # Hover row to show split screen button
+      row_element = row(work_package)
+      row_element.hover
+
       split_page = SplitWorkPackage.new(work_package, project)
 
-      loading_indicator_saveguard
-      page.driver.browser.mouse.double_click(row(work_package).native)
+      row_element.find('.wp-table--details-link').click
 
       split_page
     end
 
-    def open_full_screen(work_package)
+    def open_full_screen_by_doubleclick(work_package)
+
+      loading_indicator_saveguard
+      page.driver.browser.mouse.double_click(row(work_package).native)
+
+      FullWorkPackage.new(work_package)
+    end
+
+    def open_full_screen_by_button(work_package)
       row(work_package).check(I18n.t('js.description_select_work_package',
                                      id: work_package.id))
+
 
       click_button(I18n.t('js.label_activate') + ' ' + I18n.t('js.button_show_view'))
 

--- a/spec/support/work_packages/inline_edit_field.rb
+++ b/spec/support/work_packages/inline_edit_field.rb
@@ -14,13 +14,13 @@ class InlineEditField
   end
 
   def expect_text(text)
-    expect(page).to have_selector(selector, text: text)
+    expect(page).to have_selector(selector, text: text, wait: 10)
   end
 
   ##
   # Activate the field and check it opened correctly
   def activate!
-    edit_field.click
+    edit_field.find('.wp-table--cell-span').click
     expect_active!
   end
 


### PR DESCRIPTION
This PR introduces:
1. Inline editing only on the cell spans, not on the entire column.
2. Using the whitespace for click handling (selection, double click)
3. Creating a minimum width for editable fields when text content is narrow.

![bildschirmfoto 2016-04-04 um 14 26 01](https://cloud.githubusercontent.com/assets/459462/14253750/07c4be88-fa8d-11e5-8fc4-2075bf553115.png)

Supersedes https://github.com/opf/openproject/pull/4280

https://community.openproject.com/work_packages/22916/activity
