### PR TITLE
[20457] [Accessibility] The heading "Hauptmenü" was positioned wrongly on all pages

### DIFF
--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -78,12 +78,12 @@ See doc/COPYRIGHT.rdoc for more details.
               <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
             <div id="top-menu-items">
+              <h1 class="hidden-for-sighted">
+                <%= l(:label_top_menu) %>
+              </h1>
               <%= render_top_menu_left %>
               <div class="top-menu-items-right">
                 <%= render partial: 'search/mini_form' %>
-                <h1 class="hidden-for-sighted">
-                  <%= l(:label_top_menu) %>
-                </h1>
                 <%= render_top_menu_right %>
               </div>
             </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -75,12 +75,12 @@ See doc/COPYRIGHT.rdoc for more details.
               <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
             <div id="top-menu-items">
+              <h1 class="hidden-for-sighted">
+                <%= l(:label_top_menu) %>
+              </h1>
               <%= render_top_menu_left %>
               <div class="top-menu-items-right">
                 <%= render partial: 'search/mini_form' %>
-                <h1 class="hidden-for-sighted">
-                  <%= l(:label_top_menu) %>
-                </h1>
                 <%= render_top_menu_right %>
               </div>
             </div>


### PR DESCRIPTION
This relocates the hidden headline for the top menu. Now it is read before the first top menu entry. Thus it is clear for blind users what belongs to the menu.

https://community.openproject.com/work_packages/20457/activity
