### PR TITLE
[20397] [Accessibility] Navigating through the entries of some drop down lists causes a page update

### DIFF
--- a/app/views/queries/_filters.html.erb
+++ b/app/views/queries/_filters.html.erb
@@ -168,6 +168,10 @@ when  :list, :list_optional, :list_status, :list_subprojects %>
       <i class="icon-add icon4"></i>
       <%= l(:label_filter_add) %>
     </label>
+    <label for="add_filter_select" class="hidden-for-sighted">
+       {{ I18n.t('js.filter.description.text_open_filter') }}
+       {{ I18n.t('js.filter.description.text_close_filter') }}
+    </label>
     <div class="advanced-filters--add-filter-value">
        <%= select_tag 'add_filter_select',
                       options_for_select(entries_for_filter_select_sorted(query)),

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -63,6 +63,9 @@ en:
     description_selected_columns: "Selected Columns"
     description_subwork_package: "Sub work package of"
     filter:
+      description:
+        text_open_filter: "Open this filter with 'ALT' and arrow keys."
+        text_close_filter: "To select an entry leave the focus for example by pressing enter. To leave without filter select the first (empty) entry."
       noneElement: "(none)"
       sorting:
         criteria:

--- a/frontend/app/templates/work_packages/query_filters.html
+++ b/frontend/app/templates/work_packages/query_filters.html
@@ -20,8 +20,12 @@
 
       <!-- Operator -->
       <div class="advanced-filters--filter-operator">
+         <label for="operators-{{filter.name}}" class="hidden-for-sighted">
+          {{ localisedFilterName(query.availableWorkPackageFilters[filter.name]) }}
+          {{ I18n.t('js.filter.description.text_open_filter') }}
+        </label>
         <select require
-                focus="$index == focusElementIndex"
+                focus="{{$index == focusElementIndex}}"
                 class="advanced-filters--select"
                 id="operators-{{filter.name}}"
                 name="op[{{filter.name}}]"
@@ -147,10 +151,14 @@
         <i class="icon-add icon4"></i>
         {{ I18n.t('js.work_packages.label_filter_add') }}:
       </label>
+      <label for="add_filter_select" class="hidden-for-sighted">
+        {{ I18n.t('js.filter.description.text_open_filter') }}
+        {{ I18n.t('js.filter.description.text_close_filter') }}
+      </label>
       <div class="advanced-filters--add-filter-value">
         <select class="advanced-filters--select"
           id="add_filter_select"
-          focus="focusElementIndex == -1"
+          focus="{{focusElementIndex == -1}}"
           ng-model="filterToBeAdded"
           ng-options="filterName as localisedFilterName(query.availableWorkPackageFilters[filterName])
             for filterName

--- a/frontend/app/work_packages/directives/query-filters-directive.js
+++ b/frontend/app/work_packages/directives/query-filters-directive.js
@@ -43,6 +43,8 @@ module.exports = function($timeout, FiltersHelper, I18n, ADD_FILTER_SELECT_INDEX
             if (filterName) {
               scope.query.addFilter(filterName);
               scope.filterToBeAdded = undefined;
+              var index = scope.query.getActiveFilters().length;
+              updateFilterFocus(index);
             }
           });
 
@@ -68,7 +70,7 @@ module.exports = function($timeout, FiltersHelper, I18n, ADD_FILTER_SELECT_INDEX
 
             $timeout(function() {
               scope.$broadcast('updateFocus');
-            });
+            }, 300);
           }
         }
       };


### PR DESCRIPTION
This adds a helping text to the filter in WP overview which updates automatically after selecting a filter. Further the focus is set on the newly added filter.

https://github.com/finnlabs/reporting_engine/pull/74 is doing a similar thing for the cost reports filter.

https://community.openproject.com/work_packages/20397/activity
