### PR TITLE
[22158] Fix CopyProjectJob notifications

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -343,12 +343,12 @@ class UserMailer < BaseMailer
   def mail_for_author(author, headers = {}, &block)
     message = mail headers, &block
 
-    remove_self_notifications(message, author)
+    self.class.remove_self_notifications(message, author)
 
     message
   end
 
-  def remove_self_notifications(message, author)
+  def self.remove_self_notifications(message, author)
     if author.pref && author.pref[:no_self_notified]
       message.to = message.to.reject { |address| address == author.mail } if message.to.present?
     end

--- a/app/models/journal_notification_mailer.rb
+++ b/app/models/journal_notification_mailer.rb
@@ -39,6 +39,7 @@ class JournalNotificationMailer
 
     def handle_work_package_journal(journal)
       return nil unless send_notification? journal
+      return nil unless ::UserMailer.perform_deliveries
 
       aggregated = find_aggregated_journal_for(journal)
 

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -60,11 +60,11 @@ class CopyProjectJob
     }
 
     if target_project
-      UserMailer.copy_project_succeeded(user, source_project, target_project, errors)
+      UserMailer.copy_project_succeeded(user, source_project, target_project, errors).deliver_now
     else
       target_project_name = target_project_params[:name]
 
-      UserMailer.copy_project_failed(user, source_project, target_project_name)
+      UserMailer.copy_project_failed(user, source_project, target_project_name).deliver_now
     end
   end
 

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -141,9 +141,15 @@ describe CopyProjectsController, type: :controller do
   end
 
   describe 'copy sends eMail' do
+    let(:maildouble) { double('Mail::Message', deliver: true) }
+
+    before do
+      allow(maildouble).to receive(:deliver_now).and_return nil
+    end
+
     context 'on success' do
       it 'user receives success mail' do
-        expect(UserMailer).to receive(:copy_project_succeeded).and_return(double('mailer', deliver: true))
+        expect(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
 
         copy_project(project)
       end
@@ -155,7 +161,7 @@ describe CopyProjectsController, type: :controller do
       end
 
       it 'user receives success mail' do
-        expect(UserMailer).to receive(:copy_project_failed).and_return(double('mailer', deliver: true))
+        expect(UserMailer).to receive(:copy_project_failed).and_return(maildouble)
 
         copy_project(project)
       end

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -33,6 +33,11 @@ describe CopyProjectJob, type: :model do
   let(:user) { FactoryGirl.create(:user) }
   let(:role) { FactoryGirl.create(:role, permissions: [:copy_projects]) }
   let(:params) { { name: 'Copy', identifier: 'copy' } }
+  let(:maildouble) { double('Mail::Message', deliver: true) }
+
+  before do
+    allow(maildouble).to receive(:deliver_now).and_return nil
+  end
 
   describe 'copy localizes error message' do
     let(:user_de) { FactoryGirl.create(:admin, language: :de) }
@@ -52,7 +57,7 @@ describe CopyProjectJob, type: :model do
       # (see https://github.com/collectiveidea/delayed_job#rails-3-mailers).
       # Thus, we need to return a message object here, otherwise 'Delayed Job'
       # will complain about an object without a method #deliver.
-      allow(UserMailer).to receive(:copy_project_failed).and_return(double('Mail::Message', deliver: true))
+      allow(UserMailer).to receive(:copy_project_failed).and_return(maildouble)
     end
 
     it 'sets locale correctly' do
@@ -97,7 +102,7 @@ describe CopyProjectJob, type: :model do
       # (see https://github.com/collectiveidea/delayed_job#rails-3-mailers).
       # Thus, we need to return a message object here, otherwise 'Delayed Job'
       # will complain about an object without a method #deliver.
-      allow(UserMailer).to receive(:copy_project_succeeded).and_return(double('Mail::Message', deliver: true))
+      allow(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
 
       @copied_project, @errors = copy_job.send(:create_project_copy,
                                                source_project,
@@ -138,7 +143,7 @@ describe CopyProjectJob, type: :model do
       let(:subproject) { FactoryGirl.create(:project, parent: project) }
 
       describe 'invalid parent' do
-        before do expect(UserMailer).to receive(:copy_project_failed).and_return(double('mailer', deliver: true)) end
+        before do expect(UserMailer).to receive(:copy_project_failed).and_return(maildouble) end
 
         include_context 'copy project' do
           let(:project_to_copy) { subproject }
@@ -157,7 +162,7 @@ describe CopyProjectJob, type: :model do
         }
 
         before do
-          expect(UserMailer).to receive(:copy_project_succeeded).and_return(double('mailer', deliver: true))
+          expect(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
 
           member_add_subproject
         end


### PR DESCRIPTION
This PR fixes two issues with notifications while copying projects:
1. Success / Error notifications were not delivered, only created.
2. Journal notification are aggregated and sent after N minutes, after which the UserMailer deliveries are being re-enabled. We thus have to check when creating the jobs. This isn't really an ideal solution, however the overall (disabling of) notifications need to be re-worked which is out of scope here.

https://community.openproject.com/work_packages/22158/activity
