### PR TITLE
[20462] [Accessibility] Some content is not completely visible when adjusting the text size

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -60,6 +60,10 @@ $ng-modal-image-width:   $ng-modal-image-height
     .ng-modal-inner
       top: 0
 
+  &.columns-modal
+    .ng-modal-inner
+      overflow: visible
+
 .ng-modal-inner
   +transition(opacity 0.25s ease)
   background: $ng-modal-background
@@ -68,7 +72,9 @@ $ng-modal-image-width:   $ng-modal-image-height
   position: relative
   width: 95%
   padding: $ng-modal-padding / 2
-  margin-top: .6em
+  margin-top: 5%
+  overflow-y: auto
+  overflow-x: hidden
   //+media($medium-screen)
   //padding: $ng-modal-padding
   //width: 50%
@@ -77,7 +83,6 @@ $ng-modal-image-width:   $ng-modal-image-height
 
   //+media($large-screen)
   width: 40%
-  margin-top: 10em
 
   .modal-header
     padding: 0

--- a/frontend/app/components/modals/columns-modal/columns-modal.template.html
+++ b/frontend/app/components/modals/columns-modal/columns-modal.template.html
@@ -1,4 +1,4 @@
-<div class="ng-modal-window">
+<div class="ng-modal-window columns-modal">
   <div class="ng-modal-inner">
     <div class="modal-header">
       <i class="icon-close" ng-click="vm.closeMe()" title="{{ ::vm.text.closePopup }}"></i>


### PR DESCRIPTION
This sets the `overflow` values for the modal windows opened in the WP overview. Thus when the font size is increased or the window size decreased there appears a scrollbar. 
The modal for columns is excepted in this PR since this will be done in the scope of ticket 20407.

https://community.openproject.com/work_packages/20462/activity
