### PR TITLE
[20363] [Accessibility] Sub menus cannot be used as declared

### DIFF
--- a/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
+++ b/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
@@ -1,52 +1,51 @@
 <div id="column-context-menu"
-     role="menu"
      class="dropdown-relative dropdown action-menu"
      ng-class="{'dropdown-anchor-right': column && column.name !== 'id'}">
   <ul class="dropdown-menu">
-    <li ng-if="canSort()" role="menuitem">
-      <a role="menuitem" class="menu-item" focus href="" ng-click="sortAscending(column.name)">
+    <li ng-if="canSort()">
+      <a class="menu-item" focus href="" ng-click="sortAscending(column.name)">
         <i class="icon-action-menu icon-sort-ascending"></i>
         <span ng-bind="I18n.t('js.work_packages.query.sort_ascending')"/>
       </a>
     </li>
 
     <li ng-if="canSort()">
-      <a role="menuitem" class="menu-item" href="" ng-click="sortDescending(column.name)">
+      <a class="menu-item" href="" ng-click="sortDescending(column.name)">
         <i class="icon-action-menu icon-sort-descending"></i>
         <span ng-bind="I18n.t('js.work_packages.query.sort_descending')"/>
       </a>
     </li>
 
     <li ng-if="isGroupable">
-      <a role="menuitem" class="menu-item" focus="focusFeature('group')" href="" ng-click="groupBy(column.name)">
+      <a class="menu-item" focus="focusFeature('group')" href="" ng-click="groupBy(column.name)">
         <i class="icon-action-menu icon-group-by"></i>
         <span ng-bind="I18n.t('js.work_packages.query.group')"/>
       </a>
     </li>
 
     <li ng-if="canMoveLeft()">
-      <a role="menuitem" class="menu-item" focus="focusFeature('moveLeft')" href="" ng-click="moveLeft(column.name)">
+      <a class="menu-item" focus="focusFeature('moveLeft')" href="" ng-click="moveLeft(column.name)">
         <i class="icon-action-menu icon-column-left"></i>
         <span ng-bind="I18n.t('js.work_packages.query.move_column_left')"/>
       </a>
     </li>
 
     <li ng-if="canMoveRight()">
-      <a role="menuitem" class="menu-item" focus="focusFeature('moveRight')" href="" ng-click="moveRight(column.name)">
+      <a class="menu-item" focus="focusFeature('moveRight')" href="" ng-click="moveRight(column.name)">
         <i class="icon-action-menu icon-column-right"></i>
         <span ng-bind="I18n.t('js.work_packages.query.move_column_right')"/>
       </a>
     </li>
 
     <li ng-if="canBeHidden()">
-      <a role="menuitem" class="menu-item" focus="focusFeature('hide')" href="" ng-click="hideColumn(column.name)">
+      <a class="menu-item" focus="focusFeature('hide')" href="" ng-click="hideColumn(column.name)">
         <i class="icon-action-menu icon-delete"></i>
         <span ng-bind="I18n.t('js.work_packages.query.hide_column')"/>
       </a>
     </li>
 
     <li>
-      <a role="menuitem" class="menu-item" focus="focusFeature('insert')" href="" ng-click="insertColumns()">
+      <a class="menu-item" focus="focusFeature('insert')" href="" ng-click="insertColumns()">
         <i class="icon-action-menu icon-columns"></i>
         <span ng-bind="I18n.t('js.work_packages.query.insert_columns')"/>
       </a>

--- a/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
+++ b/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
@@ -1,10 +1,10 @@
 <div class="dropdown action-menu dropdown-relative dropdown-anchor-right dropdownToolbar"
-     id="tasksDropdown" role="menu">
+     id="tasksDropdown">
 
   <ul class="dropdown-menu">
     <li ng-repeat="type in vm.types">
       <a ui-sref="{{ vm.stateName }}({ projectPath: vm.projectIdentifier, type: type.id })"
-         role="menuitem" class="menu-item">
+         class="menu-item">
 
         {{ type.name }}
       </a>

--- a/frontend/app/templates/work_packages/menus/details_more_dropdown_menu.html
+++ b/frontend/app/templates/work_packages/menus/details_more_dropdown_menu.html
@@ -1,10 +1,10 @@
-<div class="dropdown dropdown-relative dropdown-anchor-right dropdown-anchor-top" id="moreDropdown" role="menu">
+<div class="dropdown dropdown-relative dropdown-anchor-right dropdown-anchor-top" id="moreDropdown">
   <ul class="dropdown-menu" ng-if="actionsAvailable">
     <li ng-repeat="(action, properties) in permittedActions"
         class="{{action}}">
       <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
       properly. Thus, don't remove the hrefs or the empty URLs! -->
-      <a role="menuitem" href="" focus="{{ !$index }}"
+      <a href="" focus="{{ !$index }}"
          ng-click="triggerMoreMenuAction(action, properties.link)"
          ng-class="['icon-context'].concat(properties.css)"
          ng-bind="I18n.t('js.button_' + action)">

--- a/frontend/app/templates/work_packages/menus/settings_dropdown_menu.html
+++ b/frontend/app/templates/work_packages/menus/settings_dropdown_menu.html
@@ -1,14 +1,14 @@
-<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar" id="settingsDropdown" role="menu">
+<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar" id="settingsDropdown">
   <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
   properly. Thus, don't remove the hrefs or the empty URLs! -->
   <ul class="dropdown-menu">
     <li>
-      <a role="menuitem" class="menu-item" href="" ng-click="showColumnsModal($event)"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a>
+      <a class="menu-item" href="" ng-click="showColumnsModal($event)"><i class="icon-action-menu icon-columns"></i>{{ I18n.t('js.toolbar.settings.columns') }}</a>
     </li>
     <li><a class="menu-item" href="" ng-click="showSortingModal($event)"><i class="icon-action-menu icon-sort-by"></i>{{ I18n.t('js.toolbar.settings.sort_by') }}</a></li>
     <li><a class="menu-item" href="" ng-click="showGroupingModal($event)"><i class="icon-action-menu icon-group-by"></i>{{ I18n.t('js.toolbar.settings.group_by') }}</a></li>
     <li>
-      <a role="menuitem" class="menu-item" href="" ng-click="toggleDisplaySums($event)">
+      <a class="menu-item" href="" ng-click="toggleDisplaySums($event)">
         <i ng-if="query.displaySums" class="icon-action-menu icon-checkmark"></i><i ng-if="!query.displaySums" class="icon-action-menu no-icon"></i>
         <accessible-element visible-text="I18n.t('js.toolbar.settings.display_sums')"
                             readable-text="displaySumsLabel">
@@ -16,32 +16,32 @@
       </a>
     </li>
     <li class="dropdown-divider"></li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="saveQuery($event)"
+    <li><a class="menu-item" href="" ng-click="saveQuery($event)"
            inaccessible-by-tab="saveQueryInvalid()"
            ng-class="{'inactive': saveQueryInvalid()}">
         <i class="icon-action-menu icon-save"></i>{{ I18n.t('js.toolbar.settings.save') }}</a>
     </li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="showSaveAsModal($event)"
+    <li><a class="menu-item" href="" ng-click="showSaveAsModal($event)"
            inaccessible-by-tab="showSaveModalInvalid()"
            ng-class="{'inactive': showSaveModalInvalid()}">
       <i class="icon-action-menu icon-save"></i>{{ I18n.t('js.toolbar.settings.save_as') }}</a>
     </li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="deleteQuery($event)"
+    <li><a class="menu-item" href="" ng-click="deleteQuery($event)"
            inaccessible-by-tab="deleteQueryInvalid()"
            ng-class="{'inactive': deleteQueryInvalid()}">
       <i class="icon-action-menu icon-delete"></i>{{ I18n.t('js.toolbar.settings.delete') }}</a>
     </li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="showExportModal($event)"
+    <li><a class="menu-item" href="" ng-click="showExportModal($event)"
            inaccessible-by-tab="showExportModalInvalid()"
            ng-class="{'inactive': showExportModalInvalid()}">
       <i class="icon-action-menu icon-export"></i>{{ I18n.t('js.toolbar.settings.export') }}</a>
     </li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="showShareModal($event)"
+    <li><a class="menu-item" href="" ng-click="showShareModal($event)"
            inaccessible-by-tab="showShareModalInvalid()"
            ng-class="{'inactive': showShareModalInvalid()}">
       <i class="icon-action-menu icon-publish"></i>{{ I18n.t('js.toolbar.settings.share') }}</a>
     </li>
-    <li><a role="menuitem" class="menu-item" href="" ng-click="showSettingsModal($event)"
+    <li><a class="menu-item" href="" ng-click="showSettingsModal($event)"
            inaccessible-by-tab="showSettingsModalInvalid()"
            ng-class="{'inactive': showSettingsModalInvalid()}">
       <i class="icon-action-menu icon-settings"></i>{{ I18n.t('js.toolbar.settings.page_settings') }}</a>

--- a/frontend/app/templates/work_packages/menus/show_more_dropdown_menu.html
+++ b/frontend/app/templates/work_packages/menus/show_more_dropdown_menu.html
@@ -1,10 +1,10 @@
-<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar" role="menu">
+<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar">
   <ul class="dropdown-menu" ng-if="actionsAvailable">
     <li ng-repeat="(action, properties) in permittedActions"
         class="{{action}}">
       <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
       properly. Thus, don't remove the hrefs or the empty URLs! -->
-      <a role="menuitem" href="" focus="{{ !$index }}"
+      <a href="" focus="{{ !$index }}"
          ng-click="triggerMoreMenuAction(action, properties.link)"
          ng-class="['icon-context'].concat(properties.css)"
          ng-bind="I18n.t('js.button_' + action)">

--- a/frontend/app/templates/work_packages/menus/work_package_context_menu.html
+++ b/frontend/app/templates/work_packages/menus/work_package_context_menu.html
@@ -1,15 +1,15 @@
-<div id="work-package-context-menu" class="action-menu dropdown" role="menu">
+<div id="work-package-context-menu" class="action-menu dropdown">
   <ul class="dropdown-menu">
     <li class="open"
         feature-flag="detailsView">
-      <a role="menuitem" focus="isDetailsViewLinkPresent()" ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
+      <a focus="isDetailsViewLinkPresent()" ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
         <i ng-class="['icon-action-menu', 'icon-view-split']"></i>
         <span ng-bind="I18n.t('js.button_open_details')"/>
       </a>
     </li>
     <li ng-repeat="(action, link) in permittedActions"
         class="{{action}}">
-      <a role="menuitem" focus="$index == 0 && !isDetailsViewLinkPresent()" href="" ng-click="triggerContextMenuAction(action, link)">
+      <a focus="$index == 0 && !isDetailsViewLinkPresent()" href="" ng-click="triggerContextMenuAction(action, link)">
         <i ng-class="['icon-action-menu', 'icon-' + action]"></i>
         <span ng-bind="I18n.t('js.button_' + action)"/>
       </a>


### PR DESCRIPTION
This removes the `role` attribute from submenu to avoid incorrect screen reader output. The screen reader reads otherwise that the user shall navigate with arrow keys but this is done by tab.

https://community.openproject.com/work_packages/20363/activity
