### PR TITLE
[22948] Fields overlap in add member section (IE)

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -654,5 +654,6 @@ a.impaired--empty-link,
 
 // Avoid content cut off in IE
 #new-member-message + div.grid-block
+  min-height: 6rem
   div.grid-block
     overflow: visible


### PR DESCRIPTION
This sets a `min-height` to the input block of the add-member section. Thus an overlapping is avoided.

https://community.openproject.com/work_packages/22948/activity
