### PR TITLE
[22953] Set earlier breakpoint for switching WP details view to mobile view

### DIFF
--- a/app/assets/stylesheets/content/_accounts_mobile.sass
+++ b/app/assets/stylesheets/content/_accounts_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   body.controller-account
     #login-form,
     #content .login-auth-providers,

--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   form
     .grid-block
       display: block

--- a/app/assets/stylesheets/content/_notifications_mobile.sass
+++ b/app/assets/stylesheets/content/_notifications_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .notification-box--wrapper,
   .flash,
   #errorExplanation

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -124,7 +124,7 @@ $widget-box--enumeration-width: 20px
           //necessary for correct alignment even with long texts
           width: calc(100% - #{$widget-box--enumeration-width})
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .widget-boxes
     &.-flex
       .widget-box

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -196,7 +196,7 @@ blockquote
 .toolbar-container ~ .wiki-content
   margin-top: -64px
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .toolbar-container ~ .wiki-content
     margin-top: 0
 

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   html
     min-width: 0 !important
 

--- a/app/assets/stylesheets/layout/_drop_down_mobile.sass
+++ b/app/assets/stylesheets/layout/_drop_down_mobile.sass
@@ -30,7 +30,7 @@
 // https://github.com/plapier/jquery-dropdown
 // (dual MIT/GPL-Licensed)
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .dropdown .dropdown-menu,
   .toolbar .legacy-actions-more
     LI > A,

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -272,7 +272,7 @@
   *
     outline: none
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .toolbar-container .toolbar-items
     background: #fff
     display: flex

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   #logo
     background-color: transparent
 

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   body.controller-work_packages
 
     &.action-show #content

--- a/app/assets/stylesheets/specific/homescreen.sass
+++ b/app/assets/stylesheets/specific/homescreen.sass
@@ -62,7 +62,7 @@
       font-size: 3rem
       color: $homescreen-footer-icon-color
 
-@include breakpoint(680px down)
+@include breakpoint(960px down)
   .homescreen--links
     padding: 20px
     flex-wrap: wrap


### PR DESCRIPTION
This increases the pixel width on which the application changes to mobile view.

https://community.openproject.com/work_packages/22953/activity
