### PR TITLE
[20524] [Accessibility] Some pages do not have their own window title

### DIFF
--- a/app/views/account/exit.html.erb
+++ b/app/views/account/exit.html.erb
@@ -33,6 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% disable_accessibility_css! %>
 
+<% html_title l(:label_login) %>
 <% breadcrumb_paths(l(:label_login)) %>
 <%= call_hook :view_account_login_top %>
 

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% disable_accessibility_css! %>
 
 <% breadcrumb_paths(l(:label_login)) %>
+<% html_title l(:label_login) %>
 <%= call_hook :view_account_login_top %>
 <div id="login-form" class="form -bordered">
   <h1><%= I18n.t(:label_login) %></h1>

--- a/app/views/account/lost_password.html.erb
+++ b/app/views/account/lost_password.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% disable_accessibility_css! %>
+<% html_title l(:label_password_lost) %>
 <%= toolbar title: l(:label_password_lost) %>
 <section class="form--section">
   <%= styled_form_tag({action: "lost_password"}) do %>

--- a/app/views/account/password_recovery.html.erb
+++ b/app/views/account/password_recovery.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% disable_accessibility_css! %>
+<% html_title l(:label_password_lost) %>
 <%= toolbar title: l(:label_password_lost) %>
 <%= error_messages_for 'user' %>
 <%= styled_form_tag({token: @token.value}, autocomplete: 'off') do %>

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -28,6 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% disable_accessibility_css! %>
+<% html_title l(:label_register) %>
 <%= toolbar title: l(:label_register) %>
 
 <%= labelled_tabular_form_for(@user, url: url_for(action: 'register')) do |f| %>

--- a/app/views/custom_fields/index.html.erb
+++ b/app/views/custom_fields/index.html.erb
@@ -30,4 +30,4 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= render_tabs custom_fields_tabs %>
 
-<% html_title(l(:label_custom_field_plural)) -%>
+<% html_title(l(:label_administration), l(:label_custom_field_plural)) -%>

--- a/app/views/users/deletion_info.html.erb
+++ b/app/views/users/deletion_info.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
+<% html_title(l(:label_administration), "#{ l('account.deletion_info.heading', name: @user.name)}") -%>
 <%= labelled_tabular_form_for :user, url: user_path(@user), html: { method: :delete, class: 'confirm_required form danger-zone' } do %>
   <div class='wiki'>
     <section class="form--section">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
+<% html_title l(:label_administration), l(:label_user_plural) -%>
 <%= toolbar title: l(:label_user_plural) do %>
   <%= link_to new_user_path, class: 'button -alt-highlight' do %>
     <i class="button--icon icon-add"></i>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :header_tags do %>
   <%= call_hook :users_show_head %>
 <% end %>
-
+<% html_title l(:label_administration), l(:label_user_plural) -%>
 <%= toolbar title: "#{avatar @user} #{h(@user.name)}".html_safe do %>
   <% if User.current.admin? %>
     <li class="toolbar-item">

--- a/app/views/workflows/copy.html.erb
+++ b/app/views/workflows/copy.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
+<% html_title l(:label_administration), l(:label_workflow_plural) -%>
 <%= render partial: 'action_menu', locals: { title: Workflow.model_name.human } %>
 
 <%= styled_form_tag({}, id: 'workflow_copy_form') do %>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
+<% html_title l(:label_administration), l(:label_workflow_plural) -%>
 <%= render partial: 'action_menu', locals: { title: Workflow.model_name.human } %>
 <%= render partial: 'layouts/action_menu_specific' %>
 <%= styled_form_tag({}, method: 'get') do %>


### PR DESCRIPTION
This inserts concrete html title attributes for some pages. Thus it is easier for blind users to navigate through the application.

https://community.openproject.com/work_packages/20524/activity
