### PR TITLE
[20525] [Accessibility] Some pages do not have a meaningful window title

### DIFF
--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: @page.pretty_title %>
+<% html_title l(:button_delete), @page.pretty_title %>
 <%= form_tag({}, method: :delete) do %>
   <div class="box">
     <p><strong><%= l(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: @page.pretty_title %>
+<% html_title l(:label_edit), @page.pretty_title %>
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -29,6 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: "#{t(:button_change_parent_page)}: #{@page.title}" %>
 
+<% html_title l('activerecord.models.wiki'), t(:button_change_parent_page) %>
 <%= error_messages_for 'page' %>
 
 <%= labelled_tabular_form_for @page, url: { id: @page, action: 'update_parent_page' } do |f| %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: @page.pretty_title %>
+<% html_title l('activerecord.models.wiki'), l(:label_history) %>
 <h3><%= l(:label_history) %></h3>
 <%= form_tag({action: "diff"}, method: :get) do %>
   <div class="generic-table--container">

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -36,8 +36,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= l("create_new_page") %>
 </h2>
 
-<%= labelled_tabular_form_for @content, as: :content, url: create_project_wiki_index_path(project_id: @project), html: {method: :post, multipart: true, id: 'wiki_form'} do |f| %>
+<% html_title l("create_new_page") %>
 
+<%= labelled_tabular_form_for @content, as: :content, url: create_project_wiki_index_path(project_id: @project), html: {method: :post, multipart: true, id: 'wiki_form'} do |f| %>
   <%= error_messages_for 'page' %>
 
     <div class="form--field -required">

--- a/app/views/wiki/rename.html.erb
+++ b/app/views/wiki/rename.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= toolbar title: "#{l(:button_rename)} #{@original_title}" %>
-
+<% html_title l(:permission_rename_wiki_pages) %>
 <%= error_messages_for 'page' %>
 
 <%= labelled_tabular_form_for @page, url: { id: @page, action: 'rename' }, as: :page do |f| %>

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -26,6 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
+
+<% html_title l(:label_bulk_edit_selected_work_packages) %>
 <h2><%= l(:label_bulk_edit_selected_work_packages) %></h2>
 <ul><%= @work_packages.collect {|i| content_tag('li', link_to(h("#{i.type} ##{i.id}"), work_package_path(i)) + h(": #{i.subject}")) }.join("\n").html_safe %></ul>
 <%= styled_form_tag(url_for(controller: '/work_packages/bulk', action: :update),

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -27,6 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<% html_title @copy ? l(:button_copy) : l(:button_move), l('activerecord.models.work_package') %>
 <h2><%= @copy ? l(:button_copy) : l(:button_move) %></h2>
 <ul>
   <% @work_packages.each do |work_package| -%>

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -79,7 +79,10 @@ angular
 
       .state('work-packages.copy', {
         url: '/work_packages/{copiedFromWorkPackageId:[0-9]+}/copy',
-        templateUrl: '/components/routing/main/work-packages.new.html'
+        templateUrl: '/components/routing/main/work-packages.new.html',
+        onEnter: () => {
+          document.title = 'Copy Work Package - OpenProject'
+        }
       })
 
       .state('work-packages.edit', {


### PR DESCRIPTION
Closely related to https://github.com/opf/openproject/pull/4308 this PR sets the html titles for wiki and WP pages.

https://community.openproject.com/work_packages/20525/activity
