### PR TITLE
[Inline Edit] Change width of clickable fields

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -62,7 +62,7 @@
 
   // Editable fields cursor
   .wp-table--cell-span
-    padding: 0 25px 0 2px
+    padding: 0 5px 0 5px
     cursor: text
     border-color: transparent
     border-style: solid
@@ -77,7 +77,8 @@
     &:focus
       border-color: $inplace-edit--border-color
 
-
+    .work-package--placeholder
+      padding: 0 10px 0 0px
 
 // Default cursor on non-editable and id fields
 .wp-table--cell-span

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.html
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.html
@@ -12,7 +12,8 @@
   </span>
 
   <span ng-switch-default
-    title="{{ vm.displayText }}">
+    title="{{ vm.displayText }}"
+    ng-class="{ 'work-package--placeholder' : vm.displayText == '-' }">
     {{ vm.displayText }}
   </span>
 </span>


### PR DESCRIPTION
This changes the widths of clickable fields in inline edit mode. Fields with entries have the same distance left and right. Fields with the placeholder element have the default width.
