### PR TITLE
[22836] Wrong filter layout in cost types 

### DIFF
--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -82,9 +82,15 @@ $filters--border-color: $gray !default
       max-width: 100%
 
     .simple-filters--filter-name
-      flex-basis: 20%
+      flex-basis: 25%
+      max-width: 25%
+      padding-right: 0
+      margin-right: 1rem
+      overflow: hidden
+      text-overflow: ellipsis
     .simple-filters--filter-value
-      flex-basis: 75%
+      flex-basis: 70%
+      max-width: 70%
       // important for consistent padding between input and select fields
       padding-right: 0.375rem
 


### PR DESCRIPTION
This increases the width of filter labels. Thus longer words are also displayed, e.g in German language. If there are words in other languages which are even longer, they will be truncated.

https://community.openproject.com/work_packages/22836/activity
