### PR TITLE
Pass the decorated work package to CreateService

### DIFF
--- a/app/services/create_work_package_service.rb
+++ b/app/services/create_work_package_service.rb
@@ -40,22 +40,20 @@ class CreateWorkPackageService
     @user = user
   end
 
-  def call(attributes:, send_notifications: true)
+  def call(work_package, send_notifications: true)
     User.execute_as user do
       JournalManager.with_send_notifications send_notifications do
-        create(attributes)
+        create(work_package)
       end
     end
   end
 
   private
 
-  def create(attributes)
-    work_package = WorkPackage.new
-
+  def create(work_package)
     initialize_contract(work_package)
-    assign_defaults(work_package, attributes)
-    assign_provided(work_package, attributes)
+    assign_defaults(work_package)
+
     result, errors = validate_and_save(work_package)
 
     ServiceResult.new(success: result,
@@ -63,12 +61,8 @@ class CreateWorkPackageService
                       result: work_package)
   end
 
-  def assign_provided(work_package, attributes)
-    work_package.attributes = attributes
-  end
-
-  def assign_defaults(work_package, attributes)
-    work_package.author = user unless attributes[:author_id]
+  def assign_defaults(work_package)
+    work_package.author ||= user
   end
 
   def initialize_contract(work_package)

--- a/lib/api/v3/work_packages/create_work_packages.rb
+++ b/lib/api/v3/work_packages/create_work_packages.rb
@@ -36,12 +36,14 @@ module API
         include ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
         def create_work_packages(request_body, current_user)
-          attributes = get_create_attributes(request_body)
+          work_package = WorkPackage.new
+          yield(work_package) if block_given?
 
-          yield(attributes) if block_given?
+          work_package = write_work_package_attributes(work_package, request_body || {})
+
 
           result = create_work_package(current_user,
-                                       attributes,
+                                       work_package,
                                        notify_according_to_params)
 
           represent_create_result(result, current_user)
@@ -60,15 +62,10 @@ module API
           end
         end
 
-        def get_create_attributes(request_body)
-          write_work_package_attributes(WorkPackage.new, request_body || {})
-            .changes.each_with_object({}) { |(k, v), h| h[k] = v.last }
-        end
-
-        def create_work_package(current_user, attributes, send_notification)
+        def create_work_package(current_user, work_package, send_notification)
           create_service = CreateWorkPackageService.new(user: current_user)
 
-          create_service.call(attributes: attributes,
+          create_service.call(work_package,
                               send_notifications: send_notification)
         end
       end

--- a/lib/api/v3/work_packages/work_packages_by_project_api.rb
+++ b/lib/api/v3/work_packages/work_packages_by_project_api.rb
@@ -43,8 +43,8 @@ module API
           end
 
           post do
-            create_work_packages(request_body, current_user) do |attributes|
-              attributes[:project_id] = @project.id
+            create_work_packages(request_body, current_user) do |work_package|
+              work_package.project_id = @project.id
             end
           end
 

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -52,6 +52,7 @@ describe 'new work package', js: true do
   end
 
   def create_work_package(type)
+    loading_indicator_saveguard
     work_packages_page.click_toolbar_button 'Work package'
 
     within '#tasksDropdown' do
@@ -142,13 +143,12 @@ describe 'new work package', js: true do
                                       options: %w(- foo bar xyz))
 
           select 'foo', from: "inplace-edit--write-value--customField#{ids.last}"
-
           save_work_package!(false)
           # Its a known bug that custom fields validation errors do not contain their names
           notification.expect_error("can't be blank.")
 
           cf1.set 'Custom field content'
-          save_work_package!(false)
+          save_work_package!(true)
 
           expect(page).to have_selector("#work-package-customField#{ids.first}", 'Custom field content')
           expect(page).to have_selector("#work-package-customField#{ids.last}", 'foo')

--- a/spec/services/create_work_package_service_spec.rb
+++ b/spec/services/create_work_package_service_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe CreateWorkPackageService do
   let(:user) { FactoryGirl.build_stubbed(:user) }
-  let(:work_package) { FactoryGirl.build_stubbed(:work_package) }
+  let(:work_package) { FactoryGirl.build_stubbed(:work_package, author: nil) }
   let(:project) { FactoryGirl.build_stubbed(:project_with_types) }
   let(:instance) { described_class.new(user: user) }
   let(:errors) { double('errors') }
@@ -78,40 +78,29 @@ describe CreateWorkPackageService do
         .and_return true
     end
 
+    subject { instance.call(work_package) }
+
     context 'if contract validates and the work package saves' do
       it 'is successful' do
-        expect(instance.call(attributes: {}))
+        expect(subject)
           .to be_success
       end
 
       it 'has no errors' do
-        expect(instance.call(attributes: {}).errors)
+        expect(subject.errors)
           .to be_empty
       end
 
       it 'returns the work package as a result' do
-        result = instance.call(attributes: {}).result
+        result = subject.result
 
         expect(result).to be_a WorkPackage
       end
 
-      it 'assigns the attributes provided' do
-        result = instance.call(attributes: attributes).result
-
-        expect(result.project_id).to eql(attributes[:project_id])
-        expect(result.subject).to eql(attributes[:subject])
-      end
-
       it 'sets the user to be the author' do
-        result = instance.call(attributes: attributes).result
+        result = subject.result
 
         expect(result.author).to eql(user)
-      end
-
-      it 'sets the type that is provided' do
-        result = instance.call(attributes: { type_id: 1 }).result
-
-        expect(result.type_id).to eql(1)
       end
     end
 
@@ -123,7 +112,7 @@ describe CreateWorkPackageService do
       end
 
       it 'is unsuccessful' do
-        expect(instance.call(attributes: {}))
+        expect(subject)
           .to_not be_success
       end
 
@@ -132,7 +121,7 @@ describe CreateWorkPackageService do
           .to receive(:errors)
           .and_return errors
 
-        expect(instance.call(attributes: {}).errors).to eql errors
+        expect(subject.errors).to eql errors
       end
     end
 
@@ -144,7 +133,7 @@ describe CreateWorkPackageService do
       end
 
       it 'is unsuccessful' do
-        expect(instance.call(attributes: {}))
+        expect(subject)
           .to_not be_success
       end
 
@@ -153,7 +142,7 @@ describe CreateWorkPackageService do
           .to receive(:errors)
           .and_return errors
 
-        expect(instance.call(attributes: {}).errors).to eql errors
+        expect(subject.errors).to eql errors
       end
     end
   end


### PR DESCRIPTION
Since associations will not be marked `dirty` when they're written by
the decorator, we are missing custom field values when creating new work
packages.

This reverts some of the changes introduced by the create service and
passes the decorated work package directly.
