### PR TITLE
Avoid RuntimeError when aggregating with nil representers

### DIFF
--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -64,6 +64,10 @@ module API
         sums.present?
       end
 
+      def model_required?
+        true
+      end
+
       private
 
       attr_reader :sums,


### PR DESCRIPTION
When aggregating columns, e.g., a custom field that contains nil values,
the AggregationGroup receives an empty represented.

This commit fixes that by allowing the represented object to be nil

```
RuntimeError (no represented object passed):
  lib/api/decorators/single.rb:54:in `initialize'
  lib/api/decorators/aggregation_group.rb:39:in `initialize'
  lib/api/v3/work_packages/work_package_list_helpers.rb:138:in `new'
  lib/api/v3/work_packages/work_package_list_helpers.rb:138:in `block in generate_groups'
  lib/api/v3/work_packages/work_package_list_helpers.rb:132:in `each'
  lib/api/v3/work_packages/work_package_list_helpers.rb:132:in `map'
  lib/api/v3/work_packages/work_package_list_helpers.rb:132:in `generate_groups'
  lib/api/v3/work_packages/work_package_list_helpers.rb:127:in `apply_and_generate_groups'
  lib/api/v3/work_packages/work_package_list_helpers.rb:42:in `work_packages_by_params'
  lib/api/v3/work_packages/work_packages_by_project_api.rb:42:in `block (2 levels) in <class:WorkPackagesByProjectAPI>'
  app/middleware/params_parser_with_exclusion.rb:38:in `call'
```
