### PR TITLE
[Performance] Introduce header and Rails caching for APIv3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,6 +200,8 @@ end
 
 # API gems
 gem 'grape', '~> 0.10.1'
+gem 'grape-cache_control', '~> 1.0.1'
+
 gem 'roar',   '~> 1.0.0'
 gem 'reform', '~> 1.2.6', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,8 @@ GEM
       rack-accept
       rack-mount
       virtus (>= 1.0.0)
+    grape-cache_control (1.0.1)
+      grape (~> 0.3)
     gravatar_image_tag (1.2.0)
     hashie (3.4.1)
     health_check (1.5.1)
@@ -595,6 +597,7 @@ DEPENDENCIES
   globalize (~> 5.0.1)
   gon (~> 4.0)
   grape (~> 0.10.1)
+  grape-cache_control (~> 1.0.1)
   gravatar_image_tag (~> 1.2.0)
   health_check
   htmldiff

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -215,8 +215,9 @@ class PermittedParams
     end
   end
 
-  def type
-    params.require(:type).permit(*self.class.permitted_attributes[:type])
+  def type(args = {})
+    permitted = permitted_attributes(:type, args)
+    params.require(:type).permit(*permitted)
   end
 
   def type_move
@@ -611,10 +612,12 @@ class PermittedParams
           :is_milestone,
           :is_default,
           :color_id,
+          Proc.new do |args|
+            { attribute_visibility: ::TypesHelper.work_package_form_attributes.keys }
+          end,
           project_ids: [],
           custom_field_ids: [],
-          attribute_visibility:
-            ::TypesHelper.work_package_form_attributes.keys],
+        ],
         user: [
           :firstname,
           :lastname,

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -612,11 +612,11 @@ class PermittedParams
           :is_milestone,
           :is_default,
           :color_id,
-          Proc.new do |args|
+          Proc.new do
             { attribute_visibility: ::TypesHelper.work_package_form_attributes.keys }
           end,
           project_ids: [],
-          custom_field_ids: [],
+          custom_field_ids: []
         ],
         user: [
           :firstname,

--- a/config/initializers/migrate_email_settings.rb
+++ b/config/initializers/migrate_email_settings.rb
@@ -3,6 +3,7 @@ OpenProject::Application.configure do
     # settings table may not exist when you run db:migrate at installation
     # time, so just ignore this block when that happens.
     if Setting.settings_table_exists_yet?
+      OpenProject::Configuration.load
       OpenProject::Configuration.migrate_mailer_configuration!
       OpenProject::Configuration.reload_mailer_configuration!
     end

--- a/lib/api/caching/helpers.rb
+++ b/lib/api/caching/helpers.rb
@@ -1,0 +1,26 @@
+module API
+  module Caching
+    module Helpers
+      def with_etag!(key)
+        etag = %(W/"#{::Digest::SHA1.hexdigest(key.to_s)}")
+        error!('Not Modified'.freeze, 304) if headers['If-None-Match'.freeze] == etag
+
+        header 'ETag'.freeze, etag
+      end
+
+      ##
+      # Store a represented object in its JSON representation
+      def cache(key, args = {})
+        # Save serialization since we're only dealing with strings here
+        args[:raw] = true
+
+        json = Rails.cache.fetch(key, args) {
+          result = yield
+          result.to_json
+        }
+
+        ::API::Caching::StoredRepresenter.new json
+      end
+    end
+  end
+end

--- a/lib/api/caching/stored_representer.rb
+++ b/lib/api/caching/stored_representer.rb
@@ -1,0 +1,13 @@
+module API
+  module Caching
+    class StoredRepresenter
+      def initialize(json)
+        @json = json
+      end
+
+      def to_json
+        @json
+      end
+    end
+  end
+end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -66,6 +66,7 @@ module API
 
     use OpenProject::Authentication::Manager
 
+    helpers API::Caching::Helpers
     helpers do
       def current_user
         User.current

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -126,9 +126,6 @@ module API
 
           schema :spent_time,
                  type: 'Duration',
-                 show_if: -> (_) do
-                   current_user_allowed_to(:view_time_entries, context: represented.project)
-                 end,
                  required: false
 
           schema :percentage_done,

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -46,6 +46,10 @@ module API
               def raise404
                 raise ::API::Errors::NotFound.new
               end
+
+              def cache_key(project_id, type_id)
+                "api/v3/work_packages/schema/#{project_id}-#{type_id}"
+              end
             end
 
             # The schema identifier is an artificial identifier that is composed of a work packages
@@ -56,25 +60,30 @@ module API
             namespace ':project-:type' do
               before do
                 begin
-                  project = Project.find(params[:project])
-                  type = Type.find(params[:type])
+                  @project = Project.find(params[:project])
+                  @type = Type.find(params[:type])
                 rescue ActiveRecord::RecordNotFound
                   raise404
                 end
 
-                authorize(:view_work_packages, context: project) do
+                authorize(:view_work_packages, context: @project) do
                   raise404
                 end
 
-                schema = TypedWorkPackageSchema.new(project: project, type: type)
-                self_link = api_v3_paths.work_package_schema(project.id, type.id)
-                @representer = WorkPackageSchemaRepresenter.create(schema,
-                                                                   self_link: self_link,
-                                                                   current_user: current_user)
+                # Compare with ETag composed of project and customizations
+                # to avoid evaluating the server request
+                @custom_fields = @project.all_work_package_custom_fields
+                with_etag! "#{@project.id}/#{@custom_fields.count}/#{@custom_fields.to_param}"
               end
 
               get do
-                @representer
+                cache(key: [cache_key(@project.id, @type.id), @custom_fields]) do
+                  schema = TypedWorkPackageSchema.new(project: @project, type: @type)
+                  self_link = api_v3_paths.work_package_schema(@project.id, @type.id)
+                  WorkPackageSchemaRepresenter.create(schema,
+                                                      self_link: self_link,
+                                                      current_user: nil)
+                end
               end
             end
 

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -77,7 +77,7 @@ module API
               end
 
               get do
-                cache(key: [cache_key(@project.id, @type.id), @custom_fields]) do
+                cache([cache_key(@project.id, @type.id), @type.updated_at, @custom_fields]) do
                   schema = TypedWorkPackageSchema.new(project: @project, type: @type)
                   self_link = api_v3_paths.work_package_schema(@project.id, @type.id)
                   WorkPackageSchemaRepresenter.create(schema,

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -280,18 +280,6 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:required) { false }
         let(:writable) { false }
       end
-
-      context 'not allowed to view time entries' do
-        before do
-          allow(current_user).to receive(:allowed_to?).with(:view_time_entries,
-                                                            work_package.project)
-            .and_return false
-        end
-
-        it 'does not show spentTime' do
-          is_expected.not_to have_json_path('spentTime')
-        end
-      end
     end
 
     describe 'percentageDone' do

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -50,6 +50,10 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
         it 'should return HTTP 200' do
           expect(last_response.status).to eql(200)
         end
+
+        it 'should set a weak ETag' do
+          expect(last_response.headers['ETag']).to match(/W\/\"\w+\"/)
+        end
       end
 
       context 'id is too long' do

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -81,6 +81,55 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
         expect(last_response.status).to eql(404)
       end
     end
+
+    describe 'schema caching' do
+      # Reproduce the schema cache key.
+      # This is somewhat deeper knowledge, but I can't reliably access
+      # the embedded helper
+      def schema_cache_key
+        [
+          "api/v3/work_packages/schema/#{project.id}-#{type.id}/#{type.updated_at}",
+          project.all_work_package_custom_fields
+        ]
+      end
+
+      let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+      before do
+        allow(Rails).to receive(:cache).and_return(cache)
+        allow(User).to receive(:current).and_return(current_user)
+      end
+
+      it 'should only create the representer once' do
+        expect(::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter)
+          .to receive(:create).once
+          .and_call_original
+
+        expect(Rails.cache.read(schema_cache_key)).to be_nil
+
+        # First request causes schema to be cached
+        get schema_path
+        expect(Rails.cache.read(schema_cache_key)).not_to be_nil
+
+        get schema_path
+        expect(last_response.status).to eql(200)
+      end
+
+      it 'refreshes the cache when the type changes' do
+        expect(::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter)
+          .to receive(:create).twice
+          .and_call_original
+
+        get schema_path
+        expect(Rails.cache.read(schema_cache_key)).not_to be_nil
+
+        expect {
+          type.update_attribute(:updated_at, 1.day.from_now)
+        }.to change { schema_cache_key }
+
+        get schema_path
+        expect(Rails.cache.read(schema_cache_key)).not_to be_nil
+      end
+    end
   end
 
   describe 'GET /api/v3/work_packages/schemas/sums' do


### PR DESCRIPTION
This commit introduces cached project-scoped work packages schema.
Their caches are expired on a key based on
- the Project ID
- the Type ID
- the allowed custom fields for the given project

This commit only caches schema, not form endpoints.

This is closely related to both 
https://community.openproject.com/work_packages/18404/activity
https://community.openproject.com/work_packages/13702/activity
