### PR TITLE
[22953] Set earlier breakpoint for switching WP details view to mobile view (2)

### DIFF
--- a/app/assets/stylesheets/content/_accounts_mobile.sass
+++ b/app/assets/stylesheets/content/_accounts_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   body.controller-account
     #login-form,
     #content .login-auth-providers,

--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   form
     .grid-block
       display: block

--- a/app/assets/stylesheets/content/_notifications_mobile.sass
+++ b/app/assets/stylesheets/content/_notifications_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .notification-box--wrapper,
   .flash,
   #errorExplanation

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -124,7 +124,7 @@ $widget-box--enumeration-width: 20px
           //necessary for correct alignment even with long texts
           width: calc(100% - #{$widget-box--enumeration-width})
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .widget-boxes
     &.-flex
       .widget-box

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -196,7 +196,7 @@ blockquote
 .toolbar-container ~ .wiki-content
   margin-top: -64px
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .toolbar-container ~ .wiki-content
     margin-top: 0
 

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   html
     min-width: 0 !important
 

--- a/app/assets/stylesheets/layout/_drop_down_mobile.sass
+++ b/app/assets/stylesheets/layout/_drop_down_mobile.sass
@@ -30,7 +30,7 @@
 // https://github.com/plapier/jquery-dropdown
 // (dual MIT/GPL-Licensed)
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .dropdown .dropdown-menu,
   .toolbar .legacy-actions-more
     LI > A,

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -272,7 +272,7 @@
   *
     outline: none
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .toolbar-container .toolbar-items
     background: #fff
     display: flex

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   #logo
     background-color: transparent
 

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -26,8 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include breakpoint(960px down)
+@include breakpoint(1248px down)
   body.controller-work_packages
+    overflow: auto !important
+    overflow-y: scroll !important
+
+    #main,
+    #content
+      position: relative !important
+
+    #content
+      height: 100% !important
 
     &.action-show #content
       overflow: visible
@@ -38,29 +47,8 @@
 
     .work-packages--show-view
       padding: 0
+      padding-right: 20px
 
-      #toolbar-items
-        background: #fff
-        display: flex
-        margin-bottom: 20px
-        width: calc(100% + 5px)
-
-        > li
-          -webkit-flex: 1 0 0
-          flex: 1 0 0
-
-          &:first-child
-            -webkit-flex: 3 0 0
-            flex: 3 0 0
-
-          button
-            width: 100%
-
-        .wp-create-button .dropdown
-          left: 0 !important
-
-        .action_menu_main .dropdown
-          left: auto !important
 
       .work-packages--split-view
         display: block
@@ -193,3 +181,31 @@
 
     .work-packages--list
       padding-bottom: 55px
+
+@include breakpoint (680px down)
+  body.controller-work_packages.action-show #content
+    .work-packages--show-view
+      padding-right: 0
+
+  #toolbar-items
+    background: #fff
+    display: flex
+    margin-bottom: 20px
+    width: calc(100% + 5px)
+
+    > li
+      -webkit-flex: 1 0 0
+      flex: 1 0 0
+
+      &:first-child
+        -webkit-flex: 3 0 0
+        flex: 3 0 0
+
+      button
+        width: 100%
+
+    .wp-create-button .dropdown
+      left: 0 !important
+
+    .action_menu_main .dropdown
+      left: auto !important

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -28,18 +28,34 @@
 
 @include breakpoint(1248px down)
   body.controller-work_packages
-    overflow: auto !important
-    overflow-y: scroll !important
 
-    #main,
-    #content
-      position: relative !important
+    &.action-show
+      overflow: auto !important
+      overflow-y: scroll !important
 
-    #content
-      height: 100% !important
+      #main,
+      #content
+        position: relative !important
 
-    &.action-show #content
-      overflow: visible
+      #main
+        padding-bottom: 0
+
+      #content
+        height: 100% !important
+        overflow: visible
+
+      .work-packages--list-table-area
+        position: relative
+
+      .work-packages--list
+        padding-bottom: 55px
+
+      .work-packages--page-container
+        .toolbar  > .work-packages--split-view
+          display: block
+
+      #content
+        overflow: visible
 
     .toolbar-container
       margin-bottom: 4px
@@ -159,7 +175,7 @@
 
     .work-packages--page-container
       .toolbar
-        padding: 0
+        padding-right: 20px
 
         .title-container
           max-width: 40%
@@ -173,21 +189,19 @@
             text-overflow: ellipsis
             white-space: nowrap
 
-      > .work-packages--split-view
-        display: block
 
-    .work-packages--list-table-area
-      position: relative
-
-    .work-packages--list
-      padding-bottom: 55px
 
 @include breakpoint (680px down)
-  body.controller-work_packages.action-show #content
-    .work-packages--show-view
-      padding-right: 0
+  body.controller-work_packages
+    .work-packages--page-container
+      .toolbar
+        padding-right: 0
 
-  #toolbar-items
+    &.action-show #content
+      .work-packages--show-view
+        padding-right: 0
+
+  .toolbar-items
     background: #fff
     display: flex
     margin-bottom: 20px
@@ -209,3 +223,9 @@
 
     .action_menu_main .dropdown
       left: auto !important
+
+  .work-packages--list-table-area
+    position: relative
+
+  .work-packages--list
+    padding-bottom: 55px

--- a/app/assets/stylesheets/specific/homescreen.sass
+++ b/app/assets/stylesheets/specific/homescreen.sass
@@ -62,7 +62,7 @@
       font-size: 3rem
       color: $homescreen-footer-icon-color
 
-@include breakpoint(960px down)
+@include breakpoint(680px down)
   .homescreen--links
     padding: 20px
     flex-wrap: wrap


### PR DESCRIPTION
As discussed in the ticket this PR changes the behavior of the work package overview for smaller screens. The changes done in the scope of #4305 are undone. 

https://community.openproject.com/work_packages/22953/activity
