### PR TITLE
[22997] WP title is truncated too early in mobile view

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -174,7 +174,7 @@
         padding: 0
 
         .title-container
-          max-width: 40%
+          max-width: 90%
           overflow: hidden
 
           span


### PR DESCRIPTION
This increases the width of the WP table title. Thus on small screens it is not too early truncated.

https://community.openproject.com/work_packages/22997/activity
