### PR TITLE
[Inline Create] Show create row in global work package list

### DIFF
--- a/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
+++ b/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
@@ -57,6 +57,13 @@ export class ApiWorkPackagesService {
     return this.wpApiPath(projectIdentifier).one('form').customPOST();
   }
 
+  /**
+   * Returns a promise to GET `/api/v3/work_packages/available_projects`.
+   */
+  public availableProjects(projectIdentifier?:string):ng.IPromise<op.HalResource> {
+    return this.wpApiPath(projectIdentifier).one('available_projects').get();
+  }
+
   public wpApiPath(projectIdentifier?: any) {
     if (!!projectIdentifier) {
       return this.apiV3.service('work_packages', this.apiV3.one('projects', projectIdentifier));

--- a/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.controller.ts
@@ -47,7 +47,7 @@ export default class WorkPackageCreateButtonController {
 
     if (this.inProjectContext) {
       this.ProjectService.fetchProjectResource(this.projectIdentifier).then(project => {
-        this.canCreate = !!project.links.createWorkPackage;
+        this.canCreate = !!project.createWorkPackage;
       });
 
       this.ProjectService.getProject(this.projectIdentifier).then(project  => {

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -34,9 +34,11 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
   public rows:any[];
   public hidden:boolean = false;
   private _wp;
+  private availableProjects = [];
 
   constructor(
     protected $state,
+    protected $scope,
     protected $rootScope,
     protected $element,
     protected I18n,
@@ -53,6 +55,11 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
       }
     });
 
+    this.apiWorkPackages.availableProjects().then(resource => {
+      this.canCreate = (resource && resource.total > 0);
+      this.availableProjects = resource.elements;
+    });
+
     $rootScope.$on('inlineWorkPackageCreateCancelled', (_event, index, row) => {
       if (row.object === this._wp) {
         this.rows.splice(index, 1);
@@ -61,14 +68,16 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     });
   }
 
+  public isDisabled() {
+    return !this.canCreate || this.$state.includes('**.new');
+  }
+
   public addWorkPackageRow() {
-    this.WorkPackageResource.fromCreateForm(this.projectIdentifier).then(wp => {
+    this.WorkPackageResource.fromCreateForm(this.availableProjects[0].identifier).then(wp => {
       this._wp = wp;
       wp.inlineCreated = true;
-      this.rows.push({ level: 0, ancestors: [], object: wp, parent: undefined });
+      this.rows.push({ level: 0, ancestors: [], object: wp, parent: void 0 });
       this.hide();
-
-
     });
   }
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -105,7 +105,8 @@ export class WorkPackageEditFieldController {
     // Mark the td field if it is inline-editable
     // We're resolving the non-form schema here since its loaded anyway for the table
     this.workPackage.schema.$load().then(schema => {
-      this.editable = schema[this.fieldName].writable;
+      var fieldSchema = schema[this.fieldName];
+      this.editable = fieldSchema && fieldSchema.writable;
     });
   }
 

--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -46,8 +46,13 @@ angular.module('openproject.services')
     './pagination-service')])
   .service('PriorityService', ['$http', 'PathHelper', require(
     './priority-service')])
-  .service('ProjectService', ['$http', 'PathHelper', 'FiltersHelper', 'HALAPIResource', require(
-    './project-service')])
+  .service('ProjectService', [
+    '$http',
+    'PathHelper',
+    'FiltersHelper',
+    'apiV3',
+    require('./project-service')
+  ])
   .service('RoleService', ['$http', 'PathHelper', require('./role-service')])
   .service('SortService', require('./sort-service'))
   .service('StatusService', ['$http', 'PathHelper', require('./status-service')])

--- a/frontend/app/services/project-service.js
+++ b/frontend/app/services/project-service.js
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function($http, PathHelper, FiltersHelper, HALAPIResource) {
+module.exports = function($http, PathHelper, FiltersHelper, apiV3) {
 
   var ProjectService = {
     getProject: function(projectIdentifier) {
@@ -64,7 +64,7 @@ module.exports = function($http, PathHelper, FiltersHelper, HALAPIResource) {
     },
 
     fetchProjectResource: function (projectIdentifier) {
-      return HALAPIResource.setup('/api/v3/projects/' + projectIdentifier).fetch();
+      return apiV3.one('projects', projectIdentifier).get();
     }
   };
 

--- a/spec/features/work_packages/table_inline/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table_inline/create_work_packages_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'inline create work package', js: true do
+  let(:type) { FactoryGirl.create(:type_with_workflow) }
+  let(:types) { [type] }
+
+  let(:user) { FactoryGirl.create :admin }
+
+  let!(:project) { FactoryGirl.create(:project, is_public: true, types: types) }
+  let!(:existing_wp) { FactoryGirl.create(:work_package, project: project) }
+  let!(:priority) { FactoryGirl.create :priority, is_default: true }
+
+  before do
+    login_as user
+  end
+
+  shared_examples 'inline create work package' do
+    context 'when user may create work packages' do
+      it 'allows to create work packages' do
+        wp_table.expect_work_package_listed(existing_wp)
+
+        wp_table.click_inline_create
+        expect(page).to have_selector('.wp--row', count: 2)
+        expect(page).to have_selector('.wp--row.-new')
+
+        # Expect subject to be activated
+        subject_field = InlineEditField.new(nil, :subject)
+        subject_field.expect_active!
+        subject_field.set_value 'Some subject'
+        subject_field.save!
+
+        # Expect new create row to exist
+        expect(page).to have_selector('.wp--row', count: 3)
+        expect(page).to have_selector('.wp--row.-new')
+
+        subject_field = InlineEditField.new(nil, :subject)
+        subject_field.expect_active!
+        subject_field.set_value 'Another subject'
+        subject_field.save!
+
+        expect(page).to have_selector('.wp--row .subject', text: 'Some subject')
+        expect(page).to have_selector('.wp--row .subject', text: 'Another subject')
+
+        # Cancel creation
+        expect(page).to have_selector('.wp--row.-new')
+        page.find('.wp-table--cancel-create-link').click
+        expect(page).to have_no_selector('.wp--row.-new')
+        expect(page).to have_selector('.wp-inline-create--add-link')
+      end
+    end
+
+    context 'when user may not create work packages' do
+      let(:user) {
+        FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+      }
+      let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+      let(:permissions) { [:view_work_packages] }
+
+      it 'renders the work package, but no create row' do
+        wp_table.expect_work_package_listed(existing_wp)
+        expect(page).to have_no_selector('.wp-inline-create--add-link')
+      end
+    end
+  end
+
+  describe 'global create' do
+    let(:wp_table) { ::Pages::WorkPackagesTable.new }
+
+    before do
+      wp_table.visit!
+    end
+
+    it_behaves_like 'inline create work package'
+  end
+
+  describe 'project context create' do
+    let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+
+    before do
+      wp_table.visit!
+    end
+
+    it_behaves_like 'inline create work package'
+  end
+end

--- a/spec/features/work_packages/table_inline/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table_inline/edit_work_packages_spec.rb
@@ -40,7 +40,6 @@ describe 'Inline editing work packages', js: true do
   }
 
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
-  let(:fields) { InlineEditField.new(wp_table, work_package) }
 
   let(:workflow) do
     FactoryGirl.create :workflow,

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -43,6 +43,11 @@ module Pages
       end
     end
 
+    def click_inline_create
+      find('.wp-inline-create--add-link').click
+      expect(page).to have_selector('.wp--row.-new')
+    end
+
     def open_split_view(work_package)
 
       # Hover row to show split screen button

--- a/spec/support/work_packages/inline_edit_field.rb
+++ b/spec/support/work_packages/inline_edit_field.rb
@@ -9,7 +9,13 @@ class InlineEditField
     @attribute = attribute
     @field_type = field_type
 
-    @selector = "#work-package-#{work_package.id} .#{attribute}"
+    @selector =
+      if work_package.nil?
+        ".wp--row.-new .#{attribute}"
+      else
+        "#work-package-#{work_package.id} .#{attribute}"
+      end
+
     @element = page.find(selector)
   end
 


### PR DESCRIPTION
When no project context is available, this PR fetches the
`available_projects` endpoint and suggests using the first project for
creating a new row
