### PR TITLE
Add information for default admin user to quick start

### DIFF
--- a/doc/QUICK_START.md
+++ b/doc/QUICK_START.md
@@ -137,6 +137,11 @@ These are generic (and condensed) installation instructions for the **current de
         echo "concurrency: web=1,assets=1,worker=0" >> .foreman
 
    For more information refer to Foreman documentation section on [default options][foreman-defaults].
+   
+  You can access the application with the admin-account having the following credentials:
+
+        Username: admin
+        Password: admin
 
 ## Full Guide
 


### PR DESCRIPTION
Looks like there isn't any information about the default admin user in the quick start guide. To find it, a developer has to scroll through the full guide. It would be handy to have in the quick start as well.
