### PR TITLE
[22852] Preselect values of new work package from filter values

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -67,6 +67,29 @@ function wpResource(
       return !this[fieldName] && fieldSchema.writable && fieldSchema.required;
     }
 
+    public allowedValuesFor(field):op.HalResource[] {
+      var deferred = $q.defer();
+      this.getForm().then(form => {
+        const allowedValues = form.$embedded.schema[field].allowedValues;
+
+        if (Array.isArray(allowedValues)) {
+          deferred.resolve(allowedValues);
+        } else {
+          return allowedValues.$load().then(loadedValues => {
+            deferred.resolve(loadedValues.elements);
+          });
+        }
+      });
+
+      return deferred.promise;
+    }
+
+    public setAllowedValueFor(field, href) {
+      this.allowedValuesFor(field).then(allowedValues => {
+        this[field] = _.find(allowedValues, entry => (entry.href === href));
+      });
+    }
+
     public getForm() {
       if (!this.form) {
         this.form = this.$links.update(this);

--- a/frontend/app/components/query/query.service.js
+++ b/frontend/app/components/query/query.service.js
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-function QueryConstructorService(Filter, Sortation, UrlParamsHelper, INITIALLY_SELECTED_COLUMNS) {
+function QueryConstructorService(Filter, Sortation, UrlParamsHelper, PathHelper, INITIALLY_SELECTED_COLUMNS) {
 
   var Query = function (queryData, options) {
     angular.extend(this, queryData, options);
@@ -200,6 +200,37 @@ function QueryConstructorService(Filter, Sortation, UrlParamsHelper, INITIALLY_S
 
     setColumns: function(columns) {
       this.columns = columns;
+    },
+
+    applyDefaultsFromFilters: function(workPackage) {
+      angular.forEach(this.filters, function(filter) {
+
+        // Ignore any filters except =
+        if (filter.operator !== '=') {
+          return;
+        }
+
+        // Select the first value
+        var value = filter.values;
+        if (Array.isArray(filter.values)) {
+          value = filter.values[0];
+        }
+
+        // Avoid empty values
+        if (!value) {
+          return;
+        }
+
+        switch(filter.name) {
+          case 'type':
+            workPackage.setAllowedValueFor('type', PathHelper.apiV3TypePath(value));
+            break;
+          case 'assignee':
+            workPackage.setAllowedValueFor('assignee', PathHelper.apiV3UserPath(value));
+            break;
+        }
+
+      });
     },
 
     /**

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -30,7 +30,7 @@ import {wpButtonsModule} from '../../../angular-modules';
 import WorkPackageCreateButtonController from '../wp-create-button/wp-create-button.controller';
 
 class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonController {
-  public columns:any[];
+  public query: op.Query;
   public rows:any[];
   public hidden:boolean = false;
   private _wp;
@@ -76,6 +76,9 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     this.WorkPackageResource.fromCreateForm(this.availableProjects[0].identifier).then(wp => {
       this._wp = wp;
       wp.inlineCreated = true;
+
+      this.query.applyDefaultsFromFilters(this._wp);
+
       this.rows.push({ level: 0, ancestors: [], object: wp, parent: void 0 });
       this.hide();
     });

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.directive.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.directive.ts
@@ -35,7 +35,7 @@ function wpInlineCreateButton() {
     scope: {
       projectIdentifier: '=',
       rows: '=',
-      columns: '='
+      query: '='
     },
 
     bindToController: true,

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -171,7 +171,6 @@
               </wp-td>
             </td>
         </tr>
-        <tr wp-inline-create-row></tr>
       </tbody>
       <tfoot>
         <!-- Inline create button -->
@@ -180,6 +179,7 @@
           <td colspan="{{ columns.length + 2 }}">
             <wp-inline-create-button
                 project-identifier="projectIdentifier"
+                query="query"
                 rows="rows"
             ></wp-inline-create-button>
           </td>


### PR DESCRIPTION
This allows to assign default values for new work packages from the
current query filter.

Due to the incompatibility in APIexperimental query filters APIv3
values, this link is made solely for the types assignees and types.

**Issues**:
- `<< me >>` is not properly resolved since we don't know the current user.
- The mapping between experimental and V3 values require specific knowledge on the query service, thus I'm restricting this feature to type and assignee for now.

https://community.openproject.com/work_packages/22852/activity
