### PR TITLE
[Bugfix] Work package grouping header

### DIFF
--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -72,7 +72,6 @@
                 rows="rows"
                 query="query"
                 group-by="query.groupBy"
-                group-by-column="groupByColumn"
                 display-sums="query.displaySums"
                 resource="resource"
                 activation-callback="openWorkPackageInFullView(id, force)">

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -54,6 +54,11 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
       }
     });
 
+    // Need to reset the state when the work package is refreshed hard
+    $rootScope.$on('workPackagesRefreshRequired', _ => {
+      this.show();
+    });
+
     this.apiWorkPackages.availableProjects().then(resource => {
       this.canCreate = (resource && resource.total > 0);
       this.availableProjects = resource.elements;

--- a/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.js
+++ b/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.js
@@ -33,29 +33,26 @@ angular
 function wpGroupHeader() {
   return {
     restrict: 'A',
+    link: function(scope) {
 
-    compile: function() {
-      return {
-        pre: function(scope) {
-          scope.currentGroup = scope.row.groupName;
+      scope.currentGroup = scope.row.groupName;
 
-          scope.currentGroupObject = _.find(scope.resource.groups, function(o) {
-            return o.value === scope.row.groupName;
-          });
+      scope.currentGroupObject = _.find(scope.resource.groups, function(o) {
+        var value = o.value == null ? '' : o.value;
+        return value === scope.row.groupName;
+      });
 
-          pushGroup(scope.currentGroup);
+      pushGroup(scope.currentGroup);
 
-          scope.toggleCurrentGroup = function() {
-            scope.groupExpanded[scope.currentGroup] = !scope.groupExpanded[scope.currentGroup];
-          };
-
-          function pushGroup(group) {
-            if (scope.groupExpanded[group] === undefined) {
-              scope.groupExpanded[group] = true;
-            }
-          }
-        }
+      scope.toggleCurrentGroup = function() {
+        scope.groupExpanded[scope.currentGroup] = !scope.groupExpanded[scope.currentGroup];
       };
+
+      function pushGroup(group) {
+        if (scope.groupExpanded[group] === undefined) {
+          scope.groupExpanded[group] = true;
+        }
+      }
     }
   };
 }

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -44,6 +44,7 @@
             ng-repeat-start="row in rows track by row.object.id+row.groupName"
             ng-if="!!groupByColumn &&
                    ($first || row.groupName !== rows[$index-1].groupName)"
+            ng-show="row.groupName != undefined"
             ng-class="{
               group: true,
               open: groupExpanded[currentGroup],

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -41,7 +41,7 @@
         <!-- Group headers -->
 
         <tr wp-group-header
-            ng-repeat-start="row in rows track by row.object.id"
+            ng-repeat-start="row in rows track by row.object.id+row.groupName"
             ng-if="!!groupByColumn &&
                    ($first || row.groupName !== rows[$index-1].groupName)"
             ng-class="{

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -98,9 +98,11 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
       });
 
       function applyGrouping() {
-        scope.groupByColumn = scope.workPackagesTableData.groupByColumn;
-        scope.grouped = scope.groupByColumn !== undefined;
-        scope.groupExpanded = {};
+        if (scope.groupByColumn != scope.workPackagesTableData.groupByColumn) {
+          scope.groupByColumn = scope.workPackagesTableData.groupByColumn;
+          scope.grouped = scope.groupByColumn !== undefined;
+          scope.groupExpanded = {};
+        }
       }
 
       function fetchTotalSums() {

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -60,9 +60,7 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
         event.pageY -= topMenuHeight;
       };
 
-      // groupings
-      scope.grouped = scope.groupByColumn !== undefined;
-      scope.groupExpanded = {};
+      applyGrouping();
 
       scope.$watchCollection('columns', function() {
         // force Browser rerender
@@ -88,6 +86,8 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
         if (scope.displaySums) {
           fetchSumsSchema();
         }
+
+        applyGrouping();
       });
 
       scope.$watch('displaySums', function(sumsToBeDisplayed) {
@@ -96,6 +96,12 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
           if (!sumsSchemaFetched()) { fetchSumsSchema(); }
         }
       });
+
+      function applyGrouping() {
+        scope.groupByColumn = scope.workPackagesTableData.groupByColumn;
+        scope.grouped = scope.groupByColumn !== undefined;
+        scope.groupExpanded = {};
+      }
 
       function fetchTotalSums() {
         apiWorkPackages
@@ -124,17 +130,6 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
       scope.setCheckedStateForAllRows = function(state) {
         WorkPackagesTableService.setCheckedStateForAllRows(scope.rows, state);
       };
-
-      var groupableColumns = WorkPackagesTableService.getGroupableColumns();
-      scope.$watch('query.groupBy', function(groupBy) {
-        if (scope.columns) {
-          var groupByColumnIndex = groupableColumns.map(function(column){
-            return column.name;
-          }).indexOf(groupBy);
-
-          scope.groupByColumn = groupableColumns[groupByColumnIndex];
-        }
-      });
 
       // Thanks to http://stackoverflow.com/a/880518
       function clearSelection() {

--- a/frontend/app/components/wp-table/wp-table.service.js
+++ b/frontend/app/components/wp-table/wp-table.service.js
@@ -116,8 +116,15 @@ function WorkPackagesTableService($filter, QueryService, WorkPackagesTableHelper
       return workPackagesTableData.groupBy;
     },
 
+    getGroupByColumn: function() {
+      return workPackagesTableData.groupByColumn;
+    },
+
     setGroupBy: function(groupBy) {
+      var groupableColumns = workPackagesTableData.groupableColumns;
+
       workPackagesTableData.groupBy = groupBy;
+      workPackagesTableData.groupByColumn = _.find(groupableColumns, { name: groupBy });
     },
 
     removeRow: function(row) {

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -65,7 +65,7 @@ module API
       end
 
       def model_required?
-        true
+        false
       end
 
       private


### PR DESCRIPTION
Currently, changes to groupBy causes the work package to be immediately
refreshed before the actual groups are collected from the backend.
This watch has been removed, since its unneeded.

The work package table is now tracked by the row id and the current
group, which causes the ng-repeat to re-evaluate when the group changes,
thus fixing the group header bug.

Additionally, we now carry the groupByColumn in the wpTableService,
where the other grouping values are derived as well.

Allow nil aggregation group, which should fix https://community.openproject.com/work_packages/22816/activity
