### PR TITLE
Show table even when empty

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -382,9 +382,8 @@ en:
         header: 'New Work Package'
         header_with_parent: 'New work package (Child of %{type} #%{id})'
       no_results:
-        title: No work packages to display
-        description_html: |
-          <p>Either none have been created or all work packages are filtered out.</p>
+        title: No work packages to display.
+        description: Either none have been created or all work packages are filtered out.
       property_groups:
         details: "Details"
         people: "People"

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -71,8 +71,16 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     return !this.canCreate || this.$state.includes('**.new');
   }
 
+  public get projectIdentifierForCreate() {
+    if (this.inProjectContext) {
+      return this.projectIdentifier;
+    } else {
+      return this.availableProjects[0].identifier;
+    }
+  }
+
   public addWorkPackageRow() {
-    this.WorkPackageResource.fromCreateForm(this.availableProjects[0].identifier).then(wp => {
+    this.WorkPackageResource.fromCreateForm(this.projectIdentifierForCreate).then(wp => {
       this._wp = wp;
       wp.inlineCreated = true;
 

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -1,6 +1,6 @@
 <div class="generic-table--container work-package-table--container"
   ng-class="{ '-with-footer': displaySums }">
-  <div class="generic-table--results-container" ng-if="rows.length">
+  <div class="generic-table--results-container">
     <table interactive-table class="keyboard-accessible-list generic-table">
       <colgroup>
         <col highlight-col />
@@ -37,6 +37,16 @@
       </thead>
 
       <tbody>
+        <!-- Empty row notification -->
+        <tr id="empty-row-notification" ng-if="!rows.length">
+          <td colspan="{{ numTableColumns }}">
+            <span>
+              <i class="icon-info1 icon-context"></i>
+              <strong ng-bind="text.noResults"></strong>
+              <span ng-bind="text.noResultsDescription"></span>
+            </span>
+          </td>
+        </tr>
 
         <!-- Group headers -->
 
@@ -51,7 +61,7 @@
               keyboard_hover: true
             }"
             id="group-header-{{ row.groupName }}">
-          <td colspan="{{ columns.length + 2 - (!!hideWorkPackageDetails * 1) }}">
+          <td colspan="{{ numTableColumns }}">
             <div ng-class="[
                     'expander',
                     'icon-context',
@@ -176,7 +186,7 @@
         <!-- Inline create button -->
         <tr class="wp-inline-create-button-row">
           <!--  Add 2 to the colspan attr because of the id and the checkbox columns  -->
-          <td colspan="{{ columns.length + 2 }}">
+          <td colspan="{{ numTableColumns }}">
             <wp-inline-create-button
                 project-identifier="projectIdentifier"
                 query="query"
@@ -206,13 +216,5 @@
     </table>
     <div class="generic-table--header-background"></div>
     <div class="generic-table--footer-background" ng-if="sumsLoaded()"></div>
-  </div>
-  <div class="generic-table--no-results-container" ng-if="!rows.length">
-    <i class="icon-info1"></i>
-    <h2 class="generic-table--no-results-title">
-      {{ text.noResults }}
-    </h2>
-    <div class="generic-table--no-results-description"
-      ng-bind-html="text.noResultsDescription"></div>
   </div>
 </div>

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -52,6 +52,9 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
     link: function(scope, element) {
       var activeSelectionBorderIndex;
 
+      // Total columns = all available columns + id + checkbox
+      scope.numTableColumns = scope.columns.length + 2;
+
       scope.workPackagesTableData = WorkPackagesTableService.getWorkPackagesTableData();
       scope.workPackagePath = PathHelper.workPackagePath;
 
@@ -221,7 +224,7 @@ function WorkPackagesTableController($scope, $rootScope) {
     sumFor: I18n.t('js.label_sum_for'),
     allWorkPackages: I18n.t('js.label_all_work_packages'),
     noResults: I18n.t('js.work_packages.no_results.title'),
-    noResultsDescription: I18n.t('js.work_packages.no_results.description_html')
+    noResultsDescription: I18n.t('js.work_packages.no_results.description')
   };
 
   $scope.$watch('workPackagesTableData.allRowsChecked', function(checked) {


### PR DESCRIPTION
Display the work package table even when its empty, allowing users to inline create work packages as follows.
