### PR TITLE
wp form config polish

### DIFF
--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -69,7 +69,7 @@ module ::TypesHelper
 
     # within the form date is shown as a single entry including start and due
     if merge_date
-      attributes['date'] = { required: false }
+      attributes['date'] = { required: false, has_default: false }
       attributes.delete 'due_date'
       attributes.delete 'start_date'
     end
@@ -77,6 +77,7 @@ module ::TypesHelper
     WorkPackageCustomField.all.each do |field|
       attributes["custom_field_#{field.id}"] = {
         required: field.is_required,
+        has_default: field.default_value,
         display_name: field.name
       }
     end
@@ -99,6 +100,14 @@ module ::TypesHelper
       key = attr_i18n_key(name)
       I18n.t("activerecord.attributes.work_package.#{key}", default: '')
         .presence || I18n.t("attributes.#{key}")
+    end
+  end
+
+  def translated_attribute_name(name, attr)
+    if attr[:name_source]
+      attr[:name_source].call
+    else
+      attr[:display_name] || attr_translate(name)
     end
   end
 

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -88,13 +88,15 @@ See doc/COPYRIGHT.rdoc for more details.
             <%
               attributes = ::TypesHelper
                 .work_package_form_attributes(merge_date: true)
-                .reject { |name, attr| not name =~ /custom_field_/ and attr[:required] }
+                .reject { |name, attr|
+                  not name =~ /custom_field_/ and (attr[:required] and not attr[:has_default])
+                }
             %>
             <% attributes.each do |name, attr| %>
               <tr>
                 <td>
                   <%= label "type_attribute_visibility_#{name}",
-                            attr[:display_name] || attr_translate(name),
+                            translated_attribute_name(name, attr),
                             value: "type_attribute_visibility[#{name}]",
                             class: 'form--label' %>
                 </td>

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -50,37 +50,21 @@ See doc/COPYRIGHT.rdoc for more details.
       <!--[eoform:type]-->
     </section>
   </div>
-  <div class="grid-content medium-6">
-    <% if @projects.any? %>
-      <fieldset class="form--fieldset" id="type_project_ids">
-        <legend class="form--fieldset-legend"><%= l(:label_project_plural) %></legend>
-        <div class="form--fieldset-control">
-          <span class="form--fieldset-control-container">
-            (<%= check_all_links 'type_project_ids' %>)
-          </span>
-        </div>
-        <%= project_nested_ul(@projects) do |p|
-          content_tag('label',
-            check_box_tag('type[project_ids][]', p.id, controller.type.projects.include?(p), id: nil) +
-              ' ' + h(p), class: 'form--label-with-check-box')
-        end %>
-        <%= hidden_field_tag('type[project_ids][]', '', id: nil) %>
-      </fieldset>
-    <% end %>
-  </div>
 </div>
 
 <div class="grid-block">
   <div class="grid-content medium-6">
-    <fieldset class="form--fieldset -collapsible collapsed" id="type_attribute_visibility">
-      <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= I18n.t('label_form_configuration')%></legend>
-      <div style="display: none;">
+    <fieldset class="form--fieldset -collapsible" id="type_attribute_visibility">
+      <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
+        <%= I18n.t('label_form_configuration')%>
+      </legend>
+      <div>
         <p><%= I18n.t('text_form_configuration') %></p>
         <table class="attributes-table">
           <thead>
             <tr>
               <td><%= I18n.t('label_attribute') %></td>
-              <td><%= I18n.t('label_default') %></td>
+              <td><%= I18n.t('label_active') %></td>
               <td><%= I18n.t('label_always_visible') %></td>
             </tr>
           </thead>
@@ -89,10 +73,15 @@ See doc/COPYRIGHT.rdoc for more details.
               attributes = ::TypesHelper
                 .work_package_form_attributes(merge_date: true)
                 .reject { |name, attr|
+                  # display all custom fields     don't display required fields without a default
                   not name =~ /custom_field_/ and (attr[:required] and not attr[:has_default])
                 }
+              keys = attributes.keys.sort_by do |name|
+                translated_attribute_name(name, attributes[name])
+              end
             %>
-            <% attributes.each do |name, attr| %>
+            <% keys.each do |name| %>
+            <%   attr = attributes[name] %>
               <tr>
                 <td>
                   <%= label "type_attribute_visibility_#{name}",
@@ -123,6 +112,31 @@ See doc/COPYRIGHT.rdoc for more details.
         </table>
       </div>
     </fieldset>
+  </div>
+</div>
+
+<div class="grid-block">
+  <div class="grid-content medium-6">
+    <% if @projects.any? %>
+      <fieldset class="form--fieldset -collapsible" id="type_project_ids">
+        <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
+          <%= l(:label_project_plural) %>
+        </legend>
+        <div>
+          <div class="form--fieldset-control">
+            <span class="form--fieldset-control-container">
+              (<%= check_all_links 'type_project_ids' %>)
+            </span>
+          </div>
+          <%= project_nested_ul(@projects) do |p|
+            content_tag('label',
+              check_box_tag('type[project_ids][]', p.id, controller.type.projects.include?(p), id: nil) +
+                ' ' + h(p), class: 'form--label-with-check-box')
+          end %>
+          <%= hidden_field_tag('type[project_ids][]', '', id: nil) %>
+        </div>
+      </fieldset>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -834,6 +834,7 @@ en:
       indefinite_expiration: "Never"
 
   label_account: "Account"
+  label_active: "Active"
   label_activity: "Activity"
   label_add_edit_translations: "Add and edit translations"
   label_add_another_file: "Add another file"
@@ -1769,7 +1770,8 @@ en:
   text_form_configuration: >
     You can customize which attributes will be displayed by default
     in forms for work packages of this type.
-    Fields that are required cannot be customized and will always be shown.
+    Fields that are required but don't have a default value cannot be customized.
+    They will always be shown.
   text_caracters_maximum: "%{count} characters maximum."
   text_caracters_minimum: "Must be at least %{count} characters long."
   text_comma_separated: "Multiple values allowed (comma separated)."
@@ -2050,7 +2052,7 @@ en:
   tooltip:
     attribute_visibility:
       default: Show if not empty
-      visible: Always show
+      visible: Show even if empty
       hidden: Hide by default
 
   queries:

--- a/frontend/app/components/inplace-edit/wp-field/wp-field.service.js
+++ b/frontend/app/components/inplace-edit/wp-field/wp-field.service.js
@@ -92,7 +92,7 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
 
     var attrVisibility = getVisibility(workPackage, field);
 
-    var notRequired = !isRequired(workPackage, field);
+    var notRequired = !isRequired(workPackage, field) || hasDefault(workPackage, field);
     var empty = isEmpty(workPackage, field);
     var visible = attrVisibility == 'visible'; // always show
     var hidden = attrVisibility == 'hidden'; // never show
@@ -229,6 +229,14 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
       return false;
     }
     return schema.props[field].required;
+  }
+
+  function hasDefault(workPackage, field) {
+    var schema = getSchema(workPackage);
+    if (_.isUndefined(schema.props[field])) {
+      return false;
+    }
+    return schema.props[field].hasDefault;
   }
 
   function isEmbedded(workPackage, field) {

--- a/frontend/app/components/inplace-edit/wp-field/wp-field.service.js
+++ b/frontend/app/components/inplace-edit/wp-field/wp-field.service.js
@@ -96,13 +96,9 @@ function WorkPackageFieldService($q, $http, $filter, I18n,  WorkPackagesHelper, 
     var empty = isEmpty(workPackage, field);
     var visible = attrVisibility == 'visible'; // always show
     var hidden = attrVisibility == 'hidden'; // never show
-    // !hidden && !visible => show if not empty
+    // not hidden and not visible => show if not empty (default)
 
-    if (workPackage.isNew === true) {
-      return notRequired && hidden;
-    } else {
-      return notRequired && !visible && (empty || hidden);
-    }
+    return notRequired && !visible && (empty || hidden);
   }
 
   function getVisibility(workPackage, field) {

--- a/frontend/app/work_packages/helpers/work-package-display-helper.js
+++ b/frontend/app/work_packages/helpers/work-package-display-helper.js
@@ -32,9 +32,7 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
   var unhideableFields = [
     'subject',
     'type',
-    'status',
-    'description',
-    'priority'
+    'description'
   ];
   var firstTimeFocused = false;
   var isGroupHideable = function (groupedFields, groupName, workPackage, cb) {
@@ -76,10 +74,6 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
 
         if (_.contains(unhideableFields, field)) {
           return !WorkPackageFieldService.isEditable(workPackage, field);
-        }
-
-        if (WorkPackageFieldService.isRequired(workPackage, field)) {
-          return false;
         }
 
         return WorkPackageFieldService.isHideable(workPackage, field);

--- a/frontend/app/work_packages/helpers/work-package-display-helper.js
+++ b/frontend/app/work_packages/helpers/work-package-display-helper.js
@@ -31,7 +31,6 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
   // specifies unhideable (during creation)
   var unhideableFields = [
     'subject',
-    'type',
     'description'
   ];
   var firstTimeFocused = false;
@@ -39,6 +38,11 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
         if (!workPackage) {
           return true;
         }
+
+        if (groupName === 'details') {
+          return false; // never hide details to keep show all button arround
+        }
+
         var group = _.find(groupedFields, {groupName: groupName});
         var isHideable = typeof cb === 'undefined' ? isFieldHideable : cb;
         return group.attributes.length === 0 || _.every(group.attributes, function(field) {

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -41,6 +41,7 @@ module API
                      value_representer:,
                      link_factory:,
                      required: true,
+                     has_default: false,
                      writable: true,
                      visibility: nil,
                      current_user: nil)
@@ -50,6 +51,7 @@ module API
         super(type: type,
               name: name,
               required: required,
+              has_default: has_default,
               writable: writable,
               visibility: visibility,
               current_user: current_user)

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -34,12 +34,13 @@ module API
   module Decorators
     class PropertySchemaRepresenter < ::API::Decorators::Single
       def initialize(
-        type:, name:, required: true, writable: true,
+        type:, name:, required: true, has_default: false, writable: true,
         visibility: nil, current_user: nil
       )
         @type = type
         @name = name
         @required = required
+        @has_default = has_default
         @writable = writable
         @visibility = visibility || 'default'
 
@@ -49,6 +50,7 @@ module API
       attr_accessor :type,
                     :name,
                     :required,
+                    :has_default,
                     :writable,
                     :visibility,
                     :min_length,
@@ -58,6 +60,7 @@ module API
       property :type, exec_context: :decorator
       property :name, exec_context: :decorator
       property :required, exec_context: :decorator
+      property :has_default, exec_context: :decorator
       property :writable, exec_context: :decorator
       property :visibility, exec_context: :decorator
       property :min_length, exec_context: :decorator

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -237,6 +237,7 @@ module API
                         type: TYPE_MAP[custom_field.field_format],
                         name_source: -> (*) { custom_field.name },
                         required: custom_field.is_required,
+                        has_default: (not custom_field.default_value.nil?),
                         writable: true,
                         min_length: (custom_field.min_length if custom_field.min_length > 0),
                         max_length: (custom_field.max_length if custom_field.max_length > 0),

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -194,7 +194,8 @@ module API
                                              href: api_v3_paths.type(type.id),
                                              title: type.name
                                            }
-                                         }
+                                         },
+                                         has_default: true
 
           schema_with_allowed_collection :status,
                                          value_representer: Statuses::StatusRepresenter,

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -203,7 +203,8 @@ module API
                                              href: api_v3_paths.status(status.id),
                                              title: status.name
                                            }
-                                         }
+                                         },
+                                         has_default: true
 
           schema_with_allowed_collection :category,
                                          value_representer: Categories::CategoryRepresenter,
@@ -232,7 +233,8 @@ module API
                                              href: api_v3_paths.priority(priority.id),
                                              title: priority.name
                                            }
-                                         }
+                                         },
+                                         has_default: true
         end
       end
     end

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -67,6 +67,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
                      'name': 'Estimated time',
                      'visibility': 'default',
                      'required': false,
+                     'hasDefault': false,
                      'writable': false }
         expect(subject).to be_json_eql(expected.to_json).at_path('estimatedTime')
       end
@@ -91,6 +92,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
                      'name': custom_field.name,
                      'visibility': 'default',
                      'required': false,
+                     'hasDefault': false,
                      'writable': false }
         expect(subject).to be_json_eql(expected.to_json).at_path("customField#{custom_field.id}")
       end

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -159,6 +159,7 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
                        'name': 'Estimated time',
                        'visibility': 'default',
                        'required': false,
+                       'hasDefault': false,
                        'writable': false }
           expect(subject.body).to be_json_eql(expected.to_json).at_path('estimatedTime')
         end


### PR DESCRIPTION
- sort attributes in type form by name
- allow hiding required fields with default value (such as Priority, Status, Type)
- updated labels/text
- visibility same on edit and new work package forms

Related to #4349
