### PR TITLE
[20452] [Accessibility] Broken tabbing order on login form

### DIFF
--- a/app/assets/stylesheets/content/_accounts.sass
+++ b/app/assets/stylesheets/content/_accounts.sass
@@ -37,6 +37,7 @@
     .login-links
       float: right
       text-align: right
+      margin-top: -3rem
 
 #content .login-auth-providers.wide
   width: auto

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -33,14 +33,14 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="form--field">
     <%= styled_label_tag 'username', User.human_attribute_name(:login) %>
     <div class="form--field-container">
-      <%= styled_text_field_tag 'username', params[:username], tabindex: 1 %>
+      <%= styled_text_field_tag 'username', params[:username] %>
     </div>
   </div>
 
   <div class="form--field">
     <%= styled_label_tag 'password', User.human_attribute_name(:password) %>
     <div class="form--field-container">
-      <%= styled_password_field_tag 'password', nil, tabindex: 2, autofocus: params.include?(:username) %>
+      <%= styled_password_field_tag 'password', nil, autofocus: params.include?(:username) %>
     </div>
   </div>
 
@@ -55,17 +55,18 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
   <% end %>
 
+  <input type="submit" name="login" value="<%=l(:button_login)%>" class="button -highlight" />
+
   <div class="login-options-container">
     <div class="login-links">
       <% if Setting.lost_password? %>
-        <%= link_to l(:label_password_lost), { controller: '/account', action: 'lost_password' }, tabindex: "4" %>
+        <%= link_to l(:label_password_lost), { controller: '/account', action: 'lost_password' } %>
         <br>
       <% end %>
       <% if Setting.self_registration? %>
-        <%= link_to l(:label_register), { controller: '/account', action: 'register' }, tabindex: "5" %>
+        <%= link_to l(:label_register), { controller: '/account', action: 'register' } %>
       <% end %>
     </div>
   </div>
-  <input type="submit" name="login" value="<%=l(:button_login)%>" class="button -highlight" tabindex="3" />
   <%= javascript_tag "Form.Element.focus('username');" %>
 <% end %>

--- a/app/views/hooks/login/_auth_provider.html.erb
+++ b/app/views/hooks/login/_auth_provider.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% unless Rails.env.production? %>
-  <a tabindex="6" href="<%= url_for controller: '/auth', action: 'developer' %>" class="auth-provider auth-provider-developer">
+  <a href="<%= url_for controller: '/auth', action: 'developer' %>" class="auth-provider auth-provider-developer">
     <span class="auth-provider-name">Omniauth Developer</span>
   </a>
 <% end %>


### PR DESCRIPTION
This removes the `tab index` attribute from the input elements on the login form. Thus the tabbing order matches the DOM appearances.

https://community.openproject.com/work_packages/20452/activity
