### PR TITLE
Integrate openproject-announcements

### DIFF
--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -112,6 +112,7 @@
 @import content/select2
 
 @import specific/homescreen
+@import specific/announcements
 
 @import misc_legacy
 @import jstoolbar

--- a/app/assets/stylesheets/specific/announcements.sass
+++ b/app/assets/stylesheets/specific/announcements.sass
@@ -1,0 +1,6 @@
+#announcement
+  margin-left: auto
+  margin-right: auto
+  margin-top: 1rem
+  width: 511px
+

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,30 @@
+class AnnouncementsController < ApplicationController
+  layout 'admin'
+
+  before_filter :require_admin
+
+  def edit
+    @announcement = Announcement.only_one
+  end
+
+  def update
+    @announcement = Announcement.only_one
+    @announcement.attributes = announcement_params
+
+    if @announcement.save
+      flash[:success] = t(:notice_successful_update)
+    end
+
+    render action: 'edit'
+  end
+
+  private
+
+  def default_breadcrumb
+    t(:label_announcement)
+  end
+
+  def announcement_params
+    params.require(:announcement).permit('text', 'show_until', 'active')
+  end
+end

--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -1,0 +1,9 @@
+module AnnouncementsHelper
+  def notice_annoucement_active
+    if @announcement.active_and_current?
+      l(:'announcements.is_active')
+    else
+      l(:'announcements.is_inactive')
+    end
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,26 @@
+class Announcement < ActiveRecord::Base
+  scope :active,  -> { where(active: true) }
+  scope :current, -> { where('show_until >= ?', Date.today) }
+
+  validates :show_until, presence: true
+
+  def self.active_and_current
+    active.current.first
+  end
+
+  def self.only_one
+    a = first
+    a = create_default_announcement if a.nil?
+    a
+  end
+
+  def active_and_current?
+    active? && show_until && show_until >= Date.today
+  end
+
+  def self.create_default_announcement
+    Announcement.create text: 'Announcement',
+                        show_until: Date.today + 14.days,
+                        active: false
+  end
+end

--- a/app/views/announcements/_show.html.erb
+++ b/app/views/announcements/_show.html.erb
@@ -1,0 +1,10 @@
+<% announcement = Announcement.active_and_current %>
+<% if announcement.present? %>
+<div id="announcement">
+  <div class="notification-box -info">
+    <div class="notification-box--content">
+      <%= format_text announcement.text %>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/announcements/edit.html.erb
+++ b/app/views/announcements/edit.html.erb
@@ -1,0 +1,22 @@
+<% html_title t(:label_administration), t(:label_announcement) %>
+
+<%= error_messages_for 'announcement' %>
+
+<%= toolbar title: "#{t(:label_announcement)} (#{notice_annoucement_active})" %>
+
+<%= labelled_tabular_form_for @announcement,
+             :url => {:action => :update},
+             :html => {:method => :put} do |f|%>
+  <div class="form--field">
+    <%= f.text_area :text, :cols => 80, :rows => 5, label: t(:label_text) %>
+  </div>
+  <div class="form--field">
+    <%= f.text_field :show_until, label: t('announcements.show_until') %>
+    <%= calendar_for("announcement_show_until") %>
+  </div>
+  <div class="form--field">
+    <%= f.check_box :active, label: t(:label_active) %>
+  </div>
+  <hr class="form-separator">
+  <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+<% end %>

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -34,6 +34,8 @@ See doc/COPYRIGHT.rdoc for more details.
   </h2>
 </div>
 
+<%= render partial: 'announcements/show' %>
+
 <% if @homescreen[:blocks].any? %>
   <section class="widget-boxes -flex">
   <% @homescreen[:blocks].each do |block| %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -68,11 +68,11 @@ end
 Redmine::MenuManager.map :account_menu do |menu|
   menu.push :administration,
             { controller: '/admin', action: 'projects' },
-            html: { class: 'hidden-for-mobile'},
+            html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.admin? }
   menu.push :my_account,
             { controller: '/my', action: 'account' },
-            html: { class: 'hidden-for-mobile'},
+            html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.logged? }
   menu.push :logout, :signout_path,
             if: Proc.new { User.current.logged? }
@@ -166,6 +166,11 @@ Redmine::MenuManager.map :admin_menu do |menu|
             { controller: '/ldap_auth_sources', action: 'index' },
             html: { class: 'server_authentication icon2 icon-flag' },
             if: proc { !OpenProject::Configuration.disable_password_login? }
+
+  menu.push :announcements,
+            { controller: '/announcements', action: 'edit' },
+            caption: 'Announcement',
+            html: { class: 'icon2 icon-news' }
 
   menu.push :plugins,
             { controller: '/admin', action: 'plugins' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,11 @@ en:
     plugins:
       no_results_title_text: There are currently no plugins available.
 
+  announcements:
+    show_until: Show until
+    is_active: currently displayed
+    is_inactive: currently not displayed
+
   auth_sources:
     index:
       no_results_content_title: There are currently no authentication modes.
@@ -209,6 +214,8 @@ en:
 
   activerecord:
     attributes:
+      announcements:
+        show_until: "Display until"
       attachment:
         downloads: "Downloads"
         file: "File"
@@ -854,6 +861,7 @@ en:
   label_all_time: "all time"
   label_all_words: "All words"
   label_always_visible: "Always displayed"
+  label_announcement: "Announcement"
   label_and_its_subprojects: "%{value} and its subprojects"
   label_api_access_key: "API access key"
   label_api_access_key_created_on: "API access key created %{value} ago"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,6 @@ OpenProject::Application.routes.draw do
       get 'identifier', action: 'identifier'
       patch 'identifier', action: 'update_identifier'
 
-
       match 'copy_project_from_(:coming_from)' => 'copy_projects#copy_project', via: :get, as: :copy_from,
             constraints: { coming_from: /(admin|settings)/ }
       match 'copy_from_(:coming_from)' => 'copy_projects#copy', via: :post, as: :copy,
@@ -288,7 +287,6 @@ OpenProject::Application.routes.draw do
     end
 
     resources :work_packages, only: [] do
-
       collection do
         get '/report/:detail' => 'work_packages/reports#report_details'
         get '/report' => 'work_packages/reports#report'
@@ -357,6 +355,7 @@ OpenProject::Application.routes.draw do
   scope 'admin' do
     match '/projects' => 'admin#projects', via: :get, as: :admin_projects
 
+    resource :announcements, only: [:edit, :update]
     resources :enumerations
 
     resources :groups do

--- a/db/migrate/20121114100641_aggregated_announcements_migrations.rb
+++ b/db/migrate/20121114100641_aggregated_announcements_migrations.rb
@@ -1,0 +1,28 @@
+require Rails.root.join('db', 'migrate', 'migration_utils', 'migration_squasher').to_s
+require 'open_project/plugins/migration_mapping'
+# This migration aggregates the migrations detailed in the MIGRATION_FILES
+class AggregatedAnnouncementsMigrations < ActiveRecord::Migration
+  MIGRATION_FILES = <<-MIGRATIONS
+    001_create_announcements.rb
+    20121114100640_index_on_announcements.rb
+  MIGRATIONS
+
+  OLD_PLUGIN_NAME = 'redmine_announcements'
+
+  def up
+    migration_names = OpenProject::Plugins::MigrationMapping.migration_files_to_migration_names(MIGRATION_FILES, OLD_PLUGIN_NAME)
+    Migration::MigrationSquasher.squash(migration_names) do
+      create_table :announcements do |t|
+        t.text :text
+        t.date :show_until
+        t.boolean :active, default: false
+        t.timestamps
+      end
+      add_index :announcements, [:show_until, :active]
+    end
+  end
+
+  def down
+    drop_table :announcements
+  end
+end

--- a/lib/open_project/hooks.rb
+++ b/lib/open_project/hooks.rb
@@ -34,3 +34,4 @@ end
 
 # actual hooks are added with the following require statemens
 require 'open_project/hooks/view_account_login_auth_provider'
+require 'open_project/hooks/view_account_login_bottom'

--- a/lib/open_project/hooks/view_account_login_bottom.rb
+++ b/lib/open_project/hooks/view_account_login_bottom.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,18 +26,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class HomescreenController < ApplicationController
-  def index
-    @newest_projects = Project.visible.newest.take(3)
-    @newest_users = User.newest.take(3)
-    @news = News.latest(count: 3)
-    @announcement = Announcement.active_and_current
-
-    @homescreen = OpenProject::Homescreen
+module OpenProject
+  module Hooks
+    class ViewAccountLoginBottom < Redmine::Hook::ViewListener
+      render_on :view_account_login_bottom, partial: 'announcements/show'
+    end
   end
-
-  def robots
-    @projects = Project.active.public_projects
-  end
-  caches_action :robots
 end

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe AnnouncementsController, type: :controller do
+  let(:announcement) { FactoryGirl.build :announcement }
+  before do
+    allow(controller).to receive(:check_if_login_required)
+    expect(controller).to receive(:require_admin)
+
+    allow(Announcement).to receive(:only_one).and_return(announcement)
+  end
+
+  describe '#edit' do
+    before do
+      get :edit
+    end
+
+    it do expect(assigns(:announcement)).to eql announcement end
+    it { expect(response).to be_success }
+  end
+
+  describe '#update' do
+    before do
+      expect(announcement).to receive(:save).and_call_original
+      put :update,
+          announcement: {
+            until_date: '2011-01-11',
+            text: 'announcement!!!',
+            active: 1
+          }
+    end
+
+    it 'edits the announcement' do
+      expect(response).to render_template 'edit'
+      expect(controller).to set_flash[:success].to I18n.t(:notice_successful_update)
+    end
+  end
+end

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -80,6 +80,13 @@ describe HomescreenController, type: :controller do
         expect(response).not_to render_template(partial: 'homescreen/blocks/_welcome')
       end
 
+      context 'with enabled announcement' do
+        let!(:announcement) { FactoryGirl.create :active_announcement }
+        it 'renders the announcement' do
+          expect(response).to render_template(partial: 'announcements/_show')
+        end
+      end
+
       context 'with enabled welcome block' do
         before do
           allow(Setting).to receive(:welcome_text).and_return('h1. foobar')

--- a/spec/factories/announcement_factory.rb
+++ b/spec/factories/announcement_factory.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :announcement do
+    text 'Announcement text'
+    show_until Date.today + 14.days
+    active true
+
+    factory :active_announcement do
+      active true
+    end
+
+    factory :inactive_announcement do
+      active false
+    end
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe Announcement, type: :model do
+  it do is_expected.to respond_to :text end
+  it do is_expected.to respond_to :text= end
+  it do is_expected.to respond_to :show_until end
+  it do is_expected.to respond_to :show_until= end
+  it do is_expected.to respond_to :active? end
+  it do is_expected.to respond_to :active= end
+
+  describe 'class methods' do
+    describe '#only_one' do
+      context 'WHEN no announcement exists' do
+        it do expect(Announcement.only_one.text).to eql 'Announcement' end
+        it do expect(Announcement.only_one.show_until).to eql(Date.today + 14.days) end
+        it { expect(Announcement.only_one.active).to eql false }
+      end
+
+      context 'WHEN an announcement exists' do
+        let!(:announcement) { FactoryGirl.create :announcement }
+        it 'returns the true one announcement' do
+          expect(Announcement.only_one).to eql announcement
+        end
+      end
+    end
+
+    describe '#active_and_current' do
+      describe 'WHEN no announcement is active' do
+        let!(:announcement) { FactoryGirl.create(:inactive_announcement) }
+
+        it 'returns no announcement' do
+          expect(Announcement.active_and_current).to be_nil
+        end
+      end
+
+      describe 'WHEN the one announcement is active and today is before show_until' do
+        let!(:announcement) {
+          FactoryGirl.create(:active_announcement, show_until: Date.today + 14.days)
+        }
+
+        it 'returns that announcement' do
+          expect(Announcement.active_and_current).to eql announcement
+        end
+      end
+
+      describe 'WHEN the one announcement is active and today is after show_until' do
+        let!(:announcement) {
+          FactoryGirl.create(:active_announcement, show_until: Date.today - 14.days)
+        }
+
+        it 'returns no announcement' do
+          expect(Announcement.active_and_current).to be_nil
+        end
+      end
+
+      describe 'WHEN the one announcement is active and today equals show_until' do
+        let!(:announcement) {
+          FactoryGirl.create(:active_announcement, show_until: Date.today)
+        }
+        it 'returns that announcement' do
+          expect(Announcement.active_and_current).to eql announcement
+        end
+      end
+    end
+
+    describe 'instance methods' do
+      describe '#active_and_current?' do
+        describe 'WHEN the announcement is not active' do
+          let(:announcement) { FactoryGirl.build(:inactive_announcement) }
+
+          it { expect(announcement.active_and_current?).to be_falsey }
+        end
+
+        describe 'WHEN the announcement is active and today is before show_until' do
+          let(:announcement) {
+            FactoryGirl.build(:active_announcement, show_until: Date.today + 14.days)
+          }
+
+          it { expect(announcement.active_and_current?).to be_truthy }
+        end
+
+        describe 'WHEN the announcement is active and today is after show_until' do
+          let!(:announcement) {
+            FactoryGirl.create(:active_announcement, show_until: Date.today - 14.days)
+          }
+
+          it { expect(announcement.active_and_current?).to be_falsey }
+        end
+
+        describe 'WHEN the announcement is active and today equals show_until' do
+          let!(:announcement) {
+            FactoryGirl.build(:active_announcement, show_until: Date.today)
+          }
+
+          it { expect(announcement.active_and_current?).to be_truthy }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR integrates the announcement functionality of openproject-announcements.

It extends the functionality:
1. It renders the announcement as a notification
2. Renders entered text using `format_text`
3. It also displays the announcement on the homescreen:
   ![bildschirmfoto 2016-04-28 um 15 49 30](https://cloud.githubusercontent.com/assets/459462/14888076/bd8737a4-0d58-11e6-9d70-403066f53c34.png)

https://community.openproject.com/work_packages/22972/activity
