### PR TITLE
[20618] Remove traces from openproject-ui-components

### DIFF
--- a/doc/operation_guides/manual/installation-guide.md
+++ b/doc/operation_guides/manual/installation-guide.md
@@ -475,7 +475,7 @@ If you need to restart the server (for example after a configuration change), do
   We heard that `bower install` can fail, if your server is behind a firewall which does not allow `git://` URLs. The error looks like this:
 
   ```
-  bower openproject-ui_components#with-bower ECMDERR Failed to execute "git ls-remote --tags --heads git://github.com/opf/openproject-ui_components.git", exit code of #128
+  ECMDERR Failed to execute "git ls-remote --tags --heads git://github.com/finnlabs/angular-modal.git", exit code of #128
 
   Additional error details:
   fatal: unable to connect to github.com:

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -128,8 +128,6 @@ module.exports = {
       'angular-context-menu': 'angular-context-menu/dist/angular-context-menu.js',
       'mousetrap': 'mousetrap/mousetrap.js',
       'hyperagent': 'hyperagent/dist/hyperagent',
-      'openproject-ui_components':
-        'openproject-ui_components/app/assets/javascripts/angular/ui-components-app',
       'ngFileUpload': 'ng-file-upload/ng-file-upload'
     }, pluginAliases)
   },


### PR DESCRIPTION
There are still ui_components, however that module has long been integrated into the core by @furinvader.

https://community.openproject.com/work_packages/20618/activity
