### PR TITLE
[23052] Double Breadcrumb in administration

### DIFF
--- a/app/views/auth_sources/edit.html.erb
+++ b/app/views/auth_sources/edit.html.erb
@@ -28,6 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{l(:label_auth_source)} #{@auth_source.name}" %>
+<% local_assigns[:additional_breadcrumb] = @auth_source.name %>
 <%= toolbar title: "#{l(:label_auth_source)} (#{@auth_source.auth_method_name})" %>
 
 <%= labelled_tabular_form_for @auth_source, as: :auth_source do |f| %>

--- a/app/views/auth_sources/new.html.erb
+++ b/app/views/auth_sources/new.html.erb
@@ -28,6 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_auth_source_new) %>
+<% local_assigns[:additional_breadcrumb] = l(:label_auth_source_new) %>
 <%= toolbar title: "#{l(:label_auth_source_new)} (#{@auth_source.auth_method_name})" %>
 
 <%= labelled_tabular_form_for @auth_source, as: :auth_source do |f| %>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -29,8 +29,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{CustomField.model_name.human} #{h @custom_field.name}" %>
 
-<%= breadcrumb_toolbar link_to(l(:label_custom_field_plural), custom_fields_path),
-                       link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+<% local_assigns[:additional_breadcrumb] =  link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+                       @custom_field.name %>
+<%= breadcrumb_toolbar link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        @custom_field.name
 %>
 

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -28,8 +28,9 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_custom_field_new) %>
-<%= breadcrumb_toolbar link_to(l(:label_custom_field_plural), custom_fields_path),
-                       link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+<% local_assigns[:additional_breadcrumb] = link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
+                       l(:label_custom_field_new) %>
+<%= breadcrumb_toolbar link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        l(:label_custom_field_new)
 %>
 

--- a/app/views/enumerations/edit.html.erb
+++ b/app/views/enumerations/edit.html.erb
@@ -28,7 +28,9 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Enumeration.model_name.human} #{h @enumeration.name}" %>
-<%= breadcrumb_toolbar link_to(l(@enumeration.option_name), enumerations_path), @enumeration %>
+
+<% local_assigns[:additional_breadcrumb] =  @enumeration %>
+<%= breadcrumb_toolbar @enumeration %>
 
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/enumerations/new.html.erb
+++ b/app/views/enumerations/new.html.erb
@@ -28,7 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_enumeration_new) %>
-<%= breadcrumb_toolbar link_to(l(@enumeration.option_name), enumerations_path), l(:label_enumeration_new) %>
+<% local_assigns[:additional_breadcrumb] =  l(:label_enumeration_new) %>
+<%= breadcrumb_toolbar l(:label_enumeration_new) %>
 <%= labelled_tabular_form_for @enumeration do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= styled_button_tag l(:button_create), class: '-highlight -with-icon icon-checkmark' %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -28,5 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Group.model_name.human} #{h @group.name}" %>
-<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), @group.name %>
+
+<% local_assigns[:additional_breadcrumb] = @group.name %>
+<%= breadcrumb_toolbar @group.name %>
 <%= render_tabs group_settings_tabs %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -28,7 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l("label_group_new") %>
-<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), l(:label_group_new) %>
+<% local_assigns[:additional_breadcrumb] = l(:label_group_new) %>
+<%= breadcrumb_toolbar l(:label_group_new) %>
 
 <%= labelled_tabular_form_for(@group) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= breadcrumb_toolbar link_to(l(:label_group_plural), groups_path), @group.name %>
+<%= breadcrumb_toolbar @group.name %>
 <ul>
   <% @group.users.each do |user| %>
     <li><%=h user %></li>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -27,8 +27,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% breadcrumb_paths(link_to(l(:label_administration), controller: '/admin'),
-                    default_breadcrumb) %>
+<% local_assigns[:additional_breadcrumb].nil? ? (breadcrumb_paths(link_to(l(:label_administration), controller: '/admin'),
+                     default_breadcrumb)) : (breadcrumb_paths(link_to(l(:label_administration), controller: '/admin'),
+                     default_breadcrumb, local_assigns[:additional_breadcrumb])) %>
 <% @page_header_title = l(:label_administration) %>
 <% content_for :main_menu do %>
   <%= render partial: 'admin/menu' %>

--- a/app/views/planning_element_type_colors/edit.html.erb
+++ b/app/views/planning_element_type_colors/edit.html.erb
@@ -28,6 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{l("timelines.admin_menu.color")} #{h @color.name}" %>
+<% local_assigns[:additional_breadcrumb] = @color.name %>
 
 <%= labelled_tabular_form_for @color,
             url: color_url(@color),

--- a/app/views/planning_element_type_colors/new.html.erb
+++ b/app/views/planning_element_type_colors/new.html.erb
@@ -28,6 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_new)} #{l("timelines.admin_menu.color")}" %>
+<% local_assigns[:additional_breadcrumb] = l(:label_new) + ' ' + l("timelines.admin_menu.color") %>
 
 <%= labelled_tabular_form_for @color,
             url: colors_url,

--- a/app/views/project_types/edit.html.erb
+++ b/app/views/project_types/edit.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{l("timelines.admin_menu.project_type")} #{h @project_type.name}" %>
+<% local_assigns[:additional_breadcrumb] = @project_type.name %>
 <%= toolbar title: "#{l(:label_edit)} #{l("timelines.admin_menu.project_type")} #{@project_type.name}" %>
 <%= labelled_tabular_form_for(@project_type,
              url: project_type_path(@project_type),

--- a/app/views/project_types/new.html.erb
+++ b/app/views/project_types/new.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
 <% html_title l(:label_administration), "#{l(:label_new)} #{l("timelines.admin_menu.project_type")}" %>
+<% local_assigns[:additional_breadcrumb] = l(:label_new) + ' ' + l("timelines.admin_menu.project_type") %>
 <%= toolbar title: l('timelines.new_project_type') %>
 <%= labelled_tabular_form_for(@project_type,
              url: project_types_path,

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -29,7 +29,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Role.model_name.human} #{h @role.name}" %>
 
-<%= breadcrumb_toolbar link_to(l(:label_role_plural), roles_path), @role.name %>
+
+<% local_assigns[:additional_breadcrumb] = @role.name %>
+<%= breadcrumb_toolbar @role.name %>
 
 
 <%= labelled_tabular_form_for @role, html: { id: 'role_form' }, as: :role do |f| %>

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -29,7 +29,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), l("label_group_new") %>
 
-<%= breadcrumb_toolbar link_to(l(:label_role_plural), roles_path), l(:label_role_new) %>
+<% local_assigns[:additional_breadcrumb] = l(:label_role_new) %>
+<%= breadcrumb_toolbar l(:label_role_new) %>
 
 <%= labelled_tabular_form_for @role, html: {id: 'role_form'}, as: :role do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -28,7 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Status.model_name.human} #{h @status.name}" %>
-<%= breadcrumb_toolbar link_to(l(:label_work_package_status_plural), new_status_path), @status.name %>
+<% local_assigns[:additional_breadcrumb] =  @status.name %>
+<%= breadcrumb_toolbar @status.name %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -28,7 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_work_package_status_new) %>
-<%= breadcrumb_toolbar link_to(l(:label_work_package_status_plural), new_status_path), l(:label_work_package_status_new) %>
+<% local_assigns[:additional_breadcrumb] =  l(:label_work_package_status_new) %>
+<%= breadcrumb_toolbar l(:label_work_package_status_new) %>
 
 <%= labelled_tabular_form_for(@status) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -29,7 +29,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title l(:label_administration), "#{l(:label_edit)} #{Type.model_name.human} #{h @type.name}" %>
 
-<%= breadcrumb_toolbar link_to(t(:label_type_plural), types_path), @type.name %>
+
+<% local_assigns[:additional_breadcrumb] = @type.name %>
+<%= breadcrumb_toolbar @type.name %>
 
 <%= form_for @type, builder: TabularFormBuilder, lang: current_language do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/types/new.html.erb
+++ b/app/views/types/new.html.erb
@@ -28,7 +28,10 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_administration), l(:label_type_new) %>
-<%= breadcrumb_toolbar link_to(t(:label_type_plural), types_path), t(:label_type_new) %>
+
+
+<% local_assigns[:additional_breadcrumb] = t(:label_type_new) %>
+<%= breadcrumb_toolbar t(:label_type_new) %>
 
 <%= form_for controller.type, builder: TabularFormBuilder, lang: current_language  do |f| %>
   <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/users/_toolbar.html
+++ b/app/views/users/_toolbar.html
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= breadcrumb_toolbar(link_to(l(:label_user_plural), users_path), @user.new_record? ? l(:label_user_new) : @user.name) do %>
+<%= breadcrumb_toolbar(@user.new_record? ? l(:label_user_new) : @user.name) do %>
   <% unless @user.new_record? %>
     <% if @user.invited? and current_user.admin? %>
       <li class="toolbar-item">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -29,6 +29,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
 <% html_title(l(:label_administration), "#{l(:label_edit)} #{User.model_name.human} #{h(@user.name)}") -%>
+
+<% local_assigns[:additional_breadcrumb] = @user.name %>
 <%= render partial: 'toolbar', locals: { new_user: false } %>
 
 <%= render_tabs user_settings_tabs %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= javascript_include_tag 'new_user' %>
 
 <% html_title l(:label_administration), l("label_user_new") %>
+<% local_assigns[:additional_breadcrumb] = l(:label_user_new) %>
 <%= render partial: 'toolbar', locals: { new_user: true } %>
 <%= labelled_tabular_form_for @user,
                               url: { action: "create" },


### PR DESCRIPTION
This changes toolbar and breadcrumb elements in the admin view. The doubled information was removed.

Plugin PRs:
- https://github.com/finnlabs/openproject-costs/pull/234
- https://github.com/finnlabs/openproject-global_roles/pull/62
- https://github.com/finnlabs/openproject-pdf_export/pull/51

https://community.openproject.com/work_packages/23052/activity
