### PR TITLE
Open last selected work package using details view

### DIFF
--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -30,7 +30,14 @@ angular
   .module('openproject.workPackages.directives')
   .directive('wpTable', wpTable);
 
-function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages, $state){
+function wpTable(
+  WorkPackagesTableService,
+  WorkPackageService,
+  $window,
+  PathHelper,
+  apiWorkPackages,
+  $state
+){
   return {
     restrict: 'E',
     replace: true,
@@ -173,6 +180,11 @@ function wpTable(WorkPackagesTableService, $window, PathHelper, apiWorkPackages,
       }
 
       scope.selectWorkPackage = function(row, $event) {
+        // The current row is the last selected work package
+        // not matter what other rows are (de-)selected below.
+        // Thus save that row for the details view button
+        WorkPackageService.cache().put('preselectedWorkPackageId', row.object.id);
+
         if ($event.target.type != 'checkbox') {
           var currentRowCheckState = row.checked;
           var multipleChecked = mulipleRowsChecked();

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -333,5 +333,19 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
         find('#work-packages--edit-actions-cancel').click
       end
     end
+
+    describe 'opening last selected work package' do
+      before do
+        select_work_package_row(2)
+        check_row_selection_state(2)
+      end
+
+      it do
+        find('#work-packages-details-view-button').click
+
+        expect(page).to have_selector('#work-package-subject', text: work_package_2.subject)
+        find('#work-packages-list-view-button').click
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, the split view button opens the first work package. It should instead open the work package that was selected last.
