### PR TITLE
Use fuubar formatter for non-parallel, non-ci spec runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,8 @@ group :test do
   gem 'rspec-example_disabler', git: 'https://github.com/finnlabs/rspec-example_disabler.git'
   gem 'rspec-legacy_formatters', require: false
   gem 'capybara', '~> 2.6.2'
-  gem 'capybara-screenshot', '~> 1.0.11'
+  gem 'capybara-screenshot', '~> 1.0.12'
+  gem 'fuubar'
   gem 'capybara-select2', github: 'goodwill/capybara-select2'
   gem 'capybara-ng', '~> 0.2.2'
   gem 'selenium-webdriver', '~> 2.52.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       xpath (~> 2.0)
     capybara-ng (0.2.2)
       awesome_print (>= 1.2.0)
-    capybara-screenshot (1.0.11)
+    capybara-screenshot (1.0.13)
       capybara (>= 1.0, < 3)
       launchy
     childprocess (0.5.9)
@@ -264,6 +264,9 @@ GEM
     formatador (0.2.5)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
+    fuubar (2.0.0)
+      rspec (~> 3.0)
+      ruby-progressbar (~> 1.4)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.6)
@@ -319,7 +322,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile2 (2.0.0)
     minisyntax (0.2.5)
     minitest (5.8.4)
@@ -582,7 +585,7 @@ DEPENDENCIES
   bourbon (~> 4.2.0)
   capybara (~> 2.6.2)
   capybara-ng (~> 0.2.2)
-  capybara-screenshot (~> 1.0.11)
+  capybara-screenshot (~> 1.0.12)
   capybara-select2!
   carrierwave!
   cocaine
@@ -602,6 +605,7 @@ DEPENDENCIES
   faker
   fog-aws
   friendly_id (~> 5.1.0)
+  fuubar
   globalize (~> 5.0.1)
   gon (~> 4.0)
   grape (~> 0.10.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,10 @@ RSpec.configure do |config|
   # config.mock_with :rr
   config.mock_with :rspec
 
+  unless ENV['TEST_ENV_NUMBER'] || ENV['CI']
+    config.formatter = Fuubar
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
I suggest that we switch to fuubar as the default rspec formatter when running rspec on its own (no parallel_test or CI).

fuubar is an instafailing formatter for rspec that prints errors as they come.
![bildschirmfoto 2016-04-29 um 08 34 23](https://cloud.githubusercontent.com/assets/459462/14910388/1380e788-0ded-11e6-9dd7-fd6e2c264b3a.png)

Also updates capybara-screenshot for compatibility with fuubar.
