### PR TITLE
Allow global create for split screen

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -38,23 +38,15 @@ function wpResource(
     public schema;
     public id;
 
-    public static fromCreateForm(projectIdentifier?:string):ng.IPromise<WorkPackageResource> {
-      var deferred = $q.defer();
+    public static fromCreateForm(form: op.WorkPackageForm) {
+      var wp = new WorkPackageResource(form.payload.$plain(), true);
 
-      apiWorkPackages.emptyCreateForm(projectIdentifier)
-      .then(resource => {
-        var wp = new WorkPackageResource(resource.payload.$source, true);
+      // Copy resources from form response
+      wp.schema = form.schema;
+      wp.form = $q.when(form);
+      wp.id = 'new-' + Date.now();
 
-        // Copy resources from form response
-        wp.schema = resource.schema;
-        wp.form = $q.when(resource);
-        wp.id = 'new-' + Date.now();
-
-        deferred.resolve(wp);
-      })
-      .catch(deferred.reject);
-
-      return deferred.promise;
+      return wp;
     }
 
     public get isNew():boolean {

--- a/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
+++ b/frontend/app/components/context-menus/types-drop-down-menu/types-drop-down-menu.template.html
@@ -3,7 +3,7 @@
 
   <ul class="dropdown-menu">
     <li ng-repeat="type in vm.types">
-      <a ui-sref="{{ vm.stateName }}({ projectPath: vm.projectIdentifier, type: type.id })"
+      <a ui-sref="{{ vm.stateName }}({ projectPath: vm.firstAvailableProject, type: type.id })"
          class="menu-item">
 
         {{ type.name }}

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -35,7 +35,6 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
   public hidden:boolean = false;
 
   private _wp;
-  private availableProjects = [];
 
   constructor(
     protected $state,
@@ -46,7 +45,7 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     protected WorkPackageResource,
     protected apiWorkPackages
   ) {
-    super($state, I18n, ProjectService);
+    super($state, I18n, ProjectService, apiWorkPackages);
 
     $rootScope.$on('workPackageSaved', (event, savedWp) => {
       if (savedWp === this._wp) {
@@ -59,11 +58,6 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
       this.show();
     });
 
-    this.apiWorkPackages.availableProjects().then(resource => {
-      this.canCreate = (resource && resource.total > 0);
-      this.availableProjects = resource.elements;
-    });
-
     $rootScope.$on('inlineWorkPackageCreateCancelled', (event, index, row) => {
       if (row.object === this._wp) {
         this.rows.splice(index, 1);
@@ -72,28 +66,13 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     });
   }
 
-  public isDisabled() {
-    return !this.canCreate || this.$state.includes('**.new');
-  }
-
-  public get projectIdentifierForCreate() {
-    if (this.inProjectContext) {
-      return this.projectIdentifier;
-    } else {
-      return this.availableProjects[0].identifier;
-    }
-  }
-
   public addWorkPackageRow() {
-    this.WorkPackageResource.fromCreateForm(this.projectIdentifierForCreate).then(wp => {
-      this._wp = wp;
-      wp.inlineCreated = true;
+    this._wp = this.WorkPackageResource.fromCreateForm(this.form);
+    this._wp.inlineCreated = true;
 
-      this.query.applyDefaultsFromFilters(this._wp);
-
-      this.rows.push({level: 0, ancestors: [], object: wp, parent: void 0});
-      this.hide();
-    });
+    this.query.applyDefaultsFromFilters(this._wp);
+    this.rows.push({level: 0, ancestors: [], object: this._wp, parent: void 0});
+    this.hide();
   }
 
   public hide() {

--- a/frontend/app/typings/open-project.typings.ts
+++ b/frontend/app/typings/open-project.typings.ts
@@ -226,6 +226,11 @@ declare namespace op {
     schema:FieldSchema;
   }
 
+  interface WorkPackageForm {
+    payload: op.HalResource;
+    schema: op.HalResource;
+  }
+
   interface WorkPackage extends api.v3.WorkPackage, WorkPackageLinks {
 
     getForm();


### PR DESCRIPTION
This PR enables the global green work package button and selects the first available project.

We can thus:
1. Load the form upon loading the table to make the inline creation faster.
2. Pre-select a project identifier to use for creation (currently the first retrieved from `available_projects`, but we could store that for each user)

**Todos**
- [ ] Actually use global form and show the project attribute.
- [ ] Re-use the form already loaded for the split screen.
