### PR TITLE
Accessibility for inline-create row

### DIFF
--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -41,6 +41,8 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
     protected $state,
     protected $scope,
     protected $rootScope,
+    protected $element,
+    protected FocusHelper,
     protected I18n,
     protected ProjectService,
     protected WorkPackageResource,
@@ -68,6 +70,7 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
       if (row.object === this._wp) {
         this.rows.splice(index, 1);
         this.show();
+        FocusHelper.focusElement(this.$element);
       }
     });
   }

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.directive.html
@@ -5,6 +5,7 @@
           ng-click="$ctrl.addWorkPackageRow()"
           ng-disabled="$ctrl.isDisabled()"
           aria-label="{{ ::$ctrl.text.create }}"
+          data-click-on-keypress="[13, 32]"
           aria-haspopup="true">
 
     <i class="icon icon-add"></i>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -41,6 +41,7 @@ export class WorkPackageEditFieldController {
   protected pristineValue:any;
 
   protected _active:boolean = false;
+  protected _forceFocus:boolean = false;
 
   // Since we load the schema asynchronously
   // all fields are initially viewed as editable until it is loaded
@@ -48,7 +49,10 @@ export class WorkPackageEditFieldController {
 
   constructor(
     protected wpEditField:WorkPackageEditFieldService,
+    protected $scope,
     protected $element,
+    protected $timeout,
+    protected FocusHelper,
     protected NotificationsService,
     protected I18n) {
 
@@ -67,9 +71,9 @@ export class WorkPackageEditFieldController {
       .then(() => this.deactivate());
   }
 
-  public activate(forceFocus = true) {
+  public activate() {
     if (this._active) {
-      this.setFocus(forceFocus);
+      this.focusField();
       return;
     }
 
@@ -86,7 +90,7 @@ export class WorkPackageEditFieldController {
         ));
       }
 
-      this.setFocus(forceFocus);
+      this.focusField();
     });
   }
 
@@ -120,16 +124,17 @@ export class WorkPackageEditFieldController {
   }
 
   public shouldFocus() {
-    return !this.workPackage.isNew || this.formCtrl.firstActiveField === this.fieldName;
+    return this._forceFocus ||
+           !this.workPackage.isNew ||
+           this.formCtrl.firstActiveField === this.fieldName;
   }
 
-  public setFocus(focus = true) {
-    if (focus) {
-      this.$element.find('.wp-inline-edit--field').focus();
-    }
+  public focusField() {
+    this.$timeout(_ => this.$scope.$broadcast('updateFocus'));
   }
 
   public deactivate():boolean {
+    this._forceFocus = false;
     return this._active = false;
   }
 

--- a/frontend/app/components/wp-table/wp-row/wp-row.directive.js
+++ b/frontend/app/components/wp-table/wp-row/wp-row.directive.js
@@ -49,12 +49,6 @@ function wpRow(WorkPackagesTableService){
       scope.workPackage = scope.row.object;
       setCheckboxTitle(scope);
 
-      scope.$watch('row.object.schema.$loaded', function(isLoaded) {
-        if (!isLoaded) {
-          scope.row.object.schema.$load();
-        }
-      });
-
       if (scope.row.parent) setHiddenWorkPackageLabel(scope);
 
       scope.$watch('row.checked', function(checked, formerState) {

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -132,11 +132,12 @@
           </td>
           <td ng-if="row.object.isNew" class="cancel-inline-create -short">
             <span>
-              <a class="wp-table--cancel-create-link"
-                 ng-click="cancelInlineWorkPackage($index, row)">
-                <i class="icon icon-cancel"></i>
-                <span ng-bind="I18n.t('js.button_cancel')"/>
-              </a>
+              <accessible-by-keyboard
+                          execute="cancelInlineWorkPackage($index, row)"
+                          span-class="icon icon-cancel"
+                          link-title="{{ text.cancel }}"
+                          link-class="wp-table--cancel-create-link">
+              </accessible-by-keyboard>
             </span>
           </td>
 

--- a/frontend/app/components/wp-table/wp-table.directive.js
+++ b/frontend/app/components/wp-table/wp-table.directive.js
@@ -228,6 +228,7 @@ function WorkPackagesTableController($scope, $rootScope) {
   $scope.locale = I18n.locale;
 
   $scope.text = {
+    cancel: I18n.t('js.button_cancel'),
     collapse: I18n.t('js.label_collapse'),
     expand: I18n.t('js.label_expand'),
     sumFor: I18n.t('js.label_sum_for'),


### PR DESCRIPTION
1. Allows entering the inline-create mode by keyboard
2. Allows cancelling by x button with keyboard
3. Re-focuses the inline-create button when cancelling creation
