### PR TITLE
eager load models required for available projects index

### DIFF
--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -37,6 +37,8 @@ module API
     module Projects
       class ProjectCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
         element_decorator ::API::V3::Projects::ProjectRepresenter
+
+        self.to_eager_load = ::API::V3::Projects::ProjectRepresenter.to_eager_load
       end
     end
   end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -78,6 +78,8 @@ module API
         def _type
           'Project'
         end
+
+        self.to_eager_load = [:enabled_modules, :project_type]
       end
     end
   end

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -38,7 +38,9 @@ module API
           end
 
           get do
-            available_projects = WorkPackage.allowed_target_projects_on_create(current_user)
+            available_projects = WorkPackage
+                                 .allowed_target_projects_on_create(current_user)
+                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
             self_link = api_v3_paths.available_projects_on_create
             Projects::ProjectCollectionRepresenter.new(available_projects,
                                                        self_link,

--- a/lib/api/v3/work_packages/available_projects_on_edit_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_edit_api.rb
@@ -38,7 +38,9 @@ module API
           end
 
           get do
-            available_projects = WorkPackage.allowed_target_projects_on_move(current_user)
+            available_projects = WorkPackage
+                                 .allowed_target_projects_on_move(current_user)
+                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
             self_link = api_v3_paths.available_projects_on_edit(@work_package.id)
             Projects::ProjectCollectionRepresenter.new(available_projects,
                                                        self_link,


### PR DESCRIPTION
This should speed up available_projects for create as well as for edit by eager loading the models the representer needs.
