### PR TITLE
Inline edit: Fix display of disabled fields.

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -66,7 +66,6 @@
 
 // Editable fields cursor
 .-editable .wp-table--cell-span
-  padding: 0 5px 0 5px
   cursor: text
   border-color: transparent
   border-style: solid
@@ -85,6 +84,7 @@
 
 // Default cursor on non-editable and id fields
 .wp-table--cell-span
+  padding: 0 5px 0 5px
   cursor: not-allowed
 
   &.id

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -116,7 +116,7 @@ export class WorkPackageEditFieldController {
 
   public set editable(enabled:boolean) {
     this._editable = enabled;
-    this.$element.toggleClass('-editable', enabled);
+    this.$element.toggleClass('-editable', !!enabled);
   }
 
   public shouldFocus() {


### PR DESCRIPTION
_Remove padding from editable-only fields_
Otherwise empty _editable_ values are shifted right, while empty
read-only values are not.

_toggleClass requires actual booleans_
`-editable` was not correctly removed when field schema is nonExistant.
