### PR TITLE
[23075][23087] Force selection of values when select is required

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -198,6 +198,7 @@ en:
 
     placeholders:
       default: '-'
+      selection: 'Please select'
 
     text_are_you_sure: "Are you sure?"
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -143,7 +143,7 @@ export class WorkPackageResource extends HalResource {
 
       angular.forEach(schema, (field, name) => {
         if (this[name] && field && field.writable && field.$isHal
-          && Array.isArray(field.allowedValues)) {
+          && (Array.isArray(field.allowedValues) && field.allowedValues.length > 0)) {
 
           this[name] = _.where(field.allowedValues, {name: this[name].name})[0];
         }

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -70,6 +70,12 @@ export class WorkPackageResource extends HalResource {
 
   public requiredValueFor(fieldName):boolean {
     var fieldSchema = this.schema[fieldName];
+
+    // The field schema may be undefined if a custom field
+    // is used as a column, but not available for this type.
+    if (fieldSchema === undefined) {
+      return false;
+    }
     return !this[fieldName] && fieldSchema.writable && fieldSchema.required;
   }
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -258,8 +258,8 @@ export class WorkPackageResource extends HalResource {
 
     // Merged linked properties from form payload
     angular.forEach(plainPayload._links, (_value, key) => {
-      if (this[key] && typeof(schema[key]) === 'object' && schema[key]['writable'] === true) {
-        var value = this[key].href === 'null' ? null : this[key].href;
+      if (typeof(schema[key]) === 'object' && schema[key]['writable'] === true) {
+        var value = this[key] === undefined ? null : this[key].href;
         plainPayload._links[key] = {href: value};
       }
     });

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -6,5 +6,9 @@
         ng-blur="vm.handleUserBlur()"
         focus="vm.shouldFocus()"
         ng-attr-id="{{vm.htmlId}}">
-  <option value="" ng-if="false"></option>
+  <option value=""
+          ng-bind="vm.field.text.requiredPlaceholder"
+          ng-if="vm.field.schema.required"
+          disabled selected>
+  </option>
 </select>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -8,7 +8,7 @@
         ng-attr-id="{{vm.htmlId}}">
   <option value=""
           ng-bind="vm.field.text.requiredPlaceholder"
-          ng-if="vm.field.schema.required"
+          ng-if="vm.field.schema.required && vm.workPackage[vm.fieldName] === undefined"
           ng-selected="!vm.workPackage[vm.fieldName]"
           disabled>
   </option>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -9,6 +9,7 @@
   <option value=""
           ng-bind="vm.field.text.requiredPlaceholder"
           ng-if="vm.field.schema.required"
-          disabled selected>
+          ng-selected="!vm.workPackage[vm.fieldName]"
+          disabled>
   </option>
 </select>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -32,6 +32,7 @@ export class SelectField extends Field {
   public options:any[];
   public placeholder:string = '-';
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html'
+  public text;
 
   constructor(workPackage, fieldName, schema) {
     super(workPackage, fieldName, schema);
@@ -45,13 +46,19 @@ export class SelectField extends Field {
         this.addEmptyOption();
       });
     }
+
+    const I18n = this.$injector.get('I18n');
+    this.text = {
+      requiredPlaceholder: I18n.t('js.placeholders.selection'),
+      placeholder: I18n.t('js.placeholders.default')
+    }
   }
 
   private addEmptyOption() {
     if (!this.schema.required) {
       this.options.unshift({
         href: "null",
-        name: this.placeholder,
+        name: this.text.placeholder,
       });
     }
   }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -37,7 +37,7 @@ export class SelectField extends Field {
   constructor(workPackage, fieldName, schema) {
     super(workPackage, fieldName, schema);
 
-    const I18n = this.$injector.get('I18n');
+    const I18n:any = this.$injector.get('I18n');
     this.text = {
       requiredPlaceholder: I18n.t('js.placeholders.selection'),
       placeholder: I18n.t('js.placeholders.default')

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -37,6 +37,12 @@ export class SelectField extends Field {
   constructor(workPackage, fieldName, schema) {
     super(workPackage, fieldName, schema);
 
+    const I18n = this.$injector.get('I18n');
+    this.text = {
+      requiredPlaceholder: I18n.t('js.placeholders.selection'),
+      placeholder: I18n.t('js.placeholders.default')
+    };
+
     if (angular.isArray(this.schema.allowedValues)) {
       this.options = angular.copy(this.schema.allowedValues);
       this.addEmptyOption();
@@ -46,18 +52,11 @@ export class SelectField extends Field {
         this.addEmptyOption();
       });
     }
-
-    const I18n = this.$injector.get('I18n');
-    this.text = {
-      requiredPlaceholder: I18n.t('js.placeholders.selection'),
-      placeholder: I18n.t('js.placeholders.default')
-    }
   }
 
   private addEmptyOption() {
     if (!this.schema.required) {
       this.options.unshift({
-        href: "null",
         name: this.text.placeholder,
       });
     }

--- a/spec/features/work_packages/table/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/create_work_packages_spec.rb
@@ -1,16 +1,34 @@
 require 'spec_helper'
 
 describe 'inline create work package', js: true do
-  let(:type) { FactoryGirl.create(:type_with_workflow) }
+  let(:type) { FactoryGirl.create(:type) }
   let(:types) { [type] }
 
-  let(:user) { FactoryGirl.create :admin }
+  let(:role) do
+    FactoryGirl.create :role,
+                       permissions: [:view_work_packages,
+                                     :add_work_packages]
+  end
+  let(:user) do
+    FactoryGirl.create :user,
+                       member_in_project: project,
+                       member_through_role: role
+  end
+  let(:status) { FactoryGirl.create(:default_status) }
+  let(:workflow) do
+    FactoryGirl.create :workflow,
+                       type_id: type.id,
+                       old_status: status,
+                       new_status: FactoryGirl.create(:status),
+                       role: role
+  end
 
   let!(:project) { FactoryGirl.create(:project, is_public: true, types: types) }
   let!(:existing_wp) { FactoryGirl.create(:work_package, project: project) }
   let!(:priority) { FactoryGirl.create :priority, is_default: true }
 
   before do
+    workflow
     login_as user
   end
 

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -5,6 +5,7 @@ class WorkPackageField
   attr_reader :element,
               :selector,
               :property_name
+  attr_accessor :field_type
 
   def initialize(context,
                  property_name,

--- a/spec/support/work_packages/work_package_text_area_field.rb
+++ b/spec/support/work_packages/work_package_text_area_field.rb
@@ -1,3 +1,4 @@
+require 'support/work_packages/work_package_field'
 class WorkPackageTextAreaField < WorkPackageField
 
   attr_reader :trigger


### PR DESCRIPTION
This changes the disabled default option for required select fields to select that by default and disable it.
This causes a required field to have a default selection of `Please select` similar to the Rails selects.

![bildschirmfoto 2016-05-04 um 08 31 16](https://cloud.githubusercontent.com/assets/459462/15006617/ac029fcc-11d2-11e6-89f2-7b12adbe4e90.png)

![bildschirmfoto 2016-05-04 um 08 31 21](https://cloud.githubusercontent.com/assets/459462/15006616/aa95f12a-11d2-11e6-8888-ad8f9a6c3f16.png)

https://community.openproject.com/work_packages/23075/activity

---

Angular doesn't seem to respect the string 'null' option correctly when
removing an assigned field.

Instead, the model is set to undefined and we need to check for that.

https://community.openproject.com/work_packages/23087/activity
