### PR TITLE
[23052] Double Breadcrumb in administration (2)

### DIFF
--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -31,8 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% local_assigns[:additional_breadcrumb] =  link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        @custom_field.name %>
-<%= breadcrumb_toolbar link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
-                       @custom_field.name
+<%= breadcrumb_toolbar @custom_field.name
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -30,8 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title l(:label_administration), l(:label_custom_field_new) %>
 <% local_assigns[:additional_breadcrumb] = link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        l(:label_custom_field_new) %>
-<%= breadcrumb_toolbar link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
-                       l(:label_custom_field_new)
+<%= breadcrumb_toolbar l(:label_custom_field_new)
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,


### PR DESCRIPTION
This removes the hierarchy information from the toolbar in admin/custom fields. 

https://community.openproject.com/work_packages/23052/activity
