### PR TITLE
[23046] Missing required icon (asterisk) for custom fields

### DIFF
--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -30,6 +30,7 @@
 require 'action_view/helpers/form_helper'
 
 class CustomFieldFormBuilder < TabularFormBuilder
+  include ActionView::Context
   # Return custom field html tag corresponding to its format
   def custom_field(options = {})
     input = custom_field_input(options)
@@ -99,15 +100,22 @@ class CustomFieldFormBuilder < TabularFormBuilder
   # Return custom field label tag
   def custom_field_label_tag
     custom_value = object
+    is_required = object.custom_field.is_required?
 
     classes = 'form--label'
     classes << ' error' unless custom_value.errors.empty?
+    classes << ' -required'if is_required
 
     content_tag 'label',
-                custom_value.custom_field.name,
                 for: custom_field_field_id,
                 class: classes,
                 title: custom_value.custom_field.name,
-                lang: custom_value.custom_field.name_locale
+                lang: custom_value.custom_field.name_locale do
+                  content_tag('span', custom_value.custom_field.name) +
+                  (content_tag('span',
+                             '*',
+                             class: 'form--label-required',
+                             :'aria-hidden' => true) if is_required)
+    end
   end
 end


### PR DESCRIPTION
This adds an additional span with an asterix to required custom fields.

https://community.openproject.com/work_packages/23046/activity
