### PR TITLE
Set embedded schema link to null when embedded

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -144,9 +144,8 @@ function halResource($q, _, lazy, halTransform, HalLink) {
                 if (val && val.$isHal) {
                   this.$source._links[linkName] = val.$links.self.$link;
                 }
-
-                return val;
               }
+              return val;
             }
           })
       });

--- a/frontend/app/components/api/api-v3/hal-transform/hal-transform.service.ts
+++ b/frontend/app/components/api/api-v3/hal-transform/hal-transform.service.ts
@@ -30,11 +30,16 @@ function halTransform(halTransformTypes) {
   return (element:op.ApiResult) => {
     const resourceClass = halTransformTypes[element._type] || halTransformTypes.default;
 
-    if (element._embedded || element._links) {
-      return new resourceClass(element);
+    if (!(element._embedded || element._links)) {
+      return element;
     }
 
-    return element;
+    // Add explicit null self link as per HAL recommendation.
+    if (element._links && element._links.self === undefined) {
+      element._links.self = { href: null };
+    }
+
+    return new resourceClass(element);
   };
 }
 


### PR DESCRIPTION
The hal-resource setter expects a $self link at all times in order to
accept a link.

Since we employ the embedded schema in the form resource to replace the
work package specific schema resource, it requires a resource link.

This commit suggests to extend the hal-transform service to set an explicit null link to a resource when none is given, but the element should be transformed.

/cc @ulferts , @furinvader 
