### PR TITLE
Fix reference to children links that are no HAL links

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -156,7 +156,8 @@ function wpResource(
     }
 
     public get isLeaf():boolean {
-      return !(this as any).children;
+      var children = this.$links.children;
+      return !(children && children.length > 0);
     }
 
     public isParentOf(otherWorkPackage) {


### PR DESCRIPTION
Children links were lost in the halTransform due to the non-hal structure of `children` in the links, thus we cannot reliably access it in an accessor.

https://community.openproject.com/work_packages/23085/activity
