### PR TITLE
Fix/invalid date entry

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
@@ -55,7 +55,15 @@ function errorResource(HalResource:typeof op.HalResource, NotificationsService:a
     }
 
     public getInvolvedColumns():string[] {
-      var columns = this.details ? [{ details: this.details }] : this.errors;
+      var columns = [];
+
+      if (this.details) {
+        columns = [{ details: this.details }]
+      }
+      else if (this.errors) {
+        columns = this.errors;
+      }
+
       return columns.map(field => field.details.attribute);
     }
   }

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -103,6 +103,27 @@ function wpResource(
       return this.form;
     }
 
+    public updateForm(payload) {
+      // Always resolve form to the latest form
+      // This way, we won't have to actively reset it.
+      // But store the existing form in case of an error.
+      // Because if we get an error, the object returned is not a form
+      // and thus lacks the links the implementation dependes upon.
+      var oldForm = this.form
+      this.form = this.$links.update(payload);
+
+      var deferred = $q.defer();
+
+      this.form
+        .then(deferred.resolve)
+        .catch(error => {
+          this.form = oldForm;
+          deferred.reject(error);
+        });
+
+      return deferred.promise;
+    }
+
     public getSchema() {
       return this.getForm().then(form => {
         const schema = form.$embedded.schema;
@@ -120,25 +141,10 @@ function wpResource(
     }
 
     public save() {
-      const plain = this.$plain();
-
-      delete plain.createdAt;
-      delete plain.updatedAt;
-
       var deferred = $q.defer();
 
-      // Always resolve form to the latest form
-      // This way, we won't have to actively reset it.
-      this.form = this.$links.update(this.$source);
-
-      this.form
-        .catch(deferred.reject)
+      this.updateForm(this.$source)
         .then(form => {
-          if (form === undefined) {
-            deferred.reject;
-            return;
-          }
-
           // Override the current schema with
           // the changes from API
           this.schema = form.$embedded.schema;
@@ -154,7 +160,8 @@ function wpResource(
             }).catch((error) => {
               deferred.reject(error);
             });
-        });
+        })
+        .catch(deferred.reject);
 
       return deferred.promise;
     }

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -134,6 +134,10 @@ function wpResource(
       this.form
         .catch(deferred.reject)
         .then(form => {
+          if (form === undefined) {
+            deferred.reject;
+            return;
+          }
 
           // Override the current schema with
           // the changes from API

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -102,6 +102,8 @@ export class WorkPackageEditFormController {
   }
 
   private handleErrorenousColumns(columns:string[]) {
+    return if (columns.length === 0);
+
     var selected = this.QueryService.getSelectedColumnNames();
     var active = _.find(this.fields, (f:any) => f.active);
     columns.reverse().map(name => {


### PR DESCRIPTION
Allows to correct errors made when data of an invalid format is inserted to one of the WP inline edit fields, e.g. when 'aaaaa' is inserted for 'start date'.

Before the fix, the promise calling 'POST work_packages/:id/form' was assigned to the work package resource. But in case of an error, the result of the promise is an error and not a form. As we do rely on the links present in the form, we need to ensure that we always have a form where we expect it.

The PR also fixes a couple of errors in the js console when invalid information is added which are caused by the API not specifying the invalid column. While the PR increases the robustness of the front end, it does not improve the API.

https://community.openproject.com/work_packages/23077/activity
