### PR TITLE
[23092] Reset cached custom values when switching project, not only type

### DIFF
--- a/app/services/move_work_package_service.rb
+++ b/app/services/move_work_package_service.rb
@@ -49,6 +49,9 @@ class MoveWorkPackageService
 
     move_to_type(modified_work_package, new_type)
 
+    # Reset cached custom values after project/type change
+    modified_work_package.reset_custom_values!
+
     bulk_assign_attributes(modified_work_package, attributes)
 
     modified_work_package
@@ -101,7 +104,6 @@ class MoveWorkPackageService
   def move_to_type(work_package, new_type)
     if new_type
       work_package.type = new_type
-      work_package.reset_custom_values!
     end
   end
 

--- a/spec/services/move_work_package_service_spec.rb
+++ b/spec/services/move_work_package_service_spec.rb
@@ -325,6 +325,30 @@ describe MoveWorkPackageService, type: :model do
           it { is_expected.to be_nil }
         end
 
+        context 'required custom field in the target project' do
+          let(:custom_field) {
+            FactoryGirl.create(
+              :work_package_custom_field,
+              field_format:    'text',
+              is_required:     true,
+              is_for_all:      false
+            )
+          }
+          let!(:target_type) { FactoryGirl.create(:type, custom_fields: [custom_field]) }
+          let!(:target_project) {
+            FactoryGirl.create(
+              :project,
+              types: [target_type],
+              work_package_custom_fields: [custom_field]
+            )
+          }
+          it 'does not copy the work package' do
+            mock_allowed_to_move_to_project(target_project)
+            result = instance.call(target_project, target_type, copy: true)
+            expect(result).to be_falsey
+          end
+        end
+
         describe '#attributes' do
           let(:copy) {
             mock_allowed_to_move_to_project(target_project)


### PR DESCRIPTION
When moving/copying to a project or type with different custom_values,
the accessor in the work package has to be reset.

Otherwise, the first save will be successful, only to fail at the second
attempt (e.g., when trying to create a journal note).

https://community.openproject.com/work_packages/23092/activity
