### PR TITLE
add ability to activate inline edit fields via keyboard

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -90,6 +90,12 @@ export class WorkPackageEditFieldController {
     });
   }
 
+  public activateIfEditable() {
+    if (this.isEditable) {
+      this.activate();
+    }
+  }
+
   public initializeField() {
     // Activate field when creating a work package
     // and the schema requires this field
@@ -171,14 +177,6 @@ function wpEditFieldLink(
     if (event.keyCode === 27) {
       scope.$evalAsync(_ => scope.vm.reset());
     }
-  });
-
-  // Find inline edit cells to handle click on
-  element.find('.wp-table--cell-span').click(event => {
-    if (scope.vm.isEditable) {
-      scope.vm.activate();
-    }
-    event.stopImmediatePropagation();
   });
 }
 

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -98,7 +98,7 @@
             trigger-on-event="contextmenu"
             target="WorkPackageContextMenu"
             locals="rows,row,$index"
-            after-focus-on=".id :focusable"
+            after-focus-on=".id :tabbable"
             single-click="!row.object.isNew && selectWorkPackage(row, $event)"
             ng-dblclick="!row.object.isNew && openWorkPackageInFullView(row)"
             ng-class="[

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.html
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.html
@@ -1,19 +1,24 @@
-<span class="wp-table--cell-span"
-      ng-switch="vm.displayType"
-      wp-field="vm.workPackage"
-      field-name="vm.attribute">
-  <progress-bar ng-switch-when="Percent"
-                progress="vm.displayText"
-                width="80px">
-  </progress-bar>
+<span>
+  <span class="wp-table--cell-span"
+        ng-switch="vm.displayType"
+        wp-field="vm.workPackage"
+        field-name="vm.attribute"
+        ng-click="vm.activateIfEditable($event)"
+        data-click-on-keypress="[13, 32]"
+        tabindex="0">
+    <progress-bar ng-switch-when="Percent"
+                  progress="vm.displayText"
+                  width="80px">
+    </progress-bar>
 
-  <span ng-switch-when="SelfLink" title="{{ vm.displayText }}">
-    <a ng-href="{{ vm.displayLink }}">{{ vm.displayText }}</a>
-  </span>
+    <span ng-switch-when="SelfLink" title="{{ vm.displayText }}">
+      <a ng-href="{{ vm.displayLink }}">{{ vm.displayText }}</a>
+    </span>
 
-  <span ng-switch-default
-    title="{{ vm.displayText }}"
-    ng-class="{ 'work-package--placeholder' : vm.displayText == '-' }">
-    {{ vm.displayText }}
+    <span ng-switch-default
+      title="{{ vm.displayText }}"
+      ng-class="{ 'work-package--placeholder' : vm.displayText == '-' }">
+      {{ vm.displayText }}
+    </span>
   </span>
 </span>

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.html
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.html
@@ -5,7 +5,7 @@
         field-name="vm.attribute"
         ng-click="vm.activateIfEditable($event)"
         data-click-on-keypress="[13, 32]"
-        tabindex="0">
+        ng-attr-tabindex="{{vm.isEditable() ? '0' : '-1'}}">
     <progress-bar ng-switch-when="Percent"
                   progress="vm.displayText"
                   width="80px">

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.js
@@ -105,6 +105,10 @@ function WorkPackageTdController($scope, I18n, PathHelper, WorkPackagesHelper) {
 
       event.stopImmediatePropagation();
     };
+
+    vm.isEditable = function() {
+      return vm.wpEditField && vm.wpEditField._editable;
+    };
   }
 
   $scope.$watch('vm.object.' + vm.attribute, updateAttribute);

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.js
@@ -42,7 +42,7 @@ function wpTd(){
       attribute: '='
     },
 
-    require: ['^wpEditField'],
+    require: ['^?wpEditField'],
     link: wpTdLink,
 
     bindToController: true,

--- a/frontend/app/components/wp-table/wp-td/wp-td.directive.js
+++ b/frontend/app/components/wp-table/wp-td/wp-td.directive.js
@@ -42,10 +42,22 @@ function wpTd(){
       attribute: '='
     },
 
+    require: ['^wpEditField'],
+    link: wpTdLink,
+
     bindToController: true,
     controller: WorkPackageTdController,
     controllerAs: 'vm'
   };
+}
+
+function wpTdLink(
+  scope,
+  element,
+  attr,
+  controllers) {
+
+  scope.vm.wpEditField = controllers[0];
 }
 
 function WorkPackageTdController($scope, I18n, PathHelper, WorkPackagesHelper) {
@@ -87,6 +99,12 @@ function WorkPackageTdController($scope, I18n, PathHelper, WorkPackagesHelper) {
 
       vm.displayText = WorkPackagesHelper.formatValue(text, vm.displayType);
     });
+
+    vm.activateIfEditable = function(event) {
+      vm.wpEditField.activateIfEditable();
+
+      event.stopImmediatePropagation();
+    };
   }
 
   $scope.$watch('vm.object.' + vm.attribute, updateAttribute);

--- a/frontend/app/services/keyboard-shortcut-service.js
+++ b/frontend/app/services/keyboard-shortcut-service.js
@@ -128,7 +128,7 @@ module.exports = function($window, $rootScope, $timeout, PathHelper) {
     focusElements = [];
     domLists = angular.element(accessibleListSelector);
     domLists.find('tbody tr').each(function(index, tr){
-      var firstLink = angular.element(tr).find(':visible:focusable:not(.toggle-all, input)')[0];
+      var firstLink = angular.element(tr).find(':visible:tabbable:not(.toggle-all, input)')[0];
       if ( firstLink !== undefined ) { focusElements.push(firstLink); }
     });
     return focusElements;
@@ -142,7 +142,7 @@ module.exports = function($window, $rootScope, $timeout, PathHelper) {
       angular
         .element(document.activeElement)
         .parents(accessibleRowSelector)
-        .find(':visible:focusable:not(input)')[0]
+        .find(':visible:tabbable:not(input)')[0]
     );
     angular.element(list[(index+offset+list.length) % list.length]).focus();
   }


### PR DESCRIPTION
Allows tabbing on the inline edit field.

https://community.openproject.com/work_packages/23076/activity

I feel that one scenario is still not supported the way it should be. If the user presses the "ESC" key while being in an inline edit input, the input disappears and the text representation is displayed as desired. But the focus is not placed on the text so it becomes hard to reactivate the field as the user has to start the tabbing journey anew. 

I couldn't get this to work as the field can only be focused after it reappears.  
