### PR TITLE
[20421][Accessibility] Sorting arrows are not pronounced by screen reader (2)

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -277,6 +277,8 @@ en:
         one: "You can only select one item"
         other: "You can only select {{limit}} items"
         zero: "You cannot select any items"
+
+    text_hint_wp_table: "With the links in the table headers you can sort, group, reorder, remove and add table columns."
     text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
     text_query_destroy_confirmation: "Are you sure you want to delete the selected query?"
     text_attachment_destroy_confirmation: "Are you sure you want to delete the attachment?"

--- a/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.html
@@ -1,5 +1,5 @@
 <div class="generic-table--sort-header-outer">
-  <span title="{{ fullTitle }}" class="generic-table--sort-header">
+  <span class="generic-table--sort-header">
     <a href="javascript://"
        ng-if="sortable"
        ng-class="[currentSortDirection && 'sort', currentSortDirection]"

--- a/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.js
+++ b/frontend/app/components/wp-table/directives/sort-header/sort-header.directive.js
@@ -53,19 +53,18 @@ function sortHeader(){
           scope.currentSortDirection = latestSortElement.direction;
         }
 
-        setFullTitle();
+        setFullTitleAndSummary();
       }, true);
 
       scope.$watch('currentSortDirection', setActiveColumnClass);
 
-      function setFullTitle() {
-        if(!scope.sortable) scope.fullTitle = '';
+      function setFullTitleAndSummary() {
+        scope.fullTitle = scope.headerTitle;
 
         if(scope.currentSortDirection) {
           var sortDirectionText = (scope.currentSortDirection == 'asc') ? I18n.t('js.label_ascending') : I18n.t('js.label_descending');
-          scope.fullTitle = sortDirectionText + " " + I18n.t('js.label_sorted_by') + ' \"' + scope.headerTitle + '\"';
-        } else {
-          scope.fullTitle = I18n.t('js.label_open_menu') + ' \"' + scope.headerTitle + '\"';
+          var summaryContent = I18n.t('js.label_work_package_plural') + " " + sortDirectionText + " " + I18n.t('js.label_sorted_by') + " " + scope.headerTitle + '. ' + I18n.t('js.text_hint_wp_table');
+          jQuery('#wp-table-summary').text(summaryContent);
         }
       }
 

--- a/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/directives/wp-table/wp-table.directive.html
@@ -6,6 +6,8 @@
         <col highlight-col />
         <col highlight-col ng-repeat="column in columns" />
       </colgroup>
+      <caption id="wp-table-summary" class="hidden-for-sighted">
+      </caption>
       <thead>
         <tr>
           <th class="checkbox -short hide-when-print">
@@ -15,7 +17,7 @@
                  class="no-decoration-on-hover"
                  ng-click="setCheckedStateForAllRows(!(rows | allRowsChecked))"
                  title="{{ text.toggleRows }}">
-                
+
                 <icon-wrapper icon-title="{{ text.toggleRows }}"
                               icon-name="checkmark"></icon-wrapper>
               </a>

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -108,27 +108,21 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
     shared_examples_for 'sort column' do
       it do
         expect(page).to have_selector(column_header_selector)
-        expect(find(column_header_selector + ' span.generic-table--sort-header')[:title]).to eq(sort_text)
       end
     end
 
     shared_examples_for 'unsorted column' do
-      let(:sort_text) { I18n.t(:label_open_menu) + " \"#{link_caption}\"" }
-
       it_behaves_like 'sort column'
     end
 
     shared_examples_for 'ascending sorted column' do
-      let(:sort_text) { "#{I18n.t(:label_ascending)} #{I18n.t(:label_sorted_by, value: "\"#{link_caption}\"")}" }
-
       it_behaves_like 'sort column'
     end
 
     shared_examples_for 'descending sorted column' do
-      let(:sort_text) { "#{I18n.t(:label_descending)} #{I18n.t(:label_sorted_by, value: "\"#{link_caption}\"")}" }
-
       it_behaves_like 'sort column'
     end
+
 
     shared_examples_for 'sortable column' do
       before do expect(page).to have_selector(column_header_selector) end


### PR DESCRIPTION
This adds a `summary` to the wp table including the sorting order.

https://community.openproject.com/work_packages/20421/activity
