### PR TITLE
place the registered project activities where they will not be unloaded

### DIFF
--- a/config/constants/project_activity.rb
+++ b/config/constants/project_activity.rb
@@ -1,0 +1,44 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Constants
+  module ProjectActivity
+    class << self
+      def register(on:, chain: [], attribute:)
+        @registered ||= []
+
+        @registered << { on: on,
+                         chain: chain,
+                         attribute: attribute }
+      end
+
+      attr_reader :registered
+    end
+  end
+end


### PR DESCRIPTION
Fixes problem of loosing the registered project activity joins upon constant reloading in development.

The config/ path is not registered in the autoload_path. Hence, putting values in variables placed there, will survive the constant reloading in the dev environment.

I am not sure if the config/constants directory is the best place to persists such information but I didn't want to add another top level directory.

We should probably move more code into places that does not get reloaded. E.g. the textile capability of OP comes to mind.
