### PR TITLE
[23052] Remove indentation for correct alignment

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -657,3 +657,7 @@ a.impaired--empty-link,
   min-height: 6rem
   div.grid-block
     overflow: visible
+
+.edit_type
+  .grid-content:first-of-type
+    padding-left: 0


### PR DESCRIPTION
This removes the indentation of `grid-content` class in Admin/WP-Types. Thus the content is correctly aligned with the toolbar above.

https://community.openproject.com/work_packages/23052/activity
