### PR TITLE
Use Warden::Test::Helpers for session access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,7 +151,6 @@ group :test do
   gem 'factory_girl_rails', '~> 4.5', require: false
 
   gem 'cucumber-rails', '~> 1.4.2', require: false
-  gem 'rack_session_access'
   gem 'database_cleaner', '~> 1.4.1'
   gem 'rspec', '~> 3.3.0'
   # also add to development group, so "spec" rake task gets loaded

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,9 +392,6 @@ GEM
       rack (>= 1.0.0)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack_session_access (0.1.1)
-      builder (>= 2.0.0)
-      rack (>= 1.0.0)
     rails (4.2.5.1)
       actionmailer (= 4.2.5.1)
       actionpack (= 4.2.5.1)
@@ -646,7 +643,6 @@ DEPENDENCIES
   rack-attack
   rack-protection!
   rack-test (~> 0.6.2)
-  rack_session_access
   rails (~> 4.2.5)
   rails-observers
   rails_12factor

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,9 +30,6 @@
 OpenProject::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Access to rack session
-  config.middleware.use RackSessionAccess::Middleware
-
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/features/step_definitions/work_package_steps.rb
+++ b/features/step_definitions/work_package_steps.rb
@@ -27,8 +27,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'rack_session_access/capybara'
-
 InstanceFinder.register(WorkPackage, Proc.new { |name| WorkPackage.find_by(subject: name) })
 RouteMap.register(WorkPackage, '/work_packages')
 
@@ -53,7 +51,7 @@ end
 
 Given /^user is already watching "(.*?)"$/  do |work_package_subject|
   work_package = WorkPackage.find_by(subject: work_package_subject)
-  user = User.find(page.get_rack_session['user_id'])
+  user = User.current
 
   work_package.add_watcher user
 end

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -31,7 +31,7 @@ require 'features/projects/projects_page'
 
 describe 'user deletion: ', type: :feature, js: true do
   before do
-    page.set_rack_session(user_id: current_user.id)
+    login_as(curent_user)
   end
 
   context 'regular user' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -171,11 +171,6 @@ Rails.application.config.plugins_to_test_paths.each do |dir|
   end
 end
 
-require 'rack_session_access/capybara'
-Rails.application.config do
-  config.middleware.use RackSessionAccess::Middleware
-end
-
 module OpenProject::RspecCleanup
   def self.cleanup
     # Cleanup after specs changing locale explicitly or

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -26,16 +26,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'rack_session_access/capybara'
-
 module AuthenticationHelpers
+  include Warden::Test::Helpers
+
   def login_as(user)
     if is_a? RSpec::Rails::FeatureExampleGroup
       # If we want to mock having finished the login process
       # we must set the user_id in rack.session accordingly
       # Otherwise e.g. calls to Warden will behave unexpectantly
       # as they will login AnonymousUser
-      page.set_rack_session(user_id: user.id)
+      Warden.on_next_request do |proxy|
+        proxy.raw_session[:user_id] = user.id
+      end
     end
 
     allow(User).to receive(:current).and_return(user)


### PR DESCRIPTION
We may be able to use the proxy session of the warden test helper to 'login' a user
through the session hash instead of going through two full requests when
using RackSessionAccess.

This appears to work for feature specs, not sure about cucumber, but we shall see.
