### PR TITLE
Fix/no text cf columns

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -230,10 +230,14 @@ class Query < ActiveRecord::Base
                             project.all_work_package_custom_fields :
                             WorkPackageCustomField.all
                           ).map { |cf| ::QueryCustomFieldColumn.new(cf) }
+
     if WorkPackage.done_ratio_disabled?
       @available_columns.select! { |column| column.name != :done_ratio }
     end
-    @available_columns
+
+    # have to use this instead of
+    # #select! as #select! can return nil
+    @available_columns = @available_columns.select(&:available?)
   end
 
   def self.available_columns=(v)

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -226,14 +226,11 @@ class Query < ActiveRecord::Base
   def available_columns
     return @available_columns if @available_columns
     @available_columns = ::Query.available_columns
-    @available_columns += (project ?
-                            project.all_work_package_custom_fields :
+    @available_columns += if project
+                            project.all_work_package_custom_fields
+                          else
                             WorkPackageCustomField.all
-                          ).map { |cf| ::QueryCustomFieldColumn.new(cf) }
-
-    if WorkPackage.done_ratio_disabled?
-      @available_columns.select! { |column| column.name != :done_ratio }
-    end
+                          end.map { |cf| ::QueryCustomFieldColumn.new(cf) }
 
     # have to use this instead of
     # #select! as #select! can return nil

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -40,14 +40,18 @@ class QueryColumn
 
   def initialize(name, options = {})
     self.name = name
-    self.sortable = options[:sortable]
-    self.groupable = options[:groupable]
-    self.summable = options[:summable]
+
+    %i(sortable
+       groupable
+       summable
+       default_order).each do |attribute|
+      send("#{attribute}=", options[attribute])
+    end
+
     self.available = options.fetch(:available, true)
 
     self.join = options.delete(:join)
 
-    self.default_order = options[:default_order]
     @caption_key = options[:caption] || name.to_s
   end
 

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -81,6 +81,14 @@ class QueryColumn
     available
   end
 
+  def available
+    if name == :done_ratio
+      !WorkPackage.done_ratio_disabled?
+    else
+      @available
+    end
+  end
+
   def sum_of(work_packages)
     if work_packages.is_a?(Array)
       # TODO: Sums::grouped_sums might call through here without an AR::Relation

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -28,7 +28,13 @@
 #++
 
 class QueryColumn
-  attr_accessor :name, :sortable, :groupable, :summable, :join, :default_order
+  attr_accessor :name,
+                :sortable,
+                :groupable,
+                :summable,
+                :available,
+                :join,
+                :default_order
   alias_method :summable?, :summable
   include Redmine::I18n
 
@@ -37,6 +43,7 @@ class QueryColumn
     self.sortable = options[:sortable]
     self.groupable = options[:groupable]
     self.summable = options[:summable]
+    self.available = options.fetch(:available, true)
 
     self.join = options.delete(:join)
 
@@ -68,6 +75,10 @@ class QueryColumn
 
   def value(issue)
     issue.send name
+  end
+
+  def available?
+    available
   end
 
   def sum_of(work_packages)

--- a/app/models/query_custom_field_column.rb
+++ b/app/models/query_custom_field_column.rb
@@ -29,6 +29,7 @@
 
 class QueryCustomFieldColumn < QueryColumn
   def initialize(custom_field)
+    super
     self.name = "cf_#{custom_field.id}".to_sym
     self.sortable = custom_field.order_statements || false
     if %w(list date bool int).include?(custom_field.field_format)
@@ -36,6 +37,7 @@ class QueryCustomFieldColumn < QueryColumn
     end
     self.groupable ||= false
     self.summable = %w(float int).include?(custom_field.field_format)
+    self.available = custom_field.field_format != 'text'
 
     @cf = custom_field
   end

--- a/spec/models/query_column_spec.rb
+++ b/spec/models/query_column_spec.rb
@@ -33,4 +33,18 @@ describe ::QueryColumn, type: :model do
   let(:instance) { QueryColumn.new(:query_column) }
 
   it_behaves_like 'query column'
+
+  describe '#available?' do
+    context ':done_ratio column' do
+      let(:instance) { QueryColumn.new(:done_ratio) }
+
+      it 'is not available if the setting disables it' do
+        allow(WorkPackage)
+          .to receive(:done_ratio_disabled?)
+          .and_return(true)
+
+        expect(instance).to_not be_available
+      end
+    end
+  end
 end

--- a/spec/models/query_custom_field_column_spec.rb
+++ b/spec/models/query_custom_field_column_spec.rb
@@ -29,8 +29,25 @@
 require 'spec_helper'
 require_relative 'shared_query_column_specs'
 
-describe ::QueryColumn, type: :model do
-  let(:instance) { QueryColumn.new(:query_column) }
+describe ::QueryCustomFieldColumn, type: :model do
+  let(:custom_field) {
+    mock_model(CustomField, field_format: 'string',
+                            order_statements: nil)
+  }
+  let(:instance) { described_class.new(custom_field) }
 
   it_behaves_like 'query column'
+
+  describe '#available?' do
+    context 'for text custom fields' do
+      let(:custom_field) {
+        mock_model(CustomField, field_format: 'text',
+                                order_statements: nil)
+      }
+
+      it 'is false for long text custom fields' do
+        expect(instance.available?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -40,7 +40,7 @@ describe Query, type: :model do
 
     context 'with work_package_done_ratio disabled' do
       before do
-        allow(Setting).to receive(:work_package_done_ratio).and_return('disabled')
+        allow(WorkPackage).to receive(:done_ratio_disabled?).and_return(true)
       end
 
       it 'should NOT include the done_ratio column' do

--- a/spec/models/shared_query_column_specs.rb
+++ b/spec/models/shared_query_column_specs.rb
@@ -1,0 +1,133 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+shared_examples_for 'query column' do
+  describe '#groupable' do
+    it 'is the name if true is provided' do
+      instance.groupable = true
+
+      expect(instance.groupable).to eql(instance.name.to_s)
+    end
+
+    it 'is the value if something trueish is provided' do
+      instance.groupable = 'lorem ipsum'
+
+      expect(instance.groupable).to eql('lorem ipsum')
+    end
+
+    it 'is false if false is provided' do
+      instance.groupable = false
+
+      expect(instance.groupable).to be_falsey
+    end
+
+    it 'is false if nothing is provided' do
+      instance.groupable = nil
+
+      expect(instance.groupable).to be_falsey
+    end
+  end
+
+  describe '#sortable' do
+    it 'is the name if true is provided' do
+      instance.sortable = true
+
+      expect(instance.sortable).to eql(instance.name.to_s)
+    end
+
+    it 'is the value if something trueish is provided' do
+      instance.sortable = 'lorem ipsum'
+
+      expect(instance.sortable).to eql('lorem ipsum')
+    end
+
+    it 'is false if false is provided' do
+      instance.sortable = false
+
+      expect(instance.sortable).to be_falsey
+    end
+
+    it 'is false if nothing is provided' do
+      instance.sortable = nil
+
+      expect(instance.sortable).to be_falsey
+    end
+  end
+
+  describe '#groupable?' do
+    it 'is false by default' do
+      expect(instance.groupable?).to be_falsey
+    end
+
+    it 'is true if told so' do
+      instance.groupable = true
+
+      expect(instance.groupable?).to be_truthy
+    end
+
+    it 'is true if a value is provided (e.g. for specifying sql code)' do
+      instance.groupable = 'COALESCE(null, 1)'
+
+      expect(instance.groupable?).to be_truthy
+    end
+  end
+
+  describe '#sortable?' do
+    it 'is false by default' do
+      expect(instance.sortable?).to be_falsey
+    end
+
+    it 'is true if told so' do
+      instance.sortable = true
+
+      expect(instance.sortable?).to be_truthy
+    end
+
+    it 'is true if a value is provided (e.g. for specifying sql code)' do
+      instance.sortable = 'COALESCE(null, 1)'
+
+      expect(instance.sortable?).to be_truthy
+    end
+  end
+
+  describe '#available?' do
+    it 'is true by default' do
+      expect(instance.available?).to be_truthy
+    end
+
+    it 'is whatever one tells it to be' do
+      instance.available = false
+
+      expect(instance.available?).to be_falsey
+
+      instance.available = true
+
+      expect(instance.available?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Removes custom field columns from the query when the custom fields has `field_format == text`.

Displaying long text is not feasible inside the small space the work package table offers.
