### PR TITLE
[23104] Query select too short

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -182,7 +182,7 @@
           overflow: hidden
 
           span
-            display: block
+            display: inline-block
 
           a span span
             overflow: hidden


### PR DESCRIPTION
Firefox is crashing here because of its box model. `Display: inline-block` enables the correct display for both models and thus all browsers.

https://community.openproject.com/work_packages/23104/activity
