### PR TITLE
[23120,23121] Add required fields, labels to wp-edit-fields 

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -3,6 +3,7 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-change="vm.submit()"
+       ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        focus="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -6,6 +6,7 @@
   <input ng-model="vm.workPackage[vm.fieldName]"
          type="text"
          class="wp-inline-edit--field"
+         ng-required="vm.field.required"
          focus="vm.shouldFocus()"
          ng-attr-id="{{vm.htmlId}}" />
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
@@ -3,6 +3,7 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        duration-value
+       ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        focus="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
@@ -2,6 +2,7 @@
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
+       ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        float-value
        focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
@@ -2,6 +2,7 @@
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
+       ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        focus="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -3,6 +3,7 @@
         wp-edit-field-requirements="vm.field.schema"
         ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
         ng-change="vm.submit()"
+        ng-required="vm.field.required"
         ng-blur="vm.handleUserBlur()"
         focus="vm.shouldFocus()"
         ng-attr-id="{{vm.htmlId}}">

--- a/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
@@ -2,6 +2,7 @@
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
+       ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -8,6 +8,7 @@
           name="value"
           focus="vm.shouldFocus()"
           ng-hide="vm.field.isPreview"
+          ng-required="vm.field.required"
           ng-disabled="vm.field.isBusy"
           ng-model="vm.field.fieldVal.raw"
           ng-attr-id="{{vm.htmlId}}">  </textarea>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -242,7 +242,7 @@ function wpEditField() {
 
     scope: {
       fieldName: '=wpEditField',
-      fieldLabel: '=wpEditFieldLabel',
+      fieldLabel: '=?wpEditFieldLabel',
       fieldIndex: '=',
       columns: '=',
       wrapperClasses: '=wpEditFieldWrapperClasses'

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -37,6 +37,7 @@ export class WorkPackageEditFieldController {
   public fieldName: string;
   public fieldType: string;
   public fieldIndex: number;
+  public fieldLabel: string;
   public field: Field;
   public errorenous: boolean;
 
@@ -119,6 +120,7 @@ export class WorkPackageEditFieldController {
 
       this.editable = fieldSchema && fieldSchema.writable;
       this.fieldType = fieldSchema && this.wpEditField.fieldType(fieldSchema.type);
+      this.fieldLabel = this.fieldLabel || fieldSchema.name;
 
       // Activate the field automatically when in editAllMode
       if (this.inEditMode && this.isEditable) {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
@@ -40,9 +40,14 @@ export class Field {
     return (this.constructor as typeof Field).type;
   }
 
+  public get required():boolean {
+    return this.schema.required;
+  }
+
   public isEmpty():boolean {
     return !this.value;
   }
+
 
   protected get $injector():ng.auto.IInjectorService {
     return (this.constructor as typeof Field).$injector;

--- a/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
@@ -89,7 +89,11 @@ describe 'custom field inplace editor', js: true, selenium: true do
 
       it 'renders errors for invalid entries' do
         # Invalid input (non-digit)
-        expect_field_invalid ''
+        field.set_value ''
+        field.expect_invalid
+
+        expect(UpdateWorkPackageService).not_to receive(:new)
+        field.save!
       end
     end
   end

--- a/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
@@ -89,9 +89,7 @@ describe 'custom field inplace editor', js: true, selenium: true do
 
       it 'renders errors for invalid entries' do
         # Invalid input (non-digit)
-        expect_update '',
-                      type: :error,
-                      message: "MyNumber can't be blank"
+        expect_field_invalid ''
       end
     end
   end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -100,12 +100,9 @@ describe 'Inline editing work packages', js: true do
 
       subject_field.set_value('')
 
-      expect(UpdateWorkPackageService).to receive(:new).and_call_original
+      expect(UpdateWorkPackageService).not_to receive(:new)
       subject_field.save!
-      subject_field.expect_error
-
-      work_package.reload
-      expect(work_package.subject).to eq('Foobar')
+      subject_field.expect_invalid
     end
   end
 

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -99,10 +99,10 @@ describe 'Inline editing work packages', js: true do
       subject_field.activate!
 
       subject_field.set_value('')
+      subject_field.expect_invalid
 
       expect(UpdateWorkPackageService).not_to receive(:new)
       subject_field.save!
-      subject_field.expect_invalid
     end
   end
 

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -47,6 +47,10 @@ class WorkPackageField
     expect(element).to have_no_selector(field_type, wait: 10)
   end
 
+  def expect_invalid
+    expect(element).to have_selector("#{input_selector}:invalid")
+  end
+
   def expect_error
     expect(page).to have_selector("#{field_selector}.-error")
   end


### PR DESCRIPTION
- Add default label (name) to fields  
- Mark fields as required when schema says so

https://community.openproject.com/work_packages/23121/activity
https://community.openproject.com/work_packages/23120/activity
