### PR TITLE
Add form--select to inline select fields

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -1,5 +1,5 @@
 <select ng-model="vm.workPackage[vm.fieldName]"
-        class="wp-inline-edit--field"
+        class="wp-inline-edit--field form--select"
         wp-edit-field-requirements="vm.field.schema"
         ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
         ng-change="vm.submit()"


### PR DESCRIPTION
Fixes the missing dropdown arrow in IE11

![bildschirmfoto 2016-05-18 um 09 02 01](https://cloud.githubusercontent.com/assets/459462/15350021/137b8a88-1cd7-11e6-81ae-ddb31ee46b81.png)
