### PR TITLE
[23143] Avoid click propagation from active edit-fields

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -8,6 +8,8 @@
      ]">
 
   <form ng-if="vm.workPackage && vm.active"
+        ng-click="vm.haltUserFormClick($event)"
+        ng-dblclick="vm.haltUserFormClick($event)"
         name="vm.fieldForm"
         ng-submit="vm.submit()">
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -179,6 +179,15 @@ export class WorkPackageEditFieldController {
     return this.reset(focus);
   }
 
+  /**
+   *  Avoid clicks within the form to bubble up to the row handler.
+   *  Otherwise, clicks within wp-edit-fields may cause the split / full view to open.
+   */
+  public haltUserFormClick(event) {
+    event.stopPropagation();
+    return false;
+  }
+
   public setErrorState(error = true) {
     this.errorenous = error;
     this.$element.toggleClass('-error', error);

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -163,7 +163,7 @@ function wpTable(
 
       function openWhenInSplitView(workPackage) {
         if ($state.includes('work-packages.list.details')) {
-          $state.transitionTo(
+          $state.go(
             'work-packages.list.details.overview',
             { workPackageId: workPackage.id }
           );


### PR DESCRIPTION
Avoid clicks within the form to bubble up to the row handler.
Otherwise, clicks within wp-edit-fields may cause the split / full view to open.

https://community.openproject.com/work_packages/23143/
