### PR TITLE
Fix: robots authentication

### DIFF
--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -28,6 +28,9 @@
 #++
 
 class HomescreenController < ApplicationController
+
+  skip_before_filter :check_if_login_required, only: [:robots]
+
   def index
     @newest_projects = Project.visible.newest.take(3)
     @newest_users = User.newest.take(3)


### PR DESCRIPTION
This PR fixes the 500 internal server error occuring in OpenProject instances whose `robots.txt` is requested while `Setting.login_required` is true.

The actual exception is thrown in [this](https://github.com/opf/openproject/blob/dev/app/controllers/application_controller.rb#L253) block because there is no handler registered for the format TXT.

But it doesn't make sense to even do the login required check for this action anyway. So we just skip the filter and all is well.
