### PR TITLE
[23109] Subject in wrong column

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -79,7 +79,7 @@ body.controller-work_packages.action-show {
     padding-left: 0.375rem;
 
     .work-packages--panel-inner {
-      padding: 2px 20px 20px 0px;
+      padding: 5px 20px 20px 0px;
 
       // These styles were taken over from the details tab styling.
       // Thus the header and the details tab can be aligned on the same line.
@@ -213,9 +213,9 @@ body.controller-work_packages.action-show {
 
   .subject-header {
     float: left;
-    margin-right: -570px;
+    margin-right: -470px;
     margin-top: 0;
-    padding: 10px 570px 0 0;
+    padding: 10px 470px 0 0;
     width: 100%;
 
     .subject-header-inner {

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -58,7 +58,7 @@
         overflow: visible
 
     .toolbar-container
-      margin-bottom: 4px
+      margin-bottom: 1em
       min-height: 0
 
     .work-packages--show-view
@@ -90,10 +90,6 @@
 
             &.selected
               border-bottom: 2px solid $content-link-color
-
-      .subject-header
-        margin: 0
-        padding: 0
 
       .work-packages--left-panel,
       .work-packages--right-panel
@@ -142,7 +138,6 @@
       width: 100%
 
       .inplace-edit--read-value span
-        overflow: visible
         white-space: normal
 
     .work-packages--left-panel
@@ -200,6 +195,10 @@
     &.action-show #content
       .work-packages--show-view
         padding-right: 0
+
+      .subject-header
+        margin: 0
+        padding: 0
 
   .toolbar-items
     background: #fff


### PR DESCRIPTION
This changes the responsive styling rules to avoid an early line break of the subject header.

https://community.openproject.com/work_packages/23109/activity
