### PR TITLE
use $plain to get rid of the getters/setters

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -244,7 +244,7 @@ export class WorkPackageResource extends HalResource {
   }
 
   private mergeWithForm(form) {
-    var plainPayload = form.payload.$source;
+    var plainPayload = form.payload.$plain();
     var schema = form.$embedded.schema;
 
     // Merge embedded properties from form payload


### PR DESCRIPTION
This avoids problems where setting the values will be ignored for reasons I have been unable to figure out
