### PR TITLE
[23140] Change wording of cg-busy and create title

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -148,6 +148,7 @@ en:
     label_open_work_packages: "open"
     label_previous: "Previous"
     label_per_page: "Per page:"
+    label_please_wait: "Please wait"
     label_quote_comment: "Quote this comment"
     label_remove_columns: "Remove selected columns"
     label_save_as: "Save as"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -380,7 +380,7 @@ en:
       inline_create:
        title: 'Click here to add a new work package to this list'
       create:
-        header: 'New Work Package'
+        header: 'New work package'
         header_with_parent: 'New work package (Child of %{type} #%{id})'
       no_results:
         title: No work packages to display.

--- a/frontend/app/components/modals/columns-modal/columns-modal.template.html
+++ b/frontend/app/components/modals/columns-modal/columns-modal.template.html
@@ -6,7 +6,7 @@
 
     <h3>{{ ::vm.text.columnsLabel }}</h3>
 
-    <div cg-busy="vm.promise" class="columns-modal-content select2-modal-content" ng-if="!vm.impaired">
+    <div cg-busy="{promise: vm.promise, message: I18n.t('js.label_please_wait')}" class="columns-modal-content select2-modal-content" ng-if="!vm.impaired">
       <label for="selected_columns" class="hidden-for-sighted">{{ ::vm.text.selectedColumns }}</label>
 
       <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2"
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <div cg-busy="vm.promise" class="columns-modal-content select2-modal-content" ng-if="vm.impaired">
+    <div cg-busy="{promise: vm.promise, message: I18n.t('js.label_please_wait')}" class="columns-modal-content select2-modal-content" ng-if="vm.impaired">
       <label for="selected_columns" class="hidden-for-sighted">{{ ::vm.text.selectedColumns }}</label>
 
       <div ng-repeat="column in vm.availableColumns | orderBy:'title'">

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -63,7 +63,7 @@
 <back-url></back-url>
 
 <div class="work-packages--split-view"
-     cg-busy="loadingIndicator.mainPage"
+     cg-busy="{promise: loadingIndicator.mainPage, message: I18n.t('js.label_please_wait')}"
      ng-class="{'edit-all-mode': editAll.state}">
   <div class="work-packages--list">
     <div class="work-packages--list-table-area">

--- a/frontend/app/components/work-packages/wp-create-form/wp-create-form.directive.html
+++ b/frontend/app/components/work-packages/wp-create-form/wp-create-form.directive.html
@@ -1,4 +1,4 @@
-<div cg-busy="vm.loaderPromise" class="work-packages--details-content -create-mode">
+<div cg-busy="{promise: vm.loaderPromise, message: I18n.t('js.label_please_wait')}" class="work-packages--details-content -create-mode">
   <div ng-if="vm.workPackage">
     <h2>{{ vm.getHeading() }}</h2>
 

--- a/frontend/app/components/work-packages/wp-create-form/wp-full-create-form.directive.html
+++ b/frontend/app/components/work-packages/wp-create-form/wp-full-create-form.directive.html
@@ -1,4 +1,4 @@
-<div cg-busy="vm.loaderPromise">
+<div cg-busy="{promise: vm.loaderPromise, message: I18n.t('js.label_please_wait')}">
   <div ng-if="vm.workPackage">
     <h2>{{ vm.getHeading() }}</h2>
 

--- a/frontend/app/templates/work_packages/modals/sorting.html
+++ b/frontend/app/templates/work_packages/modals/sorting.html
@@ -6,7 +6,7 @@
     <h3>{{ ::I18n.t('js.label_sorting') }}</h3>
 
     <form name="modalSortingForm">
-      <div id="modal-sorting" class="modal-content-container" cg-busy="promise">
+      <div id="modal-sorting" class="modal-content-container" cg-busy="{promise: promise, message: I18n.t('js.label_please_wait')}">
         <div class="form--row" ng-repeat="element in sortElements">
           <div class="form--field -full-width">
             <label


### PR DESCRIPTION
`cg-busy` allows to set a default value for `message:` in the module initialization, but that isn't properly switched according to the locale.

https://community.openproject.com/work_packages/23140/activity
