### PR TITLE
reflect value update in accessibility labels

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
@@ -1,7 +1,7 @@
 <span class="inplace-edit--read-value--container">
   <span class="hidden-for-sighted"
         ng-attr-id="{{$ctrl.labelId}}">
-    {{::$ctrl.label}} {{::$ctrl.displayText}}
+    {{ ::$ctrl.label }} {{ $ctrl.displayText }}
   </span>
   <span class="wp-table--cell-span inplace-edit--read-value--value"
         ng-switch="$ctrl.displayType"


### PR DESCRIPTION
Otherwise, the screen reader will still read the old value even after the user changed it.
