### PR TITLE
style inline edit placeholders

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -235,6 +235,12 @@
 .inplace-edit--read-value--value,
   @include grid-block
 
+  &.-placeholder
+    font-style: italic
+
+    .progress-bar-legend
+      font-style: initial
+
 // When user is not allowed to edit the field
 #work-package-description
   span:not(.inplace-editing--container)

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
@@ -9,6 +9,7 @@
         data-click-on-keypress="[13, 32]"
         focus="$ctrl.shouldFocus()"
         ng-attr-tabindex="{{$ctrl.isEditable() ? '0' : '-1'}}"
+        ng-class="{ '-placeholder' : $ctrl.isEmpty }"
         aria-labelledby="{{$ctrl.labelId}}">
     <progress-bar ng-switch-when="Percent"
                   progress="$ctrl.displayText"
@@ -22,8 +23,7 @@
     <span
         title="{{ $ctrl.displayText }}"
         class="cell-span--value"
-        ng-switch-default
-        ng-class="{ 'work-package--placeholder' : $ctrl.displayText == '-' }">
+        ng-switch-default >
       <span ng-if="$ctrl.isDisplayAsHtml" ng-bind-html="$ctrl.displayText"></span>
       <span ng-if="!$ctrl.isDisplayAsHtml" ng-bind="$ctrl.displayText"></span>
     </span>

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
@@ -71,6 +71,7 @@ describe('wpDisplayAttr directive', () => {
         type: {id: 1, name: 'Bug'},
         sheep: 10,
         customField1: 'asdf1234',
+        emptyField: null
       };
       scope.schema = {
         "$load": () => $q.when(true),
@@ -106,6 +107,12 @@ describe('wpDisplayAttr directive', () => {
         "customField1": {
           "type": "String",
           "name": "foobar",
+          "required": false,
+          "writable": true
+        }
+        "emptyField": {
+          "type": "String",
+          "name": "empty field",
           "required": false,
           "writable": true
         }
@@ -204,6 +211,17 @@ describe('wpDisplayAttr directive', () => {
         var tag = getInnermostSpan(element);
 
         expect(tag.attr('title')).to.equal('');
+      });
+    });
+
+    describe('rendering an empty field', () => {
+      beforeEach(() => {
+        scope.attribute = 'emptyField';
+        compile();
+      });
+
+      it('should adorne the element with the -placeholder class', () => {
+        expect(element.find('.inplace-edit--read-value--value.-placeholder').length).to.eql(1);
       });
     });
   });

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -33,7 +33,6 @@ import {WorkPackageEditFieldController} from "../../wp-edit/wp-edit-field/wp-edi
 export class WorkPackageDisplayAttributeController {
   public wpEditField:WorkPackageEditFieldController;
   public displayText:string;
-  public isDisplayAsHtml:boolean = false;
   public displayType:string;
   public displayLink:string;
   public attribute:string;
@@ -77,6 +76,14 @@ export class WorkPackageDisplayAttributeController {
     return 'wp-' + this.workPackage.id + '-display-attr-' + this.attribute + '-aria-label';
   }
 
+  public get isEmpty(): boolean {
+    return !this.getValue();
+  }
+
+  public get isDisplayAsHtml(): boolean {
+    return this.workPackage[this.attribute] && this.workPackage[this.attribute].hasOwnProperty('html');
+  }
+
   protected setDisplayType() {
     // TODO: alter backend so that percentageDone has the type 'Percent' already
     if (this.attribute === 'percentageDone') {
@@ -87,6 +94,9 @@ export class WorkPackageDisplayAttributeController {
       this.displayType = 'SelfLink';
       this.displayLink = this.PathHelper.workPackagePath(this.workPackage.id);
     }
+    else if (!this.schema[this.attribute]) {
+      this.displayType = 'Text';
+    }
     else {
       this.displayType = this.schema[this.attribute].type;
     }
@@ -94,35 +104,33 @@ export class WorkPackageDisplayAttributeController {
 
   protected updateAttribute() {
     this.schema.$load().then(() => {
-      const wpAttr:any = this.workPackage[this.attribute];
-
       if (this.workPackage.isNew && this.attribute === 'id') {
         this.displayText = '';
         return;
       }
 
-      if (!wpAttr) {
-        this.displayText = this.placeholder;
-        return;
-      }
-
       this.setDisplayType();
 
-      var text = wpAttr.value || wpAttr.name || wpAttr;
-
-      if (wpAttr.hasOwnProperty('html')) {
-        this.isDisplayAsHtml = true;
-
-        if (wpAttr.html.length > 0) {
-          text = wpAttr.html;
-        }
-        else {
-          text = this.placeholder;
-        }
-      }
+      var text = this.getValue() || this.placeholder;
 
       this.displayText = this.WorkPackagesHelper.formatValue(text, this.displayType);
     });
+  }
+
+  protected getValue() {
+    const wpAttr:any = this.workPackage[this.attribute];
+
+    if (!wpAttr) {
+      return null;
+    }
+
+    var value = wpAttr.value || wpAttr.name || wpAttr;
+
+    if (wpAttr.hasOwnProperty('html')) {
+      value = wpAttr.html;
+    }
+
+    return value;
   }
 }
 


### PR DESCRIPTION
Style the placeholder the way they used to be styled. That way they are distinguishable from user entered text.
