### PR TITLE
Add separate webpack config for production

### DIFF
--- a/frontend/webpack.production.config.js
+++ b/frontend/webpack.production.config.js
@@ -1,0 +1,33 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+var getWebpackMainConfig = require('./webpack-main-config');
+
+module.exports = [
+    getWebpackMainConfig(),
+];

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -45,7 +45,7 @@ namespace :assets do
   desc 'Compile assets with webpack'
   task :webpack do
     Dir.chdir Rails.root.join('frontend') do
-      sh '$(npm bin)/webpack --config webpack.config.js'
+      sh '$(npm bin)/webpack --config webpack.production.config.js'
     end
   end
 


### PR DESCRIPTION
With https://github.com/opf/openproject/pull/4433, rake assets:precompile also compiles the tests, which takes quite some time (25s), despite not being needed.

This commit adds a separate webpack config for production that only
exposes the main config.

/cc @furinvader 
