### PR TITLE
[23145] Restyle right elements in main header

### DIFF
--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -242,3 +242,9 @@ $icon-font-file-formats: eot woff ttf
 .icon-wiki-page
   @extend .icon-wiki-edit
 
+.icon.-circle:before,
+.icon-context.-circle:before
+  border: 2px solid $font-color-on-primary
+  border-radius: 50%
+  padding: 5px
+

--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -241,10 +241,3 @@ $icon-font-file-formats: eot woff ttf
 
 .icon-wiki-page
   @extend .icon-wiki-edit
-
-.icon.-circle:before,
-.icon-context.-circle:before
-  border: 2px solid $font-color-on-primary
-  border-radius: 50%
-  padding: 5px
-

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -139,6 +139,10 @@
     > ul
       padding: 6px 0
 
+    &.-hide-icon
+      > a:after
+        display: none
+
   .drop-down--projects
     > li
       &:nth-last-child(2)
@@ -287,6 +291,16 @@ input.top-menu-search--input
       padding: 0 9px 0
     > ul > li
       max-width: 350px
+
+#account-nav-right
+  .drop-down.last-child
+    .avatar
+      // To accommodate the padding of the help icon which exisits because of the circle
+      margin-top: -5px
+  .icon-help1:before
+    padding-right: 0
+  .icon-user
+    font-size: 18px
 
 // Temporary overwrite searchfield styles for mobile view
 // until we have a full responsive layout

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -315,7 +315,8 @@ end
 
 Then /^I should be logged in as "([^\"]*)"?$/ do |username|
   user = User.find_by_login(username) || User.anonymous
-  page.should have_xpath("//div[contains(., 'Logged in as #{username}')] | //a[contains(.,'#{user.name}')]")
+  page.should have_xpath("//div[contains(., 'Logged in as #{username}')] |
+                                            //a[@title='#{user.name}']")
 
   User.current = user
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -43,6 +43,14 @@ Then /^there should not be a main menu$/ do
   page.should_not have_css('#main-menu')
 end
 
+Then /^I should (not )?see "(.*?)" as being logged in$/ do |negative, name|
+  if negative
+    page.should_not have_link(name)
+  else
+    page.should have_link(name)
+  end
+end
+
 # opens a menu item in the main menu
 When /^I open the "([^"]+)" (?:sub)?menu$/ do |menu_name|
   nodes = all(:css, ".menu_root a[title=\"#{menu_name}\"]")

--- a/features/users/brute_force_prevention.feature
+++ b/features/users/brute_force_prevention.feature
@@ -33,24 +33,24 @@ Feature: Prevent brute force attacks
 
   Scenario: A user failing to login on the first time can login on second attempt
     When I try to log in with user "bob" and a wrong password
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     When I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
 
   Scenario: A user can't login after two failed attempts, but can after waiting 5 minutes
     When I try to log in with user "bob" and a wrong password
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     When I try to log in with user "bob" and a wrong password
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     When I try to log in with user "bob"
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     When the time is 6 minutes later
     And I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
 
   Scenario: Brute force prevention is disabled
     Given users are blocked for 5 minutes after 0 failed login attempts
     When I try to log in with user "bob" and a wrong password
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     When I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in

--- a/features/users/force_password_change.feature
+++ b/features/users/force_password_change.feature
@@ -67,7 +67,7 @@ Feature: Forced Password Change
     When I try to log in with user "bob"
     And I fill out the change password form
     Then there should be a flash notice message
-    And I should see "Bob Bobbit"
+    And I should see "Bob Bobbit" as being logged in
     # Try again to check password change is not enforced on second login
     And I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in

--- a/features/users/password_expiry.feature
+++ b/features/users/password_expiry.feature
@@ -35,23 +35,23 @@ Feature: Pasword expiry
     When I set passwords to expire after 30 days
     # login should succeed
     And I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
     When the time is 31 days later
     # 31 days later, the login should fail
     And I try to log in with user "bob"
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
     And there should be a flash error message
     # After changing the password, the user should be logged in
     When I fill out the change password form
     Then there should be a flash notice message
-    And I should see "Bob Bobbit"
+    And I should see "Bob Bobbit" as being logged in
 
   Scenario: An admin deactivating password expiry allows a user to login
     When I set passwords to expire after 0 days
     # login should succeed
     And I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
     When the time is 31 days later
     # 31 days later, the login should fail
     And I try to log in with user "bob"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in

--- a/features/users/status.feature
+++ b/features/users/status.feature
@@ -66,7 +66,7 @@ Feature: User Status
     And I click "Unlock"
     Then I should not see "bobby"
     And I try to log in with user "bobby"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
 
   Scenario: A locked and blocked user gets unlocked and unblocked
     Given the user "bobby" is locked
@@ -74,13 +74,13 @@ Feature: User Status
     When I edit the user "bobby"
     And I click "Unlock and reset failed logins"
     When I try to log in with user "bobby"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in
 
   Scenario: An active user gets locked
     When I edit the user "bobby"
     And I click "Lock permanently"
     When I try to log in with user "bobby"
-    Then I should not see "Bob Bobbit"
+    Then I should not see "Bob Bobbit" as being logged in
 
   Scenario: A registered user gets activated
     Given the user "bobby" is registered and not activated
@@ -90,4 +90,4 @@ Feature: User Status
     And I edit the user "bobby"
     And I click "Activate"
     When I try to log in with user "bobby"
-    Then I should see "Bob Bobbit"
+    Then I should see "Bob Bobbit" as being logged in

--- a/features/users/user_auth.feature
+++ b/features/users/user_auth.feature
@@ -36,7 +36,7 @@ Feature: User Authentication
   Scenario: A user is able to login successfully with provided credentials
     Given I am on the login page
     And I am admin
-    Then I should see "Admin" within "#top-menu-items"
+    Then I should see "Admin" as being logged in
 
   @javascript
   Scenario: Lost password notification mail will not be sent in case incorrect mail is given

--- a/lib/redmine/menu_manager/help_menu_helper.rb
+++ b/lib/redmine/menu_manager/help_menu_helper.rb
@@ -44,7 +44,8 @@ module Redmine::MenuManager::HelpMenuHelper
                                   aria: { haspopup: 'true' }
 
     result = ''.html_safe
-    render_drop_down_menu_node(link_to_help_pop_up, class: 'drop-down -hide-icon hidden-for-mobile') do
+    render_drop_down_menu_node(link_to_help_pop_up,
+                               class: 'drop-down hidden-for-mobile -hide-icon') do
       content_tag :ul, style: 'display:none', class: 'drop-down--help' do
         render_onboarding result
         render_help_and_support result

--- a/lib/redmine/menu_manager/help_menu_helper.rb
+++ b/lib/redmine/menu_manager/help_menu_helper.rb
@@ -44,7 +44,7 @@ module Redmine::MenuManager::HelpMenuHelper
                                   aria: { haspopup: 'true' }
 
     result = ''.html_safe
-    render_drop_down_menu_node(link_to_help_pop_up, class: 'drop-down hidden-for-mobile') do
+    render_drop_down_menu_node(link_to_help_pop_up, class: 'drop-down -hide-icon hidden-for-mobile') do
       content_tag :ul, style: 'display:none', class: 'drop-down--help' do
         render_onboarding result
         render_help_and_support result

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -130,13 +130,18 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_user_drop_down(items)
-    if homescreen_user_avatar == avatar(User.current)
-      avatar = avatar(User.current)
-    else
-      avatar = ''
-    end
+    avatar =
+      if homescreen_user_avatar == avatar(User.current)
+        homescreen_user_avatar
+      else
+        ''
+      end
 
-    render_drop_down_menu_node link_to(avatar, '', title: User.current.to_s, aria: { haspopup: 'true' }, class: (avatar == '' ? 'icon-user icon-context': '') ),
+    render_drop_down_menu_node link_to(avatar,
+                                       '',
+                                       title: User.current.to_s,
+                                       aria: { haspopup: 'true' },
+                                       class: (avatar == '' ? 'icon-user icon-context' : '')),
                                items,
                                class: 'drop-down -hide-icon last-child'
   end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -130,9 +130,15 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_user_drop_down(items)
-    render_drop_down_menu_node link_to_user(User.current, title: User.current.to_s, aria: { haspopup: 'true' }),
+    if homescreen_user_avatar == avatar(User.current)
+      avatar = avatar(User.current)
+    else
+      avatar = ''
+    end
+
+    render_drop_down_menu_node link_to(avatar, '', title: User.current.to_s, aria: { haspopup: 'true' }, class: (avatar == '' ? 'icon-user icon-context': '') ),
                                items,
-                               class: 'drop-down last-child'
+                               class: 'drop-down -hide-icon last-child'
   end
 
   def render_login_partial

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -81,7 +81,7 @@ describe 'Omniauth authentication', type: :feature do
       fill_in('email', with: user.mail)
       click_link_or_button 'Sign In'
 
-      expect(page).to have_content('omni bob')
+      expect(page).to have_link('omni bob')
       expect(page).to have_link('Sign out')
     end
 

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -87,7 +87,7 @@ describe 'create users', type: :feature, selenium: true do
 
           # landed on the 'my page'
           expect(page).to have_text 'Welcome, your account has been activated. You are logged in now.'
-          expect(page).to have_text 'bobfirst boblast'
+          expect(page).to have_link 'bobfirst boblast'
         end
       end
     end
@@ -127,6 +127,7 @@ describe 'create users', type: :feature, selenium: true do
 
           expect(page).to have_text 'OpenProject'
           expect(current_path).to eq '/'
+          expect(page).to have_link 'bobfirst boblast'
         end
       end
     end


### PR DESCRIPTION
This changes the top menu elements on the right side. The help icon gets a circle like on the website The user name is replaced by the users avatar. If there is no avatar the gravatar is shown. Similar to the home screen the user icon is shown if the plugin is missing.

https://community.openproject.com/work_packages/23145/activity 
