### PR TITLE
#23152 - enable save button for empty wiki-textareas if no value required

### DIFF
--- a/frontend/app/components/wp-edit/field-controls/wp-edit-field-controls.directive.html
+++ b/frontend/app/components/wp-edit/field-controls/wp-edit-field-controls.directive.html
@@ -2,8 +2,8 @@
   <div class="inplace-edit--controls"
        ng-hide="!vm.fieldCtrl.active">
     <accessible-by-keyboard execute="vm.fieldCtrl.submit()"
-                            ng-disabled="vm.field.isEmpty()"
-                            is-disabled="vm.field.isEmpty()"
+                            ng-disabled="vm.field.required && vm.field.isEmpty()"
+                            is-disabled="vm.field.required && vm.field.isEmpty()"
                             link-title="{{ vm.saveTitle }}"
                             class="inplace-edit--control inplace-edit--control--save">
       <icon-wrapper icon-name="checkmark" icon-title="{{ vm.saveTitle }}">


### PR DESCRIPTION
https://community.openproject.com/work_packages/23152/activity 

@ulferts 
out of scope: description fields are set to 'required' by default - should be optional?
