### PR TITLE
[23147] Add auto-complete directive

### DIFF
--- a/frontend/app/components/inplace-edit/field-directives/edit-wiki-textarea/edit-wiki-textarea.directive.html
+++ b/frontend/app/components/inplace-edit/field-directives/edit-wiki-textarea/edit-wiki-textarea.directive.html
@@ -6,6 +6,7 @@
   </label>
   <textarea
           wiki-toolbar
+          op-auto-complete
           style="min-height: 114px"
           msd-elastic="\n"
           class="focus-input inplace-edit--textarea -animated"

--- a/frontend/app/components/input/op-auto-complete.directive.ts
+++ b/frontend/app/components/input/op-auto-complete.directive.ts
@@ -1,0 +1,40 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {openprojectModule} from "../../angular-modules";
+function opAutoComplete(AutoCompleteHelper) {
+  return {
+    restrict: 'A',
+    scope: false,
+    link: function(scope, element) {
+      AutoCompleteHelper.enableTextareaAutoCompletion(element);
+    },
+  };
+}
+
+openprojectModule.directive('opAutoComplete', opAutoComplete);

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.js
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.js
@@ -31,7 +31,7 @@ angular
   .directive('workPackageComment', workPackageComment);
 
 function workPackageComment($timeout, $location, EditableFieldsState, FocusHelper,
-  inplaceEditMultiStorage, ConfigurationService, AutoCompleteHelper, inplaceEditAll) {
+  inplaceEditMultiStorage, ConfigurationService, inplaceEditAll) {
 
   function commentFieldDirectiveController($scope, $element) {
     var field = {
@@ -163,12 +163,6 @@ function workPackageComment($timeout, $location, EditableFieldsState, FocusHelpe
 
     controllerAs: 'fieldController',
     bindToController: true,
-    controller: commentFieldDirectiveController,
-
-    link: function(scope, element) {
-      $timeout(function() {
-        AutoCompleteHelper.enableTextareaAutoCompletion(element.find('textarea'));
-      });
-    }
+    controller: commentFieldDirectiveController
   };
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -1,6 +1,7 @@
 <div class="textarea-wrapper" ng-class="{'-preview': vm.field.isPreview}">
   <textarea
           wiki-toolbar
+          op-auto-complete
           msd-elastic="\n"
           preview-toggle="vm.field.togglePreview()"
           style="min-height: 114px"

--- a/spec/features/work_packages/details/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/activity_comments_spec.rb
@@ -119,6 +119,15 @@ describe 'activity comments', js: true, selenium: true do
         end
       end
 
+      describe 'autocomplete' do
+        let!(:wp2) { FactoryGirl.create(:work_package, project: project, subject: 'AutoFoo') }
+
+        it 'autocompletes the other work package' do
+          comment_field.input_element.send_keys("##{wp2.id}")
+          expect(page).to have_selector('.atwho-view-ul li', text: wp2.to_s.strip)
+        end
+      end
+
       describe 'quoting' do
         it 'can quote a previous comment' do
           expect(page).to have_selector('.user-comment .message',

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -71,5 +71,16 @@ describe 'description inplace editor', js: true, selenium: true do
     end
   end
 
+  context 'autocomplete' do
+    let!(:wp2) { FactoryGirl.create(:work_package, project: project, subject: 'AutoFoo') }
+    let(:description_text) { '' }
+
+    it 'autocompletes the other work package' do
+      field.activate!
+      field.input_element.send_keys("##{wp2.id}")
+      expect(page).to have_selector('.atwho-view-ul li', text: wp2.to_s)
+    end
+  end
+
   it_behaves_like 'a cancellable field'
 end


### PR DESCRIPTION
This adds a specific autocompletion directive for use on textareas, without timeouts. Used for description and comment fields.

Supersedes https://github.com/opf/openproject/pull/4443
