### PR TITLE
Remove ng-transclude in wp-edit-field

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -16,12 +16,8 @@
     <div
         wp-edit-field="'description'"
         wp-edit-field-wrapper-classes="'-no-label'"
+        display-placeholder="$ctrl.I18n.t('js.work_packages.placeholders.description')"
         class="single-attribute wiki">
-      <wp-display-attr
-          work-package="$ctrl.workPackage"
-          attribute="'description'"
-          placeholder="$ctrl.I18n.t('js.work_packages.placeholders.description')">
-      </wp-display-attr>
     </div>
   </div>
 
@@ -62,11 +58,6 @@
           wp-edit-field-label="$ctrl.singleViewWp.getLabel(field)"
           wp-edit-field-wrapper-classes="'-small'"
           class="attributes-key-value--value-container">
-        <wp-display-attr
-            work-package="$ctrl.workPackage"
-            attribute="field"
-            label="$ctrl.singleViewWp.getLabel(field)">
-        </wp-display-attr>
       </div>
 
       <div
@@ -95,29 +86,16 @@
         <div
             wp-edit-field="field.fields[0]"
             wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[0])"
-            wp-edit-field-wrapper-classes="'-small -shrink'">
-
-          <wp-display-attr
-              work-package="$ctrl.workPackage"
-              attribute="field.fields[0]"
-              placeholder="::$ctrl.text.fields[field.label][field.fields[0]]"
-              label="$ctrl.singleViewWp.getLabel(field.fields[0])">
-          </wp-display-attr>
-        </div>
+            wp-edit-field-wrapper-classes="'-small -shrink'"
+            display-placeholder="::$ctrl.text.fields[field.label][field.fields[0]]">
 
         <span class="attributes-key-value--value-separator"></span>
 
         <div
             wp-edit-field="field.fields[1]"
             wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[1])"
-            wp-edit-field-wrapper-classes="'-small -shrink'">
-
-          <wp-display-attr
-              work-package="$ctrl.workPackage"
-              attribute="field.fields[1]"
-              placeholder="::$ctrl.text.fields[field.label][field.fields[1]]"
-              label="$ctrl.singleViewWp.getLabel(field.fields[1])">
-          </wp-display-attr>
+            wp-edit-field-wrapper-classes="'-small -shrink'"
+            display-placeholder="::$ctrl.text.fields[field.label][field.fields[1]]">
         </div>
       </div>
     </div>

--- a/frontend/app/components/work-packages/wp-subject/wp-subject.directive.html
+++ b/frontend/app/components/work-packages/wp-subject/wp-subject.directive.html
@@ -4,10 +4,6 @@
       wp-edit-field="'subject'"
       wp-edit-field-wrapper-classes="'-no-label'"
       class="work-packages--details--subject">
-    <wp-display-attr
-        work-package="$ctrl.workPackage"
-        attribute="'subject'">
-    </wp-display-attr>
   </div>
 
 </div>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -1,4 +1,5 @@
 <div class="wp-edit-field inplace-edit"
+     ng-if="vm.workPackage"
      ng-class="[
       vm.errorenous && '-error' || '',
       vm.isEditable && '-editable' || '',
@@ -7,7 +8,7 @@
       vm.wrapperClasses === undefined ? '-small' : vm.wrapperClasses
      ]">
 
-  <form ng-if="vm.workPackage && vm.active"
+  <form ng-show="vm.active"
         ng-click="vm.haltUserFormClick($event)"
         ng-dblclick="vm.haltUserFormClick($event)"
         name="vm.fieldForm"
@@ -22,7 +23,13 @@
 
   </form>
 
-  <ng-transclude class="-hidden-overflow inplace-edit--read-value"
-                 ng-hide="vm.active">
-  </ng-transclude>
+  <wp-display-attr attribute="vm.fieldName"
+                   schema="vm.workPackage.schema"
+                   work-package="vm.workPackage"
+                   placeholder="vm.displayPlaceholder"
+                   label="vm.fieldLabel"
+                   class="-hidden-overflow inplace-edit--read-value"
+                   ng-hide="vm.active"
+                   ng-class="vm.displayClasses">
+  </wp-display-attr>
 </div>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -257,7 +257,9 @@ function wpEditField() {
       fieldLabel: '=?wpEditFieldLabel',
       fieldIndex: '=',
       columns: '=',
-      wrapperClasses: '=wpEditFieldWrapperClasses'
+      wrapperClasses: '=wpEditFieldWrapperClasses',
+      displayPlaceholder: '=?',
+      displayClasses: '=?',
     },
 
     require: ['^wpEditForm', 'wpEditField'],

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -149,14 +149,11 @@
               lang="{{column.custom_field && column.custom_field.name_locale || locale}}"
               wp-edit-field="getTableColumnName(row.object, column.name)"
               wp-edit-field-wrapper-classes="'-small -shrink'"
+              display-classes="[row.level > 0 && column.name == 'subject' && 'icon-context icon-arrow-right5 icon-small']"
               columns="columns"
               field-index="$index"
               class="wp-table--cell"
               ng-class="{ '-short': column.name == 'id' }">
-            <wp-display-attr attribute="getTableColumnName(row.object, column.name)"
-                   work-package="row.object"
-                   ng-class="[row.level > 0 && column.name == 'subject' && 'icon-context icon-arrow-right5 icon-small']">
-            </wp-display-attr>
           </td>
         </tr>
 


### PR DESCRIPTION
This moves the `display-attr` directives into the wp-edit field. Note that `display-attr` is used outside of the scope of wp-edit-field, too (e.g., table sums).

/cc @romanroe 
