### PR TITLE
[23178] Redirect to work package path when module enabled

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -94,7 +94,7 @@ class ProjectsController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:notice] = l(:notice_successful_create)
-          redirect_to controller: '/projects', action: 'settings', id: @project
+          work_packages_or_settings_redirect
         end
       end
     else
@@ -250,6 +250,12 @@ class ProjectsController < ApplicationController
     authorize
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  def work_packages_or_settings_redirect
+    return if redirect_to_project_menu_item(@project, :work_packages)
+
+    redirect_to controller: '/projects', action: 'settings', id: @project
   end
 
   def jump_to_project_menu_item

--- a/spec/features/projects/projects_spec.rb
+++ b/spec/features/projects/projects_spec.rb
@@ -53,7 +53,23 @@ describe 'Projects', type: :feature do
 
       expect(page).to have_content 'Successful creation.'
       expect(page).to have_content 'Foo bar'
-      expect(current_path).to eq '/projects/foo/settings'
+      expect(current_path).to eq '/projects/foo/work_packages'
+    end
+
+    context 'work_packages module disabled',
+            with_settings: { default_projects_modules: %q(wiki) } do
+      it 'creates a project and redirects to settings' do
+        click_on 'New project'
+
+        fill_in 'project[name]', with: 'Foo bar'
+        click_on 'Advanced settings'
+        fill_in 'project[identifier]', with: 'foo'
+        click_on 'Create'
+
+        expect(page).to have_content 'Successful creation.'
+        expect(page).to have_content 'Foo bar'
+        expect(current_path).to eq '/projects/foo/settings'
+      end
     end
 
     it 'can create a subproject' do
@@ -64,7 +80,7 @@ describe 'Projects', type: :feature do
       click_on 'Create'
 
       expect(page).to have_content 'Successful creation.'
-      expect(current_path).to eq '/projects/foo-child/settings'
+      expect(current_path).to eq '/projects/foo-child/work_packages'
     end
 
     it 'does not create a project with an already existing identifier' do

--- a/spec_legacy/functional/projects_controller_spec.rb
+++ b/spec_legacy/functional/projects_controller_spec.rb
@@ -150,7 +150,7 @@ describe ProjectsController, type: :controller do
                work_package_custom_field_ids: ['9'],
                enabled_module_names: ['work_package_tracking', 'news', 'repository']
              }
-        assert_redirected_to '/projects/blog/settings'
+        assert_redirected_to '/projects/blog/work_packages'
 
         project = Project.find_by(name: 'blog')
         assert_kind_of Project, project
@@ -172,7 +172,7 @@ describe ProjectsController, type: :controller do
                                  custom_field_values: { '3' => 'Beta' },
                                  parent_id: 1
                                 }
-        assert_redirected_to '/projects/blog/settings'
+        assert_redirected_to '/projects/blog/work_packages'
 
         project = Project.find_by(name: 'blog')
         assert_kind_of Project, project
@@ -196,7 +196,7 @@ describe ProjectsController, type: :controller do
                                  enabled_module_names: ['work_package_tracking', 'news', 'repository']
                                 }
 
-        assert_redirected_to '/projects/blog/settings'
+        assert_redirected_to '/projects/blog/work_packages'
 
         project = Project.find_by(name: 'blog')
         assert_kind_of Project, project
@@ -242,7 +242,7 @@ describe ProjectsController, type: :controller do
                                  custom_field_values: { '3' => 'Beta' },
                                  parent_id: 1
                                 }
-        assert_redirected_to '/projects/blog/settings'
+        assert_redirected_to '/projects/blog/work_packages'
         project = Project.find_by(name: 'blog')
       end
 


### PR DESCRIPTION
When a user creates a project, this redirects to the work package path.
If the work package module is disabled by default, it redirects to the
settings as before.

https://community.openproject.com/work_packages/23178
