### PR TITLE
Remove dropdown scroll listener

### DIFF
--- a/frontend/app/components/context-menus/has-dropdown-menu/has-dropdown-menu-directive.js
+++ b/frontend/app/components/context-menus/has-dropdown-menu/has-dropdown-menu-directive.js
@@ -243,13 +243,6 @@ function hasDropdownMenu($rootScope, $injector, $window, FocusHelper) {
       // or move to the compile function of the directive
       // or move to a service and make sure it's called only once
 
-      var repositioningEventString = 'resize.dropdown.openproject, mousewheel.dropdown.openproject';
-      win
-        .off(repositioningEventString)
-        .on(repositioningEventString, function () {
-          $rootScope.$broadcast('openproject.dropdown.reposition');
-        });
-
       var keyUpEventString = 'keyup.dropdown.openproject';
       win
         .off(keyUpEventString).on(keyUpEventString, function (event) {


### PR DESCRIPTION
It doesn't seem to work anyway (dropdown is not repositioned) and it
eats quite a lot of resources during scrolling.
