### PR TITLE
[23195] Updated demo data

### DIFF
--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -61,7 +61,6 @@ module DemoData
     def project_data_seeders(project)
       seeders = [
         DemoData::CustomFieldSeeder,
-        DemoData::WikiSeeder,
         DemoData::WorkPackageSeeder,
         DemoData::QuerySeeder
       ]
@@ -133,10 +132,11 @@ module DemoData
 
       def project_data
         {
-          name:         project_name,
-          identifier:   project_identifier,
-          description:  project_description,
-          types:        project_types
+          name:                 project_name,
+          identifier:           project_identifier,
+          description:          project_description,
+          enabled_module_names: project_modules,
+          types:                project_types
         }
       end
 
@@ -154,6 +154,10 @@ module DemoData
 
       def project_types
         Type.all
+      end
+
+      def project_modules
+        Setting.default_projects_modules - %w(news wiki meetings calendar)
       end
 
       def find_demo_project

--- a/app/seeders/demo_data/query_seeder.rb
+++ b/app/seeders/demo_data/query_seeder.rb
@@ -55,7 +55,6 @@ module DemoData
     def data
       [
         { name: "Bugs",         filters: [Queries::WorkPackages::Filter.new(:status_id, operator: "o"), Queries::WorkPackages::Filter.new(:type_id, operator: "=", values: ['7'])], user_id: User.admin.first.id, is_public: true, column_names: [:id, :type, :status, :priority, :subject, :assigned_to, :create_at] },
-        { name: "Epics",        filters: [Queries::WorkPackages::Filter.new(:status_id, operator: "o"), Queries::WorkPackages::Filter.new(:type_id, operator: "=", values: ['5'])], user_id: User.admin.first.id, is_public: true, column_names: [:id, :type, :status, :priority, :subject, :assigned_to] },
         { name: "Milestones",   filters: [Queries::WorkPackages::Filter.new(:status_id, operator: "o"), Queries::WorkPackages::Filter.new(:type_id, operator: "=", values: ['2'])], user_id: User.admin.first.id, is_public: true, column_names: [:id, :type, :status, :subject, :start_date, :due_date] },
         { name: "Phases",       filters: [Queries::WorkPackages::Filter.new(:status_id, operator: "o"), Queries::WorkPackages::Filter.new(:type_id, operator: "=", values: ['3'])], user_id: User.admin.first.id, is_public: true, column_names: [:id, :type, :status, :subject, :start_date, :due_date] },
         { name: "Tasks",        filters: [Queries::WorkPackages::Filter.new(:status_id, operator: "o"), Queries::WorkPackages::Filter.new(:type_id, operator: "=", values: ['1'])], user_id: User.admin.first.id, is_public: true, column_names: [:id, :type, :status, :priority, :subject, :assigned_to] },

--- a/config/locales/en.seeders.yml
+++ b/config/locales/en.seeders.yml
@@ -75,29 +75,9 @@ en:
           status_name: :default_status_in_progress
           type_name: :default_type_phase
           start: 1
-          duration: 10
+          duration: 38
           relations: []
-          children:
-          - subject: Collect ideas
-            status_name: :default_status_closed
-            type_name: :default_type_task
-            start: 1
-            duration: 3
-            relations: []
-
-          - subject: Ensure financing
-            status_name: :default_status_closed
-            type_name: :default_type_task
-            start: 1
-            duration: 3
-            relations: []
-
-          - subject: Build a project team
-            status_name: :default_status_in_progress
-            type_name: :default_type_task
-            start: 7
-            duration: 4
-            relations: []
+          children: []
 
         - subject: Development
           status_name: :default_status_scheduled
@@ -106,14 +86,6 @@ en:
           duration: 26
           relations: []
           children:
-          - subject: Nice feature
-            status_name: :default_status_in_development
-            type_name: :default_type_feature
-            start: 14
-            duration: 26
-            version: Sprint 1
-            relations: []
-
           - subject: Great feature
             status_name: :default_status_developed
             type_name: :default_type_feature
@@ -130,16 +102,6 @@ en:
             version: Sprint 2
             relations: []
 
-          - subject: Awful bug
-            status_name: :default_status_confirmed
-            type_name: :default_type_bug
-            start: 31
-            duration: 7
-            version: Sprint 1
-            relations:
-              - to: Terrible bug
-                type: relates
-
           - subject: Terrible bug
             status_name: :default_status_confirmed
             type_name: :default_type_bug
@@ -148,7 +110,7 @@ en:
             version: Sprint 1
             relations: []
 
-        - subject: Release public beta
+        - subject: Go-Live
           status_name: :default_status_scheduled
           type_name: :default_type_milestone
           start: 41
@@ -156,30 +118,6 @@ en:
           relations:
             - to: 'Development'
               type: 'follows'
-          children: []
-
-        - subject: Documentation and help resources
-          status_name: :default_status_new
-          type_name: :default_type_phase
-          start: 43
-          duration: 16
-          relations: []
-          children: []
-
-        - subject: Testing and bugfixing
-          status_name: :default_status_new
-          type_name: :default_type_phase
-          start: 43
-          duration: 16
-          relations: []
-          children: []
-
-        - subject: Go-Live
-          status_name: :default_status_to_be_scheduled
-          type_name: :default_type_milestone
-          start: 60
-          duration: 1
-          relations: []
           children: []
 
       wiki:

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -44,9 +44,9 @@ describe 'seeds' do
 
       expect(User.where(admin: true).count).to eq 1
       expect(Project.count).to eq 1
-      expect(WorkPackage.count).to eq 15
-      expect(Wiki.count).to eq 1
-      expect(Query.count).to eq 6
+      expect(WorkPackage.count).to eq 7
+      expect(Wiki.count).to eq 0
+      expect(Query.count).to eq 5
     ensure
       ActionMailer::Base.perform_deliveries = perform_deliveries
     end


### PR DESCRIPTION
Work packages:
- Removed children of „Project planning“
- Removed „Documentation and help resources“
- Removed „Testing und Bugfixing“
- Removed „Go-Live“
- Removed “Nice Feature”
- Removed “Awful Bug”
- Rename „Release public betat“ to „Go-Live“
- Extend project planning:
  - `start_date` to `due_date` of Kick-off +1
  - `due_date` to `start_date` -1

Modules:
- Disabled news, wiki, meetings, calendar

Query:
- Removed 'epic' query

https://community.openproject.com/work_packages/23195/activity
