### PR TITLE
[23189] Reference statuses and projects in empty grouping

### DIFF
--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -42,7 +42,10 @@ class ::Query::Results
 
   # Returns the work package count
   def work_package_count
-    WorkPackage.includes(:status, :project).where(query.statement).count
+    WorkPackage.includes(:status, :project)
+               .where(query.statement)
+               .references(:statuses, :projects)
+               .count
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)
   end


### PR DESCRIPTION
The group_by query for a result of only empty work packages resulted
in an invalid statement.

```
Query::StatementInvalid: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "statuses"
LINE 1: SELECT COUNT(*) FROM "work_packages" WHERE ((statuses.is_clo...
```

https://community.openproject.com/work_packages/23189
