### PR TITLE
[23194] Update work package table after split view changes

### DIFF
--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -53,7 +53,7 @@ function WorkPackageDetailsController($scope,
   // TODO This is an ugly hack since most of this controller relies on the old HALAPIResource.
   // We should move all that to the new WorkPackageResource.
   scopedObservable($scope, wpCacheService.loadWorkPackage($state.params.workPackageId))
-    .subscribe((wp: WorkPackageResource) => {
+    .subscribe((wp:WorkPackageResource) => {
       $scope.workPackageResource = wp;
       wp.schema.$load();
     });
@@ -171,6 +171,9 @@ function WorkPackageDetailsController($scope,
     return !!($scope.workPackage && $scope.workPackage.embedded.watchers !== undefined);
   };
 
+  $scope.onWorkPackageSave = function () {
+    $rootScope.$emit('workPackagesRefreshInBackground');
+  };
 
   function getFocusAnchorLabel(tab, workPackage) {
     var tabLabel = I18n.t('js.work_packages.tabs.' + tab),
@@ -182,6 +185,5 @@ function WorkPackageDetailsController($scope,
 
     return I18n.t('js.label_work_package_details_you_are_here', params);
   }
-
 
 }

--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -1,5 +1,6 @@
 <div class="work-packages--details">
   <div wp-edit-form="workPackageResource"
+       wp-edit-form-on-save="onWorkPackageSave()"
        has-edit-mode="true"
        ng-if="workPackageResource">
     <div id="tabs">


### PR DESCRIPTION
Reloads the wp table after split view updates in the same style to inline create/edit.

https://community.openproject.com/work_packages/23194/activity
