### PR TITLE
introduce strategy for displaying fields

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
@@ -11,21 +11,7 @@
         ng-attr-tabindex="{{$ctrl.isEditable() ? '0' : '-1'}}"
         ng-class="{ '-placeholder' : $ctrl.isEmpty }"
         aria-labelledby="{{$ctrl.labelId}}">
-    <progress-bar ng-switch-when="Percent"
-                  progress="$ctrl.displayText"
-                  width="80px">
-    </progress-bar>
 
-    <span ng-switch-when="SelfLink" title="{{ $ctrl.displayText }}">
-      <a ng-href="{{ $ctrl.displayLink }}">{{ $ctrl.displayText }}</a>
-    </span>
-
-    <span
-        title="{{ $ctrl.displayText }}"
-        class="cell-span--value"
-        ng-switch-default >
-      <span ng-if="$ctrl.isDisplayAsHtml" ng-bind-html="$ctrl.displayText"></span>
-      <span ng-if="!$ctrl.isDisplayAsHtml" ng-bind="$ctrl.displayText"></span>
-    </span>
-</span>
+    <ng-include src="$ctrl.field.template"></ng-include>
+  </span>
 </span>

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
@@ -35,6 +35,7 @@ describe('wpDisplayAttr directive', () => {
   var I18n;
 
   beforeEach(angular.mock.module(
+    'openproject',
     'openproject.workPackages.directives',
     'openproject.templates',
     'openproject.api',
@@ -79,7 +80,7 @@ describe('wpDisplayAttr directive', () => {
     I18n.t.restore();
   });
 
-  var getInnermostSpan = start => start.find('.cell-span--value');
+  var getInnermostSpan = start => start.find('span:not(:has(span)):not(.hidden-for-sighted)');
 
   describe('element', () => {
     beforeEach(angular.mock.inject(($q) => {
@@ -91,49 +92,50 @@ describe('wpDisplayAttr directive', () => {
         customField1: 'asdf1234',
         emptyField: null,
         schema: {
-        "$load": () => $q.when(true),
-        "_type": "Schema",
-        "type": {
-          "type": "Type",
-          "name": "Type",
-          "required": true,
-          "writable": true,
-          "_links": {},
-          "_embedded": {}
-        },
-        "subject": {
-          "type": "String",
-          "name": "Subject",
-          "required": true,
-          "writable": true,
-          "minLength": 1,
-          "maxLength": 255
-        },
-        "mybool": {
-          "type": "Boolean",
-          "name": "My Bool",
-          "required": false,
-          "writable": true
-        },
-        "sheep": {
-          "type": "Integer",
-          "name": "Sheep",
-          "required": true,
-          "writable": true
-        },
-        "customField1": {
-          "type": "String",
-          "name": "foobar",
-          "required": false,
-          "writable": true
-        },
-        "emptyField": {
-          "type": "String",
-          "name": "empty field",
-          "required": false,
-          "writable": true
+          "$load": () => $q.when(true),
+          "_type": "Schema",
+          "type": {
+            "type": "Type",
+            "name": "Type",
+            "required": true,
+            "writable": true,
+            "_links": {},
+            "_embedded": {}
+          },
+          "subject": {
+            "type": "String",
+            "name": "Subject",
+            "required": true,
+            "writable": true,
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "mybool": {
+            "type": "Boolean",
+            "name": "My Bool",
+            "required": false,
+            "writable": true
+          },
+          "sheep": {
+            "type": "Integer",
+            "name": "Sheep",
+            "required": true,
+            "writable": true
+          },
+          "customField1": {
+            "type": "String",
+            "name": "foobar",
+            "required": false,
+            "writable": true
+          },
+          "emptyField": {
+            "type": "String",
+            "name": "empty field",
+            "required": false,
+            "writable": true
+          }
         }
-      };
+      }
     }));
 
     describe('rendering an object field', () => {

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -32,27 +32,20 @@ import {WorkPackageEditFieldController} from "../../wp-edit/wp-edit-field/wp-edi
 import {WorkPackageCacheService} from "../work-package-cache.service";
 import {scopedObservable} from "../../../helpers/angular-rx-utils";
 import {WorkPackageResource} from "../../api/api-v3/hal-resources/work-package-resource.service";
+import {DisplayField} from "../../wp-display/wp-display-field/wp-display-field.module";
+import {WorkPackageDisplayFieldService} from "../../wp-display/wp-display-field/wp-display-field.service";
 
 export class WorkPackageDisplayAttributeController {
   public wpEditField:WorkPackageEditFieldController;
-  public displayText:string;
-  public displayType:string;
-  public displayLink:string;
   public attribute:string;
-  public placeholder:string;
   public placeholderOptional:string;
   public workPackage:any;
   public customSchema:HalResource;
+  public field: DisplayField;
 
-  constructor(protected $scope:ng.IScope,
-              protected I18n:op.I18n,
+  constructor(protected wpDisplayField: WorkPackageDisplayFieldService,
               protected wpCacheService:WorkPackageCacheService,
-              protected PathHelper:any,
-              protected WorkPackagesHelper:any) {
-
-    this.placeholder = this.placeholderOptional ||
-                         I18n.t('js.work_packages.placeholders.default');
-    this.displayText = this.placeholder;
+              protected $scope:ng.IScope) {
 
     // Update the attribute initially
     if (this.workPackage) {
@@ -67,6 +60,10 @@ export class WorkPackageDisplayAttributeController {
     event.stopImmediatePropagation();
   }
 
+  public get placeholder() {
+    return this.placeholderOptional || (this.field && this.field.placeholder);
+  };
+
   public isEditable() {
     return this.wpEditField && this.wpEditField.isEditable;
   };
@@ -80,8 +77,7 @@ export class WorkPackageDisplayAttributeController {
   }
 
   public get isEmpty(): boolean {
-    var value = this.getValue();
-    return !(value === false || value)
+    return !this.field || this.field.isEmpty();
   }
 
   /**
@@ -92,65 +88,20 @@ export class WorkPackageDisplayAttributeController {
     return this.customSchema || this.workPackage.schema;
   }
 
-  public get isDisplayAsHtml(): boolean {
-    return this.workPackage[this.attribute] && this.workPackage[this.attribute].hasOwnProperty('html');
-  }
-
-  protected setDisplayType() {
-    // TODO: alter backend so that percentageDone has the type 'Percent' already
-    if (this.attribute === 'percentageDone') {
-      this.displayType = 'Percent';
+  public get displayText(): string {
+    if (this.isEmpty) {
+      return this.placeholder;
     }
-    else if (this.attribute === 'id') {
-      // Show a link to the work package for the ID
-      this.displayType = 'SelfLink';
-      this.displayLink = this.PathHelper.workPackagePath(this.workPackage.id);
-    } else {
-      this.displayType = this.schema[this.attribute].type;
+    else {
+      return this.field.valueString;
     }
   }
 
   protected updateAttribute(wp) {
     this.workPackage = wp;
     this.schema.$load().then(() => {
-      var text;
-      const wpAttr:any = wp[this.attribute];
-
-      if (this.workPackage.isNew && this.attribute === 'id') {
-        this.displayText = '';
-        return;
-      }
-
-      if (!this.schema[this.attribute]) {
-        this.displayType = 'Text';
-        text = this.placeholder;
-      } else {
-        this.setDisplayType();
-        var formatted = this.WorkPackagesHelper.formatValue(this.getValue(), this.displayType);
-        text = formatted || this.placeholder;
-      }
-
-      if (this.displayText !== text) {
-        this.$scope.$evalAsync(() => {
-          this.displayText = text || this.placeholder;
-        });
-      }
+      this.field = <DisplayField>this.wpDisplayField.getField(this.workPackage, this.attribute, this.schema[this.attribute]);
     });
-  }
-
-  protected getValue() {
-    const wpAttr:any = this.workPackage[this.attribute];
-
-    if (wpAttr == null) {
-      return null;
-    }
-
-    var value = wpAttr.value || wpAttr.name || wpAttr;
-
-    if (wpAttr.hasOwnProperty('html')) {
-      value = wpAttr.html;
-    }
-    return value;
   }
 }
 

--- a/frontend/app/components/wp-display/field-types/wp-display-boolean-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-boolean-field.module.ts
@@ -26,15 +26,31 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
+import {HalResource} from "../../api/api-v3/hal-resources/hal-resource.service"
 
-export class EditField extends Field{
-}
+export class BooleanDisplayField extends DisplayField {
+  public WorkPackagesHelper:op.WorkPackagesHelper;
 
-export class EditFieldFactory extends FieldFactory{
+  constructor(public resource:HalResource,
+              public name:string,
+              public schema) {
+    super(resource, name, schema);
 
-  protected static fields = {};
-  protected static classes = {};
+    this.WorkPackagesHelper = <op.WorkPackagesHelper>this.$injector.get('WorkPackagesHelper');
+  }
+
+  public get valueString() {
+    return this.WorkPackagesHelper.formatValue(this.value, 'Boolean');
+  }
+
+  public get placeholder() {
+    return this.WorkPackagesHelper.formatValue(false, 'Boolean');
+  }
+
+  public isEmpty():boolean {
+    // We treat an empty value the same as if the user had set
+    // the value to false;
+    return false;
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-date-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-date-field.module.ts
@@ -26,15 +26,14 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
+export class DateDisplayField extends DisplayField {
+  public template:string = '/components/wp-display/field-types/wp-display-default-field.directive.html';
 
-export class EditFieldFactory extends FieldFactory{
+  public get valueString() {
+    const WorkPackagesHelper:any = this.$injector.get('WorkPackagesHelper');
 
-  protected static fields = {};
-  protected static classes = {};
+    return WorkPackagesHelper.formatValue(this.value, 'Date');
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-default-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-default-field.directive.html
@@ -1,0 +1,3 @@
+<span title="{{ $ctrl.displayText }}">
+  {{ $ctrl.displayText }}
+</span>

--- a/frontend/app/components/wp-display/field-types/wp-display-duration-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-duration-field.module.ts
@@ -26,15 +26,12 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
+export class DurationDisplayField extends DisplayField {
+  public get valueString() {
+    const WorkPackagesHelper:any = this.$injector.get('WorkPackagesHelper');
 
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+    return WorkPackagesHelper.formatValue(this.value, 'Duration');
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
@@ -1,0 +1,4 @@
+<span>
+   <span ng-bind-html="$ctrl.displayText"></span>
+</span>
+

--- a/frontend/app/components/wp-display/field-types/wp-display-formattable-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-formattable-field.module.ts
@@ -26,15 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
+export class FormattableDisplayField extends DisplayField {
+  public template:string = '/components/wp-display/field-types/wp-display-formattable-field.directive.html'
 
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+  public get value() {
+    if(this.schema) {
+      return this.resource[this.name].html;
+    }
+    else {
+      return null;
+    }
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-id-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-id-field.directive.html
@@ -1,0 +1,9 @@
+<span ng-if="!$ctrl.field.isEmpty()" title="{{ $ctrl.displayText }}">
+  <a ng-href="{{ $ctrl.field.valueLink }}">
+    {{ $ctrl.displayText }}
+  </a>
+</span>
+
+<span ng-if="$ctrl.field.isEmpty()" title="{{ $ctrl.displayText }}">
+  {{ $ctrl.displayText }}
+</span>

--- a/frontend/app/components/wp-display/field-types/wp-display-id-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-id-field.module.ts
@@ -26,15 +26,23 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
+export class IdDisplayField extends DisplayField {
+  public template:string = '/components/wp-display/field-types/wp-display-id-field.directive.html'
 
-export class EditFieldFactory extends FieldFactory{
+  public get value() {
+    if (this.resource.isNew) {
+      return null;
+    }
+    else {
+      return this.resource[this.name];
+    }
+  }
 
-  protected static fields = {};
-  protected static classes = {};
+  public get valueLink() {
+    let PathHelper = <op.PathHelper>this.$injector.get('PathHelper');
+
+    return PathHelper.workPackagePath(this.value);
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-progress-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-progress-field.directive.html
@@ -1,0 +1,5 @@
+<span title="{{ $ctrl.displayText }}">
+  <progress-bar progress="$ctrl.displayText"
+                width="80px">
+  </progress-bar>
+<span>

--- a/frontend/app/components/wp-display/field-types/wp-display-progress-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-progress-field.module.ts
@@ -26,15 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
+export class ProgressDisplayField extends DisplayField {
+  public template:string = '/components/wp-display/field-types/wp-display-progress-field.directive.html'
 
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+  public get value() {
+    if(this.schema) {
+      return this.resource[this.name] || 0;
+    }
+    else {
+      return null;
+    }
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-resource-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-resource-field.module.ts
@@ -26,15 +26,15 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
-
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+export class ResourceDisplayField extends DisplayField {
+  public get value() {
+    if(this.schema) {
+      return this.resource[this.name] && this.resource[this.name].name;
+    }
+    else {
+      return null;
+    }
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-string-object-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-object-field.module.ts
@@ -26,15 +26,15 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
-
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+export class StringObjectDisplayField extends DisplayField {
+  public get value() {
+    if(this.schema) {
+      return this.resource[this.name] && this.resource[this.name].value;
+    }
+    else {
+      return null;
+    }
+  }
 }

--- a/frontend/app/components/wp-display/field-types/wp-display-text-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-text-field.module.ts
@@ -26,15 +26,10 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
-export class EditField extends Field{
-}
-
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
+export class TextDisplayField extends DisplayField {
+  public get valueString() {
+    return this.value;
+  }
 }

--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.config.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.config.ts
@@ -1,0 +1,61 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {WorkPackageDisplayFieldService} from "./wp-display-field.service";
+import {DisplayField} from "./wp-display-field.module";
+import {TextDisplayField} from "../field-types/wp-display-text-field.module";
+import {ResourceDisplayField} from "../field-types/wp-display-resource-field.module";
+import {StringObjectDisplayField} from "../field-types/wp-display-string-object-field.module";
+import {FormattableDisplayField} from "../field-types/wp-display-formattable-field.module";
+import {DurationDisplayField} from "../field-types/wp-display-duration-field.module";
+import {DateDisplayField} from "../field-types/wp-display-date-field.module";
+import {IdDisplayField} from "../field-types/wp-display-id-field.module";
+import {BooleanDisplayField} from "../field-types/wp-display-boolean-field.module";
+import {ProgressDisplayField} from "../field-types/wp-display-progress-field.module";
+import {openprojectModule} from "../../../angular-modules";
+
+openprojectModule
+  .run((wpDisplayField:WorkPackageDisplayFieldService) => {
+    wpDisplayField.defaultType = 'text';
+    wpDisplayField
+      .addFieldType(TextDisplayField, 'text', ['String'])
+      .addFieldType(ResourceDisplayField, 'resource', ['User',
+                                                       'Project',
+                                                       'Type',
+                                                       'Status',
+                                                       'Priority',
+                                                       'Version',
+                                                       'Category'])
+      .addFieldType(StringObjectDisplayField, 'string_object', ['StringObject'])
+      .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])
+      .addFieldType(DurationDisplayField, 'duration', ['Duration'])
+      .addFieldType(DateDisplayField, 'date', ['Date'])
+      .addFieldType(BooleanDisplayField, 'boolean', ['Boolean'])
+      .addFieldType(ProgressDisplayField, 'progress', ['percentageDone'])
+      .addFieldType(IdDisplayField, 'id', ['id']);
+  });

--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
@@ -1,0 +1,102 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
+import {Field} from '../../wp-field/wp-field.module'
+import {FieldFactory} from '../../wp-field/wp-field.module'
+
+export class DisplayField extends Field{
+  public static type:string;
+  public static $injector:ng.auto.IInjectorService;
+  public template:string = '/components/wp-display/field-types/wp-display-default-field.directive.html'
+  public I18n:op.I18n;
+
+  public get value() {
+    if(this.schema) {
+      return this.resource[this.name];
+    }
+    else {
+      return null;
+    }
+  }
+
+  public get type():string {
+    return (this.constructor as typeof DisplayField).type;
+  }
+
+  public get required():boolean {
+    return this.schema.required;
+  }
+
+  public isEmpty():boolean {
+    return !this.value;
+  }
+
+  public get placeholder():string {
+    return this.I18n.t('js.work_packages.placeholders.default');
+  }
+
+  public get valueString():string {
+    return this.value;
+  }
+
+  protected get $injector():ng.auto.IInjectorService {
+    return (this.constructor as typeof DisplayField).$injector;
+  }
+
+  constructor(public resource:HalResource,
+              public name:string,
+              public schema) {
+    super(resource, name, schema);
+
+    this.I18n = <op.I18n>this.$injector.get('I18n');
+  }
+}
+
+export class DisplayFieldFactory extends FieldFactory {
+
+  protected static fields = {};
+  protected static classes = {};
+
+  public static create(workPackage:HalResource,
+                       fieldName:string,
+                       schema:op.FieldSchema):DisplayField {
+    let type = DisplayFieldFactory.getSpecificType(fieldName) ||
+      schema && DisplayFieldFactory.getType(schema.type) ||
+      DisplayFieldFactory.defaultType;
+    let fieldClass = DisplayFieldFactory.classes[type];
+
+    return <DisplayField>(new fieldClass(workPackage, fieldName, schema));
+  }
+
+  protected static getSpecificType(type:string):string {
+    let fields = DisplayFieldFactory.fields;
+
+    return fields[type];
+  }
+}

--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.service.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.service.ts
@@ -26,15 +26,16 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module'
-import {FieldFactory} from '../../wp-field/wp-field.module'
+import {DisplayFieldFactory} from './wp-display-field.module';
+import {DisplayField} from "./wp-display-field.module";
+import {WorkPackageFieldService} from "../../wp-field/wp-field.service"
 
-export class EditField extends Field{
+export class WorkPackageDisplayFieldService extends WorkPackageFieldService {
+  public static get fieldFactory() {
+    return DisplayFieldFactory;
+  }
 }
 
-export class EditFieldFactory extends FieldFactory{
-
-  protected static fields = {};
-  protected static classes = {};
-}
+angular
+  .module('openproject')
+  .service('wpDisplayField', WorkPackageDisplayFieldService);

--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class BooleanField extends Field {
+export class BooleanEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-boolean-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class DateField extends Field {
+export class DateEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-date-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class DurationField extends Field {
+export class DurationEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-duration-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-float-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-float-field.module.ts
@@ -25,8 +25,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class FloatField extends Field {
+export class FloatEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-float-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class IntegerField extends Field {
+export class IntegerEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-integer-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -26,9 +26,9 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class SelectField extends Field {
+export class SelectEditField extends EditField {
   public options:any[];
   public placeholder:string = '-';
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html'

--- a/frontend/app/components/wp-edit/field-types/wp-edit-text-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-text-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 
-export class TextField extends Field {
+export class TextEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-text-field.directive.html'
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -26,10 +26,10 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Field} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from "../wp-edit-field/wp-edit-field.module";
 import {WorkPackageResource} from "../../api/api-v3/hal-resources/work-package-resource.service";
 
-export class WikiTextareaField extends Field {
+export class WikiTextareaEditField extends EditField {
 
   // Template
   public template:string = '/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html';

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.config.ts
@@ -27,19 +27,19 @@
 // ++
 
 import {WorkPackageEditFieldService} from "./wp-edit-field.service";
-import {Field} from "./wp-edit-field.module";
-import {TextField} from "../field-types/wp-edit-text-field.module";
-import {IntegerField} from "../field-types/wp-edit-integer-field.module";
-import {DurationField} from "../field-types/wp-edit-duration-field.module";
-import {SelectField} from "../field-types/wp-edit-select-field.module";
-import {FloatField} from "../field-types/wp-edit-float-field.module";
-import {BooleanField} from "../field-types/wp-edit-boolean-field.module";
-import {DateField} from "../field-types/wp-edit-date-field.module";
-import {WikiTextareaField} from "../field-types/wp-edit-wiki-textarea-field.module";
+import {EditField} from "./wp-edit-field.module";
+import {TextEditField} from "../field-types/wp-edit-text-field.module";
+import {IntegerEditField} from "../field-types/wp-edit-integer-field.module";
+import {DurationEditField} from "../field-types/wp-edit-duration-field.module";
+import {SelectEditField} from "../field-types/wp-edit-select-field.module";
+import {FloatEditField} from "../field-types/wp-edit-float-field.module";
+import {BooleanEditField} from "../field-types/wp-edit-boolean-field.module";
+import {DateEditField} from "../field-types/wp-edit-date-field.module";
+import {WikiTextareaEditField} from "../field-types/wp-edit-wiki-textarea-field.module";
 import {openprojectModule} from "../../../angular-modules";
 
 //TODO: Implement
-class DateRangeField extends Field {
+class DateRangeEditField extends EditField {
 }
 
 
@@ -49,10 +49,10 @@ openprojectModule
   .run((wpEditField:WorkPackageEditFieldService) => {
     wpEditField.defaultType = 'text';
     wpEditField
-      .addFieldType(TextField, 'text', ['String'])
-      .addFieldType(IntegerField, 'integer', ['Integer'])
-      .addFieldType(DurationField, 'duration', ['Duration'])
-      .addFieldType(SelectField, 'select', ['Priority',
+      .addFieldType(TextEditField, 'text', ['String'])
+      .addFieldType(IntegerEditField, 'integer', ['Integer'])
+      .addFieldType(DurationEditField, 'duration', ['Duration'])
+      .addFieldType(SelectEditField, 'select', ['Priority',
         'Status',
         'Type',
         'User',
@@ -60,9 +60,9 @@ openprojectModule
         'Category',
         'StringObject',
         'Project'])
-      .addFieldType(FloatField, 'float', ['Float'])
-      .addFieldType(IntegerField, 'integer', ['Integer'])
-      .addFieldType(BooleanField, 'boolean', ['Boolean'])
-      .addFieldType(DateField, 'date', ['Date'])
-      .addFieldType(WikiTextareaField, 'wiki-textarea', ['Formattable']);
+      .addFieldType(FloatEditField, 'float', ['Float'])
+      .addFieldType(IntegerEditField, 'integer', ['Integer'])
+      .addFieldType(BooleanEditField, 'boolean', ['Boolean'])
+      .addFieldType(DateEditField, 'date', ['Date'])
+      .addFieldType(WikiTextareaEditField, 'wiki-textarea', ['Formattable']);
   });

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -28,7 +28,7 @@
 
 import {WorkPackageEditFormController} from "./../wp-edit-form.directive";
 import {WorkPackageEditFieldService} from "./wp-edit-field.service";
-import {Field} from "./wp-edit-field.module";
+import {EditField} from "./wp-edit-field.module";
 import {scopedObservable} from "../../../helpers/angular-rx-utils";
 import {WorkPackageResource} from "../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageCacheService} from "../../work-packages/work-package-cache.service";
@@ -41,7 +41,7 @@ export class WorkPackageEditFieldController {
   public fieldType: string;
   public fieldIndex: number;
   public fieldLabel: string;
-  public field: Field;
+  public field: EditField;
   public errorenous: boolean;
   public workPackage: WorkPackageResource;
 
@@ -210,7 +210,7 @@ export class WorkPackageEditFieldController {
 
   protected buildEditField(): ng.IPromise<any> {
     return this.formCtrl.loadSchema().then(schema => {
-      this.field = this.wpEditField.getField(this.workPackage, this.fieldName, schema[this.fieldName]);
+      this.field = <EditField>this.wpEditField.getField(this.workPackage, this.fieldName, schema[this.fieldName]);
       this.workPackage.storePristine(this.fieldName);
     });
   }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
@@ -26,35 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {FieldFactory} from './wp-edit-field.module';
-import {Field} from "./wp-edit-field.module";
+import {EditFieldFactory} from './wp-edit-field.module';
+import {EditField} from "./wp-edit-field.module";
+import {WorkPackageFieldService} from "../../wp-field/wp-field.service"
 
-export class WorkPackageEditFieldService {
-  public set defaultType(value) {
-    FieldFactory.defaultType = value;
-  }
-
-  constructor(protected $injector) {
-  }
-
-  public getField(resource, fieldName:string, schema) {
-    return FieldFactory.create(resource, fieldName, schema);
-  }
-
-  public fieldType(name) {
-    return FieldFactory.getType(name);
-  }
-
-  public addFieldType(fieldClass:typeof Field, displayType:string, fields:string[]) {
-    fieldClass.type = displayType;
-    fieldClass.$injector = this.$injector;
-    FieldFactory.register(fieldClass, fields);
-    return this;
-  }
-
-  public extendFieldType(displayType:string, fields:string[]) {
-    var fieldClass = FieldFactory.getClassFor(displayType);
-    return this.addFieldType(fieldClass, displayType, fields);
+export class WorkPackageEditFieldService extends WorkPackageFieldService  {
+  public static get fieldFactory() {
+    return EditFieldFactory;
   }
 }
 

--- a/frontend/app/components/wp-field/wp-field.module.ts
+++ b/frontend/app/components/wp-field/wp-field.module.ts
@@ -1,0 +1,91 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
+
+export class Field {
+  public static type:string;
+  public static $injector:ng.auto.IInjectorService;
+
+  public get value() {
+    return this.resource[this.name];
+  }
+
+  public get type():string {
+    return (this.constructor as typeof Field).type;
+  }
+
+  public get required():boolean {
+    return this.schema.required;
+  }
+
+  public isEmpty():boolean {
+    return !this.value;
+  }
+
+  protected get $injector():ng.auto.IInjectorService {
+    return (this.constructor as typeof Field).$injector;
+  }
+
+  constructor(public resource:HalResource,
+              public name:string,
+              public schema) {
+  }
+}
+
+export class FieldFactory {
+  public static defaultType:string;
+
+  protected static fields = {};
+  protected static classes = {};
+
+  public static register(fieldClass:typeof Field, fields:string[] = []) {
+    fields.forEach(field => this.fields[field] = fieldClass.type);
+    this.classes[fieldClass.type] = fieldClass;
+  }
+
+  public static create(workPackage:HalResource,
+                       fieldName:string,
+                       schema:op.FieldSchema):Field {
+    let type = this.getType(schema.type);
+    let fieldClass = this.classes[type];
+
+    return new fieldClass(workPackage, fieldName, schema);
+  }
+
+  public static getClassFor(fieldName:string):typeof Field {
+    return this.classes[fieldName];
+  }
+
+  public static getType(type:string):string {
+    let fields = this.fields;
+    let defaultType = this.defaultType;
+
+    return fields[type] || defaultType;
+  }
+}

--- a/frontend/app/components/wp-field/wp-field.service.ts
+++ b/frontend/app/components/wp-field/wp-field.service.ts
@@ -26,52 +26,42 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {WorkPackageEditFieldController} from "../wp-edit-field/wp-edit-field.directive";
-import {EditField} from "../wp-edit-field/wp-edit-field.module";
+import {FieldFactory} from './wp-field.module';
+import {Field} from "./wp-field.module";
 
-
-export class WorkPackageFieldControlsController {
-  public fieldCtrl: WorkPackageEditFieldController;
-  public cancelTitle: string;
-  public saveTitle: string;
-
-  constructor() {
+export class WorkPackageFieldService {
+  public static get fieldFactory() {
+    return FieldFactory;
   }
 
-  public get field():EditField {
-    return this.fieldCtrl.field;
+  public set defaultType(value) {
+    (this.constructor as typeof WorkPackageFieldService).fieldFactory.defaultType = value;
+  }
+
+  constructor(protected $injector) {
+  }
+
+  public getField(resource, fieldName:string, schema) {
+    return (this.constructor as typeof WorkPackageFieldService).fieldFactory.create(resource, fieldName, schema);
+  }
+
+  public fieldType(name) {
+    return (this.constructor as typeof WorkPackageFieldService).fieldFactory.getType(name);
+  }
+
+  public addFieldType(fieldClass:typeof Field, displayType:string, fields:string[]) {
+    fieldClass.type = displayType;
+    fieldClass.$injector = this.$injector;
+    (this.constructor as typeof WorkPackageFieldService).fieldFactory.register(fieldClass, fields);
+    return this;
+  }
+
+  public extendFieldType(displayType:string, fields:string[]) {
+    var fieldClass = (this.constructor as typeof WorkPackageFieldService).fieldFactory.getClassFor(displayType);
+    return this.addFieldType(fieldClass, displayType, fields);
   }
 }
 
-function wpEditFieldLink(
-  scope,
-  element,
-  attrs,
-  controllers: [WorkPackageEditFieldController]) {
-
-  scope.vm.fieldCtrl = controllers[0];
-}
-
-
-function wpEditFieldControls() {
-  return {
-    restrict: 'E',
-    templateUrl: '/components/wp-edit/field-controls/wp-edit-field-controls.directive.html',
-    require: ['^wpEditField'],
-
-    scope: {
-      cancelTitle: '@',
-      saveTitle: '@'
-    },
-
-    link: wpEditFieldLink,
-    controller: WorkPackageFieldControlsController,
-    controllerAs: 'vm',
-    bindToController: true
-  };
-}
-
-//TODO: Use 'openproject.wpEdit' module
 angular
   .module('openproject')
-  .directive('wpEditFieldControls', wpEditFieldControls);
+  .service('wpField', WorkPackageFieldService);

--- a/frontend/app/typings/open-project.typings.ts
+++ b/frontend/app/typings/open-project.typings.ts
@@ -229,4 +229,12 @@ declare namespace op {
     showSums?:boolean;
     sortBy?:any[];
   }
+
+  interface PathHelper {
+    workPackagePath(id):string;
+  }
+
+  interface WorkPackagesHelper {
+    formatValue(value, type):string;
+  }
 }


### PR DESCRIPTION
In order improve the code structure and in order to enable plugins to
add display strategies for fields, that are not covered by the core yet,
a strategy pattern is introduced for displaying fields.

The mechanism is identical to the way EditFields are handled. In fact,
the DisplayFields and EditFields now inherit from a common superclass,
Field. Also, the service and the factory inherit from a common
superclass.

Prepares the core for: https://community.openproject.com/work_packages/23071/activity

Also fixes: https://community.openproject.com/work_packages/23173/activity
