### PR TITLE
[23188] Restore project's WP custom fields on errors

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -200,13 +200,15 @@ class ProjectsController < ApplicationController
   end
 
   def custom_fields
-    @project.work_package_custom_field_ids = permitted_params.project[:work_package_custom_field_ids]
-    if @project.save
-      flash[:notice] = l(:notice_successful_update)
-    else
-      flash[:error] = l(:notice_project_cannot_update_custom_fields)
+    Project.transaction do
+      @project.work_package_custom_field_ids = permitted_params.project[:work_package_custom_field_ids]
+      if @project.save
+        flash[:notice] = l(:notice_successful_update)
+      else
+        flash[:error] = l(:notice_project_cannot_update_custom_fields)
+        raise ActiveRecord::Rollback
+      end
     end
-
     redirect_to action: 'settings', id: @project, tab: 'custom_fields'
   end
 


### PR DESCRIPTION
When assigning the work package custom fields, we can't use
changed to reset the assocations. Since they seem to be stored
regardless of the project, we should restore them manually.

https://community.openproject.com/work_packages/23188
