### PR TITLE
[23203] Set closed status ID on initial seeding

### DIFF
--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -108,7 +108,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="form--field -wide-label">
           <%= styled_label_tag :settings_commit_fix_status_id, l(:label_applied_status) %>
           <div class="form--field-container">
-            <%= setting_select :commit_fix_status_id, [["", 0]] + Status.all.collect{|status| [status.name, status.id.to_s]}, label: false %>
+            <%= setting_select :commit_fix_status_id, [["--- #{l(:actionview_instancetag_blank_option)} ---", '0', { disabled: true }]] + Status.all.collect{|status| [status.name, status.id.to_s]}, label: false %>
           </div>
         </div>
         <div class="form--field -wide-label">

--- a/spec/seeders/setting_seeder_spec.rb
+++ b/spec/seeders/setting_seeder_spec.rb
@@ -1,0 +1,70 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'SettingSeeder' do
+  subject { ::BasicData::SettingSeeder.new }
+
+  let(:new_project_role) { Role.find_by(name: I18n.t(:default_role_project_admin)) }
+  let(:closed_status) { Status.find_by(name: I18n.t(:default_status_closed)) }
+
+  before do
+    allow(STDOUT).to receive(:puts)
+    allow(ActionMailer::Base).to receive(:perform_deliveries).and_return(false)
+    allow(Delayed::Worker).to receive(:delay_jobs).and_return(false)
+
+    expect { BasicDataSeeder.new.seed! }.not_to raise_error
+  end
+
+  def reseed!
+    expect(subject).to receive(:update_unless_present).twice.and_call_original
+    expect(subject).to be_applicable
+    expect { subject.seed! }.not_to raise_error
+  end
+
+  it 'applies initial settings' do
+    Setting.where(name: %w(commit_fix_status_id new_project_user_role_id)).delete_all
+
+    reseed!
+
+    expect(Setting.commit_fix_status_id).to eq closed_status.id
+    expect(Setting.new_project_user_role_id).to eq new_project_role.id
+  end
+
+  it 'does not override settings' do
+    Setting.commit_fix_status_id = 1337
+    Setting.where(name: 'new_project_user_role_id').delete_all
+
+    reseed!
+
+    expect(Setting.commit_fix_status_id).to eq 1337
+    expect(Setting.new_project_user_role_id).to eq new_project_role.id
+  end
+end


### PR DESCRIPTION
This selects the `closed` status seeded by default upon seeding the
settings.

This also fixes n+1 evaluations of the `data` method during the seeding
process and refactors the `new_project_role` assignment to function
properly.

https://community.openproject.com/work_packages/23203
