### PR TITLE
Use explicit selector for the actual edit field

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -52,8 +52,7 @@
   &.-error
 
     .wp-table--cell-span,
-    input,
-    select
+    .wp-inline-edit--field
       background: $nm-color-error-background
       border-color: $nm-color-error-border
 


### PR DESCRIPTION
We used `input, select` selectors before which matches the datepicker selects
embedded within the edit field.

https://community.openproject.com/work_packages/23174/activity
