### PR TITLE
Fix/date visiblity

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -70,7 +70,9 @@ class TypesController < ApplicationController
 
   def edit
     @projects = Project.all
-    @type  = ::Type.find(params[:id])
+    @type = ::Type.includes(:projects,
+                            :custom_fields)
+                  .find(params[:id])
   end
 
   def update

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -74,7 +74,7 @@ module ::TypesHelper
       attributes.delete 'start_date'
     end
 
-    WorkPackageCustomField.all.each do |field|
+    WorkPackageCustomField.includes(:translations).all.each do |field|
       attributes["custom_field_#{field.id}"] = {
         required: field.is_required,
         has_default: field.default_value.present?,

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -112,39 +112,12 @@ module ::TypesHelper
   end
 
   ##
-  # There isn't actually a 'date' field for work packages.
-  # There are two fields: 'start_date' and 'due_date'
-  # Though they are displayed together in one row, as one 'field'.
-  # Since the schema doesn't know any field named 'date' we
-  # derive the visibility for the imaginary 'date' field from
-  # the actual schema values of 'due_date' and 'start_date'.
-  #
-  # 'visible' > 'default' > 'hidden'
-  # Meaning, for instance, that if at least one field is 'visible'
-  # both will be shown. Even if the other is 'hidden'.
-  #
-  # Note: this is duplicated in wp-field.service.js
-  #
-  # Also bases visibility of custom fields on `type.custom_field_ids`
+  # Bases visibility of custom fields on `type.custom_field_ids`
   # if no visibility is defined yet. After the first update
   # attribute_visibility and custom_field_ids will be kept in sync
-  # by the types controller (see #extract_custom_field_ids).
+  # by the type service.
   def attr_visibility(name)
-    if name == 'date'
-      values = ['start_date', 'due_date'].map do |n|
-        @type.attribute_visibility[n]
-      end
-
-      if values.include? 'visible'
-        'visible'
-      elsif values.include? 'default'
-        'default'
-      elsif values.include? 'hidden'
-        'hidden'
-      else
-        nil
-      end
-    elsif name =~ /^custom_field_/
+    if name =~ /^custom_field_/
       id = name.split('_').last.to_i
       value = @type.attribute_visibility[name]
 

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -1,0 +1,95 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class BaseTypeService
+  attr_accessor :type
+
+  def call(attributes: {})
+    update(attributes)
+  end
+
+  private
+
+  def update(attributes)
+    success = Type.transaction {
+      type.attributes = attributes
+
+      set_date_attribute_visibility
+      set_active_custom_fields
+
+      if type.save
+        true
+      else
+        raise ActiveRecord::Rollback
+      end
+    }
+
+    ServiceResult.new(success: success,
+                      errors: type.errors)
+  end
+
+  def set_date_attribute_visibility
+    if type.is_milestone? && !type.attribute_visibility['date']
+      set_date_milestone_attribute_visibility
+    elsif !type.is_milestone? && type.attribute_visibility['date']
+      set_date_non_milestone_attribute_visibility
+    end
+  end
+
+  def set_date_milestone_attribute_visibility
+    values = [type.attribute_visibility.delete('start_date'),
+              type.attribute_visibility.delete('due_date')]
+
+    new_value = values.detect { |x| ['visible', 'default', 'hidden'].include?(x) } || 'default'
+
+    type.attribute_visibility['date'] = new_value
+  end
+
+  def set_date_non_milestone_attribute_visibility
+    visibility = type.attribute_visibility.delete('date')
+
+    type.attribute_visibility['start_date'] = visibility
+    type.attribute_visibility['due_date'] = visibility
+  end
+
+  ##
+  # Syncs visibility settings for custom fields with enabled custom fields
+  # for this type. If a custom field is hidden it is removed from the
+  # custom_field_ids list.
+  def set_active_custom_fields
+    enabled = ['default', 'visible']
+
+    active_cf_ids = type
+                    .attribute_visibility
+                    .select { |key, value| key =~ /custom_field_/ && enabled.include?(value) }
+                    .map { |key, _| key.gsub(/^custom_field_/, '').to_i }
+
+    type.custom_field_ids = active_cf_ids
+  end
+end

--- a/app/services/create_type_service.rb
+++ b/app/services/create_type_service.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class CreateTypeService < BaseTypeService
+  def initialize
+    self.type = Type.new
+  end
+end

--- a/app/services/update_type_service.rb
+++ b/app/services/update_type_service.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class UpdateTypeService < BaseTypeService
+  def initialize(type:)
+    self.type = type
+  end
+end

--- a/spec/services/create_type_service_spec.rb
+++ b/spec/services/create_type_service_spec.rb
@@ -1,0 +1,38 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'services/shared_type_service'
+
+describe CreateTypeService do
+  let(:type) { instance.type }
+  let(:instance) { described_class.new }
+
+  it_behaves_like 'type service'
+end

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -1,0 +1,116 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+shared_examples_for 'type service' do
+  let(:success) { true }
+
+  describe '#call' do
+    before do
+      expect(type)
+        .to receive(:save)
+        .and_return(success)
+    end
+
+    it 'returns a success service result' do
+      expect(instance.call).to be_success
+    end
+
+    it 'set the values provided on the call' do
+      attributes = { name: 'blubs blubs' }
+
+      instance.call(attributes: attributes)
+
+      expect(type.name).to eql attributes[:name]
+    end
+
+    it 'enables the custom fields that are passed via attribute_visibility' do
+      attributes = { 'attribute_visibility' => { 'custom_field_3' => 'visible',
+                                                 'custom_field_54' => 'default',
+                                                 'custom_field_86' => 'hidden' } }
+
+      expect(type)
+        .to receive(:custom_field_ids=)
+        .with([3, 54])
+
+      instance.call(attributes: attributes)
+    end
+
+    context 'for a milestone' do
+      before do
+        type.is_milestone = true
+      end
+
+      it 'takes the values from the start and due_date if no value is set for date' do
+        attributes = { 'attribute_visibility' => { 'start_date' => 'visible',
+                                                   'due_date' => 'visible' } }
+
+        instance.call(attributes: attributes)
+
+        expect(type.attribute_visibility).not_to include('start_date')
+        expect(type.attribute_visibility).not_to include('due_date')
+
+        expect(type.attribute_visibility['date']).to eql('visible')
+      end
+    end
+
+    context 'for a non milestone' do
+      before do
+        type.is_milestone = false
+      end
+
+      it 'takes the values from the date for start and due_date if no value is set' do
+        attributes = { 'attribute_visibility' => { 'date' => 'visible' } }
+
+        instance.call(attributes: attributes)
+
+        expect(type.attribute_visibility).not_to include('date')
+
+        expect(type.attribute_visibility['due_date']).to eql('visible')
+        expect(type.attribute_visibility['start_date']).to eql('visible')
+      end
+    end
+
+    context 'on failure' do
+      let(:success) { false }
+
+      it 'returns a failed service result' do
+        expect(instance.call).not_to be_success
+      end
+
+      it 'returns the errors of the type' do
+        type_errors = 'all the errors'
+        allow(type)
+          .to receive(:errors)
+          .and_return(type_errors)
+
+        expect(instance.call.errors).to eql type_errors
+      end
+    end
+  end
+end

--- a/spec/services/update_type_service_spec.rb
+++ b/spec/services/update_type_service_spec.rb
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'services/shared_type_service'
+
+describe UpdateTypeService do
+  let(:type) { FactoryGirl.build_stubbed(:type) }
+
+  let(:instance) { described_class.new(type: type) }
+
+  it_behaves_like 'type service'
+end


### PR DESCRIPTION
Consists of four parts:
- Fixes a bug that would ignore the visibility setting defined on `type/:id/edit` for the `date` field on milestone typed work packages. The bug was made possible by the change to handle `date` as a field in it's own right on the work package resource instead of mimicking everything in the front end.
- Fixes two n+1 queries on `type/:id/edit` which would slow down the application by a lot when a lot of projects where defined for the instance.
- Refactors most of the custom handing for `attribute_visibility` on the types model into a service. 
- Adds tests for the services.  
