### PR TITLE
fix editing durations

### DIFF
--- a/frontend/app/services/timezone-service.js
+++ b/frontend/app/services/timezone-service.js
@@ -67,9 +67,12 @@ module.exports = function(ConfigurationService, I18n) {
         d.format(TimezoneService.getTimeFormat());
     },
 
+    toHours: function(durationString) {
+      return Number(moment.duration(durationString).asHours().toFixed(2));
+    },
+
     formattedDuration: function(durationString) {
-      var hours = Number(moment.duration(durationString).asHours().toFixed(2));
-      return I18n.t('js.units.hour', { count: hours });
+      return I18n.t('js.units.hour', { count: TimezoneService.toHours(durationString) });
     },
 
     formattedISODate: function(date) {

--- a/frontend/app/ui_components/duration-directive.js
+++ b/frontend/app/ui_components/duration-directive.js
@@ -39,7 +39,7 @@ module.exports = function($filter, TimezoneService) {
       });
 
       ngModelController.$formatters.push(function(value) {
-        return TimezoneService.formattedDuration(value);
+        return TimezoneService.toHours(value);
       });
     }
   };


### PR DESCRIPTION
Allows to edit duration attributes (e.g. estimated time) again by not having 'hours' in the value that is passed to ng-model.
