### PR TITLE
[23238] Double scroll bar in work package view

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -81,7 +81,6 @@
   +display(flex)
   +flex-direction(column)
   height: 100%
-  overflow-y: scroll
 
   > .toolbar-container
     // not flex-item
@@ -139,6 +138,8 @@
   padding:  0
   border-left: 4px solid #eee
   border-top: 4px solid #eee
+  // To accommodate the border
+  right: -4px
 
 .work-packages--details
 


### PR DESCRIPTION
This removes a doubled scroll bar in split screen view. Further there were parts of the split screen in the list view visible. This was fixed too.

https://community.openproject.com/work_packages/23238/activity
