### PR TITLE
[23239] Design bugs in member section for users with long names

### DIFF
--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -60,7 +60,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
     <div class="grid-block">
-      <div class="grid-block medium-4">
+      <div class="grid-block medium-6">
         <div class="grid-block">
           <div id="principal_results">
             <%= render partial: 'members/autocomplete_for_member', locals: { principals: principals, roles: roles } %>


### PR DESCRIPTION
This increases the width of the blocks. Thus the cut off is avoided. Since the number of letters is restricted, this works for the longest possible name.

https://community.openproject.com/work_packages/23239/activity
