### PR TITLE
[20428] [Accessibility] Some form fields are not pronounced with their entire label (2) (Core)

### DIFF
--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -120,8 +120,8 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     prefix, suffix = options.values_at(:prefix, :suffix)
 
     # TODO (Rails 4): switch to SafeBuffer#prepend
-    ret = content_tag(:span, prefix.html_safe, class: 'form--field-affix').concat(ret) if prefix
-    ret.concat content_tag(:span, suffix.html_safe, class: 'form--field-affix') if suffix
+    ret = content_tag(:span, prefix.html_safe, class: 'form--field-affix', aria: { hidden: true }).concat(ret) if prefix
+    ret.concat content_tag(:span, suffix.html_safe, class: 'form--field-affix', aria: { hidden: true }) if suffix
 
     field_container_wrap_field(ret, options)
   end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -117,7 +117,7 @@ describe TabularFormBuilder do
 
         it 'should output elements' do
           expect(output).to be_html_eql(%{
-            <span class="form--field-affix"><span style="color:red">Prefix</span></span>
+            <span class="form--field-affix" aria-hidden="true"><span style="color:red">Prefix</span></span>
             <span class="form--text-field-container">
               <input class="form--text-field"
                 id="user_name" name="user[name]" title="Name" type="text"
@@ -137,7 +137,7 @@ describe TabularFormBuilder do
                 id="user_name" name="user[name]" title="Name" type="text"
                 value="JJ Abrams" />
             </span>
-            <span class="form--field-affix"><span style="color:blue">Suffix</span></span>
+            <span class="form--field-affix" aria-hidden="true"><span style="color:blue">Suffix</span></span>
           }).within_path('span.form--field-container')
         end
       end
@@ -152,13 +152,13 @@ describe TabularFormBuilder do
 
         it 'should output elements' do
           expect(output).to be_html_eql(%{
-            <span class="form--field-affix"><span style="color:yellow">PREFIX</span></span>
+            <span class="form--field-affix" aria-hidden="true"><span style="color:yellow">PREFIX</span></span>
             <span class="form--text-field-container">
               <input class="form--text-field"
                 id="user_name" name="user[name]" title="Name" type="text"
                 value="JJ Abrams" />
             </span>
-            <span class="form--field-affix"><span style="color:green">SUFFIX</span></span>
+            <span class="form--field-affix" aria-hidden="true"><span style="color:green">SUFFIX</span></span>
           }).within_path('span.form--field-container')
         end
       end


### PR DESCRIPTION
This sets the `aria` attribute hidden, so that the screen reader does not read the suffix/affix twice. The text should appear in the description label.

According meeting PR: https://github.com/finnlabs/openproject-meeting/pull/123
According cost PR: https://github.com/finnlabs/openproject-costs/pull/241

https://community.openproject.com/work_packages/20428/activity
