### PR TITLE
Fix/customfield error params

### DIFF
--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -58,11 +58,12 @@ module ActiveModel
     # dependent on specific errors (which we use in the APIv3).
     # We therefore add a second information store containing pairs of [symbol, translated_message].
     def add_with_storing_error_symbols(attribute, message = :invalid, options = {})
+      error_symbol = options.fetch(:error_symbol) { message }
       add_without_storing_error_symbols(attribute, message, options)
 
       if store_new_symbols?
-        if message.is_a?(Symbol)
-          symbol = message
+        if error_symbol.is_a?(Symbol)
+          symbol = error_symbol
           partial_message = normalize_message(attribute, message, options)
           full_message = full_message(attribute, partial_message)
         else

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -71,7 +71,7 @@ module ActiveModel
           full_message = message
         end
 
-        writable_symbols_and_messages_for(attribute) << [symbol, full_message]
+        writable_symbols_and_messages_for(attribute) << [symbol, full_message, partial_message]
       end
     end
 
@@ -143,8 +143,8 @@ class Reform::Contract::Errors
     @store_new_symbols = true
 
     errors.keys.each do |attribute|
-      errors.symbols_and_messages_for(attribute).each do |symbol, message|
-        writable_symbols_and_messages_for(attribute) << [symbol, message]
+      errors.symbols_and_messages_for(attribute).each do |symbol, full_message, partial_message|
+        writable_symbols_and_messages_for(attribute) << [symbol, full_message, partial_message]
       end
     end
   end

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -77,7 +77,7 @@ module API
 
           errors.keys.each do |attribute|
             api_attribute_name = ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
-            errors.symbols_and_messages_for(attribute).each do |symbol, full_message|
+            errors.symbols_and_messages_for(attribute).each do |symbol, full_message, _|
               if symbol == :error_readonly
                 api_errors << ::API::Errors::UnwritableProperty.new(api_attribute_name)
               else

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -133,10 +133,10 @@ module Redmine
               # This is important e.g. in the API v3 where the error messages are
               # post processed.
               name = cv.custom_field.accessor_name.to_sym
-              cv.errors.symbols_and_messages_for(attribute).each do |symbol, message|
+              cv.errors.symbols_and_messages_for(attribute).each do |symbol, _, partial_message|
                 # Use the generated message by the custom field
                 # as it may contain specific parameters (e.g., :too_long requires :count)
-                errors.add(name, message, error_symbol: symbol)
+                errors.add(name, partial_message, error_symbol: symbol)
               end
             end
           end

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -132,8 +132,11 @@ module Redmine
               # make the same symbol available on the customized object itself.
               # This is important e.g. in the API v3 where the error messages are
               # post processed.
-              cv.errors.symbols_for(attribute).each do |symbol|
-                errors.add(cv.custom_field.accessor_name.to_sym, symbol)
+              name = cv.custom_field.accessor_name.to_sym
+              cv.errors.symbols_and_messages_for(attribute).each do |symbol, message|
+                # Use the generated message by the custom field
+                # as it may contain specific parameters (e.g., :too_long requires :count)
+                errors.add(name, message, error_symbol: symbol)
               end
             end
           end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -283,5 +283,28 @@ describe WorkPackage, type: :model do
         it { is_expected.to eq(value) }
       end
     end
+
+    describe 'validation error interpolation' do
+      let :custom_field do
+        FactoryGirl.create :work_package_custom_field,
+                           name: 'PIN',
+                           field_format: 'text',
+                           max_length: 4,
+                           is_required: true
+      end
+
+      include_context 'project with required custom field'
+
+      it 'works for the max length validation' do
+        work_package.custom_field_values.first.value = '12345'
+
+        # don't want to see I18n::MissingInterpolationArgument specifically
+        expect { work_package.valid? }.not_to raise_error
+        expect(work_package.valid?).to be_falsey
+
+        expect(work_package.errors.full_messages.first)
+          .to eq ('PIN is too long (maximum is 4 characters).')
+      end
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/opf/openproject/pull/4127 which should've gone into the release branch to begin with.

Fixes internal server error occurring for instance when trying to save a value for a custom field which is too long. Also adds a spec to make sure this doesn't brake again.
