### PR TITLE
remove duplicate sub uri on bulk delete path

### DIFF
--- a/frontend/app/components/common/path-heleper/path-helper.service.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.js
@@ -126,7 +126,7 @@ function PathHelper() {
       return PathHelper.projectWorkPackagesPath(projectIdentifier) + '/details/' + workPackageId + '/copy';
     },
     workPackagesBulkDeletePath: function() {
-      return PathHelper.staticBase + PathHelper.workPackagesPath() + '/bulk';
+      return PathHelper.workPackagesPath() + '/bulk';
     },
     workPackagesBulkEditPath: function(workPackageIds) {
       var query = _.reduce(workPackageIds, function(idsString, id) {


### PR DESCRIPTION
`PathHelper.workPackagesPath()` does already contain the sub uri.

https://community.openproject.com/work_packages/23248/activity
