### PR TITLE
remove html-class setting already present in the template

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -49,7 +49,7 @@ export class WorkPackageEditFieldController {
   protected _forceFocus: boolean = false;
 
   // Since we load the schema asynchronously
-  // all fields are initially viewed as editable until it is loaded
+  // all fields are initially viewed as uneditable until it is loaded
   protected _editable: boolean = false;
 
   constructor(protected wpEditField: WorkPackageEditFieldService,
@@ -142,7 +142,6 @@ export class WorkPackageEditFieldController {
 
   public set editable(enabled: boolean) {
     this._editable = enabled;
-    this.$element.toggleClass('-editable', !!enabled);
   }
 
   public shouldFocus() {


### PR DESCRIPTION
There is already an ng-class statement setting the desired class upon edit-ability. As the wp-edit-field directive is applied via an attribute, the $element is the dom element the directive is an attribute of. That way, the -editable class is applied twice.

https://community.openproject.com/work_packages/23240/activity
