### PR TITLE
Fix/accessible columns modal

### DIFF
--- a/frontend/app/components/modals/columns-modal/columns-modal.controller.js
+++ b/frontend/app/components/modals/columns-modal/columns-modal.controller.js
@@ -104,10 +104,12 @@ function ColumnsModalController($scope, columnsModal, QueryService, WorkPackageS
   };
 
   vm.setSelectedColumn = function(column) {
-    if (vm.selectedColumnMap[column.name])
+    if (vm.selectedColumnMap[column.name]) {
       vm.selectedColumns.push(column);
-    else
-      _.remove(vm.selectedColumns, function(c) { c.name === column.name });
+    }
+    else {
+      _.remove(vm.selectedColumns, function(c) { return c.name === column.name; });
+    }
   };
 
   //hack to prevent dragging of close icons

--- a/frontend/app/components/modals/columns-modal/columns-modal.template.html
+++ b/frontend/app/components/modals/columns-modal/columns-modal.template.html
@@ -10,7 +10,7 @@
       <label for="selected_columns" class="hidden-for-sighted">{{ ::vm.text.selectedColumns }}</label>
 
       <ui-select multiple sortable="true" ng-model="vm.selectedColumns" theme="select2"
-                 id="selected_columns" focus-on="columnsModalOpened"
+                 id="selected_columns" focus
                  aria-labelledby="column_multiselect_description" title="{{ ::vm.text.columnsLabel }}">
 
         <ui-select-match>{{ $item.title }}</ui-select-match>
@@ -42,9 +42,10 @@
             <input id="column-{{column.title}}"
                    type="checkbox"
                    title="{{ column.title }}"
-                   ng-attr-autofocus="{{ $first || undefined }}"
                    ng-model="vm.selectedColumnMap[column.name]"
-                   ng-change="vm.setSelectedColumn(column)"/>
+                   ng-change="vm.setSelectedColumn(column)"
+                   focus="$first"
+                   focus-force="true" />
           </div>
           {{column.title}}
         </label>

--- a/frontend/app/ui_components/focus-directive.js
+++ b/frontend/app/ui_components/focus-directive.js
@@ -66,7 +66,7 @@ module.exports = function(FocusHelper, ConfigurationService) {
   return {
     link: function(scope, element, attrs) {
       // Set initial focus only when not on accessibility mode
-      if (!ConfigurationService.accessibilityModeEnabled()) {
+      if (!ConfigurationService.accessibilityModeEnabled() || scope.$eval(attrs.focusForce)) {
         updateFocus(scope, element, attrs);
       }
 


### PR DESCRIPTION
Fixes adding and removing columns when being in the accessibility mode and forces the focus to be set correctly for that modal.

As the focus directive will not focus when being in the accessibility mode, a `forceFocus` property was introduced which overrides this limitation.

https://community.openproject.com/work_packages/23262/activity
