### PR TITLE
Fix/route to tabs

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -73,7 +73,11 @@ const panels = {
 openprojectModule
   .config(($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) => {
 
-    $urlRouterProvider.when('/work_packages/', '/work_packages');
+    $urlRouterProvider.when('/work_packages/', '/work_packages')
+                      .when('/work_packages/{workPackageId:[0-9]+}?query_id&query_props', ($match, $state) => {
+                        $state.go('work-packages.show.activity', $match, { location: 'replace' });
+                        return true;
+                      });
     $urlMatcherFactoryProvider.strictMode(false);
 
     $stateProvider
@@ -130,12 +134,6 @@ openprojectModule
         // CSS.
         onEnter: ($state, $timeout) => {
           angular.element('body').addClass('action-show');
-
-          $timeout(() => {
-            if ($state.is('work-packages.show')) {
-              $state.go('work-packages.show.activity');
-            }
-          });
         },
 
         onExit: () => {

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -164,7 +164,7 @@ function wpTable(
       function openWhenInSplitView(workPackage) {
         if ($state.includes('work-packages.list.details')) {
           $state.go(
-            'work-packages.list.details.overview',
+            $state.$current.name,
             { workPackageId: workPackage.id }
           );
         }


### PR DESCRIPTION
Fixes keeping the previous selected tab when switching between work packages in the split view:

https://community.openproject.com/work_packages/23260/activity

Additionally refactors the redirect on the show page (from work_packages/:id to work_packages/:id/activity) to actually be a redirect and to not exist in the history.
