### PR TITLE
fix focusing the hidden label when being in the accessibility mode

### DIFF
--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -31,7 +31,7 @@
       </ul>
     </div>
     <div class="work-packages--details-content">
-    <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="focusAnchorLabel">
+    <span class="hidden-for-sighted" tabindex="-1" focus focus-force="true" ng-bind="focusAnchorLabel">
     </span>
 
       <wp-subject></wp-subject>

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -72,7 +72,7 @@
     </div>
     <div class="work-packages--right-panel">
       <div class="work-packages--panel-inner">
-        <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="focusAnchorLabel"></span>
+        <span class="hidden-for-sighted" tabindex="-1" focus focus-force="true" ng-bind="focusAnchorLabel"></span>
         <div id="tabs">
           <ul class="tabrow">
             <!-- The hrefs with empty URLs are necessary for IE10 to focus these links


### PR DESCRIPTION
In the accessibility mode, for which this element was created in the first place, we need to also apply the `force-focus` attribute in order for the focus to happen.

We need to double check why that behaviour of not following the focus directive when in accessibility mode was introduced. It leads to a lot of errors when in that mode and I find that limitation weird as especially people using the accessibility mode are dependent on the focus being set.

https://community.openproject.com/work_packages/17808/activity
