### PR TITLE
[23280] Do not pass empty values to smtp configuration

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -256,7 +256,10 @@ module OpenProject
             ActionMailer::Base.perform_deliveries = true
             ActionMailer::Base.delivery_method = Setting.email_delivery_method
             %w{address port domain authentication user_name password}.each do |setting|
-              ActionMailer::Base.smtp_settings[setting.to_sym] = Setting["smtp_#{setting}".to_sym]
+              value = Setting["smtp_#{setting}".to_sym]
+              if value.present?
+                ActionMailer::Base.smtp_settings[setting.to_sym] = value
+              end
             end
             ActionMailer::Base.smtp_settings[:enable_starttls_auto] = Setting.smtp_enable_starttls_auto?
           when :sendmail


### PR DESCRIPTION
Even when specifying `SMTP_AUTHENTICATION=none`, SMTP doesn't really have such an authentication method.
Instead, it looks for presence of `user_name` and `password` and when found, assumes an authentication method to be available.

It then fails to find the auth method `none`.

This is a regression of the configurable mail settings. With settings,
default values are empty strings instead of nil values coming from
missing or empty configuration / ENV variables.

Checking the values for presence is sufficient to resolve the issue.
https://community.openproject.com/work_packages/23280
