### PR TITLE
fix payload object to not show percentageDone when calculated

### DIFF
--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -76,7 +76,7 @@ module API
         property :done_ratio,
                  as: :percentageDone,
                  render_nil: true,
-                 if: -> (*) { Setting.work_package_done_ratio != 'disabled' }
+                 if: -> (*) { Setting.work_package_done_ratio == 'field' }
 
         property :estimated_hours,
                  as: :estimatedTime,

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -105,10 +105,16 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
           end
         end
 
-        context 'percentage done disabled' do
-          before do allow(Setting).to receive(:work_package_done_ratio).and_return('disabled') end
+        %w(disabled status).each do |setting|
+          context "work package done ratio setting on #{setting}" do
+            before do
+              allow(Setting).to receive(:work_package_done_ratio).and_return(setting)
+            end
 
-          it { is_expected.to_not have_json_path('percentageDone') }
+            it 'has no percentageDone attribute' do
+              is_expected.to_not have_json_path('percentageDone')
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Fixes the payload object to not include `percentageDone` when the setting is set to calculated the value. When the attribute exists despite of the setting

https://community.openproject.com/work_packages/23279/activity

is caused.
