### PR TITLE
Implement proper array resource handling for HalResource

### DIFF
--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
@@ -29,7 +29,14 @@
 var $q:ng.IQService;
 var apiV3:restangular.IService;
 
-export class HalLink {
+export interface HalLinkInterface {
+  href:string;
+  method:string;
+  title?:string;
+  templated?:boolean;
+}
+
+export class HalLink implements HalLinkInterface {
   public static fromObject(link):HalLink {
     return new HalLink(link.href, link.title, link.method, link.templated);
   }

--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {opApiModule} from "../../../../angular-modules";
+
 var $q:ng.IQService;
 var apiV3:restangular.IService;
 
@@ -77,13 +79,13 @@ export class HalLink implements HalLinkInterface {
   }
 }
 
-function halLink(_$q_:ng.IQService, _apiV3_:restangular.IService) {
+function halLinkService(_$q_:ng.IQService, _apiV3_:restangular.IService) {
   $q = _$q_;
   apiV3 = _apiV3_;
 
   return HalLink;
 }
 
-angular
-  .module('openproject.api')
-  .factory('HalLink', ['$q', 'apiV3', halLink]);
+halLinkService.$inject = ['$q', 'apiV3'];
+
+opApiModule.factory('HalLink', halLinkService);

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -396,7 +396,7 @@ describe('HalResource service', () => {
       expect(resource.values).to.have.lengthOf(2);
     });
 
-    describe.skip('when adding resources to the array', () => {
+    describe('when adding resources to the array', () => {
       beforeEach(() => {
         resource.values.push(resource);
       });
@@ -408,10 +408,33 @@ describe('HalResource service', () => {
       it('should update the $source property', () => {
         expect(resource.$source._links.values).to.have.lengthOf(3);
       });
+    });
 
-      it('should ignore values that are no resources', () => {
+    describe('when adding arbitrary values to the array', () => {
+      beforeEach(() => {
         resource.values.push('something');
-        expect(resource.values).to.have.lengthOf(3);
+      });
+
+      it('should not update the values', () => {
+        expect(resource.values).to.have.lengthOf(2);
+      });
+
+      it('should not update the values of the source', () => {
+        expect(source._links.values).to.have.lengthOf(2);
+      });
+    });
+
+    describe('when removing resources from the array', () => {
+      beforeEach(() => {
+        resource.values.pop();
+      });
+
+      it('should update the source', () => {
+        expect(source._links.values).to.have.lengthOf(1);
+      });
+
+      it('should update the $source property', () => {
+        expect(resource.$source._links.values).to.have.lengthOf(1);
       });
     });
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -370,6 +370,20 @@ describe('HalResource service', () => {
   });
 
   describe('when creating a resource from a source with a linked array property', () => {
+    var expectLengthsToBe = (length, update = 'update') => {
+      it(`should ${update} the values of the resource`, () => {
+        expect(resource.values).to.have.lengthOf(length);
+      });
+
+      it(`should ${update} the source`, () => {
+        expect(source._links.values).to.have.lengthOf(length);
+      });
+
+      it(`should ${update} the $source property`, () => {
+        expect(resource.$source._links.values).to.have.lengthOf(length);
+      });
+    };
+
     beforeEach(() => {
       source = {
         _links: {
@@ -392,50 +406,27 @@ describe('HalResource service', () => {
       expect(resource).to.have.property('values').that.is.an('array');
     });
 
-    it('should should be the same amount of items as the original', () => {
-      expect(resource.values).to.have.lengthOf(2);
-    });
+    expectLengthsToBe(2);
 
     describe('when adding resources to the array', () => {
       beforeEach(() => {
         resource.values.push(resource);
       });
-
-      it('should update the source', () => {
-        expect(source._links.values).to.have.lengthOf(3);
-      });
-
-      it('should update the $source property', () => {
-        expect(resource.$source._links.values).to.have.lengthOf(3);
-      });
+      expectLengthsToBe(3);
     });
 
     describe('when adding arbitrary values to the array', () => {
       beforeEach(() => {
         resource.values.push('something');
       });
-
-      it('should not update the values', () => {
-        expect(resource.values).to.have.lengthOf(2);
-      });
-
-      it('should not update the values of the source', () => {
-        expect(source._links.values).to.have.lengthOf(2);
-      });
+      expectLengthsToBe(2, 'not update');
     });
 
     describe('when removing resources from the array', () => {
       beforeEach(() => {
         resource.values.pop();
       });
-
-      it('should update the source', () => {
-        expect(source._links.values).to.have.lengthOf(1);
-      });
-
-      it('should update the $source property', () => {
-        expect(resource.$source._links.values).to.have.lengthOf(1);
-      });
+      expectLengthsToBe(1);
     });
 
     describe('when each value is transformed', () => {

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -51,10 +51,6 @@ describe('HalResource service', () => {
     expect(new HalResource().href).to.equal(null);
   });
 
-  it('should return null for the href if it has no self link', () => {
-    expect(new HalResource({}).href).to.equal(null);
-  });
-
   it('should set its source to _plain if _plain is a property of the source', () => {
     source = {_plain: {prop: true}};
     resource = new HalResource(source);
@@ -214,6 +210,20 @@ describe('HalResource service', () => {
     });
   });
 
+  describe('when creating a resource with a source that has no links', () => {
+    beforeEach(() => {
+      resource = new HalResource({});
+    });
+
+    it('should return null for the href if it has no self link', () => {
+      expect(resource.href).to.equal(null);
+    });
+
+    it('should have a $link object with null href', () => {
+      expect(resource.$link.href).to.equal(null);
+    });
+  });
+
   describe('when transforming an object with _links', () => {
     beforeEach(() => {
       source = {
@@ -308,10 +318,6 @@ describe('HalResource service', () => {
       };
 
       resource = new HalResource(source);
-    });
-
-    it('should return an empty $links object', () => {
-      expect(resource.$links).to.eql({});
     });
 
     it('should not be restangularized', () => {
@@ -561,14 +567,9 @@ describe('HalResource service', () => {
       var embeddedResource;
       beforeEach(() => {
         embeddedResource = {
-          $isHal: true,
-          $links: {
-            self: {
-              $link: {
-                method: 'get',
-                href: 'newHref'
-              }
-            }
+          $link: {
+            method: 'get',
+            href: 'newHref'
           }
         };
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -49,26 +49,14 @@ export class HalResource {
     return {_links: {self: {href: null}}};
   }
 
-  public $isHal:boolean = true;
   public $self:ng.IPromise<HalResource>;
 
   private _name:string;
   private _$links:any;
-  private _$embedded:any;
-
-  public get name():string {
-    return this._name || this.$links.self.$link.title || '';
-  }
-
-  public set name(name:string) {
-    this._name = name;
-  }
-
-  public get href():string|void {
-    if (this.$links.self) {
-      return this.$links.self.$link.href;
-    }
-    return null;
+  private _$embedded:any;';
+  
+  public get $isHal():boolean {
+    return true;
   }
 
   public get $links() {
@@ -90,6 +78,21 @@ export class HalResource {
 
       return halTransform(element);
     });
+  }
+
+  public get name():string {
+    return this._name || this.$links.self.$link.title || '';
+  }
+
+  public set name(name:string) {
+    this._name = name;
+  }
+
+  public get href():string|void {
+    if (this.$links.self) {
+      return this.$links.self.$link.href;
+    }
+    return null;
   }
 
   constructor(public $source:any = HalResource.getEmptyResource(), public $loaded:boolean = true) {
@@ -199,7 +202,7 @@ export class HalResource {
   }
 }
 
-function halResource(_$q_, _lazy_, _halTransform_, _HalLink_) {
+function halResourceService(_$q_, _lazy_, _halTransform_, _HalLink_) {
   $q = _$q_;
   lazy = _lazy_;
   halTransform = _halTransform_;
@@ -208,4 +211,6 @@ function halResource(_$q_, _lazy_, _halTransform_, _HalLink_) {
   return HalResource;
 }
 
-opApiModule.factory('HalResource', ['$q', 'lazy', 'halTransform', 'HalLink', halResource]);
+halResourceService.$inject = ['$q', 'lazy', 'halTransform', 'HalLink'];
+
+opApiModule.factory('HalResource', halResourceService);

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -157,7 +157,7 @@ export class HalResource {
     _.without(Object.keys(this.$links), 'self').forEach(linkName => {
       lazy(this, linkName,
         () => {
-          const link = this.$links[linkName].$link || this.$links[linkName];
+          const link:any = this.$links[linkName].$link || this.$links[linkName];
 
           if (Array.isArray(link)) {
             var items = link.map(item => HalResource.fromLink(item.$link));

--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1218,6 +1218,9 @@
     "json-loader": {
       "version": "0.5.1"
     },
+    "json5": {
+      "version": "0.4.0"
+    },
     "lodash": {
       "version": "2.4.2"
     },
@@ -1452,6 +1455,61 @@
           "dependencies": {
             "indexof": {
               "version": "0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "observable-array": {
+      "version": "0.0.4",
+      "dependencies": {
+        "d": {
+          "version": "0.1.1"
+        },
+        "es5-ext": {
+          "version": "0.10.11",
+          "dependencies": {
+            "es6-iterator": {
+              "version": "2.0.0"
+            },
+            "es6-symbol": {
+              "version": "3.0.2"
+            }
+          }
+        },
+        "event-emitter": {
+          "version": "0.3.4"
+        },
+        "memoizee": {
+          "version": "0.3.10",
+          "dependencies": {
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.3"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "lru-queue": {
+              "version": "0.1.0"
+            },
+            "next-tick": {
+              "version": "0.2.2"
+            },
+            "timers-ext": {
+              "version": "0.1.0"
+            }
+          }
+        },
+        "observable-value": {
+          "version": "0.0.5",
+          "dependencies": {
+            "es6-symbol": {
+              "version": "3.1.0"
             }
           }
         }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "lodash": "^2.4.2",
     "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^0.1.2",
+    "observable-array": "0.0.4",
     "polyfill-function-prototype-bind": "0.0.1",
     "shelljs": "^0.3.0",
     "style-loader": "^0.8.2",


### PR DESCRIPTION
Linked and embedded array resources that got proxied to properties of the resource would not update the `$source` property when changed, which is crucial for saving resources later on.
