### PR TITLE
Fix/email notification styling

### DIFF
--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -28,20 +28,19 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="form--field">
-  <%= label_tag "user_mail_notification",
-        l(:description_user_mail_notification),
-        class: "hidden-for-sighted" %>
+  <%= styled_label_tag "user_mail_notification", t(:'user.settings.mail_notifications') %>
   <div class="form--field-container">
-    <%= styled_select_tag 'user[mail_notification]',
-          options_for_select(user_mail_notification_options(@user),
-          @user.mail_notification),
-          onchange: 'if (this.value == "selected") {Element.show("notified-projects")} else {Element.hide("notified-projects")}',
-          container_class: '-auto' %>
+    <div class="form--select-container">
+      <%= styled_select_tag 'user[mail_notification]',
+            options_for_select(user_mail_notification_options(@user),
+            @user.mail_notification),
+            onchange: 'if (this.value == "selected") {Element.show("notified-projects")} else {Element.hide("notified-projects")}' %>
+    </div>
   </div>
 </div>
 
 <%= content_tag 'div', id: 'notified-projects', style: (@user.mail_notification == 'selected' ? '' : 'display:none;') do %>
-  <div class="form--field">
+  <div class="form--field -no-label">
     <div class="form--field-container -vertical">
       <% @user.projects.each do |project| %>
         <label class="form--label-with-check-box">
@@ -50,17 +49,17 @@ See doc/COPYRIGHT.rdoc for more details.
         </label>
       <% end %>
     </div>
-    <div> <%# TODO: Apply form--field-instructions %>
-      <em><%= l(:text_user_mail_option) %></em>
+    <div class="form--field-instructions">
+      <%= t(:'user.settings.mail_project_explanaition') %>
     </div>
   </div>
 <% end %>
 
 <div class="form--field">
+  <%= styled_label_tag 'self_notified', t(:'user.settings.mail_self_notified') %>
   <div class="form--field-container">
-    <label class="form--label-with-check-box">
+    <div class="form--check-box-container">
       <%= styled_check_box_tag 'self_notified', 1, @user.pref.self_notified? %>
-      <%= l(:label_user_mail_self_notified) %>
-    </label>
+    </div>
   </div>
 </div>

--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -34,12 +34,13 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_select_tag 'user[mail_notification]',
             options_for_select(user_mail_notification_options(@user),
             @user.mail_notification),
-            onchange: 'if (this.value == "selected") {Element.show("notified-projects")} else {Element.hide("notified-projects")}' %>
+            :'ng-model' => 'mail_notifications',
+            :'ng-init' => "mail_notifications = '#{@user.mail_notification}'" %>
     </div>
   </div>
 </div>
 
-<%= content_tag 'div', id: 'notified-projects', style: (@user.mail_notification == 'selected' ? '' : 'display:none;') do %>
+<%= content_tag 'div', id: 'notified-projects', :'ng-show' => "mail_notifications === 'selected'" do %>
   <div class="form--field -no-label">
     <div class="form--field-container -vertical">
       <% @user.projects.each do |project| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,7 +748,6 @@ en:
   description_selected_columns: "Selected Columns"
   description_sub_work_package: "Sub work package of current"
   description_toc_toggle: "Show/Hide table of contents"
-  description_user_mail_notification: "Mail notification settings"
   description_wiki_subpages_reassign: "Choose new parent page"
 
   # Text direction: Left-to-Right (ltr) or Right-to-Left (rtl)
@@ -1255,7 +1254,6 @@ en:
   label_used_by: "Used by"
   label_user_activity: "%{value}'s activity"
   label_user_anonymous: "Anonymous"
-  label_user_mail_self_notified: "I want to be notified of changes that I make myself"
   label_user_mail_option_all: "For any event on all my projects"
   label_user_mail_option_none: "No events"
   label_user_mail_option_only_assigned: "Only for things I am assigned to"
@@ -1850,7 +1848,6 @@ en:
   text_type_no_workflow: "No workflow defined for this type"
   text_unallowed_characters: "Unallowed characters"
   text_user_invited: The user has been invited and is pending registration.
-  text_user_mail_option: "For unselected projects, you will only receive notifications about things you watch or you're involved in (eg. work packages you're the author or assignee)."
   text_user_wrote: "%{value} wrote:"
   text_warn_on_leaving_unsaved: "The current page contains unsaved text that will be lost if you leave this page."
   text_wiki_destroy_confirmation: "Are you sure you want to delete this wiki and all its content?"
@@ -2112,6 +2109,10 @@ en:
     password_change_unsupported: Change of password is not supported.
     authorization_rejected: "You are not allowed to sign in."
     invite: Invite user via email
+    settings:
+      mail_notifications: "Send email notifications"
+      mail_self_notified: "I want to be notified of changes that I make myself"
+      mail_project_explanaition: "For unselected projects, you will only receive notifications about things you watch or you're involved in (e.g. work packages you're the author or assignee of)."
 
   version_status_closed: "closed"
   version_status_locked: "locked"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2090,6 +2090,7 @@ en:
     authentication_settings_disabled_due_to_external_authentication: >
       This user authenticates via an external authentication provider, so there is no password
       in OpenProject to be changed.
+    authorization_rejected: "You are not allowed to sign in."
     assign_random_password: "Assign random password (sent to user via email)"
     blocked: "locked temporarily"
     blocked_num_failed_logins:
@@ -2097,22 +2098,21 @@ en:
       other: "locked temporarily (%{count} failed login attempts)"
     deleted: "Deleted user"
     error_status_change_failed: "Changing the user status failed due to the following errors: %{errors}"
+    invite: Invite user via email
+    invited: invited
     lock: "Lock permanently"
     locked: "locked permanently"
+    no_login: "This user authenticates through login by password. Since it is disabled, they cannot log in."
+    password_change_unsupported: Change of password is not supported.
     registered: "registered"
-    invited: invited
     reset_failed_logins: "Reset failed logins"
+    settings:
+      mail_notifications: "Send email notifications"
+      mail_project_explanaition: "For unselected projects, you will only receive notifications about things you watch or you're involved in (e.g. work packages you're the author or assignee of)."
+      mail_self_notified: "I want to be notified of changes that I make myself"
     status_user_and_brute_force: "%{user} and %{brute_force}"
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
-    no_login: "This user authenticates through login by password. Since it is disabled, they cannot log in."
-    password_change_unsupported: Change of password is not supported.
-    authorization_rejected: "You are not allowed to sign in."
-    invite: Invite user via email
-    settings:
-      mail_notifications: "Send email notifications"
-      mail_self_notified: "I want to be notified of changes that I make myself"
-      mail_project_explanaition: "For unselected projects, you will only receive notifications about things you watch or you're involved in (e.g. work packages you're the author or assignee of)."
 
   version_status_closed: "closed"
   version_status_locked: "locked"


### PR DESCRIPTION
Turns the email notification settings for users into this:

![image](https://cloud.githubusercontent.com/assets/617519/15957883/379ca5b4-2ef2-11e6-96f6-196ca019b9a5.png)

meaning it is styled the same as the rest of the form.

Additionally, it replaces inline prototype with angular (although I am not sure whether I will go to developer hell for this hack 🙈 ).

Last but not least, it sorts the i10n for users alphabetically.
