### PR TITLE
remove wpEditField dependency from wpDisplayAttr

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
@@ -4,14 +4,12 @@
         aria-hidden="true">
   </span>
 
-  <span class="wp-table--cell-span inplace-edit--read-value--value __d__cell"
-        ng-click="$ctrl.activateIfEditable($event)"
-        data-click-on-keypress="[13, 32]"
-        focus="$ctrl.shouldFocus()">
+  <span class="wp-table--cell-span inplace-edit--read-value--value __d__cell" >
 
     <span class="__d__renderer">
       <ng-include ng-if="::!$ctrl.field.isManualRenderer"
-                  src="::$ctrl.field.template"></ng-include>
+                  src="::$ctrl.field.template">
+      </ng-include>
     </span>
 
   </span>

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -58,13 +58,6 @@ export class WorkPackageDisplayAttributeController {
     }
   }
 
-  public activateIfEditable(event) {
-    if (this.wpEditField.isEditable) {
-      this.wpEditField.handleUserActivate();
-    }
-    event.stopImmediatePropagation();
-  }
-
   public get placeholder() {
     return this.placeholderOptional || (this.field && this.field.placeholder);
   };
@@ -74,14 +67,6 @@ export class WorkPackageDisplayAttributeController {
       (this.schema[this.attribute] && this.schema[this.attribute].name) ||
       this.attribute;
   };
-
-  public isEditable() {
-    return this.wpEditField && this.wpEditField.isEditable;
-  };
-
-  public shouldFocus() {
-    return this.wpEditField && this.wpEditField.shouldFocus();
-  }
 
   public get labelId(): string {
     return 'wp-' + this.workPackage.id + '-display-attr-' + this.attribute + '-aria-label';
@@ -123,7 +108,6 @@ export class WorkPackageDisplayAttributeController {
         this.__d__hiddenForSighted.text(this.label + " " + this.displayText);
 
         this.__d__cell = this.__d__cell || this.$element.find(".__d__cell");
-        this.__d__cell.attr("tabindex", this.isEditable() ? "0" : "-1");
         this.__d__cell.attr("aria-labelledby", this.labelId);
         this.__d__cell.toggleClass("-placeholder", this.isEmpty);
     });
@@ -137,10 +121,8 @@ function wpDisplayAttrDirective() {
                     attr,
                     controllers) {
 
-    scope.$ctrl.wpEditField = controllers[0];
-
     // Listen for changes to the work package on the form ctrl
-    var formCtrl = controllers[1];
+    var formCtrl = controllers[0];
 
     if (formCtrl && !scope.$ctrl.customSchema) {
       formCtrl.onWorkPackageUpdated('wp-display-attr-' + scope.$ctrl.attribute, (wp) => {
@@ -153,7 +135,7 @@ function wpDisplayAttrDirective() {
     restrict: 'E',
     replace: true,
     templateUrl: '/components/work-packages/wp-display-attr/wp-display-attr.directive.html',
-    require: ['^?wpEditField', '^?wpEditForm'],
+    require: ['^?wpEditForm'],
     link: wpTdLink,
 
     scope: {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -23,7 +23,6 @@
     </label>
 
     <ng-include src="vm.field.template"></ng-include>
-
   </form>
 
   <wp-display-attr ng-switch-when="false"
@@ -32,7 +31,9 @@
                    work-package="::vm.workPackage"
                    placeholder="::vm.displayPlaceholder"
                    label="vm.fieldLabel"
-                   class="-hidden-overflow inplace-edit--read-value"
-                   ng-class="vm.displayClasses">
+                   class="-hidden-overflow inplace-edit--read-value __d__inplace-edit--read-value"
+                   ng-class="vm.displayClasses"
+                   ng-click="vm.activateIfEditable($event)"
+                   focus="vm.shouldFocus()">
   </wp-display-attr>
 </div>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -52,6 +52,8 @@ export class WorkPackageEditFieldController {
   // all fields are initially viewed as uneditable until it is loaded
   protected _editable: boolean = false;
 
+  private __d__inplaceEditReadValue: JQuery;
+
   constructor(protected wpEditField: WorkPackageEditFieldService,
               protected $scope,
               protected $element,
@@ -121,6 +123,8 @@ export class WorkPackageEditFieldController {
       this.editable = fieldSchema && fieldSchema.writable;
       this.fieldType = fieldSchema && this.wpEditField.fieldType(fieldSchema.type);
 
+      this.updateDisplayAttributes();
+
       if (fieldSchema) {
         this.fieldLabel = this.fieldLabel || fieldSchema.name;
 
@@ -130,6 +134,13 @@ export class WorkPackageEditFieldController {
         }
       }
     });
+  }
+
+  public activateIfEditable(event) {
+    if (this.isEditable) {
+      this.handleUserActivate();
+    }
+    event.stopImmediatePropagation();
   }
 
   public get isEditable(): boolean {
@@ -236,6 +247,10 @@ export class WorkPackageEditFieldController {
     });
   }
 
+  protected updateDisplayAttributes() {
+    this.__d__inplaceEditReadValue = this.__d__inplaceEditReadValue || this.$element.find(".__d__inplace-edit--read-value");
+    this.__d__inplaceEditReadValue.attr("tabindex", this.isEditable ? "0" : "-1");
+  }
 }
 
 function wpEditFieldLink(scope,

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -140,6 +140,29 @@ export class WorkPackageEditFieldController {
     return this.formCtrl.inEditMode;
   }
 
+  public isRequired(): boolean {
+    return this.workPackage.schema[this.fieldName].required;
+  }
+
+  public isEmpty(): boolean {
+    return !this.workPackage[this.fieldName];
+  }
+
+  public isChanged(): boolean {
+    return this.workPackage.$pristine[this.fieldName] !== this.workPackage[this.fieldName];
+  }
+
+  public isErrorenous(): boolean {
+    return this.errorenous;
+  }
+
+  public isSubmittable(): boolean {
+    return !(this.inEditMode ||
+             (this.isRequired() && this.isEmpty()) ||
+             (this.isErrorenous() && !this.isChanged()));
+
+  }
+
   public set editable(enabled: boolean) {
     this._editable = enabled;
   }
@@ -166,7 +189,7 @@ export class WorkPackageEditFieldController {
   }
 
   public handleUserBlur(): boolean {
-    if (this.inEditMode) {
+    if (!this.isSubmittable()) {
       return;
     }
 
@@ -198,7 +221,6 @@ export class WorkPackageEditFieldController {
 
   public setErrorState(error = true) {
     this.errorenous = error;
-    this.$element.toggleClass('-error', error);
   }
 
   public reset() {

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -80,7 +80,7 @@ class WorkPackageField
   end
 
   def trigger_link_selector
-    '.inplace-edit--read-value--value'
+    '.inplace-edit--read-value--container'
   end
 
   def field_selector


### PR DESCRIPTION
That dependency is unnecessary as we can remove the inplace edit trigger functionality one dom element up.

We unfortunately still need the wpEditForm dependency to update the work package upon changes.

Depends on #4525 which it now includes. Otherwise, specs break which but that breaking is unrelated to the changes in the PR.
