### PR TITLE
[23251] Fix summing done_ratio when estimated_hours is zero

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -699,19 +699,24 @@ class WorkPackage < ActiveRecord::Base
   def inherit_done_ratio_from_leaves
     return if WorkPackage.done_ratio_disabled?
 
-    # done ratio = weighted average ratio of leaves
-    unless WorkPackage.use_status_for_done_ratio? && status && status.default_done_ratio
-      leaves_count = leaves.count
-      if leaves_count > 0
-        average = leaves.average(:estimated_hours).to_f
-        if average == 0
-          average = 1
-        end
-        done = leaves.joins(:status).sum("COALESCE(estimated_hours, #{average}) * (CASE WHEN is_closed = #{self.class.connection.quoted_true} THEN 100 ELSE COALESCE(done_ratio, 0) END)").to_f
-        progress = done / (average * leaves_count)
+    return if WorkPackage.use_status_for_done_ratio? && status && status.default_done_ratio
 
-        self.done_ratio = progress.round
+    # done ratio = weighted average ratio of leaves
+    leaves_count = leaves.count
+    if leaves_count > 0
+      average = leaves.average(:estimated_hours).to_f
+      if average == 0
+        average = 1
       end
+
+      # Do not take into account estimated_hours when it is either nil or set to 0.0
+      sum_sql = <<-SQL
+      COALESCE((CASE WHEN estimated_hours = 0.0 THEN NULL ELSE estimated_hours END), #{average})
+      * (CASE WHEN is_closed = #{self.class.connection.quoted_true} THEN 100 ELSE COALESCE(done_ratio, 0) END)
+      SQL
+      done = leaves.joins(:status).sum(sum_sql)
+      progress = done / (average * leaves_count)
+      self.done_ratio = progress.round
     end
   end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -630,6 +630,28 @@ describe WorkPackage, type: :model do
       end
     end
 
+    context 'with parent set' do
+      let(:parent) { FactoryGirl.create(:work_package) }
+      let(:work_package) { FactoryGirl.create(:work_package, parent: parent) }
+
+      it 'sets parent done_ratio from child' do
+        work_package.done_ratio = 50
+        work_package.save!
+
+        parent.reload
+        expect(parent.done_ratio).to eq(50)
+      end
+
+      it 'sets parent done_ratio from child when estimated_hours is 0' do
+        work_package.estimated_hours = 0.0
+        work_package.done_ratio = 100
+        work_package.save!
+
+        parent.reload
+        expect(parent.done_ratio).to eq(100)
+      end
+    end
+
     describe '#update_done_ratio_from_status' do
       context 'work package field' do
         before do


### PR DESCRIPTION
When `estimated_hours` is `0.0`, it is still taken into consideration
when weighting average done ratios for a parent. That results in the
parent becoming `0%` done.

As 0.0 is being set in the frontend as the default value, this is now
happening all over the board.

A separate PR should refactor the frontend for 5.1. to allow null as a
value for estimated_hours.

https://community.openproject.com/work_packages/23251/activity
