### PR TITLE
Fix HalLink `delete()` method

### DIFF
--- a/frontend/app/components/api/api-v3/api-v3-cache.config.ts
+++ b/frontend/app/components/api/api-v3/api-v3-cache.config.ts
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {opApiModule} from "../../../angular-modules";
+
 function apiV3CacheConfig($provide) {
   // Add caching wrapper around $http using angular-cache
   $provide.decorator('$http', ($delegate:ng.IHttpService, CacheService:op.CacheService) => {
@@ -66,6 +68,4 @@ function apiV3CacheConfig($provide) {
   });
 }
 
-angular
-  .module('openproject.api')
-  .config(apiV3CacheConfig);
+opApiModule.config(apiV3CacheConfig);

--- a/frontend/app/components/api/api-v3/api-v3.config.ts
+++ b/frontend/app/components/api/api-v3/api-v3.config.ts
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {opApiModule} from "../../../angular-modules";
+
 function apiV3Config(apiV3, halTransform) {
   apiV3.addResponseInterceptor((data, operation, what) => {
     apiV3.addElementTransformer(what, halTransform);
@@ -33,7 +35,7 @@ function apiV3Config(apiV3, halTransform) {
       data._plain = angular.copy(data);
 
       if (data._type === 'Collection') {
-        let resp = [];
+        const resp = [];
         angular.extend(resp, data);
         return resp;
       }
@@ -46,6 +48,4 @@ function apiV3Config(apiV3, halTransform) {
   });
 }
 
-angular
-  .module('openproject.api')
-  .run(apiV3Config);
+opApiModule.run(apiV3Config);

--- a/frontend/app/components/api/api-v3/api-v3.service.test.ts
+++ b/frontend/app/components/api/api-v3/api-v3.service.test.ts
@@ -26,17 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {opApiModule, opServicesModule} from "../../../angular-modules";
+
+const expect = chai.expect;
+
 describe('apiV3 service', () => {
   var apiV3:restangular.IService;
   var $httpBackend:ng.IHttpBackendService;
 
-  beforeEach(angular.mock.module('openproject.api'));
-  beforeEach(angular.mock.module('openproject.services'));
-
-  beforeEach(angular.mock.inject((_apiV3_, _$httpBackend_) => {
-    apiV3 = _apiV3_;
-    $httpBackend = _$httpBackend_;
-
+  beforeEach(angular.mock.module(opApiModule.name, opServicesModule.name));
+  beforeEach(angular.mock.inject(function (_$httpBackend_, _apiV3_) {
+    [$httpBackend, apiV3] = arguments;
     apiV3.setBaseUrl('/base');
     apiV3.setDefaultHttpFields({cache: false});
   }));

--- a/frontend/app/components/api/api-v3/api-v3.service.ts
+++ b/frontend/app/components/api/api-v3/api-v3.service.ts
@@ -27,6 +27,7 @@
 // ++
 
 import {ApiPathsService} from "../api-paths/api-paths.service";
+import {opApiModule} from "../../../angular-modules";
 
 function apiV3Service(apiPaths:ApiPathsService,
                       Restangular:restangular.IService) {
@@ -36,6 +37,4 @@ function apiV3Service(apiPaths:ApiPathsService,
   });
 }
 
-angular
-  .module('openproject.api')
-  .factory('apiV3', apiV3Service);
+opApiModule.factory('apiV3', apiV3Service);

--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.test.ts
@@ -26,16 +26,18 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {opApiModule, opServicesModule} from "../../../../angular-modules";
+
+const expect = chai.expect;
+
 describe('HalLink service', () => {
   var $httpBackend:ng.IHttpBackendService;
   var HalLink;
   var apiV3;
 
-  beforeEach(angular.mock.module('openproject.api', 'openproject.services'));
-  beforeEach(angular.mock.inject((_apiV3_, _HalLink_, _$httpBackend_) => {
-    apiV3 = _apiV3_;
-    HalLink = _HalLink_;
-    $httpBackend = _$httpBackend_;
+  beforeEach(angular.mock.module(opApiModule.name, opServicesModule.name));
+  beforeEach(angular.mock.inject(function (_$httpBackend_, _apiV3_, _HalLink_) {
+    [$httpBackend, apiV3, HalLink] = arguments;
 
     apiV3.setDefaultHttpFields({cache: false});
   }));

--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.test.ts
@@ -27,6 +27,7 @@
 //++
 
 import {opApiModule, opServicesModule} from "../../../../angular-modules";
+import {HalLink} from "./hal-link.service";
 
 const expect = chai.expect;
 
@@ -34,6 +35,7 @@ describe('HalLink service', () => {
   var $httpBackend:ng.IHttpBackendService;
   var HalLink;
   var apiV3;
+  var link:HalLink;
 
   beforeEach(angular.mock.module(opApiModule.name, opServicesModule.name));
   beforeEach(angular.mock.inject(function (_$httpBackend_, _apiV3_, _HalLink_) {
@@ -47,8 +49,6 @@ describe('HalLink service', () => {
   });
 
   describe('when creating a HalLink from an empty object', () => {
-    var link;
-
     beforeEach(() => {
       link = HalLink.fromObject({});
     });
@@ -62,8 +62,21 @@ describe('HalLink service', () => {
     });
   });
 
+  describe('when the method of the link is "delete"', () => {
+    beforeEach(() => {
+      link = HalLink.fromObject({
+        href: 'home',
+        method: 'delete'
+      });
+    });
+
+    it('should throw no error', () => {
+      const fetch = () => link.$fetch();
+      expect(fetch).not.to.throw(Error);
+    });
+  });
+
   describe('when using the link', () => {
-    var link;
     var promise;
     var response;
     var apiRequest = () => {

--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
@@ -79,10 +79,8 @@ export class HalLink implements HalLinkInterface {
   }
 }
 
-function halLinkService(_$q_:ng.IQService, _apiV3_:restangular.IService) {
-  $q = _$q_;
-  apiV3 = _apiV3_;
-
+function halLinkService() {
+  [$q, apiV3] = arguments;
   return HalLink;
 }
 

--- a/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
+++ b/frontend/app/components/api/api-v3/hal-link/hal-link.service.ts
@@ -47,6 +47,13 @@ export class HalLink implements HalLinkInterface {
     return HalLink.fromObject(link).$toFunc();
   }
 
+  /**
+   *  Return the restangular element.
+   */
+  public get $route():restangular.IElement {
+    return apiV3.oneUrl('route', this.href);
+  }
+
   constructor(public href:string = null,
               public title:string = '',
               public method:string = 'get',
@@ -62,18 +69,13 @@ export class HalLink implements HalLinkInterface {
       params.unshift('');
     }
 
-    return this.$toRoute()[this.method](...params);
-  }
-
-  /** Returns the restangular route object */
-  public $toRoute() {
-    return apiV3.oneUrl('route', this.href);
+    return this.$route[this.method === 'delete' && 'remove' || this.method](...params);
   }
 
   public $toFunc() {
     const func:any = (...params) => this.$fetch(...params);
     func.$link = this;
-    func.$route = this.$toRoute();
+    func.$route = this.$route;
 
     return func;
   }

--- a/frontend/app/components/api/api-v3/hal-resources/collection-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/collection-resource.service.test.ts
@@ -26,27 +26,29 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {opApiModule, opServicesModule} from "../../../../angular-modules";
+
+const expect = chai.expect;
+
 describe('CollectionResource', () => {
   var CollectionResource;
 
-  beforeEach(angular.mock.module('openproject.api'));
-  beforeEach(angular.mock.module('openproject.services'));
-
+  beforeEach(angular.mock.module(opApiModule.name, opServicesModule.name));
   beforeEach(angular.mock.inject((_CollectionResource_) => {
     CollectionResource = _CollectionResource_;
   }));
 
   describe('getElements', () => {
     it('returns the embedded elements', () => {
-      var plain = {
-                    $embedded: {
-                      elements: [1,2,3]
-                    }
-                  }
+      var source = {
+        $embedded: {
+          elements: [1, 2, 3]
+        }
+      };
 
-      var resource = new CollectionResource(plain);
+      var resource = new CollectionResource(source);
 
-      expect(resource.getElements()).to.eql(plain.$embedded.elements);
+      expect(resource.getElements()).to.eql(source.$embedded.elements);
     });
   });
 });

--- a/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
@@ -73,8 +73,8 @@ export class ErrorResource extends HalResource {
     return columns.map(field => field.details.attribute);
   }
 
-  public getMessagesPerAttribute(): object {
-    var perAttribute = {}
+  public getMessagesPerAttribute():any {
+    var perAttribute = {};
 
     if (this.details) {
       perAttribute[this.details.attribute] = [this.message];
@@ -94,9 +94,11 @@ export class ErrorResource extends HalResource {
   }
 }
 
-function errorResource(_NotificationsService_) {
-  NotificationsService = _NotificationsService_;
+function errorResourceService() {
+  [NotificationsService] = arguments;
   return ErrorResource;
 }
 
-opApiModule.factory('ErrorResource', ['NotificationsService', errorResource]);
+errorResourceService.$inject = ['NotificationsService'];
+
+opApiModule.factory('ErrorResource', errorResourceService);

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -37,9 +37,7 @@ describe('HalResource service', () => {
 
   beforeEach(angular.mock.module(opApiModule.name, opServicesModule.name));
   beforeEach(angular.mock.inject((_$httpBackend_, _HalResource_, apiV3) => {
-    $httpBackend = _$httpBackend_;
-    HalResource = _HalResource_;
-
+    [$httpBackend, HalResource] = arguments;
     apiV3.setDefaultHttpFields({cache: false});
   }));
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -223,12 +223,8 @@ export class HalResource {
   }
 }
 
-function halResourceService(_$q_, _lazy_, _halTransform_, _HalLink_) {
-  $q = _$q_;
-  lazy = _lazy_;
-  halTransform = _halTransform_;
-  HalLink = _HalLink_;
-
+function halResourceService() {
+  [$q, lazy, halTransform, HalLink] = arguments;
   return HalResource;
 }
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -305,19 +305,11 @@ export class WorkPackageResource extends HalResource {
 export interface WorkPackageResourceInterface extends WorkPackageResourceLinks, WorkPackageResourceEmbedded, WorkPackageResource {
 }
 
-function wpResource(_$q_, _apiWorkPackages_, _wpCacheService_, _NotificationsService_) {
-  $q = _$q_;
-  apiWorkPackages = _apiWorkPackages_;
-  wpCacheService = _wpCacheService_;
-  NotificationsService = _NotificationsService_;
-
+function wpResource() {
+  [$q, apiWorkPackages, wpCacheService, NotificationsService] = arguments;
   return WorkPackageResource;
 }
 
-opApiModule.factory('WorkPackageResource', [
-  '$q',
-  'apiWorkPackages',
-  'wpCacheService',
-  'NotificationsService',
-  wpResource
-]);
+wpResource.$inject = ['$q', 'apiWorkPackages', 'wpCacheService', 'NotificationsService'];
+
+opApiModule.factory('WorkPackageResource', wpResource);

--- a/frontend/app/components/api/api-v3/hal-transform/hal-transform.service.ts
+++ b/frontend/app/components/api/api-v3/hal-transform/hal-transform.service.ts
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {opApiModule} from "../../../../angular-modules";
+
 function halTransform(halTransformTypes) {
   return (element:op.ApiResult) => {
     const resourceClass = halTransformTypes[element._type] || halTransformTypes.default;
@@ -43,6 +45,4 @@ function halTransform(halTransformTypes) {
   };
 }
 
-angular
-  .module('openproject.api')
-  .factory('halTransform', halTransform);
+opApiModule.factory('halTransform', halTransform);

--- a/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
+++ b/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
@@ -27,6 +27,7 @@
 //++
 
 import {HalResource} from '../api-v3/hal-resources/hal-resource.service';
+import {opApiModule} from "../../../angular-modules";
 
 export class ApiWorkPackagesService {
   protected wpBaseApi;
@@ -113,6 +114,4 @@ export class ApiWorkPackagesService {
   }
 }
 
-angular
-  .module('openproject.api')
-  .service('apiWorkPackages', ApiWorkPackagesService);
+opApiModule.service('apiWorkPackages', ApiWorkPackagesService);

--- a/frontend/app/components/api/restangular.config.ts
+++ b/frontend/app/components/api/restangular.config.ts
@@ -26,10 +26,10 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {opApiModule} from "../../angular-modules";
+
 function restangularConfiguration(RestangularProvider: restangular.IProvider) {
   RestangularProvider.setDefaultHttpFields({cache: true});
 }
 
-angular
-  .module('openproject.api')
-  .config(restangularConfiguration);
+opApiModule.config(restangularConfiguration);

--- a/frontend/app/components/api/restangular.config.ts
+++ b/frontend/app/components/api/restangular.config.ts
@@ -30,6 +30,7 @@ import {opApiModule} from "../../angular-modules";
 
 function restangularConfiguration(RestangularProvider: restangular.IProvider) {
   RestangularProvider.setDefaultHttpFields({cache: true});
+  RestangularProvider.setDefaultHeaders({'Content-Type': 'application/json;charset=UTF-8'});
 }
 
 opApiModule.config(restangularConfiguration);


### PR DESCRIPTION
Fetching a `DELETE` link did not work prior to this PR, because `restangular` uses `remove()` instead of `delete()` internally.
