### PR TITLE
[23299] Long text with formatting

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -198,6 +198,11 @@ export class WorkPackageResource extends HalResource {
         // Override the current schema with
         // the changes from API
         this.schema = form.$embedded.schema;
+
+        // Take over new values from the form
+        // this resource doesn't know yet.
+        this.assignNewValues(form.$embedded.payload);
+
         deferred.resolve(form);
       })
       .catch(error => {
@@ -299,6 +304,14 @@ export class WorkPackageResource extends HalResource {
     });
 
     return plainPayload;
+  }
+
+  private assignNewValues(formPayload) {
+    Object.keys(formPayload.$source).forEach(key => {
+      if (angular.isUndefined(this[key])) {
+        this[key] = formPayload[key];
+      }
+    });
   }
 }
 

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -310,7 +310,7 @@ module API
             value = send custom_field.accessor_name
 
             if custom_field.field_format == 'text'
-              ::API::Decorators::Formattable.new(value, format: 'plain')
+              ::API::Decorators::Formattable.new(value)
             else
               value
             end

--- a/spec/features/work_packages/details/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/activity_comments_spec.rb
@@ -33,6 +33,11 @@ describe 'activity comments', js: true, selenium: true do
       wp_page.ensure_page_loaded
     end
 
+    describe 'preview' do
+      let(:field) { comment_field }
+      it_behaves_like 'a previewable field'
+    end
+
     context 'in edit state' do
       before do
         comment_field.activate!
@@ -101,22 +106,16 @@ describe 'activity comments', js: true, selenium: true do
         end
       end
 
-      describe 'preview' do
-        it 'previews the comment' do
-          comment_field.input_element.set '*Highlight*'
-          preview = comment_field.element.find('.jstb_preview')
+      it 'saves while in preview mode' do
+        comment_field.input_element.set '*Highlight*'
+        preview = comment_field.element.find('.jstb_preview')
 
-          # Enable preview
-          preview.click
-          expect(comment_field.element).to have_selector('strong', text: 'Highlight')
+        # Enable preview
+        preview.click
+        expect(comment_field.element).to have_selector('strong', text: 'Highlight')
 
-          # Disable preview
-          preview.click
-          expect(comment_field.element).to have_no_selector('strong')
-
-          comment_field.submit_by_click
-          expect(page).to have_selector('.user-comment .message', text: 'Highlight')
-        end
+        comment_field.submit_by_click
+        expect(page).to have_selector('.user-comment .message', text: 'Highlight')
       end
 
       describe 'autocomplete' do

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -71,16 +71,6 @@ describe 'description inplace editor', js: true, selenium: true do
     end
   end
 
-  context 'autocomplete' do
-    let!(:wp2) { FactoryGirl.create(:work_package, project: project, subject: 'AutoFoo') }
-    let(:description_text) { '' }
-
-    it 'autocompletes the other work package' do
-      field.activate!
-      field.input_element.send_keys("##{wp2.id}")
-      expect(page).to have_selector('.atwho-view-ul li', text: wp2.to_s)
-    end
-  end
-
   it_behaves_like 'a cancellable field'
+  it_behaves_like 'an autocomplete field'
 end

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -87,7 +87,7 @@ shared_examples 'a cancellable field' do
 
   context 'by click' do
     before do
-      field.activate_edition
+      field.activate!
       field.cancel_by_click
     end
 
@@ -96,10 +96,37 @@ shared_examples 'a cancellable field' do
 
   context 'by escape' do
     before do
-      field.activate_edition
+      field.activate!
       field.cancel_by_escape
     end
 
     it_behaves_like 'cancelling properly'
+  end
+end
+
+shared_examples 'a previewable field' do
+  it 'can preview the field' do
+    field.activate!
+
+    field.input_element.set '*Highlight*'
+    preview = field.element.find('.jstb_preview')
+
+    # Enable preview
+    preview.click
+    expect(field.element).to have_selector('strong', text: 'Highlight')
+
+    # Disable preview
+    preview.click
+    expect(field.element).to have_no_selector('strong')
+  end
+end
+
+shared_examples 'an autocomplete field' do
+  let!(:wp2) { FactoryGirl.create(:work_package, project: project, subject: 'AutoFoo') }
+
+  it 'autocompletes the other work package' do
+    field.activate!
+    field.input_element.send_keys("##{wp2.id}")
+    expect(page).to have_selector('.atwho-view-ul li', text: wp2.to_s.strip)
   end
 end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -356,7 +356,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
           {
             format: 'textile',
             raw: value,
-            html: "<p><strong>Foobar</strong></p>"
+            html: '<p><strong>Foobar</strong></p>'
           }
         end
         let(:expected_setter) { value }

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -351,12 +351,12 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'text custom field' do
       it_behaves_like 'injects property custom field' do
         let(:field_format) { 'text' }
-        let(:value) { 'Foobar' }
+        let(:value) { '*Foobar*' }
         let(:json_value) do
           {
-            format: 'plain',
+            format: 'textile',
             raw: value,
-            html: "<p>#{value}</p>"
+            html: "<p><strong>Foobar</strong></p>"
           }
         end
         let(:expected_setter) { value }


### PR DESCRIPTION
_Use default Setting.text_formatting for text CF_
This changes the forced formatting of 'plain' to the default formatting, thus allowing textile formatting.

Also fixes a bug found when switching to types with long text CF. 
When switching types and the type requires, e.g., a long text CF, that object is not available in the resource.

https://community.openproject.com/work_packages/23299/activity
