### PR TITLE
Hide email configuration in UI when using legacy configuration

### DIFF
--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -68,7 +68,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
       <% end %>
     </fieldset>
-    <fieldset id="mail_configuration" class="form--fieldset">
+    <%= content_tag :fieldset, id: "mail_configuration", class: "form--fieldset" do %>
       <legend class="form--fieldset-legend"><%=l(:text_setup_mail_configuration)%></legend>
       <div class="form--field"><%= setting_select(:email_delivery_method, [:smtp, :sendmail], id: "email_delivery_method_switch") %></div>
       <div id="email_delivery_method_smtp" class="email_delivery_method_settings">
@@ -83,7 +83,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <div id="email_delivery_method_sendmail" class="email_delivery_method_settings">
         <div class="form--field"><%= setting_text_field :sendmail_location %></div>
       </div>
-    </fieldset>
+    <% end unless OpenProject::Configuration['email_delivery_configuration'] == 'legacy' %>
 
     <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
     <div style="float:none;display:inline-block;font-weight:bold;">

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -221,6 +221,8 @@ module OpenProject
       end
 
       def migrate_mailer_configuration!
+        # do not migrate if forced to legacy configuration (using settings or ENV)
+        return true if @config['email_delivery_configuration'] == 'legacy'
         # do not migrate if no legacy configuration
         return true if @config['email_delivery_method'].blank?
         # do not migrate if the setting already exists and is not blank

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -229,6 +229,12 @@ describe OpenProject::Configuration do
       expect(OpenProject::Configuration.migrate_mailer_configuration!).to eq(true)
     end
 
+    it 'does nothing if email_delivery_configuration forced to legacy' do
+      OpenProject::Configuration['email_delivery_configuration'] = 'legacy'
+      expect(Setting).to_not receive(:email_delivery_method=)
+      expect(OpenProject::Configuration.migrate_mailer_configuration!).to eq(true)
+    end
+
     it 'does nothing if setting already set' do
       OpenProject::Configuration['email_delivery_method'] = :sendmail
       Setting.email_delivery_method = :sendmail
@@ -276,6 +282,7 @@ describe OpenProject::Configuration do
       Setting.email_delivery_method = :smtp
       Setting.smtp_password = 'p4ssw0rd'
       Setting.smtp_address = 'smtp.example.com'
+      Setting.smtp_domain = 'example.com'
       Setting.smtp_port = 587
       Setting.smtp_user_name = 'username'
       Setting.smtp_enable_starttls_auto = 1


### PR DESCRIPTION
This is especially important for the hosted version, since it will use the legacy configuration.
