### PR TITLE
[23508] Fokus im Accessibilitymodus nicht sichtbar (IE)

### DIFF
--- a/app/assets/stylesheets/accessibility.sass
+++ b/app/assets/stylesheets/accessibility.sass
@@ -63,3 +63,9 @@ h3:hover a.wiki-anchor
 
     &:hover
       border-color: $font-color-on-primary-dark
+
+// Neccessary to have enough space for the border in IE
+.wp-table--cell
+  .inplace-edit .inplace-edit--read-value.inplace-edit--read-value--container,
+  .id a
+    margin: 3px


### PR DESCRIPTION
In accessibility mode in IE the focus border was not correctly shown in the WP table. This is because there is no space and the outline implementation does not change the height/width. Therefore I added the space in accessibility mode. Thus the border is shown now.

https://community.openproject.com/work_packages/23508/activity
