### PR TITLE
[23410] Use $state.transition for moving to fullscreen

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-id-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-id-field.directive.html
@@ -1,5 +1,8 @@
 <span ng-if="!$ctrl.field.isEmpty()" title="{{ $ctrl.displayText }}">
-  <a ng-href="{{ $ctrl.field.valueLink }}">
+
+  <a role="link"
+     title='{{ $ctrl.field.text.linkTitle }}'
+     ui-sref="work-packages.show({workPackageId: $ctrl.field.value})">
     {{ $ctrl.displayText }}
   </a>
 </span>

--- a/frontend/app/components/wp-display/field-types/wp-display-id-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-id-field.module.ts
@@ -29,7 +29,19 @@
 import {DisplayField} from "../wp-display-field/wp-display-field.module";
 
 export class IdDisplayField extends DisplayField {
-  public template:string = '/components/wp-display/field-types/wp-display-id-field.directive.html'
+  public template: string = '/components/wp-display/field-types/wp-display-id-field.directive.html'
+  public text: Object;
+
+
+  constructor(public resource:HalResource,
+              public name:string,
+              public schema) {
+    super(resource, name, schema);
+
+    this.text = {
+      linkTitle: this.I18n.t('js.work_packages.message_successful_show_in_fullscreen')
+    }
+  }
 
   public get value() {
     if (this.resource.isNew) {
@@ -42,11 +54,5 @@ export class IdDisplayField extends DisplayField {
 
   public isEmpty(): boolean {
     return false;
-  }
-
-  public get valueLink() {
-    let PathHelper = <op.PathHelper>this.$injector.get('PathHelper');
-
-    return PathHelper.workPackagePath(this.value);
   }
 }


### PR DESCRIPTION
This uses an accessible-by-keyboard for moving from table to show view
in the ID links.

The link still has an href to allow opening them in, e.g., a new tab.

https://community.openproject.com/work_packages/23410/activity
