### PR TITLE
Bump rails_12factor to 0.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,8 +422,8 @@ GEM
       rails_stdout_logging
     rails_autolink (1.1.6)
       rails (> 3.1)
-    rails_serve_static_assets (0.0.4)
-    rails_stdout_logging (0.0.4)
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)


### PR DESCRIPTION
Fixes a logging error with Rails 4.2.6
https://github.com/rails/rails/issues/24142
https://github.com/heroku/rails_stdout_logging/pull/22
