### PR TITLE
[23289] [Accessibility] Focusverlust nach dem Speichern eines Eintrags

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -85,7 +85,11 @@ export class WorkPackageEditFieldController {
     }
 
     this.formCtrl.updateWorkPackage()
-      .finally(() => this.deactivate());
+      .finally(() => {
+        this.deactivate();
+        this._forceFocus = true;
+        this.focusField();
+      });
   }
 
   public deactivate() {


### PR DESCRIPTION
This sets the focus if a field in the wp table is submitted.

https://community.openproject.com/work_packages/23289/activity
