### PR TITLE
[23281] [Accessibility] Doppelte Zellinhalte im DOM

### DIFF
--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.html
@@ -8,7 +8,7 @@
        id="{{ headerTitle }}"
        onclick="setTimeout(function(){ $(document).getElementsByClassName('menu-item')[0].focus(); }, 100);">{{headerTitle}}</a>
     <a ng-if="!sortable">{{headerTitle}}</a>
-    <label class="hidden-for-sighted" for="{{ headerTitle }}"> {{ fullTitle }} </label>
+    <label class="hidden-for-sighted" aria-hidden="true" for="{{ headerTitle }}"> {{ fullTitle }} </label>
     <icon-wrapper css-class="dropdown-indicator icon-small"
                   icon-name="pulldown"
                   title="{{I18n.t('js.label_open_menu')}}"></icon-wrapper>


### PR DESCRIPTION
This adds an `aria-hidden: true` to the wp table header. Thus the content is not read twice.

https://community.openproject.com/work_packages/23281/activity
