### PR TITLE
TypeFixes 

### DIFF
--- a/frontend/app/typings/type-fixes.d.ts
+++ b/frontend/app/typings/type-fixes.d.ts
@@ -1,0 +1,14 @@
+declare namespace typeFixes {
+  
+  interface ArrayFix {
+    length: number;
+    filter(callback: Function, thisArg?: any);
+    find(callback: Function, thisArg?: any);
+    findIndex(callback: Function, thisArg?: any);
+    forEach(callback: Function);
+    indexOf(searchElement: any, fromIndex?: any);
+    push(elements: any);
+    sort(compareFunction: Function);
+  }
+
+}


### PR DESCRIPTION
Some Types do not provide definitions for properties that are actually available.
Example: `FileList` or `DOMStringList`

In a JS context they are arrays but the TS-Compiler throws an error when trying to access their array methods / properties.

We can use and extend this fix until we find a better solution or until the methods will become included by default.

Usage: ( [docs for intersection types](https://www.typescriptlang.org/docs/handbook/advanced-types.html) )
`const foo: FileList & typeFixes.ArrayFix`;
