### PR TITLE
[23300] Fix date fields not being updated

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
@@ -29,7 +29,6 @@
 describe('wpDisplayAttr directive', () => {
   var compile;
   var element;
-  var wpEditForm;
   var rootScope;
   var scope;
   var I18n;
@@ -49,7 +48,7 @@ describe('wpDisplayAttr directive', () => {
     });
   }));
 
-  beforeEach(angular.mock.inject(($rootScope, $compile, _I18n_) => {
+  beforeEach(angular.mock.inject(($rootScope, $compile, _I18n_, _$httpBackend_) => {
     var html = `
       <wp-display-attr work-package="workPackage" attribute="attribute">
       </wp-display-attr>
@@ -64,11 +63,8 @@ describe('wpDisplayAttr directive', () => {
     rootScope = $rootScope;
     scope = $rootScope.$new();
 
-    // Link to wpEditForm
-    wpEditForm = {
-      onWorkPackageUpdated: sinon.spy()
-    }
-    element.data("$wpEditFormController", wpEditForm);
+    // Expected request for updates
+    _$httpBackend_.expectGET('/api/v3/work_packages').respond(200);
 
     compile = () => {
       $compile(element)(scope);
@@ -142,10 +138,6 @@ describe('wpDisplayAttr directive', () => {
       beforeEach(() => {
         scope.attribute = 'type';
         compile();
-      });
-
-      it('should register the observer for that field', () => {
-        expect(wpEditForm.onWorkPackageUpdated.calledWith('wp-display-attr-type')).to.be.true;
       });
 
       it('should contain the object title', () => {

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -131,7 +131,6 @@ function wpDisplayAttrDirective(wpCacheService:WorkPackageCacheService) {
     restrict: 'E',
     replace: true,
     templateUrl: '/components/work-packages/wp-display-attr/wp-display-attr.directive.html',
-    require: ['^?wpEditForm'],
     link: wpTdLink,
 
     scope: {

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -32,6 +32,8 @@ import {WorkPackageEditFieldController} from "../../wp-edit/wp-edit-field/wp-edi
 import {WorkPackageCacheService} from "../work-package-cache.service";
 import {DisplayField} from "../../wp-display/wp-display-field/wp-display-field.module";
 import {WorkPackageDisplayFieldService} from "../../wp-display/wp-display-field/wp-display-field.service";
+import {scopedObservable} from "../../../helpers/angular-rx-utils";
+import {WorkPackageResource} from "../../api/api-v3/hal-resources/work-package-resource.service";
 
 export class WorkPackageDisplayAttributeController {
 
@@ -110,20 +112,18 @@ export class WorkPackageDisplayAttributeController {
   }
 }
 
-function wpDisplayAttrDirective() {
+function wpDisplayAttrDirective(wpCacheService:WorkPackageCacheService) {
 
   function wpTdLink(scope,
                     element,
                     attr,
                     controllers) {
 
-    // Listen for changes to the work package on the form ctrl
-    var formCtrl = controllers[0];
-
-    if (formCtrl && !scope.$ctrl.customSchema) {
-      formCtrl.onWorkPackageUpdated('wp-display-attr-' + scope.$ctrl.attribute, (wp) => {
-        scope.$ctrl.updateAttribute(wp);
-      });
+    if (!scope.$ctrl.customSchema) {
+      scopedObservable(scope, wpCacheService.loadWorkPackage(scope.$ctrl.workPackage.id))
+        .subscribe((wp: WorkPackageResource) => {
+          scope.$ctrl.updateAttribute(wp);
+        });
     }
   }
 

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -272,36 +272,38 @@ export class WorkPackageEditFieldController {
   }
 }
 
-function wpEditFieldLink(scope,
-                         element,
-                         attrs,
-                         controllers: [WorkPackageEditFormController, WorkPackageEditFieldController]) {
+function wpEditField(wpCacheService: WorkPackageCacheService) {
 
-  var formCtrl = controllers[0];
-  controllers[1].formCtrl = formCtrl;
+  function wpEditFieldLink(scope,
+                           element,
+                           attrs,
+                           controllers: [WorkPackageEditFormController, WorkPackageEditFieldController]) {
 
-  formCtrl.registerField(scope.vm);
-  formCtrl.onWorkPackageUpdated('wp-edit-field-' + scope.vm.fieldName, (wp) => {
-    scope.vm.workPackage = wp;
-    scope.vm.initializeField();
-  });
+    var formCtrl = controllers[0];
+    controllers[1].formCtrl = formCtrl;
 
-  if (formCtrl.workPackage) {
-    scope.vm.workPackage = formCtrl.workPackage;
-    scope.vm.initializeField();
+    formCtrl.registerField(scope.vm);
+    scopedObservable(scope, wpCacheService.loadWorkPackage(formCtrl.workPackage.id))
+      .subscribe((wp: WorkPackageResource) => {
+        scope.vm.workPackage = wp;
+        scope.vm.initializeField();
+      });
+
+    if (formCtrl.workPackage) {
+      scope.vm.workPackage = formCtrl.workPackage;
+      scope.vm.initializeField();
+    }
+
+    element.addClass(scope.vm.fieldName);
+    element.keyup(event => {
+      if (event.keyCode === 27) {
+        scope.$evalAsync(() => {
+          scope.vm.handleUserCancel(true);
+        });
+      }
+    });
   }
 
-  element.addClass(scope.vm.fieldName);
-  element.keyup(event => {
-    if (event.keyCode === 27) {
-      scope.$evalAsync(() => {
-        scope.vm.handleUserCancel(true);
-      });
-    }
-  });
-}
-
-function wpEditField() {
   return {
     restrict: 'A',
     templateUrl: '/components/wp-edit/wp-edit-field/wp-edit-field.directive.html',

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -39,7 +39,6 @@ export class WorkPackageEditFormController {
   public errorHandler: Function;
   public successHandler: Function;
   public fields = {};
-  public observers:{[name: string]: Function} = {};
 
   private errorsPerAttribute: Object = {};
   public firstActiveField: string;
@@ -58,21 +57,6 @@ export class WorkPackageEditFormController {
     if (this.hasEditMode) {
       wpEditModeState.register(this);
     }
-
-    scopedObservable(this.$scope, this.wpCacheService.loadWorkPackage(this.workPackage.id))
-      .subscribe((wp: WorkPackageResource) => {
-        this.workPackage = wp;
-        angular.forEach(this.observers, (callback, name) => {
-          callback(wp);
-        })
-      });
-  }
-
-  /**
-   * Add an observer to the wpCacheService observed work package
-   */
-  public onWorkPackageUpdated(name: string, callback:Function) {
-    this.observers[name] = callback;
   }
 
   public isFieldRequired(fieldName) {


### PR DESCRIPTION
For Milestone rows, start and due date are both mapped to `date` and
thus collide with the wpEditForm#callbacks helper that propagate changes
from the `wpCacheService` down to edit and display fields.

This fails to update the last field since they registers callbacks based on their attribute name.
This commit instead suggests to use the wpCacheService directly, since
the scopedObservable will handle deregistration correctly on its own.

This implcitly fixes: https://community.openproject.com/work_packages/23300/activity

@romanroe: As we discussed, this removes the custom callbacks. I've compared both timelines in the console, and can neither observe noticable differences for 100 WPs nor see significant changes in the timeline. The scopedObservable is obviously called more often, however it appears to be quite fast.

Still, could you take another look and merge this, if Travis and you agrees?
