### PR TITLE
Allow multiline else and catch statement tslint

### DIFF
--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -39,8 +39,6 @@
     "one-line": [
       true,
       "check-open-brace",
-      "check-catch",
-      "check-else",
       "check-whitespace"
     ],
     "quotemark": [


### PR DESCRIPTION
Allowing `catch` and `else` statements in new lines would make the code more readable and also fit well with the ruby theme.

```
if (foo) {
}
else { 
}
```
