### PR TITLE
[23511] Avoid checking for `.watch` for Firefox debugging helper

### DIFF
--- a/frontend/app/components/work-packages/work-package.service.js
+++ b/frontend/app/components/work-packages/work-package.service.js
@@ -366,9 +366,9 @@ function WorkPackageService($http, PathHelper, UrlParamsHelper, WorkPackagesHelp
       return promise;
     },
 
-    toggleWatch: function(workPackage) {
-      var toggleWatchLink = (workPackage.links.watch === undefined) ?
-                             workPackage.links.unwatch : workPackage.links.watch;
+    toggleWatch: function (workPackage) {
+      var toggleWatchLink = (workPackage.links.hasOwnProperty('unwatch')) ?
+          workPackage.links.unwatch : workPackage.links.watch;
       var fetchOptions = { method: toggleWatchLink.props.method };
 
       if(toggleWatchLink.props.payload !== undefined) {


### PR DESCRIPTION
Firefox has a `Object.prototype.watch` that is always defined on all
objects and conflicts with our watch link.
https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/watch

Instead, look for a property on the wp itself.
