### PR TITLE
Fix/activate inplace edit in ie

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.html
@@ -36,6 +36,7 @@
                    class="-hidden-overflow inplace-edit--read-value __d__inplace-edit--read-value"
                    ng-class="vm.displayClasses"
                    ng-click="vm.activateIfEditable($event)"
+                   data-click-on-keypress="[13, 32]"
                    focus="vm.shouldFocus()">
   </wp-display-attr>
 </div>

--- a/frontend/app/ui_components/click-on-keypress-directive.js
+++ b/frontend/app/ui_components/click-on-keypress-directive.js
@@ -31,12 +31,9 @@ module.exports = function() {
 
   return {
     restrict: 'A',
-    scope: {
-      clickOnKeypress: '='
-    },
-    link: function(scope, element) {
+    link: function(scope, element, attr) {
       var doIfWatchedKey = function(keyEvent, callback) {
-        if (scope.clickOnKeypress.indexOf(keyEvent.which) !== -1){
+        if (attr.clickOnKeypress.indexOf(keyEvent.which) !== -1){
           keyEvent.stopPropagation();
           keyEvent.preventDefault();
 


### PR DESCRIPTION
Fixes the inplace edit trigger in IE. That trigger got removed in 43a4ecc as it was not possible to apply the click-on-keypress directive to the root element of another element because of the isolated scope. As it seemed to work fine, this was no longer worked on. 

The isolated scope has now been removed and the directive applied.

https://community.openproject.com/work_packages/23520/activity
