### PR TITLE
Fix/date field errors

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2160,6 +2160,9 @@ en:
       code_404: "The requested resource could not be found."
       code_409: "Couldn\'t update the resource because of conflicting modifications."
       code_500: "An internal error has occured."
+      expected:
+        date: "YYYY-MM-DD (ISO 8601 date only)"
+        duration: "ISO 8601 duration"
       invalid_content_type: "Expected CONTENT-TYPE to be '%{content_type}' but got '%{actual}'."
       invalid_format: "Invalid format for property '%{property}': Expected format like '%{expected_format}', but got '%{actual}'."
       invalid_json: "The request could not be parsed as JSON."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -63,6 +63,8 @@ en:
     description_select_work_package: "Select work package #%{id}"
     description_selected_columns: "Selected Columns"
     description_subwork_package: "Child of work package #%{id}"
+    error:
+      internal: "An internal error has occcurred."
     filter:
       description:
         text_open_filter: "Open this filter with 'ALT' and arrow keys."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -370,7 +370,6 @@ en:
         format:
           date: "%{attribute} is no valid date - YYYY-MM-DD expected."
         general: "An error has occured."
-      error_update_failed: "The work package could not be updated."
       edit_attribute: "%{attribute} - Edit"
       key_value: "%{key}: %{value}"
       label_enable_multi_select: "Enable multiselect"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -365,8 +365,11 @@ en:
       description_enter_text: "Enter text"
       description_options_hide: "Hide options"
       description_options_show: "Show options"
-      error: "An error has occured."
-      error_edit_prohibited: "Editing %{attribute} is blocked for this work package. Either this attribute is derived from relations (e.g, children) or otherwise not configurable."
+      error:
+        edit_prohibited: "Editing %{attribute} is blocked for this work package. Either this attribute is derived from relations (e.g, children) or otherwise not configurable."
+        format:
+          date: "%{attribute} is no valid date - YYYY-MM-DD expected."
+        general: "An error has occured."
       error_update_failed: "The work package could not be updated."
       edit_attribute: "%{attribute} - Edit"
       key_value: "%{key}: %{value}"

--- a/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
@@ -29,8 +29,6 @@
 import {HalResource} from './hal-resource.service';
 import {opApiModule} from "../../../../angular-modules";
 
-var NotificationsService:any;
-
 export class ErrorResource extends HalResource {
   public errors:any[];
   public message:string;
@@ -47,17 +45,6 @@ export class ErrorResource extends HalResource {
 
   public isMultiErrorMessage() {
     return this.errorIdentifier === 'urn:openproject-org:api:v3:errors:MultipleErrors';
-  }
-
-  public showErrorNotification() {
-    var messages = this.errorMessages;
-
-    if (messages.length > 1) {
-      NotificationsService.addError('', messages);
-    }
-    else {
-      NotificationsService.addError(messages[0]);
-    }
   }
 
   public getInvolvedAttributes():string[] {
@@ -95,10 +82,7 @@ export class ErrorResource extends HalResource {
 }
 
 function errorResourceService() {
-  [NotificationsService] = arguments;
   return ErrorResource;
 }
-
-errorResourceService.$inject = ['NotificationsService'];
 
 opApiModule.factory('ErrorResource', errorResourceService);

--- a/frontend/app/components/common/notification-box/notification-box.directive.html
+++ b/frontend/app/components/common/notification-box/notification-box.directive.html
@@ -1,5 +1,5 @@
-<div class="notification-box{{' -' + content.type}}" tabindex="0" aria-atomic="true">
-  <div class="notification-box--content" role="alert">
+<div class="notification-box{{' -' + content.type}}" tabindex="0">
+  <div class="notification-box--content" role="alert" aria-atomic="true">
     <p>
       <span>{{::content.message}}</span>
       <a ng-click="content.link.target()"

--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -115,7 +115,7 @@ function WorkPackageDetailsController($scope,
   }
 
   function outputError(error) {
-    outputMessage(error.message || I18n.t('js.work_packages.error'), true);
+    outputMessage(error.message || I18n.t('js.work_packages.error.general'), true);
   }
 
   function setWorkPackageScopeProperties(workPackage) {

--- a/frontend/app/components/routing/wp-show/wp-show.controller.ts
+++ b/frontend/app/components/routing/wp-show/wp-show.controller.ts
@@ -152,7 +152,7 @@ function WorkPackageShowController($scope,
   }
 
   function outputError(error) {
-    outputMessage(error.message || I18n.t('js.work_packages.error'), true);
+    outputMessage(error.message || I18n.t('js.work_packages.error.general'), true);
   }
 
   $scope.outputMessage = outputMessage; // expose to child controllers

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -7,6 +7,7 @@
          type="text"
          class="wp-inline-edit--field"
          transform-date-value
+         ng-blur="vm.onlyInAccessibilityMode(vm.handleUserBlur)"
          ng-required="vm.field.required"
          focus="vm.shouldFocus()"
          focus-priority="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -62,6 +62,7 @@ export class WorkPackageEditFieldController {
               protected $q,
               protected FocusHelper,
               protected NotificationsService,
+              protected ConfigurationService,
               protected wpCacheService: WorkPackageCacheService,
               protected I18n) {
 
@@ -249,6 +250,12 @@ export class WorkPackageEditFieldController {
     this.workPackage.restoreFromPristine(this.fieldName);
     this.fieldForm.$setPristine();
     this.deactivate();
+  }
+
+  public onlyInAccessibilityMode(callback) {
+    if (this.ConfigurationService.accessibilityModeEnabled()) {
+      callback.apply(this);
+    }
   }
 
   protected buildEditField(): ng.IPromise<any> {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -203,7 +203,7 @@ export class WorkPackageEditFieldController {
       // despite the field being editable.
       if (this.isEditable && !active) {
         this.NotificationsService.addError(this.I18n.t(
-          'js.work_packages.error_edit_prohibited',
+          'js.work_packages.error.edit_prohibited',
           {attribute: this.field.schema.name}
         ));
       }

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -134,7 +134,7 @@ export class WorkPackageEditFormController {
           this.WorkPackageNotificationService.showGeneralError;
           return deferred.reject([]);
         }
-        this.WorkPackageNotificationService.showError(error.data);
+        this.WorkPackageNotificationService.showError(error.data, this.workPackage);
         this.handleSubmissionErrors(error.data, deferred);
       });
 

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -53,7 +53,7 @@ export class WorkPackageNotificationService {
   }
 
   public showGeneralError() {
-    this.NotificationsService.addError("An internal error has occcurred.");
+    this.NotificationsService.addError(I18n.t('js.error.internal'));
   }
 
   private showCustomError(errorResource, workPackage) {

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -48,7 +48,36 @@ export class WorkPackageNotificationService {
     });
   }
 
-  public showError(errorResource) {
+  public showError(errorResource, workPackage) {
+    this.showCustomError(errorResource, workPackage) || this.showApiErrorMessages(errorResource);
+  }
+
+  public showGeneralError() {
+    this.NotificationsService.addError("An internal error has occcurred.");
+  }
+
+  private showCustomError(errorResource, workPackage) {
+    if (errorResource.errorIdentifier === 'urn:openproject-org:api:v3:errors:PropertyFormatError') {
+
+      let attributeName  = workPackage.schema[errorResource.details.attribute].name;
+      let attributeType = workPackage.schema[errorResource.details.attribute].type.toLowerCase();
+      let i18nString = 'js.work_packages.error.format.' + attributeType;
+
+      if (this.I18n.lookup(i18nString) === undefined) {
+        return false;
+      }
+
+      this.NotificationsService.addError(this.I18n.t(i18nString,
+                                                     { attribute: attributeName }));
+
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+  private showApiErrorMessages(errorResource) {
     var messages = errorResource.errorMessages;
 
     if (messages.length > 1) {
@@ -57,10 +86,8 @@ export class WorkPackageNotificationService {
     else {
       this.NotificationsService.addError(messages[0]);
     }
-  }
 
-  public showGeneralError() {
-    this.NotificationsService.addError("An internal error has occcurred.");
+    return true;
   }
 }
 

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -1,0 +1,69 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+export class WorkPackageNotificationService {
+
+  constructor(protected I18n,
+              protected $state,
+              protected NotificationsService,
+              protected loadingIndicator) { }
+
+  public showSave(workPackage) {
+    var message = 'js.notice_successful_' + (workPackage.inlineCreated ? 'create' : 'update');
+    this.NotificationsService.addSuccess({
+      message: this.I18n.t(message),
+      link: {
+        target: _ => {
+          this.loadingIndicator.mainPage = this.$state.go.apply(this.$state,
+                                                                ["work-packages.show.activity",
+                                                                 {workPackageId: workPackage.id}]);
+        },
+        text: this.I18n.t('js.work_packages.message_successful_show_in_fullscreen')
+      }
+    });
+  }
+
+  public showError(errorResource) {
+    var messages = errorResource.errorMessages;
+
+    if (messages.length > 1) {
+      this.NotificationsService.addError('', messages);
+    }
+    else {
+      this.NotificationsService.addError(messages[0]);
+    }
+  }
+
+  public showGeneralError() {
+    this.NotificationsService.addError("An internal error has occcurred.");
+  }
+}
+
+angular
+  .module('openproject')
+  .service('WorkPackageNotificationService', WorkPackageNotificationService);

--- a/lib/api/errors/property_format_error.rb
+++ b/lib/api/errors/property_format_error.rb
@@ -32,12 +32,20 @@ module API
     class PropertyFormatError < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:PropertyFormatError'
 
+      attr_accessor :property
+
       def initialize(property, expected_format, actual_value)
+        self.property = property
+
         message = I18n.t('api_v3.errors.invalid_format',
                          property: property,
                          expected_format: expected_format,
                          actual: actual_value)
         super 422, message
+      end
+
+      def details
+        { attribute: property }
       end
     end
   end

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -66,18 +66,6 @@ module API
           datetime.to_datetime.utc.iso8601
         end
 
-        def self.parse_datetime(value, property_name, allow_nil: false)
-          return nil if value.nil? && allow_nil
-
-          begin
-            return DateTime.iso8601(value).utc
-          rescue ArgumentError
-            raise API::Errors::PropertyFormatError.new(property_name,
-                                                       'ISO 8601 date and time',
-                                                       value)
-          end
-        end
-
         def self.format_duration_from_hours(hours, allow_nil: false)
           return nil if hours.nil? && allow_nil
 

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -42,7 +42,9 @@ module API
           begin
             date_and_time = DateTime.iso8601(value)
           rescue ArgumentError
-            raise API::Errors::PropertyFormatError.new(property_name, 'ISO 8601 date only', value)
+            raise API::Errors::PropertyFormatError.new(property_name,
+                                                       I18n.t('api_v3.errors.expected.date'),
+                                                       value)
           end
 
           date_only = date_and_time.to_date
@@ -51,7 +53,9 @@ module API
           # but not "2015-01-31T01:02:03".
           # However Date.iso8601 is too generous and would accept that
           unless date_and_time == date_only
-            raise API::Errors::PropertyFormatError.new(property_name, 'ISO 8601 date only', value)
+            raise API::Errors::PropertyFormatError.new(property_name,
+                                                       I18n.t('api_v3.errors.expected.date'),
+                                                       value)
           end
 
           date_only
@@ -88,7 +92,7 @@ module API
             iso_duration.to_seconds / 3600.0
           rescue ISO8601::Errors::UnknownPattern
             raise API::Errors::PropertyFormatError.new(property_name,
-                                                       'ISO 8601 duration',
+                                                       I18n.t('api_v3.errors.expected.duration'),
                                                        duration)
           end
         end

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -110,29 +110,6 @@ describe :DateTimeFormatter do
     end
   end
 
-  describe 'parse_datetime' do
-    it 'parses ISO 8601 dates' do
-      expect(subject.parse_datetime(date.iso8601, 'prop')).to eql(date.to_datetime)
-    end
-
-    it 'parses ISO 8601 date + time' do
-      expected = Time.at(datetime.to_i).to_datetime.utc # trim milliseconds
-      expect(subject.parse_datetime(datetime.iso8601, 'prop')).to eql(expected)
-    end
-
-    it 'rejects parsing non ISO date formats' do
-      bad_format = date.strftime('%d.%m.%Y %H:%M')
-      expect {
-        subject.parse_datetime(bad_format, 'prop')
-      }.to raise_error(API::Errors::PropertyFormatError)
-    end
-
-    it_behaves_like 'can parse nil' do
-      let(:method) { :parse_datetime }
-      let(:input) { datetime.utc.iso8601 }
-    end
-  end
-
   describe 'format_duration_from_hours' do
     it 'formats floats' do
       expect(subject.format_duration_from_hours(5.0)).to eql('PT5H')

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -277,7 +277,7 @@ describe 'API v3 Work package form resource', type: :request do
                 it_behaves_like 'format error',
                                 I18n.t('api_v3.errors.invalid_format',
                                        property: 'startDate',
-                                       expected_format: 'ISO 8601 date only',
+                                       expected_format: I18n.t('api_v3.errors.expected.date'),
                                        actual: 'not a date')
               end
             end
@@ -304,7 +304,7 @@ describe 'API v3 Work package form resource', type: :request do
                 it_behaves_like 'format error',
                                 I18n.t('api_v3.errors.invalid_format',
                                        property: 'dueDate',
-                                       expected_format: 'ISO 8601 date only',
+                                       expected_format: I18n.t('api_v3.errors.expected.date'),
                                        actual: 'not a date')
               end
             end


### PR DESCRIPTION
- submits date fields on blur in accessibility mode as no date picker is available then which would require us to not submit
- applies i18n to the API's format error message and provides additional hints in the l10n
- adds the attribute to the error message (via the details) so that the malformed field can be identified
- in a desperate attempt to get JAWS 15 to read out the errors, the aria-atomic attribute is moved

This might fix everything listed in 
https://community.openproject.com/work_packages/23284/activity#activity-7

with the exception of the in-transparent automatic fixing of malformed date inputs as I believe this relates to the old create form which is going to be replaced anyway.

Additionally fixes: https://community.openproject.com/work_packages/23290/activity
