### PR TITLE
correctly handle 'undefined' as a pristine value

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -116,7 +116,7 @@ export class WorkPackageResource extends HalResource {
       var args = [this[key], value];
 
       if (this[key] instanceof HalResource) {
-        args = args.map(arg => arg.$source);
+        args = args.map(arg => (arg ? arg.$source : arg));
       }
 
       if (!_.isEqual(...args)) {
@@ -256,7 +256,7 @@ export class WorkPackageResource extends HalResource {
   }
 
   public storePristine(attribute:string) {
-    if (angular.isDefined(this.$pristine[attribute])) {
+    if (this.$pristine.hasOwnProperty(attribute)) {
       return;
     }
 


### PR DESCRIPTION
Some attributes, e.g. responsible, assignee may very well be 'undefined' if no value is set. That value should also be kept in the $pristine object.
