### PR TITLE
do not focus an already active field

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -96,9 +96,11 @@ export class WorkPackageEditFieldController {
   public activate(forceFocus = false) {
     this._forceFocus = forceFocus;
 
+    let alreadyActive = this._active;
+
     return this.buildEditField().then(() => {
       this._active = this.field.schema.writable;
-      if (this._active) {
+      if (this._active && !alreadyActive) {
         this.focusField();
       }
       return this._active;


### PR DESCRIPTION
Otherwise, changes to a resource will lead to a reinitialization which will lead to a refocus
