### PR TITLE
remove one time binding

### DIFF
--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -152,7 +152,7 @@
               lang="::{{column.custom_field && column.custom_field.name_locale || locale}}"
               wp-edit-field="::getTableColumnName(row.object, column.name)"
               wp-edit-field-wrapper-classes="'-small -shrink'"
-              display-classes="::[row.level > 0 && column.name == 'subject' && 'icon-context icon-arrow-right5 icon-small']"
+              display-classes="[row.level > 0 && column.name == 'subject' && 'icon-context icon-arrow-right5 icon-small']"
               columns="::columns"
               field-index="::$index"
               class="wp-table--cell"


### PR DESCRIPTION
With the one time binding in place, changes to the parent/child relationship are not reflected in the table. Thereby, setting a parent in the split view will not display the arrows indicating a child.

This removes a one time binding added for performance reasons. As this watcher is multiplied by columns and rows, we might want to look into a different, less costly solution.

/cc @romanroe 
