### PR TITLE
Fix execution of cancelling edit-mode confirmation

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -361,6 +361,7 @@ en:
       comment_added: "The comment was successfully added."
       comment_send_failed: "An error has occured. Could not submit the comment."
       comment_updated: "The comment was successfully updated."
+      confirm_edit_cancel: "Are you sure you want to cancel editing the work package?"
       description_filter: "Filter"
       description_enter_text: "Enter text"
       description_options_hide: "Hide options"

--- a/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
@@ -35,11 +35,11 @@ export class WorkPackageEditModeStateService {
 
   constructor(protected $rootScope, protected $window, protected I18n) {
 
-    $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
-      if (this.form && fromParams.workPackageId
+    $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
+      if (this.active && fromParams.workPackageId
         && toParams.workPackageId !== fromParams.workPackageId) {
 
-        if (!$window.confirm(I18n.t('js.text_are_you_sure'))) {
+        if (!$window.confirm(I18n.t('js.work_packages.confirm_edit_cancel'))) {
           return event.preventDefault();
         }
 


### PR DESCRIPTION
The confirmation check when state is changing in the edit mode was not executed
