### PR TITLE
remove precedence of default types for a new work_package's type

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -773,8 +773,7 @@ class WorkPackage < ActiveRecord::Base
   end
 
   def set_default_type
-    self.type ||= project.types.default.order(:position).first ||
-                  project.types.order(:position).first
+    self.type ||= project.types.order(:position).first
   end
 
   def add_time_entry_for(user, attributes)

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -53,31 +53,15 @@ describe WorkPackage, type: :model do
   }
 
   describe '.new' do
-
     context 'type' do
-      let(:non_default_type) {
-        type = FactoryGirl.create(:type, is_default: false)
-        project.types << type
-        type
-      }
-      let(:non_default_type2) {
-        type = FactoryGirl.create(:type, is_default: false)
-        project.types << type
-        type
-      }
-      let(:default_type2) {
-        type = FactoryGirl.create(:type, is_default: true)
-        project.types << type
-        type
-      }
+      let(:type2) { FactoryGirl.create(:type) }
+      let(:project) { FactoryGirl.create(:project, types: [type, type2]) }
 
       before do
-        project # loads type as well
-        non_default_type
+        project # loads types as well
       end
 
       context 'no project chosen' do
-
         it 'has no type set if no project was chosen' do
           expect(WorkPackage.new.type)
             .to be_nil
@@ -85,27 +69,18 @@ describe WorkPackage, type: :model do
       end
 
       context 'project chosen' do
-
-        it 'has the first default type of the project set' do
+        it 'has the first type of the project set if none is provided' do
+          project.types = [type, type2]
           type.update_attribute :position, 2
-          default_type2.update_attribute :position, 1
+          type2.update_attribute :position, 1
 
           expect(WorkPackage.new(project: project).type)
-            .to eql default_type2
-        end
-
-        it 'has the first type of the project set if there is no default type inside the project' do
-          project.types = [non_default_type, non_default_type2]
-          non_default_type.update_attribute :position, 2
-          non_default_type2.update_attribute :position, 1
-
-          expect(WorkPackage.new(project: project).type)
-            .to eql non_default_type2
+            .to eql type2
         end
 
         it 'has the provided type if one is provided' do
-          expect(WorkPackage.new(project: project, type: non_default_type2).type)
-            .to eql non_default_type2
+          expect(WorkPackage.new(project: project, type: type2).type)
+            .to eql type2
         end
       end
     end

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -83,7 +83,7 @@ describe ::API::V3::WorkPackages::CreateProjectFormAPI do
   end
 
   describe 'with all minimum parameters' do
-    let(:type) { project.types.default.first }
+    let(:type) { project.types.order(:position).first }
     let(:parameters) {
       {
         _links: {
@@ -99,7 +99,7 @@ describe ::API::V3::WorkPackages::CreateProjectFormAPI do
       expect(subject.body).to have_json_size(0).at_path('_embedded/validationErrors')
     end
 
-    it 'has the first default type active in the project set' do
+    it 'has the first type active in the project set' do
       type_link = {
         href: "/api/v3/types/#{type.id}",
         title: type.name


### PR DESCRIPTION
The 'default' flag is meant to signal the type to be a selected by default when a new project is created

https://community.openproject.com/work_packages/23534/activity
