### PR TITLE
[23533] Use showUser path from APIv3 response to link to user

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -2942,6 +2942,7 @@ This endpoint lists the types that are *available* in a given project.
 | Link                | Description                                                          | Condition                                  |
 |:-------------------:| -------------------------------------------------------------------- | ------------------------------------------ |
 | lock                | Restrict the user from logging in and performing any actions         | not locked; **Permission**: Administrator  |
+| showUser            | Link to the OpenProject user page (HTML)                             |                                            |
 | unlock              | Allow a locked user to login and act again                           | locked; **Permission**: Administrator      |
 | delete              | Permanently remove a user from the instance                          | **Permission**: Administrator, self-delete |
 
@@ -2981,6 +2982,10 @@ The `status` of a user can be one of:
                     "self": {
                         "href": "/api/v3/users/1",
                         "title": "John Sheppard - j.sheppard"
+                    },
+                    "showUser": {
+                        "href": "/users/1",
+                        "type": 'text/html'
                     },
                     "lock": {
                         "href": "/api/v3/users/1/lock",
@@ -4339,6 +4344,10 @@ For more details and all possible responses see the general specification of [Fo
                             "self": {
                                 "href": "/api/v3/users/1",
                                 "title": "John Sheppard - j.sheppard"
+                            },
+                            "showUser": {
+                                "href": "/users/1",
+                                "type": 'text/html'
                             },
                             "lock": {
                                 "href": "/api/v3/users/1/lock",

--- a/frontend/app/templates/work_packages/watchers/watcher.html
+++ b/frontend/app/templates/work_packages/watchers/watcher.html
@@ -5,10 +5,10 @@
       <span class="inplace-editing--container">
         <span class="inplace-edit--read-value" >
           <span data-ng-class="{'loading':watcher.loading,'deleting':deleting}">
-            <a ng-href="/users/{{watcher.id}}"
+            <a ng-href="{{ watcher._links.showUser.href }}"
                data-ng-focus="focus()"
                data-ng-blur="blur()"
-               title="{{watcher.name}}">
+               title="{{ watcher.name }}">
               <img data-ng-src="{{watcher.avatar}}" alt="{{watcher.name}}" data-ng-show="watcher.avatar" class="avatar-mini">
               <span class="work-package--watcher-name">{{watcher.name}}</span>
             </a>

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -48,6 +48,13 @@ module API
 
         self_link
 
+        link :showUser do
+          {
+            href: api_v3_paths.show_user(represented.id),
+            type: 'text/html'
+          }
+        end
+
         link :lock do
           {
             href: api_v3_paths.user_lock(represented.id),

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -157,6 +157,10 @@ module API
             show_revision_project_repository_path(project_id, identifier)
           end
 
+          def self.show_user(user_id)
+            user_path(user_id)
+          end
+
           def self.statuses
             "#{root}/statuses"
           end

--- a/spec/lib/api/v3/users/user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_collection_representer_spec.rb
@@ -30,10 +30,10 @@ require 'spec_helper'
 
 describe ::API::V3::Users::UserCollectionRepresenter do
   let(:users) {
-    FactoryGirl.build_list(:user,
-                           3,
-                           created_on: Time.now,
-                           updated_on: Time.now)
+    FactoryGirl.build_stubbed_list(:user,
+                                   3,
+                                   created_on: Time.now,
+                                   updated_on: Time.now)
   }
   let(:representer) {
     described_class.new(users,

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -85,6 +85,11 @@ describe ::API::V3::Users::UserRepresenter do
         expect(subject).to have_json_path('_links/self/href')
       end
 
+      it_behaves_like 'has an untitled link' do
+        let(:link) { 'showUser' }
+        let(:href) { "/users/#{user.id}" }
+      end
+
       context 'when regular current_user' do
         it 'should have no lock-related links' do
           expect(subject).not_to have_json_path('_links/lock/href')

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -353,7 +353,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       describe 'assignee' do
         context 'assignee is set' do
           let(:work_package) {
-            FactoryGirl.build(:work_package, id: 42, assigned_to: FactoryGirl.build(:user))
+            FactoryGirl.build(:work_package, id: 42, assigned_to: FactoryGirl.build_stubbed(:user))
           }
 
           it_behaves_like 'has a titled link' do
@@ -373,7 +373,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       describe 'responsible' do
         context 'responsible is set' do
           let(:work_package) {
-            FactoryGirl.build(:work_package, id: 42, responsible: FactoryGirl.build(:user))
+            FactoryGirl.build(:work_package, id: 42, responsible: FactoryGirl.build_stubbed(:user))
           }
 
           it_behaves_like 'has a titled link' do


### PR DESCRIPTION
Adds a addUser link to the response in the same fashion as revisions / time entries.

This avoids fixed path building of user link in the frontend and fixes https://community.openproject.com/work_packages/23533/activity
