### PR TITLE
don't submit an unchanged wp resource

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -115,6 +115,10 @@ export class WorkPackageEditFormController {
   }
 
   public updateWorkPackage() {
+    if (!this.workPackage.dirty) {
+      return this.$q.when();
+    }
+
     var deferred = this.$q.defer();
 
     // Reset old error notifcations

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -77,16 +77,14 @@ describe 'Inline editing work packages', js: true do
 
       subject_field.activate!
       subject_field.set_value('Other subject!')
-
-      # save is triggered by activating the status_field which
-      # causes a blur on the subject_field
-
-      status_field.activate!
+      subject_field.save!
 
       wp_table.expect_notification(message: 'Successful update')
+      wp_table.dismiss_notification!
+      wp_table.expect_no_notification(message: 'Successful update')
 
+      status_field.activate!
       status_field.set_value(status2.name)
-
       status_field.save!
 
       subject_field.expect_inactive!


### PR DESCRIPTION
Checks the wp's `dirty` flag before actually submitting the wp. Thereby, `updateWorkPackage` becomes a noop if a wp has no changes.

https://community.openproject.com/work_packages/23531/activity
