### PR TITLE
[23529] Remove extra title in inner span

### DIFF
--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
@@ -72,7 +72,6 @@ export class DisplayField extends Field {
   }
 
   public render(element: JQuery, fieldDisplay: WorkPackageDisplayAttributeController): void {
-    element.attr("title", fieldDisplay.displayText);
     element.text(fieldDisplay.displayText);
   }
 


### PR DESCRIPTION
The extra title attribute causes JAWS to read the content twice.
The `inplace-edit--read-value` already has a combined title of
`<Attribute>: <Value>` that is sufficient.

https://community.openproject.com/work_packages/23529/activity
