### PR TITLE
[20521] Fix loading of accessibility styles

### DIFF
--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -114,6 +114,7 @@
 @import specific/homescreen
 @import specific/announcements
 @import specific/onboarding
+@import specific/accessibility
 
 @import misc_legacy
 @import jstoolbar

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -106,6 +106,7 @@ $main-menu-selected-font-color:                 $font-color-on-primary !default
 $main-menu-font-size:                           15px !default
 $main-menu-selected-hover-indicator-color:      $primary-color-dark !default
 $main-menu-selected-hover-indicator-width:      4px !default
+$main-menu-selected-hover-border-color:         $main-menu-border-color !default
 
 $main-menu-navigation-toggler-font-hover-color: #FFFFFF !default
 $main-menu-toggler-separator-color:             #EAEAEA !default

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -26,46 +26,42 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@import open_project_global/variables
+body.accessibility-mode
+  a:focus,
+  input:focus,
+  select:focus,
+  textarea:focus,
+  button:focus,
+  *:focus
+    outline: 3px solid darkblue
 
-a:focus,
-input:focus,
-select:focus,
-textarea:focus,
-button:focus,
-*:focus
-  outline: 3px solid darkblue
+  .form--field-container input:out-of-range,
+  .form--field-container input:invalid
+    border: 2px solid #9E2A1C
 
-.form--field-container input:out-of-range,
-.form--field-container input:invalid
-  border: 2px solid #9E2A1C
+  h1:hover a.wiki-anchor,
+  h2:hover a.wiki-anchor,
+  h3:hover a.wiki-anchor
+    display: none
 
-h1:hover a.wiki-anchor,
-h2:hover a.wiki-anchor,
-h3:hover a.wiki-anchor
-  display: none
-
-.ng-modal-window.columns-modal .ng-modal-inner
-  overflow: auto
-  margin-top: 5vh
+  .ng-modal-window.columns-modal .ng-modal-inner
+    overflow: auto
+    margin-top: 5vh
 
 
-// Mark currently selected top menu items
-#top-menu
-  li a,
-  li.drop-down a
-    border: 1px solid transparent
+  // Mark currently selected top menu items
+  #top-menu
+    li a,
+    li.drop-down a
+      border: 1px solid transparent
 
-  li a.selected,
-  li.drop-down.selected a
-    background: $primary-color-dark !important
-    color: $font-color-on-primary-dark !important
+    li a.selected,
+    li.drop-down.selected a
+      background: $primary-color-dark !important
+      color: $font-color-on-primary-dark !important
 
-    &:hover
-      border-color: $font-color-on-primary-dark
-
-// Neccessary to have enough space for the border in IE
-.wp-table--cell
-  .inplace-edit .inplace-edit--read-value,
-  .id a
-    margin: 3px
+  // Neccessary to have enough space for the border in IE
+  .wp-table--cell
+    .inplace-edit .inplace-edit--read-value,
+    .id a
+      margin: 3px

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -57,8 +57,11 @@ body.accessibility-mode
 
     li a.selected,
     li.drop-down.selected a
-      background: $primary-color-dark !important
-      color: $font-color-on-primary-dark !important
+      background: $main-menu-bg-hover-selected-background !important
+      color: $main-menu-selected-font-color !important
+
+      &:hover
+        border-color: $main-menu-border-color
 
   // Neccessary to have enough space for the border in IE
   .wp-table--cell

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -457,6 +457,11 @@ module ApplicationHelper
   # HTML body.
   def body_css_classes
     css = ['theme-' + current_theme.identifier.to_s]
+
+    if accessibility_css_enabled? && User.current.impaired?
+      css << 'accessibility-mode'
+    end
+
     if params[:controller] && params[:action]
       css << 'controller-' + params[:controller]
       css << 'action-' + params[:action]

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,10 +41,6 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= csrf_meta_tags %>
     <%= render 'common/favicons' %>
     <%= stylesheet_link_tag current_theme.stylesheet_manifest, media: "all" %>
-    <% if User.current.impaired? && accessibility_css_enabled? %>
-      <%= stylesheet_link_tag 'accessibility' %>
-    <% end %>
-
     <%= javascript_include_tag 'application' %>
     <!-- user specific tags -->
     <%= user_specific_javascript_includes %>


### PR DESCRIPTION
Load accessibility styles within default.sass.
Otherwise, variables within won't be overridden. For this end, dynamically add a body class rather than loading the stylesheet separately.

https://community.openproject.com/work_packages/20521/activity

Please also merge: https://github.com/finnlabs/openproject-themes-myproject/pull/24
