### PR TITLE
Fix/datepicker

### DIFF
--- a/frontend/app/angular-modules.ts
+++ b/frontend/app/angular-modules.ts
@@ -159,7 +159,6 @@ export const wpButtonsModule = angular.module('openproject.wpButtons',
 
 // main app
 export const openprojectModule = angular.module('openproject', [
-  'ui.date',
   'ui.router',
   'openproject.config',
   'openproject.uiComponents',

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -61,9 +61,8 @@
 
       <div
           class="attributes-key-value--key"
-          ng-hide="$ctrl.hideEmptyFields &&
-                   $ctrl.singleViewWp.canHideField(field.fields[0]) &&
-                   $ctrl.singleViewWp.canHideField(field.fields[1])"
+          ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
+                   $ctrl.shouldHideField(field.fields[1])"
           ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
                  $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
                  $ctrl.singleViewWp.isSpecified(field.fields[1]) "
@@ -74,9 +73,8 @@
         <span class="required" ng-if="$ctrl.singleViewWp.hasNiceStar(field.label)"> *</span>
       </div>
       <div
-          ng-hide="$ctrl.hideEmptyFields &&
-                   $ctrl.singleViewWp.canHideField(field.fields[0]) &&
-                   $ctrl.singleViewWp.canHideField(field.fields[1])"
+          ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
+                   $ctrl.shouldHideField(field.fields[1])"
           ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
                  $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
                  $ctrl.singleViewWp.isSpecified(field.fields[1]) "

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -31,6 +31,7 @@ import {scopedObservable} from '../../../helpers/angular-rx-utils';
 import {WorkPackageResource} from '../../api/api-v3/hal-resources/work-package-resource.service';
 
 export class WorkPackageSingleViewController {
+  public formCtrl: WorkPackageEditFormController;
   public workPackage:any|WorkPackageResource;
   public singleViewWp;
   public groupedFields:any[] = [];
@@ -91,7 +92,9 @@ export class WorkPackageSingleViewController {
   }
 
   public shouldHideField(field) {
-    return this.singleViewWp.shouldHideField(field, this.hideEmptyFields);
+    let hideEmpty = !this.formCtrl.fields[field].active && this.hideEmptyFields;
+
+    return this.singleViewWp.shouldHideField(field, hideEmpty);
   };
 
   public setFocus() {
@@ -141,6 +144,15 @@ export class WorkPackageSingleViewController {
 }
 
 function wpSingleViewDirective() {
+
+  function wpSingleViewLink(scope,
+                            element,
+                            attrs,
+                            controllers: [WorkPackageEditFormController, WorkPackageSingleViewController]) {
+
+    controllers[1].formCtrl = controllers[0];
+
+  }
   return {
     restrict: 'E',
     templateUrl: '/components/work-packages/wp-single-view/wp-single-view.directive.html',
@@ -148,6 +160,9 @@ function wpSingleViewDirective() {
     scope: {
       workPackage: '=?'
     },
+
+    require: ['^wpEditForm', 'wpSingleView'],
+    link: wpSingleViewLink,
 
     bindToController: true,
     controller: WorkPackageSingleViewController,

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -1,6 +1,5 @@
 <op-date-picker
   on-change="vm.submit()"
-  on-deactivate="vm.deactivate()"
   ng-model="vm.workPackage[vm.fieldName]">
 
   <input ng-model="vm.workPackage[vm.fieldName]"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.module.ts
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {EditField} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from '../wp-edit-field/wp-edit-field.module';
 
 export class DateEditField extends EditField {
-  public template:string = '/components/wp-edit/field-types/wp-edit-date-field.directive.html'
+  public template:string = '/components/wp-edit/field-types/wp-edit-date-field.directive.html';
 }

--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.html
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.html
@@ -1,7 +1,3 @@
 <div>
   <ng-transclude></ng-transclude>
-  <!-- This input is there to be used by the datepicker.
-    That way, we don't force the usage of an input element on directives that transclude us -->
-  <input class="hidden-date-picker-input" type="hidden">
-  <div class="ui-datepicker--container"></div>
 </div>

--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
@@ -59,7 +59,8 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
 
   function showDatePicker() {
     let options = { onSelect: (date) => {
-        datePickerInstance.destroy();
+        datePickerInstance.hide();
+
         let val = date;
 
         if (input.val().trim() === '') {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -100,7 +100,7 @@ export class WorkPackageEditFieldController {
 
     return this.buildEditField().then(() => {
       this._active = this.field.schema.writable;
-      if (this._active && !alreadyActive) {
+      if (this._active && (!alreadyActive || this.errorenous)) {
         this.focusField();
       }
       return this._active;

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -48,7 +48,6 @@ require('angular-i18n/angular-locale_' + documentLang + '.js');
 
 require('angular-ui-router');
 
-require('angular-ui-date');
 require('angular-truncate');
 
 require('angular-busy/dist/angular-busy');

--- a/frontend/app/work_packages/models/datepicker.js
+++ b/frontend/app/work_packages/models/datepicker.js
@@ -60,11 +60,8 @@ module.exports = function(TimezoneService, ConfigurationService) {
     this.datepickerInstance.datepicker('setDate' , null);
   };
 
-  Datepicker.prototype.destroy = function() {
-    // HACK: it should suffice to remove the datepicker by only the first line of code. It doesn't.
-    this.datepickerInstance.datepicker('destroy');
-    this.datepickerInstance.removeClass('hasDatepicker');
-    angular.element('#ui-datepicker-div').hide();
+  Datepicker.prototype.hide = function() {
+    this.datepickerInstance.datepicker('hide');
   };
 
   return Datepicker;

--- a/frontend/app/work_packages/models/datepicker.js
+++ b/frontend/app/work_packages/models/datepicker.js
@@ -26,151 +26,45 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function(TimezoneService, ConfigurationService, $timeout) {
-  var datepickerFormat = 'yy-mm-dd',
-    addButton = function(appendTo, text, className, callback) {
-      return jQuery('<button>', {
-          text: text
-        })
-        .addClass('ui-state-default ui-priority-primary ui-corner-all ' + className)
-        .appendTo(appendTo)
-        .on('click', callback);
-    };
+module.exports = function(TimezoneService, ConfigurationService) {
+  var datepickerFormat = 'yy-mm-dd';
 
-  function Datepicker(datepickerElem, textboxElem, date) {
+  function Datepicker(datepickerElem, date, options) {
     this.date = date;
-    this.prevDate = TimezoneService.formattedISODate(this.date);
     this.datepickerCont = angular.element(datepickerElem);
-    this.textbox = angular.element(textboxElem);
-    this.editTimerId = 0;
-    this._disabled = false;
-    this.initialize();
-    this.setDate(this.date);
+    this.datepickerInstance = null;
+    this.initialize(options);
   }
 
-  Datepicker.prototype.addDoneButton = function() {
-    var self = this;
-    setTimeout(function() {
-      var buttonPane = self.datepickerCont.find('.ui-datepicker-buttonpane');
-
-      if (buttonPane.find('.ui-datepicker-done').length !== 0) {
-        return;
-      }
-
-      addButton(buttonPane, 'Done', 'ui-datepicker-done', function(e) {
-        self.onDone();
-        e.preventDefault();
-      });
-    }, 1);
-  };
-
-  Datepicker.prototype.setDate = function(date) {
-    if (date) {
-      this.datepickerCont.datepicker('option', 'defaultDate', TimezoneService.formattedISODate(date));
-      this.datepickerCont.datepicker('option', 'setDate', TimezoneService.formattedISODate(date));
-      this.textbox.val(TimezoneService.formattedISODate(date));
-    } else {
-      this.datepickerCont.datepicker('option', 'defaultDate', null);
-      this.datepickerCont.datepicker('option', 'setDate', null);
-      this.textbox.val('');
-      this.textbox.change();
-    }
-  };
-
-  Datepicker.prototype.initialize = function() {
+  Datepicker.prototype.initialize = function(options) {
     var self = this,
         firstDayOfWeek = ConfigurationService.startOfWeekPresent() ?
-        ConfigurationService.startOfWeek() :
-        jQuery.datepicker._defaults.firstDay;
-    this.datepickerCont.datepicker({
+          ConfigurationService.startOfWeek() :
+          jQuery.datepicker._defaults.firstDay;
+
+    var mergedOptions = angular.extend({}, options, {
       firstDay: firstDayOfWeek,
       showWeeks: true,
       changeMonth: true,
+      changeYear: true,
       dateFormat: datepickerFormat,
       defaultDate: TimezoneService.formattedISODate(self.date),
       inline: true,
-      showButtonPanel: true,
-      beforeShow: function() {
-        self.addDoneButton();
-      },
-      onChangeMonthYear: function() {
-        self.addDoneButton();
-      },
-      alterOffset: function(offset) {
-        var wHeight = angular.element(window).height(),
-          dpHeight = angular.element('#ui-datepicker-div').height(),
-          inputTop = self.datepickerCont.offset().top,
-          inputHeight = self.datepickerCont.innerHeight();
-
-        if ((inputTop + inputHeight + dpHeight) > wHeight) {
-          offset.top -= inputHeight - 4;
-        }
-        return offset;
-      },
-      onSelect: function(selectedDate) {
-        if (!selectedDate || selectedDate === self.prevDate) {
-          return;
-        }
-        self.prevDate = TimezoneService.parseISODate(selectedDate);
-        $timeout(function() {
-          self.onChange(TimezoneService.formattedISODate(self.prevDate));
-        });
-        self.textbox.focus();
-        self.datepickerCont.hide();
-        self.addDoneButton();
-      }
+      showButtonPanel: true
     });
+
+    this.datepickerInstance = this.datepickerCont.datepicker(mergedOptions);
   };
 
-  Datepicker.prototype.hide = function() {
-    this.datepickerCont.hide();
+  Datepicker.prototype.clear = function() {
+    this.datepickerInstance.datepicker('setDate' , null);
   };
 
-  Datepicker.prototype.show = function() {
-    if(!this._disabled) {
-      this.datepickerCont.show();
-    }
-  };
-
-  Datepicker.prototype.focus = function() {
-    this.textbox.click().focus();
-  };
-
-  Datepicker.prototype.disable = function () {
-    this._disabled = true;
-    this.hide();
-  };
-
-  Datepicker.prototype.enable = function () {
-    this._disabled = false;
-  };
-
-  Datepicker.prototype.setState = function (enable) {
-    this[enable ? 'enable' : 'disable']();
-  };
-
-  Datepicker.prototype.onChange = angular.noop;
-  Datepicker.prototype.onDone = angular.noop;
-  Datepicker.prototype.onEdit = function() {
-    var self = this;
-    if (self.textbox.val().trim() === '') {
-      self.onChange(null);
-      self.textbox.val('');
-      $timeout.cancel(self.editTimerId);
-      return;
-    }
-    $timeout.cancel(self.editTimerId);
-    self.editTimerId = $timeout(function() {
-      var date = self.textbox.val(),
-        isValid = TimezoneService.isValidISODate(date);
-
-      if (isValid) {
-        self.prevDate = TimezoneService.parseISODate(date);
-        self.onChange(TimezoneService.formattedISODate(self.prevDate));
-      } else {
-        self.textbox.val(TimezoneService.formattedISODate(self.prevDate));
-      }
-    }, 1000);
+  Datepicker.prototype.destroy = function() {
+    // HACK: it should suffice to remove the datepicker by only the first line of code. It doesn't.
+    this.datepickerInstance.datepicker('destroy');
+    this.datepickerInstance.removeClass('hasDatepicker');
+    angular.element('#ui-datepicker-div').hide();
   };
 
   return Datepicker;

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -10,7 +10,6 @@
     "angular": "~1.3.14",
     "angular-animate": "~1.3.14",
     "angular-aria": "~1.3.14",
-    "angular-ui-date": "0.0.3",
     "angular-ui-router": "0.2.15",
     "angular-i18n": "~1.3.0",
     "angular-modal": "finnlabs/angular-modal#d45eb9ceb720b8785613ba89ba0f14f8ab197569",

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -126,7 +126,6 @@ function getWebpackMainConfig() {
         'locales': './../../config/locales',
         'core-components': path.resolve(__dirname, 'app', 'components'),
 
-        'angular-ui-date': 'angular-ui-date/src/date',
         'angular-truncate': 'angular-truncate/src/truncate',
         'angular-context-menu': 'angular-context-menu/dist/angular-context-menu.js',
         'mousetrap': 'mousetrap/mousetrap.js',


### PR DESCRIPTION
The PR:
- replaces a lot of datepicker code handwritten before by using datepicker defaults. The handwritten code was not used in most parts as far as I can see or they where used to achieve behaviour which no longer works with our new inline edit functionality. The most obvious example for that is the binding of the date picker to a div instead of binding it to the input field directly. This led us to having to work on positioning the date picker in the table which is not necessary if the date picker is positioned absolutely. In addition, when binding it the field directly, the data binding between date picker and input field works right away. Doing this, also switches the date fields into edit mode when "edit all" is used: https://community.openproject.com/work_packages/23538/activity
- removes the angular-ui-date library which was no longer in use. I tried to build the functionality using that library but because a JS Date object has to be used when using ng-model, I refrained from doing so as it would have required us to change the resource as well.
- prevents hiding fields when they are in edit mode (and not having edit all active). Formerly, when using backspace or del to clear the date field, the date field would disappear once the field was finally empty. https://community.openproject.com/work_packages/23536/activity
- allows to refocus an already active field if it is erroneous.
