### PR TITLE
links for work package export as PDF/Atom

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -59,6 +59,8 @@ en:
     button_settings: "Settings"
     button_uncheck_all: "Uncheck all"
     button_update: "Update"
+    button_export-pdf: "Download PDF"
+    button_export-atom: "Download Atom"
     description_available_columns: "Available Columns"
     description_select_work_package: "Select work package #%{id}"
     description_selected_columns: "Selected Columns"

--- a/frontend/app/work_packages/controllers/menus/index.js
+++ b/frontend/app/work_packages/controllers/menus/index.js
@@ -86,6 +86,14 @@ angular.module('openproject.workPackages')
     {
       icon: 'delete',
       link: 'delete'
+    },
+    {
+      icon: 'export-pdf',
+      link: 'pdf'
+    },
+    {
+      icon: 'export-atom',
+      link: 'atom'
     }
   ])
   .factory('DetailsMoreDropdownMenu', [

--- a/frontend/app/work_packages/directives/index.js
+++ b/frontend/app/work_packages/directives/index.js
@@ -39,7 +39,9 @@ angular.module('openproject.workPackages.directives')
     { key: 'log_time', link: 'logTime', resource: 'workPackage' },
     { key: 'move', link: 'move', resource: 'workPackage' },
     { key: 'delete', link: 'delete', resource: 'workPackage' },
-    { key: 'copy', link: 'createWorkPackage', resource: 'project' }
+    { key: 'copy', link: 'createWorkPackage', resource: 'project' },
+    { key: 'export-pdf', link: 'pdf', resource: 'workPackage' },
+    { key: 'export-atom', link: 'atom', resource: 'workPackage' }
   ])
   .directive('workPackageDynamicAttribute', ['$compile', require(
     './work-package-dynamic-attribute-directive')])

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -110,6 +110,22 @@ module API
           } if current_user_allowed_to(:move_work_packages, context: represented.project)
         end
 
+        link :pdf do
+          {
+            href: work_package_path(id: represented.id, format: :pdf),
+            type: 'application/pdf',
+            title: 'Export as PDF'
+          } if current_user_allowed_to(:export_work_packages, context: represented.project)
+        end
+
+        link :atom do
+          {
+            href: work_package_path(id: represented.id, format: :atom),
+            type: 'application/rss+xml',
+            title: 'Atom feed'
+          } if current_user_allowed_to(:export_work_packages, context: represented.project)
+        end
+
         linked_property :type, embed_as: ::API::V3::Types::TypeRepresenter
         linked_property :status, embed_as: ::API::V3::Statuses::StatusRepresenter
 

--- a/spec/lib/api/v3/support/link_examples.rb
+++ b/spec/lib/api/v3/support/link_examples.rb
@@ -38,6 +38,8 @@ shared_examples_for 'action link' do
                               member_through_role: role)
   }
 
+  let(:href) { nil }
+
   before do login_as(user) end
 
   it { expect(subject).not_to have_json_path("_links/#{action}/href") }
@@ -49,6 +51,12 @@ shared_examples_for 'action link' do
     end
 
     it { expect(subject).to have_json_path("_links/#{action}/href") }
+
+    it do
+      if href
+        expect(subject).to be_json_eql(href.to_json).at_path("_links/#{action}/href")
+      end
+    end
   end
 end
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -791,6 +791,22 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
       end
 
+      describe 'pdf' do
+        it_behaves_like 'action link' do
+          let(:action) { 'pdf' }
+          let(:permission) { :export_work_packages }
+          let(:href) { "/work_packages/#{work_package.id}.pdf" }
+        end
+      end
+
+      describe 'atom' do
+        it_behaves_like 'action link' do
+          let(:action) { 'atom' }
+          let(:permission) { :export_work_packages }
+          let(:href) { "/work_packages/#{work_package.id}.atom"}
+        end
+      end
+
       describe 'changeParent' do
         it_behaves_like 'action link' do
           let(:action) { 'changeParent' }


### PR DESCRIPTION
WP [#22768](https://community.openproject.com/work_packages/22768/activity)

Adds links to download PDFs and the Atom feed for a work package in both the index [1] and single [2] 
work package view.

[1]
![wp_list_pdf_download](https://cloud.githubusercontent.com/assets/158871/16305091/3ed127fc-3950-11e6-9b31-d35fa91901e2.png)

[2]
![wp_show_pdf_download](https://cloud.githubusercontent.com/assets/158871/16305110/4f0b2096-3950-11e6-845a-9b9c57caba14.png)
