### PR TITLE
[23508] Fokus im Accessibilitymodus nicht sichtbar (IE) (2)

### DIFF
--- a/app/assets/stylesheets/accessibility.sass
+++ b/app/assets/stylesheets/accessibility.sass
@@ -66,6 +66,6 @@ h3:hover a.wiki-anchor
 
 // Neccessary to have enough space for the border in IE
 .wp-table--cell
-  .inplace-edit .inplace-edit--read-value.inplace-edit--read-value--container,
+  .inplace-edit .inplace-edit--read-value,
   .id a
     margin: 3px


### PR DESCRIPTION
This fixes a broken selector in a styling rule. Thus the focused element in the wp table is visible again.

https://community.openproject.com/work_packages/23508/activity
