### PR TITLE
[23239] Design bugs in member section for users with long names (2)

### DIFF
--- a/app/views/members/_autocomplete_for_member.html.erb
+++ b/app/views/members/_autocomplete_for_member.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<fieldset class="form--fieldset principals">
+<fieldset class="form--fieldset principals medium-11">
   <legend class="form--fieldset-legend"><%="#{l(:label_user_plural)}/#{l(:label_group_plural)}" %></legend>
   <% if principals.empty? %>
     <%= l('notice_no_principals_found') %>

--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -66,12 +66,12 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
     <div class="grid-block">
-      <div class="grid-block medium-6">
-        <div class="grid-block" id="principal_results">
+      <div class="grid-block">
+        <div class="grid-block medium-4" id="principal_results">
           <%= render partial: 'members/autocomplete_for_member', locals: { principals: principals, roles: roles } %>
         </div>
-        <div class="grid-block roles">
-          <fieldset class="form--fieldset">
+        <div class="grid-block medium-4 roles">
+          <fieldset class="form--fieldset medium-11">
             <legend class="form--fieldset-legend"><%= l(:label_role_plural) %></legend>
             <%= labeled_check_box_tags 'member[role_ids][]', roles %>
           </fieldset>


### PR DESCRIPTION
This sets the width to avoid early cut off and overlapping in the members section.

https://community.openproject.com/work_packages/23239/activity
