### PR TITLE
[23522] Design errors in wiki "Change parent" page

### DIFF
--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -28,20 +28,18 @@
 #++
 
 module WikiHelper
-  def wiki_page_options_for_select(pages, selected = nil, parent = nil, level = 0)
+  def wiki_page_options_for_select(pages, parent = nil, level = 0)
     pages = pages.group_by(&:parent) unless pages.is_a?(Hash)
-    s = ''
+    s = []
     if pages.has_key?(parent)
       pages[parent].each do |page|
-        attrs = "value='#{page.id}'"
-        attrs << " selected='selected'" if selected == page
-        indent = (level > 0) ? ('&nbsp;' * level * 2 + '&#187; ') : nil
+        indent = (level > 0) ? ('&nbsp;' * level * 2 + '&#187; ') : ''
 
-        s << "<option #{attrs}>#{indent}#{h(page.pretty_title)}</option>\n" +
-          wiki_page_options_for_select(pages, selected, page, level + 1)
+        s << [(indent + h(page.pretty_title)).html_safe, page.id]
+        s += wiki_page_options_for_select(pages, page, level + 1)
       end
     end
-    s.html_safe
+    s
   end
 
   def breadcrumb_for_page(page, action = nil)

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -35,10 +35,11 @@ See doc/COPYRIGHT.rdoc for more details.
       <label><%= radio_button_tag 'todo', 'destroy', false %> <%= l(:text_wiki_page_destroy_children) %></label>
       <% if @reassignable_to.any? %>
         <br />
-        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= l(:text_wiki_page_reassign_children) %></label>:
+        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= l(:text_wiki_page_reassign_children) %></label>
         <%= label_tag "reassign_to_id", l(:description_wiki_subpages_reassign), class: "hidden-for-sighted" %>
-        <%= select_tag 'reassign_to_id', wiki_page_options_for_select(@reassignable_to),
-                                 onclick: "$('todo_reassign').checked = true;" %>
+        <%= select_tag 'reassign_to_id',
+                       options_for_select(wiki_page_options_for_select(@reassignable_to)),
+                       onclick: "$('todo_reassign').checked = true;" %>
       <% end %>
     </p>
   </div>

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -36,10 +36,10 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="box">
     <p>
       <%= f.select :parent_id,
-            "<option value=''></option>".html_safe + wiki_page_options_for_select(@parent_pages,
+            ("<option value=''>"+ I18n.t('js.placeholders.default') +"</option>").html_safe + wiki_page_options_for_select(@parent_pages,
                                                                                   @page.parent),
             {label: WikiPage.human_attribute_name(:parent_title) },
-            {size: "#{@parent_pages.size + 2}", class: "parent-select"} %>
+            {class: "parent-select"} %>
     </p>
 
     <%= javascript_tag do -%>

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -36,10 +36,10 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="box">
     <p>
       <%= f.select :parent_id,
-            ("<option value=''>"+ I18n.t('js.placeholders.default') +"</option>").html_safe + wiki_page_options_for_select(@parent_pages,
-                                                                                  @page.parent),
-            {label: WikiPage.human_attribute_name(:parent_title) },
-            {class: "parent-select"} %>
+            wiki_page_options_for_select(@parent_pages),
+            { label: WikiPage.human_attribute_name(:parent_title),
+              include_blank: t('placeholders.default') },
+            { class: "parent-select" } %>
     </p>
 
     <%= javascript_tag do -%>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -51,10 +51,10 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="form--field -required">
         <%= f.fields_for :page, @page do |page_fields| %>
           <%= page_fields.select :parent_id,
-                "<option value=''></option>".html_safe + wiki_page_options_for_select(@wiki.pages,
-                                                                                      @page.parent),
-                {label: WikiPage.human_attribute_name(:parent_title)},
-                {class: "parent-select form--select"} %>
+                                 wiki_page_options_for_select(@wiki.pages),
+                                 { label: WikiPage.human_attribute_name(:parent_title),
+                                   include_blank: t('placeholders.default') },
+                                 { class: "parent-select form--select" } %>
         <% end%>
       </div>
     <% end %>

--- a/app/views/wiki_menu_items/select_main_menu_item.html.erb
+++ b/app/views/wiki_menu_items/select_main_menu_item.html.erb
@@ -34,9 +34,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <fieldset class="form--fieldset" id="wiki_menu_item_setting">
     <legend class="form--fieldset-legend"><%= l(:label_wiki_page) %></legend>
     <p>
-      <%= f.select :id, wiki_page_options_for_select(@possible_wiki_pages, @page),
-                          {label: WikiPage.human_attribute_name(:title)},
-                          {size: @possible_wiki_pages.size, id: 'main-menu-item-select'} %>
+      <%= f.select :id,
+                   wiki_page_options_for_select(@possible_wiki_pages),
+                   { label: WikiPage.human_attribute_name(:title) },
+                   { size: @possible_wiki_pages.size,
+                     id: 'main-menu-item-select' } %>
     </p>
   </fieldset>
   <%= submit_tag t(:button_save), class: 'button -highlight' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1528,6 +1528,9 @@ en:
   permission_view_wiki_edits: "View wiki history"
   permission_view_wiki_pages: "View wiki"
 
+  placeholders:
+    default: "-"
+
   project:
     destroy:
       confirmation: "If you continue, the project %{identifier} and all related data will be permanently destroyed."

--- a/features/wiki/parent_page.feature
+++ b/features/wiki/parent_page.feature
@@ -50,7 +50,7 @@ Feature: Parent wiki page
     When I go to the wiki page "Test page" for the project called "Test"
     And I click on "More"
     And I follow "Change parent page"
-    And I select "" from "Parent page"
+    And I select "-" from "Parent page"
     And I press "Save"
     Then I should be on the wiki page "Test page" for the project called "Test"
     And the breadcrumbs should not have the element "Parent page"


### PR DESCRIPTION
This fixes styling issues on the 'change parent' select box of a wiki page. Earlier the box was to small and confusing. Now it is a normal select box.

https://community.openproject.com/work_packages/23522/activity
