### PR TITLE
Allow setting null resources

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -234,14 +234,21 @@ describe('HalResource service', () => {
 
   describe('when using $plain', () => {
     var plain;
-    source = {hello: 'world'};
 
     beforeEach(() => {
+      source = {
+        _links: {self: {href: 'bunny'}},
+        rabbit: 'fluffy'
+      };
       plain = new HalResource(source).$plain();
     });
 
     it('should return an object that is equal to the source', () => {
       expect(plain).to.eql(source);
+    });
+
+    it('should not be the exact same object', () => {
+      expect(plain).not.to.equal(source);
     });
   });
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -232,6 +232,46 @@ describe('HalResource service', () => {
     });
   });
 
+  describe('when setting a property that is a resource to null', () => {
+    beforeEach(() => {
+      source = {
+        _links: {
+          resource: {
+            method: 'get',
+            href: 'resource/1'
+          }
+        }
+      };
+      resource = new HalResource(source);
+      resource.resource = null;
+    });
+
+    it('should be null', () => {
+      expect(resource.resource).to.be.null;
+    });
+
+    it('should set the respective link href to null', () => {
+      expect(resource.$source._links.resource.href).to.be.null;
+    });
+  });
+
+  describe('when a property that is a resource has a null href', () => {
+    beforeEach(() => {
+      source = {
+        _links: {
+          property: {
+            href: null
+          }
+        }
+      };
+      resource = new HalResource(source);
+    });
+
+    it('should be null', () => {
+      expect(resource.property).to.be.null;
+    });
+  });
+
   describe('when using $plain', () => {
     var plain;
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -189,6 +189,8 @@ function initializeResource(halResource:HalResource) {
 
             return createLinkedResource(linkName, link);
           }
+
+          return null;
         },
 
         val => setter(val, linkName)
@@ -236,15 +238,18 @@ function initializeResource(halResource:HalResource) {
   }
 
   function setter(val, linkName) {
-    if (val && val.$link) {
+    if (!val) {
+      halResource.$source._links[linkName] = {href: null};
+    }
+    else if (val.$link) {
       const link = val.$link;
 
       if (link.href) {
         halResource.$source._links[linkName] = link;
       }
-
-      return val;
     }
+
+    return val;
   }
 }
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -312,7 +312,7 @@ export class WorkPackageResource extends HalResource {
     // Merged linked properties from form payload
     Object.keys(plainPayload._links).forEach(key => {
       if (typeof(schema[key]) === 'object' && schema[key].writable === true) {
-        var value = angular.isUndefined(this[key]) ? null : this[key].href;
+        var value = this[key] ? this[key].href : null;
         plainPayload._links[key] = {href: value};
       }
     });

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -10,7 +10,7 @@
         ng-attr-id="{{vm.htmlId}}">
   <option value=""
           ng-bind="vm.field.text.requiredPlaceholder"
-          ng-if="vm.field.schema.required && vm.workPackage[vm.fieldName] === undefined"
+          ng-if="vm.field.schema.required && vm.workPackage[vm.fieldName] == null"
           ng-selected="!vm.workPackage[vm.fieldName]"
           disabled>
   </option>


### PR DESCRIPTION
Setting a property, that is a linked resource, to `null` now sets the property and the source href correctly to `null`.
