### PR TITLE
[23243] Allow changing parent work packages with changeParent link

### DIFF
--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -47,7 +47,20 @@ module WorkPackages
 
     def user_allowed_to_edit
       with_unchanged_project_id do
-        errors.add :base, :error_unauthorized unless @can.allowed?(model, :edit)
+
+        next if @can.allowed?(model, :edit)
+        next user_allowed_to_change_parent if @can.allowed?(model, :manage_subtasks)
+
+        errors.add :base, :error_unauthorized
+      end
+    end
+
+    def user_allowed_to_change_parent
+      allowed_changes = { parent_id: true, lock_version: true }
+
+      model.changed.each do |key|
+        next if allowed_changes[key.to_sym]
+        return errors.add :base, :error_unauthorized
       end
     end
 

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -47,7 +47,6 @@ module WorkPackages
 
     def user_allowed_to_edit
       with_unchanged_project_id do
-
         next if @can.allowed?(model, :edit)
         next user_allowed_to_change_parent if @can.allowed?(model, :manage_subtasks)
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -60,7 +60,7 @@ interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
   addComment(comment:HalResource):ng.IPromise<any>;
   addRelation(relation:any):ng.IPromise<any>;
   addWatcher(watcher:HalResource):ng.IPromise<any>;
-  changeParent(newParent:WorkPackageResource):ng.IPromise<any>;
+  changeParent(params:any):ng.IPromise<any>;
   copy():ng.IPromise<WorkPackageResource>;
   delete():ng.IPromise<any>;
   logTime():ng.IPromise<any>;

--- a/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
+++ b/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
@@ -59,12 +59,12 @@ export class ApiWorkPackagesService {
 
   /**
    * Loads a WorkPackage.
-   * 
+   *
    * @param id The ID of the WorkPackage.
    * @returns {IPromise<any>|IPromise<WorkPackageResource>} A promise for the WorkPackage.
    */
   public loadWorkPackageById(id: number) {
-    return this.apiV3.one("work_packages", id).get();
+    return this.apiV3.one("work_packages", id).get({});
   }
 
   /**

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -44,7 +44,7 @@ export class WorkPackageEditFormController {
   constructor(protected $scope:ng.IScope,
               protected $q,
               protected $rootScope,
-              protected WorkPackageNotificationService,
+              protected wpNotificationsService,
               protected QueryService,
               protected loadingIndicator,
               protected wpEditModeState:WorkPackageEditModeStateService,
@@ -128,15 +128,15 @@ export class WorkPackageEditFormController {
         angular.forEach(this.fields, field => field.setErrors([]));
         deferred.resolve(this.workPackage);
 
-        this.WorkPackageNotificationService.showSave(this.workPackage, this.loadingIndicator);
+        this.wpNotificationsService.showSave(this.workPackage, this.loadingIndicator);
         this.successHandler({workPackage: this.workPackage, fields: this.fields});
       })
       .catch((error) => {
         if (!(error.data instanceof ErrorResource)) {
-          this.WorkPackageNotificationService.showGeneralError;
+          this.wpNotificationsService.showGeneralError;
           return deferred.reject([]);
         }
-        this.WorkPackageNotificationService.showError(error.data, this.workPackage);
+        this.wpNotificationsService.showError(error.data, this.workPackage);
         this.handleSubmissionErrors(error.data, deferred);
       });
 

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -90,4 +90,4 @@ export class WorkPackageNotificationService {
   }
 }
 
-openprojectModule.service('WorkPackageNotificationService', WorkPackageNotificationService);
+openprojectModule.service('wpNotificationsService', WorkPackageNotificationService);

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -118,4 +118,52 @@ describe WorkPackages::UpdateContract do
       end
     end
   end
+
+  describe 'parent_id' do
+    let(:parent) { FactoryGirl.create(:work_package) }
+
+    before do
+      work_package.parent_id = parent.id
+      contract.validate
+    end
+
+    context 'if the user has only edit permissions' do
+      it { expect(contract.errors.symbols_for(:base)).to include(:error_unauthorized) }
+    end
+
+    context 'if the user has edit and subtasks permissions' do
+      let(:permissions) { [:edit_work_packages, :view_work_packages, :manage_subtasks] }
+      it('is valid') { expect(contract.errors).to be_empty }
+
+      describe 'invalid lock version' do
+        before do
+          work_package.lock_version = 9999
+          contract.validate
+        end
+
+        it { expect(contract.errors.symbols_for(:base)).to include(:error_conflict) }
+      end
+    end
+
+    context 'no write access' do
+      let(:permissions) { [:view_work_packages] }
+
+      it { expect(contract.errors.symbols_for(:base)).to include(:error_unauthorized) }
+    end
+
+    context 'with manage_subtasks permission' do
+      let(:permissions) { [:view_work_packages, :manage_subtasks] }
+
+      it('is valid') { expect(contract.errors).to be_empty }
+
+      describe 'changing more than the parent_id' do
+        before do
+          work_package.subject = 'Foobar!'
+          contract.validate
+        end
+
+        it { expect(contract.errors.symbols_for(:base)).to include(:error_unauthorized) }
+      end
+    end
+  end
 end

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -133,7 +133,10 @@ describe WorkPackages::UpdateContract do
 
     context 'if the user has edit and subtasks permissions' do
       let(:permissions) { [:edit_work_packages, :view_work_packages, :manage_subtasks] }
-      it('is valid') { expect(contract.errors).to be_empty }
+
+      it('is valid') do
+        expect(contract.errors).to be_empty
+      end
 
       describe 'invalid lock version' do
         before do
@@ -154,7 +157,9 @@ describe WorkPackages::UpdateContract do
     context 'with manage_subtasks permission' do
       let(:permissions) { [:view_work_packages, :manage_subtasks] }
 
-      it('is valid') { expect(contract.errors).to be_empty }
+      it('is valid') do
+        expect(contract.errors).to be_empty
+      end
 
       describe 'changing more than the parent_id' do
         before do

--- a/spec/features/work_packages/details/details_relations_spec.rb
+++ b/spec/features/work_packages/details/details_relations_spec.rb
@@ -51,9 +51,7 @@ describe 'Work package relations tab', js: true, selenium: true do
     end
 
     context 'with insufficient permissions' do
-      let(:permissions) {
-        [ :view_work_packages, :edit_work_packages ]
-      }
+      let(:permissions) { %i(view_work_packages edit_work_packages) }
 
       it 'does not allow editing the parent' do
         within '.relation.parent' do
@@ -68,9 +66,7 @@ describe 'Work package relations tab', js: true, selenium: true do
     end
 
     context 'with permissions' do
-      let(:permissions) {
-        [ :view_work_packages, :manage_subtasks ]
-      }
+      let(:permissions) { %i(view_work_packages manage_subtasks) }
 
       it 'shows the parent relationship expanded' do
         within '.relation.parent' do


### PR DESCRIPTION
Instead of using the regular `update(Immediately)` links of the work package resource, this PR allows using the changeParent link.

This accounts for the case where a user has the `:manage_subtasks`, but not the `:edit_work_packages` permission and thus, those links are not available.

The `UpdateContract`  is extended to allow a user to update the work package in this exact scenario: Setting the `parentId` (and optionally, an invalid lock version for clearer error output) is accepted when a user has the above permission set.

https://community.openproject.com/work_packages/23243/activity
