### PR TITLE
Fix/performance on list cfs

### DIFF
--- a/frontend/app/components/api/api-v3/api-v3.config.ts
+++ b/frontend/app/components/api/api-v3/api-v3.config.ts
@@ -31,8 +31,13 @@ import {opApiModule} from '../../../angular-modules';
 function apiV3Config(apiV3, HalResource) {
   apiV3.addResponseInterceptor((data, operation, what) => {
     apiV3.addElementTransformer(what, HalResource.create);
+
     if (data) {
-      data._plain = angular.copy(data);
+      // lodash's clone seems to have better performance in our situation
+      // when compared to angular.clone
+      // see also:
+      // https://github.com/angular/angular.js/issues/11099
+      data._plain = _.clone(data, true);
 
       if (data._type === 'Collection') {
         const resp = [];

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -184,8 +184,8 @@ module API
                                                 type: 'Version',
                                                 name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
-                                                  customized.assignable_values(:version,
-                                                                               current_user)
+                                                  customized
+                                                    .assignable_custom_field_values(custom_field)
                                                 },
                                                 writable: true,
                                                 value_representer: Versions::VersionRepresenter,
@@ -219,7 +219,8 @@ module API
                                                 type: 'StringObject',
                                                 name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
-                                                  customized.assignable_custom_field_values(custom_field)
+                                                  customized
+                                                    .assignable_custom_field_values(custom_field)
                                                 },
                                                 value_representer: representer,
                                                 writable: true,

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -144,7 +144,7 @@ module API
           when 'user'
             inject_user_schema(custom_field, customized)
           when 'list'
-            inject_list_schema(custom_field)
+            inject_list_schema(custom_field, customized)
           else
             inject_basic_schema(custom_field)
           end
@@ -213,13 +213,13 @@ module API
                                           }
         end
 
-        def inject_list_schema(custom_field)
+        def inject_list_schema(custom_field, customized)
           representer = StringObjects::StringObjectRepresenter
           @class.schema_with_allowed_collection property_name(custom_field.id),
                                                 type: 'StringObject',
                                                 name_source: -> (*) { custom_field.name },
                                                 values_callback: -> (*) {
-                                                  custom_field.possible_values
+                                                  customized.assignable_custom_field_values(custom_field)
                                                 },
                                                 value_representer: representer,
                                                 writable: true,

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -73,6 +73,10 @@ module API
             nil
           end
 
+          def assignable_custom_field_values(_custom_field)
+            nil
+          end
+
           def available_custom_fields
             []
           end

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -62,6 +62,13 @@ module API
             end
           end
 
+          def assignable_custom_field_values(custom_field)
+            case custom_field.field_format
+            when 'list'
+              custom_field.possible_values
+            end
+          end
+
           def available_custom_fields
             # we might have received a (currently) invalid work package
             return [] if project.nil? || type.nil?

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -66,6 +66,8 @@ module API
             case custom_field.field_format
             when 'list'
               custom_field.possible_values
+            when 'version'
+              assignable_values(:version, nil)
             end
           end
 

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -80,6 +80,17 @@ FactoryGirl.define do
       end
     end
 
+    factory :wp_custom_field, class: WorkPackageCustomField do
+      sequence(:name) do |n| "Work package custom field #{n}" end
+      type 'WorkPackageCustomField'
+
+      factory :list_wp_custom_field do
+        sequence(:name) do |n| "List work package custom field #{n}" end
+        field_format 'list'
+        possible_values ['1', '2', '3', '4', '5', '6', '7']
+      end
+    end
+
     factory :issue_custom_field, class: WorkPackageCustomField do
       sequence(:name) do |n| "Issue Custom Field #{n}" end
 

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -89,6 +89,11 @@ FactoryGirl.define do
         field_format 'list'
         possible_values ['1', '2', '3', '4', '5', '6', '7']
       end
+
+      factory :version_wp_custom_field do
+        sequence(:name) do |n| "Version work package custom field #{n}" end
+        field_format 'version'
+      end
     end
 
     factory :issue_custom_field, class: WorkPackageCustomField do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -152,6 +152,13 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     describe 'list custom field' do
+      before do
+        allow(schema)
+          .to receive(:assignable_custom_field_values)
+          .with(custom_field)
+          .and_return(custom_field.possible_values)
+      end
+
       let(:custom_field) {
         FactoryGirl.build(:custom_field,
                           field_format: 'list',

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -57,13 +57,8 @@ describe ::API::V3::Utilities::CustomFieldInjector do
              defines_assignable_values?: true,
              available_custom_fields: [custom_field])
     }
-    let(:versions) { [] }
 
     subject { modified_class.new(schema, current_user: nil, form_embedded: true).to_json }
-
-    before do
-      allow(schema).to receive(:assignable_values).with(:version, anything).and_return(versions)
-    end
 
     describe 'basic custom field' do
       it_behaves_like 'has basic schema properties' do
@@ -121,13 +116,18 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     describe 'version custom field' do
       let(:custom_field) {
-        FactoryGirl.build(:custom_field,
-                          field_format: 'version',
+        FactoryGirl.build(:version_wp_custom_field,
                           is_required: true)
       }
+
       let(:assignable_versions) { FactoryGirl.build_list(:version, 3) }
 
       before do
+        allow(schema)
+          .to receive(:assignable_custom_field_values)
+          .with(custom_field)
+          .and_return(assignable_versions)
+
         allow(::API::V3::Versions::VersionRepresenter).to receive(:new).and_return(double)
       end
 
@@ -141,13 +141,15 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       it_behaves_like 'links to allowed values directly' do
         let(:path) { cf_path }
-        let(:hrefs) { versions.map { |version| api_v3_paths.version version.id } }
+        let(:hrefs) { assignable_versions.map { |version| api_v3_paths.version version.id } }
       end
 
       it 'embeds allowed values' do
         # N.B. we do not use the stricter 'links to and embeds allowed values directly' helper
         # because this would not allow us to easily mock the VersionRepresenter away
-        is_expected.to have_json_size(versions.size).at_path("#{cf_path}/_embedded/allowedValues")
+        is_expected
+          .to have_json_size(assignable_versions.size)
+          .at_path("#{cf_path}/_embedded/allowedValues")
       end
     end
 
@@ -160,8 +162,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       end
 
       let(:custom_field) {
-        FactoryGirl.build(:custom_field,
-                          field_format: 'list',
+        FactoryGirl.build(:list_wp_custom_field,
                           is_required: true,
                           possible_values: values)
       }

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -283,9 +283,20 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
 
   describe '#assignable_custom_field_values' do
     let(:list_cf) { FactoryGirl.build_stubbed(:list_wp_custom_field) }
+    let(:version_cf) { FactoryGirl.build_stubbed(:version_wp_custom_field) }
 
-    it "be the custom fields' possible values" do
+    it "is a list custom fields' possible values" do
       expect(subject.assignable_custom_field_values(list_cf)).to eql list_cf.possible_values
+    end
+
+    it "is a version custom fields' project values" do
+      result = double('versions')
+
+      allow(work_package)
+        .to receive(:assignable_versions)
+        .and_return(result)
+
+      expect(subject.assignable_custom_field_values(version_cf)).to eql result
     end
   end
 end

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -280,4 +280,12 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
       end
     end
   end
+
+  describe '#assignable_custom_field_values' do
+    let(:list_cf) { FactoryGirl.build_stubbed(:list_wp_custom_field) }
+
+    it "be the custom fields' possible values" do
+      expect(subject.assignable_custom_field_values(list_cf)).to eql list_cf.possible_values
+    end
+  end
 end

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -87,9 +87,14 @@ describe ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
 
   describe '#assignable_custom_field_values' do
     let(:list_cf) { FactoryGirl.build_stubbed(:list_wp_custom_field) }
+    let(:version_cf) { FactoryGirl.build_stubbed(:version_wp_custom_field) }
 
-    it 'is nil' do
+    it 'is nil for a list cf' do
       expect(subject.assignable_custom_field_values(list_cf)).to be_nil
+    end
+
+    it 'is nil for a version cf' do
+      expect(subject.assignable_custom_field_values(version_cf)).to be_nil
     end
   end
 end

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -84,4 +84,12 @@ describe ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
       is_expected.not_to be_milestone
     end
   end
+
+  describe '#assignable_custom_field_values' do
+    let(:list_cf) { FactoryGirl.build_stubbed(:list_wp_custom_field) }
+
+    it 'is nil' do
+      expect(subject.assignable_custom_field_values(list_cf)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Increases the performance of the wp list in cases where listed work packages have a custom field of type list. On my machine with list custom fields having 200 entries, it reduced the time for 50 work package by about 10 seconds.

The problem was caused by two code issues:
1.  The work package schema would always return the available values for list custom fields. This behaved differently from the other attributes which had no values included which makes sense as a lot of the available values are determined by the work package's state. While that is not the case for list custom fields, we now have a consistent behaviour for the whole of the attributes. Now available values are not embedded/linked for the typed schema (available at `api/v3/work_packages/schemas/:project-id-:type-id`) but are embedded/linked for the specific schema (available at `api/v3/work_packages/:id/schema`). As we employ the typed schema rather than the specific schema, for the benefit of being able to reuse that schema across a number of work packages, we now have to deal with less data in problem 2.
2.  The deep copy of  the original (restangularized) response in the response interceptor https://github.com/opf/openproject/compare/dev...ulferts:fix/performance_on_list_cfs?expand=1#diff-2d13ec0c69e4c3f75bd5e676d1226760R40 performs poorly because of the large amount of data with a deeply nested object hierarchy. When testing, lodash's clone performed better when compared to angular's copy. For 50 work packages, using `clone` would save about 2 seconds as long as problem 1 was not fixed.

The PR fixes problem 1 but only marginally improves problem 2. With 1 fixed, the improvement of using `clone` was no longer recognizable in my setup but I left it there because there might be other cases where a deeply nested server response will have to be processed.
#### Thoughts

Problem 2 will probably show up again rather sooner than later. Things we could do:
1. no longer copy the entire object. We might want to start with an empty object or an object gained from calling `plain()`. Along the same line of thought, we might look into only copying the `plain()` object which would at least limit the amount of attributes that need copying. Additionally, it would make sense from a naming standpoint because `data` is not plain but restangularized in some cases.
2. no longer copy at all. I know @furinvader has already looked into it but we should do so again.
3. avoid getting the schema from the http cache that often. We have already talked about it but what I have seen, leads me to revisit that line of thought. Currently, the response intercepter and thereby `copy` is called once for every work package we present in the list. Using a work package schema cache would reduce that number significantly except for the worst case scenario where every work package is of a different project/type. It would also improve the performance when changing the filter or when visiting another page of the same filter.  

/cc @furinvader, @romanroe, @oliverguenther 
