### PR TITLE
[23546] Allow tab read-only display fields, but highlight them

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -82,13 +82,16 @@
     .work-package--placeholder
       padding: 0 10px 0 0px
 
+// Mark focused, non-editable read-values
+.inplace-edit--read-value.-read-only
+  &:focus, &:hover
+    color: $inplace-edit--color--disabled
+    background: $inplace-edit--bg-color--disabled
+  cursor: not-allowed
+
 // Default cursor on non-editable and id fields
 .wp-table--cell-span
   padding: 0 5px 0 5px
-  cursor: not-allowed
-
-  &.id
-    cursor: pointer
 
 // Animations on leaving work packages
 .wp--row.-animated-leave

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -208,5 +208,5 @@ $inplace-edit--dark-background:                 $gray-light
 $inplace-edit--color--very-dark:                #cacaca
 $inplace-edit--color-highlight:                 $primary-color
 $inplace-edit--selected-date-border-color:      $primary-color-dark
-$inplace-edit--color--disabled:                 #999
+$inplace-edit--color--disabled:                 #4d4d4d
 $inplace-edit--bg-color--disabled:              #eee

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -144,8 +144,10 @@ export class WorkPackageEditFieldController {
     if (this.isEditable) {
       this.handleUserActivate();
     }
+
     event.stopImmediatePropagation();
   }
+
 
   public get isEditable(): boolean {
     return this._editable && this.workPackage.isEditable;
@@ -270,14 +272,21 @@ export class WorkPackageEditFieldController {
   protected updateDisplayAttributes() {
     this.__d__inplaceEditReadValue = this.__d__inplaceEditReadValue || this.$element.find(".__d__inplace-edit--read-value");
 
-    if (this.isEditable) {
-      this.__d__inplaceEditReadValue.attr("role", "button");
-      this.__d__inplaceEditReadValue.attr("tabindex", "0");
-    }
-    else {
-      this.__d__inplaceEditReadValue.removeAttr("role");
-      this.__d__inplaceEditReadValue.removeAttr("tabindex");
-    }
+    // Unfortunately, ID fields are Edit fields at the moment
+    // and we need to treat them differently
+    const isIDField = this.fieldName === 'id';
+
+    // Usability: Highlight non-editable fields
+    const readOnly = !(this.isEditable || isIDField );
+    this.__d__inplaceEditReadValue.toggleClass("-read-only", readOnly);
+
+    // Accessibility: Mark editable fields as button role
+    const role = this.isEditable ? 'button' : null;
+    this.__d__inplaceEditReadValue.attr("role", role);
+
+    // Accessibility: Allow tab on all fields except id
+    const tabIndex = isIDField ? -1 : 0;
+    this.__d__inplaceEditReadValue.attr("tabindex", tabIndex);
   }
 }
 

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -237,29 +237,20 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
     end
 
     shared_examples_for 'context menu' do
-      describe 'activate' do
-        before do
-          expect(page).to have_selector(source_link)
-          element = find(source_link)
-          element.native.send_keys(keys)
-        end
+      it 'resets the context menu focus properly' do
+        expect(page).to have_selector(source_link)
+        element = find(source_link)
+        element.native.send_keys(keys)
 
-        it {
-          expect(page).to have_focus_on(target_link) if sets_focus
-        }
+        # Expect to open and focus the menu
+        expect(page).to have_focus_on(target_link) if sets_focus
+        element = find(target_link)
 
-        describe 'reset' do
-          before do
-            expect(page).to have_selector(target_link)
-            element = find(target_link)
-            element.native.send_keys(:escape)
-            expect(page).not_to have_selector(target_link)
-          end
+        element.native.send_keys(:escape)
+        expect(page).not_to have_selector(target_link)
 
-          it {
-            expect(page).to have_focus_on(source_link) if sets_focus
-          }
-        end
+        # Expect reset focus on originating element
+        expect(page).to have_focus_on(source_link) if sets_focus
       end
     end
 


### PR DESCRIPTION
This styles the background of read-only values when focussing or
hovering them.

Also, all fields regain a tabindex value of 0 to make them reachable.

https://community.openproject.com/work_packages/23546/activity

![anim](https://cloud.githubusercontent.com/assets/459462/16409670/02f345b2-3d1f-11e6-9402-33eea3ad2c0b.gif)
