### PR TITLE
Replace webpack-fail-plugin

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -2420,9 +2420,6 @@
         }
       }
     },
-    "webpack-fail-plugin": {
-      "version": "1.0.4"
-    },
     "yaml-loader": {
       "version": "0.1.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,6 @@
     "typescript": "^1.7.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.13.1",
-    "webpack-fail-plugin": "^1.0.4",
     "yaml-loader": "^0.1.0"
   },
   "scripts": {

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -32,8 +32,8 @@ var path = require('path');
 var _ = require('lodash');
 var pathConfig = require('./rails-plugins.conf');
 
+var TypeScriptDiscruptorPlugin = require('./webpack/typescript-disruptor.plugin.js');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var failPlugin = require('webpack-fail-plugin');
 
 var pluginEntries = _.reduce(pathConfig.pluginNamesPaths, function (entries, path, name) {
   entries[name.replace(/^openproject\-/, '')] = name;
@@ -144,10 +144,10 @@ function getWebpackMainConfig() {
     },
 
     plugins: [
-      // The fail plugin returns a status code of 1 if
+      // Add a simple fail plugin to return a status code of 2 if
       // errors are detected (this includes TS warnings)
-      // It is not executed when `--watch` is passed.
-      failPlugin,
+      // It is ONLY executed when `ENV[CI]` is set or `--bail` is used.
+      TypeScriptDiscruptorPlugin,
       new ExtractTextPlugin('openproject-[name].css'),
       new webpack.ProvidePlugin({
         '_': 'lodash',

--- a/frontend/webpack/typescript-disruptor.plugin.js
+++ b/frontend/webpack/typescript-disruptor.plugin.js
@@ -1,0 +1,13 @@
+module.exports = function() {
+  this.plugin('done', function(stats) {
+
+    if (!(process.argv.indexOf('--bail') !== -1 || process.env.CI)) {
+      return;
+    }
+
+    if (stats.compilation.errors && stats.compilation.errors.length) {
+      console.error(" ~~ The TYPESCRIPT DISCRUPTOR PLUGIN strikes again. ~~ ");
+      process.exit(2);
+    }
+  });
+};


### PR DESCRIPTION
Replace webpack-fail-plugin with custom plugin that will fail only when `CI=true`  or `--bail` is set.
Otherwise, configs won't be built anymore due to warnings in plugins.
