### PR TITLE
Feature/reschedule on due date back

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -99,7 +99,7 @@ class Relation < ActiveRecord::Base
   end
 
   def move_target_dates_by(delta)
-    to.reschedule_by(delta)
+    to.reschedule_by(delta) if relation_type == TYPE_PRECEDES
   end
 
   def set_dates_of_target

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -98,6 +98,10 @@ class Relation < ActiveRecord::Base
     set_dates_of_target
   end
 
+  def move_target_dates_by(delta)
+    to.reschedule_by(delta)
+  end
+
   def set_dates_of_target
     soonest_start = successor_soonest_start
     if soonest_start && to

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -371,8 +371,16 @@ class WorkPackage < ActiveRecord::Base
 
   # Updates start/due dates of following issues
   def reschedule_following_issues
-    if start_date_changed? || due_date_changed?
+    if start_date_changed?
       relations_from.each(&:set_dates_of_target)
+    elsif due_date_changed?
+      due_date_delta = (due_date_was || due_date || 0) - (due_date || 0)
+      if due_date_delta > 0
+        # due date moved back
+        relations_from.each { |r| r.move_target_dates_by( -1 * due_date_delta) }
+      else
+        relations_from.each(&:set_dates_of_target)
+      end
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -371,16 +371,12 @@ class WorkPackage < ActiveRecord::Base
 
   # Updates start/due dates of following issues
   def reschedule_following_issues
-    if start_date_changed?
+    due_date_delta = (due_date || due_date_was || 0) - (due_date_was || due_date || 0)
+
+    if due_date_delta < 0
+      relations_from.each { |r| r.move_target_dates_by(due_date_delta) }
+    elsif start_date_changed? || due_date_changed?
       relations_from.each(&:set_dates_of_target)
-    elsif due_date_changed?
-      due_date_delta = (due_date || 0) - (due_date_was || due_date || 0)
-      if due_date_delta < 0
-        # due date moved back
-        relations_from.each { |r| r.move_target_dates_by(due_date_delta) }
-      else
-        relations_from.each(&:set_dates_of_target)
-      end
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -302,11 +302,6 @@ class WorkPackage < ActiveRecord::Base
     self
   end
 
-  # Returns true if the work_package is overdue
-  def overdue?
-    !due_date.nil? && (due_date < Date.today) && !status.is_closed?
-  end
-
   # ACTS AS JOURNALIZED
   def activity_type
     'work_packages'

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -124,7 +124,7 @@ class WorkPackage < ActiveRecord::Base
 
   include OpenProject::NestedSet::WithRootIdScope
 
-  after_save :reschedule_following_issues,
+  after_save :reschedule_following_work_packages,
              :update_parent_attributes
 
   after_move :remove_invalid_relations,
@@ -367,27 +367,6 @@ class WorkPackage < ActiveRecord::Base
                         .flatten
                         .map(&:successor_soonest_start)
     ).compact.max
-  end
-
-  # Updates start/due dates of following issues
-  def reschedule_following_issues
-    delta = date_rescheduling_delta
-
-    if delta < 0
-      relations_from.each { |r| r.move_target_dates_by(delta) }
-    elsif start_date_changed? || due_date_changed?
-      relations_from.each(&:set_dates_of_target)
-    end
-  end
-
-  def date_rescheduling_delta
-    if due_date.present?
-      due_date - (due_date_was || 0)
-    elsif start_date.present?
-      start_date - (start_date_was || 0)
-    else
-      0
-    end
   end
 
   # Users/groups the work_package can be assigned to
@@ -663,6 +642,42 @@ class WorkPackage < ActiveRecord::Base
       issue.relations.each do |relation|
         relation.destroy unless relation.valid?
       end
+    end
+  end
+
+  # Updates start/due dates of following work packages.
+  # If
+  #   * there no start/due dates are set
+  #     => no scheduling will happen.
+  #   * a due date is set and the due date is moved backwards
+  #     => following work package is moved backwards as well
+  #   * a due date is set and the due date is moved forward
+  #     => following work package is moved forward to the point that
+  #        the work package is again scheduled to be after this work package.
+  #        If a delay is defined, that delay is adhered to.
+  #   * only a start date is set and the start date is moved backwards
+  #     => following work package is moved backwards as well
+  #   * only a start date is set and the start date is moved forward
+  #     => following work package is moved forward to the point that
+  #        the work package is again scheduled to be after this work package.
+  #        If a delay is defined, that delay is adhered to.
+  def reschedule_following_work_packages
+    delta = date_rescheduling_delta
+
+    if delta < 0
+      relations_from.each { |r| r.move_target_dates_by(delta) }
+    elsif start_date_changed? || due_date_changed?
+      relations_from.each(&:set_dates_of_target)
+    end
+  end
+
+  def date_rescheduling_delta
+    if due_date.present?
+      due_date - (due_date_was || 0)
+    elsif start_date.present?
+      start_date - (start_date_was || 0)
+    else
+      0
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -374,10 +374,10 @@ class WorkPackage < ActiveRecord::Base
     if start_date_changed?
       relations_from.each(&:set_dates_of_target)
     elsif due_date_changed?
-      due_date_delta = (due_date_was || due_date || 0) - (due_date || 0)
-      if due_date_delta > 0
+      due_date_delta = (due_date || 0) - (due_date_was || due_date || 0)
+      if due_date_delta < 0
         # due date moved back
-        relations_from.each { |r| r.move_target_dates_by( -1 * due_date_delta) }
+        relations_from.each { |r| r.move_target_dates_by(due_date_delta) }
       else
         relations_from.each(&:set_dates_of_target)
       end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -371,12 +371,22 @@ class WorkPackage < ActiveRecord::Base
 
   # Updates start/due dates of following issues
   def reschedule_following_issues
-    due_date_delta = (due_date || due_date_was || 0) - (due_date_was || due_date || 0)
+    delta = date_rescheduling_delta
 
-    if due_date_delta < 0
-      relations_from.each { |r| r.move_target_dates_by(due_date_delta) }
+    if delta < 0
+      relations_from.each { |r| r.move_target_dates_by(delta) }
     elsif start_date_changed? || due_date_changed?
       relations_from.each(&:set_dates_of_target)
+    end
+  end
+
+  def date_rescheduling_delta
+    if due_date.present?
+      due_date - (due_date_was || 0)
+    elsif start_date.present?
+      start_date - (start_date_was || 0)
+    else
+      0
     end
   end
 

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -34,6 +34,22 @@ module WorkPackage::SchedulingRules
     # add class-methods (validations, scope) here
   end
 
+  def reschedule_by(delta)
+    return if delta == 0
+
+    if leaf?
+      self.start_date += delta
+      self.due_date += delta
+      save
+    else
+      leaves.each do |leaf|
+        # this depends on the "update_parent_attributes" after save hook
+        # updating the start/end date of each work package between leaf and self
+        leaf.reschedule_by(delta)
+      end
+    end
+  end
+
   def reschedule_after(date)
     return if date.nil?
     if leaf?

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -38,8 +38,16 @@ module WorkPackage::SchedulingRules
     return if delta == 0
 
     if leaf?
-      self.start_date += delta
-      self.due_date += delta
+      current_buffer = soonest_start - start_date
+
+      max_allowed_delta = if current_buffer < delta
+                            delta
+                          else
+                            current_buffer
+                          end
+
+      self.start_date += max_allowed_delta
+      self.due_date += max_allowed_delta
       save
     else
       leaves.each do |leaf|

--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -95,7 +95,9 @@ module WorkPackage::Validations
 
   def validate_start_date_before_soonest_start_date
     if start_date && soonest_start && start_date < soonest_start
-      errors.add :start_date, :invalid
+      errors.add :start_date,
+                 :violates_relationships,
+                 soonest_start: soonest_start
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -409,6 +409,8 @@ en:
               cannot_be_in_another_project: "cannot be in another project."
               not_a_valid_parent: "is invalid."
               does_not_exist: "does not exist."
+            start_date:
+              violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
             status_id:
               status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
             priority_id:

--- a/spec/models/work_package/work_package_scheduling_spec.rb
+++ b/spec/models/work_package/work_package_scheduling_spec.rb
@@ -340,7 +340,8 @@ describe WorkPackage, type: :model do
         end
 
         context 'when the date is moved backwards' do
-          let(:new_work_package1_due) { work_package1_due - 1 }
+          let(:move_by) { -1 }
+          let(:new_work_package1_due) { work_package1_due + move_by }
 
           before do
             work_package1.due_date = new_work_package1_due
@@ -348,9 +349,8 @@ describe WorkPackage, type: :model do
           end
 
           it_behaves_like 'scheduled work package' do
-            # not updated
-            let(:expected_start) { work_package2_start }
-            let(:expected_due) { work_package2_due }
+            let(:expected_start) { work_package2_start + move_by }
+            let(:expected_due) { work_package2_due + move_by }
           end
         end
       end

--- a/spec/models/work_package/work_package_scheduling_spec.rb
+++ b/spec/models/work_package/work_package_scheduling_spec.rb
@@ -353,6 +353,40 @@ describe WorkPackage, type: :model do
             let(:expected_due) { work_package2_due + move_by }
           end
         end
+
+        context 'when there is another work package also preceding the wp' do
+          let(:work_package3) {
+            FactoryGirl.create(:work_package,
+                               start_date: work_package1_start,
+                               due_date: work_package1_due)
+          }
+          let(:follows_relation2) {
+            FactoryGirl.create(:relation,
+                               relation_type: Relation::TYPE_PRECEDES,
+                               from: work_package3,
+                               to: work_package2)
+          }
+
+          before do
+            follows_relation2
+          end
+
+          context 'when the date is moved backwards' do
+            let(:move_by) { -3 }
+            let(:new_work_package1_due) { work_package1_due + move_by }
+
+            before do
+              work_package1.due_date = new_work_package1_due
+              work_package1.save!
+            end
+
+            it_behaves_like 'scheduled work package' do
+              # moved backwards as much as possible
+              let(:expected_start) { work_package3.due_date + delay + 1 }
+              let(:expected_due) { work_package3.due_date + delay + 1 + (work_package3.due_date - work_package3.start_date) }
+            end
+          end
+        end
       end
 
       context 'upon removing the start and due date of the preceding work package' do

--- a/spec/models/work_package/work_package_scheduling_spec.rb
+++ b/spec/models/work_package/work_package_scheduling_spec.rb
@@ -301,6 +301,25 @@ describe WorkPackage, type: :model do
             end
           end
         end
+
+        context 'when the preceding work package has only the start date set' do
+          let(:work_package1_due) { nil }
+
+          it_behaves_like 'scheduled work package' do
+            let(:expected_start) { work_package1_start + 1 }
+            let(:expected_due) { work_package1_start + 1 }
+          end
+        end
+
+        context 'when the preceding work package has no dates set' do
+          let(:work_package1_start) { nil }
+          let(:work_package1_due) { nil }
+
+          it_behaves_like 'scheduled work package' do
+            let(:expected_start) { nil }
+            let(:expected_due) { nil }
+          end
+        end
       end
 
       context 'upon preceding work package due date update' do
@@ -355,6 +374,20 @@ describe WorkPackage, type: :model do
           end
         end
 
+        context 'when the due date is removed' do
+          let(:new_work_package1_due) { nil }
+
+          before do
+            work_package1.due_date = new_work_package1_due
+            work_package1.save!
+          end
+
+          it_behaves_like 'scheduled work package' do
+            let(:expected_start) { work_package2_start }
+            let(:expected_due) { work_package2_due }
+          end
+        end
+
         context 'when there is another work package also preceding the wp' do
           let(:work_package3) {
             FactoryGirl.create(:work_package,
@@ -384,7 +417,65 @@ describe WorkPackage, type: :model do
             it_behaves_like 'scheduled work package' do
               # moved backwards as much as possible
               let(:expected_start) { work_package3.due_date + delay + 1 }
-              let(:expected_due) { work_package3.due_date + delay + 1 + (work_package3.due_date - work_package3.start_date) }
+              let(:expected_due) {
+                work_package3.due_date + delay + 1 +
+                  (work_package3.due_date - work_package3.start_date)
+              }
+            end
+          end
+        end
+      end
+
+      context 'upon preceding work package start date update' do
+        let(:work_package2_start) { work_package1_due + 2 }
+        let(:work_package2_due) { work_package1_due + 5 }
+
+        context 'when moving backwards' do
+          let(:new_work_package1_start) { work_package1_start - 6 }
+
+          before do
+            work_package1.start_date = new_work_package1_start
+            work_package1.save
+          end
+
+          it_behaves_like 'scheduled work package' do
+            let(:expected_start) { work_package2_start }
+            let(:expected_due) { work_package2_due }
+          end
+
+          context 'when the preceding work package has no due date set' do
+            let(:work_package2_start) { work_package1_start + 2 }
+            let(:work_package2_due) { work_package1_start + 5 }
+            let(:work_package1_due) { nil }
+
+            it_behaves_like 'scheduled work package' do
+              let(:expected_start) { work_package2_start - 6 }
+              let(:expected_due) { work_package2_due - 6 }
+            end
+          end
+        end
+
+        context 'when moving forward' do
+          let(:new_work_package1_start) { work_package1_start + 6 }
+
+          before do
+            work_package1.start_date = new_work_package1_start
+            work_package1.save
+          end
+
+          it_behaves_like 'scheduled work package' do
+            let(:expected_start) { work_package2_start }
+            let(:expected_due) { work_package2_due }
+          end
+
+          context 'when the preceding work package has no due date set' do
+            let(:work_package2_start) { work_package1_start + 2 }
+            let(:work_package2_due) { work_package1_start + 5 }
+            let(:work_package1_due) { nil }
+
+            it_behaves_like 'scheduled work package' do
+              let(:expected_start) { work_package2_start + delay + 5 }
+              let(:expected_due) { work_package2_due + delay + 5 }
             end
           end
         end


### PR DESCRIPTION
Adds the functionality of updating the dates of work packages in a preceds/follows relationship with a work package of which dates are moved backwards (meaning to an earlier date). The update of the following work package when upon moving the dates of the preceding work package forward (meaning to a later date) is left unchanged.

The behaviour of updating the dates differs depending on whether the dates of the preceding work package are moved backwards or forwards. If they are moved forwards, the dates are only updated, when the scheduling would otherwise conflict, i.e. the preceding work package's due date would be later than the following work package's start date. If the dates are moved backwards however, the dates of the following work packages are always updated.

https://community.openproject.com/projects/openproject/work_packages/details/15875/overview?query_id=860  
##### minor improvements
- a set of tests have been written to cover the rescheduling
- A duplicate method `overdue?` has been removed from `WorkPackage`
- A more specific error message has been introduced for when a start date violates the work package's relationship constraints.
##### Out of scope
- Work packages which are automatically scheduled are not visibly updated on the wp table/split or full view
- The overall design of the rescheduling has not been touched. The current design has a couple of drawbacks most notably the possibility of data corruption when a rescheduled work package's validations report an error and the hard to understand code flow relying on bubbling updates up the work package ancestors chain.
