### PR TITLE
Fix/force datepicker open upon first focus

### DIFF
--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
@@ -37,7 +37,6 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
   }
 
   let input = element.find('input');
-  let datePickerContainer = element.find('.ui-datepicker--container');
   let datePickerInstance;
   let DatePicker = this.Datepicker;
   let onChange = scope.onChange;

--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
@@ -71,6 +71,7 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
     };
     datePickerInstance = new DatePicker(input, ngModel.$viewValue, options);
 
+    datePickerInstance.show();
   }
 }
 

--- a/frontend/app/work_packages/models/datepicker.js
+++ b/frontend/app/work_packages/models/datepicker.js
@@ -64,6 +64,10 @@ module.exports = function(TimezoneService, ConfigurationService) {
     this.datepickerInstance.datepicker('hide');
   };
 
+  Datepicker.prototype.show = function() {
+    this.datepickerInstance.datepicker('show');
+  };
+
   return Datepicker;
 };
 


### PR DESCRIPTION
Without it, the datepicker is only shown on the wp create page after the second focus.

https://community.openproject.com/work_packages/23573/activity
