### PR TITLE
HalResource redesign

### DIFF
--- a/frontend/app/components/api/api-v3/hal-request/hal-request.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-request/hal-request.service.test.ts
@@ -32,11 +32,12 @@ import {HalResource} from '../hal-resources/hal-resource.service';
 
 describe('halRequest service', () => {
   var $httpBackend:ng.IHttpBackendService;
+  var $rootScope:ng.IRootScopeService;
   var halRequest:HalRequestService;
 
   beforeEach(angular.mock.module(opApiModule.name));
-  beforeEach(angular.mock.inject(function (_$httpBackend_, _halRequest_) {
-    [$httpBackend, halRequest] = _.toArray(arguments);
+  beforeEach(angular.mock.inject(function (_$httpBackend_, _$rootScope_, _halRequest_) {
+    [$httpBackend, $rootScope, halRequest] = _.toArray(arguments);
   }));
 
   it('should exist', () => {
@@ -96,6 +97,24 @@ describe('halRequest service', () => {
     describe('when calling request()', () => {
       runRequests(() => {
         promise = halRequest.request(method, 'href', data);
+      });
+    });
+
+    describe('when requesting a null href', () => {
+      beforeEach(() => {
+        promise = halRequest.request('get', null);
+      });
+
+      afterEach(() => {
+        $rootScope.$apply();
+      });
+
+      it('should return a fulfilled promise', () => {
+        expect(promise).to.eventually.be.fulfilled;
+      });
+
+      it('should return a null promise', () => {
+        expect(promise).to.eventually.be.null;
       });
     });
   });

--- a/frontend/app/components/api/api-v3/hal-request/hal-request.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-request/hal-request.service.test.ts
@@ -1,0 +1,102 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+import {opApiModule} from '../../../../angular-modules';
+import {HalRequestService} from './hal-request.service';
+import {HalResource} from '../hal-resources/hal-resource.service';
+
+describe('halRequest service', () => {
+  var $httpBackend:ng.IHttpBackendService;
+  var halRequest:HalRequestService;
+
+  beforeEach(angular.mock.module(opApiModule.name));
+  beforeEach(angular.mock.inject(function (_$httpBackend_, _halRequest_) {
+    [$httpBackend, halRequest] = _.toArray(arguments);
+  }));
+
+  it('should exist', () => {
+    expect(halRequest).to.exist;
+  });
+
+  describe('when requesting data', () => {
+    var resource:HalResource;
+    var promise:ng.IPromise<HalResource>;
+    var method:string;
+    var data:any;
+    const methods = ['get', 'put', 'post', 'patch', 'delete'];
+    const runExpectations = () => {
+      it('should return a HalResource', () => {
+        expect(resource).to.be.an.instanceOf(HalResource);
+      });
+    };
+    const respond = status => {
+      $httpBackend.expect(method.toUpperCase(), 'href', data).respond(status, {});
+      promise
+        .then(res => resource = res)
+        .catch(res => resource = res);
+      $httpBackend.flush();
+    };
+    const runRequests = callback => {
+      methods.forEach(requestMethod => {
+        describe(`when performing a ${requestMethod} request`, () => {
+          beforeEach(() => {
+            method = requestMethod;
+
+            if (method !== 'get') {
+              data = {foo: 'bar'};
+            }
+
+            callback();
+          });
+
+          describe('when no error occurs', () => {
+            beforeEach(() => respond(200));
+            runExpectations();
+          });
+
+          describe('when an error occurs', () => {
+            beforeEach(() => respond(400));
+            runExpectations();
+          });
+        });
+      });
+    };
+
+    describe('when calling the http methods of the service', () => {
+      runRequests(() => {
+        promise = halRequest[method]('href', data);
+      });
+    });
+
+    describe('when calling request()', () => {
+      runRequests(() => {
+        promise = halRequest.request(method, 'href', data);
+      });
+    });
+  });
+});

--- a/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
+++ b/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
@@ -1,0 +1,110 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+import {opApiModule} from '../../../../angular-modules';
+import {HalResource} from '../hal-resources/hal-resource.service';
+
+export class HalRequestService {
+  constructor(protected $q:ng.IQService,
+              protected $http:ng.IHttpService,
+              protected HalResource) {
+  }
+
+  /**
+   * Perform a HTTP request and return a HalResource promise.
+   *
+   * @param method
+   * @param href
+   * @param data
+   * @returns {IPromise<HalResource>}
+   */
+  public request(method:string, href:string, data?:any):ng.IPromise<HalResource> {
+    return this.$http({
+      method: method,
+      url: href,
+      data: data
+    })
+      .then(response => this.HalResource.init(response.data))
+      .catch(response => this.HalResource.init(response.data));
+  }
+
+  /**
+   * Perform a GET request and return a resource promise.
+   *
+   * @param href
+   * @returns {ng.IPromise<HalResource>}
+   */
+  public get(href:string):ng.IPromise<HalResource> {
+    return this.request('get', href);
+  }
+
+  /**
+   * Perform a PUT request and return a resource promise.
+   * @param href
+   * @param data
+   * @returns {ng.IPromise<HalResource>}
+   */
+  public put(href:string, data?:any):ng.IPromise<HalResource> {
+    return this.request('put', href, data);
+  }
+
+  /**
+   * Perform a POST request and return a resource promise.
+   *
+   * @param href
+   * @param data
+   * @returns {ng.IPromise<HalResource>}
+   */
+  public post(href:string, data?:any):ng.IPromise<HalResource> {
+    return this.request('post', href, data);
+  }
+
+  /**
+   * Perform a PATCH request and return a resource promise.
+   *
+   * @param href
+   * @param data
+   * @returns {ng.IPromise<HalResource>}
+   */
+  public patch(href:string, data?:any):ng.IPromise<HalResource> {
+    return this.request('patch', href, data);
+  }
+
+  /**
+   * Perform a DELETE request and return a resource promise
+   *
+   * @param href
+   * @param data
+   * @returns {ng.IPromise<HalResource>}
+   */
+  public delete(href:string, data?:any):ng.IPromise<HalResource> {
+    return this.request('delete', href, data);
+  }
+}
+
+opApiModule.service('halRequest', HalRequestService);

--- a/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
+++ b/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
@@ -28,11 +28,12 @@
 
 import {opApiModule} from '../../../../angular-modules';
 import {HalResource} from '../hal-resources/hal-resource.service';
+import {HalResourceFactoryService} from '../hal-resource-factory/hal-resource-factory.service';
 
 export class HalRequestService {
   constructor(protected $q:ng.IQService,
               protected $http:ng.IHttpService,
-              protected HalResource) {
+              protected halResourceFactory:HalResourceFactoryService) {
   }
 
   /**
@@ -48,13 +49,11 @@ export class HalRequestService {
       return this.$q.when(null);
     }
 
-    return this.$http({
-      method: method,
-      url: href,
-      data: data
-    })
-      .then(response => this.HalResource.init(response.data))
-      .catch(response => this.HalResource.init(response.data));
+    const config = {method: method, url: href, data: data};
+    const createResource =
+      response => this.halResourceFactory.createHalResource(response.data);
+
+    return this.$http(config).then(createResource, createResource);
   }
 
   /**

--- a/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
+++ b/frontend/app/components/api/api-v3/hal-request/hal-request.service.ts
@@ -44,6 +44,10 @@ export class HalRequestService {
    * @returns {IPromise<HalResource>}
    */
   public request(method:string, href:string, data?:any):ng.IPromise<HalResource> {
+    if (!href) {
+      return this.$q.when(null);
+    }
+
     return this.$http({
       method: method,
       url: href,

--- a/frontend/app/components/api/api-v3/hal-resource-factory/hal-resource-factory.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-factory/hal-resource-factory.service.test.ts
@@ -1,0 +1,109 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {opApiModule} from '../../../../angular-modules';
+import {HalResourceFactoryService} from './hal-resource-factory.service';
+import {HalResource} from '../hal-resources/hal-resource.service';
+
+describe('halResourceFactory', () => {
+  var halResourceFactory:HalResourceFactoryService;
+  var resource:HalResource;
+
+  class OtherResource extends HalResource {
+  }
+
+  beforeEach(angular.mock.module(opApiModule.name));
+  beforeEach(angular.mock.module(opApiModule.name, $provide => {
+    $provide.value('OtherResource', OtherResource);
+  }));
+  beforeEach(angular.mock.inject(function (_halResourceFactory_) {
+    [halResourceFactory] = _.toArray(arguments);
+  }));
+
+  it('should exist', () => {
+    expect(halResourceFactory).to.exist;
+  });
+
+  it('should have HalResource as its default class', () => {
+    expect(halResourceFactory.defaultClass).to.equal(HalResource);
+  });
+
+  describe('when no resource type is configured', () => {
+    describe('when creating a resource', () => {
+      beforeEach(() => {
+        resource = halResourceFactory.createHalResource({});
+      });
+
+      it('should create an instance of the default type', () => {
+        expect(resource).to.be.an.instanceOf(halResourceFactory.defaultClass);
+      });
+    });
+  });
+
+  describe('when a resource type is configured', () => {
+    beforeEach(() => {
+      halResourceFactory.setResourceType('Other', OtherResource);
+    });
+
+    describe('when creating a resource of that type', () => {
+      beforeEach(() => {
+        resource = halResourceFactory.createHalResource({_type: 'Other'});
+      });
+
+      it('should be an instance of the configured type', () => {
+        expect(resource).to.be.an.instanceOf(OtherResource);
+      });
+    });
+
+    describe('when adding attribute configuration for that type', () => {
+      beforeEach(() => {
+        halResourceFactory.setResourceTypeAttributes('Other', {
+          attr: 'Other'
+        });
+        resource = halResourceFactory.createLinkedHalResource({}, 'Other', 'attr');
+      });
+
+      it('should be an instance of the configured attr type', () => {
+        expect(resource).to.be.an.instanceOf(OtherResource);
+      });
+    });
+  });
+
+  describe('when adding attr type configuration to for a non configured type', () => {
+    beforeEach(() => {
+      halResourceFactory.setResourceTypeAttributes('NonExistent', {
+        attr: 'NonExistent'
+      });
+      resource = halResourceFactory.createLinkedHalResource({}, 'NonExistent', 'attr');
+    });
+
+    it('should create a resource from the default tpye', () => {
+      expect(resource).to.be.an.instanceOf(halResourceFactory.defaultClass);
+    });
+  });
+});

--- a/frontend/app/components/api/api-v3/hal-resource-factory/hal-resource-factory.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-factory/hal-resource-factory.service.ts
@@ -30,7 +30,7 @@
 import {opApiModule} from '../../../../angular-modules';
 import {HalResource} from '../hal-resources/hal-resource.service';
 
-export class HalResourceTypesStorageService {
+export class HalResourceFactoryService {
   private config:any = {};
 
   public get defaultClass() {
@@ -80,4 +80,4 @@ export class HalResourceTypesStorageService {
   }
 }
 
-opApiModule.service('halResourceTypesStorage', HalResourceTypesStorageService);
+opApiModule.service('halResourceFactory', HalResourceFactoryService);

--- a/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.config.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.config.ts
@@ -29,7 +29,7 @@
 import {opApiModule} from '../../../../angular-modules';
 import {HalResourceTypesService} from './hal-resource-types.service';
 
-function halResourceTypesStorage(halResourceTypes:HalResourceTypesService) {
+function halResourceTypesConfig(halResourceTypes:HalResourceTypesService) {
   halResourceTypes.setResourceTypeConfig({
     WorkPackage: {
       className: 'WorkPackageResource',
@@ -53,4 +53,4 @@ function halResourceTypesStorage(halResourceTypes:HalResourceTypesService) {
   });
 }
 
-opApiModule.run(halResourceTypesStorage);
+opApiModule.run(halResourceTypesConfig);

--- a/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.test.ts
@@ -55,24 +55,20 @@ describe('halResourceTypes service', () => {
 
   const expectResourceClassAdded = () => {
     it('should add the respective class object to the storage', () => {
-      const cls = halResourceFactory.getResourceClassOfType('Other');
-      expect(cls).to.equal(compareCls);
+      const resource = halResourceFactory.createHalResource({_type: 'Other'});
+      expect(resource).to.be.an.instanceOf(compareCls);
     });
   };
 
   const expectAttributeClassAdded = () => {
     it('should add the attribute type config to the storage', () => {
-      const cls = halResourceFactory.getResourceClassOfAttribute('Other', 'attr');
-      expect(cls).to.equal(compareCls);
+      const resource = halResourceFactory.createLinkedHalResource({}, 'Other', 'attr');
+      expect(resource).to.be.an.instanceOf(compareCls);
     });
   };
 
   it('should exist', () => {
     expect(halResourceTypes).to.exist;
-  });
-
-  it('should have added HalResource as the default type', () => {
-    expect(halResourceFactory.defaultClass).to.equal(HalResource);
   });
 
   describe('when configuring the type with class and attributes', () => {

--- a/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.test.ts
@@ -28,11 +28,11 @@
 
 import {opApiModule} from '../../../../angular-modules';
 import {HalResourceTypesService} from './hal-resource-types.service';
-import {HalResourceTypesStorageService} from '../hal-resource-types-storage/hal-resource-types-storage.service';
+import {HalResourceFactoryService} from '../hal-resource-factory/hal-resource-factory.service';
 
 describe('halResourceTypes service', () => {
   var halResourceTypes:HalResourceTypesService;
-  var halResourceTypesStorage:HalResourceTypesStorageService;
+  var halResourceFactory:HalResourceFactoryService;
   var config:any;
   var compareCls:typeof HalResource;
 
@@ -49,20 +49,20 @@ describe('halResourceTypes service', () => {
     $provide.value('FooResource', FooResource);
   }));
 
-  beforeEach(angular.mock.inject(function (_halResourceTypes_, _halResourceTypesStorage_) {
-    [halResourceTypes, halResourceTypesStorage] = _.toArray(arguments);
+  beforeEach(angular.mock.inject(function (_halResourceTypes_, _halResourceFactory_) {
+    [halResourceTypes, halResourceFactory] = _.toArray(arguments);
   }));
 
   const expectResourceClassAdded = () => {
     it('should add the respective class object to the storage', () => {
-      const cls = halResourceTypesStorage.getResourceClassOfType('Other');
+      const cls = halResourceFactory.getResourceClassOfType('Other');
       expect(cls).to.equal(compareCls);
     });
   };
 
   const expectAttributeClassAdded = () => {
     it('should add the attribute type config to the storage', () => {
-      const cls = halResourceTypesStorage.getResourceClassOfAttribute('Other', 'attr');
+      const cls = halResourceFactory.getResourceClassOfAttribute('Other', 'attr');
       expect(cls).to.equal(compareCls);
     });
   };
@@ -72,7 +72,7 @@ describe('halResourceTypes service', () => {
   });
 
   it('should have added HalResource as the default type', () => {
-    expect(halResourceTypesStorage.defaultClass).to.equal(HalResource);
+    expect(halResourceFactory.defaultClass).to.equal(HalResource);
   });
 
   describe('when configuring the type with class and attributes', () => {
@@ -107,7 +107,7 @@ describe('halResourceTypes service', () => {
 
   describe('when configuring the type with only the attribute types', () => {
     beforeEach(() => {
-      compareCls = halResourceTypesStorage.defaultClass;
+      compareCls = halResourceFactory.defaultClass;
       config = {
         Other: {
           attr: 'Other'

--- a/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.service.ts
@@ -27,13 +27,13 @@
 // ++
 
 import {opApiModule} from '../../../../angular-modules';
-import {HalResourceTypesStorageService} from '../hal-resource-types-storage/hal-resource-types-storage.service';
+import {HalResourceFactoryService} from '../hal-resource-factory/hal-resource-factory.service';
 
 export class HalResourceTypesService {
   constructor(protected $injector,
-              protected halResourceTypesStorage:HalResourceTypesStorageService,
+              protected halResourceFactory:HalResourceFactoryService,
               HalResource) {
-    halResourceTypesStorage.defaultClass = HalResource;
+    halResourceFactory.defaultClass = HalResource;
   }
 
   public setResourceTypeConfig(config) {
@@ -41,7 +41,7 @@ export class HalResourceTypesService {
       const value = config[typeName];
       const result = {
         typeName: typeName,
-        className: value.className || this.getClassName(this.halResourceTypesStorage.defaultClass),
+        className: value.className || this.getClassName(this.halResourceFactory.defaultClass),
         attrTypes: value.attrTypes || {}
       };
 
@@ -57,13 +57,13 @@ export class HalResourceTypesService {
     });
 
     types.forEach(typeConfig => {
-      this.halResourceTypesStorage
+      this.halResourceFactory
         .setResourceType(typeConfig.typeName, this.$injector.get(typeConfig.className));
     });
 
     types
       .forEach(typeConfig => {
-        this.halResourceTypesStorage.setResourceTypeAttributes(typeConfig.typeName, typeConfig.attrTypes);
+        this.halResourceFactory.setResourceTypeAttributes(typeConfig.typeName, typeConfig.attrTypes);
       });
   }
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.test.ts
@@ -28,11 +28,11 @@
 
 import {opApiModule, opServicesModule} from '../../../../angular-modules';
 import {HalResource} from './hal-resource.service';
-import {HalResourceTypesStorageService} from '../hal-resource-types-storage/hal-resource-types-storage.service';
+import {HalResourceFactoryService} from '../hal-resource-factory/hal-resource-factory.service';
 
 describe('HalResource service', () => {
   var $httpBackend:ng.IHttpBackendService;
-  var halResourceTypesStorage:HalResourceTypesStorageService;
+  var halResourceFactory:HalResourceFactoryService;
   var resource;
   var source;
 
@@ -43,9 +43,9 @@ describe('HalResource service', () => {
     $provide.value('OtherResource', OtherResource);
   }));
   beforeEach(angular.mock.inject(function (_$httpBackend_,
-                                           _halResourceTypesStorage_,
+                                           _halResourceFactory_,
                                            apiV3) {
-    [$httpBackend, halResourceTypesStorage] = _.toArray(arguments);
+    [$httpBackend, halResourceFactory] = _.toArray(arguments);
     apiV3.setDefaultHttpFields({cache: false});
   }));
 
@@ -54,7 +54,7 @@ describe('HalResource service', () => {
   });
 
   it('should be instantiable using a default object', () => {
-    expect(new HalResource().href).to.equal(null);
+    expect(new HalResource().$href).to.equal(null);
   });
 
   it('should set its source to _plain if _plain is a property of the source', () => {
@@ -87,8 +87,8 @@ describe('HalResource service', () => {
           }
         };
 
-        halResourceTypesStorage.setResourceType('Other', OtherResource);
-        halResourceTypesStorage.setResourceTypeAttributes('Other', {
+        halResourceFactory.setResourceType('Other', OtherResource);
+        halResourceFactory.setResourceTypeAttributes('Other', {
           someResource: 'Other'
         });
 

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -28,20 +28,20 @@
 
 import {opApiModule} from '../../../../angular-modules';
 import {HalLinkInterface} from '../hal-link/hal-link.service';
-import {HalResourceTypesStorageService} from '../hal-resource-types-storage/hal-resource-types-storage.service';
+import {HalResourceFactoryService} from '../hal-resource-factory/hal-resource-factory.service';
 
 const ObservableArray:any = require('observable-array');
 
 var $q:ng.IQService;
 var lazy;
 var HalLink;
-var halResourceTypesStorage:HalResourceTypesStorageService;
+var halResourceFactory:HalResourceFactoryService;
 
 export class HalResource {
   public static _type:string;
 
   public static init(source:any) {
-    const resourceClass = halResourceTypesStorage.getResourceClassOfType(source._type);
+    const resourceClass = halResourceFactory.getResourceClassOfType(source._type);
     return new resourceClass(source);
   }
 
@@ -50,7 +50,7 @@ export class HalResource {
       return element;
     }
 
-    const resourceClass = halResourceTypesStorage.getResourceClassOfType(element._type);
+    const resourceClass = halResourceFactory.getResourceClassOfType(element._type);
     return new resourceClass(element);
   }
 
@@ -274,7 +274,7 @@ function initializeResource(halResource:HalResource) {
     var resource = HalResource.getEmptyResource();
     resource._links.self = link;
 
-    const resourceClass = halResourceTypesStorage
+    const resourceClass = halResourceFactory
       .getResourceClassOfAttribute(halResource.constructor._type, linkName);
 
     return new resourceClass(resource, false);
@@ -297,7 +297,7 @@ function initializeResource(halResource:HalResource) {
 }
 
 function halResourceService(...args) {
-  [$q, lazy, HalLink, halResourceTypesStorage] = args;
+  [$q, lazy, HalLink, halResourceFactory] = args;
   return HalResource;
 }
 
@@ -305,7 +305,7 @@ halResourceService.$inject = [
   '$q',
   'lazy',
   'HalLink',
-  'halResourceTypesStorage'
+  'halResourceFactory'
 ];
 
 opApiModule.factory('HalResource', halResourceService);

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -40,18 +40,12 @@ var halResourceFactory:HalResourceFactoryService;
 export class HalResource {
   public static _type:string;
 
-  public static init(source:any) {
-    const resourceClass = halResourceFactory.getResourceClassOfType(source._type);
-    return new resourceClass(source);
-  }
-
   public static create(element, force:boolean = false) {
     if (!force && !(element._embedded || element._links)) {
       return element;
     }
 
-    const resourceClass = halResourceFactory.getResourceClassOfType(element._type);
-    return new resourceClass(element);
+    return halResourceFactory.createHalResource(element);
   }
 
   public static fromLink(link:HalLinkInterface) {
@@ -143,8 +137,9 @@ export class HalResource {
    */
   protected $loadHeaders(force:boolean) {
     var headers:any = {};
+
     if (force) {
-      headers.caching = { enabled: false };
+      headers.caching = {enabled: false};
     }
 
     return headers;
@@ -271,13 +266,11 @@ function initializeResource(halResource:HalResource) {
   }
 
   function createLinkedResource(linkName, link) {
-    var resource = HalResource.getEmptyResource();
+    const resource = HalResource.getEmptyResource();
+    const type = halResource.constructor._type;
     resource._links.self = link;
 
-    const resourceClass = halResourceFactory
-      .getResourceClassOfAttribute(halResource.constructor._type, linkName);
-
-    return new resourceClass(resource, false);
+    return halResourceFactory.createLinkedHalResource(resource, type, linkName);
   }
 
   function setter(val:HalResource, linkName:string) {

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -40,6 +40,11 @@ var halResourceTypesStorage:HalResourceTypesStorageService;
 export class HalResource {
   public static _type:string;
 
+  public static init(source:any) {
+    const resourceClass = halResourceTypesStorage.getResourceClassOfType(source._type);
+    return new resourceClass(source);
+  }
+
   public static create(element, force:boolean = false) {
     if (!force && !(element._embedded || element._links)) {
       return element;

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -80,7 +80,18 @@ export class HalResource {
     this._name = name;
   }
 
+  /**
+   * Alias for $href.
+   * Please use $href instead.
+   *
+   * @deprecated
+   * @returns {string}
+   */
   public get href():string {
+    return this.$link.href;
+  }
+
+  public get $href():string {
     return this.$link.href;
   }
 


### PR DESCRIPTION
# HalResource Redesign
# TODO
- [ ] Typing of attributes is possible (`Date`, for example)
- [ ] Cache service for GET resources
- [ ] FactoryService instead of factory methods in `HalResource`
- [ ] Remove `restangular` dependency
## Development

One goal is to package the HAL implementation in the near future.
### Testing

It is crucial, that everything is tested thoroughly, as the HAL API is fundamental for the project.

Please consider to write the tests first, according to the design suggested below. That way, it's easier to detect potential flaws.

**Testing Example**
Currently, the best example for a well-written test is the [`hal-request.service.test.ts`](https://github.com/furinvader/openproject/blob/feature/hal/hal-request/frontend/app/components/api/hal/hal-request/hal-request.service.test.ts), as it is DRY and makes use of all the nifty things like TS imports and proper use of variable scoping.

Also, it circumvents the complexity of testing asynchronous code:
By calling `$httpBackend.flush()` before the tests, the promise is resolved or rejected instantly, which is why you can assign variables (like `resource` in that case) and test them in a synchronous fashion.

Tests also serve as a kind of **documentation**, which is why they should be readable and understandable.
### Naming

For consistency, please prefix every service with `hal`  - or `Hal`, if it's a class name.

Although names starting with `$` signs are suggested to be reserved for AngularJS components, we'll prefix all members of the `HalResource` class with `$` to prevent potential conflicts with the properties provided by the server's response, as they get merged into the resource object.
Currently the `HalLink` class follows the pattern, but this **should be changed**.

**Note on $**
You could argue, that it is more consistent to prefix all the members of our components with `$`.
But - although not consistent - having only one service with that prefix, would make it more of an exception and thus highlight, that there is a reason for it.

This could be discussed with @romanroe, if deemed necessary.
### Documentation

Parts of this PR description will be used as documentation for the HAL consumption package.
#### Doc Comments

Please write doc comments for every method and every class ([JSDoc](http://usejsdoc.org/) should suffice). We will use those for the API documentation later on.

See [`hal-request.service.ts`](https://github.com/furinvader/openproject/blob/feature/hal/hal-request/frontend/app/components/api/hal/hal-request/hal-request.service.ts), for example.
Here though, the general description of the service is missing, which is bad.
### Refactoring

If a refactoring of old code is necessary, please open a new PR and refer it to this one. This is to avoid having failing tests/specs that are not directly related.
## Design Proposal (draft)
### HalResource

The `HalResource` class should be designed to be user friendly and possibly interchangeable.
We want to expose properties, relations and let's call them 'action resources' in an intuitive fashion.

Also, all the `HalResource` methods and properties (those starting with a `$`) should be used as rarely as possible. `$get` and `$fetch` should probably be the only things that are accessed publicly.
Having this, allows us to change the API implementation easily, should we choose to.
#### Properties

//TODO: revise properties section
Although implementation wise being properties of the resource object, relations have their own section.
By properties, we mean those properties, that are sent by the server, which aren't `_links` or `_embedded`.

**Example**

```
_links: {...}, // relations
_embedded: {...} // relations
name: 'Bob', // property
state: 'silent' // property
...
```
#### Relations
##### Links
##### Embedded resources
#### Schemas and Configuration
### HalLink
### halRequest
### halResourceStorage
