### PR TITLE
Fix/move project empty options

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -10,8 +10,8 @@
         ng-attr-id="{{vm.htmlId}}">
   <option value=""
           ng-bind="vm.field.text.requiredPlaceholder"
-          ng-if="vm.field.schema.required && vm.workPackage[vm.fieldName] == null"
-          ng-selected="!vm.workPackage[vm.fieldName]"
+          ng-if="vm.field.currentValueInvalid"
+          ng-selected="vm.field.currentValueInvalid"
           disabled>
   </option>
 </select>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -26,12 +26,12 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {EditField} from "../wp-edit-field/wp-edit-field.module";
+import {EditField} from '../wp-edit-field/wp-edit-field.module';
 
 export class SelectEditField extends EditField {
   public options:any[];
   public placeholder:string = '-';
-  public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html'
+  public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text;
 
   constructor(workPackage, fieldName, schema) {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -30,7 +30,6 @@ import {EditField} from '../wp-edit-field/wp-edit-field.module';
 
 export class SelectEditField extends EditField {
   public options:any[];
-  public placeholder:string = '-';
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text;
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -34,6 +34,8 @@ export class SelectEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text;
 
+  public currentValueInvalid:boolean = false;
+
   constructor(workPackage, fieldName, schema) {
     super(workPackage, fieldName, schema);
 
@@ -44,16 +46,28 @@ export class SelectEditField extends EditField {
     };
 
     if (angular.isArray(this.schema.allowedValues)) {
-      this.options = angular.copy(this.schema.allowedValues);
-      this.addEmptyOption();
+      this.setValues(this.schema.allowedValues);
     } else if (this.schema.allowedValues) {
       this.schema.allowedValues.$load().then((values) => {
-        this.options = angular.copy(values.elements);
-        this.addEmptyOption();
+        this.setValues(values.elements);
       });
     } else {
-      this.options = [];
+      this.setValues([]);
     }
+  }
+
+  private setValues(availableValues) {
+    this.options = angular.copy(availableValues);
+    this.addEmptyOption();
+    this.checkCurrentValueValidity();
+  }
+
+  private checkCurrentValueValidity() {
+    this.currentValueInvalid = (this.value &&
+                                !_.some(this.options, (option) => (option.href === this.value.href))
+                               ) ||
+                               (!this.value &&
+                                this.schema.required);
   }
 
   private addEmptyOption() {


### PR DESCRIPTION
A dropdown will now display a "Please select" option whenever the current value is not one of the available options which can happen in a couple of cases:
- The wp was moved across projects and the current category does not exist in the new project
- A custom field has become required and no value has been provided as of yet
- The currently selected assignee/responsible is no longer part of the wp's project team
- ...

https://community.openproject.com/work_packages/23086/activity 
