### PR TITLE
[23589] Replace angular expressions before ng-non-bindable

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -45,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
 <% end %>
 <div class="form--field -required">
-  <%= f.text_area :content, required: true, label: l(:description_message_content), class: 'wiki-edit', data: {:'ng-non-bindable' => '' } %>
+  <%= f.text_area :content, required: true, label: l(:description_message_content), class: 'wiki-edit' %>
   <%= wikitoolbar_for("#{f.object_name}_content") %>
 </div>
 <%= render partial: 'attachments/form' %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -68,7 +68,7 @@ See doc/COPYRIGHT.rdoc for more details.
 </div>
 <div class="message">
   <p><span class="author"><%= authoring @topic.created_on, @topic.author %></span></p>
-  <div class="wiki" ng-non-bindable>
+  <div class="wiki">
     <%= format_text(@topic.content, object: @topic, attachments: @topic.attachments) %>
   </div>
   <%= link_to_attachments @topic, author: false %>
@@ -107,7 +107,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   class: 'button -small',
                   alt: l(:button_delete)) if message.destroyable_by?(User.current) %>
       </div>
-      <div class="wiki" ng-non-bindable>
+      <div class="wiki">
         <%= format_text message, :content, attachments: message.attachments %>
       </div>
       <%= link_to_attachments message, author: false %>

--- a/app/views/news/_form.html.erb
+++ b/app/views/news/_form.html.erb
@@ -34,7 +34,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= f.text_area :summary, cols: 60, rows: 2 %>
 </div>
 <div class="form--field">
-  <%= f.text_area :description, required: true, cols: 60, rows: 15, class: 'wiki-edit',
-                :'ng-non-bindable' => '' %>
+  <%= f.text_area :description, required: true, cols: 60, rows: 15, class: 'wiki-edit' %>
 </div>
 <%= wikitoolbar_for 'news_description' %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -70,7 +70,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <p><% unless @news.summary.blank? %><em><%=h @news.summary %></em><br />
   <% end %>
   <span class="author"><%= authoring @news.created_on, @news.author %></span></p>
-<div class="wiki" ng-non-bindable>
+<div class="wiki">
   <%= format_text(@news.description, object: @news) %>
 </div>
 <br />

--- a/app/views/project_associations/_form.html.erb
+++ b/app/views/project_associations/_form.html.erb
@@ -27,7 +27,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <div class="form--field -required">
-  <%= f.text_area(:description, class: 'timelines-project-association-description wiki-edit', rows: 10,
-                  :'ng-non-bindable' => '') %>
+  <%= f.text_area(:description,
+                  class: 'timelines-project-association-description wiki-edit',
+                  rows: 10 %>
 </div>
 <%= wikitoolbar_for 'project_association_description' %>

--- a/app/views/projects/form/attributes/_description.html.erb
+++ b/app/views/projects/form/attributes/_description.html.erb
@@ -30,7 +30,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="form--field">
   <%= form.text_area :description,
                      rows: 5,
-                     class: 'wiki-edit',
-                     :'ng-non-bindable' => '' %>
+                     class: 'wiki-edit' %>
 </div>
 <%= wikitoolbar_for 'project_description' %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% breadcrumb_paths(l(:label_overview)) %>
 
-<div class="wiki" ng-non-bindable>
+<div class="wiki">
   <%= format_text @project.description %>
 </div>
 <ul>

--- a/app/views/reportings/edit.html.erb
+++ b/app/views/reportings/edit.html.erb
@@ -57,8 +57,10 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
 
     <div class="form--field">
-      <%= f.text_area(:reported_project_status_comment, class: 'wiki-edit', rows: 10,
-                      :'ng-non-bindable' => '', label: Reporting.human_attribute_name(:reported_project_status_comment)) %>
+      <%= f.text_area(:reported_project_status_comment,
+                      class: 'wiki-edit',
+                      rows: 10,
+                      label: Reporting.human_attribute_name(:reported_project_status_comment)) %>
     </div>
     <%= wikitoolbar_for 'reporting_reported_project_status_comment' %>
   </fieldset>

--- a/app/views/reportings/index.html.erb
+++ b/app/views/reportings/index.html.erb
@@ -101,7 +101,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <td class="timelines-rep-short">
               <%=h reporting.reported_project_status.try(:name) || "-" %>
             </td>
-            <td class="timelines-rep-comment" ng-non-bindable>
+            <td class="timelines-rep-comment">
               <%= format_text reporting, :reported_project_status_comment %>
             </td>
             <td class="timelines-rep-last_change">

--- a/app/views/settings/_general.html.erb
+++ b/app/views/settings/_general.html.erb
@@ -63,7 +63,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <legend class="form--fieldset-legend"><%= l(:setting_welcome_text) %></legend>
       <div class="form--field"><%= setting_text_field :welcome_title, size: 30 %></div>
       <div class="form--field">
-        <%= setting_text_area :welcome_text, cols: 60, rows: 5, class: 'wiki-edit', :'ng-non-bindable' => '' %>
+        <%= setting_text_area :welcome_text, cols: 60, rows: 5, class: 'wiki-edit' %>
         <%= wikitoolbar_for 'settings_welcome_text' %>
       </div>
       <div class="form--field"><%= setting_check_box :welcome_on_homescreen %></div>

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -104,10 +104,19 @@ module OpenProject
         replace_toc(text, @parsed_headings)
       end
 
+      escape_non_macros(text)
       text.html_safe
     end
     deprecated_alias :textilizable, :format_text
     deprecated_alias :textilize,    :format_text
+
+    ##
+    # Escape double curly braces after macro expansion.
+    # This will avoid arbitrary angular expressions to be evaluated in
+    # formatted text marked html_safe.
+    def escape_non_macros(text)
+      text.gsub!('{{', '{{ DOUBLE_LEFT_CURLY_BRACE }}')
+    end
 
     def parse_non_pre_blocks(text)
       s = StringScanner.new(text)

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
@@ -47,7 +47,7 @@ describe Redmine::WikiFormatting::Macros, type: :helper do
     assert format_text(text).match(/Hello world!/)
     # escaping
     text = '!{{hello_world}}'
-    assert_equal '<p>{{hello_world}}</p>', format_text(text)
+    assert_equal '<p>{{ DOUBLE_LEFT_CURLY_BRACE }}hello_world}}</p>', format_text(text)
   end
 
   it 'should macro include' do


### PR DESCRIPTION
Since we do have macros we'd like to edit, we need to evaluate the escaped variants of `{{macro}}`.

For example, if a textarea with the attr `ng-non-bindable` set contains a macro `{{foo}` that is not marked as html_safe, the macro is properly escaped `{{ DOUBLE_LEFT_CURLY_BRACE }}foo}}`. Due to ng-non-bindable hoever, that expression is never removed by angular.

https://community.openproject.com/work_packages/23589/activity
