### PR TITLE
Fix/project description in list

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -215,26 +215,6 @@ div
     text-align: right
     white-space: nowrap
 
-ul.projects
-  margin: 0
-  padding-left: 1em
-  &.root
-    margin: 0
-    padding: 0
-  ul
-    border: none
-    &.projects
-      border-left: 3px solid #e0e0e0
-  li
-    &.root
-      list-style-type: none
-      margin-bottom: 1em
-    &.child
-      list-style-type: none
-      margin-top: 1em
-  div.root a.project
-    font-weight: bold
-    margin: 0 0 10px 0
 
 #type_project_ids
   ul
@@ -344,35 +324,6 @@ li
   &.root
     margin-bottom: 24px
 
-.nosidebar ul.projects
-  margin: 24px 0 0
-  ul
-    margin: 0
-
-.nosidebar ul.projects li
-  list-style: none outside none
-  background: none
-
-ul.projects
-  a
-    font-weight: bold
-  li div.root
-    margin-bottom: 12px
-
-  .description
-    height: 100px
-    position: relative
-    overflow-y: hidden
-
-    &:after
-      position: absolute
-      bottom: 0
-      height: 100%
-      width: 100%
-      content: ""
-      background: linear-gradient(to top, rgba(255,255,255, 1) 10%, rgba(255,255,255, 0) 90%)
-      pointer-events: none
-
 .profile-wrap
   float: right
   position: relative
@@ -415,9 +366,6 @@ form#issue-list
 
 tr.context-menu-selection td.priority
   background: none !important
-
-ul.projects div.root a.project
-  font-family: inherit
 
 div.issue div#relations
   margin-top: 25px

--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -360,13 +360,18 @@ ul.projects
     margin-bottom: 12px
 
   .description
-    height: 30px
+    height: 100px
+    position: relative
     overflow-y: hidden
 
-    *
-      @include text-shortener
+    &:after
+      position: absolute
+      bottom: 0
+      height: 100%
       width: 100%
-
+      content: ""
+      background: linear-gradient(to top, rgba(255,255,255, 1) 10%, rgba(255,255,255, 0) 90%)
+      pointer-events: none
 
 .profile-wrap
   float: right

--- a/app/assets/stylesheets/content/_projects_list.sass
+++ b/app/assets/stylesheets/content/_projects_list.sass
@@ -29,13 +29,16 @@
 ul.projects
   margin: 0
   padding-left: 1em
+
   &.root
     margin: 0
     padding: 0
+
   ul
     border: none
     &.projects
       border-left: 3px solid #e0e0e0
+
   li
     &.root
       list-style-type: none
@@ -43,27 +46,12 @@ ul.projects
     &.child
       list-style-type: none
       margin-top: 1em
-  div.root a.project
-    font-weight: bold
-    margin: 0 0 10px 0
 
-.nosidebar ul.projects
-  margin: 24px 0 0
-  ul
-    margin: 0
-
-.nosidebar ul.projects li
-  list-style: none outside none
-  background: none
-
-ul.projects
   a
     font-weight: bold
-  li div.root
-    margin-bottom: 12px
 
   .description
-    height: 100px
+    max-height: 100px
     position: relative
     overflow-y: hidden
 
@@ -73,8 +61,24 @@ ul.projects
       height: 100%
       width: 100%
       content: ""
-      background: linear-gradient(to top, rgba(255,255,255, 1) 10%, rgba(255,255,255, 0) 90%)
+      background: linear-gradient(to top, rgba(255,255,255, 1) 10%, rgba(255,255,255, 0) 80%)
       pointer-events: none
 
-ul.projects div.root a.project
-  font-family: inherit
+  div.root
+    margin-bottom: 12px
+
+    a.project
+      font-weight: bold
+      margin: 0 0 10px 0
+      font-family: inherit
+
+  .nosidebar &
+    margin: 24px 0 0
+
+    ul
+      margin: 0
+
+    li
+      list-style: none outside none
+      background: none
+

--- a/app/assets/stylesheets/content/_projects_list.sass
+++ b/app/assets/stylesheets/content/_projects_list.sass
@@ -1,0 +1,80 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+ul.projects
+  margin: 0
+  padding-left: 1em
+  &.root
+    margin: 0
+    padding: 0
+  ul
+    border: none
+    &.projects
+      border-left: 3px solid #e0e0e0
+  li
+    &.root
+      list-style-type: none
+      margin-bottom: 1em
+    &.child
+      list-style-type: none
+      margin-top: 1em
+  div.root a.project
+    font-weight: bold
+    margin: 0 0 10px 0
+
+.nosidebar ul.projects
+  margin: 24px 0 0
+  ul
+    margin: 0
+
+.nosidebar ul.projects li
+  list-style: none outside none
+  background: none
+
+ul.projects
+  a
+    font-weight: bold
+  li div.root
+    margin-bottom: 12px
+
+  .description
+    height: 100px
+    position: relative
+    overflow-y: hidden
+
+    &:after
+      position: absolute
+      bottom: 0
+      height: 100%
+      width: 100%
+      content: ""
+      background: linear-gradient(to top, rgba(255,255,255, 1) 10%, rgba(255,255,255, 0) 90%)
+      pointer-events: none
+
+ul.projects div.root a.project
+  font-family: inherit

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -105,6 +105,8 @@
 @import content/autocomplete
 @import content/diff
 
+@import content/projects_list
+
 @import content/jquery_ui
 @import content/datepicker
 @import content/atwho


### PR DESCRIPTION
Reworks the solution merged in #3607 which implements the feature request in https://community.openproject.com/work_packages/20771/activity because the solution was only working for descriptions starting with text in normal font size.

When images are involved or a different font size is employed, the solution would cut of the text/image.

The solution now uses a gradient to let the description fade out towards the bottom:

![image](https://cloud.githubusercontent.com/assets/617519/16577311/b7d144fa-4294-11e6-8b8b-4ddf33a6ad71.png)

This should work in way more cases while not being able to guarantee the optimal result in all cases and thus fix:

https://community.openproject.com/work_packages/22956/activity
