### PR TITLE
Remove duplicate setTableWidths execution

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -103,7 +103,6 @@ export class WorkPackageSingleViewController {
   public setFocus() {
     if (!this.firstTimeFocused) {
       this.firstTimeFocused = true;
-      angular.element(this.$window).trigger('resize');
       angular.element('.work-packages--details--subject .focus-input').focus();
     }
   }

--- a/frontend/app/ui_components/interactive-table-directive.js
+++ b/frontend/app/ui_components/interactive-table-directive.js
@@ -108,11 +108,10 @@ module.exports = function($timeout, $window){
         if(!getTable().is(':visible')) {
           return;
         }
-        $timeout(function() {
-          invalidateWidths();
-          setTableContainerWidths();
-          setHeaderFooterWidths();
-        });
+
+        invalidateWidths();
+        setTableContainerWidths();
+        setHeaderFooterWidths();
       };
 
       var cloneSpacer = function() {


### PR DESCRIPTION
Removes:
- Throwing resize in single-view, since `$timeout` is used anyway in the initialization.
- double timeout execution in interactive-table

Contributes to https://community.openproject.com/work_packages/23139
