### PR TITLE
[22987] Fix destruction of onboarding modal

### DIFF
--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -34,9 +34,11 @@ See doc/COPYRIGHT.rdoc for more details.
   </h2>
 </div>
 
-<foundation-modal-container showing="<%= !!params[:first_time_user] %>">
-  <%= render partial: '/onboarding/starting_video_modal' %>
-</foundation-modal-container>
+<% if params[:first_time_user] %>
+  <foundation-modal-container showing="true">
+    <%= render partial: '/onboarding/starting_video_modal' %>
+  </foundation-modal-container>
+<% end %>
 
 <%= render partial: 'announcements/show' %>
 

--- a/app/views/onboarding/_starting_video_modal.html.erb
+++ b/app/views/onboarding/_starting_video_modal.html.erb
@@ -28,29 +28,31 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div foundation-modal modal-class="onboarding--start-modal" class="foundation-modal--template">
-  <div id="top-menu" class="onboarding--top-menu">
-    <%= homescreen_user_avatar %>
-    <h2><%= I18n.t('onboarding.welcome', name: current_user.name) %></h2>
-    <a class="icon-context icon-close" ng-click="close()"></a>
-  </div>
+  <div class="onboarding--start-modal">
+    <div id="top-menu" class="onboarding--top-menu">
+      <%= homescreen_user_avatar %>
+      <h2><%= I18n.t('onboarding.welcome', name: current_user.name) %></h2>
+      <a class="icon-context icon-close" ng-click="close()"></a>
+    </div>
 
-  <div class="onboarding--main">
-    <h2><%= I18n.t('top_menu.getting_started') %></h2>
-    <div class="onboarding--video-block">
-      <div class="onboarding--video-text">
-        <span><%= I18n.t('onboarding.text_getting_started') %></span>
-      </div>
-      <div class="onboarding--video">
-        <iframe src="<%= OpenProject::Configuration.onboarding_video_url %>" height="282" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+    <div class="onboarding--main">
+      <h2><%= I18n.t('top_menu.getting_started') %></h2>
+      <div class="onboarding--video-block">
+        <div class="onboarding--video-text">
+          <span><%= I18n.t('onboarding.text_getting_started') %></span>
+        </div>
+        <div class="onboarding--video">
+          <iframe src="<%= OpenProject::Configuration.onboarding_video_url %>" height="282" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="onboarding--footer">
-    <em><label><%= I18n.t('onboarding.text_show_again') %></label></em>
-    <button class="button -highlight -large"
-            ng-click="close()"
-            title=<%= l(:label_next)%>> <%= l(:label_next)%>
-    </button>
+    <div class="onboarding--footer">
+      <em><label><%= I18n.t('onboarding.text_show_again') %></label></em>
+      <button class="button -highlight -large"
+              ng-click="close()"
+              title=<%= l(:label_next)%>> <%= l(:label_next)%>
+      </button>
+    </div>
   </div>
 </div>

--- a/frontend/app/components/common/modal/foundation-modal.directive.ts
+++ b/frontend/app/components/common/modal/foundation-modal.directive.ts
@@ -43,6 +43,10 @@ function foundationModal(ModalFactory) {
         close: function () {
           foundationModalContainer.hide();
           modal.deactivate();
+
+          // modal.destroy SHOULD be enough, but it is actually delayed
+          // by foundation by 3 seconds...
+          angular.element('.' + scope.modalClass).remove();
         }
       }
     });


### PR DESCRIPTION
While `modal.destroy` is enough for the modal to close, it only does so
after three seconds, leaving the video running for the time before that.

Fixes https://community.openproject.com/work_packages/22987
