### PR TITLE
Fix/history on wp list

### DIFF
--- a/frontend/app/components/filters/query/query-service.service.ts
+++ b/frontend/app/components/filters/query/query-service.service.ts
@@ -114,8 +114,8 @@ function QueryService($rootScope,
       QueryService.getAvailableFilters(query.projectId)
         .then(function(availableFilters) {
           query.setAvailableWorkPackageFilters(availableFilters);
-          if(queryData.filters && queryData.filters.length) {
-            query.setFilters(queryData.filters);
+          if(values.filters && values.filters.length) {
+            query.setFilters(values.filters);
           }
 
           return query;

--- a/frontend/app/components/filters/query/query-service.service.ts
+++ b/frontend/app/components/filters/query/query-service.service.ts
@@ -97,16 +97,16 @@ function QueryService($rootScope,
     updateQuery: function(values:any, afterUpdate) {
       var queryData = <any> {
       };
-      if(!!values.displaySums) {
+      if (!!values.displaySums) {
         queryData.displaySums = values.displaySums;
       }
-      if(!!values.columns) {
+      if (!!values.columns) {
         queryData.columns = values.columns;
       }
-      if(!!values.groupBy) {
+      if (!!values.groupBy) {
         queryData.groupBy = values.groupBy;
       }
-      if(!!values.sortCriteria) {
+      if (!!values.sortCriteria) {
         queryData.sortCriteria = values.sortCriteria;
       }
       query.update(queryData);

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -190,6 +190,14 @@ function WorkPackagesListController($scope,
     $scope.selectedTitle = queryName || I18n.t('js.label_work_package_plural');
   });
 
+  $scope.$watchCollection(function(){
+      return $state.params;
+  }, function(params) {
+    if ($scope.query && UrlParamsHelper.encodeQueryJsonParams($scope.query) !== params.query_props) {
+      initialSetup();
+    }
+  });
+
   $rootScope.$on('queryStateChange', function () {
     $scope.maintainUrlQueryState();
     $scope.maintainBackUrl();

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -168,8 +168,7 @@ function WorkPackagesListController($scope,
   $scope.loadQuery = function (queryId) {
     loadingIndicator.mainPage = $state.go('work-packages.list',
       {'query_id': queryId,
-       'query_props': null},
-      {reload: true});
+       'query_props': null});
   };
 
   function updateResults() {
@@ -193,7 +192,9 @@ function WorkPackagesListController($scope,
   $scope.$watchCollection(function(){
       return $state.params;
   }, function(params) {
-    if ($scope.query && UrlParamsHelper.encodeQueryJsonParams($scope.query) !== params.query_props) {
+    if ($scope.query &&
+        (params.query_id !== $scope.query.id ||
+         UrlParamsHelper.encodeQueryJsonParams($scope.query) !== params.query_props)) {
       initialSetup();
     }
   });

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {WorkPackageCacheService} from "../../work-packages/work-package-cache.service";
+import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
 
 function WorkPackagesListController($scope,
                                     $rootScope,
@@ -87,7 +87,7 @@ function WorkPackagesListController($scope,
     var cachedQuery = QueryService.getQuery();
     var urlQueryId = $state.params.query_id;
 
-    if (cachedQuery && urlQueryId && cachedQuery.id == urlQueryId) {
+    if (cachedQuery && urlQueryId && cachedQuery.id === urlQueryId) {
       // Augment current unsaved query with url param data
       var updateData = angular.extend(queryData, {columns: columnData});
       $scope.query = QueryService.updateQuery(updateData);
@@ -149,8 +149,8 @@ function WorkPackagesListController($scope,
     $scope.resource = json.resource;
 
     // Authorisation
-    AuthorisationService.initModelAuth("work_package", meta._links);
-    AuthorisationService.initModelAuth("query", meta.query._links);
+    AuthorisationService.initModelAuth('work_package', meta._links);
+    AuthorisationService.initModelAuth('query', meta.query._links);
   }
 
   $scope.maintainBackUrl = function () {
@@ -236,7 +236,7 @@ function WorkPackagesListController($scope,
   $scope.nextAvailableWorkPackage = nextAvailableWorkPackage;
 
   $scope.openWorkPackageInFullView = function (id, force) {
-    if (force || $state.current.url != "") {
+    if (force || $state.current.url !== '') {
       loadingIndicator.mainPage = $state.go('work-packages.show', {
         workPackageId: id,
         query_props: $state.params.query_props

--- a/spec/features/work_packages/table/query_history_spec.rb
+++ b/spec/features/work_packages/table/query_history_spec.rb
@@ -1,0 +1,145 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Going back and forth through the browser history', type: :feature, js: true do
+  let(:user) {
+    FactoryGirl.create(:user,
+                       member_in_project: project,
+                       member_through_role: role)
+  }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:type) { project.types.first }
+  let(:role) {
+    FactoryGirl.create(:role,
+                       permissions: [:view_work_packages,
+                                     :save_queries])
+  }
+
+  let(:work_package_1) {
+    FactoryGirl.create(:work_package,
+                       project: project,
+                       type: type)
+  }
+  let(:work_package_2) {
+    FactoryGirl.create(:work_package,
+                       project: project,
+                       type: type,
+                       assigned_to: user)
+  }
+  let(:version) {
+    FactoryGirl.create(:version,
+                       project: project)
+  }
+  let(:work_package_3) {
+    FactoryGirl.create(:work_package,
+                       project: project,
+                       type: type,
+                       fixed_version: version)
+  }
+  let(:assignee_query) {
+    query = FactoryGirl.create(:query,
+                               project: project,
+                               user: user)
+
+    query.add_filter('assigned_to_id', '=', [user.id])
+    query.save!
+
+    query
+  }
+  let(:version_query) {
+    query = FactoryGirl.create(:query,
+                               project: project,
+                               user: user)
+
+    query.add_filter('fixed_version_id', '=', [version.id])
+    query.save!
+
+    query
+  }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+
+  before do
+    login_as(user)
+
+    work_package_1
+    work_package_2
+    work_package_3
+
+    assignee_query
+    version_query
+  end
+
+  it 'updates the filters and query results on history back and forth' do
+    wp_table.visit!
+    wp_table.visit_query(assignee_query)
+    wp_table.visit_query(version_query)
+    wp_table.add_filter('Assignee', 'is', '<< me >>')
+
+    wp_table.expect_no_work_package_listed
+
+    page.evaluate_script('window.history.back()')
+
+    wp_table.expect_work_package_listed work_package_3
+    wp_table.expect_filter('Status', 'open', nil)
+    wp_table.expect_filter('Version', 'is', version.name)
+
+    page.evaluate_script('window.history.back()')
+
+    wp_table.expect_work_package_listed work_package_2
+    wp_table.expect_filter('Status', 'open', nil)
+    wp_table.expect_filter('Assignee', 'is', user.name)
+
+    page.evaluate_script('window.history.back()')
+
+    wp_table.expect_work_package_listed work_package_1
+    wp_table.expect_work_package_listed work_package_2
+    wp_table.expect_work_package_listed work_package_3
+    wp_table.expect_filter('Status', 'open', nil)
+
+    page.evaluate_script('window.history.forward()')
+
+    wp_table.expect_work_package_listed work_package_2
+    wp_table.expect_filter('Status', 'open', nil)
+    wp_table.expect_filter('Assignee', 'is', user.name)
+
+    page.evaluate_script('window.history.forward()')
+
+    wp_table.expect_work_package_listed work_package_3
+    wp_table.expect_filter('Status', 'open', nil)
+    wp_table.expect_filter('Version', 'is', version.name)
+
+    page.evaluate_script('window.history.forward()')
+
+    wp_table.expect_no_work_package_listed
+    wp_table.expect_filter('Status', 'open', nil)
+    wp_table.expect_filter('Version', 'is', version.name)
+    wp_table.expect_filter('Assignee', 'is', '<< me >>')
+  end
+end

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -47,6 +47,12 @@ module Pages
       end
     end
 
+    def expect_no_work_package_listed
+      within(table_container) do
+        expect(page).to have_selector('#empty-row-notification')
+      end
+    end
+
     def click_inline_create
       find('.wp-inline-create--add-link').click
       expect(page).to have_selector('.wp--row.-new')
@@ -62,6 +68,26 @@ module Pages
       row_element.find('.wp-table--details-link').click
 
       split_page
+    end
+
+    def add_filter(label, operator, value)
+      open_filter_section
+
+      select(label, from: 'Add filter:')
+
+      filter_name = get_filter_name(label)
+
+      select(operator, from: "operators-#{filter_name}") if operator
+      select(value, from: "values-#{filter_name}") if value
+    end
+
+    def expect_filter(label, operator, value)
+      open_filter_section
+
+      filter_name = get_filter_name(label)
+
+      expect(page).to have_select("operators-#{filter_name}", selected: operator) if operator
+      expect(page).to have_select("values-#{filter_name}", selected: value) if value
     end
 
     def click_on_row(work_package)
@@ -104,6 +130,12 @@ module Pages
       WorkPackageField.new(context, attribute)
     end
 
+    def open_filter_section
+      unless page.has_selector?('#work-packages-filter-toggle-button.-active')
+        click_button('work-packages-filter-toggle-button')
+      end
+    end
+
     private
 
     def path
@@ -112,6 +144,14 @@ module Pages
 
     def table_container
       find('#content .work-package-table--container')
+    end
+
+    def get_filter_name(label)
+      filter_container = page
+                         .find('.advanced-filters--filter-name', text: label)
+                         .first(:xpath, './..')
+
+      filter_container['id'].gsub('filter_', '')
     end
   end
 end


### PR DESCRIPTION
Updates the filters and the filter results when the browser url is changed e.g. when the user changes it via the back or fro button:

https://community.openproject.com/work_packages/23598/activity
#### TODO
- [x] Check how to avoid a page reload when changing the query_id
