### PR TITLE
[23556] Replace workflow toggled fieldset with directive

### DIFF
--- a/app/assets/javascripts/styleguide.js
+++ b/app/assets/javascripts/styleguide.js
@@ -26,21 +26,14 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-//= require ../javascripts/bundles/openproject-global
-//= require ../javascripts/tooltips
+//= require application
 
+window.openProject = {
+  environment: 'dev'
+};
+
+angular.element(document).ready(function() {
+  angular.bootstrap(document, ['openproject']);
+});
 angular.module('openproject-style-guide', ['ui.select', 'ngSanitize']);
 
-// Add uiComponents to the styleguide.
-// In order to be able to do that, we have to mock some
-// services that directives in uiComponents rely on.
-angular.module('openproject-style-guide')
-  .service('ActivityService', function() {} )
-  .service('ConfigurationService', function() {} )
-  .service('AutoCompleteHelper', function() {} )
-  .service('NotificationsService', function() {
-    return {
-      addError: function() {},
-      addSuccess: function() {}
-    };
-}).requires.push('openproject.uiComponents');

--- a/app/assets/stylesheets/content/_collapsible_section.lsg
+++ b/app/assets/stylesheets/content/_collapsible_section.lsg
@@ -1,0 +1,23 @@
+# Collapsible section
+
+```
+<collapsible-section initially-expanded="true"
+                   id="my-expanded-section"
+                   section-title="My section title">
+
+<div>
+<p><strong>Initially expanded</strong></p>
+</div>
+</collapsible-section>
+```
+
+
+```
+<collapsible-section id="my-closed-section"
+                   	 section-title="My closed section title">
+
+<div>
+<p><strong>Initially closed</strong></p>
+</div>
+</collapsible-section>
+```

--- a/app/assets/stylesheets/content/_collapsible_section.sass
+++ b/app/assets/stylesheets/content/_collapsible_section.sass
@@ -1,0 +1,27 @@
+.collapsible-section
+  margin: 2rem 0
+
+.collapsible-section--legend
+  &:before
+    @include icon-common
+    @extend .icon-arrow-down1:before
+    font-size: 0.75rem
+    padding:   0.625rem 0.25rem 0 0.25rem
+
+    .collapsible-section.-expanded &
+      @extend .icon-arrow-up1:before
+
+.collapsible-section--toggle-link
+  @include without-link-styling
+  display: block
+  cursor: pointer
+  color: $body-font-color
+  font-size: 1rem
+  font-weight: bold
+  line-height: 1.8
+  text-transform: uppercase
+  border-bottom: 1px solid $gray
+
+  &:hover
+    color: $content-link-color
+    text-decoration: none

--- a/app/assets/stylesheets/content/_select2.lsg
+++ b/app/assets/stylesheets/content/_select2.lsg
@@ -55,7 +55,7 @@ jQuery(function($) {
 ```
 @javascript
 
-angular.module('openproject-style-guide').controller('UiSelectExample', ['$scope', function($scope) {
+angular.module('openproject').controller('UiSelectExample', ['$scope', function($scope) {
   $scope.disabled = undefined;
 
   $scope.enable = function() {

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -51,6 +51,7 @@
 @import content/forms
 @import content/forms_mobile
 @import content/choice
+@import content/collapsible_section
 @import content/copy_to_clipboard
 @import content/ui_select
 @import content/notifications

--- a/app/assets/stylesheets/styleguide.html.lsg
+++ b/app/assets/stylesheets/styleguide.html.lsg
@@ -59,6 +59,10 @@
       font-size: 30px
 
 
+@head
+  <base href="/assets/styleguide.html"/>
+
+
 @header
   <header class="livingstyleguide--header">
     <div class="styleguide-banner">
@@ -68,13 +72,13 @@
 
   <nav class="styleguide-nav">
     <ul class="styleguide-nav--menu-items">
-      <li><a href="#color-variables">Colors</a></li>
-      <li><a href="#fonts">Fonts</a></li>
-      <li><a href="#forms">Forms</a></li>
-      <li><a href="#notifications">Notifications</a></li>
-      <li><a href="#buttons">Buttons</a></li>
-      <li><a href="#boxes">Boxes</a></li>
-      <li><a href="#pagination">Pagination</a></li>
+      <li><a target="_self" href="#color-variables">Colors</a></li>
+      <li><a target="_self" href="#fonts">Fonts</a></li>
+      <li><a target="_self" href="#forms">Forms</a></li>
+      <li><a target="_self" href="#notifications">Notifications</a></li>
+      <li><a target="_self" href="#buttons">Buttons</a></li>
+      <li><a target="_self" href="#boxes">Boxes</a></li>
+      <li><a target="_self" href="#pagination">Pagination</a></li>
     </ul>
   </nav>
 

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -69,28 +69,21 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= render partial: 'form',
                  locals: { name: 'always', workflows: @workflows['always'] } %>
 
-      <% author_expanded = @workflows['author'].present? ? '' : 'collapsed' %>
-      <% assignee_expanded = @workflows['assignee'].present? ? '' : 'collapsed' %>
-      <fieldset class="form--fieldset -collapsible <%= author_expanded %>"
-                style="margin-top: 0.5em;">
-        <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
-          <a href="javascript:"><%= l(:label_additional_workflow_transitions_for_author) %></a>
-        </legend>
-        <div id="author_workflows" style="margin: 0.5em 0 0.5em 0;">
-          <%= render partial: 'form',
-                     locals: { name: 'author', workflows: @workflows['author'] } %>
-        </div>
-      </fieldset>
+      <% author_expanded = @workflows['author'].present? ? 'true' : '' %>
+      <% assignee_expanded = @workflows['assignee'].present? ? 'true' : '' %>
+       
+      <collapsible-section initially-expanded="<%= author_expanded %>"
+                           id="author_workflows"
+                           section-title="<%= t(:label_additional_workflow_transitions_for_author) %>">
+        <%= render partial: 'form', locals: { name: 'author', workflows: @workflows['author'] } %>
+      </collapsible-section>
 
-      <fieldset class="form--fieldset -collapsible <%= assignee_expanded %>">
-        <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
-          <a href="javascript:"><%= l(:label_additional_workflow_transitions_for_assignee) %></a>
-        </legend>
-        <div id="assignee_workflows" style="margin: 0.5em 0 0.5em 0;">
-          <%= render partial: 'form',
-                     locals: { name: 'assignee', workflows: @workflows['assignee'] } %>
-        </div>
-      </fieldset>
+      <collapsible-section initially-expanded="<%= assignee_expanded %>"
+                           id="assignee_workflows"
+                           section-title="<%= t(:label_additional_workflow_transitions_for_assignee) %>">
+        <%= render partial: 'form', locals: { name: 'assignee', workflows: @workflows['assignee'] } %>
+      </collapsible-section>
+
       <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
     <% end %>
 <% end %>

--- a/frontend/app/angular-modules.ts
+++ b/frontend/app/angular-modules.ts
@@ -34,6 +34,9 @@ angular.module('openproject.uiComponents',
   .run(['$rootScope', function($rootScope){
     $rootScope.I18n = I18n;
   }]);
+export const animationsModule = angular.module('openproject.animations', [
+  'ngAnimate'
+]);
 export const configModule = angular.module('openproject.config', []);
 export const opServicesModule = angular.module('openproject.services', [
   'openproject.uiComponents',
@@ -160,6 +163,7 @@ export const wpButtonsModule = angular.module('openproject.wpButtons',
 // main app
 export const openprojectModule = angular.module('openproject', [
   'ui.router',
+  'openproject.animations',
   'openproject.config',
   'openproject.uiComponents',
   'openproject.timelines',

--- a/frontend/app/components/animations/toggle-slide.animation.ts
+++ b/frontend/app/components/animations/toggle-slide.animation.ts
@@ -1,0 +1,59 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {animationsModule} from '../../angular-modules';
+function toggleSlideAnimation($window) {
+
+  // Since the content of the animation may require a reflow,
+  // we trigger resize to let, e.g., tables recompute their widths
+  function onSlide(done) {
+    return function() {
+      angular.element($window).trigger('resize');
+      done();
+    }
+  }
+
+  return {
+    beforeAddClass: function (element, className, done) {
+      if (className === 'ng-hide') {
+        element.slideUp(150, onSlide(done));
+      } else {
+        done();
+      }
+    },
+    beforeRemoveClass: function (element, className, done) {
+      if (className === 'ng-hide') {
+        element.slideDown(150, onSlide(done));
+      } else {
+        done();
+      }
+    }
+  };
+}
+
+animationsModule.animation('.toggle-slide-animation', toggleSlideAnimation);

--- a/frontend/app/components/common/collapsible-section/collapsible-section.directive.html
+++ b/frontend/app/components/common/collapsible-section/collapsible-section.directive.html
@@ -1,0 +1,11 @@
+<section class="collapsible-section" ng-class="{ '-expanded': $ctrl.expanded }">
+  <accessible-by-keyboard execute="$ctrl.toggle()"
+                          aria-label="{{ ::$ctrl.sectionTitle }}"
+                          link-class="collapsible-section--toggle-link"
+                          span-class="collapsible-section--legend">
+    <span ng-bind="::$ctrl.sectionTitle"></span>
+  </accessible-by-keyboard>
+  <div class="collapsible-section--body toggle-slide-animation" ng-show="$ctrl.expanded">
+    <ng-transclude></ng-transclude>
+  </div>
+</section>

--- a/frontend/app/components/common/collapsible-section/collapsible-section.directive.ts
+++ b/frontend/app/components/common/collapsible-section/collapsible-section.directive.ts
@@ -1,0 +1,67 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {wpDirectivesModule} from "../../../angular-modules";
+
+export class CollapsibleSectionController {
+  public text:any;
+  public expanded:boolean = false;
+  public sectionTitle:string;
+
+  constructor(public $scope:ng.IScope,
+              public $attrs:ng.IAttributes) {
+
+
+    if ($attrs['initiallyExpanded']) {
+      this.expanded = true;
+    }
+  }
+
+  public toggle() {
+    this.expanded = !this.expanded;
+  }
+}
+
+function CollapsibleSection() {
+  return {
+    restrict: 'E',
+    replace: true,
+    transclude: true,
+    templateUrl: '/components/common/collapsible-section/collapsible-section.directive.html',
+
+    scope: {
+      sectionTitle: '@'
+    },
+
+    bindToController: true,
+    controller: CollapsibleSectionController,
+    controllerAs: '$ctrl'
+  };
+}
+
+wpDirectivesModule.directive('collapsibleSection', CollapsibleSection);


### PR DESCRIPTION
This PR adds a collapsible-section directive that mirrors the functionality of the -collapsible fieldset without all that hacking.

This should replace the awful toggleFieldset in the long run.

I also have extended the styleguide to include an exemplary application of the directive. To make the styleguide use the entire components, I've included the application.js asset with the styleguide that is already built anyway. I don't think it has a significant performance impact and it reduces the custom hacks for the styleguide while allowing application directives to just be used.

https://community.openproject.com/work_packages/23556/activity
