### PR TITLE
Disable animations unless explicitly requested with -ng-animated

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -160,7 +160,7 @@
   &[msd-elastic]
     resize: none
 
-  &.-animated:focus
+  &.-animated-elastic:focus
     transition: height 50ms ease-in-out
 
 .inplace-edit--text-field

--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -94,7 +94,7 @@
   padding: 0 5px 0 5px
 
 // Animations on leaving work packages
-.wp--row.-animated-leave
+.wp--row.-animated
   &.ng-leave
     -webkit-transition: all 1s ease-in-out
     -moz-transition: all 1s ease-in-out

--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -93,16 +93,3 @@
 .wp-table--cell-span
   padding: 0 5px 0 5px
 
-// Animations on leaving work packages
-.wp--row.-animated
-  &.ng-leave
-    -webkit-transition: all 1s ease-in-out
-    -moz-transition: all 1s ease-in-out
-    -o-transition: all 1s ease-in-out
-    transition: all 1s ease-in-out
-
-  &.ng-leave-active
-    height: 0
-    line-height: 0
-    opacity: 0
-

--- a/frontend/app/components/common/notification-box/notification-box.directive.html
+++ b/frontend/app/components/common/notification-box/notification-box.directive.html
@@ -1,4 +1,4 @@
-<div class="notification-box{{' -' + content.type}}" tabindex="0">
+<div class="notification-box{{' -' + content.type}} -ng-animated" tabindex="0">
   <div class="notification-box--content" role="alert" aria-atomic="true">
     <p>
       <span>{{::content.message}}</span>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -5,7 +5,7 @@
           msd-elastic="\n"
           preview-toggle="vm.field.togglePreview()"
           style="min-height: 114px"
-          class="focus-input wp-inline-edit--field inplace-edit--textarea -animated"
+          class="focus-input wp-inline-edit--field inplace-edit--textarea -animated-elastic"
           name="value"
           focus="vm.shouldFocus()"
           focus-priority="vm.shouldFocus()"

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -113,8 +113,7 @@
               !row.object['leaf?'] && 'parent' || '',
               row.level > 0 && 'child idnt' || '',
               row.level > 0 && ('idnt-' + row.level) || '',
-              row.object.isNew && '-new' || '',
-              !(row.object.isNew || row.object.inlineCreate) && '-animated' || '',
+              row.object.isNew && '-new' || ''
             ]"
             ng-show="!groupByColumn || groupExpanded[row.groupName]"
 

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -94,7 +94,7 @@ opApp
 
 
         // Enable nganimate only for the following class
-        $animateProvider.classNameFilter(/-animated/);
+        $animateProvider.classNameFilter(/\-ng\-animated/);
       }
     ])
     .value('cgBusyDefaults', {

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -66,8 +66,9 @@ window.appBasePath = jQuery('meta[name=app_base_path]').attr('content') || '';
 opApp
     .config([
       '$locationProvider',
+      '$animateProvider',
       '$httpProvider',
-      function($locationProvider, $httpProvider) {
+      function($locationProvider, $animateProvider, $httpProvider) {
         $locationProvider.html5Mode(true);
         $httpProvider.defaults.headers.common['X-CSRF-TOKEN'] = jQuery(
             'meta[name=csrf-token]').attr('content');
@@ -90,6 +91,10 @@ opApp
             }
           };
         });
+
+
+        // Enable nganimate only for the following class
+        $animateProvider.classNameFilter(/-animated/);
       }
     ])
     .value('cgBusyDefaults', {


### PR DESCRIPTION
This adds a classNameFilter of `-animated` to ngAnimate. If this class is missing, default animate classes will not be applied.

Contributes to https://community.openproject.com/work_packages/23139/activity
