### PR TITLE
add href attribute to turn an anchor into a valid hyperlink

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,11 +67,6 @@ module ApplicationHelper
     end
   end
 
-  def link_to_function(content, function, html_options = {})
-    onclick = "#{function}; return false;"
-    content_tag(:a, content, html_options.merge(onclick: onclick))
-  end
-
   def required_field_name(name = '')
     safe_join [name, ' ', content_tag('span', '*', class: 'required')]
   end

--- a/app/helpers/removed_js_helpers_helper.rb
+++ b/app/helpers/removed_js_helpers_helper.rb
@@ -1,0 +1,40 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Contains tag helpers still existing in the OP code but already
+# removed from rails. Please consider removing the occurences in
+# the code rather than adding additional helpers here.
+
+module RemovedJsHelpersHelper
+  # removed in rails 4.1
+  def link_to_function(content, function, html_options = {})
+    onclick = "#{function}; return false;"
+    content_tag(:a, content, html_options.merge(onclick: onclick, href: ''))
+  end
+end

--- a/spec/helpers/removed_js_helpers_helper_spec.rb
+++ b/spec/helpers/removed_js_helpers_helper_spec.rb
@@ -1,0 +1,49 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe RemovedJsHelpersHelper, type: :helper do
+  include RemovedJsHelpersHelper
+
+  describe 'link_to_function' do
+    it 'returns a valid link' do
+      expect(link_to_function('blubs', nil))
+        .to be_html_eql %{
+          <a onclick="; return false;" href="">blubs</a>
+        }
+    end
+
+    it 'adds the provided method to the onclick handler' do
+      expect(link_to_function('blubs', 'doTheMagic(now)'))
+        .to be_html_eql %{
+          <a onclick="doTheMagic(now); return false;" href="">blubs</a>
+        }
+    end
+  end
+end


### PR DESCRIPTION
While not having an `href` attribute on an anchor tag seems to be valid since html5, it also means that the element is not interpreted as a hyperlink. It will e.g. not be focusable. 

While there seems to [quite some discussion regarding the attribute value](http://stackoverflow.com/questions/493175/how-can-i-create-an-empty-html-anchor-so-the-page-doesnt-jump-up-when-i-click) we clearly need to have the attribute. Let's try the `''` value first. It seemed to work for me.
