### PR TITLE
Fix embedding properties that are not embedded

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -212,7 +212,11 @@ function initializeResource(halResource:HalResource) {
   }
 
   function setEmbeddedAsProperties() {
-    Object.keys(halResource.$embedded).forEach(name => {
+    if (!halResource.$source._embedded) {
+      return;
+    }
+
+    Object.keys(halResource.$source._embedded).forEach(name => {
       lazy(halResource, name, () => halResource.$embedded[name], val => setter(val, name));
     });
   }

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -102,6 +102,25 @@ describe 'edit work package', js: true do
                               category: category.name
   end
 
+  it 'correctly assigns and un-assigns users' do
+    wp_page.view_all_attributes
+
+    wp_page.update_attributes assignee: manager.name
+    wp_page.expect_attributes assignee: manager.name
+
+    wp_page.update_attributes assignee: '-'
+    wp_page.expect_attributes assignee: '-'
+
+    # Ensure the value is not only stored in the WP resource
+    wp_page.visit!
+    wp_page.ensure_page_loaded
+    wp_page.view_all_attributes
+    wp_page.expect_attributes assignee: '-'
+
+    work_package.reload
+    expect(work_package.assigned_to).to be_nil
+  end
+
   context 'switching to custom field with required CF' do
     let(:custom_field) {
       FactoryGirl.create(


### PR DESCRIPTION
This caused links such as assignee to appear to be embedded, which were
in turn not cleared by the update after save and thus resulted in old
data turning up.

https://community.openproject.com/work_packages/23543/activity
