### PR TITLE
Fix/global wp create

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -136,8 +136,6 @@
 .work-package--details-container
   position: relative
   padding:  0
-
-.action-details .work-package--details-container
   border-left: 4px solid #eee
   border-top: 4px solid #eee
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -424,6 +424,7 @@ OpenProject::Application.routes.draw do
     # states managed by client-side (angular) routing on work_package#show
     get '/' => 'work_packages#index', on: :collection, as: 'index'
     get '/create_new' => 'work_packages#index', on: :collection, as: 'new_split'
+    get '/new' => 'work_packages#index', on: :collection, as: 'new', state: 'new'
     get '(/*state)' => 'work_packages#show', on: :member, as: ''
     get '/edit' => 'work_packages#show', on: :member, as: 'edit'
   end

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -99,6 +99,12 @@ openprojectModule
         reloadOnSearch: false,
         onEnter: () => angular.element('body').addClass('full-create'),
         onExit: () => angular.element('body').removeClass('full-create'),
+        params: {
+          // value: null makes the parameter optional
+          // squash: true avoids duplicate slashes when the paramter is not provided
+          projectPath: {value: null, squash: true},
+          projects: {value: null, squash: true}
+        }
       })
 
       .state('work-packages.copy', {

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -43,7 +43,7 @@ const panels = {
       url: '/watchers',
       reloadOnSearch: false,
       template: '<watchers-panel ng-if="workPackage" work-package="workPackage"></watchers-panel>'
-    }
+    };
   },
 
   get activity() {
@@ -51,7 +51,7 @@ const panels = {
       url: '/activity',
       reloadOnSearch: false,
       template: '<activity-panel ng-if="workPackage" work-package="workPackage"></activity-panel>'
-    }
+    };
   },
 
   get activityDetails() {

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -69,7 +69,8 @@ export class WorkPackageSingleViewController {
           startDate: I18n.t('js.label_no_start_date'),
           dueDate: I18n.t('js.label_no_due_date')
         }
-      }
+      },
+      idLabel: ''
     };
 
     scopedObservable($scope, wpCacheService.loadWorkPackage(wpId)).subscribe(wp => this.init(wp));
@@ -92,6 +93,17 @@ export class WorkPackageSingleViewController {
     if (!this.firstTimeFocused) {
       this.firstTimeFocused = true;
       angular.element('.work-packages--details--subject .focus-input').focus();
+    }
+  }
+
+  public setIdLabel() {
+    if (!this.workPackage.type) {
+      return;
+    }
+
+    this.text.idLabel = this.workPackage.type.name;
+    if (!this.workPackage.isNew) {
+      this.text.idLabel += ' #' + this.workPackage.id;
     }
   }
 
@@ -120,10 +132,6 @@ export class WorkPackageSingleViewController {
       });
     });
 
-    this.text.idLabel = this.workPackage.type.name;
-    if (!this.workPackage.isNew) {
-      this.text.idLabel += ' #' + this.workPackage.id;
-    }
   }
 }
 
@@ -136,6 +144,9 @@ function wpSingleViewDirective() {
 
     controllers[1].formCtrl = controllers[0];
 
+    scope.$watch(_ => controllers[1].workPackage.type, _ => {
+      controllers[1].setIdLabel();
+    });
   }
   return {
     restrict: 'E',

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -32,7 +32,7 @@ import {
   WorkPackageResource,
   WorkPackageResourceInterface
 } from '../../api/api-v3/hal-resources/work-package-resource.service';
-import {WorkPackageEditFormController} from "../../wp-edit/wp-edit-form.directive";
+import {WorkPackageEditFormController} from '../../wp-edit/wp-edit-form.directive';
 import {WorkPackageNotificationService} from '../../wp-edit/wp-notification.service';
 
 export class WorkPackageSingleViewController {

--- a/spec/routing/work_packages_spec.rb
+++ b/spec/routing/work_packages_spec.rb
@@ -40,6 +40,21 @@ describe WorkPackagesController, type: :routing do
                                                              action: 'index')
   end
 
+  it 'connects GET /work_packages/new to work_packages#index' do
+    expect(get('/work_packages/new'))
+      .to route_to(controller: 'work_packages',
+                   action: 'index',
+                   state: 'new')
+  end
+
+  it 'connects GET /projects/:project_id/work_packages/new to work_packages#index' do
+    expect(get('/projects/1/work_packages/new'))
+      .to route_to(controller: 'work_packages',
+                   action: 'index',
+                   project_id: '1',
+                   state: 'new')
+  end
+
   it 'should connect GET /work_packages/:id/overview to work_packages#show' do
     expect(get('/work_packages/1/overview'))
       .to route_to(controller: 'work_packages',


### PR DESCRIPTION
- supports deep links so that one can call `work_packages/new`
- fixes opening the work package form when in a global context. The type is set to null when in that context which broke the controller. https://community.openproject.com/work_packages/23595/activity
- harmonises the usage of a border for show/edit and create split view
- avoids a url of `[domain]///work_packages/new` when switching from split to full view in a global context
#### Out of scope
- adding 403 error messages when a request to the API by the angular front end fails with that error. Currently, the content remains blank which does not reveal any information. https://community.openproject.com/work_packages/23615/activity
