### PR TITLE
[23603] Fix edge-case when user has global add_work_packages permission

### DIFF
--- a/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.controller.ts
@@ -34,7 +34,7 @@ export default class WorkPackageCreateButtonController {
   public types:any;
   public stateName:string;
 
-  public allowed;
+  public allowed:boolean;
 
   constructor(protected $state,
               protected I18n) {

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -196,7 +196,7 @@
           <td colspan="{{ numTableColumns }}">
             <wp-inline-create-button
                 project-identifier="projectIdentifier"
-                allowed="!!resource.$links.createWorkPackage"
+                allowed="!!resource.createWorkPackage"
                 query="query"
                 rows="rows"
             ></wp-inline-create-button>

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -41,11 +41,13 @@ module API
         def initialize(models,
                        self_link,
                        query: {},
+                       project: nil,
                        groups:,
                        total_sums:,
                        page: nil,
                        per_page: nil,
                        current_user:)
+          @project = project
           @groups = groups
           @total_sums = total_sums
 
@@ -67,14 +69,14 @@ module API
           {
             href: api_v3_paths.create_work_package_form,
             method: :post
-          } if current_user.allowed_to?(:add_work_packages, nil, global: true)
+          } if current_user_allowed_to_add_work_packages?
         end
 
         link :createWorkPackageImmediate do
           {
             href: api_v3_paths.work_packages,
             method: :post
-          } if current_user.allowed_to?(:add_work_packages, nil, global: true)
+          } if current_user_allowed_to_add_work_packages?
         end
 
         collection :elements,
@@ -122,7 +124,12 @@ module API
 
         private
 
-        attr_reader :groups,
+        def current_user_allowed_to_add_work_packages?
+          current_user.allowed_to?(:add_work_packages, project, global: project.nil?)
+        end
+
+        attr_reader :project,
+                    :groups,
                     :total_sums
       end
     end

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -184,6 +184,7 @@ module API
           ::API::V3::WorkPackages::WorkPackageCollectionRepresenter.new(
             work_packages,
             self_link,
+            project: project,
             query: query_params,
             page: params[:offset] ? params[:offset].to_i : nil,
             per_page: params[:pageSize] ? params[:pageSize].to_i : nil,

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -38,6 +38,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   let(:query) { {} }
   let(:groups) { nil }
   let(:total_sums) { nil }
+  let(:project) { nil }
 
   let(:page_parameter) { nil }
   let(:page_size_parameter) { nil }
@@ -49,6 +50,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
       work_packages,
       self_base_link,
       query: query,
+      project: project,
       groups: groups,
       total_sums: total_sums,
       page: page_parameter,
@@ -106,6 +108,20 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
         is_expected
           .to be_json_eql(:post.to_json)
           .at_path('_links/createWorkPackageImmediate/method')
+      end
+
+      context 'in project context' do
+        let(:project) { FactoryGirl.build_stubbed :project }
+
+        it 'has no link to create work_packages' do
+          is_expected
+            .to_not have_json_path('_links/createWorkPackage')
+        end
+
+        it 'has no link to create work_packages immediately' do
+          is_expected
+            .to_not have_json_path('_links/createWorkPackageImmediate')
+        end
       end
     end
 


### PR DESCRIPTION
When in project context, createWorkPackage(Immediate) links should not
be generated with a global permission.

This caused the create buttons to remain active despite the user having no permission to add work packages.

https://community.openproject.com/work_packages/23603/activity
