### PR TITLE
hide child relations section for milestone wps

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -118,6 +118,13 @@ export class WorkPackageResource extends HalResource {
     return isNaN(Number(this.id));
   }
 
+  public get isMilestone(): boolean {
+    /**
+     * it would be better if this was not deduced but rather taken from the type
+     */
+    return this.hasOwnProperty('date');
+  }
+
   /**
    * Returns true if any field is in edition in this resource.
    */

--- a/frontend/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations.service.ts
@@ -54,16 +54,21 @@ export class WorkPackageRelationsService {
   }
 
   public getWpRelationGroups(workPackage:WorkPackageResourceInterface) {
-    return this.relationsConfig.map(config => {
-      if (config.type === 'parent') {
-        return new this.WorkPackageParentRelationGroup(workPackage, config);
-      }
+    let configsOfInterest = this.relationsConfig;
 
-      if (config.type === 'children') {
-        return new this.WorkPackageChildRelationsGroup(workPackage, config);
-      }
+    if (workPackage.isMilestone) {
+      configsOfInterest = _.reject(configsOfInterest, {name: 'children'});
+    }
 
-      return new this.WorkPackageRelationGroup(workPackage, config);
+    return configsOfInterest.map(config => {
+      switch (config.type) {
+        case 'parent':
+          return new this.WorkPackageParentRelationGroup(workPackage, config);
+        case 'children':
+          return new this.WorkPackageChildRelationsGroup(workPackage, config);
+        default:
+          return new this.WorkPackageRelationGroup(workPackage, config);
+      }
     });
   }
 }


### PR DESCRIPTION
As milestone work packages can not have children, that section of the relations tab is now hidden altogether. 

By that https://community.openproject.com/work_packages/23605/activity gets fixed. But instead of only removing the create button, we remove the complete section as there will also never be entries in that list.
