### PR TITLE
[23614] Mobile option button (e.g. sign out) not displayed in 5.1

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -62,6 +62,7 @@
       &:last-child
         display: block
 
+      &.last-child
         > a
           display: block
           padding: 0
@@ -69,7 +70,7 @@
           text-indent: -10000px
           width: 68px
 
-          &:after
+          &:before
             content: "\e0d0" !important
             display: block
             font-size: 1.5rem !important


### PR DESCRIPTION
This fixes the display of the mobile menu. 

https://community.openproject.com/work_packages/23614/activity
