### PR TITLE
[23399] [20] Icons zu Dateiänderungen in Revisionen unterscheiden sich nur farblich

### DIFF
--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -124,23 +124,37 @@ module RepositoriesHelper
         style << ' folder'
         path_param = without_leading_slash(to_path_param(@repository.relative_path(file)))
         text = link_to(h(text),
-                       controller: '/repositories',
-                       action: 'show',
-                       project_id: @project,
-                       path: path_param,
-                       rev: @changeset.identifier)
+                       { controller: '/repositories',
+                         action: 'show',
+                         project_id: @project,
+                         path: path_param,
+                         rev: @changeset.identifier },
+                       title: l(:label_folder))
 
         output << "<li class='#{style} icon icon-folder-#{calculate_folder_action(s)}'>#{text}</li>"
         output << render_changes_tree(s)
       elsif c = tree[file][:c]
         style << " change-#{c.action}"
         path_param = without_leading_slash(to_path_param(@repository.relative_path(c.path)))
+        case c.action
+        when 'A'
+          title_text =  l(:label_added)
+        when 'D'
+          title_text =  l(:label_deleted)
+        when 'C'
+          title_text =  l(:label_copied)
+        when 'R'
+          title_text =  l(:label_renamed)
+        else
+          title_text =  l(:label_modified)
+        end
         text = link_to(h(text),
-                       controller: '/repositories',
-                       action: 'entry',
-                       project_id: @project,
-                       path: path_param,
-                       rev: @changeset.identifier) unless c.action == 'D'
+                       { controller: '/repositories',
+                         action: 'entry',
+                         project_id: @project,
+                         path: path_param,
+                         rev: @changeset.identifier },
+                       title: title_text) unless c.action == 'D'
         text << raw(" - #{h(c.revision)}") unless c.revision.blank?
         text << raw(' (' + link_to(l(:label_diff),
                                    controller: '/repositories',
@@ -151,11 +165,20 @@ module RepositoriesHelper
         text << raw(' ' + content_tag('span', h(c.from_path), class: 'copied-from')) unless c.from_path.blank?
         case c.action
         when 'A'
-          output << "<li class='#{style} icon icon-add'>#{text}</li>"
+          output << "<li class='#{style} icon icon-add'
+                         title='#{l(:label_added)}'>#{text}</li>"
         when 'D'
-          output << "<li class='#{style} icon icon-delete'>#{text}</li>"
+          output << "<li class='#{style} icon icon-delete'
+                         title='#{l(:label_deleted)}'>#{text}</li>"
+        when 'C'
+          output << "<li class='#{style} icon icon-copy'
+                         title='#{l(:label_copied)}'>#{text}</li>"
+        when 'R'
+          output << "<li class='#{style} icon icon-rename'
+                         title='#{l(:label_renamed)}'>#{text}</li>"
         else
-          output << "<li class='#{style} icon icon-arrow-right5'>#{text}</li>"
+          output << "<li class='#{style} icon icon-arrow-left-right'
+                         title='#{l(:label_modified)}'>#{text}</li>"
         end
       end
     end

--- a/app/views/repositories/revision.html.erb
+++ b/app/views/repositories/revision.html.erb
@@ -63,11 +63,11 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if User.current.allowed_to?(:browse_repository, @project) %>
   <h3><%= l(:label_attachment_plural) %></h3>
   <ul id="changes-legend">
-    <li class="change change-A icon icon-add"><%= l(:label_added) %></li>
-    <li class="change change-M icon icon-arrow-right5"><%= l(:label_modified) %></li>
-    <li class="change change-C icon icon-arrow-right5"><%= l(:label_copied) %></li>
-    <li class="change change-R icon icon-arrow-right5"><%= l(:label_renamed) %></li>
-    <li class="change change-D icon icon-delete"><%= l(:label_deleted) %></li>
+    <li class="change change-A icon icon-add" title=<%= l(:label_added) %>><%= l(:label_added) %></li>
+    <li class="change change-M icon icon-arrow-left-right" title=<%= l(:label_modified) %>><%= l(:label_modified) %></li>
+    <li class="change change-C icon icon-copy" title=<%= l(:label_copied) %>><%= l(:label_copied) %></li>
+    <li class="change change-R icon icon-rename" title=<%= l(:label_renamed) %>><%= l(:label_renamed) %></li>
+    <li class="change change-D icon icon-delete" title=<%= l(:label_deleted) %>><%= l(:label_deleted) %></li>
   </ul>
   <p><%= link_to(l(:label_view_diff), action: 'diff', project_id: @project, path: nil, rev: @changeset.identifier) if @changeset.file_changes.any? %></p>
   <div class="changeset-changes">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -994,6 +994,7 @@ en:
   label_filter_add: "Add filter"
   label_filter_plural: "Filters"
   label_float: "Float"
+  label_folder: "Folder"
   label_follows: "follows"
   label_force_user_language_to_default: "Set language of users having a non allowed language to default"
   label_form_configuration: Form configuration


### PR DESCRIPTION
This changes the icons of the repo legend. Now every action has its own icon and a title which describes the action. Thus the screenreader reads the file and the action that was done.

https://community.openproject.com/work_packages/23399/relations
