### PR TITLE
[23616] Restore WP autocompletion in Wikis

### DIFF
--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -38,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
        </div>
      </div>
-    <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %>
+    <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit op-auto-complete', :accesskey => accesskey(:edit) %>
   </div>
 
   <div class="form--field">

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -64,7 +64,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
          </div>
        </div>
-      <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %>
+      <%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit op-auto-complete', :accesskey => accesskey(:edit) %>
     </div>
 
     <div class="form--field">

--- a/frontend/app/components/input/op-auto-complete.directive.ts
+++ b/frontend/app/components/input/op-auto-complete.directive.ts
@@ -29,7 +29,7 @@
 import {openprojectModule} from "../../angular-modules";
 function opAutoComplete(AutoCompleteHelper) {
   return {
-    restrict: 'A',
+    restrict: 'AC',
     scope: false,
     link: function(scope, element) {
       AutoCompleteHelper.enableTextareaAutoCompletion(element);


### PR DESCRIPTION
### [#23616](https://community.openproject.com/projects/openproject/work_packages/details/23616/overview)

this adds the `op-auto-complete` directive to the wiki form for `edit` and `new`
