### PR TITLE
[23508] Fokus im Accessibilitymodus nicht sichtbar (IE) (3)

### DIFF
--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -64,7 +64,7 @@ body.accessibility-mode
         border-color: $main-menu-border-color
 
   // Neccessary to have enough space for the border in IE
-  .wp-table--cell
+  .work-packages--page-container
     .inplace-edit .inplace-edit--read-value,
     .id a
       margin: 3px


### PR DESCRIPTION
This sets a higher DOM element for the styling rule. Thus the elements of split and full screen are also included. Now the accessibility border is also visible in IE.

https://community.openproject.com/work_packages/23508/activity
