### PR TITLE
[23621] Re-implement the ModalFactory ourselves

### DIFF
--- a/app/views/onboarding/_starting_video_modal.html.erb
+++ b/app/views/onboarding/_starting_video_modal.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <div id="top-menu" class="onboarding--top-menu">
       <%= homescreen_user_avatar %>
       <h2><%= I18n.t('onboarding.welcome', name: current_user.name) %></h2>
-      <a class="icon-context icon-close" ng-click="close()"></a>
+      <a class="icon-context icon-close" ng-click="$ctrl.close()"></a>
     </div>
 
     <div class="onboarding--main">
@@ -50,7 +50,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="onboarding--footer">
       <em><label><%= I18n.t('onboarding.text_show_again') %></label></em>
       <button class="button -highlight -large"
-              ng-click="close()"
+              ng-click="$ctrl.close()"
               title=<%= l(:label_next)%>> <%= l(:label_next)%>
       </button>
     </div>


### PR DESCRIPTION
We cannot properly pass 'overlayClose' to the ModalFactory since it's
transformed into 'overlayclose' instead through the `attr` API.

Instead, re-implement the whole factory so we actually have control over
what happens when.

https://community.openproject.com/work_packages/23621/
