### PR TITLE
remove non performant copy as the values are not altered anyway

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -56,7 +56,7 @@ export class SelectEditField extends EditField {
   }
 
   private setValues(availableValues) {
-    this.options = angular.copy(availableValues);
+    this.options = availableValues;
     this.addEmptyOption();
     this.checkCurrentValueValidity();
   }


### PR DESCRIPTION
This should speed up creating select fields considerably when the options are somewhat complex objects e.g. projects.

The problem was worsened by the objects already carrying a copy of themselves in their `plain` method.

https://community.openproject.com/work_packages/23602/activity?query_id=860 
