### PR TITLE
preload permissions before collection rendering

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -114,6 +114,7 @@ module API
       end
 
       class_attribute :to_eager_load
+      class_attribute :checked_permissions
 
       def current_user_allowed_to(permission, context:)
         current_user.allowed_to?(permission, context)

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -39,6 +39,7 @@ module API
         element_decorator ::API::V3::Projects::ProjectRepresenter
 
         self.to_eager_load = ::API::V3::Projects::ProjectRepresenter.to_eager_load
+        self.checked_permissions = ::API::V3::Projects::ProjectRepresenter.checked_permissions
       end
     end
   end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -79,7 +79,8 @@ module API
           'Project'
         end
 
-        self.to_eager_load = [:enabled_modules, :project_type]
+        self.to_eager_load = [:project_type]
+        self.checked_permissions = [:add_work_packages]
       end
     end
   end

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -38,6 +38,9 @@ module API
           end
 
           get do
+            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
+            current_user.preload_projects_allowed_to(checked_permissions)
+
             available_projects = WorkPackage
                                  .allowed_target_projects_on_create(current_user)
                                  .includes(Projects::ProjectCollectionRepresenter.to_eager_load)

--- a/lib/api/v3/work_packages/available_projects_on_edit_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_edit_api.rb
@@ -38,6 +38,9 @@ module API
           end
 
           get do
+            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
+            current_user.preload_projects_allowed_to(checked_permissions)
+
             available_projects = WorkPackage
                                  .allowed_target_projects_on_move(current_user)
                                  .includes(Projects::ProjectCollectionRepresenter.to_eager_load)

--- a/spec/decorators/single_spec.rb
+++ b/spec/decorators/single_spec.rb
@@ -48,4 +48,21 @@ describe ::API::Decorators::Single do
       expect(single.current_user_allowed_to(:view_work_packages, context: project)).to be_falsey
     end
   end
+
+  describe '.checked_permissions' do
+    let(:permissions) { [:add_work_packages] }
+    let!(:initial_value) { described_class.checked_permissions }
+
+    it 'stores the value' do
+      expect(described_class.checked_permissions).to be_nil
+
+      described_class.checked_permissions = permissions
+
+      expect(described_class.checked_permissions).to match_array permissions
+    end
+
+    after do
+      described_class.checked_permissions = initial_value
+    end
+  end
 end

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -110,4 +110,10 @@ describe ::API::V3::Projects::ProjectRepresenter do
       end
     end
   end
+
+  describe '.checked_permissions' do
+    it 'lists add_work_packages' do
+      expect(described_class.checked_permissions).to match_array([:add_work_packages])
+    end
+  end
 end

--- a/spec/models/users/allowed_to_spec.rb
+++ b/spec/models/users/allowed_to_spec.rb
@@ -1,0 +1,580 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe User, 'allowed_to?' do
+  let(:user) { FactoryGirl.build(:user) }
+  let(:anonymous) { FactoryGirl.build(:anonymous) }
+  let(:project) { FactoryGirl.build(:project, is_public: false) }
+  let(:project2) { FactoryGirl.build(:project, is_public: false) }
+  let(:role) { FactoryGirl.build(:role) }
+  let(:role2) { FactoryGirl.build(:role) }
+  let(:anonymous_role) { FactoryGirl.build(:anonymous_role) }
+  let(:member) {
+    FactoryGirl.build(:member, project: project,
+                               roles: [role],
+                               principal: user)
+  }
+  let(:member2) {
+    FactoryGirl.build(:member, project: project2,
+                               roles: [role2],
+                               principal: user)
+  }
+
+  before do
+    user.save!
+  end
+
+  shared_examples_for 'w/ inquiring for project' do
+    let(:permission) { :add_work_packages }
+    let(:final_setup_step) {}
+
+    context 'w/ the user being admin' do
+      before do
+        user.update_attribute(:admin, true)
+
+        project.save
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being admin
+             w/ the project being archived' do
+      before do
+        user.update_attribute(:admin, true)
+        project.update_attribute(:status, Project::STATUS_ARCHIVED)
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being admin
+             w/ the project module the permission belongs to being inactive' do
+      before do
+        user.update_attribute(:admin, true)
+        project.enabled_module_names = []
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/o the role having the necessary permission' do
+      before do
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/ the role having the necessary permission' do
+      before do
+        role.permissions << permission
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/ the role having the necessary permission
+             w/o the module being active' do
+      let(:permission) { :view_news }
+
+      before do
+        role.permissions << permission
+        project.enabled_module_names = []
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/ the role having the necessary permission
+             w/ asking for a controller/action hash
+             w/o the module being active' do
+      let(:permission) { { controller: 'news', action: 'show' } }
+
+      before do
+        role.permissions << :view_news
+        project.enabled_module_names = []
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/o the role having the necessary permission
+             w/ non members having the necessary permission' do
+      before do
+        project.is_public = false
+
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/o the role having the necessary permission
+             w/ inquiring for a permission that is public' do
+      let(:permission) { :view_project }
+
+      before do
+        project.is_public = false
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/o the user being member in the project
+             w/ non member being allowed the action
+             w/ the project being private' do
+      before do
+        project.is_public = false
+        project.save!
+
+        non_member = Role.non_member
+
+        non_member.permissions << permission
+        non_member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/o the user being member in the project
+             w/ the project being public
+             w/ non members being allowed the action' do
+      before do
+        project.is_public = true
+        project.save!
+
+        non_member = Role.non_member
+
+        non_member.permissions << permission
+        non_member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ the project being public
+             w/ anonymous being allowed the action' do
+      before do
+        project.is_public = true
+        project.save!
+
+        anonymous_role.permissions << permission
+        anonymous_role.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(anonymous.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ the project being public
+             w/ querying for a public permission' do
+      let(:permission) { :view_project }
+
+      before do
+        project.is_public = true
+        project.save!
+
+        anonymous_role.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(anonymous.allowed_to?(permission, project)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ requesting a controller and action allowed by multiple permissions
+             w/ the project beeing public
+             w/ anonymous being allowed the action' do
+      let(:permission) { { controller: 'projects', action: 'settings' } }
+
+      before do
+        project.is_public = true
+        project.save!
+
+        anonymous_role.permissions << :manage_categories
+        anonymous_role.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(anonymous.allowed_to?(permission, project))
+          .to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ the project being public
+             w/ anonymous being not allowed the action' do
+      before do
+        project.is_public = true
+        project.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(anonymous.allowed_to?(permission, project)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in two projects
+             w/ the user being allowed the action in both projects' do
+      before do
+        role.permissions << permission
+        role2.permissions << permission
+
+        member.save!
+        member2.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, [project, project2])).to be_truthy
+      end
+    end
+
+    context 'w/ the user being a member in two projects
+             w/ the user being allowed in only one project' do
+      before do
+        role.permissions << permission
+
+        member.save!
+        member2.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, [project, project2])).to be_falsey
+      end
+    end
+
+    context 'w/o the user being a member in the two projects
+             w/ both projects being public
+             w/ non member being allowed the action' do
+      before do
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        project.update_attribute(:is_public, true)
+        project2.update_attribute(:is_public, true)
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, [project, project2])).to be_truthy
+      end
+    end
+
+    context 'w/o the user being a member in the two projects
+             w/ only one project being public
+             w/ non member being allowed the action' do
+      before do
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        project.update_attribute(:is_public, true)
+        project2.update_attribute(:is_public, false)
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, [project, project2])).to be_falsey
+      end
+    end
+
+    context 'w/ requesting a controller and action
+             w/ the user being allowed the action' do
+      before do
+        role.permissions << permission
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?({ controller: 'work_packages', action: 'new' }, project))
+          .to be_truthy
+      end
+    end
+
+    context 'w/ requesting a controller and action allowed by multiple permissions
+             w/ the user being allowed the action' do
+      let(:permission) { :manage_categories }
+
+      before do
+        role.permissions << permission
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?({ controller: 'projects', action: 'settings' }, project))
+          .to be_truthy
+      end
+    end
+  end
+
+  shared_examples_for 'w/ inquiring globally' do
+    let(:permission) { :add_work_packages }
+    let(:final_setup_step) {}
+
+    context 'w/ the user being admin' do
+      before do
+        user.admin = true
+        user.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, nil, global: true)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being a member in a project
+             w/o the role having the necessary permission' do
+      before do
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(user.allowed_to?(permission, nil, global: true)).to be_falsey
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/ the role having the necessary permission' do
+      before do
+        role.permissions << permission
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, nil, global: true)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/ inquiring for controller and action
+             w/ the role having the necessary permission' do
+      before do
+        role.permissions << permission
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?({ controller: 'work_packages', action: 'new' }, nil, global: true))
+          .to be_truthy
+      end
+    end
+
+    context 'w/ the user being a member in the project
+             w/o the role having the necessary permission
+             w/ non members having the necessary permission' do
+      before do
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, nil, global: true)).to be_truthy
+      end
+    end
+
+    context 'w/o the user being a member in the project
+             w/ non members being allowed the action' do
+      before do
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?(permission, nil, global: true)).to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ anonymous being allowed the action' do
+      before do
+        anonymous_role.permissions << permission
+        anonymous_role.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(anonymous.allowed_to?(permission, nil, global: true)).to be_truthy
+      end
+    end
+
+    context 'w/ requesting a controller and action allowed by multiple permissions
+             w/ the user being a member in the project
+             w/o the role having the necessary permission
+             w/ non members having the necessary permission' do
+      let(:permission) { :manage_categories }
+
+      before do
+        non_member = Role.non_member
+        non_member.permissions << permission
+        non_member.save!
+
+        member.save!
+
+        final_setup_step
+      end
+
+      it 'should be true' do
+        expect(user.allowed_to?({ controller: 'projects', action: 'settings' }, nil, global: true))
+          .to be_truthy
+      end
+    end
+
+    context 'w/ the user being anonymous
+             w/ anonymous being not allowed the action' do
+      before do
+        final_setup_step
+      end
+
+      it 'should be false' do
+        expect(anonymous.allowed_to?(permission, nil, global: true)).to be_falsey
+      end
+    end
+  end
+
+  context 'w/o preloaded permissions' do
+    it_behaves_like 'w/ inquiring for project'
+    it_behaves_like 'w/ inquiring globally'
+  end
+
+  context 'w/ preloaded permissions' do
+    it_behaves_like 'w/ inquiring for project' do
+      let(:final_setup_step) {
+        user.preload_projects_allowed_to(permission)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Speeds up API v3's available_projects (for create as well as for edit) endpoint by introducing a preloading mechanism for project based permission evaluation.

Because a list of projects is returned and each project representer has links which are displayed depending on the current user's permissions, OP has to check the permission for every project.  OP would typically do that by evaluating the permissions in ruby. Especially when additional plugins are involved, this might become quite slow and lead to n+1 queries.

By loading the list of projects (or only their ids) in which the user has the permission beforehand, the performance can be improved greatly.
#### Out of scope

General improvements of the permission evaluation. We should still switch to an sql based approach for the default permission check as well.
#### Addresses

https://community.openproject.com/work_packages/23602/activity
