### PR TITLE
easy ssl setup via let's encrypt

### DIFF
--- a/doc/operation_guides/packager/installation-guide.md
+++ b/doc/operation_guides/packager/installation-guide.md
@@ -236,6 +236,25 @@ and running the `openproject configure` command.
 
 # Advanced
 
+## Easy SSL setup via Let's Encrypt
+
+You can get an SSL certificate for free via Let's Encrypt.
+Here is how you do it using [certbot](https://github.com/certbot/certbot):
+
+    curl https://dl.eff.org/certbot-auto > /usr/local/bin
+    chmod a+x /usr/local/bin/certbot-auto
+    
+    certbot-auto certonly --webroot --webroot-path /opt/openproject/public -d openprojecct.mydomain.com
+
+This requires your OpenProject server to be available from the Internet on port 443 or 80.
+If this works the certificate (`cert.pem`) and private key (`privkey.pem`) will be created under `/etc/letsencrypt/live/openproject.mydomain.com/`. Configure these for OpenProject to use by running `openproject reconfigure` and choosing yes when the wizard asks for SSL.
+
+Now this Let's Encryt certificate is only valid for 90 days. To renew it automatically all you have to do is to add the following entry to your crontab (run `crontab -e`):
+
+    0 1 * * * certbot renew --standalone --post-hook "service apache2 restart"
+    
+This will execute `certbot renew` every day at 1am. The command checks if the certificate is expired and renews it if that is the case. The web server is restarted in a post hook in order for it to pick up the new certificate.
+
 ## Adding custom plugins to the installation
 
 [A number of plugins](https://www.openproject.org/open-source/openproject-plugins/) exist for use with OpenProject. Most plugins that are maintained by us are shipping with OpenProject, however there are several plugins contributed by the community.


### PR DESCRIPTION
Add instructions on how to setup let's encrypt to provide an SSL certificate for OpenProject and how to renew it automatically.
