### PR TITLE
only watch for changes in the state params we are interested in

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -206,7 +206,10 @@ function WorkPackagesListController($scope,
   });
 
   $scope.$watchCollection(function(){
-      return $state.params;
+    return {
+      query_id: $state.params.query_id,
+      query_props: $state.params.query_props
+    };
   }, function(params) {
     if ($scope.query &&
         (params.query_id !== $scope.query.id ||


### PR DESCRIPTION
This prevents updating the query when the split view is opened which will change $state.current

https://community.openproject.com/work_packages/23625/activity?query_id=860
