### PR TITLE
[23631] Fix stale group-header numbers due to caching

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -151,6 +151,7 @@ function WorkPackagesListController($scope,
     $scope.groupableColumns = WorkPackagesTableService.getGroupableColumns();
     $scope.totalEntries = QueryService.getTotalEntries();
     $scope.resource = json.resource;
+    $scope.groupHeaders = WorkPackagesTableService.buildGroupHeaders(json.resource);
 
     // Authorisation
     AuthorisationService.initModelAuth('work_package', meta._links);

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -80,6 +80,7 @@
                 rows="rows"
                 query="query"
                 group-by="query.groupBy"
+                group-headers="groupHeaders"
                 display-sums="query.displaySums"
                 resource="resource"
                 activation-callback="openWorkPackageInFullView(id, force)">

--- a/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.test.js
+++ b/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.test.js
@@ -71,7 +71,7 @@ describe('workPackageGroupHeader Directive', function() {
         });
 
         it('should toggle current group expansion to be false', function() {
-          scope.toggleCurrentGroup();
+          scope.$ctrl.toggleCurrentGroup();
           expect(scope.groupExpanded['llama']).to.be.false;
         });
       });

--- a/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.ts
+++ b/frontend/app/components/wp-table/wp-group-header/wp-group-header.directive.ts
@@ -26,37 +26,57 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-angular
-  .module('openproject.workPackages.directives')
-  .directive('wpGroupHeader', wpGroupHeader);
+import {wpDirectivesModule} from '../../../angular-modules';
+
+export class WorkPackageGroupHeaderController {
+  constructor(public $scope, public I18n) {
+    this.pushGroup(this.currentGroup);
+  }
+
+  public get resource() {
+    return this.$scope.resource;
+  }
+
+  public get currentGroup() {
+    return this.$scope.row.groupName;
+  }
+
+  public get currentGroupObject() {
+    return this.$scope.groupHeaders[this.currentGroup];
+  }
+
+  /**
+   * Return the group name. As the internal value may be emtpy (''),
+   * we return the default placeholder in that case.
+   */
+  public get currentGroupName() {
+    const value = this.currentGroupObject.value;
+
+    if (value === '') {
+      return this.I18n.t('js.placeholders.default');
+    }
+
+    return value;
+  }
+
+  public toggleCurrentGroup() {
+    this.$scope.groupExpanded[this.currentGroup] = !this.$scope.groupExpanded[this.currentGroup];
+  }
+
+  public pushGroup(group) {
+    if (this.$scope.groupExpanded[group] === undefined) {
+      this.$scope.groupExpanded[group] = true;
+    }
+  }
+}
 
 function wpGroupHeader() {
   return {
     restrict: 'A',
-    link: function(scope) {
-
-      scope.currentGroup = scope.row.groupName;
-
-      scope.currentGroupObject = _.find(scope.resource.groups, function(o) {
-        var value = o.value == null ? '' : o.value;
-        return value === scope.row.groupName;
-      });
-
-      if (scope.currentGroupObject && scope.currentGroupObject.value === null) {
-        scope.currentGroupObject.value = I18n.t('js.placeholders.default');
-      }
-
-      pushGroup(scope.currentGroup);
-
-      scope.toggleCurrentGroup = function() {
-        scope.groupExpanded[scope.currentGroup] = !scope.groupExpanded[scope.currentGroup];
-      };
-
-      function pushGroup(group) {
-        if (scope.groupExpanded[group] === undefined) {
-          scope.groupExpanded[group] = true;
-        }
-      }
-    }
+    controller: WorkPackageGroupHeaderController,
+    controllerAs: '$ctrl',
+    bindToController: true,
   };
 }
+
+wpDirectivesModule.directive('wpGroupHeader', wpGroupHeader);

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -59,14 +59,14 @@
         <!-- Group headers -->
 
         <tr wp-group-header
-            ng-repeat-start="row in rows track by row.object.id+row.groupName"
+            ng-repeat-start="row in rows track by row.object.id"
             ng-if="!!groupByColumn &&
                    ($first || row.groupName !== rows[$index-1].groupName)"
             ng-show="row.groupName != undefined"
             ng-class="{
               group: true,
-              open: groupExpanded[currentGroup],
-              closed: !groupExpanded[currentGroup],
+              open: groupExpanded[$ctrl.currentGroup],
+              closed: !groupExpanded[$ctrl.currentGroup],
               keyboard_hover: true
             }"
             id="group-header-{{ row.groupName }}">
@@ -74,23 +74,23 @@
             <div ng-class="[
                     'expander',
                     'icon-context',
-                    'icon-' + (groupExpanded[currentGroup] && 'minus2' || 'plus')
+                    'icon-' + (groupExpanded[$ctrl.currentGroup] && 'minus2' || 'plus')
                   ]"
-                  ng-click="toggleCurrentGroup()">
+                  ng-click="$ctrl.toggleCurrentGroup()">
               <span ng-class="{
                 'hidden-for-sighted': true,
-                expand: !groupExpanded[currentGroup],
-                collapse: groupExpanded[currentGroup]
+                expand: !groupExpanded[$ctrl.currentGroup],
+                collapse: groupExpanded[$ctrl.currentGroup]
               }">
-                {{ groupExpanded[currentGroup] && text.collapse || text.expand }}
+                {{ groupExpanded[$ctrl.currentGroup] && text.collapse || text.expand }}
               </span>
               <span class="hidden-for-sighted collapse">{{ text.collapse }}</span>
             </div>
 
             <div>
-              {{ currentGroupObject.value }}
+              {{ $ctrl.currentGroupName }}
               <span class="count">
-                ({{ currentGroupObject.count }})
+                ({{ $ctrl.currentGroupObject.count }})
               </span>
             </div>
 

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -53,6 +53,7 @@ function wpTable(
       rows: '=',
       query: '=',
       groupBy: '=',
+      groupHeaders: '=',
       displaySums: '=',
       isSmaller: '=',
       resource: '=',

--- a/frontend/app/components/wp-table/wp-table.service.js
+++ b/frontend/app/components/wp-table/wp-table.service.js
@@ -86,6 +86,19 @@ function WorkPackagesTableService($filter, QueryService, WorkPackagesTableHelper
       this.setRows(WorkPackagesTableHelper.buildRows(workPackages, groupBy, splitViewWorkPackageId));
     },
 
+    buildGroupHeaders: function(resource) {
+      var groups = {};
+
+      if (resource.groups) {
+        resource.groups.forEach(function(group) {
+          group.value = group.value || '';
+          groups[group.value] = group;
+        });
+      }
+
+      return groups;
+    },
+
     setRows: function(rows) {
       workPackagesTableData.rows = rows;
     },

--- a/spec/features/work_packages/table/group_headers_spec.rb
+++ b/spec/features/work_packages/table/group_headers_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'Work Package table group headers', js: true do
+  let(:user) { FactoryGirl.create :admin }
+
+  let(:project) { FactoryGirl.create(:project) }
+  let(:category) { FactoryGirl.create :category, project: project, name: 'Foo' }
+  let(:category2) { FactoryGirl.create :category, project: project, name: 'Bar' }
+
+  let!(:wp_cat1) { FactoryGirl.create(:work_package, project: project, category: category) }
+  let!(:wp_cat2) { FactoryGirl.create(:work_package, project: project, category: category2) }
+  let!(:wp_none) { FactoryGirl.create(:work_package, project: project) }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+
+  let!(:query) do
+    query              = FactoryGirl.build(:query, user: user, project: project)
+    query.column_names = ['subject', 'category']
+
+    query.save!
+    query
+  end
+
+  before do
+    login_as(user)
+
+    wp_table.visit_query(query)
+    wp_table.expect_work_package_listed(wp_cat1)
+    wp_table.expect_work_package_listed(wp_cat2)
+    wp_table.expect_work_package_listed(wp_none)
+  end
+
+  it 'shows group headers for group by category' do
+    # Group by category
+    wp_table.click_setting_item 'Group by ...'
+    select 'Category', from: 'selected_columns_new'
+    click_button 'Apply'
+
+    # Expect table to be grouped as WP created above
+    expect(page).to have_selector('tr.group .count', count: 3)
+    expect(page).to have_selector('tr.group div', text: 'Foo (1)')
+    expect(page).to have_selector('tr.group div', text: 'Bar (1)')
+    expect(page).to have_selector('tr.group div', text: '- (1)')
+
+    # Update category of wp_none
+    cat = wp_table.edit_field(wp_none, :category)
+    cat.activate!
+    cat.set_value 'Foo'
+
+    loading_indicator_saveguard
+
+    # Expect changed groups
+    expect(page).to have_selector('tr.group .count', count: 2)
+    expect(page).to have_selector('tr.group div', text: 'Foo (2)')
+    expect(page).to have_selector('tr.group div', text: 'Bar (1)')
+  end
+end

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -130,6 +130,11 @@ module Pages
       WorkPackageField.new(context, attribute)
     end
 
+    def click_setting_item(label)
+      find('#work-packages-settings-button').click
+      find('#settingsDropdown .menu-item', text: label).click
+    end
+
     def open_filter_section
       unless page.has_selector?('#work-packages-filter-toggle-button.-active')
         click_button('work-packages-filter-toggle-button')


### PR DESCRIPTION
Group values were cached in group-header directive and thus were invalid on background refresh.

This PR maps values for group headers once during initialization, and uses that value in the header directive. Also adds a spec for the group-by workflow, and checks that headers do actually change.

https://community.openproject.com/work_packages/23631/activity
