### PR TITLE
[23626] Work package attributes missing on timeline WP create modal

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -154,7 +154,7 @@
 
     .work-package--new-state
       margin-bottom: 0
-      overflow: visible
+      overflow: auto
       padding-right: 0
 
       .work-packages--edit-actions


### PR DESCRIPTION
This changes the overflow value to enable scrolling in WP create forms. This affects the timeline create WP as well as the full screen create. 

https://community.openproject.com/work_packages/23626/activity
