### PR TITLE
prevent editing a work package while saving takes place

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -111,6 +111,7 @@ export class WorkPackageResource extends HalResource {
   public subject:string;
   public lockVersion:number;
   public description:any;
+  public inFlight:boolean;
 
   private form;
 
@@ -254,6 +255,7 @@ export class WorkPackageResource extends HalResource {
 
   public save() {
     var deferred = $q.defer();
+    this.inFlight = true;
 
     this.updateForm(this.$source)
       .then(form => {
@@ -270,10 +272,14 @@ export class WorkPackageResource extends HalResource {
             deferred.reject(error);
           })
           .finally(() => {
+            this.inFlight = false;
             wpCacheService.updateWorkPackage(this);
           });
       })
-      .catch(deferred.reject);
+      .catch(() => {
+        this.inFlight = false;
+        deferred.reject();
+      });
 
     return deferred.promise;
   }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -5,6 +5,7 @@
        ng-false-value="false"
        ng-change="vm.submit()"
        ng-blur="vm.handleUserBlur()"
+       ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -8,6 +8,7 @@
          transform-date-value
          ng-blur="vm.onlyInAccessibilityMode(vm.handleUserBlur)"
          ng-required="vm.field.required"
+         ng-disabled="vm.workPackage.inFlight"
          focus="vm.shouldFocus()"
          focus-priority="vm.shouldFocus()"
          ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
@@ -5,6 +5,7 @@
        transform-duration-value
        ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
+       ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
@@ -5,6 +5,7 @@
        ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
        transform-float-value
+       ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
@@ -4,6 +4,7 @@
        ng-model="vm.workPackage[vm.fieldName]"
        ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
+       ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -5,6 +5,7 @@
         ng-change="vm.submit()"
         ng-required="vm.field.required"
         ng-blur="vm.handleUserBlur()"
+        ng-disabled="vm.workPackage.inFlight"
         focus="vm.shouldFocus()"
         focus-priority="vm.shouldFocus()"
         ng-attr-id="{{vm.htmlId}}">

--- a/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
@@ -4,6 +4,7 @@
        ng-model="vm.workPackage[vm.fieldName]"
        ng-required="vm.field.required"
        ng-blur="vm.handleUserBlur()"
+       ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"
        focus-priority="vm.shouldFocus()"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -11,7 +11,7 @@
           focus-priority="vm.shouldFocus()"
           ng-hide="vm.field.isPreview"
           ng-required="vm.field.required"
-          ng-disabled="vm.field.isBusy"
+          ng-disabled="vm.field.isBusy || vm.workPackage.inFlight"
           ng-model="vm.field.fieldVal.raw"
           ng-attr-id="{{vm.htmlId}}">  </textarea>
     <div class="inplace-edit--preview" ng-show="vm.field.isPreview && !vm.field.isBusy">

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -180,7 +180,8 @@ export class WorkPackageEditFieldController {
   public isSubmittable(): boolean {
     return !(this.inEditMode ||
              (this.isRequired() && this.isEmpty()) ||
-             (this.isErrorenous() && !this.isChanged()));
+             (this.isErrorenous() && !this.isChanged()) ||
+             this.workPackage.inFlight);
   }
 
   public get errorMessageOnLabel(): string {
@@ -189,7 +190,7 @@ export class WorkPackageEditFieldController {
     }
     else {
       return this.I18n.t('js.inplace.errors.messages_on_field',
-                         { messages: this.errors.join(" ") });
+                         { messages: this.errors.join(' ') });
     }
   }
 

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -50,9 +50,7 @@ describe 'subject inplace editor', js: true, selenium: true do
     expect(options.map(&:text)).to eq(['-', version3.name, version2.name, version.name])
 
     options[1].select_option
-    field.submit_by_click
 
     field.expect_state_text(version3.name)
-
   end
 end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -85,7 +85,6 @@ describe 'Inline editing work packages', js: true do
 
       status_field.activate!
       status_field.set_value(status2.name)
-      status_field.save!
 
       subject_field.expect_inactive!
       status_field.expect_inactive!

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -79,7 +79,6 @@ describe 'Switching types in work package table', js: true do
     # Switch type
     type_field.activate!
     type_field.set_value type_bug.name
-    type_field.save!
 
     wp_table.expect_notification(
       type:    :error,
@@ -113,7 +112,6 @@ describe 'Switching types in work package table', js: true do
 
     type_field.activate!
     type_field.set_value type_task.name
-    type_field.save!
 
     wp_table.expect_notification(
       message: 'Successful update. Click here to open this work package in fullscreen view.'

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -121,7 +121,7 @@ module Pages
         field.activate_edition
 
         field.set_value value
-        field.save!
+        field.save! if field.input_element.tag_name != 'select' # select fields are saved on change
 
         unless index == key_value_map.length - 1
           ensure_no_conflicting_modifications


### PR DESCRIPTION
Otherwise, especially in IE with their custom change handler for select boxes, it was possible to make a change, trigger saving and while saving takes place, change another attribute and change that. Only the first change would work while the second would fail because of optimistic locking.

https://community.openproject.com/work_packages/23611/activity
