### PR TITLE
[23238] Doubled scroll bar in work package view

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -136,6 +136,12 @@
 .work-package--details-container
   position: relative
   padding:  0
+
+// This rule is necessary to show the border only
+// when its needed. Otherwise the border would be visible
+// in the list view too.
+.action-details .work-package--details-container,
+.action-create .work-package--details-container,
   border-left: 4px solid #eee
   border-top: 4px solid #eee
 

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -171,7 +171,9 @@ openprojectModule
         controller: 'WorkPackageCreateController',
         controllerAs: '$ctrl',
         templateUrl: '/components/routing/wp-list/wp.list.new.html',
-        reloadOnSearch: false
+        reloadOnSearch: false,
+        onEnter: () => angular.element('body').addClass('action-create'),
+        onExit: () => angular.element('body').removeClass('action-create')
       })
       .state('work-packages.list.copy', {
         url: '/details/{copiedFromWorkPackageId:[0-9]+}/copy',


### PR DESCRIPTION
To avoid the border of the split screen been visible in the list view, the border is only shown when its needed.

https://community.openproject.com/work_packages/23238/activity
