### PR TITLE
Prevent switch to edit mode when a user clicks on a link

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
@@ -1,4 +1,4 @@
 <span>
-   <span ng-bind-html="$ctrl.displayText"></span>
+   <span ng-bind-html="$ctrl.displayText" wp-display-formattable-field-helper></span>
 </span>
 

--- a/frontend/app/components/wp-display/helpers/wp-display-formattable-field-helper.directive.ts
+++ b/frontend/app/components/wp-display/helpers/wp-display-formattable-field-helper.directive.ts
@@ -1,0 +1,20 @@
+export class WpDisplayFormattableFieldHelper {
+  constructor(protected $scope,
+              protected $element,
+              protected $timeout) {
+    $timeout(function () {
+      $element.on('click', 'a', function (evt) {
+        evt.stopPropagation();
+      });
+    });
+  }
+}
+
+function wpDisplayFormattableFieldHelper():ng.IDirective {
+  return {
+    restrict: 'A',
+    controller: WpDisplayFormattableFieldHelper
+  };
+}
+
+angular.module('openproject.workPackages.directives').directive('wpDisplayFormattableFieldHelper', wpDisplayFormattableFieldHelper)

--- a/frontend/app/components/wp-display/helpers/wp-display-formattable-field-helper.directive.ts
+++ b/frontend/app/components/wp-display/helpers/wp-display-formattable-field-helper.directive.ts
@@ -1,12 +1,9 @@
 export class WpDisplayFormattableFieldHelper {
   constructor(protected $scope,
-              protected $element,
-              protected $timeout) {
-    $timeout(function () {
+              protected $element) {
       $element.on('click', 'a', function (evt) {
         evt.stopPropagation();
       });
-    });
   }
 }
 


### PR DESCRIPTION
This prevents a formattable-field from switching to edit mode when a user clicks on an html link inside of it.
