### PR TITLE
[23429] [13a] Seitentitel nicht aussagekräftig

### DIFF
--- a/app/views/wiki/annotate.html.erb
+++ b/app/views/wiki/annotate.html.erb
@@ -27,6 +27,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.pretty_title)  %>
+
 <% content_for :action_menu_specific do %>
   <%= link_to(l(:button_edit),
               {action: 'edit', id: @page},

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -57,4 +57,3 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= robot_exclusion_tag %>
 <% end %>
 
-<% html_title h(@page.pretty_title) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1802,6 +1802,7 @@ en:
   text_caracters_maximum: "%{count} characters maximum."
   text_caracters_minimum: "Must be at least %{count} characters long."
   text_comma_separated: "Multiple values allowed (comma separated)."
+  text_comment_wiki_page: "Comment to wiki page: %{page}"
   text_custom_field_possible_values_info: "One line for each value"
   text_default_administrator_account_changed: "Default administrator account changed"
   text_default_encoding: "Default: UTF-8"


### PR DESCRIPTION
This remove the doubled info on the edit wiki page title. Further a specific title for the annotate history page is added.

https://community.openproject.com/work_packages/23429/activity
