### PR TITLE
[23480] [5a] Spaltenüberschriften nicht ausgezeichnet

### DIFF
--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -63,9 +63,9 @@ See doc/COPYRIGHT.rdoc for more details.
           <table class="attributes-table">
             <thead>
               <tr>
-                <td><%= I18n.t('label_attribute') %></td>
-                <td><%= I18n.t('label_active') %></td>
-                <td><%= I18n.t('label_always_visible') %></td>
+                <th><%= I18n.t('label_attribute') %></th>
+                <th><%= I18n.t('label_active') %></th>
+                <th><%= I18n.t('label_always_visible') %></th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/app/components/wp-relations/wp-relations.directive.html
+++ b/frontend/app/components/wp-relations/wp-relations.directive.html
@@ -19,12 +19,12 @@
             <col style="width: 1rem"/>
           </colgroup>
           <thead>
-          <tr>
-            <td title="{{ $ctrl.text.table.subject }}">{{ $ctrl.text.table.subject }}</td>
-            <td title="{{ $ctrl.text.table.status }}">{{ $ctrl.text.table.status }}</td>
-            <td title="{{ $ctrl.text.table.assignee }}">{{ $ctrl.text.table.assignee }}</td>
-            <td></td>
-          </tr>
+            <tr>
+              <th title="{{ $ctrl.text.table.subject }}">{{ $ctrl.text.table.subject }}</th>
+              <th title="{{ $ctrl.text.table.status }}">{{ $ctrl.text.table.status }}</th>
+              <th title="{{ $ctrl.text.table.assignee }}">{{ $ctrl.text.table.assignee }}</th>
+              <th></th>
+            </tr>
           </thead>
           <tbody>
           <tr wp-relation-row


### PR DESCRIPTION
In some table headers the headers are not correctly declared. This makes it hard for blind users to understand the table.

https://community.openproject.com/work_packages/23480/activity
