### PR TITLE
remove code duplicated by merge/rebase

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -65,9 +65,6 @@ function WorkPackagesListController($scope,
         wpCacheService.updateWorkPackageList(json.work_packages);
 
         setupPage(json, !!$state.params.query_props);
-        QueryService.loadAvailableUnusedColumns($scope.projectIdentifier).then(function (data) {
-          $scope.availableUnusedColumns = data;
-        });
 
         QueryService.loadAvailableGroupedQueries($scope.projectIdentifier);
         QueryService.loadAvailableUnusedColumns($scope.projectIdentifier).then(function(data) {


### PR DESCRIPTION
The same code is executed in https://github.com/opf/openproject/compare/dev...ulferts:fix/remove_merge_artefact?expand=1#diff-0a46d19b0d89b4267657cf6ed14c0744R70

Removing it will save us one server round trip.
