### PR TITLE
[23483] [5d] Tabelle mit ARIA-Rolle grid ausgezeichnet

### DIFF
--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -45,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="autoscroll">
         <div class="generic-table--container">
           <div class="generic-table--results-container">
-            <table interactive-table role="grid" class="generic-table">
+            <table interactive-table class="generic-table">
               <colgroup>
                 <col highlight-col>
                 <col highlight-col>


### PR DESCRIPTION
The role 'grid' should be used for interactive tables only. To avoid that blind users get confused the role was removed.  

https://community.openproject.com/work_packages/23483/activity
