### PR TITLE
[23409] [17a] Auf wenigen interaktiven Elementen ist der Tastaturfokus schlecht sichtbar (IE)

### DIFF
--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -66,5 +66,6 @@ body.accessibility-mode
   // Neccessary to have enough space for the border in IE
   .work-packages--page-container
     .inplace-edit .inplace-edit--read-value,
-    .id a
+    .id a,
+    .inplace-edit form
       margin: 3px


### PR DESCRIPTION
Similar to the fields in normal state in the WP table, the field in edit mode need a `margin` so that the outline is visible in IE. 

https://community.openproject.com/work_packages/23409/activity
