### PR TITLE
[23637] Show remove icons when the browser window is smaller than 1248px in width

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -306,6 +306,7 @@ a.inplace-editing--trigger-link,
 
     .inplace-edit--icon-wrapper
       visibility: visible
+      display: flex
 
   // Otherwise the description will show up in one line on IE10
   .inplace-edit--read-value

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -145,10 +145,6 @@
         bottom: -20px
         width: calc(100vw + 20px)
 
-    // Stretch description to fullwidth
-    .inplace-edit--icon-wrapper
-      display: none
-
     .work-package-details-activities-messages
       font-size: 0.9rem
 


### PR DESCRIPTION
## [23637](https://community.openproject.com/work_packages/23637/activity)

Since the remove icons are the only way to actually remove attachments and watchers they must always be visible in the split view.
