### PR TITLE
[23444] [9a] Überschriften entsprechen teilweise nicht Ihrer Hierarchie

### DIFF
--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div class="news">
   <%= link_to_project(news.project) + ': ' unless @project %>
-  <h3 class='overview'><%= link_to h(news.title), news_path(news) %></h3>
+  <h4 class='overview'><%= link_to h(news.title), news_path(news) %></h4>
   <p class="author additional-information"><%= authoring news.created_on, news.author %></p>
   <div class="news--comment">
     <% unless news.summary.blank? %>


### PR DESCRIPTION
This changes the headline-tag to achieve a correct hierarchy. Thus the structure is easier to understand for blind users.

Similar meetings PR: https://github.com/finnlabs/openproject-meeting/pull/125

https://community.openproject.com/work_packages/23444/activity
