### PR TITLE
[23478] [6g] Kleine Klickfläche bei Checkboxen

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -144,6 +144,10 @@
         display: inline-flex
         justify-content: center
 
+  // Enable greater clickable area for constrained movable users
+  .wp-inline-edit--boolean-field
+    width: 100%
+
 .inplace-edit--select
   .select2-display-none
     display: none

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -69,3 +69,6 @@ body.accessibility-mode
     .id a,
     .inplace-edit form
       margin: 3px
+
+  table input
+    width: 100%

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -70,5 +70,7 @@ body.accessibility-mode
     .inplace-edit form
       margin: 3px
 
-  table input
+  // Allow a greater sensible area to click input checkboxes
+  // On the WP table this is not neccessary because the whole cell is clickable
+  table:not(.work-package-table) input[type='checkbox']
     width: 100%

--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -1,5 +1,5 @@
 <input type="checkbox"
-       class="wp-inline-edit--field"
+       class="wp-inline-edit--field wp-inline-edit--boolean-field"
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-false-value="false"

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -4,7 +4,7 @@
        wp-virtual-scroll-table
        column-count="columns.length + 1"
        row-height="44">
-    <table interactive-table class="keyboard-accessible-list generic-table">
+    <table interactive-table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
         <col highlight-col />
         <col highlight-col ng-repeat="column in columns" />


### PR DESCRIPTION
For users who have for example shaking hands it is very difficult to select small checkboxes which do not have a label to click on. This affects mostly checkboxes in tables and checkboxes in the WP overview. 

https://community.openproject.com/work_packages/23478/activity
