### PR TITLE
[23614] Mobile option button not correctly displayed

### DIFF
--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -86,7 +86,7 @@ module Redmine::MenuManager::TopMenuHelper
       label: avatar.presence || '',
       label_options: {
         title: User.current.name,
-        class: (avatar.present? ? '' : 'icon-user icon-context')
+        class: (avatar.present? ? '' : 'icon-user')
       },
       items: items,
       options: { drop_down_id: 'user-menu', menu_item_class: 'last-child -hide-icon' }


### PR DESCRIPTION
When the user has no avatar the mobile view is broken because of the styling classes. Since `icon-context` is obsolete here anyway was removed.

https://community.openproject.com/work_packages/23614/activity
