### PR TITLE
[23058] Do not 'inherit' priority from children

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -40,9 +40,9 @@ class WorkPackage < ActiveRecord::Base
 
   include OpenProject::Journal::AttachmentHelper
 
-  DONE_RATIO_OPTIONS = %w(field status disabled)
+  DONE_RATIO_OPTIONS = %w(field status disabled).freeze
   ATTRIBS_WITH_VALUES_FROM_CHILDREN =
-    %w(start_date due_date estimated_hours done_ratio)
+    %w(start_date due_date estimated_hours done_ratio).freeze
   # <<< issues.rb <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   belongs_to :project

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -42,7 +42,7 @@ class WorkPackage < ActiveRecord::Base
 
   DONE_RATIO_OPTIONS = %w(field status disabled)
   ATTRIBS_WITH_VALUES_FROM_CHILDREN =
-    %w(priority_id start_date due_date estimated_hours done_ratio)
+    %w(start_date due_date estimated_hours done_ratio)
   # <<< issues.rb <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   belongs_to :project
@@ -559,8 +559,6 @@ class WorkPackage < ActiveRecord::Base
 
     return unless p
 
-    p.inherit_priority_from_children
-
     p.inherit_dates_from_children
 
     p.inherit_done_ratio_from_leaves
@@ -579,14 +577,6 @@ class WorkPackage < ActiveRecord::Base
 
   def update_parent_attributes
     recalculate_attributes_for(parent_id) if parent_id.present?
-  end
-
-  def inherit_priority_from_children
-    # priority = highest priority of children
-    if priority_position =
-        children.joins(:priority).maximum("#{IssuePriority.table_name}.position")
-      self.priority = IssuePriority.find_by(position: priority_position)
-    end
   end
 
   def inherit_dates_from_children

--- a/features/work_packages/update.feature
+++ b/features/work_packages/update.feature
@@ -86,7 +86,6 @@ Feature: Updating work packages
     Then the work package should be shown with the following values:
       | Subject        | parent                   |
     And there should not be a "Progress \(%\)" field
-    And there should not be a "Priority" field
     And there should not be a "Start date" field
     And there should not be a "End date" field
     And there should not be a "Estimated time" field

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -83,8 +83,7 @@ module API
                 :estimated_time,
                 :start_date,
                 :due_date,
-                :date,
-                :priority].include? property
+                :date].include? property
               return false unless @work_package.leaf?
             end
 

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -269,9 +269,9 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
     end
 
     context 'priority' do
-      it 'is not writable when the work package is a parent' do
+      it 'is writable when the work package is a parent' do
         allow(work_package).to receive(:leaf?).and_return(false)
-        expect(subject.writable?(:priority)).to be false
+        expect(subject.writable?(:priority)).to be true
       end
 
       it 'is writable when the work package is a leaf' do

--- a/spec/models/work_package/work_package_planning_spec.rb
+++ b/spec/models/work_package/work_package_planning_spec.rb
@@ -310,7 +310,7 @@ describe WorkPackage, type: :model do
 
         # sanity check
         expect(child_pe.journals.size).to eq(1)
-        expect(pe.journals.size).to eq(2)
+        expect(pe.journals.size).to eq(1)
 
         # update child
         child_pe.reload
@@ -319,7 +319,7 @@ describe WorkPackage, type: :model do
         # reload parent to avoid stale journal caches
         pe.reload
 
-        expect(pe.journals.size).to eq(3)
+        expect(pe.journals.size).to eq(2)
         changes = pe.journals.last.details
 
         expect(changes.size).to eq(1)

--- a/spec_legacy/unit/issue_nested_set_spec.rb
+++ b/spec_legacy/unit/issue_nested_set_spec.rb
@@ -197,25 +197,6 @@ describe 'IssueNestedSet', type: :model do
     end
   end
 
-  it 'should parent priority should be the highest child priority' do
-    parent = create_issue!(priority: IssuePriority.find_by(name: 'Normal'))
-    # Create children
-    child1 = create_issue!(priority: IssuePriority.find_by(name: 'High'), parent_id: parent.id)
-    assert_equal 'High', parent.reload.priority.name
-    child2 = create_issue!(priority: IssuePriority.find_by(name: 'Immediate'), parent_id: child1.id)
-    assert_equal 'Immediate', child1.reload.priority.name
-    assert_equal 'Immediate', parent.reload.priority.name
-    child3 = create_issue!(priority: IssuePriority.find_by(name: 'Low'), parent_id: parent.id)
-    assert_equal 'Immediate', parent.reload.priority.name
-    # Destroy a child
-    child1.destroy
-    assert_equal 'Low', parent.reload.priority.name
-    # Update a child
-    child3.reload.priority = IssuePriority.find_by(name: 'Normal')
-    child3.save!
-    assert_equal 'Normal', parent.reload.priority.name
-  end
-
   it 'should parent dates should be lowest start and highest due dates' do
     parent = create_issue!
     create_issue!(start_date: '2010-01-25', due_date: '2010-02-15', parent_id: parent.id)


### PR DESCRIPTION
This removes updating of priority values from children to parent work
packages.

https://community.openproject.com/work_packages/23058/activity
