### PR TITLE
Don't extend top-menu styles for onboarding modal

### DIFF
--- a/app/assets/stylesheets/specific/onboarding.sass
+++ b/app/assets/stylesheets/specific/onboarding.sass
@@ -33,9 +33,11 @@
   overflow-y: auto
 
 .onboarding--top-menu
-  @extend #top-menu
   display: flex
   align-items: center
+  background-color: $header-bg-color
+  height: $header-height
+  border-bottom: $header-border-bottom-width solid $header-border-bottom-color
 
   .avatar,
   .icon-context


### PR DESCRIPTION
Using #top-menu as a base for the onboarding header will cause
`position:absolute` to be injected in the work packages pages.
