### PR TITLE
[23639] Workaround for FF bug 548397

### DIFF
--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -128,7 +128,7 @@ var ModalHelper = (function() {
 
         jQuery(this).trigger("loaded");
 
-        modalDiv.parent().show();
+        modalDiv.parent().css('visibility', 'visible');
 
         modalIframe.attr("height", modalDiv.height());
 
@@ -198,7 +198,7 @@ var ModalHelper = (function() {
   };
 
   ModalHelper.prototype.loading = function() {
-    this.modalDiv.parent().hide();
+    this.modalDiv.parent().css('visibility', 'hidden');
 
     this.loadingModal = true;
     this.showLoadingModal();


### PR DESCRIPTION
The timeline creation modal was not showing in Firefox since hidden
iframes cause `window.getComputedStyle` to return null.

This is in turn caused by foundation to try to initialize itself through
a meta style accessor.

This commit provides a hackish workaround to use visibility instead of
display to hide the modal..

Bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=548397

https://community.openproject.com/work_packages/23639/activity
