### PR TITLE
[23592] Fix attachments in create mode

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_attachments_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_attachments_tab.sass
@@ -53,6 +53,9 @@
   padding: 20px 0 0 0
   border-top: 1px solid #ddd
 
+tr.is-droppable
+  background: $nm-color-success-background !important
+
 .is-droppable
   border: 1px dotted $nm-color-success-border
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -32,7 +32,6 @@ import {WorkPackageCacheService} from '../../../work-packages/work-package-cache
 import {ApiWorkPackagesService} from '../../api-work-packages/api-work-packages.service';
 import IQService = angular.IQService;
 import {CollectionResourceInterface} from './collection-resource.service';
-import {WpAttachmentsService} from '../../../work-packages/wp-attachments/wp-attachments.service'
 interface WorkPackageResourceEmbedded {
   activities:HalResource|any;
   assignee:HalResource|any;
@@ -74,7 +73,6 @@ interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
 
 var $q:IQService;
 var apiWorkPackages:ApiWorkPackagesService;
-var wpAttachments:WpAttachmentsService;
 var wpCacheService:WorkPackageCacheService;
 var NotificationsService:any;
 var $stateParams:any;
@@ -265,8 +263,6 @@ export class WorkPackageResource extends HalResource {
 
         this.saveResource(payload)
           .then(workPackage => {
-            wpAttachments.uploadPendingAttachments(workPackage);
-            
             this.$initialize(workPackage);
             this.$pristine = {};
 
@@ -369,7 +365,7 @@ export interface WorkPackageResourceInterface extends WorkPackageResourceLinks, 
 }
 
 function wpResource(...args) {
-  [$q, $stateParams, apiWorkPackages, wpCacheService, NotificationsService, wpAttachments] = args;
+  [$q, $stateParams, apiWorkPackages, wpCacheService, NotificationsService] = args;
   return WorkPackageResource;
 }
 
@@ -378,8 +374,7 @@ wpResource.$inject = [
   '$stateParams',
   'apiWorkPackages',
   'wpCacheService',
-  'NotificationsService',
-  'wpAttachments'
+  'NotificationsService'
 ];
 
 opApiModule.factory('WorkPackageResource', wpResource);

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -257,6 +257,7 @@ export class WorkPackageResource extends HalResource {
   public save() {
     var deferred = $q.defer();
     this.inFlight = true;
+    const wasNew = this.isNew;
 
     this.updateForm(this.$source)
       .then(form => {
@@ -278,6 +279,9 @@ export class WorkPackageResource extends HalResource {
           .finally(() => {
             this.inFlight = false;
             wpCacheService.updateWorkPackage(this);
+            if (wasNew) {
+              wpCacheService.newWorkPackageCreated(this);
+            }
           });
       })
       .catch(() => {

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -32,7 +32,7 @@ import {WorkPackageCacheService} from '../../../work-packages/work-package-cache
 import {ApiWorkPackagesService} from '../../api-work-packages/api-work-packages.service';
 import IQService = angular.IQService;
 import {CollectionResourceInterface} from './collection-resource.service';
-
+import {WpAttachmentsService} from '../../../work-packages/wp-attachments/wp-attachments.service'
 interface WorkPackageResourceEmbedded {
   activities:HalResource|any;
   assignee:HalResource|any;
@@ -74,6 +74,7 @@ interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
 
 var $q:IQService;
 var apiWorkPackages:ApiWorkPackagesService;
+var wpAttachments:WpAttachmentsService;
 var wpCacheService:WorkPackageCacheService;
 var NotificationsService:any;
 var $stateParams:any;
@@ -263,10 +264,13 @@ export class WorkPackageResource extends HalResource {
 
         this.saveResource(payload)
           .then(workPackage => {
+            wpAttachments.uploadPendingAttachments(workPackage);
+            
             this.$initialize(workPackage);
             this.$pristine = {};
 
             deferred.resolve(this);
+
           })
           .catch(error => {
             deferred.reject(error);
@@ -361,7 +365,7 @@ export interface WorkPackageResourceInterface extends WorkPackageResourceLinks, 
 }
 
 function wpResource(...args) {
-  [$q, $stateParams, apiWorkPackages, wpCacheService, NotificationsService] = args;
+  [$q, $stateParams, apiWorkPackages, wpCacheService, NotificationsService, wpAttachments] = args;
   return WorkPackageResource;
 }
 
@@ -370,7 +374,8 @@ wpResource.$inject = [
   '$stateParams',
   'apiWorkPackages',
   'wpCacheService',
-  'NotificationsService'
+  'NotificationsService',
+  'wpAttachments'
 ];
 
 opApiModule.factory('WorkPackageResource', wpResource);

--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -33,6 +33,7 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
 
   constructor(public $injector,
               public $scope,
+              public $rootScope,
               public $state) {
     super($injector, $scope, $state.params['workPackageId']);
     this.observeWorkPackage();

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -37,10 +37,16 @@ export class WorkPackageCacheService {
 
   private workPackageCache: {[id: number]: WorkPackageResource} = {};
 
-  workPackagesSubject = new Rx.ReplaySubject<{[id: number]: WorkPackageResource}>(1);
+  private workPackagesSubject = new Rx.ReplaySubject<{[id: number]: WorkPackageResource}>(1);
+
+  private newWorkPackageCreatedSubject = new Rx.Subject<WorkPackageResource>();
 
   /*@ngInject*/
   constructor(private $rootScope: IScope, private apiWorkPackages: ApiWorkPackagesService) {
+  }
+
+  newWorkPackageCreated(wp: WorkPackageResource) {
+    this.newWorkPackageCreatedSubject.onNext(wp);
   }
 
   updateWorkPackage(wp: WorkPackageResource) {
@@ -62,11 +68,11 @@ export class WorkPackageCacheService {
   /**
    * Invalidate a set of links in the given work package.
    * This is a temporary fix for un-/reloading a known set of links.
-   * 
+   *
    * @param workPackage
    * @param args A list of links to forcefully $load
    */
-  loadWorkPackageLinks(workPackage, ...args:string[]) {
+  loadWorkPackageLinks(workPackage, ...args: string[]) {
     args.forEach((arg) => {
       workPackage[arg].$load(true);
     });
@@ -81,8 +87,12 @@ export class WorkPackageCacheService {
     }
 
     return this.workPackagesSubject
-        .map(cache => cache[workPackageId])
-        .filter(wp => wp !== undefined);
+      .map(cache => cache[workPackageId])
+      .filter(wp => wp !== undefined);
+  }
+
+  onNewWorkPackage(): Rx.Observable<WorkPackageResource> {
+    return this.newWorkPackageCreatedSubject.asObservable();
   }
 
 }

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
@@ -34,8 +34,8 @@ export class WpAttachmentsFormattableController {
               protected keepTab:KeepTabService) {
 
     $element.on('drop', this.handleDrop);
-    $element.on('dragover',this.highlightDroppable);
-    $element.on('dragleave',this.removeHighlight);
+    $element.on('dragover', this.highlightDroppable);
+    $element.on('dragleave', this.removeHighlight);
     $element.on('dragenter dragleave dragover', this.prevDefault);
   }
 
@@ -67,7 +67,7 @@ export class WpAttachmentsFormattableController {
       if (dropData.filesAreValidForUploading()) {
         if (!dropData.isDelayedUpload) {
 
-          this.uploadFiles(workPackage,dropData).then((updatedAttachments:any)=>{
+          this.uploadFiles(workPackage, dropData).then((updatedAttachments:any) => {
             if (angular.isUndefined(updatedAttachments)) {
               return;
             }
@@ -84,17 +84,17 @@ export class WpAttachmentsFormattableController {
 
           });
         } else {
-          this.insertDelayedAttachments(dropData,description);
+          this.insertDelayedAttachments(dropData, description);
         }
       }
     } else {
-      this.insertUrls(dropData,description);
+      this.insertUrls(dropData, description);
     }
     this.openDetailsView(workPackage.id);
     this.removeHighlight();
   };
 
-  protected uploadFiles(workPackage:WorkPackageResourceInterface, dropData:DropModel){
+  protected uploadFiles(workPackage:WorkPackageResourceInterface, dropData:DropModel) {
     const updatedAttachmentsList = this.$q.defer();
 
     this.wpAttachments.upload(workPackage, dropData.files).then(() => {
@@ -106,14 +106,14 @@ export class WpAttachmentsFormattableController {
     return updatedAttachmentsList.promise;
   }
 
-  protected sortAttachments(updatedAttachments:any){
+  protected sortAttachments(updatedAttachments:any) {
     updatedAttachments.sort(function (a:any, b:any) {
       return a.id > b.id ? 1 : -1;
     });
     return updatedAttachments;
   }
 
-  protected insertSingleAttachment(updatedAttachments:any, description:any){
+  protected insertSingleAttachment(updatedAttachments:any, description:any) {
     const currentFile:SingleAttachmentModel =
       new SingleAttachmentModel(updatedAttachments[updatedAttachments.length - 1]);
     description.insertAttachmentLink(
@@ -121,26 +121,27 @@ export class WpAttachmentsFormattableController {
       (currentFile.isAnImage) ? InsertMode.INLINE : InsertMode.ATTACHMENT);
   }
 
-  protected insertMultipleAttachments(dropData:DropModel,updatedAttachments:any,description:any):void{
+  protected insertMultipleAttachments(dropData:DropModel, updatedAttachments:any, description:any):void {
     for (let i:number = updatedAttachments.length - 1;
          i >= updatedAttachments.length - dropData.filesCount;
          i--) {
       description.insertAttachmentLink(
-        updatedAttachments[i]._links.downloadLocation.href,
+        updatedAttachments[i].downloadLocation.href,
         InsertMode.ATTACHMENT,
         true);
     }
   }
 
-  protected insertDelayedAttachments(dropData:DropModel, description):void{
-    dropData.files.forEach((file:File) => {
-      description.insertAttachmentLink(file.name.replace(/ /g, '_'), InsertMode.ATTACHMENT, true);
-      // implement pending attachments logic when create is ready
-    });
+  protected insertDelayedAttachments(dropData:DropModel, description):void {
+    for (var i = 0; i < dropData.files.length; i++) {
+      description.insertAttachmentLink(dropData.files[i].name.replace(/ /g, '_'), InsertMode.ATTACHMENT, true);
+      this.$rootScope.$broadcast('work_packages.attachment.add', dropData.files[i]);
+    }
+
     description.save();
   }
 
-  protected insertUrls(dropData: DropModel,description):void{
+  protected insertUrls(dropData: DropModel, description):void {
     const insertUrl:string = dropData.isAttachmentOfCurrentWp() ? dropData.removeHostInformationFromUrl() : dropData.webLinkUrl;
     const insertAlternative:InsertMode = dropData.isWebImage() ? InsertMode.INLINE : InsertMode.LINK;
     const insertMode:InsertMode = dropData.isAttachmentOfCurrentWp() ? InsertMode.ATTACHMENT : insertAlternative;
@@ -150,7 +151,7 @@ export class WpAttachmentsFormattableController {
   }
 
   protected openDetailsView(wpId):void {
-    if(this.$state.current.name.indexOf('work-packages.list') > -1 && this.$state.params.workPackageId !== wpId){
+    if (this.$state.current.name.indexOf('work-packages.list') > -1 && this.$state.params.workPackageId !== wpId) {
       this.loadingIndicator.mainPage = this.$state.go(this.keepTab.currentDetailsState, {
         workPackageId: wpId
       });
@@ -162,16 +163,16 @@ export class WpAttachmentsFormattableController {
     evt.stopPropagation();
   }
 
-  protected highlightDroppable=(evt:JQueryEventObject)=>{
+  protected highlightDroppable = (evt:JQueryEventObject) => {
     // use the browser's native implementation for showing the user
     // that one can drop data on this area
     (evt.originalEvent as DragEvent).dataTransfer.dropEffect = 'copy';
-    if(!this.$element.hasClass('is-droppable')){
+    if (!this.$element.hasClass('is-droppable')) {
       this.$element.addClass('is-droppable');
     }
   };
 
-  protected removeHighlight=()=>{
+  protected removeHighlight = () => {
     this.$element.removeClass('is-droppable');
   };
 }
@@ -194,6 +195,7 @@ function wpAttachmentsFormattable() {
       if (angular.isUndefined(controllers[0] && angular.isUndefined(controllers[1]))) {
         return;
       }
+
       scope.workPackage = !controllers[0] ? controllers[1].workPackage : controllers[0].workPackage;
     },
     require: ['?^wpSingleView', '?^wpEditForm'],

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.interfaces.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.interfaces.ts
@@ -1,9 +1,9 @@
-import {InsertMode} from './wp-attachments-formattable.enums'
+import {InsertMode} from './wp-attachments-formattable.enums';
 
-export interface IApplyAttachmentMarkup{
+export interface IApplyAttachmentMarkup {
     contentToInsert: string;
 
-    insertAttachmentLink: (url: string,insertMode: InsertMode, addLineBreak?:boolean) => void;
-    insertWebLink: (url: string,insertMode: InsertMode) => void;
+    insertAttachmentLink: (url: string, insertMode: InsertMode, addLineBreak?:boolean) => void;
+    insertWebLink: (url: string, insertMode: InsertMode) => void;
     save: () => void;
 }

--- a/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.html
+++ b/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.html
@@ -11,7 +11,7 @@
          data-ng-show="vm.attachments.length > 0">
       <div class="work-package--details--long-field">
         <span class="inplace-edit--read"
-              data-ng-repeat="attachment in vm.attachments track by attachment.id">
+              data-ng-repeat="attachment in vm.attachments track by attachment.name+$index">
           <span class="inplace-editing--trigger-container">
             <span class="inplace-editing--trigger-link"
                   ng-class="{'-focus': vm.focussing(attachment)}">

--- a/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.ts
+++ b/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.ts
@@ -36,6 +36,7 @@ import {CollectionResourceInterface} from '../../api/api-v3/hal-resources/collec
 
 export class WorkPackageAttachmentsController {
   public workPackage:any;
+  public wpSingleViewCtrl;
   public hideEmptyFields:boolean;
 
   public attachments:any[] = [];
@@ -52,11 +53,9 @@ export class WorkPackageAttachmentsController {
   public size:any;
 
   private currentlyFocussing;
-  public wpSingleView:ng.IScope;
 
   constructor(protected $scope:any,
               protected $element:ng.IAugmentedJQuery,
-              protected $rootScope,
               protected wpCacheService:WorkPackageCacheService,
               protected wpAttachments:WpAttachmentsService,
               protected NotificationsService:any,
@@ -66,6 +65,11 @@ export class WorkPackageAttachmentsController {
               protected ConversionService:any) {
 
     this.workPackage = $scope.vm.workPackage();
+
+    this.attachments = this.workPackage.isNew ? wpAttachments.pendingAttachments : this.attachments;
+    if (angular.isDefined($scope.vm.wpSingleViewCtrl)) {
+      $scope.vm.wpSingleViewCtrl.attachments = this.attachments;
+    }
 
     this.hasRightToUpload = !!(angular.isDefined(this.workPackage.addAttachment) || this.workPackage.isNew);
 
@@ -79,7 +83,7 @@ export class WorkPackageAttachmentsController {
       this.loadAttachments(false);
     }
 
-    $rootScope.$on('work_packages.attachment.add', file => {
+    $scope.$on('work_packages.attachment.add', (evt, file) => {
       this.attachments.push(file);
     });
 
@@ -87,8 +91,10 @@ export class WorkPackageAttachmentsController {
       scopedObservable($scope, wpCacheService.loadWorkPackage(this.workPackage.id))
         .subscribe((wp:WorkPackageResourceInterface) => {
           this.workPackage = wp;
-          this.loadAttachments(false);
+          this.loadAttachments(true);
         });
+    } else {
+      this.attachments = this.wpAttachments.pendingAttachments;
     }
   }
 
@@ -117,20 +123,20 @@ export class WorkPackageAttachmentsController {
       })
       .finally(() => {
         this.loading = false;
-        this.$scope.wpSingleView.filesExist = this.attachments.length > 0;
       });
   }
 
   public remove(file):void {
-    if (file._type === 'Attachment') {
-      file.delete()
-        .then(() => this.attachmentsChanged())
-        .catch(error => {
-          this.wpNotificationsService.handleErrorResponse(error, this.workPackage);
-        });
+    if (!this.workPackage.isNew) {
+      if (file._type === 'Attachment') {
+        file.delete()
+          .then(() => this.attachmentsChanged())
+          .catch(error => {
+            this.wpNotificationsService.handleErrorResponse(error, this.workPackage);
+          });
+      }
     }
-
-    _.remove(this.attachments, file);
+    _.pull(this.attachments, file);
   }
 
   public focus(attachment:any):void {
@@ -169,14 +175,11 @@ function wpAttachmentsDirective():ng.IDirective {
     controller: WorkPackageAttachmentsController,
     controllerAs: 'vm',
     replace: true,
-    require: ['?^wpSingleView'],
     restrict: 'E',
     scope: {
       workPackage: '&',
-      hideEmptyFields: '='
-    },
-    link: function(scope,element,attrs,controllers){
-      (scope as any).wpSingleView = !controllers[0] ? {} : controllers[0];
+      hideEmptyFields: '=',
+      wpSingleViewCtrl: '='
     },
     templateUrl: '/components/work-packages/wp-attachments/wp-attachments.directive.html'
   };

--- a/frontend/app/components/work-packages/wp-attachments/wp-attachments.service.test.ts
+++ b/frontend/app/components/work-packages/wp-attachments/wp-attachments.service.test.ts
@@ -32,12 +32,13 @@ describe('wpAttachments service', () => {
   var $q;
   var wpAttachments;
   var $httpBackend;
+  var wpNotificationsService;
 
   // mock me an attachment
   var attachment = {
     id: 1,
-    _type: "Attachment",
-    href: "/api/v3/attachments/1"
+    _type: 'Attachment',
+    href: '/api/v3/attachments/1'
   };
 
   var workPackage = {
@@ -60,10 +61,11 @@ describe('wpAttachments service', () => {
   beforeEach(angular.mock.module('openproject'));
   beforeEach(angular.mock.module('openproject.workPackages'));
 
-  beforeEach(angular.mock.inject((_wpAttachments_, _$httpBackend_, _$q_) => {
+  beforeEach(angular.mock.inject((_wpAttachments_, _wpNotificationsService_, _$httpBackend_, _$q_) => {
     $q = _$q_;
     wpAttachments = _wpAttachments_;
     $httpBackend = _$httpBackend_;
+    wpNotificationsService = _wpNotificationsService_
   }));
 
   afterEach(() => {

--- a/frontend/app/components/work-packages/wp-attachments/wp-attachments.service.ts
+++ b/frontend/app/components/work-packages/wp-attachments/wp-attachments.service.ts
@@ -37,6 +37,8 @@ import {WorkPackageNotificationService} from '../../wp-edit/wp-notification.serv
 
 export class WpAttachmentsService {
 
+  public pendingAttachments:File[] = [];
+
   constructor(protected $q:ng.IQService,
               protected $timeout:ng.ITimeoutService,
               protected $http:ng.IHttpService,
@@ -51,10 +53,15 @@ export class WpAttachmentsService {
     const notification = this.addUploadNotification(workPackage, uploads);
 
     return this.$q.all(uploads).then(() => {
+      this.pendingAttachments.length = 0;
       this.dismissNotification(notification);
     }).catch(error => {
       this.wpNotificationsService.handleErrorResponse(error, workPackage);
     });
+  }
+
+  public uploadPendingAttachments(workPackage:WorkPackageResourceInterface) {
+    return this.upload(workPackage, this.pendingAttachments);
   }
 
   /**

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -101,7 +101,8 @@
   </div>
 
   <wp-attachments
+      wp-single-view-ctrl="$ctrl"
       work-package="$ctrl.workPackage"
-      data-ng-show="!$ctrl.hideEmptyFields || $ctrl.filesExist">
+      data-ng-show="!$ctrl.hideEmptyFields || $ctrl.attachments.length > 0">
   </wp-attachments>
 </div>

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -36,13 +36,12 @@ import {WorkPackageEditFormController} from '../../wp-edit/wp-edit-form.directiv
 import {WorkPackageNotificationService} from '../../wp-edit/wp-notification.service';
 
 export class WorkPackageSingleViewController {
-  public formCtrl: WorkPackageEditFormController;
+  public formCtrl:WorkPackageEditFormController;
   public workPackage:WorkPackageResourceInterface;
   public singleViewWp;
   public groupedFields:any[] = [];
   public hideEmptyFields:boolean = true;
-  public attachments:any;
-  public filesExist:boolean = false;
+  public attachments:Array<any>;
   public text:any;
   public scope:any;
 
@@ -140,7 +139,7 @@ function wpSingleViewDirective() {
   function wpSingleViewLink(scope,
                             element,
                             attrs,
-                            controllers: [WorkPackageEditFormController, WorkPackageSingleViewController]) {
+                            controllers:[WorkPackageEditFormController, WorkPackageSingleViewController]) {
 
     controllers[1].formCtrl = controllers[0];
 
@@ -148,6 +147,7 @@ function wpSingleViewDirective() {
       controllers[1].setIdLabel();
     });
   }
+
   return {
     restrict: 'E',
     templateUrl: '/components/work-packages/wp-single-view/wp-single-view.directive.html',

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {openprojectModule} from '../../angular-modules';
+import {wpServicesModule} from '../../angular-modules.ts';
 import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {ErrorResource} from '../api/api-v3/hal-resources/error-resource.service';
 
@@ -108,4 +108,4 @@ export class WorkPackageNotificationService {
   }
 }
 
-openprojectModule.service('wpNotificationsService', WorkPackageNotificationService);
+wpServicesModule.service('wpNotificationsService', WorkPackageNotificationService);


### PR DESCRIPTION
### [[23592]](https://community.openproject.com/work_packages/23592/activity) Fix attachments in create mode

this fixes the attachments section (`wpAttachments` and `wpAttachmentsFormattableField`) for the create mode.
- [x] fix default delayed attachments upload
- [x] fix insertion and delayed upload via drag and drop
- [x] show attachments section depending on the existance of pending attachments
- [x] fix removal of pending attachments
- [x] show uploaded attachments without hard-refresh...

Supersedes https://github.com/opf/openproject/pull/4640 with using the cache service hook
