### PR TITLE
adhere to notification settings when notifying about added watcher

### DIFF
--- a/app/models/watcher_notification_mailer.rb
+++ b/app/models/watcher_notification_mailer.rb
@@ -32,7 +32,7 @@ class WatcherNotificationMailer
     def handle_watcher(watcher, watcher_setter)
       # We only handle this watcher setting if associated user wants to be notified
       # about it.
-      return unless watcher.user.notify_about?(watcher)
+      return unless notify_about_watcher_added?(watcher, watcher_setter)
 
       unless other_jobs_queued?(watcher.watchable)
         job = DeliverWatcherNotificationJob.new(watcher.id, watcher.user.id, watcher_setter.id)
@@ -48,6 +48,27 @@ class WatcherNotificationMailer
     def other_jobs_queued?(work_package)
       Delayed::Job.where('handler LIKE ?',
                          "%NotificationJob%journal_id: #{work_package.journals.last.id}%").exists?
+    end
+
+    def notify_about_watcher_added?(watcher, watcher_setter)
+      return false if notify_about_self_watching?(watcher, watcher_setter)
+
+      case watcher.user.mail_notification
+      when 'only_my_events'
+        true
+      when 'selected'
+        watching_selected_includes_project?(watcher)
+      else
+        watcher.user.notify_about?(watcher.watchable)
+      end
+    end
+
+    def notify_about_self_watching?(watcher, watcher_setter)
+      watcher.user == watcher_setter && !watcher.user.pref.self_notified?
+    end
+
+    def watching_selected_includes_project?(watcher)
+      watcher.user.notified_projects_ids.include?(watcher.watchable.project_id)
     end
   end
 end


### PR DESCRIPTION
The PR will let the users added as watchers be notified according to their settings. Especially https://community.openproject.com/work_packages/22636/activity should be fixed by it.

Unfortunately, the `#notify_about` method on `User` is not reusable here for all cases as it would have to be adjusted to fit the requirements. But that method is used for a couple of use cases and I did not want to alter it shortly before a release. The method looks weird, though as e.g. the watchers are not taken into account for 'only_my_events' which reads 'Only for things I watch or I am involved in'. Additionally, it does not care for the `self_notified?` setting. 
