### PR TITLE
[23646] Update work package after filtered values were loaded

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -193,6 +193,7 @@ export class WorkPackageResource extends HalResource {
   public setAllowedValueFor(field, href) {
     this.allowedValuesFor(field).then(allowedValues => {
       this[field] = _.find(allowedValues, entry => entry.href === href);
+      wpCacheService.updateWorkPackage(this);
     });
   }
 

--- a/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-inline-create-button/wp-inline-create-button.controller.ts
@@ -70,11 +70,11 @@ class WorkPackageInlineCreateButtonController extends WorkPackageCreateButtonCon
 
   public addWorkPackageRow() {
     this.wpCreate.createNewWorkPackage(this.projectIdentifier).then(wp => {
-      this.wpCacheService.updateWorkPackage(wp);
       this._wp = wp;
       this._wp.inlineCreated = true;
 
       this.query.applyDefaultsFromFilters(this._wp);
+      this.wpCacheService.updateWorkPackage(this._wp);
       this.rows.push({level: 0, ancestors: [], object: this._wp, parent: void 0});
       this.hide();
     });


### PR DESCRIPTION
When filtering for e.g., assignee, that value is assigned to the work package after available values where loaded. This happened after the row was rendered.

https://community.openproject.com/work_packages/23646/activity
