### PR TITLE
Fix: dont hide fields while editing

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/single-view-wp.service.ts
+++ b/frontend/app/components/work-packages/wp-single-view/single-view-wp.service.ts
@@ -50,7 +50,7 @@ export class SingleViewWorkPackage {
     var hidden = attrVisibility === 'hidden';
 
     if (this.workPackage.isNew) {
-      return field === 'author' || notRequired || hidden;
+      return !visible && (field === 'author' || notRequired || hidden);
     }
 
     return notRequired && !visible && (empty || hidden);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -83,7 +83,7 @@ export class WorkPackageSingleViewController {
   }
 
   public shouldHideField(field) {
-    let hideEmpty = !this.formCtrl.fields[field].active && this.hideEmptyFields;
+    let hideEmpty = !this.formCtrl.fields[field].hasFocus() && this.hideEmptyFields;
 
     return this.singleViewWp.shouldHideField(field, hideEmpty);
   };

--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -4,6 +4,7 @@
        ng-model="vm.workPackage[vm.fieldName]"
        ng-false-value="false"
        ng-change="vm.submit()"
+       ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
@@ -4,6 +4,7 @@
        ng-model="vm.workPackage[vm.fieldName]"
        transform-duration-value
        ng-required="vm.field.required"
+       ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
@@ -3,6 +3,7 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-required="vm.field.required"
+       ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        transform-float-value
        ng-disabled="vm.workPackage.inFlight"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
@@ -3,6 +3,7 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-required="vm.field.required"
+       ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -4,6 +4,7 @@
         ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
         ng-change="vm.submit()"
         ng-required="vm.field.required"
+        ng-focus="vm.handleUserFocus()"
         ng-blur="vm.handleUserBlur()"
         ng-disabled="vm.workPackage.inFlight"
         focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
@@ -3,6 +3,7 @@
        wp-edit-field-requirements="vm.field.schema"
        ng-model="vm.workPackage[vm.fieldName]"
        ng-required="vm.field.required"
+       ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-disabled="vm.workPackage.inFlight"
        focus="vm.shouldFocus()"

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -47,6 +47,7 @@ export class WorkPackageEditFieldController {
   public workPackage: WorkPackageResource;
 
   protected _active: boolean = false;
+  protected _hasFocus: boolean = false;
   protected _forceFocus: boolean = false;
 
   // Since we load the schema asynchronously
@@ -198,6 +199,10 @@ export class WorkPackageEditFieldController {
     this._editable = enabled;
   }
 
+  public hasFocus() {
+    return this.active && this._hasFocus;
+  }
+
   public shouldFocus() {
     return this._forceFocus || this.formCtrl.firstActiveField === this.fieldName;
   }
@@ -219,7 +224,13 @@ export class WorkPackageEditFieldController {
     });
   }
 
+  public handleUserFocus() {
+    this._hasFocus = true;
+  }
+
   public handleUserBlur(): boolean {
+    this._hasFocus = false;
+
     if (!this.isSubmittable()) {
       return;
     }

--- a/frontend/app/work_packages/helpers/work-package-display-helper.js
+++ b/frontend/app/work_packages/helpers/work-package-display-helper.js
@@ -64,33 +64,10 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
         }
         return WorkPackageFieldService.isHideable(workPackage, field);
       },
-      isFieldHideableOnCreate = function(workPackage, field) {
-        if (!workPackage) {
-          return true;
-        }
-        if (!isSpecified(workPackage, field)) {
-          return true;
-        }
-
-        if (!isEditable(workPackage, field)) {
-          return true;
-        }
-
-        if (_.contains(unhideableFields, field)) {
-          return !WorkPackageFieldService.isEditable(workPackage, field);
-        }
-
-        return WorkPackageFieldService.isHideable(workPackage, field);
-      },
       shouldHideField = function(workPackage, field, hideEmptyFields) {
         var hidden = WorkPackageFieldService.getVisibility(workPackage, field) === 'hidden';
 
         return isFieldHideable(workPackage, field) && (hideEmptyFields || hidden);
-      },
-      shouldHideFieldOnCreate = function(workPackage, field, hideEmptyFields) {
-        var hidden = WorkPackageFieldService.getVisibility(workPackage, field) === 'hidden';
-
-        return isFieldHideableOnCreate(workPackage, field) && (hideEmptyFields || hidden);
       },
       isSpecified = function (workPackage, field) {
         if (!workPackage) {
@@ -134,9 +111,7 @@ module.exports = function(WorkPackageFieldService, $window, $timeout) {
     isGroupEmpty: isGroupEmpty,
     shouldHideGroup: shouldHideGroup,
     isFieldHideable: isFieldHideable,
-    isFieldHideableOnCreate: isFieldHideableOnCreate,
     shouldHideField: shouldHideField,
-    shouldHideFieldOnCreate: shouldHideFieldOnCreate,
     isSpecified: isSpecified,
     isEditable: isEditable,
     hasNiceStar: hasNiceStar,

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -58,6 +58,13 @@ describe 'edit work package', js: true do
   let(:version) { FactoryGirl.create :version, project: project }
   let(:category) { FactoryGirl.create :category, project: project }
 
+  let(:visit_before) { true }
+
+  def visit!
+    wp_page.visit!
+    wp_page.ensure_page_loaded
+  end
+
   before do
     login_as(manager)
 
@@ -66,22 +73,24 @@ describe 'edit work package', js: true do
     priority2
     workflow
 
-    wp_page.visit!
-    wp_page.ensure_page_loaded
+    if visit_before
+      visit!
+    end
   end
 
-  it 'does not hide empty fields while they are being edited' do
-    expect(page).not_to have_text("Progress (%)")
+  context 'with progress' do
+    let(:visit_before) { false }
 
-    wp_page.view_all_attributes
-    wp_page.update_attributes percentageDone: '42'
+    before do
+      work_package.update done_ratio: 42
+      visit!
+    end
 
-    expect(page).to have_text("42% Total")
+    it 'does not hide empty progress while it is being edited' do
+      wp_page.update_attributes({ percentageDone: '0' }, save: false)
 
-    wp_page.visit!
-    wp_page.update_attributes({ percentageDone: '0' }, save: false)
-
-    expect(page).to have_text("Progress (%)")
+      expect(page).to have_text("Progress (%)")
+    end
   end
 
   it 'allows updating and seeing the results' do

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -70,6 +70,20 @@ describe 'edit work package', js: true do
     wp_page.ensure_page_loaded
   end
 
+  it 'does not hide empty fields while they are being edited' do
+    expect(page).not_to have_text("Progress (%)")
+
+    wp_page.view_all_attributes
+    wp_page.update_attributes percentageDone: '42'
+
+    expect(page).to have_text("42% Total")
+
+    wp_page.visit!
+    wp_page.update_attributes({ percentageDone: '0' }, save: false)
+
+    expect(page).to have_text("Progress (%)")
+  end
+
   it 'allows updating and seeing the results' do
     wp_page.view_all_attributes
 

--- a/spec/features/work_packages/form_configuration_spec.rb
+++ b/spec/features/work_packages/form_configuration_spec.rb
@@ -110,5 +110,41 @@ describe 'form configuration: ', js: true do
         wp_page.expect_attributes Version: nil
       end
     end
+
+    context 'during creation' do
+      context 'with version having default visibility' do
+        before do
+          type.attribute_visibility['version'] = 'default'
+          type.save!
+
+          wp_page.visit!
+
+          wp_page.expect_attribute_hidden :version
+
+          wp_page.open_new
+        end
+
+        it 'version is not shown' do
+          expect(page).not_to have_text 'Version'
+        end
+      end
+
+      context 'with version always shown' do
+        before do
+          type.attribute_visibility['version'] = 'visible'
+          type.save!
+
+          wp_page.visit!
+
+          wp_page.expect_attributes Version: nil
+
+          wp_page.open_new
+        end
+
+        it 'version is shown' do
+          expect(page).to have_text 'Version'
+        end
+      end
+    end
   end
 end

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -59,6 +59,12 @@ module Pages
       end
     end
 
+    def open_new
+      within '#toolbar-items' do
+        click_on 'Work package'
+      end
+    end
+
     def open_in_split_view
       find('#work-packages-details-view-button').click
     end
@@ -111,17 +117,18 @@ module Pages
                                     text: "##{parent.id} #{parent.type.name}: #{parent.subject}")
     end
 
-    def update_attributes(key_value_map)
-      set_attributes(key_value_map)
+    def update_attributes(key_value_map, save: true)
+      set_attributes(key_value_map, save: save)
     end
 
-    def set_attributes(key_value_map)
+    def set_attributes(key_value_map, save: true)
       key_value_map.each_with_index.map do |(key, value), index|
         field = work_package_field key
         field.activate_edition
 
         field.set_value value
-        field.save! if field.input_element.tag_name != 'select' # select fields are saved on change
+        # select fields are saved on change
+        field.save! if save && field.input_element.tag_name != 'select'
 
         unless index == key_value_map.length - 1
           ensure_no_conflicting_modifications


### PR DESCRIPTION
WP: [#23622](https://community.openproject.com/work_packages/23622/activity)
- fixes the implementation of 'not hiding fields being edited' so that it doesn't break visibility settings
- fixes the visibility logic during work package creation
- removes dead code
- adds complementary regression tests
