### PR TITLE
determine wp sums durations dynamically

### DIFF
--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -57,7 +57,9 @@ module API
 
       property :sums,
                exec_context: :decorator,
-               getter: -> (*) { sums },
+               getter: -> (*) {
+                 ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(sums) if sums
+               },
                render_nil: false
 
       def has_sums?
@@ -72,7 +74,6 @@ module API
 
       attr_reader :sums,
                   :count
-
     end
   end
 end

--- a/lib/api/v3/utilities/custom_field_sum_injector.rb
+++ b/lib/api/v3/utilities/custom_field_sum_injector.rb
@@ -47,6 +47,17 @@ module API
                           }
                         }
         end
+
+        def inject_property_value(custom_field)
+          @class.property property_name(custom_field.id),
+                          getter: property_value_getter_for(custom_field),
+                          setter: property_value_setter_for(custom_field),
+                          render_nil: true,
+                          if: -> (*) {
+                            setting = ::Setting.work_package_list_summable_columns
+                            setting.include?("cf_#{custom_field.id}")
+                          }
+        end
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -105,6 +105,11 @@ module API
 
         property :total_sums,
                  exec_context: :decorator,
+                 getter: -> (*) {
+                   if total_sums
+                     ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(total_sums)
+                   end
+                 },
                  render_nil: false
 
         # Eager load elements used in the representer later

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -147,31 +147,23 @@ module API
         end
 
         def format_query_sums(sums)
-          sums = format_column_keys sums
-          format_durations! sums
+          OpenStruct.new(format_column_keys(sums))
         end
 
         def format_column_keys(hash_by_column)
-          converter = API::Utilities::PropertyNameConverter
           ::Hash[
             hash_by_column.map { |column, value|
-              column_name = converter.from_ar_name(column.name.to_s)
+              match = /cf_(\d+)/.match(column.name.to_s)
+
+              column_name = if match
+                              "custom_field_#{match[1]}"
+                            else
+                              column.name.to_s
+                            end
+
               [column_name, value]
             }
           ]
-        end
-
-        def format_durations!(sums)
-          formatter = ::API::V3::Utilities::DateTimeFormatter
-          # FIXME: this knowledge should not be hardcoded... probably decide with the help of
-          # a WorkPackageSchema?
-          %w(estimatedTime spentTime).each do |attribute|
-            if sums.include? attribute
-              sums[attribute] = formatter.format_duration_from_hours sums[attribute]
-            end
-          end
-
-          sums
         end
 
         def collection_representer(work_packages, project:, query_params:, groups:, sums:)

--- a/lib/api/v3/work_packages/work_package_sums_representer.rb
+++ b/lib/api/v3/work_packages/work_package_sums_representer.rb
@@ -1,0 +1,34 @@
+require 'roar/decorator'
+
+module API
+  module V3
+    module WorkPackages
+      class WorkPackageSumsRepresenter < ::API::Decorators::Single
+        def initialize(sums)
+          # breaking inheritance law here
+          super(sums, current_user: nil)
+        end
+
+        def self.create_class(schema)
+          injector_class = ::API::V3::Utilities::CustomFieldSumInjector
+          injector_class.create_value_representer(schema,
+                                                  self)
+        end
+
+        def self.create(sums)
+          create_class(Schema::WorkPackageSumsSchema.new).new(sums)
+        end
+
+        property :estimated_time,
+                 exec_context: :decorator,
+                 getter: -> (*) {
+                   datetime_formatter.format_duration_from_hours(represented.estimated_hours,
+                                                                 allow_nil: true)
+                 },
+                 if: -> (*) {
+                   ::Setting.work_package_list_summable_columns.include?('estimated_hours')
+                 }
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -219,10 +219,11 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
     end
 
     context 'passing sums' do
-      let(:total_sums) { { custom: 'object' } }
+      let(:total_sums) { OpenStruct.new({ estimated_hours: 1 }) }
 
       it 'renders the groups object as json' do
-        is_expected.to be_json_eql(total_sums.to_json).at_path('totalSums')
+        expected = { 'estimatedTime': 'PT1H' }
+        is_expected.to be_json_eql(expected.to_json).at_path('totalSums')
       end
 
       it 'has a link to the sums schema' do

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
+  let(:available_custom_fields) { [] }
+  let(:sums) { double 'sums', estimated_hours: 5 }
+  let(:schema) { double 'schema', available_custom_fields: available_custom_fields }
+  let(:representer) {
+    described_class.create_class(schema).new(sums)
+  }
+  let(:summable_columns) { [] }
+
+  before do
+    allow(Setting)
+      .to receive(:work_package_list_summable_columns)
+      .and_return(summable_columns)
+  end
+
+  subject { representer.to_json }
+
+  context 'estimated_time' do
+    context 'with it being configured to be summable' do
+      let(:summable_columns) { ['estimated_hours'] }
+
+      it 'is represented' do
+        expected = 'PT5H'
+        expect(subject).to be_json_eql(expected.to_json).at_path('estimatedTime')
+      end
+    end
+
+    context 'without it being configured to be summable' do
+      it 'is not represented when the summable setting does not list it' do
+        expect(subject).to_not have_json_path('estimatedTime')
+      end
+    end
+  end
+
+  context 'custom field x' do
+    let(:custom_field)  { FactoryGirl.build_stubbed(:integer_issue_custom_field, id: 1) }
+    let(:available_custom_fields) { [custom_field] }
+    let(:sums) { double 'sums', custom_field_1: 5 }
+
+    context 'with it being configured to be summable' do
+      let(:summable_columns) { ["cf_#{custom_field.id}"] }
+
+      it 'is represented' do
+        expect(subject).to be_json_eql(sums.custom_field_1.to_json).at_path('customField1')
+      end
+    end
+
+    context 'without it being configured to be summable' do
+      it 'is not represented when the summable setting does not list it' do
+        expect(subject).to_not have_json_path("customField#{custom_field.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces rendering the sums via standard hash rendering by a dedicated WorkPackageSumsRepresenter. That way, we can determine the way summed up attributes are displayed (e.g. duration) in the representer. Additionally, plugins can also determine the way their attributes are displayed.

https://community.openproject.com/work_packages/23662
