### PR TITLE
[23660] Error message embedding timeline on work package page broken

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table_edit.sass
+++ b/app/assets/stylesheets/content/_work_packages_table_edit.sass
@@ -82,6 +82,11 @@
     .work-package--placeholder
       padding: 0 10px 0 0px
 
+  .inplace-edit--read-value--value-span
+    width: 100%
+    .error.macro-unavailable
+      display: inline-block
+
 // Mark focused, non-editable read-values
 .inplace-edit--read-value.-read-only
   &:focus, &:hover

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.html
@@ -1,7 +1,7 @@
 <span>
   <span class="wp-table--cell-span inplace-edit--read-value--value __d__cell" >
 
-    <span class="__d__renderer">
+    <span class="__d__renderer inplace-edit--read-value--value-span">
       <ng-include ng-if="::!$ctrl.field.isManualRenderer"
                   src="::$ctrl.field.template">
       </ng-include>


### PR DESCRIPTION
This fixes the broken styling of error messages in the WP overview. These messages appear when a macro cannot be loaded/displayed.

https://community.openproject.com/work_packages/23660/activity
