### PR TITLE
Fix watcher dropdown sizing

### DIFF
--- a/frontend/app/templates/work_packages/watchers/lookup.html
+++ b/frontend/app/templates/work_packages/watchers/lookup.html
@@ -23,10 +23,12 @@
                   ng-disabled="locked"
                   ng-model="selection.watcher"
                   title="{{ ::I18n.t('js.watchers.label_search_watchers') }}"
+                  append-to-body="true"
                   reset-search-input="true"
                   theme="select2">
               <ui-select-match>{{ $select.selected.name }}</ui-select-match>
               <ui-select-choices
+                      position="down"
                       repeat="watcher as watcher in watchers | filter: $select.search">
                   <div aria-label="{{ watcher.name }}" ng-bind-html="watcher.name | highlight: $select.search"></div>
               </ui-select-choices>


### PR DESCRIPTION
Due to the custom select2 styling, position=up seems to be broken.
position=down will be cut off due to overflow unless the container is added to the body.
