### PR TITLE
[23664] Query menu not closed after selection

### DIFF
--- a/frontend/app/work_packages/controllers/menus/query-select-dropdown-menu-controller.js
+++ b/frontend/app/work_packages/controllers/menus/query-select-dropdown-menu-controller.js
@@ -198,6 +198,7 @@ module.exports = function($scope, $sce, LABEL_MAX_CHARS, KEY_CODES) {
 
   scope.switchToSelectedQuery = function(queryId) {
     scope.transitionMethod(queryId);
+    $scope.$root.$broadcast('openproject.dropdown.closeDropdowns', true);
   }
 
   scope.reload = function(modelId, newTitle) {


### PR DESCRIPTION
The query select drop down was not closed after a query was chosen by enter. This closes the drop down explicitly after a query was selected.

https://community.openproject.com/work_packages/23664/activity
