### PR TITLE
[23653] Scrolling to bottom of work package timeline modal not possible

### DIFF
--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -154,7 +154,7 @@ $work-package-details--tab-height: 40px
 
 
 .work-package--new-state
-  padding: 0 20px 64px 0
+  padding: 0 20px 0px 0
   overflow-y: auto
 
   .work-packages--edit-actions

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -149,7 +149,6 @@
       font-size: 0.9rem
 
     .work-package--new-state
-      margin-bottom: 0
       overflow: auto
       padding-right: 0
 


### PR DESCRIPTION
This fixes the distance of the wp-new box to the bottom so that it works in all browsers.

https://community.openproject.com/work_packages/23653/activity
