### PR TITLE
[23468] [6b] Label-Element verweist nicht korrekt auf Formularfeld

### DIFF
--- a/app/views/timelines/_general.html.erb
+++ b/app/views/timelines/_general.html.erb
@@ -96,7 +96,8 @@ See doc/COPYRIGHT.rdoc for more details.
                             { selected: timeline.selected_columns,
                               no_label: true },
                             { multiple: true,
-                              size: 12 } %>
+                              size: 12,
+                              id: "timeline_options_columns_" } %>
             <% else %>
               <%= ff.hidden_field :columns,
                                   name: "timeline[options][columns][]",


### PR DESCRIPTION
This sets the correct ID to the select box. Thus it matches the label `for` attribute and the screen reader reads it correctly.

https://community.openproject.com/work_packages/23468/activity
