### PR TITLE
[23470] [6c] Zwei Label-Elemente verweisen auf ein Formularfeld

### DIFF
--- a/app/views/queries/_filters.html.erb
+++ b/app/views/queries/_filters.html.erb
@@ -163,7 +163,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <li style="display:none" id="filter_spacer" class="advanced-filters--spacer"></li>
 
   <li class="advanced-filters--add-filter">
-    <label for="add_filter_select" class="advanced-filters--add-filter-label">
+    <label for="add_filter_select" aria-hidden="true" class="advanced-filters--add-filter-label">
       <i class="icon-add icon4"></i>
       <%= l(:label_filter_add) %>
     </label>

--- a/app/views/queries/_filters.html.erb
+++ b/app/views/queries/_filters.html.erb
@@ -168,6 +168,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= l(:label_filter_add) %>
     </label>
     <label for="add_filter_select" class="hidden-for-sighted">
+      {{ I18n.t('js.work_packages.label_filter_add') }}
       {{ I18n.t('js.filter.description.text_open_filter') }}
       {{ I18n.t('js.filter.description.text_close_filter') }}
     </label>

--- a/frontend/app/components/filters/query-filters/query-filters.directive.html
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.html
@@ -147,7 +147,7 @@
 
     <li class="advanced-filters--add-filter">
       <!-- Add filters -->
-      <label for="add_filter_select" class="advanced-filters--add-filter-label">
+      <label for="add_filter_select" aria-hidden="true" class="advanced-filters--add-filter-label">
         <i class="icon-add icon4"></i>
         {{ I18n.t('js.work_packages.label_filter_add') }}:
       </label>

--- a/frontend/app/components/filters/query-filters/query-filters.directive.html
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.html
@@ -152,6 +152,7 @@
         {{ I18n.t('js.work_packages.label_filter_add') }}:
       </label>
       <label for="add_filter_select" class="hidden-for-sighted">
+        {{ I18n.t('js.work_packages.label_filter_add') }}
         {{ I18n.t('js.filter.description.text_open_filter') }}
         {{ I18n.t('js.filter.description.text_close_filter') }}
       </label>


### PR DESCRIPTION
This adds additional information to the hidden label. Thus there are still two labels for the field: One is visible and one is invisible and contains additional information on how to handle the field.

https://community.openproject.com/work_packages/23470/activity
