### PR TITLE
[23034] Improve settings caching

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -132,12 +132,7 @@ class Setting < ActiveRecord::Base
   validates_numericality_of :value, only_integer: true, if: Proc.new { |setting| @@available_settings[setting.name]['format'] == 'int' }
 
   def value
-    v = read_attribute(:value)
-    # Unserialize serialized settings
-    v = YAML::load(v) if @@available_settings[name]['serialized'] && v.is_a?(String)
-    v = v.to_sym if @@available_settings[name]['format'] == 'symbol' && !v.blank?
-    v = v.to_i if @@available_settings[name]['format'] == 'int' && !v.blank?
-    v
+    self.class.deserialize(name, read_attribute(:value))
   end
 
   def value=(v)
@@ -147,21 +142,30 @@ class Setting < ActiveRecord::Base
 
   # Returns the value of the setting named name
   def self.[](name)
-    Marshal.load(Rails.cache.fetch(cache_key(name)) { Marshal.dump(find_or_default(name).value) })
+    cached_or_default(name)
   end
 
   def self.[]=(name, v)
-    setting = find_or_default(name)
-    # remember the old setting and mark it as read-only
-    old_setting = setting.dup.freeze
-    setting.value = (v ? v : '')
-    Rails.cache.delete(cache_key(name))
-    if setting.save
+    old_setting = cached_or_default(name)
+    new_setting = find_or_initialize_by(name: name)
+    new_setting.value = v
+
+    # Keep the current cache key,
+    # since updated_on will change after .save
+    old_cache_key = cache_key
+
+    if new_setting.save
+      new_value = new_setting.value
+
       # fire callbacks for name and pass as much information as possible
-      fire_callbacks(name, setting, old_setting)
-      setting.value
+      fire_callbacks(name, new_value, old_setting)
+
+      # Delete the cache
+      clear_cache(old_cache_key)
+
+      new_value
     else
-      old_setting.value
+      old_setting
     end
   end
 
@@ -189,27 +193,42 @@ class Setting < ActiveRecord::Base
     per_page_options.split(%r{[\s,]}).map(&:to_i).select { |n| n > 0 }.sort
   end
 
+  def self.clear_cache(key = cache_key)
+    Rails.cache.delete(key)
+    RequestStore.delete :cached_settings
+    RequestStore.delete :settings_updated_on
+  end
+
   private
 
   # Returns the Setting instance for the setting named name
-  # (record found in database or new record with default value)
-  def self.find_or_default(name)
+  # (record found in cache or default value)
+  def self.cached_or_default(name)
     name = name.to_s
     raise "There's no setting named #{name}" unless exists? name
-    find_by(name: name) or new do |s|
-      s.name  = name
-      s.value = @@available_settings[name]['default']
-    end
+
+    value = cached_settings.fetch(name) { @@available_settings[name]['default'] }
+    deserialize(name, value)
   end
 
-  def self.cache_key(name)
+  # Returns the settings from two levels of cache
+  # 1. The current rack request using RequestStore
+  # 2. Rails.cache serialized settings hash
+  #
+  # Unless one cache hits, it plucks from the database
+  # Returns a hash of setting => (possibly serialized) value
+  def self.cached_settings
+    RequestStore.fetch(:cached_settings) {
+      Rails.cache.fetch(cache_key) {
+        Hash[Setting.pluck(:name, :value)]
+      }
+    }
+  end
+
+  def self.cache_key
     RequestStore.store[:settings_updated_on] ||= Setting.maximum(:updated_on)
     most_recent_settings_change = (RequestStore.store[:settings_updated_on] || Time.now.utc).to_i
-    base_cache_key(name, most_recent_settings_change)
-  end
-
-  def self.base_cache_key(name, timestamp)
-    "/openproject/settings/#{timestamp}/#{name}"
+    "/openproject/settings/all/#{most_recent_settings_change}"
   end
 
   def self.settings_table_exists_yet?
@@ -219,6 +238,20 @@ class Setting < ActiveRecord::Base
     # and caching this improves performance significantly for actions
     # accessing settings a lot.
     @settings_table_exists_yet ||= connection.table_exists?(table_name)
+  end
+
+  # Unserialize a serialized settings value
+  def self.deserialize(name, v)
+    default = @@available_settings[name]
+
+    v = YAML::load(v) if default['serialized'] && v.is_a?(String)
+
+    unless v.blank?
+      v = v.to_sym if default['format'] == 'symbol'
+      v = v.to_i if default['format'] == 'int'
+    end
+
+    v
   end
 
   require_dependency 'setting/callbacks'

--- a/app/models/setting/callbacks.rb
+++ b/app/models/setting/callbacks.rb
@@ -38,8 +38,8 @@ class Setting
     # instructs the underlying notifications system to publish all setting events for setting #name
     # based on the new and old setting objects different events can be triggered
     # currently, that's whenever a setting is set regardless whether the value changed
-    def fire_callbacks(name, setting, old_setting)
-      notifier.send(notification_event_for(name), event_payload_for(setting, old_setting))
+    def fire_callbacks(name, new_value, old_value)
+      notifier.send(notification_event_for(name), value: new_value, old_value: old_value)
     end
 
     private
@@ -47,11 +47,6 @@ class Setting
     # encapsulates the event name broadcast to all subscribers
     def notification_event_for(name)
       "setting.#{name}.changed"
-    end
-
-    # encapsulates the payload expected by the notifier
-    def event_payload_for(setting, old_setting)
-      { value: setting.value, old_value: old_setting.value }
     end
 
     # the notifier to delegate to

--- a/config/initializers/homescreen.rb
+++ b/config/initializers/homescreen.rb
@@ -33,7 +33,7 @@ require 'open_project/static/links'
 OpenProject::Static::Homescreen.manage :blocks do |blocks|
   blocks.push(
     { partial: 'welcome',
-      if: Proc.new { Setting.welcome_on_homescreen? && !Setting.welcome_text.empty? } },
+      if: Proc.new { Setting.welcome_on_homescreen? && Setting.welcome_text.present? } },
     { partial: 'projects' },
     { partial: 'users',
       if: Proc.new { User.current.admin? } },

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -44,18 +44,6 @@ describe ProjectsController, type: :controller do
     @params = {}
   end
 
-  def clear_settings_cache
-    Rails.cache.clear
-  end
-
-  # this is the base method for get, post, etc.
-  def process(*args)
-    clear_settings_cache
-    result = super
-    clear_settings_cache
-    result
-  end
-
   describe 'show' do
     render_views
 

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -40,18 +40,6 @@ describe SettingsController, type: :controller do
   describe 'edit' do
     render_views
 
-    def clear_settings_cache
-      Rails.cache.clear
-    end
-
-    # this is the base method for get, post, etc.
-    def process(*args)
-      clear_settings_cache
-      result = super
-      clear_settings_cache
-      result
-    end
-
     before(:all) do
       @previous_projects_modules = Setting.default_projects_modules
     end

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -60,6 +60,9 @@ describe SysController, type: :controller do
     allow(Setting).to receive(:sys_api_key).and_return(api_key)
     allow(Setting).to receive(:sys_api_enabled?).and_return(true)
     allow(Setting).to receive(:repository_authentication_caching_enabled?).and_return(true)
+
+    Rails.cache.clear
+    RequestStore.clear!
   end
 
   describe 'svn' do
@@ -516,11 +519,6 @@ describe SysController, type: :controller do
     end
   end
 
-  before(:each) do
-    Rails.cache.clear
-    allow(Rails.cache).to receive(:kind_of?).with(anything).and_return(false)
-  end
-
   describe '#cached_user_login' do
     let(:cache_key) {
       OpenProject::RepositoryAuthentication::CACHE_PREFIX +
@@ -544,18 +542,6 @@ describe SysController, type: :controller do
     end
 
     it 'should use cache' do
-      # allow the cache to return something reasonable for
-      # other requests, while ensuring that it is not queried
-      # with the cache key in question
-
-      # unfortunately, and_call_original currently fails
-      allow(Rails.cache).to receive(:fetch) do |*args|
-        expect(args.first).not_to eq(cache_key)
-
-        name = args.first.split('/').last
-        Marshal.dump(Setting.send(:find_or_default, name).value)
-      end
-      # Rails.cache.should_receive(:fetch).with(anything).and_call_original
       expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: cache_expiry) \
         .and_return(Marshal.dump(valid_user.id.to_s))
       controller.send(:cached_user_login, valid_user.login, valid_user_password)
@@ -567,16 +553,9 @@ describe SysController, type: :controller do
       end
 
       it 'should not use a cache' do
-        # allow the cache to return something reasonable for
-        # other requests, while ensuring that it is not queried
-        # with the cache key in question
-        #
-        # unfortunately, and_call_original currently fails
-        allow(Rails.cache).to receive(:fetch) do |*args|
+        allow(Rails.cache).to receive(:fetch).and_wrap_original do |m, *args, &block|
           expect(args.first).not_to eq(cache_key)
-
-          name = args.first.split('/').last
-          Marshal.dump(Setting.send(:find_or_default, name).value)
+          m.call(*args, &block)
         end
 
         controller.send(:cached_user_login, valid_user.login, valid_user_password)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -105,6 +105,90 @@ describe Setting, type: :model do
     end
   end
 
+  describe 'caching' do
+    let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+    let(:cache_key) { Setting.send :cache_key }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(cache)
+    end
+
+    context 'cache is empty' do
+      it 'requests the settings once from database' do
+        expect(Setting).to receive(:pluck).with(:name, :value)
+          .once
+          .and_call_original
+
+        expect(cache).to receive(:fetch).once.and_call_original
+        expect(RequestStore).to receive(:fetch).exactly(3).times.and_call_original
+
+        # Settings are empty by default
+        expect(RequestStore.read(:cached_settings)).to be_nil
+        expect(Rails.cache.read(cache_key)).to be_nil
+
+        # Falls back to default values, but hitting cache
+        value = Setting.app_title
+        expect(Setting.app_title).to eq 'OpenProject'
+        expect(value).to eq(Setting.app_title)
+
+        # Settings are empty by default
+        expect(RequestStore.read(:cached_settings)).to eq({})
+        expect(Rails.cache.read(cache_key)).to eq({})
+      end
+
+      it 'clears the cache when writing a setting' do
+        expect(Setting.app_title).to eq 'OpenProject'
+        expect(RequestStore.read(:cached_settings)).to eq({})
+
+        new_title = 'OpenProject with changed title'
+        Setting.app_title = new_title
+        expect(RequestStore.read(:cached_settings)).to be_nil
+        expect(Rails.cache.read(cache_key)).to be_nil
+
+        expect(Setting.app_title).to eq(new_title)
+        expect(Setting.count).to eq(1)
+        expect(RequestStore.read(:cached_settings)).to eq('app_title' => new_title)
+      end
+    end
+
+    context 'cache is not empty' do
+      let(:cached_hash) {
+        { 'available_languages' => "---\n- en\n- de\n" }
+      }
+
+      before do
+        cache.write(cache_key, cached_hash)
+      end
+
+      it 'returns the value from the deeper cache' do
+        expect(RequestStore.read(:cached_settings)).to be_nil
+        expect(Setting.available_languages).to eq(%w(en de))
+
+        expect(RequestStore.read(:cached_settings)).to eq(cached_hash)
+      end
+
+      it 'expires the cache when writing a setting' do
+        Setting.available_languages = %w(en)
+        expect(RequestStore.read(:cached_settings)).to be_nil
+        expect(Rails.cache.read(cache_key)).to be_nil
+
+        # Creates a new cache key
+        new_cache_key = Setting.send(:cache_key)
+        new_hash = { 'available_languages' => "---\n- en\n" }
+        expect(new_cache_key).not_to be eq(cache_key)
+
+        # No caching is done until first read
+        expect(RequestStore.read(:cached_settings)).to be_nil
+        expect(Rails.cache.read(cache_key)).to be_nil
+        expect(Rails.cache.read(new_cache_key)).to be_nil
+
+        expect(Setting.available_languages).to eq(%w(en))
+        expect(Rails.cache.read(new_cache_key)).to eq(new_hash)
+        expect(RequestStore.read(:cached_settings)).to eq(new_hash)
+      end
+    end
+  end
+
   # tests stuff regarding settings callbacks
   describe 'callbacks' do
     # collects data for the dummy callback

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -99,18 +99,15 @@ describe Setting, type: :model do
 
     after do
       Setting.find_by(name: 'notified_events').destroy
-      # have to clear the cache as well
-      # as settings are stored there
-      Rails.cache.clear
     end
   end
 
   describe 'caching' do
-    let(:cache) { ActiveSupport::Cache::MemoryStore.new }
     let(:cache_key) { Setting.send :cache_key }
 
     before do
-      allow(Rails).to receive(:cache).and_return(cache)
+      RequestStore.clear!
+      Rails.cache.clear
     end
 
     context 'cache is empty' do
@@ -119,7 +116,7 @@ describe Setting, type: :model do
           .once
           .and_call_original
 
-        expect(cache).to receive(:fetch).once.and_call_original
+        expect(Rails.cache).to receive(:fetch).once.and_call_original
         expect(RequestStore).to receive(:fetch).exactly(3).times.and_call_original
 
         # Settings are empty by default
@@ -157,7 +154,7 @@ describe Setting, type: :model do
       }
 
       before do
-        cache.write(cache_key, cached_hash)
+        Rails.cache.write(cache_key, cached_hash)
       end
 
       it 'returns the value from the deeper cache' do
@@ -252,9 +249,6 @@ describe Setting, type: :model do
 
     after do
       Setting.destroy_all
-      # have to clear the cache as well
-      # as settings are stored there
-      Rails.cache.clear
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,6 @@ RSpec.configure do |config|
 
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
-    RequestStore.clear!
   end
 
   config.after(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,7 @@ RSpec.configure do |config|
 
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
+    RequestStore.clear!
   end
 
   config.after(:each) do

--- a/spec_legacy/functional/projects_controller_spec.rb
+++ b/spec_legacy/functional/projects_controller_spec.rb
@@ -280,8 +280,9 @@ describe ProjectsController, type: :controller do
     end
   end
 
-  it 'should create should preserve modules on validation failure' do
-    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
+  context 'with default modules',
+          with_settings: { default_projects_modules: %w(work_package_tracking repository) } do
+    it 'should create should preserve modules on validation failure' do
       session[:user_id] = 1
       assert_no_difference 'Project.count' do
         post :create, project: {

--- a/spec_legacy/functional/user_mailer_spec.rb
+++ b/spec_legacy/functional/user_mailer_spec.rb
@@ -233,15 +233,15 @@ describe UserMailer, type: :mailer do
     assert mail.encoded.include?('href')
   end
 
-  it 'should mail from with phrase' do
-    user  = FactoryGirl.create(:user)
-    FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
-    with_settings mail_from: 'Redmine app <redmine@example.net>' do
+  context 'with mail_from set', with_settings: { mail_from: 'Redmine app <redmine@example.net>' } do
+    it 'should mail from with phrase' do
+      user  = FactoryGirl.create(:user)
+      FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
       UserMailer.test_mail(user).deliver_now
+      mail = ActionMailer::Base.deliveries.last
+      refute_nil mail
+      assert_equal 'Redmine app <redmine@example.net>', mail.header['From'].to_s
     end
-    mail = ActionMailer::Base.deliveries.last
-    refute_nil mail
-    assert_equal 'Redmine app <redmine@example.net>', mail.header['From'].to_s
   end
 
   it 'should not send email without recipient' do
@@ -317,22 +317,21 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  context('#issue_add') do
+  context '#issue_add',
+          with_settings: { available_languages: ['en', 'de'], default_language: 'de' } do
     it 'should change mail language depending on recipient language' do
       issue = FactoryGirl.create(:work_package)
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: 'de')
       FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
 
-      with_settings available_languages: ['en', 'de'] do
-        I18n.locale = 'en'
-        assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
-        assert_equal 1, ActionMailer::Base.deliveries.size
-        mail = last_email
-        assert_equal ['foo@bar.de'], mail.to
-        assert mail.body.encoded.include?('erstellt')
-        assert !mail.body.encoded.include?('reported')
-        assert_equal :en, I18n.locale
-      end
+      I18n.locale = 'en'
+      assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+      assert_equal 1, ActionMailer::Base.deliveries.size
+      mail = last_email
+      assert_equal ['foo@bar.de'], mail.to
+      assert mail.body.encoded.include?('erstellt')
+      assert !mail.body.encoded.include?('reported')
+      assert_equal :en, I18n.locale
     end
 
     it 'should falls back to default language if user has no language' do
@@ -343,17 +342,14 @@ describe UserMailer, type: :mailer do
       user  = FactoryGirl.create(:user, mail: 'foo@bar.de', language: '') # (auto)
       FactoryGirl.create(:user_preference, user: user, others: { no_self_notified: false })
 
-      with_settings available_languages: ['en', 'de'],
-                    default_language: 'de' do
-        I18n.locale = 'de'
-        assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
-        assert_equal 1, ActionMailer::Base.deliveries.size
-        mail = last_email
-        assert_equal ['foo@bar.de'], mail.to
-        assert !mail.body.encoded.include?('reported')
-        assert mail.body.encoded.include?('erstellt')
-        assert_equal :de, I18n.locale
-      end
+      I18n.locale = 'de'
+      assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+      assert_equal 1, ActionMailer::Base.deliveries.size
+      mail = last_email
+      assert_equal ['foo@bar.de'], mail.to
+      assert !mail.body.encoded.include?('reported')
+      assert mail.body.encoded.include?('erstellt')
+      assert_equal :de, I18n.locale
     end
   end
 
@@ -427,9 +423,9 @@ describe UserMailer, type: :mailer do
     assert_equal '1 work package(s) due in the next 42 days', mail.subject
   end
 
-  it 'should mailer should not change locale' do
-    with_settings available_languages: ['en', 'de'],
-                  default_language:    'en' do
+  context 'with locale settings',
+          with_settings: { available_languages: ['en', 'de'], default_language: 'de' } do
+    it 'should mailer should not change locale' do
       # Set current language to english
       I18n.locale = :en
       # Send an email to a german user
@@ -451,20 +447,16 @@ describe UserMailer, type: :mailer do
     assert ActionMailer::Base.perform_deliveries
   end
 
-  context 'layout' do
+  context 'layout',
+          with_settings: {
+            available_languages: [:en, :de],
+            localized_emails_header: 'deutscher header'
+          } do
     it 'should include the emails_header depeding on the locale' do
-      with_settings available_languages: [:en, :de],
-                    emails_header: { 'de' => 'deutscher header',
-                                     'en' => 'english header' } do
-        user = FactoryGirl.create(:user, language: :en)
-        assert UserMailer.test_mail(user).deliver_now
-        mail = ActionMailer::Base.deliveries.last
-        assert mail.body.encoded.include?('english header')
-        user.language = :de
-        assert UserMailer.test_mail(user).deliver_now
-        mail = ActionMailer::Base.deliveries.last
-        assert mail.body.encoded.include?('deutscher header')
-      end
+      user = FactoryGirl.create(:user, language: :de)
+      assert UserMailer.test_mail(user).deliver_now
+      mail = ActionMailer::Base.deliveries.last
+      assert mail.body.encoded.include?('deutscher header')
     end
   end
 

--- a/spec_legacy/integration/application_spec.rb
+++ b/spec_legacy/integration/application_spec.rb
@@ -28,7 +28,7 @@
 #++
 require_relative '../legacy_spec_helper'
 
-describe 'Application' do
+describe 'Application', with_settings: { login_required?: false } do
   include Redmine::I18n
 
   def document_root_element
@@ -36,12 +36,6 @@ describe 'Application' do
   end
 
   fixtures :all
-
-  around do |example|
-    with_settings login_required: '0' do
-      example.run
-    end
-  end
 
   it 'set localization' do
     allow(Setting).to receive(:available_languages).and_return [:de, :en]

--- a/spec_legacy/integration/layout_spec.rb
+++ b/spec_legacy/integration/layout_spec.rb
@@ -36,6 +36,20 @@ describe 'Layout' do
     html_document.root
   end
 
+  context 'with login required', with_settings: { login_required?: true } do
+    it 'should top menu navigation not visible when login required' do
+      get '/'
+      assert_select '#account-nav-left', 0
+    end
+  end
+
+  context 'with login required', with_settings: { login_required?: false } do
+    it 'should top menu navigation visible when login not required' do
+      get '/'
+      assert_select '#account-nav-left'
+    end
+  end
+
   specify 'browsing to a missing page should render the base layout' do
     get '/users/100000000'
 
@@ -45,32 +59,16 @@ describe 'Layout' do
     assert_select '#main-menu', count: 0
   end
 
-  it 'should top menu navigation not visible when login required' do
-    with_settings login_required: '1' do
-      get '/'
-      assert_select '#account-nav-left', 0
-    end
-  end
-
-  it 'should top menu navigation visible when login not required' do
-    with_settings login_required: '0' do
-      get '/'
-      assert_select '#account-nav-left'
-    end
-  end
-
-  specify 'page titles should be properly escaped' do
+  specify 'page titles should be properly escaped',
+          with_settings: { app_title: '<3' } do
     project = FactoryGirl.create(:project, name: 'C&A', is_public: true)
+    get "/projects/#{project.to_param}"
 
-    with_settings app_title: '<3' do
-      get "/projects/#{project.to_param}"
-
-      def title_html
-        title = document_root_element.at('//title') and title.inner_html
-      end
-
-      expect(title_html).to match /C&amp;A/
-      expect(title_html).to match /&lt;3/
+    def title_html
+      title = document_root_element.at('//title') and title.inner_html
     end
+
+    expect(title_html).to match /C&amp;A/
+    expect(title_html).to match /&lt;3/
   end
 end

--- a/spec_legacy/integration/lib/redmine/menu_manager_spec.rb
+++ b/spec_legacy/integration/lib/redmine/menu_manager_spec.rb
@@ -28,19 +28,13 @@
 #++
 require 'legacy_spec_helper'
 
-describe 'MenuManager' do
+describe 'MenuManager', with_settings: { login_required: 0 } do
   include Redmine::I18n
 
   fixtures :all
 
   def document_root_element
     html_document.root
-  end
-
-  around do |example|
-    with_settings login_required: '0' do
-      example.run
-    end
   end
 
   it 'project menu with specific locale' do

--- a/spec_legacy/unit/changeset_spec.rb
+++ b/spec_legacy/unit/changeset_spec.rb
@@ -31,8 +31,8 @@ require 'legacy_spec_helper'
 describe Changeset, type: :model do
   fixtures :all
 
-  it 'should ref keywords any' do
-    with_settings notified_events: %w(work_package_updated) do
+  context 'with notified events', with_settings: { notified_events: %w(work_package_updated) } do
+    it 'should ref keywords any' do
       WorkPackage.all.each(&:recreate_initial_journal!)
 
       Setting.commit_fix_status_id = Status.where(['is_closed = ?', true]).first.id
@@ -51,195 +51,212 @@ describe Changeset, type: :model do
       assert_equal 90, fixed.done_ratio
       assert_equal 2, ActionMailer::Base.deliveries.size
     end
-  end
 
-  it 'should ref keywords' do
-    Setting.commit_ref_keywords = 'refs'
-    Setting.commit_fix_keywords = ''
+    it 'should ref keywords' do
+      Setting.commit_ref_keywords = 'refs'
+      Setting.commit_fix_keywords = ''
 
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: 'Ignores #2. Refs #1')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [1], c.work_package_ids.sort
-  end
-
-  it 'should ref keywords any only' do
-    Setting.commit_ref_keywords = '*'
-    Setting.commit_fix_keywords = ''
-
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: 'Ignores #2. Refs #1')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [1, 2], c.work_package_ids.sort
-  end
-
-  it 'should ref keywords any with timelog' do
-    Setting.commit_ref_keywords = '*'
-    Setting.commit_logtime_enabled = '1'
-
-    {
-      '2' => 2.0,
-      '2h' => 2.0,
-      '2hours' => 2.0,
-      '15m' => 0.25,
-      '15min' => 0.25,
-      '3h15' => 3.25,
-      '3h15m' => 3.25,
-      '3h15min' => 3.25,
-      '3:15' => 3.25,
-      '3.25' => 3.25,
-      '3.25h' => 3.25,
-      '3,25' => 3.25,
-      '3,25h' => 3.25,
-    }.each do |syntax, expected_hours|
       c = Changeset.new(repository: Project.find(1).repository,
-                        committed_on: 24.hours.ago,
-                        comments: "Worked on this work_package #1 @#{syntax}",
-                        revision: '520',
+                        committed_on: Time.now,
+                        comments: 'Ignores #2. Refs #1')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [1], c.work_package_ids.sort
+    end
+
+    it 'should ref keywords any only' do
+      Setting.commit_ref_keywords = '*'
+      Setting.commit_fix_keywords = ''
+
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: 'Ignores #2. Refs #1')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [1, 2], c.work_package_ids.sort
+    end
+
+    it 'should ref keywords any with timelog' do
+      Setting.commit_ref_keywords = '*'
+      Setting.commit_logtime_enabled = '1'
+
+      {
+        '2' => 2.0,
+        '2h' => 2.0,
+        '2hours' => 2.0,
+        '15m' => 0.25,
+        '15min' => 0.25,
+        '3h15' => 3.25,
+        '3h15m' => 3.25,
+        '3h15min' => 3.25,
+        '3:15' => 3.25,
+        '3.25' => 3.25,
+        '3.25h' => 3.25,
+        '3,25' => 3.25,
+        '3,25h' => 3.25
+      }.each do |syntax, expected_hours|
+        c = Changeset.new(repository: Project.find(1).repository,
+                          committed_on: 24.hours.ago,
+                          comments: "Worked on this work_package #1 @#{syntax}",
+                          revision: '520',
+                          user: User.find(2))
+        assert_difference 'TimeEntry.count' do
+          c.scan_comment_for_work_package_ids
+        end
+        assert_equal [1], c.work_package_ids.sort
+
+        time = TimeEntry.order('id DESC').first
+        assert_equal 1, time.work_package_id
+        assert_equal 1, time.project_id
+        assert_equal 2, time.user_id
+        assert_equal expected_hours,
+                     time.hours,
+                     "@#{syntax} should be logged as #{expected_hours} hours but was #{time.hours}"
+        assert_equal Date.yesterday, time.spent_on
+        assert time.activity.is_default?
+        assert time.comments.include?('r520'),
+               "r520 was expected in time_entry comments: #{time.comments}"
+      end
+    end
+
+    it 'should ref keywords closing with timelog' do
+      Setting.commit_fix_status_id = Status.where(['is_closed = ?', true]).first.id
+      Setting.commit_ref_keywords = '*'
+      Setting.commit_fix_keywords = 'fixes , closes'
+      Setting.commit_logtime_enabled = '1'
+
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: 'This is a comment. Fixes #1 @4.5, #2 @1',
                         user: User.find(2))
-      assert_difference 'TimeEntry.count' do
+      assert_difference 'TimeEntry.count', 2 do
         c.scan_comment_for_work_package_ids
       end
-      assert_equal [1], c.work_package_ids.sort
 
-      time = TimeEntry.order('id DESC').first
-      assert_equal 1, time.work_package_id
-      assert_equal 1, time.project_id
-      assert_equal 2, time.user_id
-      assert_equal expected_hours, time.hours, "@#{syntax} should be logged as #{expected_hours} hours but was #{time.hours}"
-      assert_equal Date.yesterday, time.spent_on
-      assert time.activity.is_default?
-      assert time.comments.include?('r520'), "r520 was expected in time_entry comments: #{time.comments}"
+      assert_equal [1, 2], c.work_package_ids.sort
+      assert WorkPackage.find(1).closed?
+      assert WorkPackage.find(2).closed?
+
+      times = TimeEntry.order('id desc').limit(2)
+      assert_equal [1, 2], times.map(&:work_package_id).sort
     end
-  end
 
-  it 'should ref keywords closing with timelog' do
-    Setting.commit_fix_status_id = Status.where(['is_closed = ?', true]).first.id
-    Setting.commit_ref_keywords = '*'
-    Setting.commit_fix_keywords = 'fixes , closes'
-    Setting.commit_logtime_enabled = '1'
+    it 'should ref keywords any line start' do
+      Setting.commit_ref_keywords = '*'
 
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: 'This is a comment. Fixes #1 @4.5, #2 @1',
-                      user: User.find(2))
-    assert_difference 'TimeEntry.count', 2 do
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: '#1 is the reason of this commit')
       c.scan_comment_for_work_package_ids
+
+      assert_equal [1], c.work_package_ids.sort
     end
 
-    assert_equal [1, 2], c.work_package_ids.sort
-    assert WorkPackage.find(1).closed?
-    assert WorkPackage.find(2).closed?
+    it 'should ref keywords allow brackets around a work package number' do
+      Setting.commit_ref_keywords = '*'
 
-    times = TimeEntry.order('id desc').limit(2)
-    assert_equal [1, 2], times.map(&:work_package_id).sort
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: '[#1] Worked on this work_package')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [1], c.work_package_ids.sort
+    end
+
+    it 'should ref keywords allow brackets around multiple work package numbers' do
+      Setting.commit_ref_keywords = '*'
+
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: '[#1 #2, #3] Worked on these')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [1, 2, 3], c.work_package_ids.sort
+    end
+
+    it 'should commit referencing a subproject work package' do
+      c = Changeset.new(repository: Project.find(1).repository,
+                        committed_on: Time.now,
+                        comments: 'refs #5, a subproject work_package')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [5], c.work_package_ids.sort
+      assert c.work_packages.first.project != c.project
+    end
+
+    it 'should commit referencing a parent project work package' do
+      # repository of child project
+      r = Repository::Subversion.create!(
+        project: Project.find(3),
+        scm_type: 'existing',
+        url:      'svn://localhost/test')
+
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        comments: 'refs #2, an work_package of a parent project')
+      c.scan_comment_for_work_package_ids
+
+      assert_equal [2], c.work_package_ids.sort
+      assert c.work_packages.first.project != c.project
+    end
+
+    it 'should text tag revision' do
+      c = Changeset.new(revision: '520')
+      assert_equal 'r520', c.text_tag
+    end
+
+    it 'should text tag hash' do
+      c = Changeset.new(
+        scmid:    '7234cb2750b63f47bff735edc50a1c0a433c2518',
+        revision: '7234cb2750b63f47bff735edc50a1c0a433c2518')
+      assert_equal 'commit:7234cb2750b63f47bff735edc50a1c0a433c2518', c.text_tag
+    end
+
+    it 'should text tag hash all number' do
+      c = Changeset.new(scmid: '0123456789', revision: '0123456789')
+      assert_equal 'commit:0123456789', c.text_tag
+    end
+
+    it 'should previous' do
+      changeset = Changeset.find_by(revision: '3')
+      assert_equal Changeset.find_by(revision: '2'), changeset.previous
+    end
+
+    it 'should previous nil' do
+      changeset = Changeset.find_by(revision: '1')
+      assert_nil changeset.previous
+    end
+
+    it 'should next' do
+      changeset = Changeset.find_by(revision: '2')
+      assert_equal Changeset.find_by(revision: '3'), changeset.next
+    end
+
+    it 'should next nil' do
+      changeset = Changeset.find_by(revision: '10')
+      assert_nil changeset.next
+    end
   end
 
-  it 'should ref keywords any line start' do
-    Setting.commit_ref_keywords = '*'
+  context 'enabled scm', with_settings: { enabled_scm: ['subversion'] } do
+    it 'should comments empty' do
+      r = FactoryGirl.create(:repository_subversion)
 
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: '#1 is the reason of this commit')
-    c.scan_comment_for_work_package_ids
+      assert r
+      c = Changeset.new(repository: r,
+                        committed_on: Time.now,
+                        revision: '123',
+                        scmid: '12345',
+                        comments: '')
+      assert(c.save)
+      assert_equal '', c.comments
+      if c.comments.respond_to?(:force_encoding)
+        assert_equal 'UTF-8', c.comments.encoding.to_s
+      end
+    end
 
-    assert_equal [1], c.work_package_ids.sort
-  end
-
-  it 'should ref keywords allow brackets around a work package number' do
-    Setting.commit_ref_keywords = '*'
-
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: '[#1] Worked on this work_package')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [1], c.work_package_ids.sort
-  end
-
-  it 'should ref keywords allow brackets around multiple work package numbers' do
-    Setting.commit_ref_keywords = '*'
-
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: '[#1 #2, #3] Worked on these')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [1, 2, 3], c.work_package_ids.sort
-  end
-
-  it 'should commit referencing a subproject work package' do
-    c = Changeset.new(repository: Project.find(1).repository,
-                      committed_on: Time.now,
-                      comments: 'refs #5, a subproject work_package')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [5], c.work_package_ids.sort
-    assert c.work_packages.first.project != c.project
-  end
-
-  it 'should commit referencing a parent project work package' do
-    # repository of child project
-    r = Repository::Subversion.create!(
-      project: Project.find(3),
-      scm_type: 'existing',
-      url:      'svn://localhost/test')
-
-    c = Changeset.new(repository: r,
-                      committed_on: Time.now,
-                      comments: 'refs #2, an work_package of a parent project')
-    c.scan_comment_for_work_package_ids
-
-    assert_equal [2], c.work_package_ids.sort
-    assert c.work_packages.first.project != c.project
-  end
-
-  it 'should text tag revision' do
-    c = Changeset.new(revision: '520')
-    assert_equal 'r520', c.text_tag
-  end
-
-  it 'should text tag hash' do
-    c = Changeset.new(
-      scmid:    '7234cb2750b63f47bff735edc50a1c0a433c2518',
-      revision: '7234cb2750b63f47bff735edc50a1c0a433c2518')
-    assert_equal 'commit:7234cb2750b63f47bff735edc50a1c0a433c2518', c.text_tag
-  end
-
-  it 'should text tag hash all number' do
-    c = Changeset.new(scmid: '0123456789', revision: '0123456789')
-    assert_equal 'commit:0123456789', c.text_tag
-  end
-
-  it 'should previous' do
-    changeset = Changeset.find_by(revision: '3')
-    assert_equal Changeset.find_by(revision: '2'), changeset.previous
-  end
-
-  it 'should previous nil' do
-    changeset = Changeset.find_by(revision: '1')
-    assert_nil changeset.previous
-  end
-
-  it 'should next' do
-    changeset = Changeset.find_by(revision: '2')
-    assert_equal Changeset.find_by(revision: '3'), changeset.next
-  end
-
-  it 'should next nil' do
-    changeset = Changeset.find_by(revision: '10')
-    assert_nil changeset.next
-  end
-
-  it 'should comments nil' do
-    with_settings enabled_scm: ['subversion'] do
-      proj = Project.find(3)
-      r = FactoryGirl.create(:repository_subversion,
-                             project: proj)
+    it 'should comments nil' do
+      r = FactoryGirl.create(:repository_subversion)
       assert r
 
       c = Changeset.new(repository: r,
@@ -253,29 +270,10 @@ describe Changeset, type: :model do
         assert_equal 'UTF-8', c.comments.encoding.to_s
       end
     end
-  end
 
-  it 'should comments empty' do
-    with_settings enabled_scm: ['subversion'] do
-        proj = Project.find(3)
-        r = FactoryGirl.create(:repository_subversion)
-
-        assert r
-        c = Changeset.new(repository: r,
-                          committed_on: Time.now,
-                          revision: '123',
-                          scmid: '12345',
-                          comments: '')
-        assert(c.save)
-        assert_equal '', c.comments
-        if c.comments.respond_to?(:force_encoding)
-          assert_equal 'UTF-8', c.comments.encoding.to_s
-        end
-      end
+    it 'should identifier' do
+      c = Changeset.find_by(revision: '1')
+      assert_equal c.revision, c.identifier
     end
-
-  it 'should identifier' do
-    c = Changeset.find_by(revision: '1')
-    assert_equal c.revision, c.identifier
   end
 end

--- a/spec_legacy/unit/journal_spec.rb
+++ b/spec_legacy/unit/journal_spec.rb
@@ -28,14 +28,10 @@
 #++
 require 'legacy_spec_helper'
 
-describe Journal, type: :model do
+describe Journal,
+         type: :model,
+         with_settings: { notified_events: %w(work_package_updated) } do
   fixtures :all
-
-  around do |example|
-    with_settings notified_events: %w(work_package_updated) do
-      example.run
-    end
-  end
 
   it 'create should send email notification' do
     issue = WorkPackage.first

--- a/spec_legacy/unit/lib/redmine/codeset_util_spec.rb
+++ b/spec_legacy/unit/lib/redmine/codeset_util_spec.rb
@@ -41,48 +41,45 @@ require 'legacy_spec_helper'
 
 describe Redmine::CodesetUtil do
   it 'should to utf8 by setting from latin1' do
-    with_settings repositories_encodings: 'UTF-8,ISO-8859-1' do
-      s1 = "Texte encod\xc3\xa9"
-      s2 = "Texte encod\xe9"
-      s3 = s2.dup
-      if s1.respond_to?(:force_encoding)
-        s1.force_encoding('UTF-8')
-        s2.force_encoding('ASCII-8BIT')
-        s3.force_encoding('UTF-8')
-      end
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
+    Setting.repositories_encodings = 'UTF-8,ISO-8859-1'
+    s1 = "Texte encod\xc3\xa9"
+    s2 = "Texte encod\xe9"
+    s3 = s2.dup
+    if s1.respond_to?(:force_encoding)
+      s1.force_encoding('UTF-8')
+      s2.force_encoding('ASCII-8BIT')
+      s3.force_encoding('UTF-8')
     end
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
   end
 
   it 'should to utf8 by setting from euc jp' do
-    with_settings repositories_encodings: 'UTF-8,EUC-JP' do
-      s1 = "\xe3\x83\xac\xe3\x83\x83\xe3\x83\x89\xe3\x83\x9e\xe3\x82\xa4\xe3\x83\xb3"
-      s2 = "\xa5\xec\xa5\xc3\xa5\xc9\xa5\xde\xa5\xa4\xa5\xf3"
-      s3 = s2.dup
-      if s1.respond_to?(:force_encoding)
-        s1.force_encoding('UTF-8')
-        s2.force_encoding('ASCII-8BIT')
-        s3.force_encoding('UTF-8')
-      end
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
+    Setting.repositories_encodings = 'UTF-8,EUC-JP'
+    s1 = "\xe3\x83\xac\xe3\x83\x83\xe3\x83\x89\xe3\x83\x9e\xe3\x82\xa4\xe3\x83\xb3"
+    s2 = "\xa5\xec\xa5\xc3\xa5\xc9\xa5\xde\xa5\xa4\xa5\xf3"
+    s3 = s2.dup
+    if s1.respond_to?(:force_encoding)
+      s1.force_encoding('UTF-8')
+      s2.force_encoding('ASCII-8BIT')
+      s3.force_encoding('UTF-8')
     end
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
   end
 
   it 'should to utf8 by setting should be converted all latin1' do
-    with_settings repositories_encodings: 'ISO-8859-1' do
-      s1 = "\xc3\x82\xc2\x80"
-      s2 = "\xC2\x80"
-      s3 = s2.dup
-      if s1.respond_to?(:force_encoding)
-        s1.force_encoding('UTF-8')
-        s2.force_encoding('ASCII-8BIT')
-        s3.force_encoding('UTF-8')
-      end
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
-      assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
+    Setting.repositories_encodings = 'ISO-8859-1'
+    s1 = "\xc3\x82\xc2\x80"
+    s2 = "\xC2\x80"
+    s3 = s2.dup
+    if s1.respond_to?(:force_encoding)
+      s1.force_encoding('UTF-8')
+      s2.force_encoding('ASCII-8BIT')
+      s3.force_encoding('UTF-8')
     end
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s2)
+    assert_equal s1, Redmine::CodesetUtil.to_utf8_by_setting(s3)
   end
 
   it 'should to utf8 by setting blank string' do
@@ -108,28 +105,26 @@ describe Redmine::CodesetUtil do
   end
 
   it 'should to utf8 by setting invalid utf8 sequences should be stripped' do
-    with_settings repositories_encodings: '' do
-      s1 = "Texte encod\xe9 en ISO-8859-1."
-      s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
-      str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
-      if str.respond_to?(:force_encoding)
-        assert str.valid_encoding?
-        assert_equal 'UTF-8', str.encoding.to_s
-      end
-      assert_equal 'Texte encod? en ISO-8859-1.', str
+    Setting.repositories_encodings = ''
+    s1 = "Texte encod\xe9 en ISO-8859-1."
+    s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
+    str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
+    if str.respond_to?(:force_encoding)
+      assert str.valid_encoding?
+      assert_equal 'UTF-8', str.encoding.to_s
     end
+    assert_equal 'Texte encod? en ISO-8859-1.', str
   end
 
   it 'should to utf8 by setting invalid utf8 sequences should be stripped ja jis' do
-    with_settings repositories_encodings: 'ISO-2022-JP' do
-      s1 = "test\xb5\xfetest\xb5\xfe"
-      s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
-      str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
-      if str.respond_to?(:force_encoding)
-        assert str.valid_encoding?
-        assert_equal 'UTF-8', str.encoding.to_s
-      end
-      assert_equal 'test??test??', str
+    Setting.repositories_encodings = 'ISO-2022-JP'
+    s1 = "test\xb5\xfetest\xb5\xfe"
+    s1.force_encoding('ASCII-8BIT') if s1.respond_to?(:force_encoding)
+    str = Redmine::CodesetUtil.to_utf8_by_setting(s1)
+    if str.respond_to?(:force_encoding)
+      assert str.valid_encoding?
+      assert_equal 'UTF-8', str.encoding.to_s
     end
+    assert_equal 'test??test??', str
   end
 end

--- a/spec_legacy/unit/lib/redmine/helpers/calendar_spec.rb
+++ b/spec_legacy/unit/lib/redmine/helpers/calendar_spec.rb
@@ -55,21 +55,19 @@ describe Redmine::Helpers::Calendar, type: :model do
 
   it 'should monthly start day' do
     [1, 6, 7].each do |day|
-      with_settings start_of_week: day do
-        c = Redmine::Helpers::Calendar.new(Date.today, :en, :month)
-        assert_equal day, c.startdt.cwday
-        assert_equal (day + 5) % 7 + 1, c.enddt.cwday
-      end
+      Setting.start_of_week = day
+      c = Redmine::Helpers::Calendar.new(Date.today, :en, :month)
+      assert_equal day, c.startdt.cwday
+      assert_equal (day + 5) % 7 + 1, c.enddt.cwday
     end
   end
 
   it 'should weekly start day' do
     [1, 6, 7].each do |day|
-      with_settings start_of_week: day do
-        c = Redmine::Helpers::Calendar.new(Date.today, :en, :week)
-        assert_equal day, c.startdt.cwday
-        assert_equal (day + 5) % 7 + 1, c.enddt.cwday
-      end
+      Setting.start_of_week = day
+      c = Redmine::Helpers::Calendar.new(Date.today, :en, :week)
+      assert_equal day, c.startdt.cwday
+      assert_equal (day + 5) % 7 + 1, c.enddt.cwday
     end
   end
 end

--- a/spec_legacy/unit/lib/redmine/i18n_spec.rb
+++ b/spec_legacy/unit/lib/redmine/i18n_spec.rb
@@ -72,55 +72,45 @@ describe Redmine::I18n do
   it 'should time format' do
     set_language_if_valid 'en'
     now = Time.parse('2011-02-20 15:45:22')
-    with_settings time_format: '%H:%M' do
-      with_settings date_format: '' do
-        assert_equal '02/20/2011 15:45', format_time(now)
-        assert_equal '15:45', format_time(now, false)
-      end
+    Setting.time_format = '%H:%M'
+    Setting.date_format = '%Y-%m-%d'
+    assert_equal '2011-02-20 15:45', format_time(now)
+    assert_equal '15:45', format_time(now, false)
 
-      with_settings date_format: '%Y-%m-%d' do
-        assert_equal '2011-02-20 15:45', format_time(now)
-        assert_equal '15:45', format_time(now, false)
-      end
-    end
+    Setting.date_format = ''
+    assert_equal '02/20/2011 15:45', format_time(now)
+    assert_equal '15:45', format_time(now, false)
   end
 
   it 'should time format default' do
     set_language_if_valid 'en'
     now = Time.parse('2011-02-20 15:45:22')
-    with_settings time_format: '' do
-      with_settings date_format: '' do
-        assert_equal '02/20/2011 03:45 PM', format_time(now)
-        assert_equal '03:45 PM', format_time(now, false)
-      end
+    Setting.time_format = ''
+    Setting.date_format = '%Y-%m-%d'
+    assert_equal '2011-02-20 03:45 PM', format_time(now)
+    assert_equal '03:45 PM', format_time(now, false)
 
-      with_settings date_format: '%Y-%m-%d' do
-        assert_equal '2011-02-20 03:45 PM', format_time(now)
-        assert_equal '03:45 PM', format_time(now, false)
-      end
-    end
+    Setting.date_format = ''
+    assert_equal '02/20/2011 03:45 PM', format_time(now)
+    assert_equal '03:45 PM', format_time(now, false)
   end
 
   it 'should time format' do
     set_language_if_valid 'en'
     now = Time.now
-    with_settings time_format: '%H %M' do
-      with_settings date_format: '%d %m %Y' do
-        assert_equal now.strftime('%d %m %Y %H %M'), format_time(now)
-        assert_equal now.strftime('%H %M'), format_time(now, false)
-      end
-    end
+    Setting.time_format = '%H %M'
+    Setting.date_format = '%d %m %Y'
+    assert_equal now.strftime('%d %m %Y %H %M'), format_time(now)
+    assert_equal now.strftime('%H %M'), format_time(now, false)
   end
 
   it 'should utc time format' do
     set_language_if_valid 'en'
     now = Time.now
-    with_settings time_format: '%H %M' do
-      with_settings date_format: '%d %m %Y' do
-        assert_equal now.localtime.strftime('%d %m %Y %H %M'), format_time(now.utc)
-        assert_equal now.localtime.strftime('%H %M'), format_time(now.utc, false)
-      end
-    end
+    Setting.time_format = '%H %M'
+    Setting.date_format = '%d %m %Y'
+    assert_equal now.localtime.strftime('%d %m %Y %H %M'), format_time(now.utc)
+    assert_equal now.localtime.strftime('%H %M'), format_time(now.utc, false)
   end
 
   it 'should number to human size for each language' do

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -71,33 +71,37 @@ describe Project, type: :model do
     assert_equal 'eCookbook', @ecookbook.name
   end
 
-  it 'should default attributes' do
-    with_settings default_projects_public: '1' do
+  context 'when default public', with_settings: { default_projects_public?: true } do
+    it 'should default attributes' do
       assert_equal true, Project.new.is_public
       assert_equal false, Project.new(is_public: false).is_public
-    end
 
-    with_settings default_projects_public: '0' do
+      assert_equal ::Type.all, Project.new.types
+      assert_equal ::Type.find(1, 3), Project.new(type_ids: [1, 3]).types
+    end
+  end
+
+  context 'when default private', with_settings: { default_projects_public?: false } do
+    it 'should default attributes' do
       assert_equal false, Project.new.is_public
       assert_equal true, Project.new(is_public: true).is_public
     end
+  end
 
-    with_settings sequential_project_identifiers: '1' do
+  context 'with sequential identifiers',
+          with_settings: { sequential_project_identifiers?: true } do
+    it 'should default attributes' do
       assert !Project.new.identifier.blank?
       assert Project.new(identifier: '').identifier.blank?
     end
+  end
 
-    with_settings sequential_project_identifiers: '0' do
+  context 'with no sequential identifiers',
+          with_settings: { sequential_project_identifiers?: false } do
+    it 'should default attributes' do
       assert Project.new.identifier.blank?
       assert !Project.new(identifier: 'test').blank?
     end
-
-    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
-      assert_equal ['work_package_tracking', 'repository'], Project.new.enabled_module_names
-    end
-
-    assert_equal ::Type.all, Project.new.types
-    assert_equal ::Type.find(1, 3), Project.new(type_ids: [1, 3]).types
   end
 
   it 'should update' do
@@ -612,8 +616,9 @@ describe Project, type: :model do
     assert_nil Project.next_identifier
   end
 
-  it 'should enabled module names' do
-    with_settings default_projects_modules: ['work_package_tracking', 'repository'] do
+  context 'with modules',
+          with_settings: { default_projects_modules: ['work_package_tracking', 'repository'] } do
+    it 'should enabled module names' do
       project = Project.new
 
       project.enabled_module_names = %w(work_package_tracking news)

--- a/spec_legacy/unit/repository_spec.rb
+++ b/spec_legacy/unit/repository_spec.rb
@@ -33,12 +33,7 @@ describe Repository, type: :model do
 
   before do
     @repository = Project.find(1).repository
-  end
-
-  around do |example|
-    with_settings enabled_scm: %w(subversion) do
-      example.run
-    end
+    Setting.enabled_scm = %w(subversion)
   end
 
   it 'should create' do

--- a/spec_legacy/unit/repository_subversion_spec.rb
+++ b/spec_legacy/unit/repository_subversion_spec.rb
@@ -158,21 +158,20 @@ describe Repository::Subversion, type: :model do
   end
 
   it 'should log encoding ignore setting' do
-    with_settings commit_logs_encoding: 'windows-1252' do
-      s1 = "\xC2\x80"
-      s2 = "\xc3\x82\xc2\x80"
-      if s1.respond_to?(:force_encoding)
-        s1.force_encoding('ISO-8859-1')
-        s2.force_encoding('UTF-8')
-        assert_equal s1.encode('UTF-8'), s2
-      end
-      c = Changeset.new(repository: @repository,
-                        comments:   s2,
-                        revision:   '123',
-                        committed_on: Time.now)
-      assert c.save
-      assert_equal s2, c.comments
+    Setting.commit_logs_encoding = 'windows-1252'
+    s1 = "\xC2\x80"
+    s2 = "\xc3\x82\xc2\x80"
+    if s1.respond_to?(:force_encoding)
+      s1.force_encoding('ISO-8859-1')
+      s2.force_encoding('UTF-8')
+      assert_equal s1.encode('UTF-8'), s2
     end
+    c = Changeset.new(repository: @repository,
+                      comments:   s2,
+                      revision:   '123',
+                      committed_on: Time.now)
+    assert c.save
+    assert_equal s2, c.comments
   end
 
   it 'should previous' do

--- a/spec_legacy/unit/user_spec.rb
+++ b/spec_legacy/unit/user_spec.rb
@@ -82,10 +82,9 @@ describe User, type: :model do
       @user1 = FactoryGirl.create(:user, mail_notification: nil)
       assert_equal 'only_my_events', @user1.mail_notification
 
-      with_settings default_notification_option: 'all' do
-        @user2 = FactoryGirl.create(:user)
-        assert_equal 'all', @user2.mail_notification
-      end
+      Setting.default_notification_option = 'all'
+      @user2 = FactoryGirl.create(:user)
+      assert_equal 'all', @user2.mail_notification
     end
   end
 


### PR DESCRIPTION
Currently, settings are cached on a per-name basis, but that cache is
expired everytime any attribute is written.

Even when a week-old attribute is still valid, its cache is expired as
soon another setting is updated due to the max settings cache key.

Instead of caching a single attribute, I suggest to cache the entire
settings (the total number with plugins is less than 120 and 4KiB in
size) and retrieve and deserialize a single value from that hash.

That caching is two-fold, once using Rails.cache for the entirety of the current settings hash (still potentially serialized to avoid additionally marshals).
For the current request, it also holds the settings in RequestStore.

That alleviates the previous effort:
- Locating a single element from database
- Instantiate a setting object just for deserializing
- Requesting settings several times by using RequestStore

https://community.openproject.com/work_packages/23034/

This is the result of what we discussed as part of the mail notifications PR https://github.com/opf/openproject/pull/4351

Reopened from https://github.com/opf/openproject/pull/4365
