### PR TITLE
[23674] Fix invalid URLs when clicking on escaped wiki links

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -226,7 +226,7 @@ class WikiController < ApplicationController
     return render_403 unless editable?
     @page.redirect_existing_links = true
     # used to display the *original* title if some AR validation errors occur
-    @original_title = @page.pretty_title
+    @original_title = @page.title
     if request.patch? && @page.update_attributes(permitted_params.wiki_page_rename)
       flash[:notice] = l(:notice_successful_update)
       redirect_to_show
@@ -371,7 +371,7 @@ class WikiController < ApplicationController
 
   def wiki_page_title
     title = params[:id]
-    CGI.unescape(title) if title.present?
+    Wiki.from_param(title) if title.present?
   end
 
   def find_wiki

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -151,7 +151,7 @@ class WikiMenuItemsController < ApplicationController
     menu_item = if item = page.menu_item
                   item.tap { |item| item.parent_id = nil }
                 else
-                  wiki.wiki_menu_items.build(title: page.title, name: page.pretty_title)
+                  wiki.wiki_menu_items.build(title: page.title, name: page.title)
     end
 
     menu_item.options = options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,7 +149,7 @@ module ApplicationHelper
           title = if options[:timestamp] && page.updated_on
                     l(:label_updated_time, distance_of_time_in_words(Time.now, page.updated_on))
                   end
-          concat link_to(page.pretty_title, project_wiki_path(page.project, page),
+          concat link_to(page.title, project_wiki_path(page.project, page),
                          title: title)
           concat render_page_hierarchy(pages, page.id, options) if pages[page.id]
         end

--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -35,7 +35,7 @@ module WikiHelper
       pages[parent].each do |page|
         indent = (level > 0) ? ('&nbsp;' * level * 2 + '&#187; ') : ''
 
-        s << [(indent + h(page.pretty_title)).html_safe, page.id]
+        s << [(indent + h(page.title)).html_safe, page.id]
         s += wiki_page_options_for_select(pages, page, level + 1)
       end
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -201,7 +201,7 @@ class UserMailer < BaseMailer
     message_id @wiki_content, user
 
     with_locale_for(user) do
-      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_content.page.pretty_title)}"
+      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_content.page.title)}"
       mail_for_author author, to: user.mail, subject: subject
     end
   end
@@ -222,7 +222,7 @@ class UserMailer < BaseMailer
     message_id @wiki_content, user
 
     with_locale_for(user) do
-      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_content.page.pretty_title)}"
+      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_content.page.title)}"
       mail_for_author author, to: user.mail, subject: subject
     end
   end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -76,6 +76,13 @@ class Wiki < ActiveRecord::Base
     page
   end
 
+  ##
+  # Unescape the given title from user input to retrieve the
+  # unicode title of a wiki page
+  def self.from_param(title)
+    CGI.unescape(CGI.unescapeHTML(title))
+  end
+
   # Finds a page by title
   # The given string can be of one of the forms: "title" or "project:title"
   # Examples:

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -126,10 +126,6 @@ class WikiPage < ActiveRecord::Base
     wiki.redirects.where(redirects_to: title).each(&:destroy)
   end
 
-  def pretty_title
-    WikiPage.pretty_title(title)
-  end
-
   def content_for_version(version = nil)
     journal = content.versions.find_by(version: version.to_i) if version
 
@@ -158,10 +154,6 @@ class WikiPage < ActiveRecord::Base
     version = version ? version.to_i : content.version
     c = content.versions.find_by(version: version)
     c ? WikiAnnotate.new(c) : nil
-  end
-
-  def self.pretty_title(str)
-    (str && str.is_a?(String)) ? str.tr('_', ' ') : str
   end
 
   def project
@@ -197,7 +189,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def parent_title
-    @parent_title || (parent && parent.pretty_title)
+    @parent_title || (parent && parent.title)
   end
 
   def parent_title=(t)
@@ -232,7 +224,7 @@ class WikiPage < ActiveRecord::Base
     if item = menu_item
       item.name
     else
-      pretty_title
+      title
     end
   end
 

--- a/app/views/user_mailer/wiki_content_added.html.erb
+++ b/app/views/user_mailer/wiki_content_added.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p>
   <%=raw t(:mail_body_wiki_content_added,
-              id: link_to(@wiki_content.page.pretty_title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
+              id: link_to(@wiki_content.page.title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
               author: @wiki_content.author) %><br />
   <em><%= @wiki_content.comments %></em>
 </p>

--- a/app/views/user_mailer/wiki_content_added.text.erb
+++ b/app/views/user_mailer/wiki_content_added.text.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= t(:mail_body_wiki_content_added,
-          id: @wiki_content.page.pretty_title,
+          id: @wiki_content.page.title,
           author: @wiki_content.author) %>
 <%= @wiki_content.comments %>
 

--- a/app/views/user_mailer/wiki_content_updated.html.erb
+++ b/app/views/user_mailer/wiki_content_updated.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p>
   <%=raw t(:mail_body_wiki_content_updated,
-               id: link_to(@wiki_content.page.pretty_title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
+               id: link_to(@wiki_content.page.title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
                author: @wiki_content.author) %><br />
   <em><%= @wiki_content.comments %></em>
 </p>

--- a/app/views/user_mailer/wiki_content_updated.text.erb
+++ b/app/views/user_mailer/wiki_content_updated.text.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= t(:mail_body_wiki_content_updated,
-          id: @wiki_content.page.pretty_title,
+          id: @wiki_content.page.title,
           author: @wiki_content.author) %>
 <%= @wiki_content.comments %>
 

--- a/app/views/wiki/_content.html.erb
+++ b/app/views/wiki/_content.html.erb
@@ -28,6 +28,6 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="wiki wiki-content">
-  <h1 class="wiki-title"><%= content.page.pretty_title %></h1>
+  <h1 class="wiki-title"><%= content.page.title %></h1>
   <%= format_text content, :text, attachments: content.page.attachments %>
 </div>

--- a/app/views/wiki/annotate.html.erb
+++ b/app/views/wiki/annotate.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.pretty_title)  %>
+<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.title)  %>
 
 <% content_for :action_menu_specific do %>
   <%= link_to(l(:button_edit),
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
               accesskey: accesskey(:edit)) %>
   <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
 <% end %>
-<h2 class='legacy-heading'><%= h(@page.pretty_title) %></h2>
+<h2 class='legacy-heading'><%= h(@page.title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
 <p>
   <%= Version.model_name.human %> <%= link_to h(@annotate.content.version), action: 'show', id: @page, version: @annotate.content.version %>

--- a/app/views/wiki/date_index.html.erb
+++ b/app/views/wiki/date_index.html.erb
@@ -39,7 +39,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <h3><%= format_date(date) %></h3>
   <ul>
     <% @pages_by_date[date].each do |page| %>
-      <li><%= link_to page.pretty_title, project_wiki_path(page.project, page) %></li>
+      <li><%= link_to page.title, project_wiki_path(page.project, page) %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
-<% html_title l(:button_delete), @page.pretty_title %>
+<%= toolbar title: @page.title %>
+<% html_title l(:button_delete), @page.title %>
 <%= form_tag({}, method: :delete) do %>
   <div class="box">
     <p><strong><%= l(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>

--- a/app/views/wiki/diff.html.erb
+++ b/app/views/wiki/diff.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :action_menu_specific do %>
   <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
 <% end %>
-<h2 class="legacy-heading"><%= h(@page.pretty_title) %></h2>
+<h2 class="legacy-heading"><%= h(@page.title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
 <p>
   <%= Version.model_name.human %> <%= link_to @diff.content_from.version, action: 'show', id: @page, project_id: @page.project, version: @diff.content_from.version %>/<%= @page.content.version %>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
-<% html_title l(:label_edit), @page.pretty_title %>
+<%= toolbar title: @page.title %>
+<% html_title l(:label_edit), @page.title %>
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>

--- a/app/views/wiki/export.html.erb
+++ b/app/views/wiki/export.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
-    <title><%=h @page.pretty_title %></title>
+    <title><%=h @page.title %></title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <base href="<%= "#{h Setting.protocol}://#{h Setting.host_name}" %>" />
     <style>

--- a/app/views/wiki/export_multiple.html.erb
+++ b/app/views/wiki/export_multiple.html.erb
@@ -47,7 +47,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <strong><%= l(:label_index_by_title) %></strong>
     <ul>
       <% @pages.each do |page| %>
-        <li><a href="#<%= h(page.to_param) %>"><%= h(page.pretty_title) %></a></li>
+        <li><a href="#<%= h(page.to_param) %>"><%= h(page.title) %></a></li>
       <% end %>
     </ul>
     <% @pages.each do |page| %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
+<%= toolbar title: @page.title %>
 <% html_title l('activerecord.models.wiki'), l(:label_history) %>
 <h3><%= l(:label_history) %></h3>
 <%= form_tag({action: "diff"}, method: :get) do %>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -86,4 +86,4 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= robot_exclusion_tag %>
 <% end %>
 
-<% html_title @page.pretty_title %>
+<% html_title @page.title %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -117,4 +117,4 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render partial: 'wiki/sidebar' %>
 <% end %>
 
-<% html_title h(@page.pretty_title) %>
+<% html_title h(@page.title) %>

--- a/app/views/wiki_menu_items/edit.html.erb
+++ b/app/views/wiki_menu_items/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= error_messages_for "wiki_menu_item", object: @wiki_menu_item %>
 
-<% breadcrumb_paths(*@page.ancestors.reverse.collect {|parent| link_to h(parent.pretty_title), {id: parent.title, project_id: parent.project}}.push(@page_title)) %>
+<% breadcrumb_paths(*@page.ancestors.reverse.collect {|parent| link_to h(parent.title), {id: parent.title, project_id: parent.project}}.push(@page_title)) %>
 <%= toolbar title: l(:wiki_menu_item_for, title: @page_title) %>
 <%= form_for @wiki_menu_item, html: {id: 'wiki_menu_item_form', class: 'menu-item-form', method: :put}, url: wiki_menu_item_path(@project, @page) do |form| %>
 <p class="item-name">

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -245,15 +245,16 @@ module OpenProject
               anchor = $2
             end
             # check if page exists
-            wiki_page = link_project.wiki.find_page(page)
+            wiki_page_title = Wiki.from_param(page)
+            wiki_page = link_project.wiki.find_page(wiki_page_title)
             url = case options[:wiki_links]
                   when :local; "#{title}.html"
                   when :anchor; "##{title}"   # used for single-file wiki export
                   else
-                    wiki_page_id = page.present? ? page : nil
+                    wiki_page_id = wiki_page_title.present? ? wiki_page_title : nil
                     url_for(only_path: only_path, controller: '/wiki', action: 'show', project_id: link_project, id: wiki_page_id, anchor: anchor)
               end
-            link_to(h(title || page), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
+            link_to(h(title || wiki_page_title), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
           else
             # project or wiki doesn't exist
             all

--- a/lib/redmine/wiki_formatting/null_formatter/helper.rb
+++ b/lib/redmine/wiki_formatting/null_formatter/helper.rb
@@ -38,7 +38,7 @@ module Redmine
         end
 
         def initial_page_content(page)
-          page.pretty_title.to_s
+          page.title.to_s
         end
       end
     end

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -54,7 +54,7 @@ module Redmine
         end
 
         def initial_page_content(_page)
-          "h1. #{@page.pretty_title}"
+          "h1. #{@page.title}"
         end
 
         def heads_for_wiki_formatter

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -1,0 +1,101 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Wiki unicode title spec', type: :feature do
+  let(:user) { FactoryGirl.create :admin }
+  let(:project) { FactoryGirl.create :project }
+  let(:wiki_page_1) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: '<script>alert("FOO")</script>'
+  }
+  let(:wiki_page_2) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: 'Base de données'
+  }
+  let(:wiki_page_3) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: 'Base_de_données'
+  }
+
+  let(:wiki_body) {
+    <<-EOS
+    [[Base de données]]
+
+    [[Base_de_données]]
+
+    [[Base%20de%20données]]
+
+    [[<script>alert("FOO")</script>]]
+
+    [[&lt;script&gt;alert(&quot;FOO&quot;)&lt;/script&gt;]]
+    EOS
+  }
+
+  let(:expected_titles) {
+    [
+      'Base de données',
+      'Base_de_données',
+      'Base de données',
+      '<script>alert("FOO")</script>',
+      '<script>alert("FOO")</script>'
+    ]
+  }
+
+  before do
+    login_as(user)
+
+    project.wiki.pages << wiki_page_1
+    project.wiki.pages << wiki_page_2
+    project.wiki.pages << wiki_page_3
+
+    project.wiki.save!
+
+    visit project_wiki_path(project, :wiki)
+
+    # Set value
+    find('#content_text').set(wiki_body)
+    click_button 'Save'
+
+    expect(page).to have_selector('h1.wiki-title', text: 'wiki')
+    expect(page).to have_selector('a.wiki-page', count: 5)
+  end
+
+  it 'shows renders correct links' do
+    expected_titles.each_with_index do |title, i|
+      visit project_wiki_path(project, :wiki)
+      target_link = all('div.wiki-content a.wiki-page')[i]
+
+      expect(target_link.text).to eq(title)
+      target_link.click
+
+      expect(page).to have_selector('h1.wiki-title', text: title)
+    end
+  end
+end

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -314,6 +314,11 @@ describe OpenProject::TextFormatting do
                            wiki: wiki_1,
                            title: 'Another page'
       }
+      let(:wiki_page_1_3) {
+        FactoryGirl.create :wiki_page_with_content,
+                           wiki: wiki_1,
+                           title: '<script>alert("FOO")</script>'
+      }
 
       before do
         project_2.reload
@@ -330,12 +335,26 @@ describe OpenProject::TextFormatting do
 
         wiki_1.pages << wiki_page_1_1
         wiki_1.pages << wiki_page_1_2
+        wiki_1.pages << wiki_page_1_3
       end
 
       context 'Plain wiki link' do
         subject { format_text('[[CookBook documentation]]') }
 
         it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/CookBook%20documentation\">CookBook documentation</a></p>") }
+      end
+
+      context 'Escaped wiki link' do
+        subject { format_text('[[CookBook%20documentation]]') }
+
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/CookBook%20documentation\">CookBook documentation</a></p>") }
+      end
+
+      context 'Arbitrary wiki link' do
+        title = '<script>alert("FOO")</script>'
+        subject { format_text("[[#{title}]]") }
+
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki?id=#{CGI.escape(title)}\">#{h(title)}</a></p>") }
       end
 
       context 'Plain wiki page link' do


### PR DESCRIPTION
https://github.com/opf/openproject/pull/4195 introduced arbitrary content in wiki page titles used for links, for examples spaces.

When referencing the (escaped) URL of a title with spaces (e.g., `Foo bar xyz` becomes `Foo%20bar%20xyz`), that url won't properly resolve.

The wiki link textile parser now correctly unescapes these links first to allow any content to be referenced even when escaped.

Partly fixes https://community.openproject.com/work_packages/23674
