### PR TITLE
[23675] Reload work package activity after save

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -102,13 +102,18 @@ export class HalResource {
 
     // Reset and load this resource
     this.$loaded = false;
-    this.$self = this.$links.self({}, this.$loadHeaders(force)).then(source => {
+    this.$self = this.$links.self({}, this.$loadHeaders(true)).then(source => {
       this.$loaded = true;
       this.$initialize(source);
       return this;
     });
 
     return this.$self;
+  }
+
+  public $unload() {
+    this.$loaded = false;
+    this.$self = null;
   }
 
   public $plain() {

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -266,16 +266,15 @@ export class WorkPackageResource extends HalResource {
           .then(workPackage => {
             this.$initialize(workPackage);
             this.$pristine = {};
-
+            wpCacheService.loadWorkPackageLinks(this, 'activities');
             deferred.resolve(this);
-
           })
           .catch(error => {
             deferred.reject(error);
+            wpCacheService.updateWorkPackage(this);
           })
           .finally(() => {
             this.inFlight = false;
-            wpCacheService.updateWorkPackage(this);
             if (wasNew) {
               wpCacheService.newWorkPackageCreated(this);
             }

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -74,7 +74,7 @@ export class WorkPackageCacheService {
    */
   loadWorkPackageLinks(workPackage, ...args: string[]) {
     args.forEach((arg) => {
-      workPackage[arg].$load(true);
+      workPackage[arg].$unload();
     });
     return this.updateWorkPackage(workPackage);
   }

--- a/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-attachments/wp-attachments.directive.test.ts
@@ -41,12 +41,14 @@ describe('wp-attachments.directive', () => {
       $load: () => {
         return $q.when({ elements: [] });
       },
+      $unload: angular.noop,
       href: '/api/v3/work_packages/1/attachments',
     },
     activities: {
       $load: () => {
         return $q.when({ elements: [] });
       },
+      $unload: angular.noop,
       href: '/api/v3/work_packages/1/activities',
     }
   };

--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -133,12 +133,10 @@ export class WorkPackageEditFormController {
         this.successHandler({workPackage: this.workPackage, fields: this.fields});
       })
       .catch((error) => {
-        if (!(error.data instanceof ErrorResource)) {
-          this.wpNotificationsService.showGeneralError;
-          return deferred.reject([]);
+        this.wpNotificationsService.handleErrorResponse(error, this.workPackage);
+        if (error.data instanceof ErrorResource) {
+          this.handleSubmissionErrors(error.data, deferred);
         }
-        this.wpNotificationsService.showError(error.data, this.workPackage);
-        this.handleSubmissionErrors(error.data, deferred);
       });
 
     return deferred.promise;

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -106,6 +106,11 @@ module Pages
       expect(page).to have_selector(container + ' .user', text: user.name)
     end
 
+    def expect_activity_message(message)
+      expect(page).to have_selector('.work-package-details-activities-messages .message',
+                                    text: message)
+    end
+
     def expect_parent(parent = nil)
       parent ||= work_package.parent
 


### PR DESCRIPTION
Activities should be reloaded whenever the work package resource changes.

https://community.openproject.com/work_packages/23675
