### PR TITLE
Remove rb-readline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,6 @@ group :test do
   gem 'timecop', '~> 0.8'
   gem 'webmock', '~> 1.24.2', require: false
 
-  gem 'rb-readline', '~> 0.5.1' # ruby on CI needs this
   # why in Gemfile? see: https://github.com/guard/guard-test
   gem 'ruby-prof'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,6 @@ GEM
     rainbow (2.1.0)
     raindrops (0.16.0)
     rake (11.1.1)
-    rb-readline (0.5.3)
     rdoc (4.2.2)
       json (~> 1.4)
     redcarpet (3.3.4)
@@ -663,7 +662,6 @@ DEPENDENCIES
   rails-observers
   rails_12factor
   rails_autolink (~> 1.1.6)
-  rb-readline (~> 0.5.1)
   rdoc (>= 2.4.2)
   reform (~> 1.2.6)
   request_store (~> 1.3.0)


### PR DESCRIPTION
I doubt we do still need it and it causes issues with UTF-8 and pry:

`pry/history.rb:106:in`write': "\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)`
