### PR TITLE
Add support for Ubuntu 16.04. Remove Fedora 20.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/pkgr/pkgr-buildpack-imagemagick.git
 https://github.com/heroku/heroku-buildpack-nodejs.git#v71
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal
+https://github.com/pkgr/heroku-buildpack-ruby.git

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -9,11 +9,11 @@ targets:
     <<: *debian
   ubuntu-14.04:
     <<: *debian
-  fedora-20: &redhat
+  ubuntu-16.04:
+    <<: *debian
+  centos-6: &redhat
     build_dependencies:
       - ImageMagick-devel
-  centos-6:
-    <<: *redhat
   centos-7:
     <<: *redhat
     dependencies:


### PR DESCRIPTION
As discussed with @lindenthal, Fedora 20 is no longer supported, and it is replaced with Ubuntu 16.04.
