### PR TITLE
[23674] Migrate wiki titles to URL slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'tzinfo-data'
 # to generate html-diffs (e.g. for wiki comparison)
 gem 'htmldiff'
 
+# Generate url slugs with #to_url and other string niceties
+gem 'stringex', '~> 2.6.1'
+
 # generates SVG Graphs
 # used for statistics on svn repositories
 gem 'svg-graph', github: 'why-el/svg-graph', branch: 'silence-class-access-warning'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,6 +531,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    stringex (2.6.1)
     structured_warnings (0.2.0)
     syck (1.0.5)
     sys-filesystem (1.1.5)
@@ -687,6 +688,7 @@ DEPENDENCIES
   simplecov
   sprockets (~> 3.5.2)
   sqlite3
+  stringex (~> 2.6.1)
   svg-graph!
   syck (~> 1.0.5)
   sys-filesystem (~> 1.1.4)

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -370,8 +370,7 @@ class WikiController < ApplicationController
   private
 
   def wiki_page_title
-    title = params[:id]
-    CGI.unescape(title) if title.present?
+    params[:id]
   end
 
   def find_wiki

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -226,7 +226,7 @@ class WikiController < ApplicationController
     return render_403 unless editable?
     @page.redirect_existing_links = true
     # used to display the *original* title if some AR validation errors occur
-    @original_title = @page.pretty_title
+    @original_title = @page.title
     if request.patch? && @page.update_attributes(permitted_params.wiki_page_rename)
       flash[:notice] = l(:notice_successful_update)
       redirect_to_show

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -115,12 +115,12 @@ class WikiMenuItemsController < ApplicationController
   end
 
   def get_data_from_params(params)
-    @page_title = CGI.unescape(params[:id])
-    wiki_id = @project.wiki.id
+    wiki = @project.wiki
 
-    @page = WikiPage.find_by(title: @page_title, wiki_id: wiki_id)
-    @wiki_menu_item = MenuItems::WikiMenuItem.find_or_initialize_by(navigatable_id: @page.wiki.id, title: @page_title)
-    possible_parent_menu_items = MenuItems::WikiMenuItem.main_items(wiki_id) - [@wiki_menu_item]
+    @page = wiki.find_page(params[:id])
+    @page_title = @page.title
+    @wiki_menu_item = MenuItems::WikiMenuItem.find_or_initialize_by(navigatable_id: wiki.id, title: @page_title)
+    possible_parent_menu_items = MenuItems::WikiMenuItem.main_items(wiki.id) - [@wiki_menu_item]
 
     @parent_menu_item_options = possible_parent_menu_items.map { |item| [item.name, item.id] }
 

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -151,7 +151,7 @@ class WikiMenuItemsController < ApplicationController
     menu_item = if item = page.menu_item
                   item.tap { |item| item.parent_id = nil }
                 else
-                  wiki.wiki_menu_items.build(title: page.title, name: page.pretty_title)
+                  wiki.wiki_menu_items.build(title: page.title, name: page.title)
     end
 
     menu_item.options = options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,7 +149,7 @@ module ApplicationHelper
           title = if options[:timestamp] && page.updated_on
                     l(:label_updated_time, distance_of_time_in_words(Time.now, page.updated_on))
                   end
-          concat link_to(page.pretty_title, project_wiki_path(page.project, page),
+          concat link_to(page.title, project_wiki_path(page.project, page),
                          title: title)
           concat render_page_hierarchy(pages, page.id, options) if pages[page.id]
         end

--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -35,7 +35,7 @@ module WikiHelper
       pages[parent].each do |page|
         indent = (level > 0) ? ('&nbsp;' * level * 2 + '&#187; ') : ''
 
-        s << [(indent + h(page.pretty_title)).html_safe, page.id]
+        s << [(indent + h(page.title)).html_safe, page.id]
         s += wiki_page_options_for_select(pages, page, level + 1)
       end
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -201,7 +201,7 @@ class UserMailer < BaseMailer
     message_id @wiki_content, user
 
     with_locale_for(user) do
-      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_content.page.pretty_title)}"
+      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_added, id: @wiki_content.page.title)}"
       mail_for_author author, to: user.mail, subject: subject
     end
   end
@@ -222,7 +222,7 @@ class UserMailer < BaseMailer
     message_id @wiki_content, user
 
     with_locale_for(user) do
-      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_content.page.pretty_title)}"
+      subject = "[#{@wiki_content.project.name}] #{t(:mail_subject_wiki_content_updated, id: @wiki_content.page.title)}"
       mail_for_author author, to: user.mail, subject: subject
     end
   end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -64,13 +64,16 @@ class Wiki < ActiveRecord::Base
     find_page(title) || WikiPage.new(wiki: self, title: title)
   end
 
-  # find the page with the given title
+  ##
+  # Find the page with the given title.
+  # Tries the original title and the legacy titleized format.
   def find_page(title, options = {})
     title = start_page if title.blank?
-    page = pages.where(['LOWER(title) = LOWER(?)', title]).first
+
+    page = pages.where(slug: title.to_url).first
     if !page && !(options[:with_redirect] == false)
       # search for a redirect
-      redirect = redirects.where(['LOWER(title) = LOWER(?)', title]).first
+      redirect = matching_redirect(title)
       page = find_page(redirect.redirects_to, with_redirect: false) if redirect
     end
     page
@@ -104,5 +107,21 @@ class Wiki < ActiveRecord::Base
     wiki_menu_item.index_page = true
 
     wiki_menu_item.save!
+  end
+
+  private
+
+  ##
+  # Locate the redirect from an existing page.
+  # Tries to find a redirect for the given slug,
+  # falls back to finding a redirect for the title
+  def matching_redirect(title)
+    page = redirects.where(title: title.to_url).first
+
+    if page.nil?
+      page = redirects.where(title: title).first
+    end
+
+    page
   end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -79,6 +79,13 @@ class Wiki < ActiveRecord::Base
     page
   end
 
+  ##
+  # Unescape the given title from user input to retrieve the
+  # unicode title of a wiki page
+  def self.from_param(title)
+    CGI.unescape(CGI.unescapeHTML(title))
+  end
+
   # Finds a page by title
   # The given string can be of one of the forms: "title" or "project:title"
   # Examples:

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -130,7 +130,7 @@ class WikiPage < ActiveRecord::Base
 
   # Remove redirects to this page
   def remove_redirects
-    wiki.redirects.where(redirects_to: title).each(&:destroy)
+    wiki.redirects.where(redirects_to: slug).each(&:destroy)
   end
 
   def content_for_version(version = nil)

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -36,6 +36,9 @@ class WikiPage < ActiveRecord::Base
   acts_as_attachable delete_permission: :delete_wiki_pages_attachments
   acts_as_tree dependent: :nullify, order: 'title'
 
+  # Generate slug of the title
+  acts_as_url :title, url_attribute: :slug
+
   acts_as_watchable
   acts_as_event title: Proc.new { |o| "#{Wiki.model_name.human}: #{o.title}" },
                 description: :text,
@@ -237,7 +240,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def to_param
-    CGI.escape title
+    slug
   end
 
   def is_only_wiki_page?

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -232,7 +232,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def to_param
-    slug
+    slug || title.to_url
   end
 
   def is_only_wiki_page?

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -56,7 +56,6 @@ class WikiPage < ActiveRecord::Base
   attr_accessor :redirect_existing_links
 
   validates_presence_of :title
-  validates_uniqueness_of :title, scope: :wiki_id, case_sensitive: false
   validates_associated :content
 
   validate :validate_consistency_of_parent_title

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -129,10 +129,6 @@ class WikiPage < ActiveRecord::Base
     wiki.redirects.where(redirects_to: title).each(&:destroy)
   end
 
-  def pretty_title
-    WikiPage.pretty_title(title)
-  end
-
   def content_for_version(version = nil)
     journal = content.versions.find_by(version: version.to_i) if version
 
@@ -161,10 +157,6 @@ class WikiPage < ActiveRecord::Base
     version = version ? version.to_i : content.version
     c = content.versions.find_by(version: version)
     c ? WikiAnnotate.new(c) : nil
-  end
-
-  def self.pretty_title(str)
-    (str && str.is_a?(String)) ? str.tr('_', ' ') : str
   end
 
   def project
@@ -200,7 +192,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def parent_title
-    @parent_title || (parent && parent.pretty_title)
+    @parent_title || (parent && parent.title)
   end
 
   def parent_title=(t)
@@ -235,7 +227,7 @@ class WikiPage < ActiveRecord::Base
     if item = menu_item
       item.name
     else
-      pretty_title
+      title
     end
   end
 

--- a/app/views/user_mailer/wiki_content_added.html.erb
+++ b/app/views/user_mailer/wiki_content_added.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p>
   <%=raw t(:mail_body_wiki_content_added,
-              id: link_to(@wiki_content.page.pretty_title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
+              id: link_to(@wiki_content.page.title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
               author: @wiki_content.author) %><br />
   <em><%= @wiki_content.comments %></em>
 </p>

--- a/app/views/user_mailer/wiki_content_added.text.erb
+++ b/app/views/user_mailer/wiki_content_added.text.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= t(:mail_body_wiki_content_added,
-          id: @wiki_content.page.pretty_title,
+          id: @wiki_content.page.title,
           author: @wiki_content.author) %>
 <%= @wiki_content.comments %>
 

--- a/app/views/user_mailer/wiki_content_updated.html.erb
+++ b/app/views/user_mailer/wiki_content_updated.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p>
   <%=raw t(:mail_body_wiki_content_updated,
-               id: link_to(@wiki_content.page.pretty_title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
+               id: link_to(@wiki_content.page.title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
                author: @wiki_content.author) %><br />
   <em><%= @wiki_content.comments %></em>
 </p>

--- a/app/views/user_mailer/wiki_content_updated.text.erb
+++ b/app/views/user_mailer/wiki_content_updated.text.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= t(:mail_body_wiki_content_updated,
-          id: @wiki_content.page.pretty_title,
+          id: @wiki_content.page.title,
           author: @wiki_content.author) %>
 <%= @wiki_content.comments %>
 

--- a/app/views/wiki/_content.html.erb
+++ b/app/views/wiki/_content.html.erb
@@ -28,6 +28,6 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="wiki wiki-content">
-  <h1 class="wiki-title"><%= content.page.pretty_title %></h1>
+  <h1 class="wiki-title"><%= content.page.title %></h1>
   <%= format_text content, :text, attachments: content.page.attachments %>
 </div>

--- a/app/views/wiki/annotate.html.erb
+++ b/app/views/wiki/annotate.html.erb
@@ -27,20 +27,20 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.title)  %>
+<% html_title t(:project_module_wiki), t(:label_history), t(:text_comment_wiki_page, page: @page.title)  %>
 
 <% content_for :action_menu_specific do %>
-  <%= link_to(l(:button_edit),
+  <%= link_to(t(:button_edit),
               {action: 'edit', id: @page},
               class: 'icon icon-edit',
               accesskey: accesskey(:edit)) %>
-  <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
+  <%= link_to(t(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
 <% end %>
 <h2 class='legacy-heading'><%= h(@page.title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
 <p>
   <%= Version.model_name.human %> <%= link_to h(@annotate.content.version), action: 'show', id: @page, version: @annotate.content.version %>
-  <em>(<%= h(@annotate.content.journable.author ? @annotate.content.journable.author.name : l(:label_user_anonymous)) %>, <%= format_time(@annotate.content.journable.updated_on) %>)</em>
+  <em>(<%= h(@annotate.content.journable.author ? @annotate.content.journable.author.name : t(:label_user_anonymous)) %>, <%= format_time(@annotate.content.journable.updated_on) %>)</em>
 </p>
 <% colors = Hash.new {|k,v| k[v] = (k.size % 12) } %>
 <table class="filecontent annotate">

--- a/app/views/wiki/annotate.html.erb
+++ b/app/views/wiki/annotate.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.pretty_title)  %>
+<% html_title l(:project_module_wiki), l(:label_history), l(:text_comment_wiki_page, page: @page.title)  %>
 
 <% content_for :action_menu_specific do %>
   <%= link_to(l(:button_edit),
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
               accesskey: accesskey(:edit)) %>
   <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
 <% end %>
-<h2 class='legacy-heading'><%= h(@page.pretty_title) %></h2>
+<h2 class='legacy-heading'><%= h(@page.title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
 <p>
   <%= Version.model_name.human %> <%= link_to h(@annotate.content.version), action: 'show', id: @page, version: @annotate.content.version %>

--- a/app/views/wiki/date_index.html.erb
+++ b/app/views/wiki/date_index.html.erb
@@ -39,7 +39,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <h3><%= format_date(date) %></h3>
   <ul>
     <% @pages_by_date[date].each do |page| %>
-      <li><%= link_to page.pretty_title, project_wiki_path(page.project, page) %></li>
+      <li><%= link_to page.title, project_wiki_path(page.project, page) %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -27,24 +27,24 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: @page.title %>
-<% html_title l(:button_delete), @page.title %>
+<% html_title t(:button_delete), @page.title %>
 <%= form_tag({}, method: :delete) do %>
   <div class="box">
-    <p><strong><%= l(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>
-    <p><label><%= radio_button_tag 'todo', 'nullify', true %> <%= l(:text_wiki_page_nullify_children) %></label><br />
-      <label><%= radio_button_tag 'todo', 'destroy', false %> <%= l(:text_wiki_page_destroy_children) %></label>
+    <p><strong><%= t(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>
+    <p><label><%= radio_button_tag 'todo', 'nullify', true %> <%= t(:text_wiki_page_nullify_children) %></label><br />
+      <label><%= radio_button_tag 'todo', 'destroy', false %> <%= t(:text_wiki_page_destroy_children) %></label>
       <% if @reassignable_to.any? %>
         <br />
-        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= l(:text_wiki_page_reassign_children) %></label>
-        <%= label_tag "reassign_to_id", l(:description_wiki_subpages_reassign), class: "hidden-for-sighted" %>
+        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= t(:text_wiki_page_reassign_children) %></label>
+        <%= label_tag "reassign_to_id", t(:description_wiki_subpages_reassign), class: "hidden-for-sighted" %>
         <%= select_tag 'reassign_to_id',
                        options_for_select(wiki_page_options_for_select(@reassignable_to)),
                        onclick: "$('todo_reassign').checked = true;" %>
       <% end %>
     </p>
   </div>
-  <%= submit_tag l(:button_apply), class: 'button -highlight' %>
-  <%= link_to l(:button_cancel),
+  <%= submit_tag t(:button_apply), class: 'button -highlight' %>
+  <%= link_to t(:button_cancel),
       { controller: '/wiki', action: 'show', project_id: @project, id: @page },
       class: 'button' %>
 <% end %>

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
-<% html_title l(:button_delete), @page.pretty_title %>
+<%= toolbar title: @page.title %>
+<% html_title l(:button_delete), @page.title %>
 <%= form_tag({}, method: :delete) do %>
   <div class="box">
     <p><strong><%= l(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>

--- a/app/views/wiki/diff.html.erb
+++ b/app/views/wiki/diff.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content_for :action_menu_specific do %>
   <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
 <% end %>
-<h2 class="legacy-heading"><%= h(@page.pretty_title) %></h2>
+<h2 class="legacy-heading"><%= h(@page.title) %></h2>
 <%= render partial: 'layouts/action_menu_specific' %>
 <p>
   <%= Version.model_name.human %> <%= link_to @diff.content_from.version, action: 'show', id: @page, project_id: @page.project, version: @diff.content_from.version %>/<%= @page.content.version %>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: @page.title %>
-<% html_title l(:label_edit), @page.title %>
+<% html_title t(:label_edit), @page.title %>
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>
@@ -48,7 +48,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render partial: 'attachments/form' %>
 
   <hr class="form--separator" />
-  <%= f.button l(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
+  <%= f.button t(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
   <%= preview_link preview_project_wiki_path(@project, @page), 'wiki_form-preview' %>
   <%= wikitoolbar_for 'content_text' %>
 <% end %>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
-<% html_title l(:label_edit), @page.pretty_title %>
+<%= toolbar title: @page.title %>
+<% html_title l(:label_edit), @page.title %>
 <%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
   <%= error_messages_for 'content' %>

--- a/app/views/wiki/export.html.erb
+++ b/app/views/wiki/export.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
-    <title><%=h @page.pretty_title %></title>
+    <title><%=h @page.title %></title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <base href="<%= "#{h Setting.protocol}://#{h Setting.host_name}" %>" />
     <style>

--- a/app/views/wiki/export_multiple.html.erb
+++ b/app/views/wiki/export_multiple.html.erb
@@ -47,7 +47,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <strong><%= l(:label_index_by_title) %></strong>
     <ul>
       <% @pages.each do |page| %>
-        <li><a href="#<%= h(page.to_param) %>"><%= h(page.pretty_title) %></a></li>
+        <li><a href="#<%= h(page.to_param) %>"><%= h(page.title) %></a></li>
       <% end %>
     </ul>
     <% @pages.each do |page| %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: @page.pretty_title %>
+<%= toolbar title: @page.title %>
 <% html_title l('activerecord.models.wiki'), l(:label_history) %>
 <h3><%= l(:label_history) %></h3>
 <%= form_tag({action: "diff"}, method: :get) do %>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -86,4 +86,4 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= robot_exclusion_tag %>
 <% end %>
 
-<% html_title @page.pretty_title %>
+<% html_title @page.title %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -117,4 +117,4 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render partial: 'wiki/sidebar' %>
 <% end %>
 
-<% html_title h(@page.pretty_title) %>
+<% html_title h(@page.title) %>

--- a/app/views/wiki_menu_items/edit.html.erb
+++ b/app/views/wiki_menu_items/edit.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= error_messages_for "wiki_menu_item", object: @wiki_menu_item %>
 
-<% breadcrumb_paths(*@page.ancestors.reverse.collect {|parent| link_to h(parent.pretty_title), {id: parent.title, project_id: parent.project}}.push(@page_title)) %>
+<% breadcrumb_paths(*@page.ancestors.reverse.collect {|parent| link_to h(parent.title), {id: parent.title, project_id: parent.project}}.push(@page_title)) %>
 <%= toolbar title: l(:wiki_menu_item_for, title: @page_title) %>
 <%= form_for @wiki_menu_item, html: {id: 'wiki_menu_item_form', class: 'menu-item-form', method: :put}, url: wiki_menu_item_path(@project, @page) do |form| %>
 <p class="item-name">

--- a/app/views/wiki_menu_items/edit.html.erb
+++ b/app/views/wiki_menu_items/edit.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <p class="item-name">
   <%= form.label :name, l(:label_menu_item_name), {id: 'item-name'} %>
   <% if @wiki_menu_item.name.nil? %>
-  <%= form.text_field :name, size: 20, value: @page_title.gsub("_"," ") %>
+  <%= form.text_field :name, size: 20, value: @page_title %>
   <% else %>
   <%= form.text_field :name, size: 20 %>
   <% end %>

--- a/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
+++ b/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
@@ -1,0 +1,61 @@
+class AddSlugToWikiPages < ActiveRecord::Migration
+  def up
+    add_column :wiki_pages, :slug, :string
+    add_index :wiki_pages, [:wiki_id, :slug], name: 'wiki_pages_wiki_id_slug', unique: true
+
+    migrate_titles
+    change_column_null :wiki_pages, :slug, true
+  end
+
+  def down
+    remove_column :wiki_pages, :slug
+
+    # Restore the old title
+    ActiveRecord::Base.transaction do
+      WikiPage.select(:id, :wiki_id, :title).find_each do |page|
+        # Save the title with spaces restored
+        # And generate the url slug
+        old_title = page.title.gsub(' ', '_')
+
+        page.update_columns(title: old_title)
+        WikiRedirect.where(wiki_id: page.wiki_id, title: old_title).delete_all
+      end
+    end
+  end
+
+
+  ##
+  # OpenProject < 6.0.0 processed wiki titles in a specific fashion (#titleize)
+  # replacing spaces with underscores and removing some characters.
+  # With OpenProject 6.0.0, titles were allowed to contain any chars.
+  # This causes issues since a title `foo bar` was saved as `foo_bar`, but displayed with spaces again
+  # and in turn, many page links actualy use [[foo bar]] instead of the actual title.
+  # Spaces were no longer matching the existing pages.
+  #
+  # Additionally, not all characters can be properly detected in the `parse_wiki_links` steps
+  # and this makes it impossible to link to some pages.
+  #
+  # To remove this issue, we introduce wiki slugs to create proper permalinks that can be linked
+  # to, and only fall back to finding by titles for the old pages.
+  def migrate_titles
+    # Create a redirect for all old titles
+    ActiveRecord::Base.transaction do
+      WikiPage.select(:id, :wiki_id, :title).find_each do |page|
+        # Restore the spaces in the old title (`pretty_title` in wiki.rb)
+        pretty_title = page.title.gsub('_', ' ')
+
+        # Generate a URL slug from the title using stringex
+        slug = pretty_title.to_url
+
+        # Generate a redirect from the old title to the slug
+        if page.title != slug
+          WikiRedirect.create(title: page.title, wiki_id: page.wiki_id, redirects_to: slug)
+        end
+
+        # Save the title with spaces restored
+        # And generate the url slug
+        page.update_columns(title: pretty_title, slug: slug)
+      end
+    end
+  end
+end

--- a/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
+++ b/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
@@ -7,7 +7,7 @@ class AddSlugToWikiPages < ActiveRecord::Migration
 
     # Disallow null values from now on
     # Adding this above is impossible due to columns having NULL values before `migrate_titles`
-    change_column_null :wiki_pages, :slug, true
+    change_column_null :wiki_pages, :slug, false
   end
 
   def down

--- a/features/wiki/parent_page.feature
+++ b/features/wiki/parent_page.feature
@@ -44,7 +44,7 @@ Feature: Parent wiki page
     And I follow "Change parent page"
     When I select "Parent page" from "Parent page"
     And I press "Save"
-    Then I should be on the wiki page "Test page" for the project called "Test"
+    Then I should be on the wiki page "test-page" for the project called "Test"
     And the breadcrumbs should have the element "Parent page"
     # no check removing the parent
     When I go to the wiki page "Test page" for the project called "Test"
@@ -52,5 +52,5 @@ Feature: Parent wiki page
     And I follow "Change parent page"
     And I select "-" from "Parent page"
     And I press "Save"
-    Then I should be on the wiki page "Test page" for the project called "Test"
+    Then I should be on the wiki page "test-page" for the project called "Test"
     And the breadcrumbs should not have the element "Parent page"

--- a/features/wiki/wiki_rename.feature
+++ b/features/wiki/wiki_rename.feature
@@ -51,5 +51,5 @@ Feature: Renaming a wiki page
     And I click on "Rename"
     And I fill in "New WikiPage" for "Title"
     And I press "Rename"
-    Then I should be on the wiki page "New WikiPage" of the project called "project1"
+    Then I should be on the wiki page "new-wikipage" of the project called "project1"
     And I should see "Successful update." within ".notice"

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -244,6 +244,8 @@ module OpenProject
               page = $1
               anchor = $2
             end
+            # Unescape the escaped entities from textile
+            page = CGI.unescapeHTML(page)
             # check if page exists
             wiki_page = link_project.wiki.find_page(page)
             url = case options[:wiki_links]

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -248,14 +248,15 @@ module OpenProject
             page = CGI.unescapeHTML(page)
             # check if page exists
             wiki_page = link_project.wiki.find_page(page)
+            wiki_title = wiki_page.nil? ? page : wiki_page.title
             url = case options[:wiki_links]
                   when :local; "#{title}.html"
                   when :anchor; "##{title}"   # used for single-file wiki export
                   else
-                    wiki_page_id = page.present? ? page : nil
+                    wiki_page_id = wiki_page.nil? ? page.to_url : wiki_page.slug
                     url_for(only_path: only_path, controller: '/wiki', action: 'show', project_id: link_project, id: wiki_page_id, anchor: anchor)
               end
-            link_to(h(title || page), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
+            link_to(h(title || wiki_title), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
           else
             # project or wiki doesn't exist
             all

--- a/lib/redmine/wiki_formatting/null_formatter/helper.rb
+++ b/lib/redmine/wiki_formatting/null_formatter/helper.rb
@@ -38,7 +38,7 @@ module Redmine
         end
 
         def initial_page_content(page)
-          page.pretty_title.to_s
+          page.title.to_s
         end
       end
     end

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -54,7 +54,7 @@ module Redmine
         end
 
         def initial_page_content(_page)
-          "h1. #{@page.pretty_title}"
+          "h1. #{@page.title}"
         end
 
         def heads_for_wiki_formatter

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -434,7 +434,7 @@ describe WikiController, type: :controller do
 
                 expect(response).to be_success
 
-                assert_select "#content a[href='#{new_child_project_wiki_path(project_id: @project, id: @page_with_content.title)}']", 'Wiki page'
+                assert_select "#content a[href='#{new_child_project_wiki_path(project_id: @project, id: @page_with_content.slug)}']", 'Wiki page'
               end
             end
 
@@ -474,7 +474,7 @@ describe WikiController, type: :controller do
 
               expect(response).to be_success
 
-              assert_select ".toolbar-items a[href='#{new_child_project_wiki_path(project_id: @project, id: 'Wiki')}']", 'Wiki page'
+              assert_select ".toolbar-items a[href='#{new_child_project_wiki_path(project_id: @project, id: 'wiki')}']", 'Wiki page'
             end
           end
 

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -52,7 +52,7 @@ describe 'Wiki unicode title spec', type: :feature, js: true do
 
     [[base-de-donnees]] should link to wiki_page_2
 
-    [[base-de-donnees-1]] should link to wiki_page_3
+    [[base-de-donnees-1]] should link to wiki_page_3 (slug duplicate!)
 
     [[<script>alert("FOO")</script>]]
 

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -1,0 +1,101 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Wiki unicode title spec', type: :feature do
+  let(:user) { FactoryGirl.create :admin }
+  let(:project) { FactoryGirl.create :project }
+  let(:wiki_page_1) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: '<script>alert("FOO")</script>'
+  }
+  let(:wiki_page_2) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: 'Base de données'
+  }
+  let(:wiki_page_3) {
+    FactoryGirl.build :wiki_page_with_content,
+                       title: 'Base_de_données'
+  }
+
+  let(:wiki_body) {
+    <<-EOS
+    [[Base de données]]
+
+    [[Base_de_données]]
+
+    [[Base%20de%20données]]
+
+    [[<script>alert("FOO")</script>]]
+
+    [[&lt;script&gt;alert(&quot;FOO&quot;)&lt;/script&gt;]]
+    EOS
+  }
+
+  let(:expected_titles) {
+    [
+      'Base de données',
+      'Base_de_données',
+      'Base de données',
+      '<script>alert("FOO")</script>',
+      '<script>alert("FOO")</script>'
+    ]
+  }
+
+  before do
+    login_as(user)
+
+    project.wiki.pages << wiki_page_1
+    project.wiki.pages << wiki_page_2
+    project.wiki.pages << wiki_page_3
+
+    project.wiki.save!
+
+    visit project_wiki_path(project, :wiki)
+
+    # Set value
+    find('#content_text').set(wiki_body)
+    click_button 'Save'
+
+    expect(page).to have_selector('h1.wiki-title', text: 'wiki')
+    expect(page).to have_selector('a.wiki-page', count: 5)
+  end
+
+  it 'shows renders correct links' do
+    expected_titles.each_with_index do |title, i|
+      visit project_wiki_path(project, :wiki)
+      target_link = all('div.wiki-content a.wiki-page')[i]
+
+      expect(target_link.text).to eq(title)
+      target_link.click
+
+      expect(page).to have_selector('h1.wiki-title', text: title)
+    end
+  end
+end

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Wiki unicode title spec', type: :feature do
+describe 'Wiki unicode title spec', type: :feature, js: true do
   let(:user) { FactoryGirl.create :admin }
   let(:project) { FactoryGirl.create :project }
   let(:wiki_page_1) {
@@ -46,24 +46,35 @@ describe 'Wiki unicode title spec', type: :feature do
 
   let(:wiki_body) {
     <<-EOS
-    [[Base de données]]
+    [[Base de données]] should link to wiki_page_2
 
-    [[Base_de_données]]
+    [[Base_de_données]] should link to wiki_page_2
 
-    [[Base%20de%20données]]
+    [[base-de-donnees]] should link to wiki_page_2
+
+    [[base-de-donnees-1]] should link to wiki_page_3
 
     [[<script>alert("FOO")</script>]]
 
-    [[&lt;script&gt;alert(&quot;FOO&quot;)&lt;/script&gt;]]
     EOS
+  }
+
+  let(:expected_slugs) {
+    [
+      'base-de-donnees',
+      'base-de-donnees',
+      'base-de-donnees',
+      'base-de-donnees-1',
+      'alert-foo',
+    ]
   }
 
   let(:expected_titles) {
     [
       'Base de données',
-      'Base_de_données',
       'Base de données',
-      '<script>alert("FOO")</script>',
+      'Base de données',
+      'Base_de_données',
       '<script>alert("FOO")</script>'
     ]
   }
@@ -93,6 +104,7 @@ describe 'Wiki unicode title spec', type: :feature do
       target_link = all('div.wiki-content a.wiki-page')[i]
 
       expect(target_link.text).to eq(title)
+      expect(target_link[:href]).to match("\/wiki\/#{expected_slugs[i]}")
       target_link.click
 
       expect(page).to have_selector('h1.wiki-title', text: title)

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -522,7 +522,7 @@ RAW
 
       let(:expected) {
         <<-EXPECTED
-<p><a class="wiki-page" href="/projects/#{project.identifier}/wiki/CookBook%20documentation">CookBook documentation</a></p>
+<p><a class="wiki-page" href="/projects/#{project.identifier}/wiki/cookbook-documentation">CookBook documentation</a></p>
 <p><a class="issue work_package status-3 priority-1 created-by-me" href="/work_packages/#{issue.id}" title="#{issue.subject} (#{issue.status})">##{issue.id}</a></p>
 <pre>
 [[CookBook documentation]]

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -341,86 +341,86 @@ describe OpenProject::TextFormatting do
       context 'Plain wiki link' do
         subject { format_text('[[CookBook documentation]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/CookBook%20documentation\">CookBook documentation</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/cookbook-documentation\">CookBook documentation</a></p>") }
       end
 
       context 'Arbitrary wiki link' do
         title = '<script>alert("FOO")</script>'
         subject { format_text("[[#{title}]]") }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki?id=#{CGI.escape(title)}\">#{h(title)}</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/alert-foo\">#{h(title)}</a></p>") }
       end
 
       context 'Plain wiki page link' do
         subject { format_text('[[Another page|Page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/Another%20page\">Page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></p>") }
       end
 
       context 'Wiki link with anchor' do
         subject { format_text('[[CookBook documentation#One-section]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/CookBook%20documentation#One-section\">CookBook documentation</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/cookbook-documentation#One-section\">CookBook documentation</a></p>") }
       end
 
       context 'Wiki page link with anchor' do
         subject { format_text('[[Another page#anchor|Page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/Another%20page#anchor\">Page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/another-page#anchor\">Page</a></p>") }
       end
 
       context 'Wiki link to an unknown page' do
         subject { format_text('[[Unknown page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/Unknown%20page\">Unknown page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page\">Unknown page</a></p>") }
       end
 
       context 'Wiki page link to an unknown page' do
         subject { format_text('[[Unknown page|404]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/Unknown%20page\">404</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page\">404</a></p>") }
       end
 
       context "Link to another project's wiki" do
         subject { format_text('[[onlinestore:]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki\">onlinestore</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/start-page\">onlinestore</a></p>") }
       end
 
       context "Link to another project's wiki with label" do
         subject { format_text('[[onlinestore:|Wiki]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki\">Wiki</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/start-page\">Wiki</a></p>") }
       end
 
       context "Link to another project's wiki page" do
         subject { format_text('[[onlinestore:Start page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/Start%20page\">Start page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/start-page\">Start Page</a></p>") }
       end
 
       context "Link to another project's wiki page with label" do
         subject { format_text('[[onlinestore:Start page|Text]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/Start%20page\">Text</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/onlinestore/wiki/start-page\">Text</a></p>") }
       end
 
       context 'Link to an unknown wiki page in another project' do
         subject { format_text('[[onlinestore:Unknown page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/onlinestore/wiki/Unknown%20page\">Unknown page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/onlinestore/wiki/unknown-page\">Unknown page</a></p>") }
       end
 
       context 'Struck through link to wiki page' do
         subject { format_text('-[[Another page|Page]]-') }
 
-        it { is_expected.to be_html_eql("<p><del><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/Another%20page\">Page</a></del></p>") }
+        it { is_expected.to be_html_eql("<p><del><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a></del></p>") }
       end
 
       context 'Named struck through link to wiki page' do
         subject { format_text('-[[Another page|Page]] link-') }
 
-        it { is_expected.to be_html_eql("<p><del><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/Another%20page\">Page</a> link</del></p>") }
+        it { is_expected.to be_html_eql("<p><del><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/another-page\">Page</a> link</del></p>") }
       end
 
       context 'Escaped link to wiki page' do

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -314,6 +314,11 @@ describe OpenProject::TextFormatting do
                            wiki: wiki_1,
                            title: 'Another page'
       }
+      let(:wiki_page_1_3) {
+        FactoryGirl.create :wiki_page_with_content,
+                           wiki: wiki_1,
+                           title: '<script>alert("FOO")</script>'
+      }
 
       before do
         project_2.reload
@@ -330,12 +335,20 @@ describe OpenProject::TextFormatting do
 
         wiki_1.pages << wiki_page_1_1
         wiki_1.pages << wiki_page_1_2
+        wiki_1.pages << wiki_page_1_3
       end
 
       context 'Plain wiki link' do
         subject { format_text('[[CookBook documentation]]') }
 
         it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki/CookBook%20documentation\">CookBook documentation</a></p>") }
+      end
+
+      context 'Arbitrary wiki link' do
+        title = '<script>alert("FOO")</script>'
+        subject { format_text("[[#{title}]]") }
+
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page\" href=\"/projects/#{project.identifier}/wiki?id=#{CGI.escape(title)}\">#{h(title)}</a></p>") }
       end
 
       context 'Plain wiki page link' do

--- a/spec/models/wiki/wiki_titles_migration_spec.rb
+++ b/spec/models/wiki/wiki_titles_migration_spec.rb
@@ -1,0 +1,115 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require Rails.root.join('db/migrate/20160726090624_add_slug_to_wiki_pages.rb')
+
+describe Wiki, type: :model do
+  describe 'Wiki titles migration' do
+    let(:project) { FactoryGirl.create :project }
+    let(:wiki_page) {
+      FactoryGirl.create :wiki_page_with_content,
+                         wiki: project.wiki,
+                         title: 'CookBook documentation'
+    }
+
+    let(:old_page_1) {
+      FactoryGirl.create :wiki_page_with_content,
+                         wiki: project.wiki,
+                         title: 'CookBook_documentation'
+    }
+    let(:old_page_2) {
+      FactoryGirl.create :wiki_page_with_content,
+                         wiki: project.wiki,
+                         title: 'base_de_donées'
+    }
+
+    let(:old_page_3) {
+      FactoryGirl.create :wiki_page_with_content,
+                         wiki: project.wiki,
+                         title: 'asciionly'
+    }
+
+    subject { project.wiki }
+
+    before do
+      project.wiki.pages << old_page_1
+      project.wiki.pages << old_page_2
+      project.wiki.pages << old_page_3
+
+      # Run the title replacement of the migration
+      ::AddSlugToWikiPages.new.migrate_titles
+
+      old_page_1.reload
+      old_page_2.reload
+      old_page_3.reload
+    end
+
+    it 'creates a redirect for the legacy page' do
+      redirect = WikiRedirect.where(title: 'CookBook_documentation').first
+      expect(redirect).not_to be_nil
+      expect(redirect.redirects_to).to eq(old_page_1.slug)
+    end
+
+    it 'does not create a redirect unless necessary' do
+      redirect = WikiRedirect.where(title: 'asciionly').first
+      expect(redirect).to be_nil
+    end
+
+    it 'sets title and slug' do
+      expect(old_page_1.title).to eq('CookBook documentation')
+      expect(old_page_1.slug).to eq('cookbook-documentation')
+
+      expect(old_page_2.title).to eq('base de donées')
+      expect(old_page_2.slug).to eq('base-de-donees')
+
+      expect(old_page_3.title).to eq('asciionly')
+      expect(old_page_3.slug).to eq('asciionly')
+    end
+
+    it 'locates the legacy pages' do
+      page = subject.find_page('CookBook documentation')
+      expect(page).to eq(old_page_1)
+
+      page = subject.find_page('CookBook documentation')
+      expect(page).to eq(old_page_1)
+
+      page = subject.find_page('base_de_donées')
+      expect(page).to eq(old_page_2)
+
+      page = subject.find_page('base de donées')
+      expect(page).to eq(old_page_2)
+    end
+
+    context 'trying to create same page' do
+      it 'raises an error' do
+        expect { wiki_page }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end

--- a/spec/models/wiki/wiki_titles_migration_spec.rb
+++ b/spec/models/wiki/wiki_titles_migration_spec.rb
@@ -107,8 +107,11 @@ describe Wiki, type: :model do
     end
 
     context 'trying to create same page' do
-      it 'raises an error' do
-        expect { wiki_page }.to raise_error(ActiveRecord::RecordInvalid)
+      it 'will create a new slug' do
+        expect { wiki_page }.not_to raise_error
+        wiki_page.reload
+
+        expect(wiki_page.slug).to eq('cookbook-documentation-1')
       end
     end
   end

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -39,6 +39,23 @@ describe WikiPage, type: :model do
     let(:project) { model_instance.wiki.project }
   end
 
+  describe '#create' do
+
+    context 'when another project with same title exists' do
+      let(:project2) { FactoryGirl.create(:project) }
+      let(:wiki2) { project2.wiki }
+      let!(:wiki_page1) { FactoryGirl.create(:wiki_page, wiki: wiki, title: 'asdf') }
+      let!(:wiki_page2) { FactoryGirl.create(:wiki_page, wiki: wiki2, title: 'asdf') }
+
+      it 'scopes the slug correctly' do
+        pages = WikiPage.where(title: 'asdf')
+        expect(pages.count).to eq(2)
+        expect(pages.first.slug).to eq('asdf')
+        expect(pages.last.slug).to eq('asdf')
+      end
+    end
+  end
+
   describe '#nearest_parent_menu_item' do
     let(:child_page) { FactoryGirl.create(:wiki_page, parent: wiki_page, wiki: wiki) }
     let!(:child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: child_page.title, parent: wiki_page.menu_item) }

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -29,24 +29,27 @@
 require 'spec_helper'
 
 describe Wiki, type: :model do
-  let(:project) { FactoryGirl.create(:project, disable_modules: 'wiki') }
-  let(:start_page) { 'The wiki start page' }
 
-  it_behaves_like 'acts_as_watchable included' do
-    let(:model_instance) { FactoryGirl.create(:wiki) }
-    let(:watch_permission) { :view_wiki_pages }
-    let(:project) { model_instance.project }
-  end
+  describe 'creation' do
+    let(:project) { FactoryGirl.create(:project, disable_modules: 'wiki') }
+    let(:start_page) { 'The wiki start page' }
 
-  describe '#create' do
-    let(:wiki) { project.create_wiki start_page: start_page }
-
-    it 'creates a wiki menu item on creation' do
-      expect(wiki.wiki_menu_items).to be_one
+    it_behaves_like 'acts_as_watchable included' do
+      let(:model_instance) { FactoryGirl.create(:wiki) }
+      let(:watch_permission) { :view_wiki_pages }
+      let(:project) { model_instance.project }
     end
 
-    it 'sets the wiki menu item title to the name of the start page' do
-      expect(wiki.wiki_menu_items.first.title).to eq(start_page)
+    describe '#create' do
+      let(:wiki) { project.create_wiki start_page: start_page }
+
+      it 'creates a wiki menu item on creation' do
+        expect(wiki.wiki_menu_items).to be_one
+      end
+
+      it 'sets the wiki menu item title to the name of the start page' do
+        expect(wiki.wiki_menu_items.first.title).to eq(start_page)
+      end
     end
   end
 end

--- a/spec_legacy/fixtures/wiki_pages.yml
+++ b/spec_legacy/fixtures/wiki_pages.yml
@@ -30,6 +30,7 @@
 wiki_pages_001:
   created_on: 2007-03-07 00:08:07 +01:00
   title: CookBook documentation
+  slug: cookbook-documentation
   id: 1
   wiki_id: 1
   protected: true
@@ -37,6 +38,7 @@ wiki_pages_001:
 wiki_pages_002:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Another page
+  slug: another-page
   id: 2
   wiki_id: 1
   protected: false
@@ -44,6 +46,7 @@ wiki_pages_002:
 wiki_pages_003:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Start page
+  slug: start-page
   id: 3
   wiki_id: 2
   protected: false
@@ -51,6 +54,7 @@ wiki_pages_003:
 wiki_pages_004:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Page with an inline image
+  slug: page-with-an-inline-image
   id: 4
   wiki_id: 1
   protected: false
@@ -58,6 +62,7 @@ wiki_pages_004:
 wiki_pages_005:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Child 1
+  slug: child-1
   id: 5
   wiki_id: 1
   protected: false
@@ -65,6 +70,7 @@ wiki_pages_005:
 wiki_pages_006:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Child 2
+  slug: child-2
   id: 6
   wiki_id: 1
   protected: false
@@ -72,6 +78,7 @@ wiki_pages_006:
 wiki_pages_007:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Child page 1
+  slug: child-page-1
   id: 7
   wiki_id: 2
   protected: false
@@ -79,6 +86,7 @@ wiki_pages_007:
 wiki_pages_008:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Parent page
+  slug: parent-page
   id: 8
   wiki_id: 2
   protected: false
@@ -86,6 +94,7 @@ wiki_pages_008:
 wiki_pages_009:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Child page 2
+  slug: child-page-2
   id: 9
   wiki_id: 2
   protected: false
@@ -93,6 +102,7 @@ wiki_pages_009:
 wiki_pages_010:
   created_on: 2007-03-08 00:18:07 +01:00
   title: Этика менеджмента
+  slug: etika-mieniedzhmienta
   id: 10
   wiki_id: 1
   protected: false

--- a/spec_legacy/functional/wiki_controller_spec.rb
+++ b/spec_legacy/functional/wiki_controller_spec.rb
@@ -99,7 +99,7 @@ describe WikiController, type: :controller do
                  id: 'New page',
                  content: { comments: 'Created the page',
                             text: "h1. New page\n\nThis is a new page" }
-    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'New+page'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'new-page'
     page = wiki.find_page('New page')
     assert !page.new_record?
     refute_nil page.content
@@ -141,7 +141,7 @@ describe WikiController, type: :controller do
         end
       end
     end
-    assert_redirected_to '/projects/ecookbook/wiki/Another+page'
+    assert_redirected_to '/projects/ecookbook/wiki/another-page'
 
     page.reload
     assert_equal 'edited', page.content.text
@@ -310,7 +310,7 @@ describe WikiController, type: :controller do
     patch :rename, project_id: 1, id: 'Another page',
                    page: { title: 'Another renamed page',
                            redirect_existing_links: 1 }
-    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another+renamed+page'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'another-renamed-page'
     # Check redirects
     refute_nil wiki.find_page('Another page')
     assert_nil wiki.find_page('Another page', with_redirect: false)
@@ -318,10 +318,10 @@ describe WikiController, type: :controller do
 
   it 'should rename without redirect' do
     session[:user_id] = 2
-    patch :rename, project_id: 1, id: 'Another page',
+    patch :rename, project_id: 1, id: 'another-page',
                    page: { title: 'Another renamed page',
                            redirect_existing_links: '0' }
-    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another+renamed+page'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'another-renamed-page'
     # Check that there's no redirects
     assert_nil wiki.find_page('Another page')
   end
@@ -406,9 +406,9 @@ describe WikiController, type: :controller do
       it { should_assign_to :pages }
       it { should_respond_with_content_type 'text/html' }
       it 'should export all of the wiki pages to a single html file' do
-        assert_select 'a[name=?]', 'CookBook+documentation'
-        assert_select 'a[name=?]', 'Another+page'
-        assert_select 'a[name=?]', 'Page+with+an+inline+image'
+        assert_select 'a[name=?]', 'cookbook-documentation'
+        assert_select 'a[name=?]', 'another-page'
+        assert_select 'a[name=?]', 'page-with-an-inline-image'
       end
     end
 
@@ -447,7 +447,7 @@ describe WikiController, type: :controller do
     assert !page.protected?
     session[:user_id] = 2
     post :protect, project_id: 1, id: page.title, protected: '1'
-    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'Another+page'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'another-page'
     assert page.reload.protected?
   end
 
@@ -456,7 +456,7 @@ describe WikiController, type: :controller do
     assert page.protected?
     session[:user_id] = 2
     post :protect, project_id: 1, id: page.title, protected: '0'
-    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'CookBook+documentation'
+    assert_redirected_to action: 'show', project_id: 'ecookbook', id: 'cookbook-documentation'
     assert !page.reload.protected?
   end
 

--- a/spec_legacy/unit/helpers/application_helper_spec.rb
+++ b/spec_legacy/unit/helpers/application_helper_spec.rb
@@ -346,9 +346,9 @@ EXPECTED
     FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Last page'
 
     to_test = { "|[[Page|Link title]]|[[Other Page|Other title]]|\n|Cell 21|[[Last page]]|" =>
-                 "<tr><td><a class=\"wiki-page new\" href=\"/projects/#{@project.identifier}/wiki/Page\">Link title</a></td>" +
-                 "<td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/Other%20Page\">Other title</a></td>" +
-                 "</tr><tr><td>Cell 21</td><td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/Last%20page\">Last page</a></td></tr>"
+                 "<tr><td><a class=\"wiki-page new\" href=\"/projects/#{@project.identifier}/wiki/page\">Link title</a></td>" +
+                 "<td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/other-page\">Other title</a></td>" +
+                 "</tr><tr><td>Cell 21</td><td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/last-page\">Last page</a></td></tr>"
     }
 
     to_test.each { |text, result| assert_dom_equal "<table>#{result}</table>", helper.format_text(text).gsub(/[\t\n]/, '') }

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
@@ -70,8 +70,8 @@ describe Redmine::WikiFormatting::Macros, type: :helper do
 
   it 'should macro child pages' do
     expected =  "<p><ul class=\"pages-hierarchy\">" +
-                "<li><a href=\"/projects/ecookbook/wiki/Child+1\">Child 1</a></li>" +
-                "<li><a href=\"/projects/ecookbook/wiki/Child+2\">Child 2</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/child-1\">Child 1</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/child-2\">Child 2</a></li>" +
                 '</ul></p>'
 
     @project = Project.find(1)
@@ -86,10 +86,10 @@ describe Redmine::WikiFormatting::Macros, type: :helper do
 
   it 'should macro child pages with option' do
     expected =  "<p><ul class=\"pages-hierarchy\">" +
-                "<li><a href=\"/projects/ecookbook/wiki/Another+page\">Another page</a>" +
+                "<li><a href=\"/projects/ecookbook/wiki/another-page\">Another page</a>" +
                 "<ul class=\"pages-hierarchy\">" +
-                "<li><a href=\"/projects/ecookbook/wiki/Child+1\">Child 1</a></li>" +
-                "<li><a href=\"/projects/ecookbook/wiki/Child+2\">Child 2</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/child-1\">Child 1</a></li>" +
+                "<li><a href=\"/projects/ecookbook/wiki/child-2\">Child 2</a></li>" +
                 '</ul></li></ul></p>'
 
     @project = Project.find(1)

--- a/spec_legacy/unit/wiki_redirect_spec.rb
+++ b/spec_legacy/unit/wiki_redirect_spec.rb
@@ -42,14 +42,14 @@ describe WikiRedirect, type: :model do
     @original.reload
 
     assert_equal 'New title', @original.title
-    assert @wiki.redirects.find_by(title: 'Original title')
+    assert @wiki.redirects.find_by(title: 'original-title')
     assert @wiki.find_page('Original title')
     assert @wiki.find_page('ORIGINAL title')
   end
 
   it 'should update redirect' do
     # create a redirect that point to this page
-    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: 'Original title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: @original.slug)
 
     @original.title = 'New title'
     @original.save
@@ -59,25 +59,25 @@ describe WikiRedirect, type: :model do
 
   it 'should reverse rename' do
     # create a redirect that point to this page
-    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: 'Original title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: @original.slug)
 
     @original.title = 'An old page'
     @original.save
-    assert !@wiki.redirects.find_by(title: 'An old page', redirects_to: 'An old page')
-    assert @wiki.redirects.find_by(title: 'Original title', redirects_to: 'An old page')
+    assert !@wiki.redirects.find_by(title: 'an-old-page', redirects_to: 'an-old-page')
+    assert @wiki.redirects.find_by(title: 'original-title', redirects_to: 'an-old-page')
   end
 
   it 'should rename to already redirected' do
-    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: 'Other page')
+    assert WikiRedirect.create(wiki: @wiki, title: 'an-old-page', redirects_to: 'other-page')
 
     @original.title = 'An old page'
     @original.save
     # this redirect have to be removed since 'An old page' page now exists
-    assert !@wiki.redirects.find_by(title: 'An old page', redirects_to: 'Other page')
+    assert !@wiki.redirects.find_by(title: 'an-old-page', redirects_to: 'other-page')
   end
 
   it 'should redirects removed when deleting page' do
-    assert WikiRedirect.create(wiki: @wiki, title: 'An old page', redirects_to: 'Original title')
+    assert WikiRedirect.create(wiki: @wiki, title: 'an-old-page', redirects_to: @original.slug)
 
     @original.destroy
     assert !@wiki.redirects.first


### PR DESCRIPTION
OpenProject < 6.0.0 processed wiki titles in a specific fashion (#titleize)
replacing spaces with underscores and removing some characters.
With OpenProject 6.0.0, titles were allowed to contain any chars.
This causes issues since a title `foo bar` was saved as `foo_bar`, but displayed with spaces again
and in turn, many page links actualy use [[foo bar]] instead of the actual title.

Spaces were no longer matching the existing pages.

Additionally, not all characters can be properly detected in the `parse_wiki_links` steps and this makes it impossible to link to some pages. (e.g.,`[[Foo & Bar]]`)

To remove this issue, we introduce wiki slugs using `stringex` to create proper permalinks that can be linked to, and only fall back to finding by titles for the old pages.

https://community.openproject.com/work_packages/23674
