### PR TITLE
Fix $unload from cache

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -102,18 +102,13 @@ export class HalResource {
 
     // Reset and load this resource
     this.$loaded = false;
-    this.$self = this.$links.self({}, this.$loadHeaders(true)).then(source => {
+    this.$self = this.$links.self({}, this.$loadHeaders(force)).then(source => {
       this.$loaded = true;
       this.$initialize(source);
       return this;
     });
 
     return this.$self;
-  }
-
-  public $unload() {
-    this.$loaded = false;
-    this.$self = null;
   }
 
   public $plain() {

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -74,7 +74,7 @@ export class WorkPackageCacheService {
    */
   loadWorkPackageLinks(workPackage, ...args: string[]) {
     args.forEach((arg) => {
-      workPackage[arg].$unload();
+      workPackage[arg].$load(true);
     });
     return this.updateWorkPackage(workPackage);
   }


### PR DESCRIPTION
With the change in `$loadHeaders`, items are actually requested multiple times despite cached.
