### PR TITLE
[23685] Pass the project identifier to populate the create form

### DIFF
--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -29,14 +29,17 @@
 import {wpDirectivesModule} from '../../angular-modules';
 import {WorkPackageCreateController} from '../wp-create/wp-create.controller';
 import {scopedObservable} from '../../helpers/angular-rx-utils';
-import {WorkPackageResource} from '../api/api-v3/hal-resources/work-package-resource.service';
+import {
+  WorkPackageResource,
+  WorkPackageResourceInterface
+} from '../api/api-v3/hal-resources/work-package-resource.service';
 
 export class WorkPackageCopyController extends WorkPackageCreateController {
   protected newWorkPackageFromParams(stateParams) {
     var deferred = this.$q.defer();
 
     scopedObservable(this.$scope, this.wpCacheService.loadWorkPackage(stateParams.copiedFromWorkPackageId))
-      .subscribe((wp:WorkPackageResource) => {
+      .subscribe((wp:WorkPackageResourceInterface) => {
         this.createCopyFrom(wp).then(newWorkPackage => {
           deferred.resolve(newWorkPackage);
         });
@@ -45,9 +48,9 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
     return deferred.promise;
   }
 
-  private createCopyFrom(wp:WorkPackageResource) {
+  private createCopyFrom(wp:WorkPackageResourceInterface) {
     return wp.getForm().then(form => {
-      return this.wpCreate.copyWorkPackage(form);
+      return this.wpCreate.copyWorkPackage(form, wp.project.identifier);
     });
   }
 }


### PR DESCRIPTION
We populate the project resource on the copied work package resource, but the form posted to is empty and thus fails to initialize type and status initially.

https://community.openproject.com/work_packages/23685
