### PR TITLE
[23696] Fix updating wp resource values from allowedValues

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -242,10 +242,17 @@ export class WorkPackageResource extends HalResource {
       const schema = form.$embedded.schema;
 
       angular.forEach(schema, (field, name) => {
-        if (this[name] && field && field.writable && field.$isHal
-          && (Array.isArray(field.allowedValues) && field.allowedValues.length > 0)) {
+        // Assign only links from schema when an href is set
+        // and field is writable.
+        // (exclude plain properties and null values)
+        const isHalField = field.writable && this[name] && this[name].href;
 
-          this[name] = _.where(field.allowedValues, {name: this[name].name})[0];
+        // Assign only values from embedded schema that have an expanded
+        // allowedValues set (type, status, custom field lists, etc.)
+        const hasAllowedValues = Array.isArray(field.allowedValues) && field.allowedValues.length > 0;
+
+        if (isHalField && hasAllowedValues) {
+          this[name] = _.find(field.allowedValues, { href: this[name].href});
         }
       });
 

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -85,7 +85,7 @@ FactoryGirl.define do
       type 'WorkPackageCustomField'
 
       factory :list_wp_custom_field do
-        sequence(:name) do |n| "List work package custom field #{n}" end
+        sequence(:name) do |n| "List CF #{n}" end
         field_format 'list'
         possible_values ['1', '2', '3', '4', '5', '6', '7']
       end


### PR DESCRIPTION
When a form is activated, fields on the work package resource were
updated from the form's embedded schema, more precisely, from the
`allowedValues` when these existed.

However, they were checked by name instead of the href, which does not
exist on most properties.

https://community.openproject.com/work_packages/23696
