### PR TITLE
[23448] Replace wrong headline element

### DIFF
--- a/app/views/repositories/settings/_vendor_attribute_groups.html.erb
+++ b/app/views/repositories/settings/_vendor_attribute_groups.html.erb
@@ -1,9 +1,9 @@
 <div class="description attributes-group" id="<%= vendor %>-<%= type %>" style="<%=existing ? 'display: block' : 'display: none' %> ">
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
-      <h3 class="attributes-group--header-text">
+      <span class="attributes-group--header-text">
         <%= l("repositories.#{vendor}.#{type}_url") %>
-      </h3>
+      </span>
     </div>
     <% unless repository.new_record? %>
     <div class="attributes-group--header-control">


### PR DESCRIPTION
This removes the wrongly used `h3` tag and replaces it with a `span`.

https://community.openproject.com/work_packages/23448/activity
