### PR TITLE
[23697] Remove project-specific version from representer

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -269,7 +269,7 @@ module API
         linked_property :version,
                         getter: :fixed_version,
                         title_getter: -> (*) {
-                          represented.fixed_version.to_s_for_project(represented.project)
+                          represented.fixed_version.to_s
                         },
                         embed_as: ::API::V3::Versions::VersionRepresenter
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -426,7 +426,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
           it_behaves_like 'has a titled link' do
             let(:link) { 'version' }
             let(:href) { api_v3_paths.version(version.id) }
-            let(:title) { version.to_s_for_project(project) }
+            let(:title) { version.to_s }
           end
 
           it 'has the version embedded' do


### PR DESCRIPTION
Grouping versions are performed on their names, not on the
project-specific name (e.g., `parent - version` in a subproject where
this version is shared with).

This causes the group name and row value to differ and cause an error.

This commit changes the behavior as before. Grouping instead should be
made on a unique identifier (valueLink for non-scalar values) and the
grouping should generate a project-specific output so that versions can
add the above project-specific name.

https://community.openproject.com/work_packages/23697/activity
