### PR TITLE
[23710] Required icon for custom fields not initially displayed

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/single-view-wp.service.ts
+++ b/frontend/app/components/work-packages/wp-single-view/single-view-wp.service.ts
@@ -212,7 +212,7 @@ export class SingleViewWorkPackage {
   }
 
   public hasNiceStar(field) {
-    return this.isRequired(field) && this.isEditable(field);
+    return this.isRequired(field) && this.workPackage.schema[field].writable;
   }
 
   public isGroupHideable(groupedFields, groupName) {


### PR DESCRIPTION
This fixes the display of the missing asterix for required fields in the WP view. 

https://community.openproject.com/work_packages/23710/activity
