### PR TITLE
[23466] [6a] Radiobuttons ohne Beschriftung

### DIFF
--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -39,6 +39,9 @@ See doc/COPYRIGHT.rdoc for more details.
           <col highlight-col>
           <col highlight-col>
         </colgroup>
+        <caption class="hidden-for-sighted">
+          <span><%= l(:text_changeset_table_description) %></span>
+        </caption>
         <thead>
           <tr>
             <th class="-short">
@@ -91,9 +94,11 @@ See doc/COPYRIGHT.rdoc for more details.
               </td>
               <td class="checkbox -short">
                 <%= radio_button_tag('rev', changeset.identifier, (line_num==1), id: "cb-#{line_num}", onclick: "$('cbto-#{line_num+1}').checked=true;") if show_diff && (line_num < revisions.size) %>
+                <%= label_tag "cb-#{line_num}", t(:label_changeset_differences_begin), class: 'hidden-for-sighted' %>
               </td>
               <td class="checkbox -short">
                 <%= radio_button_tag('rev_to', changeset.identifier, (line_num==2), id: "cbto-#{line_num}", onclick: "if ($('cb-#{line_num}').checked==true) {$('cb-#{line_num-1}').checked=true;}") if show_diff && (line_num > 1) %>
+                <%= label_tag "cbto-#{line_num}", t(:label_changeset_differences_end), class: 'hidden-for-sighted' %>
               </td>
               <td class="committed_on">
                 <%= format_time(changeset.committed_on) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -913,6 +913,8 @@ en:
   label_change_status: "Change status"
   label_change_view_all: "View all changes"
   label_changes_details: "Details of all changes"
+  label_changeset_differences_begin: "Changeset base"
+  label_changeset_differences_end: "Changeset to compare"
   label_changeset_plural: "Changesets"
   label_checked: "checked"
   label_check_uncheck_all_in_column: "Check/Uncheck all in column"
@@ -1804,6 +1806,7 @@ en:
     Only fields that are not required or have a default value can be customized.
   text_caracters_maximum: "%{count} characters maximum."
   text_caracters_minimum: "Must be at least %{count} characters long."
+  text_changeset_table_description: "In this table the single changesets of the repository are shown. You can view the difference between any two changesets by first selecting the according checkboxes in the table. When clicking on the button below the table the difference is shown."
   text_comma_separated: "Multiple values allowed (comma separated)."
   text_comment_wiki_page: "Comment to wiki page: %{page}"
   text_custom_field_possible_values_info: "One line for each value"


### PR DESCRIPTION
This adds labels to the checkboxes in the repository changeset table. Further the table has a caption to explain to blind users the functionality.

https://community.openproject.com/work_packages/23466/activity
