### PR TITLE
[23645] Fix watcher selection

### DIFF
--- a/frontend/app/templates/work_packages/watchers/lookup.html
+++ b/frontend/app/templates/work_packages/watchers/lookup.html
@@ -24,9 +24,11 @@
                   ng-model="selection.watcher"
                   title="{{ ::I18n.t('js.watchers.label_search_watchers') }}"
                   reset-search-input="true"
+                  append-to-body="true"
                   theme="select2">
               <ui-select-match>{{ $select.selected.name }}</ui-select-match>
               <ui-select-choices
+                      position="down"
                       repeat="watcher as watcher in watchers | filter: $select.search">
                   <div aria-label="{{ watcher.name }}" ng-bind-html="watcher.name | highlight: $select.search"></div>
               </ui-select-choices>

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -25,7 +25,7 @@
     "lodash": "~2.4.1",
     "foundation-apps": "1.1.0",
     "bourbon": "~4.2.1",
-    "angular-ui-select": "~0.13.2",
+    "angular-ui-select": "~0.18.1",
     "mousetrap": "~1.4.6",
     "ng-file-upload": "~5.0.9",
     "restangular": "~1.5.1",

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -62,11 +62,11 @@ describe 'Watcher tab', js: true, selenium: true do
       trigger = find('.work-package--watchers-lookup .inplace-editing--trigger-container')
       trigger.click
 
-      form = find('.work-package--watchers-lookup')
-      form.click
+      input = find('input.ui-select-search')
+      input.click
+      input.send_keys [user.name, :return]
 
-      form.find('.ui-select-search').send_keys [user.name, :return]
-      form.find('.inplace-edit--control--save').click
+      find('.inplace-edit--control--save a').click
 
       # Expect the addition of the user to toggle WP watch button
       expect(page).to have_selector('.work-package--watcher-name', count: 1, text: user.name)


### PR DESCRIPTION
ui-select opens upwards when there's no space left below it. Since the up styling is broken, Instead, we can append it to the body so that the user can scroll towards it and open it correctly.
