### PR TITLE
Avoid unescaped angular brackets in timeline macro

### DIFF
--- a/app/views/timelines/_timeline.html.erb
+++ b/app/views/timelines/_timeline.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= include_gon %>
 
 <div ng-controller="TimelinesController" ng-init="init(<%= timeline.id %>)">
-  <timeline-container timeline-id="{{ timeline.id }}">
+  <timeline-container timeline-id="<%= timeline.id %>">
     <timeline-toolbar timeline="timeline"></timeline-toolbar>
     <timeline-table-container timeline="timeline"></timeline-table-container>
   </timeline-container>


### PR DESCRIPTION
Since the intermediate output of `format_text` is a string, we can't
html_safe portions of that string e.g., for the view rendered by the
timeline macro.

This causes Rails templates to have `{{` escaped. As a workaround, we
can instead pass the value through ERB.

https://community.openproject.com/work_packages/23689/activity
