### PR TITLE
[23430] [1l] Icon zum Anzeigen der Detailansicht wird nur bei Mouseover eingeblendet

### DIFF
--- a/app/assets/stylesheets/content/_work_packages_table.sass
+++ b/app/assets/stylesheets/content/_work_packages_table.sass
@@ -28,10 +28,12 @@
 
 // Show details view button when hovering
 .wp-table--details-link
-  display: none
-
-  .issue:hover &
-    display: inline-block
+  .issue:hover &,
+  &:focus
+    position: relative
+    left: 0
+    width: 1.5rem
+    height: 1.5rem
 
     .icon
       position: relative

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -132,7 +132,7 @@
                                  model="row.checked">
             </accessible-checkbox>
             <span>
-              <a class="wp-table--details-link"
+              <a class="wp-table--details-link hidden-for-sighted"
                  ui-state="desiredSplitViewState"
                  ui-state-params="{workPackageId: row.object.id}">
                 <i class="icon icon-view-split"></i>

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -206,10 +206,10 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
 
     context 'focus' do
       let(:first_link_selector) do
-        'table.keyboard-accessible-list tbody tr:first-child td.id a'
+        'table.keyboard-accessible-list tbody tr:first-child .wp-table--details-link'
       end
       let(:second_link_selector) do
-        'table.keyboard-accessible-list tbody tr:nth-child(2) td.id a'
+        'table.keyboard-accessible-list tbody tr:nth-child(2) .wp-table--details-link'
       end
 
       it 'navigates with J' do


### PR DESCRIPTION
This enables blind users to access the split screen icon in the table by tab. Before it was only shown on hover.

https://community.openproject.com/work_packages/23430/activity
