### PR TITLE
[23725] Fix available custom fields v3 naming

### DIFF
--- a/app/controllers/api/experimental/queries_controller.rb
+++ b/app/controllers/api/experimental/queries_controller.rb
@@ -59,7 +59,7 @@ module Api::Experimental
                       else
                         WorkPackageCustomField.for_all
                       end
-      @custom_field_filters = @query.get_custom_field_options(custom_fields)
+      @custom_field_filters = @query.get_custom_field_options(custom_fields, v3_naming: true)
 
       respond_to do |format|
         format.api

--- a/app/models/queries/work_packages/available_filter_options.rb
+++ b/app/models/queries/work_packages/available_filter_options.rb
@@ -49,7 +49,7 @@ module Queries::WorkPackages::AvailableFilterOptions
     available_work_package_filters.has_key?(key.to_s)
   end
 
-  def get_custom_field_options(custom_fields)
+  def get_custom_field_options(custom_fields, v3_naming: false)
     filters = {}
     custom_fields.select(&:is_filter?).each do |field|
       case field.field_format
@@ -72,7 +72,11 @@ module Queries::WorkPackages::AvailableFilterOptions
       else
         options = { type: :string, order: 20 }
       end
-      filters["cf_#{field.id}"] = options.merge(name: field.name)
+
+      filter_key = "cf_#{field.id}"
+      filter_key = API::Utilities::PropertyNameConverter.from_ar_name(filter_key) if v3_naming
+
+      filters[filter_key] = options.merge(name: field.name)
     end
     filters
   end


### PR DESCRIPTION
The custom field filters were not exported as their v3 names, thus
filter values were not properly expanded once a query had been saved.

https://community.openproject.com/work_packages/23725
