### PR TITLE
[23465] [7i] Zwei unnötige Tabschritte bei einzelnstehendem Radiobutton

### DIFF
--- a/app/views/repositories/settings/_vendor_form.html.erb
+++ b/app/views/repositories/settings/_vendor_form.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
      <div class="form--field">
       <%= styled_label_tag type, l("repositories.#{@repository.vendor}.#{type}_title") %>
       <div class="form--field-container">
-        <%= styled_radio_button_tag 'scm_type', type, false, id: type %>
+        <%= styled_radio_button_tag 'scm_type', type, scm_types.length == 1 ? true : false, id: type, autofocus: true %>
       </div>
     </div>
     <% end %>

--- a/app/views/repositories/settings/repository_form.js.erb
+++ b/app/views/repositories/settings/repository_form.js.erb
@@ -46,6 +46,19 @@
     // Focus on first header
     headers.first().focus();
 
+    // Open content if there is only one possible selection
+    var checkedInput = jQuery('input[name=scm_type]:checked');
+    if(checkedInput.length > 0) {
+      toggleContent(content, checkedInput.val());
+    }
+
+    // Necessary for accessibilty purpose
+    jQuery('#scm_vendor').on('change', function(){
+      window.setTimeout(function(){
+        document.getElementsByName('scm_type')[0].focus();
+      }, 500)
+    });
+
     // Toggle content
     switches.on('change', function() {
       toggleContent(content, this.value);

--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -82,7 +82,7 @@ describe 'Create repository', type: :feature, js: true, selenium: true do
       find("option[value='#{vendor}']").select_option
     end
 
-    shared_examples 'has only the type which is hidden' do |type, vendor|
+    shared_examples 'has only the type which is selected' do |type, vendor|
       it 'should display one type' do
         # There seems to be an issue with how the
         # select is accessed after the async form loading
@@ -98,7 +98,7 @@ describe 'Create repository', type: :feature, js: true, selenium: true do
 
         content = find("#"+"#{vendor}-#{type}", visible: false)
         expect(content).not_to be_nil
-        expect(content[:style]).to match("display: none")
+        scm_type.should be_checked
       end
     end
 
@@ -168,7 +168,7 @@ describe 'Create repository', type: :feature, js: true, selenium: true do
     context 'with Subversion selected' do
       let(:vendor) { 'subversion' }
 
-      it_behaves_like 'has only the type which is hidden', 'existing', 'subversion'
+      it_behaves_like 'has only the type which is selected', 'existing', 'subversion'
 
       context 'and managed repositories' do
         include_context 'with tmpdir'
@@ -186,12 +186,12 @@ describe 'Create repository', type: :feature, js: true, selenium: true do
     context 'with Git selected' do
       let(:vendor) { 'git' }
 
-      it_behaves_like 'has only the type which is hidden', 'local', 'git'
+      it_behaves_like 'has only the type which is selected', 'local', 'git'
       context 'and managed repositories, but not ours' do
         let(:config) {
           { subversion: { manages: '/tmp/whatever' } }
         }
-        it_behaves_like 'has only the type which is hidden', 'local', 'git'
+        it_behaves_like 'has only the type which is selected', 'local', 'git'
       end
 
       context 'and managed repositories' do


### PR DESCRIPTION
This sets the focus when creating a repo. Further the radio button is now directly selected, if there is only one option. 

https://community.openproject.com/work_packages/23465/activity
