### PR TITLE
Create observe_field replacement in angular

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -133,12 +133,7 @@ class MembersController < ApplicationController
     respond_to do |format|
       format.json
       format.html do
-        if request.xhr?
-          partial = 'members/autocomplete_for_member'
-        else
-          partial = 'members/member_form'
-        end
-        render partial: partial,
+        render partial: 'members/autocomplete_for_member',
                locals: { project: @project,
                          principals: @principals,
                          roles: Role.find_all_givable }

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -77,24 +77,23 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_form_tag(members_of_group_path(@group), method: :post, remote: true) do |f| %>
         <fieldset class="form--fieldset">
           <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
-          <div class="form--field -vertical">
-            <%= styled_label_tag "user_search", l(:label_user_search) %>
-            <div class="form--field-container">
-              <%= styled_text_field_tag 'user_search', nil %>
+          <remote-field-updater
+             url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group) %>"
+             request-key="q">
+            <div class="form--field -vertical">
+              <%= styled_label_tag "user_search", l(:label_user_search) %>
+              <div class="form--field-container">
+                <%= styled_text_field_tag 'user_search',
+                                          nil,
+                                          class: 'remote-field--input' %>
+              </div>
             </div>
-          </div>
-          <div class="form--field -vertical">
-            <%= observe_field(:user_search,
-                          frequency: 0.5,
-                          update: :users,
-                          url: { controller: '/groups', action: 'autocomplete_for_user', id: @group },
-                          with: 'q',
-                          method: :get)
-                      %>
-            <div id="users" class="form--field-container -vertical">
-              <%= principals_check_box_tags 'user_ids[]', users %>
+            <div class="form--field -vertical">
+              <div id="users" class="remote-field--target form--field-container -vertical">
+                <%= principals_check_box_tags 'user_ids[]', users %>
+              </div>
             </div>
-          </div>
+          </remote-field-updater>
           <div><%= styled_button_tag l(:button_add), class: '-highlight -with-icon icon-checkmark' %></div>
         </fieldset>
       <% end %>

--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -37,52 +37,46 @@ See doc/COPYRIGHT.rdoc for more details.
              complete: 'jQuery(\'#member-add-submit\').enable(); activateFlashError();',
              html: {id: "members_add_form", class: "form -vertical"}) do |f| %>
   <div class="form--section">
-    <div id="new-member-message"></div>
-    <div class="grid-block">
-      <div class="grid-block medium-6">
-        <div class="form--field">
-          <%
-             user_id_title = I18n.t(:label_principal_search)
-
-             if current_user.admin?
-               user_id_title += I18n.t(:label_principal_invite_via_email)
-             end
-          %>
-          <%= styled_label_tag :principal_search, user_id_title %>
-          <%= styled_text_field_tag :principal_search, nil %>
-          <%= observe_field(:principal_search,
-                            frequency: 0.5,
-                            update: :principal_results,
-                            complete: 'if (jQuery(\'#principal_results .form--field\').length > 0 &&
-                                           jQuery(\'.roles .form--field\').length > 0) {
-                                         jQuery(\'#member-add-submit\').show();
-                                       }
-                                       else {
-                                         jQuery(\'#member-add-submit\').hide();
-                                       };',
-                            url: { controller: '/members', action: 'autocomplete_for_member', project_id: project },
-                            with: 'q') %>
-        </div>
-      </div>
-    </div>
-    <div class="grid-block">
+    <remote-field-updater
+       url="<%= url_for(controller: '/members', action: 'autocomplete_for_member', project_id: project) %>"
+       request-key="q">
+      <div id="new-member-message"></div>
       <div class="grid-block">
-        <div class="grid-block medium-4" id="principal_results">
-          <%= render partial: 'members/autocomplete_for_member', locals: { principals: principals, roles: roles } %>
-        </div>
-        <div class="grid-block medium-4 roles">
-          <fieldset class="form--fieldset medium-11">
-            <legend class="form--fieldset-legend"><%= l(:label_role_plural) %></legend>
-            <%= labeled_check_box_tags 'member[role_ids][]', roles %>
-          </fieldset>
+        <div class="grid-block medium-6">
+          <div class="form--field">
+            <%
+               user_id_title = I18n.t(:label_principal_search)
+
+               if current_user.admin?
+                 user_id_title += I18n.t(:label_principal_invite_via_email)
+               end
+            %>
+            <%= styled_label_tag :principal_search, user_id_title %>
+            <%= styled_text_field_tag :principal_search,
+                                      nil,
+                                      class: 'remote-field--input' %>
+          </div>
         </div>
       </div>
-    </div>
-    <%= f.button l(:button_add),
-                 id: 'member-add-submit',
-                 class: 'button -highlight -with-icon icon-checkmark',
-                 style: roles.any? && (principals.any? && principals.size <= 20) ? "": "display:none" %>
-    <%= link_to I18n.t('button_cancel'), :back, class: 'button' %>
+      <div class="grid-block">
+        <div class="grid-block">
+          <div class="grid-block remote-field--target medium-4" id="principal_results">
+            <%= render partial: 'members/autocomplete_for_member', locals: { principals: principals, roles: roles } %>
+          </div>
+          <div class="grid-block medium-4 roles">
+            <fieldset class="form--fieldset medium-11">
+              <legend class="form--fieldset-legend"><%= l(:label_role_plural) %></legend>
+              <%= labeled_check_box_tags 'member[role_ids][]', roles %>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <%= f.button l(:button_add),
+                   id: 'member-add-submit',
+                   class: 'button -highlight -with-icon icon-checkmark',
+                   style: roles.any? && (principals.any? && principals.size <= 20) ? "": "display:none" %>
+      <%= link_to I18n.t('button_cancel'), :back, class: 'button' %>
+    </remote-field-updater>
   </div>
 
 <% end %>

--- a/frontend/app/components/common/remote/remote-field-updater.directive.test.ts
+++ b/frontend/app/components/common/remote/remote-field-updater.directive.test.ts
@@ -1,0 +1,71 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('remote-field-updater directive', function() {
+  var element;
+  var $compile;
+  var $rootScope;
+  var $httpBackend;
+
+  beforeEach(angular.mock.module(
+    'openproject',
+    'openproject.workPackages.directives'
+  ));
+
+  beforeEach(angular.mock.inject(function(_$compile_, _$rootScope_, _$httpBackend_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $httpBackend = _$httpBackend_;
+
+    var template = `
+      <remote-field-updater url="/foo/bar" request-key="q">
+        <input type="text" class="remote-field--input" />
+        <div class="remote-field--target"></div>
+      </remote-field-updater>`;
+    element = $compile(template)($rootScope);
+    angular.element(document.body).append(element);
+    $rootScope.$digest();
+  }));
+
+  afterEach(function() {
+    element.remove();
+  });
+
+  it('should request the given url on input', function() {
+    $httpBackend.expectGET('/foo/bar?q=foobar').respond(200, '<span>response!</span>');
+    var input = element.find('.remote-field--input');
+    input.val('foobar').trigger('keyup');
+
+    $httpBackend.flush();
+
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+
+    expect(element.find('.remote-field--target span').length).to.eql(1);
+  });
+});

--- a/frontend/app/components/common/remote/remote-field-updater.directive.ts
+++ b/frontend/app/components/common/remote/remote-field-updater.directive.ts
@@ -1,0 +1,61 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {wpDirectivesModule} from "../../../angular-modules";
+
+function remoteFieldUpdater($http) {
+  return {
+    restrict: 'E',
+    scope: {
+      requestKey: '@',
+      url: '@'
+    },
+    link: (scope, element) => {
+      const input = element.find('.remote-field--input');
+      const target = element.find('.remote-field--target');
+
+      function updater() {
+        const request = {};
+        request[scope.requestKey] = input.val();
+
+        $http.get(scope.url, {
+          params: request,
+          headers: {
+            "Accept": "text/html"
+          }
+        }).then(response => {
+          target.html(response.data);
+        });
+      }
+
+      input.on('keyup', _.debounce(updater, 250));
+    }
+  };
+}
+
+wpDirectivesModule.directive('remoteFieldUpdater', remoteFieldUpdater);

--- a/frontend/app/components/common/remote/remote-field-updater.directive.ts
+++ b/frontend/app/components/common/remote/remote-field-updater.directive.ts
@@ -53,7 +53,7 @@ function remoteFieldUpdater($http) {
         });
       }
 
-      input.on('keyup', _.debounce(updater, 250));
+      input.on('keyup', _.throttle(updater, 250));
     }
   };
 }


### PR DESCRIPTION
Replaces the `observe_field` helper in the core with a simple angular directive to throttle a requet and replace some body.
