### PR TITLE
[23739] Empty query filters

### DIFF
--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -156,6 +156,8 @@ module QueriesHelper
   # @return [Array] Returns a list of fixed field names. The list may contain nil values
   #                 for fields which could not be found.
   def fix_field_array(query, field_names)
+    return [] if field_names.nil?
+
     context = WorkPackage.new
     available_keys = query.available_work_package_filters.keys
 

--- a/spec/features/work_packages/table/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu_spec.rb
@@ -5,7 +5,7 @@ describe 'Work package table context menu', js: true do
   let(:work_package) { FactoryGirl.create(:work_package) }
 
   let(:wp_table) { Pages::WorkPackagesTable.new }
-  let(:menu) { Components::WorkPackagesContextMenu.new }
+  let(:menu) { Components::WorkPackages::ContextMenu.new }
 
   def goto_context_menu
     # Go to table

--- a/spec/features/work_packages/table/delete_work_packages.spec.rb
+++ b/spec/features/work_packages/table/delete_work_packages.spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe 'Delete work package', js: true do
   let(:user) { FactoryGirl.create(:admin) }
-  let(:context_menu) { Components::WorkPackagesContextMenu.new }
+  let(:context_menu) { Components::WorkPackages::ContextMenu.new }
 
   before do
     login_as(user)

--- a/spec/features/work_packages/table/empty_filters_spec.rb
+++ b/spec/features/work_packages/table/empty_filters_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Empty query filters', js: true do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:work_package) { FactoryGirl.create(:work_package) }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+
+  before do
+    login_as(user)
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package)
+  end
+
+  # Tests for regression #23739
+  it 'allows to delete the last query filter' do
+
+    # Open filter menu
+    filters.expect_filter_count(1)
+    filters.open
+
+    # Remove only filter
+    filters.remove_filter(:status)
+
+    loading_indicator_saveguard
+    wp_table.expect_work_package_listed(work_package)
+
+    wp_table.expect_no_notification(type: :error)
+    filters.expect_filter_count(0)
+  end
+end

--- a/spec/support/components/work_packages/context_menu.rb
+++ b/spec/support/components/work_packages/context_menu.rb
@@ -27,38 +27,40 @@
 #++
 
 module Components
-  class WorkPackagesContextMenu
-    include Capybara::DSL
-    include RSpec::Matchers
+  module WorkPackages
+    class ContextMenu
+      include Capybara::DSL
+      include RSpec::Matchers
 
-    def open_for(work_package)
-      find("#work-package-#{work_package.id}").right_click
-      expect_open
-    end
-
-    def expect_open
-      expect(page).to have_selector(selector)
-    end
-
-    def expect_closed
-      expect(page).to have_no_selector(selector)
-    end
-
-    def choose(target)
-      find("#{selector} a", text: target).click
-    end
-
-    def expect_options(options)
-      expect_open
-      options.each do |text|
-        expect(page).to have_selector("#{selector} a", text: text)
+      def open_for(work_package)
+        find("#work-package-#{work_package.id}").right_click
+        expect_open
       end
-    end
 
-    private
+      def expect_open
+        expect(page).to have_selector(selector)
+      end
 
-    def selector
-      '#work-package-context-menu'
+      def expect_closed
+        expect(page).to have_no_selector(selector)
+      end
+
+      def choose(target)
+        find("#{selector} a", text: target).click
+      end
+
+      def expect_options(options)
+        expect_open
+        options.each do |text|
+          expect(page).to have_selector("#{selector} a", text: text)
+        end
+      end
+
+      private
+
+      def selector
+        '#work-package-context-menu'
+      end
     end
   end
 end

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Components
+  module WorkPackages
+    class Filters
+      include Capybara::DSL
+      include RSpec::Matchers
+
+      def open
+        filter_button.click
+        expect_open
+      end
+
+      def expect_filter_count(num)
+        expect(filter_button).to have_selector('.badge', text: num)
+      end
+
+      def expect_open
+        expect(page).to have_selector(filters_selector, visible: true)
+      end
+
+      def expect_closed
+        expect(page).to have_selector(filters_selector, visible: :hidden)
+      end
+
+      def remove_filter(field)
+        page.within(filters_selector) do
+          find("#filter_#{field} .advanced-filters--remove-filter-icon").click
+        end
+      end
+
+      private
+
+      def filter_button
+        find(button_selector)
+      end
+
+      def button_selector
+        '#work-packages-filter-toggle-button'
+      end
+
+      def filters_selector
+        '.work-packages--filters-optional-container'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When not passing `params[:f]`, the current query implementation fails
with an error due to the V3 conversion.

https://community.openproject.com/work_packages/23739
