### PR TITLE
[23220] Request user password as confirmation for account changes

### DIFF
--- a/app/assets/stylesheets/content/_request_for_confirmation.sass
+++ b/app/assets/stylesheets/content/_request_for_confirmation.sass
@@ -1,0 +1,37 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+.request-for-confirmation--modal
+  .icon-context
+    color: $font-color-on-primary
+
+.request-for-confirmation--form
+  padding: 10px 0 20px 0
+
+  label
+    font-weight: bold

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -92,6 +92,7 @@
 @import content/journal
 @import content/pagination
 @import content/progress_bar
+@import content/request_for_confirmation
 
 @import content/form_error_messages
 @import content/ajax_indicator

--- a/app/controllers/concerns/password_confirmation.rb
+++ b/app/controllers/concerns/password_confirmation.rb
@@ -30,12 +30,22 @@
 # Acts as a filter for actions that require password confirmation to have
 # passed before it may be accessed.
 module Concerns::PasswordConfirmation
-  def require_password_confirmation
+  def check_password_confirmation
+    return true unless password_confirmation_required?
+
     password = params[:_password_confirmation]
-    return true if current_user.check_password?(password)
+    return true if password.present? && current_user.check_password?(password)
 
     flash[:error] = I18n.t(:notice_password_confirmation_failed)
     redirect_to :back
     false
   end
+
+  ##
+  # Returns whether password confirmation has been enabled globally
+  # AND the current user is internally authenticated.
+  def password_confirmation_required?
+    Setting.internal_password_confirmation? && !User.current.uses_external_authentication?
+  end
+
 end

--- a/app/controllers/concerns/password_confirmation.rb
+++ b/app/controllers/concerns/password_confirmation.rb
@@ -45,6 +45,7 @@ module Concerns::PasswordConfirmation
   # Returns whether password confirmation has been enabled globally
   # AND the current user is internally authenticated.
   def password_confirmation_required?
-    Setting.internal_password_confirmation? && !User.current.uses_external_authentication?
+    OpenProject::Configuration.internal_password_confirmation? &&
+      !User.current.uses_external_authentication?
   end
 end

--- a/app/controllers/concerns/password_confirmation.rb
+++ b/app/controllers/concerns/password_confirmation.rb
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+##
+# Acts as a filter for actions that require password confirmation to have
+# passed before it may be accessed.
+module Concerns::PasswordConfirmation
+  def require_password_confirmation
+    password = params[:_password_confirmation]
+    return true if current_user.check_password?(password)
+
+    flash[:error] = I18n.t(:notice_password_confirmation_failed)
+    redirect_to :back
+    false
+  end
+end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -28,9 +28,13 @@
 #++
 
 class MyController < ApplicationController
+  include Concerns::PasswordConfirmation
   layout 'my'
 
   before_filter :require_login
+  before_filter :require_password_confirmation,
+                only: [:account],
+                if: ->() { request.patch? }
 
   menu_item :account,             only: [:account]
   menu_item :settings,            only: [:settings]

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -32,7 +32,7 @@ class MyController < ApplicationController
   layout 'my'
 
   before_filter :require_login
-  before_filter :require_password_confirmation,
+  before_filter :check_password_confirmation,
                 only: [:account],
                 if: ->() { request.patch? }
 

--- a/app/helpers/password_helper.rb
+++ b/app/helpers/password_helper.rb
@@ -28,6 +28,37 @@
 #++
 
 module PasswordHelper
+  include Concerns::PasswordConfirmation
+
+  ##
+  # Decorate the form_for helper with the request-for-confirmation directive
+  # when the user is internally authenticated.
+  def password_confirmation_form_for(record, options = {}, &block)
+    if password_confirmation_required?
+      options.reverse_merge!(html: {})
+      data = options[:html].fetch(:data, {})
+      data[:'request-for-confirmation'] = ''
+
+      options[:html][:data] = data
+    end
+
+    form_for(record, options, &block)
+  end
+
+  ##
+  # Decorate the form_tag helper with the request-for-confirmation directive
+  # when the user is internally authenticated.
+  def password_confirmation_form_tag(url_for_options = {}, options = {}, &block)
+    if password_confirmation_required?
+      data = options.fetch(:data, {})
+      data[:'request-for-confirmation'] = ''
+
+      options[:data] = data
+    end
+
+    form_tag(url_for_options, options, &block)
+  end
+
   def render_password_complexity_tooltip
     rules = password_rules_description
 

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= labelled_tabular_form_for @user, as: :user, url: { action: 'account' },
                           lang: current_language,
-                          html: { id: 'my_account_form', class: 'form -wide-labels' } do |f| %>
+                          html: { id: 'my_account_form', class: 'request-for-confirmation form -wide-labels' } do |f| %>
   <section class="form--section">
     <div class="form--field">
       <label class="form--label" for="username">

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -33,9 +33,12 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_profile) %>
 <%= error_messages_for 'user' %>
 
-<%= labelled_tabular_form_for @user, as: :user, url: { action: 'account' },
-                          lang: current_language,
-                          html: { id: 'my_account_form', class: 'request-for-confirmation form -wide-labels' } do |f| %>
+<%= password_confirmation_form_for @user,
+                                   as: :user,
+                                   url: { action: 'account' },
+                                   builder: ::TabularFormBuilder,
+                                   lang: current_language,
+                                   html: { id: 'my_account_form', class: '-wide-labels' } do |f| %>
   <section class="form--section">
     <div class="form--field">
       <label class="form--label" for="username">

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -57,12 +57,6 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
         <div class="form--field"><%= setting_text_field :password_count_former_banned, size: 6 %></div>
         <div class="form--field"><%= setting_check_box :lost_password, label: :label_password_lost %></div>
-        <div class="form--field">
-          <%= setting_check_box :internal_password_confirmation %>
-          <span class="form--field-instructions">
-            <%= simple_format t('settings.instructions.internal_password_confirmation') %>
-          </span>
-        </div>
       <% else %>
         <div class="form--field">
           <label><%= I18n.t :note %></label>

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -57,6 +57,12 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
         <div class="form--field"><%= setting_text_field :password_count_former_banned, size: 6 %></div>
         <div class="form--field"><%= setting_check_box :lost_password, label: :label_password_lost %></div>
+        <div class="form--field">
+          <%= setting_check_box :internal_password_confirmation %>
+          <span class="form--field-instructions">
+            <%= simple_format t('settings.instructions.internal_password_confirmation') %>
+          </span>
+        </div>
       <% else %>
         <div class="form--field">
           <label><%= I18n.t :note %></label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1424,6 +1424,7 @@ en:
   notice_bad_request: "Bad Request."
   notice_not_authorized: "You are not authorized to access this page."
   notice_not_authorized_archived_project: "The project you're trying to access has been archived."
+  notice_password_confirmation_failed: "Your password is not correct. The changes were not saved."
   notice_project_not_deleted: "The project wasn't deleted."
   notice_successful_connection: "Successful connection."
   notice_successful_create: "Successful creation."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1716,6 +1716,7 @@ en:
   setting_gravatar_default: "Default Gravatar image"
   setting_gravatar_enabled: "Use Gravatar user icons"
   setting_host_name: "Host name"
+  setting_internal_password_confirmation: "Password confirmation for account changes"
   setting_work_package_done_ratio: "Calculate the work package done ratio with"
   setting_work_package_done_ratio_field: "Use the work package field"
   setting_work_package_done_ratio_status: "Use the work package status"
@@ -1781,6 +1782,10 @@ en:
     passwords: "Passwords"
     session: "Session"
     brute_force_prevention: "Automated user blocking"
+    instructions:
+      internal_password_confirmation: |
+        Require internally authenticated users to confirm their password upon changing their own account details (e.g., their email address).
+        Note: Even when checking this option, externally authenticated users do not have a password and will not be prompted on account changes.
 
   show_hide_project_menu: "Expand/Collapse project menu"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1716,7 +1716,6 @@ en:
   setting_gravatar_default: "Default Gravatar image"
   setting_gravatar_enabled: "Use Gravatar user icons"
   setting_host_name: "Host name"
-  setting_internal_password_confirmation: "Password confirmation for account changes"
   setting_work_package_done_ratio: "Calculate the work package done ratio with"
   setting_work_package_done_ratio_field: "Use the work package field"
   setting_work_package_done_ratio_status: "Use the work package status"
@@ -1782,10 +1781,6 @@ en:
     passwords: "Passwords"
     session: "Session"
     brute_force_prevention: "Automated user blocking"
-    instructions:
-      internal_password_confirmation: |
-        Require internally authenticated users to confirm their password upon changing their own account details (e.g., their email address).
-        Note: Even when checking this option, externally authenticated users do not have a password and will not be prompted on account changes.
 
   show_hide_project_menu: "Expand/Collapse project menu"
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -40,6 +40,7 @@ en:
     button_add_watcher: "Add watcher"
     button_cancel: "Cancel"
     button_check_all: "Check all"
+    button_confirm: "Confirm"
     button_copy: "Copy"
     button_delete: "Delete"
     button_delete_watcher: "Delete watcher"
@@ -150,6 +151,7 @@ en:
     label_on: "on"
     label_open_menu: "Open menu"
     label_open_work_packages: "open"
+    label_password: "Password"
     label_previous: "Previous"
     label_per_page: "Per page:"
     label_please_wait: "Please wait"
@@ -200,6 +202,10 @@ en:
     label_wait: "Please wait for configuration..."
     label_upload_counter: "%{done} of %{count} files finished"
     label_validation_error: "The work package could not be saved due to the following errors:"
+
+    password_confirmation:
+      field_description: 'You need to enter your account password to confirm this change.'
+      title: 'Confirm your password to continue'
 
     pagination:
       no_other_page: "You are on the only page."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -332,6 +332,3 @@ repository_checkout_data:
 api_max_page_size:
   format: int
   default: 500
-internal_password_confirmation:
-  format: boolean
-  default: 1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,7 @@ sendmail_arguments:
 smtp_openssl_verify_mode:
   default: "none"
 smtp_enable_starttls_auto:
-  default: 0 
+  default: 0
   format: boolean
 smtp_address:
   default: ""
@@ -332,3 +332,6 @@ repository_checkout_data:
 api_max_page_size:
   format: int
   default: 500
+internal_password_confirmation:
+  format: boolean
+  default: 1

--- a/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.directive.test.ts
+++ b/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.directive.test.ts
@@ -1,0 +1,64 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+var expect = chai.expect;
+
+describe('requestForConfirmation directive', () => {
+  var scope, element, controller, body;
+  beforeEach(angular.mock.module('openproject', 'openproject.uiComponents'));
+
+  beforeEach(angular.mock.inject(($compile, $rootScope) => {
+    var html = `
+      <form class="request-for-confirmation">
+        <input type="text" id="somevalue" />
+      </form>
+    `;
+
+    element = angular.element(html);
+
+    scope = $rootScope.$new();
+    body = angular.element(document.body);
+
+    $compile(element)(scope);
+    body.append(element);
+    scope.$digest();
+
+    controller = element.controller('requestForConfirmation');
+  }));
+
+  it('should call the dialog when submitting', () => {
+    sinon.spy(controller, 'openConfirmationDialog');
+    element.trigger('submit');
+    expect(controller.openConfirmationDialog).to.have.been.called;
+  });
+
+  afterEach(() => {
+    element.remove();
+    body.remove('.ngdialog-theme-openproject');
+  });
+});

--- a/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.directive.ts
+++ b/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.directive.ts
@@ -1,0 +1,105 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import IAugmentedJQuery = angular.IAugmentedJQuery;
+import {IDialogService} from 'ng-dialog';
+import {IDialogScope} from 'ng-dialog';
+
+export class RequestForConfirmationController {
+
+  // Allow original form submission after dialog was closed
+  private passwordConfirmed = false;
+
+  constructor(protected $element:IAugmentedJQuery,
+              protected $scope:angular.IScope,
+              protected $http:angular.IHttpService,
+              protected $q:angular.IQService,
+              protected ngDialog:IDialogService,
+              protected I18n:op.I18n) {
+
+    this.$scope['text'] = {
+      title_confirmation: I18n.t('js.password_confirmation.title'),
+      field_description: I18n.t('js.password_confirmation.field_description'),
+      confirm_button: I18n.t('js.button_confirm'),
+      password: I18n.t('js.label_password')
+    };
+
+    this.$scope['dialog'] = {
+      password_value: ''
+    };
+
+    $element.submit((evt) => {
+      if (!this.passwordConfirmed) {
+        evt.preventDefault();
+        this.openConfirmationDialog();
+      }
+    });
+  }
+
+  public openConfirmationDialog() {
+    this.ngDialog.open({
+      closeByEscape: false,
+      showClose: false,
+      closeByDocument: false,
+      scope: <IDialogScope> this.$scope,
+      template: '/components/modals/request-for-confirmation/request-for-confirmation.modal.html',
+      className: 'ngdialog-theme-openproject',
+      preCloseCallback: () => {
+        this.appendPassword();
+        this.$element.submit();
+        return true;
+      }
+    });
+  }
+
+  /**
+   * Post the confirmation to the endpoint
+   */
+  private appendPassword() {
+    angular.element('<input>').attr({
+      type: 'hidden',
+      name: '_password_confirmation',
+      value: this.$scope['dialog'].password_value
+    }).appendTo(this.$element);
+    this.passwordConfirmed = true;
+  }
+}
+
+function requestForConfirmation() {
+  return {
+    restrict: 'AC',
+    scope: {},
+    bindToController: true,
+    controller: RequestForConfirmationController,
+    controllerAs: '$ctrl',
+  };
+}
+
+angular
+  .module('openproject.uiComponents')
+  .directive('requestForConfirmation', requestForConfirmation);

--- a/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.modal.html
+++ b/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.modal.html
@@ -24,7 +24,7 @@
     </div>
 
     <div class="onboarding--footer">
-      <button class="button -highlight"
+      <button class="request-for-confirmation--submit-button button -highlight"
               ng-click="closeThisDialog()"
               ng-bind="::text.confirm_button"
               ng-attr-title="::text.confirm_button"

--- a/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.modal.html
+++ b/frontend/app/components/modals/request-for-confirmation/request-for-confirmation.modal.html
@@ -1,0 +1,35 @@
+<div class="request-for-confirmation--modal">
+  <div class="onboarding--start-modal">
+    <div class="onboarding--top-menu">
+      <span class="icon-context icon-locked"></span>
+      <h2 ng-bind="::text.title_confirmation"></h2>
+    </div>
+
+    <div class="onboarding--main">
+      <form class="request-for-confirmation--form form -vertical" ng-submit="closeThisDialog()">
+        <div class="form--field -required">
+          <label class="form--label"
+                 for="request_for_confirmation_password"
+                 ng-attr-aria-label="::text.field_description"
+                 ng-bind="::text.password">
+          </label>
+          <div class="form--field-container">
+            <div class="form--text-field-container">
+              <input type="password" ng-model="dialog.password_value" id="request_for_confirmation_password" class="form--text-field">
+            </div>
+          </div>
+          <div class="form--field-instructions" ng-bind="::text.field_description"></div>
+        </div>
+      </form>
+    </div>
+
+    <div class="onboarding--footer">
+      <button class="button -highlight"
+              ng-click="closeThisDialog()"
+              ng-bind="::text.confirm_button"
+              ng-attr-title="::text.confirm_button"
+              ng-disabled="dialog.password_value == null || dialog.password_value.length === 0">
+      </button>
+    </div>
+  </div>
+</div>

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -77,6 +77,7 @@ module OpenProject
 
       'disable_password_login' => false,
       'omniauth_direct_login_provider' => nil,
+      'internal_password_confirmation' => true,
 
       'disable_password_choice' => false,
 

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -36,8 +36,7 @@ describe 'my', type: :feature, js: true do
                        mail: 'old@mail.com',
                        login: 'bob',
                        password: user_password,
-                       password_confirmation: user_password
-                      )
+                       password_confirmation: user_password)
   end
 
   ##
@@ -68,14 +67,14 @@ describe 'my', type: :feature, js: true do
       end
 
       context 'when confirmation disabled',
-              with_settings: { internal_password_confirmation?: false } do
+              with_config: { internal_password_confirmation: false } do
         it 'does not request confirmation' do
           expect_changed!
         end
       end
 
       context 'when confirmation required',
-              with_settings: { internal_password_confirmation?: true } do
+              with_config: { internal_password_confirmation: true } do
         it 'requires the password for a regular user' do
           dialog.confirm_flow_with(user_password)
           expect_changed!

--- a/spec_legacy/functional/my_controller_spec.rb
+++ b/spec_legacy/functional/my_controller_spec.rb
@@ -57,27 +57,6 @@ describe MyController, type: :controller do
     assert_equal User.find(2), assigns(:user)
   end
 
-  it 'should update account' do
-    patch :account,
-          user: {
-            firstname: 'Joe',
-            login: 'root', # should not be allowed
-            admin: 1,
-            group_ids: ['10'],
-            custom_field_values: { '4' => '0100562500' }
-          }
-
-    assert_redirected_to '/my/account'
-    user = User.find(2)
-    assert_equal user, assigns(:user)
-    assert_equal 'Joe', user.firstname
-    assert_equal 'jsmith', user.login
-    assert_equal '0100562500', user.custom_value_for(4).value
-    # ignored
-    assert !user.admin?
-    assert user.groups.empty?
-  end
-
   it 'should page layout' do
     get :page_layout
     assert_response :success


### PR DESCRIPTION
### Implementation approach

This feature will provide:
1.  An angular directive `<request-for-confirmation>`, that will wrap a form submit event and requests the confirmation for the given change.
2. An internal Rails filter to accept a challenge tag and user password. When password was confirmed, persists the tag along with a timestamp for the given user.

The form, rendered by rails, will output with a directive attribute when password confirmation is required. The password confirmation can be globally disabled. When we're unable to confirm the password for the current user (e.g., authenticated through OmniAuth), the dialog is skipped.

The directive decorates the form submission, displays the confirmation dialog (cf., screenshot) and extends the request with the password.

A before action will check for the confirmation with the given challenge and accept or decline the request.

**Design**

The directive will overlay a modal with the password confirmation form to be handled.

![step2](https://cloud.githubusercontent.com/assets/459462/17324612/affcc12c-58a7-11e6-921f-d4efefa5310b.png)
### Alternatives

Perform the confirmation with decorated actions in the Rails world. This would require redirecting / rewriting the actual form action and provide more potential code paths.
### Out of scope
- Providing the same functionality for users with externally provided authentication (through OmniAuth). 
- Restricting admin functionality (e.g., changing user details as a logged-in admin)
### ToDos
- [x] Consolidate the available modal implementations into a usable one. Extracted into https://github.com/opf/openproject/pull/4749
- [x] Implement the confirmation modal
- [X] Implement the confirmation filter
- [X] After discussing with @machisuji, replace the setting with a configuration variable
- [x] Decorate the user's profile actions with the confirmation
  - [X] For the core
  - [x] For Mobile-OTP (https://github.com/finnlabs/openproject-mobile_otp/pull/73)

https://community.openproject.com/work_packages/23220/activity
