### PR TITLE
[23746] Fix leaving the page upon editing

### DIFF
--- a/frontend/app/components/common/config/configuration.service.ts
+++ b/frontend/app/components/common/config/configuration.service.ts
@@ -64,7 +64,8 @@ function ConfigurationService($q, $http, $window, PathHelper, I18n) {
           impaired: false,
           time_zone: '',
           others: {
-            comments_sorting: 'asc'
+            comments_sorting: 'asc',
+            warn_on_leaving_unsaved: true
           }
         }
       };
@@ -88,6 +89,9 @@ function ConfigurationService($q, $http, $window, PathHelper, I18n) {
     },
     commentsSortedInDescendingOrder: function () {
       return this.settings.user_preferences.others.comments_sorting === 'desc';
+    },
+    warnOnLeavingUnsaved: function () {
+      return this.settings.user_preferences.others.warn_on_leaving_unsaved === true;
     },
     isTimezoneSet: function () {
       return this.settings.user_preferences.time_zone !== '';

--- a/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.controller.ts
+++ b/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.controller.ts
@@ -98,8 +98,7 @@ function wpContextMenuController($scope,
       workPackageId: selected[0].id
     };
 
-    wpEditModeState.start();
-    $state.transitionTo('work-packages.show', params);
+    $state.transitionTo('work-packages.show.edit', params);
   }
 
   function getWorkPackagesFromSelectedRows() {

--- a/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.test.ts
+++ b/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.test.ts
@@ -48,7 +48,8 @@ describe('workPackageContextMenu', () => {
   beforeEach(angular.mock.module('openproject.templates', ($provide) => {
     var configurationService = {
       isTimezoneSet: sinon.stub().returns(false),
-      accessibilityModeEnabled: sinon.stub().returns(false)
+      accessibilityModeEnabled: sinon.stub().returns(false),
+      warnOnLeavingUnsaved: sinon.stub().returns(false)
     };
 
     $provide.constant('ConfigurationService', configurationService);

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -119,7 +119,7 @@ openprojectModule
       })
 
       .state('work-packages.edit', {
-        url: '/{projects}/{projectPath}/work_packages/{workPackageId}/edit',
+        url: '/{projects}/{projectPath}/work_packages/{workPackageId:[0-9]+}/edit',
         params: {
           projectPath: {value: null, squash: true},
           projects: {value: null, squash: true},

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -122,12 +122,15 @@ openprojectModule
         url: '/{projects}/{projectPath}/work_packages/{workPackageId}/edit',
         params: {
           projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true}
+          projects: {value: null, squash: true},
         },
 
-        onEnter: ($state, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
+        onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
-          $state.go('work-packages.list.details.overview', $stateParams);
+          // Transitioning to a new state may cause a reported issue
+          // $timeout is a workaround: https://github.com/angular-ui/ui-router/issues/326#issuecomment-66566642
+          // I believe we should replace this with an explicit edit state
+          $timeout(() => $state.go('work-packages.list.details.overview', $stateParams, { notify: false }));
         }
       })
 
@@ -142,9 +145,12 @@ openprojectModule
       .state('work-packages.show.edit', {
         url: '/edit',
         reloadOnSearch: false,
-        onEnter: ($state, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
+        onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
-          $state.go('work-packages.show', $stateParams);
+          // Transitioning to a new state may cause a reported issue
+          // $timeout is a workaround: https://github.com/angular-ui/ui-router/issues/326#issuecomment-66566642
+          // I believe we should replace this with an explicit edit state
+          $timeout(() => $state.go('work-packages.show', $stateParams, { notify: false }));
         }
       })
       .state('work-packages.show.activity', panels.activity)

--- a/frontend/app/components/routing/wp-details/wp-details.controller.test.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.test.ts
@@ -124,7 +124,8 @@ describe('WorkPackageDetailsController', () => {
 
   beforeEach(angular.mock.module('openproject.templates', function ($provide) {
     $provide.constant('ConfigurationService', {
-      isTimezoneSet: sinon.stub().returns(false)
+      isTimezoneSet: sinon.stub().returns(false),
+      warnOnLeavingUnsaved: sinon.stub().returns(false)
     });
 
     $provide.constant('$stateParams', stateParams);

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -261,7 +261,7 @@ function WorkPackagesListController($scope,
 
       loadingIndicator.mainPage = $state.go(
         'work-packages.show',
-        angular.extend(params, $state.params)
+        angular.extend($state.params, params)
       );
     }
   };

--- a/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
@@ -30,9 +30,9 @@ import {openprojectModule} from "../../angular-modules";
 import {WorkPackageEditFormController} from "./wp-edit-form.directive";
 
 export class WorkPackageEditModeStateService {
-  public form: WorkPackageEditFormController;
-  
-  private _active: boolean = false;
+  public form:WorkPackageEditFormController;
+
+  private _active:boolean = false;
 
   constructor(protected $rootScope, protected ConfigurationService, protected $window, protected $q, protected I18n) {
     const confirmText = I18n.t('js.work_packages.confirm_edit_cancel');
@@ -41,9 +41,8 @@ export class WorkPackageEditModeStateService {
 
     $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
       // Show confirmation message when transitioning to a new state
-      // that's not withing the current param.
-      if (this.active && toParams.workPackageId !== fromParams.workPackageId) {
-
+      // that's not withing the edit mode.
+      if (this.active && !this.allowedStateChange(toState, toParams, fromState, fromParams)) {
         if (requiresConfirmation && !$window.confirm(confirmText)) {
           return event.preventDefault();
         }
@@ -80,22 +79,22 @@ export class WorkPackageEditModeStateService {
     }
     return this._active = false;
   }
-  
+
   public save() {
     if (this.active) {
       return this.form.updateWorkPackage().then(wp => {
         // Doesn't use cancel() since that resets all values
         this.form.closeAllFields();
         this._active = false;
-        
+
         return wp;
       });
     }
 
     return this.$q.reject();
   }
-  
-  public register(form: WorkPackageEditFormController) {
+
+  public register(form:WorkPackageEditFormController) {
     this.form = form;
 
     // Activate form when it registers after the
@@ -107,6 +106,17 @@ export class WorkPackageEditModeStateService {
 
   public get active() {
     return this._active;
+  }
+
+  private allowedStateChange(toState, toParams, fromState, fromParams) {
+
+    // In new/copy mode, transitions to the same controller are allowed
+    if (fromState.name.match(/\.(new|copy)$/)) {
+      return fromState.controller === toState.controller;
+    }
+
+    // When editing an existing WP, transitions on the same WP id are allowed
+    return toParams.workPackageId !== undefined && toParams.workPackageId === fromParams.workPackageId;
   }
 }
 

--- a/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
@@ -34,14 +34,17 @@ export class WorkPackageEditModeStateService {
   
   private _active: boolean = false;
 
-  constructor(protected $rootScope, protected $window, protected $q, protected I18n) {
+  constructor(protected $rootScope, protected ConfigurationService, protected $window, protected $q, protected I18n) {
     const confirmText = I18n.t('js.work_packages.confirm_edit_cancel');
     const cancelEventName = 'beforeunload.confirm_cancel';
+    const requiresConfirmation = ConfigurationService.warnOnLeavingUnsaved();
 
-    // Show confirmation message when transitioning to a new state
-    // that's not withing the current param.
     $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
-      if (this.active && toParams.workPackageId !== fromParams.workPackageId) {
+      // Show confirmation message when transitioning to a new state
+      // that's not withing the current param.
+      if (requiresConfirmation &&
+          this.active &&
+          toParams.workPackageId !== fromParams.workPackageId) {
 
         if (!$window.confirm(confirmText)) {
           return event.preventDefault();
@@ -53,7 +56,7 @@ export class WorkPackageEditModeStateService {
 
     // Show confirmation message when browsing to a new page
     angular.element($window).on(cancelEventName, (event) => {
-      if (this.active) {
+      if (requiresConfirmation && this.active) {
         event.returnValue = confirmText;
         event.preventDefault();
 

--- a/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
@@ -35,17 +35,34 @@ export class WorkPackageEditModeStateService {
   private _active: boolean = false;
 
   constructor(protected $rootScope, protected $window, protected $q, protected I18n) {
+    const confirmText = I18n.t('js.work_packages.confirm_edit_cancel');
+    const cancelEventName = 'beforeunload.confirm_cancel';
 
+    // Show confirmation message when transitioning to a new state
+    // that's not withing the current param.
     $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
-      if (this.active && fromParams.workPackageId
-        && toParams.workPackageId !== fromParams.workPackageId) {
+      if (this.active && toParams.workPackageId !== fromParams.workPackageId) {
 
-        if (!$window.confirm(I18n.t('js.work_packages.confirm_edit_cancel'))) {
+        if (!$window.confirm(confirmText)) {
           return event.preventDefault();
         }
 
         this.cancel();
       }
+    });
+
+    // Show confirmation message when browsing to a new page
+    angular.element($window).on(cancelEventName, (event) => {
+      if (this.active) {
+        event.returnValue = confirmText;
+        event.preventDefault();
+
+        return confirmText;
+      }
+    });
+
+    $rootScope.$on('$destroy', () => {
+      return angular.element($window).off(cancelEventName);
     });
   }
 

--- a/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-mode-state.service.ts
@@ -42,11 +42,9 @@ export class WorkPackageEditModeStateService {
     $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
       // Show confirmation message when transitioning to a new state
       // that's not withing the current param.
-      if (requiresConfirmation &&
-          this.active &&
-          toParams.workPackageId !== fromParams.workPackageId) {
+      if (this.active && toParams.workPackageId !== fromParams.workPackageId) {
 
-        if (!$window.confirm(confirmText)) {
+        if (requiresConfirmation && !$window.confirm(confirmText)) {
           return event.preventDefault();
         }
 

--- a/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
+++ b/frontend/tests/unit/tests/work_packages/directives/work-package-details-toolbar-test.js
@@ -51,6 +51,7 @@ describe('workPackageDetailsToolbar', function() {
     var configurationService = {};
 
     configurationService.accessibilityModeEnabled = sinon.stub().returns(false);
+    configurationService.warnOnLeavingUnsaved = sinon.stub().returns(false);
 
     $provide.constant('$stateParams', stateParams);
     $provide.constant('ConfigurationService', configurationService);

--- a/frontend/tests/unit/tests/work_packages/helpers/work-package-context-menu-helper-test.js
+++ b/frontend/tests/unit/tests/work_packages/helpers/work-package-context-menu-helper-test.js
@@ -83,6 +83,7 @@ describe('WorkPackageContextMenuHelper', function() {
     var configurationService = {};
 
     configurationService.isTimezoneSet = sinon.stub().returns(false);
+    configurationService.warnOnLeavingUnsaved = sinon.stub().returns(false);
 
     $provide.constant('$stateParams', stateParams);
     $provide.constant('ConfigurationService', configurationService);

--- a/spec/features/work_packages/cancel_editing_spec.rb
+++ b/spec/features/work_packages/cancel_editing_spec.rb
@@ -1,0 +1,108 @@
+# -- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+# ++
+
+require 'spec_helper'
+
+describe 'Cancel editing work package', js: true do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:work_package) { FactoryGirl.create(:work_package, project: project) }
+  let(:wp_page) { ::Pages::AbstractWorkPackage.new(work_package) }
+  let(:paths) {
+    [
+      new_work_packages_path,
+      new_split_work_packages_path,
+      new_project_work_packages_path(project),
+      new_split_project_work_packages_path(project)
+    ]
+  }
+
+  before do
+    work_package
+    login_as(user)
+  end
+
+  def expect_active_edit(path)
+    visit path
+    loading_indicator_saveguard
+    expect(page).to have_selector('.wp-edit-field.subject.-active')
+  end
+
+  def expect_subject(val)
+    subject = page.find('#wp-new-inline-edit--field-subject')
+    expect(subject.value).to eq(val)
+  end
+
+  it 'shows an alert when moving to other pages' do
+    paths.each do |path|
+      expect_active_edit(path)
+      find('.home-link').click
+
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_selector('h2', text: 'OpenProject')
+    end
+  end
+
+  it 'cancels the editing when clicking the button' do
+    paths.each do |path|
+      expect_active_edit(path)
+      find('#work-packages--edit-actions-cancel').click
+
+      expect(wp_page).not_to have_alert_dialog
+    end
+  end
+
+  it 'allows to move from split to full screen in edit mode' do
+    # Start creating on split view
+    expect_active_edit(new_split_work_packages_path)
+
+    find('#wp-new-inline-edit--field-subject').set 'foobar'
+
+    # Expect editing works when moving to full screen
+    find('#work-packages-show-view-button').click
+
+    expect(wp_page).not_to have_alert_dialog
+    expect(page).to have_selector('.wp-edit-field.subject.-active')
+    expect_subject('foobar')
+
+    # Moving back also works
+    page.evaluate_script('window.history.back()')
+
+    expect(wp_page).not_to have_alert_dialog
+    expect(page).to have_selector('.wp-edit-field.subject.-active')
+    expect_subject('foobar')
+
+    # Cancel edition
+    find('#work-packages--edit-actions-cancel').click
+    expect(wp_page).not_to have_alert_dialog
+
+    # Visiting another page does not create alert
+    find('.home-link').click
+    expect(wp_page).not_to have_alert_dialog
+  end
+end

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -181,6 +181,8 @@ describe 'edit work package', js: true do
       cf_field = wp_page.edit_field("customField#{custom_field.id}")
       cf_field.expect_active!
       cf_field.expect_value('')
+
+      find('#work-packages--edit-actions-cancel').click
     end
   end
 


### PR DESCRIPTION
When in an active edit mode:
1. Moving from new/copy to other states wasn't caught by the edit mode
   alert handler
2. Moving to other (non-angular) pages weren't caught by the edit mode

https://community.openproject.com/work_packages/23746
