### PR TITLE
[23747] Add query_id and props to allowed list of params

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -160,7 +160,9 @@ openprojectModule
           // value: null makes the parameter optional
           // squash: true avoids duplicate slashes when the paramter is not provided
           projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true}
+          projects: {value: null, squash: true},
+          query_id: {value: null},
+          query_props: {value: null}
         },
         reloadOnSearch: false,
         onEnter: () => angular.element('body').addClass('action-index'),


### PR DESCRIPTION
Filters were lost in the transition of details tab to list due to missing params declaration.

https://community.openproject.com/work_packages/23747
