### PR TITLE
[23753] Fix WikiMenuItems after slug introduction

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -388,7 +388,7 @@ class WikiController < ApplicationController
   end
 
   def build_wiki_page_and_content
-    @page = WikiPage.new wiki: @wiki
+    @page = WikiPage.new wiki: @wiki, title: wiki_page_title.presence || I18n.t(:label_wiki_page)
     @page.content = WikiContent.new page: @page
 
     @content = @page.content_for_version nil

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -119,7 +119,11 @@ class WikiMenuItemsController < ApplicationController
 
     @page = wiki.find_page(params[:id])
     @page_title = @page.title
-    @wiki_menu_item = MenuItems::WikiMenuItem.find_or_initialize_by(navigatable_id: wiki.id, title: @page_title)
+    @wiki_menu_item = MenuItems::WikiMenuItem.find_or_initialize_by(
+      navigatable_id: wiki.id,
+      name: @page.slug
+    )
+    @wiki_menu_item.title ||= @page_title
     possible_parent_menu_items = MenuItems::WikiMenuItem.main_items(wiki.id) - [@wiki_menu_item]
 
     @parent_menu_item_options = possible_parent_menu_items.map { |item| [item.name, item.id] }
@@ -151,7 +155,7 @@ class WikiMenuItemsController < ApplicationController
     menu_item = if item = page.menu_item
                   item.tap { |item| item.parent_id = nil }
                 else
-                  wiki.wiki_menu_items.build(title: page.title, name: page.title)
+                  wiki.wiki_menu_items.build(title: page.slug, name: page.title)
     end
 
     menu_item.options = options

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -155,7 +155,7 @@ class WikiMenuItemsController < ApplicationController
     menu_item = if item = page.menu_item
                   item.tap { |item| item.parent_id = nil }
                 else
-                  wiki.wiki_menu_items.build(title: page.slug, name: page.title)
+                  wiki.wiki_menu_items.build(name: page.slug, title: page.title)
     end
 
     menu_item.options = options

--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -36,8 +36,12 @@ class MenuItems::WikiMenuItem < MenuItem
       .order('id ASC')
   }
 
+  def slug
+    name.to_url
+  end
+
   def item_class
-    title.dasherize
+    slug
   end
 
   def index_page

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -79,13 +79,6 @@ class Wiki < ActiveRecord::Base
     page
   end
 
-  ##
-  # Unescape the given title from user input to retrieve the
-  # unicode title of a wiki page
-  def self.from_param(title)
-    CGI.unescape(CGI.unescapeHTML(title))
-  end
-
   # Finds a page by title
   # The given string can be of one of the forms: "title" or "project:title"
   # Examples:

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -101,7 +101,7 @@ class Wiki < ActiveRecord::Base
 
   def create_menu_item_for_start_page
     wiki_menu_item = wiki_menu_items.find_or_initialize_by(title: start_page) { |item|
-      item.name = 'Wiki'
+      item.name = 'wiki'
     }
     wiki_menu_item.new_wiki_page = true
     wiki_menu_item.index_page = true

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -117,8 +117,9 @@ class WikiPage < ActiveRecord::Base
       wiki.redirects << WikiRedirect.new(title: previous_slug, redirects_to: slug) unless redirect_existing_links == '0'
 
       # Change title of dependent wiki menu item
-      dependent_item = MenuItems::WikiMenuItem.find_by(navigatable_id: wiki.id, title: @previous_title)
+      dependent_item = MenuItems::WikiMenuItem.find_by(navigatable_id: wiki.id, name: previous_slug)
       if dependent_item
+        dependent_item.name = slug
         dependent_item.title = title
         dependent_item.save!
       end
@@ -205,7 +206,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def menu_item
-    MenuItems::WikiMenuItem.find_by(title: title, navigatable_id: wiki_id)
+    MenuItems::WikiMenuItem.find_by(name: slug, navigatable_id: wiki_id)
   end
 
   def nearest_menu_item

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -87,6 +87,10 @@ class WikiPage < ActiveRecord::Base
     end
   end
 
+  def slug
+    read_attribute(:slug).presence || title.try(:to_url)
+  end
+
   def delete_wiki_menu_item
     menu_item.destroy if menu_item
     # ensure there is a menu item for the wiki

--- a/db/migrate/20160803094931_wiki_menu_titles_to_slug.rb
+++ b/db/migrate/20160803094931_wiki_menu_titles_to_slug.rb
@@ -1,0 +1,57 @@
+class WikiMenuTitlesToSlug < ActiveRecord::Migration
+  def up
+    migrate_menu_items
+  end
+
+  def down
+    rollback_menu_items
+  end
+
+  ##
+  # Fix lookup of wiki pages in menu items by referencing the actual slug in the title attribute.
+  # As the title attribute is fixed from MenuItem, and the name was used, swap the two around
+  # to avoid confusing the actual title of the menu item (previously == name).
+  def migrate_menu_items
+    ActiveRecord::Base.transaction do
+      ::MenuItems::WikiMenuItem.includes(:wiki).find_each do |item|
+        # Find the page
+        wiki_page = item.wiki.find_page(item.title)
+
+        # Set the title to the actual slug
+        # If the page could not be found, migrate the title to form a slug
+        slug = wiki_page.nil? ? item.title.to_url : wiki_page.slug
+
+        # Use the name to set the title.
+        # This clears up the previously irritating mixup of the two.
+        menu_item_title = item.name
+
+        item.update_columns(title: menu_item_title, name: slug)
+      end
+    end
+  end
+
+  ##
+  #
+  # Restore the old title wherever possible
+  # This tries to remove the slug usages without guaranteeing that links
+  # will be valid afterwards.
+  def rollback_menu_items
+    ActiveRecord::Base.transaction do
+      ::MenuItems::WikiMenuItem.includes(:wiki).find_each do |item|
+        # Find the page
+        wiki_page = item.wiki.find_page(item.title)
+
+        # Restore the switch of title and name
+        old_name = item.title
+        old_title =
+          if wiki_page.present?
+            wiki_page.title
+          else
+            item.name
+          end
+
+        item.update_columns(title: old_title, name: old_name)
+      end
+    end
+  end
+end

--- a/features/menu_items/wiki_menu_items.feature
+++ b/features/menu_items/wiki_menu_items.feature
@@ -119,9 +119,9 @@ Feature: Wiki menu items
   Scenario: When I delete the last wiki page with a menu item I can select a new menu item and the menu item is replaced
     Given the project "Awesome Project" has a wiki menu item with the following:
       | title | AwesomePage |
-      | name  | AwesomePage |
+      | name  | awesomepage |
     And the wiki menu item of the wiki page "Wiki" of project "Awesome Project" has been deleted
-    When I go to the wiki page "AwesomePage" for the project called "Awesome Project"
+    When I go to the wiki page "awesomepage" for the project called "Awesome Project"
     And I click on "More"
     And I click on "Configure menu item"
     And I choose "Do not show this wikipage in project navigation"

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -52,7 +52,7 @@ module Redmine::MenuManager::MenuHelper
     MenuItems::WikiMenuItem.main_items(project_wiki).each do |main_item|
       Redmine::MenuManager.loose :project_menu do |menu|
         menu.push "#{main_item.item_class}".to_sym,
-                  { controller: '/wiki', action: 'show', id: CGI.escape(main_item.title) },
+                  { controller: '/wiki', action: 'show', id: main_item.slug },
                   param: :project_id,
                   caption: main_item.name,
                   after: :repository,
@@ -60,13 +60,12 @@ module Redmine::MenuManager::MenuHelper
 
         main_item.children.each do |child|
           menu.push "#{child.item_class}".to_sym,
-                    { controller: '/wiki', action: 'show', id: CGI.escape(child.title) },
+                    { controller: '/wiki', action: 'show', id: child.slug },
                     param: :project_id,
                     caption: child.name,
                     html:    { class: 'icon2 icon-wiki2' },
                     parent: "#{main_item.item_class}".to_sym
         end
-        # FIXME using wiki_menu_item#title to reference the wiki page and wiki_menu_item#name as the menu item representation feels wrong
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -98,14 +98,14 @@ describe ProjectsController, type: :controller do
         it 'renders main menu with wiki menu item' do
           get 'show', @params
 
-          assert_select '#main-menu a.Wiki-menu-item', 'Wiki'
+          assert_select '#main-menu a.wiki-menu-item', 'wiki'
         end
       end
 
       describe 'with custom wiki menu item' do
         before do
-          main_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id, name: 'Example', title: 'Example')
-          sub_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id, name: 'Sub', title: 'Sub', parent_id: main_item.id)
+          main_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id, name: 'example', title: 'Example')
+          sub_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id, name: 'sub', title: 'Sub', parent_id: main_item.id)
         end
 
         it 'renders show' do
@@ -117,13 +117,13 @@ describe ProjectsController, type: :controller do
         it 'renders main menu with wiki menu item' do
           get 'show', @params
 
-          assert_select '#main-menu a.Example-menu-item', 'Example'
+          assert_select '#main-menu a.example-menu-item', 'example'
         end
 
         it 'renders main menu with sub wiki menu item' do
           get 'show', @params
 
-          assert_select '#main-menu a.Sub-menu-item', 'Sub'
+          assert_select '#main-menu a.sub-menu-item', 'sub'
         end
       end
     end

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -260,21 +260,21 @@ describe WikiController, type: :controller do
     describe '- main menu links' do
       before do
         @main_menu_item_for_page_with_content = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id,
-                                                                                    name:    'Item for Page with Content',
-                                                                                    title:   @page_with_content.title)
+                                                                                    title:    'Item for Page with Content',
+                                                                                    name:   @page_with_content.slug)
 
         @main_menu_item_for_new_wiki_page = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id,
-                                                                                name:    'Item for new WikiPage',
-                                                                                title:   'NewWikiPage')
+                                                                                title:    'Item for new WikiPage',
+                                                                                name:   'new-wiki-page')
 
         @other_menu_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id,
-                                                               name:    'Item for other page',
-                                                               title:   @unrelated_page.title)
+                                                               title:    'Item for other page',
+                                                               name:   @unrelated_page.slug)
       end
 
       shared_examples_for 'all wiki menu items' do
         it 'is inactive, when an unrelated page is shown' do
-          get 'show', id: @unrelated_page.title, project_id: @project.id
+          get 'show', id: @unrelated_page.slug, project_id: @project.id
 
           expect(response).to be_success
           expect(response).to have_exactly_one_selected_menu_item_in(:project_menu)
@@ -284,7 +284,7 @@ describe WikiController, type: :controller do
         end
 
         it "is inactive, when another wiki menu item's page is shown" do
-          get 'show', id: @other_wiki_menu_item.title, project_id: @project.id
+          get 'show', id: @other_wiki_menu_item.name, project_id: @project.id
 
           expect(response).to be_success
           expect(response).to have_exactly_one_selected_menu_item_in(:project_menu)
@@ -294,7 +294,7 @@ describe WikiController, type: :controller do
         end
 
         it 'is active, when the given wiki menu item is shown' do
-          get 'show', id: @wiki_menu_item.title, project_id: @project.id
+          get 'show', id: @wiki_menu_item.name, project_id: @project.id
 
           expect(response).to be_success
           expect(response).to have_exactly_one_selected_menu_item_in(:project_menu)
@@ -306,7 +306,7 @@ describe WikiController, type: :controller do
       shared_examples_for 'all existing wiki menu items' do
         # TODO: Add tests for new and toc options within menu item
         it 'is active on parents item, when new page is shown' do
-          get 'new_child', id: @wiki_menu_item.title, project_id: @project.identifier
+          get 'new_child', id: @wiki_menu_item.name, project_id: @project.identifier
 
           expect(response).to be_success
           expect(response).to have_no_selected_menu_item_in(:project_menu)
@@ -316,7 +316,7 @@ describe WikiController, type: :controller do
         end
 
         it 'is inactive, when a toc page is shown' do
-          get 'index', id: @wiki_menu_item.title, project_id: @project.id
+          get 'index', id: @wiki_menu_item.name, project_id: @project.id
 
           expect(response).to be_success
           expect(response).to have_no_selected_menu_item_in(:project_menu)
@@ -328,7 +328,7 @@ describe WikiController, type: :controller do
 
       shared_examples_for 'all wiki menu items with child pages' do
         it 'is active, when the given wiki menu item is an ancestor of the shown page' do
-          get 'show', id: @child_page.title, project_id: @project.id
+          get 'show', id: @child_page.slug, project_id: @project.id
 
           expect(response).to be_success
           expect(response).to have_exactly_one_selected_menu_item_in(:project_menu)
@@ -361,8 +361,8 @@ describe WikiController, type: :controller do
       describe '- wiki_menu_item containing special chars only' do
         before do
           @wiki_menu_item = FactoryGirl.create(:wiki_menu_item, navigatable_id: @project.wiki.id,
-                                                                name:    '?',
-                                                                title:   'Help')
+                                                                title:    '?',
+                                                                name:   'help')
           @other_wiki_menu_item = @other_menu_item
         end
 

--- a/spec/controllers/wiki_menu_items_controller_spec.rb
+++ b/spec/controllers/wiki_menu_items_controller_spec.rb
@@ -36,7 +36,7 @@ describe WikiMenuItemsController, type: :controller do
   let(:wiki) { project.wiki }
 
   let(:wiki_page) { FactoryGirl.create(:wiki_page, wiki: wiki) } # first wiki page without child pages
-  let!(:top_level_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, :with_menu_item_options, wiki: wiki, title: wiki_page.title) }
+  let!(:top_level_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, :with_menu_item_options, wiki: wiki, name: wiki_page.slug) }
 
   before :each do
     # log in user
@@ -46,20 +46,20 @@ describe WikiMenuItemsController, type: :controller do
   describe '#edit' do
     # more wiki pages with menu items
     let(:another_wiki_page) { FactoryGirl.create(:wiki_page, wiki: wiki) } # second wiki page with two child pages
-    let!(:another_wiki_page_top_level_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: another_wiki_page.title) }
+    let!(:another_wiki_page_top_level_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: another_wiki_page.slug) }
 
     # child pages of another_wiki_page
     let(:child_page) { FactoryGirl.create(:wiki_page, parent: another_wiki_page, wiki: wiki) }
-    let!(:child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: child_page.title) }
+    let!(:child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: child_page.slug) }
     let(:another_child_page) { FactoryGirl.create(:wiki_page, parent: another_wiki_page, wiki: wiki) }
-    let!(:another_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: another_child_page.title, parent: top_level_wiki_menu_item) }
+    let!(:another_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: another_child_page.slug, parent: top_level_wiki_menu_item) }
 
     let(:grand_child_page) { FactoryGirl.create(:wiki_page, parent: child_page, wiki: wiki) }
-    let!(:grand_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: grand_child_page.title) }
+    let!(:grand_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: grand_child_page.slug) }
 
     context 'when no parent wiki menu item has been configured yet' do
       context 'and it is a child page' do
-        before do get :edit, project_id: project.id, id: child_page.title end
+        before do get :edit, project_id: project.id, id: child_page.slug end
         subject { response }
 
         it 'preselects the wiki menu item of the parent page as parent wiki menu item option' do
@@ -72,7 +72,7 @@ describe WikiMenuItemsController, type: :controller do
         before do
           # ensure the parent page of grand_child_page is not a main item
           child_page_wiki_menu_item.tap { |page| page.parent = top_level_wiki_menu_item }.save
-          get :edit, project_id: project.id, id: grand_child_page.title
+          get :edit, project_id: project.id, id: grand_child_page.slug
         end
 
         subject { response }
@@ -84,7 +84,7 @@ describe WikiMenuItemsController, type: :controller do
     end
 
     context 'when a parent wiki menu item has already been configured' do
-      before do get :edit, project_id: project.id, id: another_child_page.title end
+      before do get :edit, project_id: project.id, id: another_child_page.slug end
       subject { response }
 
       it 'preselects the parent wiki menu item that is already assigned' do

--- a/spec/features/wiki/wiki_menu_item_migration_spec.rb
+++ b/spec/features/wiki/wiki_menu_item_migration_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require Rails.root.join('db/migrate/20160803094931_wiki_menu_titles_to_slug.rb')
+
+describe 'Wiki menu_items migration', type: :feature do
+  let(:project) { FactoryGirl.create :project }
+  let(:wiki_page) {
+    FactoryGirl.create :wiki_page_with_content,
+                       wiki: project.wiki,
+                       title: 'Base de donées'
+  }
+  let!(:menu_item) {
+    FactoryGirl.create(:wiki_menu_item,
+                       :with_menu_item_options,
+                       wiki: project.wiki,
+                       name: 'My linked page',
+                       title: wiki_page.title)
+  }
+
+  before do
+    project.wiki.pages << wiki_page
+
+    # Run the title replacement of the migration
+    ::WikiMenuTitlesToSlug.new.migrate_menu_items
+
+    menu_item.reload
+  end
+
+  it 'updates the menu item' do
+    expect(menu_item.name).to eq(wiki_page.slug)
+    expect(menu_item.title).to eq('My linked page')
+  end
+
+
+  describe 'visiting the wiki' do
+    let(:user) { FactoryGirl.create :admin }
+
+    before do
+      login_as(user)
+    end
+
+    it 'shows the menu item' do
+      visit project_wiki_path(project, project.wiki)
+      link = page.find('#menu-sidebar a.icon-wiki', text: menu_item.name)
+      link.click
+
+      expect(page).to have_selector('.wiki-title', text: wiki_page.title)
+      expect(current_path).to eq(project_wiki_path(project, wiki_page.slug))
+    end
+  end
+end

--- a/spec/models/menu_items/wiki_menu_item_spec.rb
+++ b/spec/models/menu_items/wiki_menu_item_spec.rb
@@ -43,7 +43,7 @@ describe MenuItems::WikiMenuItem, type: :model do
     @project.reload
 
     wiki_item = @project.wiki.wiki_menu_items.first
-    expect(wiki_item.name).to eql 'Wiki'
+    expect(wiki_item.name).to eql 'wiki'
     expect(wiki_item.title).to eql 'Wiki'
     expect(wiki_item.slug).to eql 'wiki'
     expect(wiki_item.options[:index_page]).to eql true

--- a/spec/models/menu_items/wiki_menu_item_spec.rb
+++ b/spec/models/menu_items/wiki_menu_item_spec.rb
@@ -45,6 +45,7 @@ describe MenuItems::WikiMenuItem, type: :model do
     wiki_item = @project.wiki.wiki_menu_items.first
     expect(wiki_item.name).to eql 'Wiki'
     expect(wiki_item.title).to eql 'Wiki'
+    expect(wiki_item.slug).to eql 'wiki'
     expect(wiki_item.options[:index_page]).to eql true
     expect(wiki_item.options[:new_wiki_page]).to eql true
   end
@@ -53,8 +54,8 @@ describe MenuItems::WikiMenuItem, type: :model do
     wikipage = FactoryGirl.create(:wiki_page, title: 'Oldtitle')
 
     menu_item_1 = FactoryGirl.create(:wiki_menu_item, navigatable_id: wikipage.wiki.id,
-                                                      name:    'Item 1',
-                                                      title:   'Oldtitle')
+                                                      title:    'Item 1',
+                                                      name:   wikipage.slug)
 
     wikipage.title = 'Newtitle'
     wikipage.save!

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -58,9 +58,9 @@ describe WikiPage, type: :model do
 
   describe '#nearest_parent_menu_item' do
     let(:child_page) { FactoryGirl.create(:wiki_page, parent: wiki_page, wiki: wiki) }
-    let!(:child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: child_page.title, parent: wiki_page.menu_item) }
+    let!(:child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: child_page.slug, parent: wiki_page.menu_item) }
     let(:grand_child_page) { FactoryGirl.create(:wiki_page, parent: child_page, wiki: wiki) }
-    let!(:grand_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, title: grand_child_page.title) }
+    let!(:grand_child_page_wiki_menu_item) { FactoryGirl.create(:wiki_menu_item, wiki: wiki, name: grand_child_page.slug) }
 
     context 'when called without options' do
       it 'returns the menu item of the parent page' do
@@ -95,7 +95,7 @@ describe WikiPage, type: :model do
 
       it 'ensures that there is still a wiki menu item named like the wiki start page' do
         expect(wiki.wiki_menu_items).to be_one
-        expect(wiki.wiki_menu_items.first.name).to eq(wiki.start_page)
+        expect(wiki.wiki_menu_items.first.name).to eq(wiki.start_page.to_url)
       end
     end
   end


### PR DESCRIPTION
Since WikiMenuItem doesn't provide any other locator other than the
title, we can employ `wiki.find_page` to locate the page by title.
That title is either matched to the slug, or found by the legacy
redirect introduced with 6.0.1.

**Adds migration to swap and correct WikiMenuItems titles and names**
Previously, the `title` attribute of a WikiMenuItem was used to identify
a page that was linked to.

With slugs, that makes no sense. We swap the name and title usage so
that:
1. Name is used for the wiki_page slug that is being linked to
2. Title is used for the displayed name

https://community.openproject.com/projects/openproject/work_packages/23753
