### PR TITLE
[23742] marked text is overlapping

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -159,6 +159,7 @@
   width: 100%
   margin-bottom: -1px
   overflow-y: auto !important
+  line-height: normal
 
   // Resize done by angular-elastic
   &[msd-elastic]


### PR DESCRIPTION
This sets a line-height to avoid overlapping in the textarea. This bug only occurred in Firefox and IE.

https://community.openproject.com/work_packages/23742/activity
