### PR TITLE
[23740] fix wiki-toolbar for project news module

### DIFF
--- a/app/views/news/_form.html.erb
+++ b/app/views/news/_form.html.erb
@@ -34,6 +34,5 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= f.text_area :summary, cols: 60, rows: 2 %>
 </div>
 <div class="form--field">
-  <%= f.text_area :description, required: true, cols: 60, rows: 15, class: 'wiki-edit' %>
+  <%= f.text_area :description, required: true, cols: 60, rows: 15, class: 'wiki-edit wiki-toolbar' %>
 </div>
-<%= wikitoolbar_for 'news_description' %>

--- a/frontend/app/ui_components/wiki-toolbar-directive.js
+++ b/frontend/app/ui_components/wiki-toolbar-directive.js
@@ -80,7 +80,7 @@ module.exports = function() {
   }
 
   return {
-    restrict: 'A',
+    restrict: 'AC',
     transclude: false,
     link: link,
     scope: {


### PR DESCRIPTION
[23740](https://community.openproject.com/work_packages/23740/activity)

this enables the wiki-toolbar for the description field in the `_form` partial (project's news module) and therefore the create and edit mode for project news.
