### PR TITLE
[23594] Error message macro on project overview not at widget

### DIFF
--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -64,6 +64,7 @@ $widget-box--enumeration-width: 20px
       margin-right: 0
 
   .widget-box
+    position: relative
     @include widget-box--style
     padding: 10px 20px 30px 20px
     min-height: 250px


### PR DESCRIPTION
This sets `position: relative` for widget boxes. Thus the error message is correctly positioned.

https://community.openproject.com/work_packages/23594/activity
