### PR TITLE
[23460] [7e] Tabellenzeilen erhalten den Fokus

### DIFF
--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -123,7 +123,8 @@
             wp-edit-form="row.object"
             wp-edit-form-on-error="handleErroneousColumns(workPackage, fields, attributes)"
             wp-edit-form-on-save="onWorkPackageSave(workPackage, fields)"
-            wp-attachments-formattable>
+            wp-attachments-formattable
+            tabindex="-1">
           <td ng-if="!row.object.isNew" class="checkbox -short hide-when-print">
             <accessible-checkbox name="ids[]"
                                  checkbox-id="work_package{{row.object.id}}"


### PR DESCRIPTION
Rows in the WP table did get focus although there was nothing to do there. Blind users could get confused by this.

https://community.openproject.com/work_packages/23460/activity
