### PR TITLE
[23459] [7d] Schalter zum Bearbeiten nur am Formularende

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -73,11 +73,15 @@ export class WorkPackageEditFormController {
         // Setup the field if it is not yet active
         if (state && field.isEditable && !field.active) {
           field.initializeField(this.workPackage);
+          window.setTimeout(function() {
+            jQuery('.work-packages--details--subject input')[0].focus();
+          }, 1000);
         }
 
         // Disable the field if is active
         if (!state && field.active) {
           field.reset();
+          jQuery('.work-packages--details-toolbar .button')[0].focus();
         }
       });
     });


### PR DESCRIPTION
This sets the focus to the subject field when editing a WP. Before the focus stayed on the edit-button.

https://community.openproject.com/work_packages/23459/activity
