### PR TITLE
[23458] [7c] Links zur Tabellennavigation erhalten erst nach der Tabelle den Fokus

### DIFF
--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -74,3 +74,8 @@ body.accessibility-mode
   // On the WP table this is not neccessary because the whole cell is clickable
   table:not(.work-package-table) input[type='checkbox']
     width: 100%
+
+  // Show WP skip links for motorically handicapped users
+  .skip-navigation-link:focus
+    top: auto
+    left: auto


### PR DESCRIPTION
To avoid that handicapped users have to tab through the whole WP table to reach the pagination there is a skip link before the table. To let motorically handicapped users know that this link exists, it is now shown when focused.

https://community.openproject.com/work_packages/23458/activity
