### PR TITLE
[23442] [1q] Links auf der Registerkarte "Aktivität" erhalten nicht den Fokus

### DIFF
--- a/frontend/app/templates/work_packages/activities/_link.html
+++ b/frontend/app/templates/work_packages/activities/_link.html
@@ -1,4 +1,3 @@
 <a id ="{{ activityHtmlId }}-link"
    ng-bind="'#' + activityNo"
-   tabindex="-1"
    ui-sref="work-packages.show.activity({ workPackageId: workPackageId, '#': activityHtmlId})"></a>


### PR DESCRIPTION
This removes the `tabindex` attribute to make the link focusable again.

https://community.openproject.com/work_packages/23442/activity
