### PR TITLE
[23498] [2o] Unverständliche Formularfeldgruppenbeschriftung

### DIFF
--- a/app/assets/javascripts/specific/toggable_fieldset.js
+++ b/app/assets/javascripts/specific/toggable_fieldset.js
@@ -38,7 +38,7 @@ function createFieldsetToggleStateLabel(legend, text) {
     legendLink.append(toggleLabel);
   }
 
-  toggleLabel.text(text);
+  toggleLabel.text(' ' + text);
 }
 
 function setFieldsetToggleState(fieldset) {


### PR DESCRIPTION
This adds a space between the description of the fieldset and the state. Thus it is easier to understand the screen reader.

https://community.openproject.com/work_packages/23498/activity
