### PR TITLE
[23438] [1o] Ausklapplisten können nicht im geschlossenen Zustand bedient werden

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -451,6 +451,7 @@ en:
         summary: "Table with rows of work package and columns of work package attributes."
         text_inline_edit: "Most cells of this table are buttons that activate inline-editing functionality of that attribute."
         text_sort_hint: "With the links in the table headers you can sort, group, reorder, remove and add table columns."
+        text_select_hint: "Select boxes should be opened with 'ALT' and arrow keys."
       tabs:
         overview: Overview
         activity: Activity

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -283,6 +283,7 @@ function WorkPackagesTableController($scope, $rootScope, I18n) {
     tableSummary: I18n.t('js.work_packages.table.summary'),
     tableSummaryHints: [
       I18n.t('js.work_packages.table.text_inline_edit'),
+      I18n.t('js.work_packages.table.text_select_hint'),
       I18n.t('js.work_packages.table.text_sort_hint')
     ].join(' ')
   };


### PR DESCRIPTION
This adds a hint text for the WP table. Thus blind users know how to open a select box here without triggering the refresh. The problem itself only occurs in IE.

Related PR: https://github.com/finnlabs/reporting_engine/pull/79

https://community.openproject.com/work_packages/23438/activity
