### PR TITLE
Avoid increasing line heights in accessibility mode

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -73,7 +73,7 @@
   border-style: solid
   border-radius: 2px
   border-width: 1px
-  line-height: 1.6
+  line-height: normal
 
   &:hover,
   &:focus

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -73,6 +73,8 @@ body.accessibility-mode
       max-width: calc(100% - 6px)
     .inplace-edit form
       display: block
+    .inplace-edit .inplace-edit--read-value
+      display: inline-block
 
   // Allow a greater sensible area to click input checkboxes
   // On the WP table this is not neccessary because the whole cell is clickable

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -16,7 +16,7 @@
         wp-attachments-formattable
         wp-edit-field-wrapper-classes="'-no-label'"
         display-placeholder="$ctrl.I18n.t('js.work_packages.placeholders.description')"
-        class="single-attribute wiki">
+        class="single-attribute wiki work-packages--details--description">
     </div>
   </div>
 


### PR DESCRIPTION
In the scope of https://github.com/opf/openproject/pull/4751 the scrolling in the WP table was improved. Thereby there were some problems with increasing line heights in accessibility mode. Now the lines keep their height when editing a field.

Before this can be merged the PR has to be merged: https://github.com/opf/openproject/pull/4751
