### PR TITLE
[23715] Allow query_id, query_props on all routes

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -86,6 +86,10 @@ openprojectModule
     $stateProvider
       .state('work-packages', {
         url: '',
+        params: {
+          query_id: {value: null},
+          query_props: {value: null}
+        },
         abstract: true,
         templateUrl: '/components/routing/main/work-packages.html',
         controller: 'WorkPackagesController'


### PR DESCRIPTION
This adds the query params globally to the work packages state, so that when passing between child states, these parameters are kept without explicitly referencing them.

This in turn means that moving to the show route always contains these parameters. I'm not sure if that is indeed desired. Instead, we may want to remember the parameters elsewhere so that moving back to the list is possible, yet the show URL is concise.

https://community.openproject.com/work_packages/23715
