### PR TITLE
[23768] Remove absolute footer from work package layout

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -42,6 +42,7 @@ body.controller-work_packages.action-show {
   }
 
   .work-packages--split-view {
+    height: auto;
     border-top: 1px solid #ccc;
     overflow: hidden;
     position: absolute;

--- a/app/assets/stylesheets/layout/_angular-busy.sass
+++ b/app/assets/stylesheets/layout/_angular-busy.sass
@@ -46,5 +46,5 @@
   margin: 12px 0
 
 .cg-busy-default-spinner
-  top: -30px
+  top: 30px
   left: 30px

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -98,7 +98,7 @@
   height: 100%
 
 .work-packages--list
-  +flex-grow(2)
+  +flex(2)
   overflow-x: auto
   height: 100%
 

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -90,23 +90,23 @@
     height: auto
 
   > .work-packages--split-view
-    +flex-grow(1)
     min-height: 100px
 
 .work-packages--split-view
   +display(flex)
   width: 100%
+  height: 100%
 
 .work-packages--list
-  +flex-grow(1)
-  position: relative
+  +flex-grow(2)
+  overflow-x: auto
+  height: 100%
+
+.action-details .work-package--details-container
+  flex: 1
 
 .work-packages--list-table-area
-  position: absolute
-  top:      0
-  bottom:   55px
-  right:    0
-  width:    100%
+  height: calc(100% - 55px)
 
   table
     tr
@@ -126,8 +126,6 @@
           white-space: normal
 
 .work-packages--list-pagination-area
-  position: absolute
-  bottom:   0
   width:    100%
   height:   55px
   padding:  3px 10px 0 0


### PR DESCRIPTION
The inner scrolling combined with the increased complexity of the table
(cells) causes FireFox to go nuts when 200+ work packages are showing.
The work package footer (pagination area) jumps up and down when
resizing and hovering in the table. This is likely caused by a repaint
that initially collapses the height of the table determined by
flex-grow.

As the height is actually always fixed (full height minus bottom
pagination), we don't need absolute positions and flex-based heights.

https://community.openproject.com/work_packages/23768
