### PR TITLE
[23775] Avoid adding a separate placeholder value

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -70,7 +70,15 @@ export class SelectEditField extends EditField {
   }
 
   private addEmptyOption() {
-    if (!this.schema.required) {
+    // Empty options are not available for required fields
+    if (this.schema.required) {
+      return;
+    }
+
+    // Since we use the original schema values, avoid adding
+    // the option if one is returned / exists already.
+    const emptyOption = _.find(this.options, { name: this.text.placeholder });
+    if (emptyOption === undefined) {
       this.options.unshift({
         name: this.text.placeholder,
       });


### PR DESCRIPTION
Since we're no longer copying select values since PR #4645,
adding an empty option is now made on the actual schema values.

This change improves performance for a large number of options, but closing and opening the field a second time causes the empty option to be re-added.

https://community.openproject.com/work_packages/23775/activity
