### PR TITLE
Fix/query performance

### DIFF
--- a/app/controllers/api/experimental/work_packages_controller.rb
+++ b/app/controllers/api/experimental/work_packages_controller.rb
@@ -76,6 +76,9 @@ module Api
 
       def query_as_json(query, user)
         json_query = query.as_json(except: :filters, include: :filters, methods: [:starred])
+        # prefer using the identifier throughout the frontend so that we can
+        # cache the requests more efficiently
+        json_query["project_id"] = @project.identifier if @project
 
         json_query[:_links] = allowed_links_on_query(query, user)
 

--- a/app/models/queries/work_packages/available_filter_options.rb
+++ b/app/models/queries/work_packages/available_filter_options.rb
@@ -153,7 +153,7 @@ module Queries::WorkPackages::AvailableFilterOptions
         @available_work_package_filters['subproject_id'] = { type: :list_subprojects, order: 13, values: subprojects.map { |s| [s.name, s.id.to_s] }, name: I18n.t('query_fields.subproject_id') }
       end
     end
-    add_custom_fields_options(project.all_work_package_custom_fields)
+    add_custom_fields_options(project.all_work_package_custom_fields(include: :translations))
   end
 
   def add_user_options
@@ -202,7 +202,8 @@ module Queries::WorkPackages::AvailableFilterOptions
     unless system_shared_versions.empty?
       @available_work_package_filters['fixed_version_id'] = { type: :list_optional, order: 7, values: system_shared_versions.sort.map { |s| ["#{s.project.name} - #{s.name}", s.id.to_s] }, name: WorkPackage.human_attribute_name('fixed_version_id') }
     end
-    add_custom_fields_options(WorkPackageCustomField.where(is_filter: true, is_for_all: true))
+    add_custom_fields_options(WorkPackageCustomField.where(is_filter: true, is_for_all: true)
+                                                    .includes(:translations))
   end
 
   def add_custom_fields_options(custom_fields)

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -376,10 +376,10 @@ class Query < ActiveRecord::Base
           # main project only
         else
           # all subprojects
-          ids += project.descendants.map(&:id)
+          ids += project.descendants.pluck(:id)
         end
       elsif Setting.display_subprojects_work_packages?
-        ids += project.descendants.map(&:id)
+        ids += project.descendants.pluck(:id)
       end
       project_clauses << "#{Project.table_name}.id IN (%s)" % ids.join(',')
     elsif project

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -364,9 +364,9 @@ class Query < ActiveRecord::Base
 
   def project_statement
     project_clauses = []
+    subproject_filter = filter_for 'subproject_id'
     if project && !project.descendants.active.empty?
       ids = [project.id]
-      subproject_filter = filter_for 'subproject_id'
       if subproject_filter
         case subproject_filter.operator
         when '='
@@ -385,7 +385,9 @@ class Query < ActiveRecord::Base
     elsif project
       project_clauses << "#{Project.table_name}.id = %d" % project.id
     end
-    project_clauses << WorkPackage.visible_condition(User.current)
+    project_clauses << WorkPackage.visible_condition(User.current,
+                                                     project: project,
+                                                     with_subprojects: !subproject_filter.nil?)
     project_clauses.join(' AND ')
   end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -113,7 +113,9 @@ class ::Query::Results
   end
 
   def all_total_sums
-    query.available_columns.inject({}) { |result, column|
+    query.available_columns.select { |column|
+      column.summable? && Setting.work_package_list_summable_columns.include?(column.name.to_s)
+    }.inject({}) { |result, column|
       sum = total_sum_of(column)
       result[column] = sum unless sum.nil?
       result

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -102,14 +102,15 @@ See doc/COPYRIGHT.rdoc for more details.
           </tr>
         </thead>
         <tbody>
-          <% Type.all.each do |type| %>
+          <% projects_types_id = project.types.pluck(:id) %>
+          <% Type.includes(:color).each do |type| %>
             <tr>
               <td class='center'>
                 <% type_id = "project_planning_element_type_ids_#{type.id}" %>
                 <%= label_tag type_id, l('timelines.enable_type_in_project', type: type.name), class: 'hidden-for-sighted' %>
                 <%= check_box_tag "project[type_ids][]",
                                   type.id,
-                                  project.types.include?(type),
+                                  projects_types_id.include?(type.id),
                                   id: type_id,
                                   :'data-standard' => type.is_standard %>
                 <%= hidden_field_tag 'project[type_ids][]', '', :'data-for' => type_id %>

--- a/frontend/app/components/filters/query/query-service.service.ts
+++ b/frontend/app/components/filters/query/query-service.service.ts
@@ -258,7 +258,7 @@ function QueryService($rootScope,
     },
 
     getProjectCustomFieldFilters: function(projectIdentifier) {
-      return QueryService.doQuery(PathHelper.apiProjectCustomFieldsPath(projectIdentifier));
+      return QueryService.doQuery(PathHelper.apiProjectCustomFieldsPath(projectIdentifier), {}, 'GET', null, null, true);
     },
 
     getCustomFieldFilters: function() {
@@ -471,7 +471,7 @@ function QueryService($rootScope,
       return QueryService.doQuery(url, null, 'PATCH', success, failure);
     },
 
-    doQuery: function(url:string, params:any = {}, method:string = 'GET', success?:any, failure?:any) {
+    doQuery: function(url:string, params:any = {}, method:string = 'GET', success?:any, failure?:any, cache:boolean = false) {
       success = success || function(response){
         return response.data;
       };
@@ -482,7 +482,7 @@ function QueryService($rootScope,
         url: url,
         params: params,
         headers: {
-          'caching': { enabled: false },
+          'caching': { enabled: cache },
           'Content-Type': 'application/x-www-form-urlencoded'
         }
       }).then(success, failure);

--- a/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
@@ -44,7 +44,7 @@ module API
           end
 
           def available_custom_fields
-            project.all_work_package_custom_fields.to_a & type.custom_fields.to_a
+            project.all_work_package_custom_fields(include: :translations).to_a & type.custom_fields.includes(:translations).to_a
           end
         end
       end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -410,10 +410,10 @@ module API
 
         self.to_eager_load = [{ children: { project: :enabled_modules } },
                               { parent: { project: :enabled_modules } },
-                              { project: :enabled_modules },
+                              { project: [:enabled_modules, :work_package_custom_fields] },
                               :status,
                               :priority,
-                              :type,
+                              { type: :custom_fields },
                               :fixed_version,
                               { custom_values: :custom_field },
                               :author,


### PR DESCRIPTION
Improves the performance of calling work_packages#index by:
- caching calls to `/api/experimental/projects/[:id]/queries/custom_field_filters` which used to be called 3-4 times
- eager loading custom field and custom field translations where necessary
- limiting the enabled_modules subquery in `Project.allowed_to_condition` to only those projects and it's descendants that are used in the query. Unfortunately, this does not work for project independent queries which is why they are still awfully slow. (https://community.openproject.com/work_packages/23783/activity would be needed to fix that problem)
- limiting summing up to only those columns that are summable and are to be summed up (according to the setting)

This bunch of changes drops the time required for some of the APIv3 work_packages#index calls on my system from 18sec to 600ms.

https://community.openproject.com/work_packages/23781
