### PR TITLE
[23715] Hoist work package params to the global state

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -87,6 +87,14 @@ openprojectModule
       .state('work-packages', {
         url: '',
         abstract: true,
+        params: {
+          // value: null makes the parameter optional
+          // squash: true avoids duplicate slashes when the paramter is not provided
+          projectPath: {value: null, squash: true},
+          projects: {value: null, squash: true},
+          query_id: {value: null},
+          query_props: {value: null}
+        },
         templateUrl: '/components/routing/main/work-packages.html',
         controller: 'WorkPackagesController'
       })
@@ -99,12 +107,6 @@ openprojectModule
         reloadOnSearch: false,
         onEnter: () => angular.element('body').addClass('full-create'),
         onExit: () => angular.element('body').removeClass('full-create'),
-        params: {
-          // value: null makes the parameter optional
-          // squash: true avoids duplicate slashes when the paramter is not provided
-          projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true}
-        }
       })
 
       .state('work-packages.copy', {
@@ -120,11 +122,6 @@ openprojectModule
 
       .state('work-packages.edit', {
         url: '/{projects}/{projectPath}/work_packages/{workPackageId:[0-9]+}/edit',
-        params: {
-          projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true},
-        },
-
         onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
           // Transitioning to a new state may cause a reported issue
@@ -135,7 +132,7 @@ openprojectModule
       })
 
       .state('work-packages.show', {
-        url: '/work_packages/{workPackageId:[0-9]+}?query_id&query_props',
+        url: '/work_packages/{workPackageId:[0-9]+}',
         templateUrl: '/components/routing/wp-show/wp.show.html',
         controller: 'WorkPackageShowController',
         controllerAs: '$ctrl',


### PR DESCRIPTION
This allows moving to show views with proper URLs while moving
back restores the params set previously.

https://community.openproject.com/projects/openproject/work_packages/details/23715/
