### PR TITLE
[23774] Fix empty ENV overrides to be parsed as false

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -313,6 +313,11 @@ module OpenProject
       # @return A ruby object (e.g. Integer, Float, String, Hash, Boolean, etc.)
       # @raise [ArgumentError] If the string could not be parsed.
       def extract_value(key, value)
+
+        # YAML parses '' as false, but empty ENV variables will be passed as that.
+        # To specify specific values, one can use !!str (-> '') or !!null (-> nil)
+        return value if value == ''
+
         YAML.load(value)
       rescue => e
         raise ArgumentError, "Configuration value for '#{key}' is invalid: #{e.message}"

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -91,6 +91,9 @@ describe OpenProject::Configuration do
   describe '.load_overrides_from_environment_variables' do
     let(:config) {
       {
+        'someemptysetting' => nil,
+        'nil' => 'foobar',
+        'str_empty' => 'foobar',
         'somesetting' => 'foo',
         'some_list_entry' => nil,
         'nested' => {
@@ -110,7 +113,10 @@ describe OpenProject::Configuration do
 
     let(:env_vars) {
       {
+        'SOMEEMPTYSETTING' => '',
         'SOMESETTING' => 'bar',
+        'NIL' => '!!null',
+        'STR_EMPTY' => '!!str',
         'OPTEST_SOME__LIST__ENTRY' => '[foo, bar , xyz, whut wat]',
         'OPTEST_NESTED_KEY' => 'baz',
         'OPTEST_NESTED_DEEPLY__NESTED_KEY' => '42',
@@ -123,6 +129,18 @@ describe OpenProject::Configuration do
       stub_const('OpenProject::Configuration::ENV_PREFIX', 'OPTEST')
 
       OpenProject::Configuration.send :override_config!, config, env_vars
+    end
+
+    it 'should not parse the empty value' do
+      expect(config['someemptysetting']).to eq('')
+    end
+
+    it 'should parse the null identifier' do
+      expect(config['nil']).to be_nil
+    end
+
+    it 'should parse the empty string' do
+      expect(config['str_empty']).to eq('')
     end
 
     it 'should override the previous setting value' do


### PR DESCRIPTION
YAML parses `''` as false, but empty ENV variables will be passed as that.
To mitigate that, we first check for an explicit empty string.

To specify specific values, one can use `!!str (-> '')` or `!!null (-> nil)`.

https://community.openproject.com/work_packages/23774/activity
