### PR TITLE
[23459] [7d] Schalter zum Bearbeiten nur am Formularende (2)

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -139,7 +139,11 @@ export class WorkPackageEditFieldController {
 
         // Activate the field automatically when in editAllMode
         if (this.inEditMode && this.isEditable) {
-          this.activate();
+          // Set focus on the first field
+          if(this.fieldName === 'subject')
+            this.activate(true);
+          else
+            this.activate();
         }
       }
     });


### PR DESCRIPTION
This sets the focus to the subject field when editing a WP. Before the focus stayed on the edit-button.

https://community.openproject.com/work_packages/23459/activity
