### PR TITLE
[23784] Extend top-shelf browser warning to IE11

### DIFF
--- a/app/assets/javascripts/top-shelf.js
+++ b/app/assets/javascripts/top-shelf.js
@@ -39,14 +39,22 @@
     var opts = mergeOptions(options);
     var message = this;
     var topShelf = $("<div/>").addClass(opts.className);
+    var link = $("<a/>").append(' ' + opts.link).attr({"href": opts.url});
+
+    if (window.localStorage.getItem(opts.id)) {
+      return;
+    }
+
+    var closeLink = $("<a/>").append(opts.close);
+    closeLink.click(function() {
+      window.localStorage.setItem(opts.id, '1');
+      topShelf.remove();
+    });
 
     if (message.length === 0) {
       topShelf.append($("<h1/>").append(opts.title))
-              .append($("<p/>").append(opts.message))
-              .append($("<h2/>").append(
-                $("<a/>").append(opts.link)
-                         .attr({"href": opts.url})
-              ));
+              .append($("<p/>").append(opts.message).append(link))
+              .append($("<h2/>").append(closeLink));
     } else {
       topShelf.append(message);
     }

--- a/app/assets/javascripts/unsupported-browsers.js
+++ b/app/assets/javascripts/unsupported-browsers.js
@@ -28,22 +28,46 @@
 
 (function($) {
 
+  function getMSIEVersion() {
+      var ua = window.navigator.userAgent;
+      var msie = ua.indexOf("MSIE ");
+
+      // IE <= 10
+      if (msie !== -1) {
+        return parseInt(ua.substring(msie + 5, ua.indexOf(".", msie)));
+      }
+
+      // IE 11
+      msie = ua.indexOf('Trident/');
+      if (msie > 0) {
+        // IE 11 => return version number
+        var rv = ua.indexOf('rv:');
+        return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+      }
+  }
+
   $(function() {
 
+    var ieVersion = getMSIEVersion();
+    var isIE = ieVersion !== undefined && ieVersion <= 11;
+    var additionalMessage = I18n.t("js.unsupported_browser.update_message");
+
     var agent = navigator.userAgent;
-    if (agent.match(/MSIE [789]\.0/) === null &&                // IE 7-9
-        agent.match(/MSIE 10\.\d/) === null &&                // IE 10.0, 10.6
-        agent.match(/Firefox\/(([1-2][0-9]|3[0-7])\.)/) === null) { // Firefox 10-37
-      return;
+    if (isIE || agent.match(/Firefox\/(([1-2][0-9]|3[0-7])\.)/)) { // Firefox 10-37
+
+      if (isIE) {
+        additionalMessage = I18n.t("js.unsupported_browser.update_ie_user");
+      }
+
+      $().topShelf({
+        id: 'op.unsupported_browsers',
+        title: I18n.t("js.unsupported_browser.title"),
+        message: I18n.t("js.unsupported_browser.message") + '<br/>' + additionalMessage,
+        link: I18n.t("js.unsupported_browser.learn_more"),
+        close: I18n.t("js.unsupported_browser.close_warning"),
+        url: "https://www.openproject.org/open-source/download/systemrequirements/"
+      });
     }
-
-    $().topShelf({
-      title: I18n.t("js.unsupported_browser.title"),
-      message: I18n.t("js.unsupported_browser.message"),
-      link: I18n.t("js.unsupported_browser.learn_more"),
-      url: "https://www.openproject.org/supported_browsers"
-    });
-
   });
 
 }(jQuery));

--- a/app/assets/stylesheets/top-shelf.css.erb
+++ b/app/assets/stylesheets/top-shelf.css.erb
@@ -48,10 +48,6 @@ See doc/COPYRIGHT.rdoc for more details.
   font-weight: bold;
 }
 
-.top-shelf p {
-  width: 800px;
-}
-
 .top-shelf h2 {
   border-bottom: 0;
   font-size: 12px;

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -348,8 +348,11 @@ en:
       outlines: "Hierarchy level"
     unsupported_browser:
       title: "Your browser version is not supported"
-      message: "The browser version you are using is no longer supported by OpenProject. Please update your browser."
+      message: "The browser version you are using is no longer supported by OpenProject."
+      update_message: 'Please update your browser.'
+      update_ie_user: "Please switch to Mozilla Firefox or Google Chrome or upgrade to Microsoft Edge."
       learn_more: "Learn more"
+      close_warning: "Ignore this warning."
     wiki_formatting:
       strong: "Strong"
       italic: "Italic"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -350,7 +350,7 @@ en:
       title: "Your browser version is not supported"
       message: "The browser version you are using is no longer supported by OpenProject."
       update_message: 'Please update your browser.'
-      update_ie_user: "Please switch to Mozilla Firefox or Google Chrome or upgrade to Microsoft Edge."
+      update_ie_user: "Please switch to Mozilla Firefox or Google Chrome, or upgrade to Microsoft Edge."
       learn_more: "Learn more"
       close_warning: "Ignore this warning."
     wiki_formatting:


### PR DESCRIPTION
Extends the unsupported browsers information to include IE11, but makes
the dialog closable with localStorage.

https://community.openproject.com/work_packages/23784
