### PR TITLE
[23785] Workaround for Safari flexbox height issue

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -88,6 +88,7 @@
   > .work-packages--filters-optional-container
     // not flex-item
     height: auto
+    flex-shrink: 0
 
   > .work-packages--split-view
     min-height: 100px
@@ -100,7 +101,6 @@
 .work-packages--list
   +flex(2)
   overflow-x: auto
-  height: 100%
 
 .work-packages--list-table-area
   height: calc(100% - 55px)


### PR DESCRIPTION
Safari shrinks the filter-container and WP list too far.

This a known bug still not fixed in current Safari versions:
https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored

https://community.openproject.com/work_packages/23785/activity
