### PR TITLE
[23801] Toolbar layout not applied in wiki history

### DIFF
--- a/app/views/wiki/annotate.html.erb
+++ b/app/views/wiki/annotate.html.erb
@@ -29,15 +29,21 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% html_title t(:project_module_wiki), t(:label_history), t(:text_comment_wiki_page, page: @page.title)  %>
 
-<% content_for :action_menu_specific do %>
-  <%= link_to(t(:button_edit),
-              {action: 'edit', id: @page},
-              class: 'icon icon-edit',
-              accesskey: accesskey(:edit)) %>
-  <%= link_to(t(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
+<%= toolbar title: h(@page.title) do %>
+  <li class="toolbar-item">
+    <%= link_to({action: 'edit', id: @page}, class: 'button', accesskey: accesskey(:edit)) do %>
+      <i class="button--icon icon-edit"></i>
+      <span class="button--text"><%= t(:button_edit) %></span>
+    <% end %>
+  </li>
+  <li class="toolbar-item">
+    <%= link_to({action: 'history', id: @page}, class: 'button') do %>
+      <i class="button--icon icon-wiki"></i>
+      <span class="button--text"><%= t(:label_history) %></span>
+    <% end %>
+  </li>
 <% end %>
-<h2 class='legacy-heading'><%= h(@page.title) %></h2>
-<%= render partial: 'layouts/action_menu_specific' %>
+
 <p>
   <%= Version.model_name.human %> <%= link_to h(@annotate.content.version), action: 'show', id: @page, version: @annotate.content.version %>
   <em>(<%= h(@annotate.content.journable.author ? @annotate.content.journable.author.name : t(:label_user_anonymous)) %>, <%= format_time(@annotate.content.journable.updated_on) %>)</em>

--- a/app/views/wiki/diff.html.erb
+++ b/app/views/wiki/diff.html.erb
@@ -26,12 +26,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
-<% content_for :action_menu_specific do %>
-  <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'icon icon-wiki') %>
+<%= toolbar title: h(@page.title) do %>
+  <li class="toolbar-item">
+    <%= link_to({action: 'history', id: @page}, class: 'button') do %>
+      <i class="button--icon icon-wiki"></i>
+      <span class="button--text"><%= t(:label_history) %></span>
+    <% end %>
+  </li>
 <% end %>
-<h2 class="legacy-heading"><%= h(@page.title) %></h2>
-<%= render partial: 'layouts/action_menu_specific' %>
+
 <p>
   <%= Version.model_name.human %> <%= link_to @diff.content_from.version, action: 'show', id: @page, project_id: @page.project, version: @diff.content_from.version %>/<%= @page.content.version %>
   <em>(<%= @diff.content_from.user ? link_to_user(@diff.content_from.user) : l(:label_user_anonymous) %>, <%= format_time(@diff.content_from.created_at) %>)</em>


### PR DESCRIPTION
This applies the new toolbar styling to the wiki history page.

https://community.openproject.com/work_packages/23801/activity
