### PR TITLE
[23454] [4d] Fokus verbleibt auf Schaltern im Hintergrund

### DIFF
--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -36,7 +36,7 @@
     </div>
 
     <div class="bottom-toolbar" ng-if="$ctrl.workPackage">
-      <wp-details-toolbar work-package='$ctrl.workPackage'></wp-details-toolbar>
+      <wp-details-toolbar ng-show="!$ctrl.wpEditModeState.active" work-package='$ctrl.workPackage'></wp-details-toolbar>
       <edit-actions-bar
           ng-show="$ctrl.wpEditModeState.active"
           on-save="$ctrl.wpEditModeState.save()"


### PR DESCRIPTION
Hide the WP details toolbar button when being in edit mode.

https://community.openproject.com/work_packages/23454/activity
