### PR TITLE
[23503] [2t] Bedienhinweis schwer verständlich

### DIFF
--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.js
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.js
@@ -60,18 +60,23 @@ function sortHeader(){
 
       function setFullTitleAndSummary() {
         scope.fullTitle = scope.headerTitle;
+        var summaryContent;
 
         if(scope.currentSortDirection) {
           var ascending = scope.currentSortDirection === 'asc';
-          var summaryContent = [
+          summaryContent = [
             ascending ? I18n.t('js.label_ascending') : I18n.t('js.label_descending'),
             I18n.t('js.label_sorted_by'),
             scope.headerTitle + '.',
             I18n.t('js.work_packages.table.text_sort_hint')
-          ];
-
-          jQuery('#wp-table-sort-summary').text(summaryContent.join(" "));
+          ]
+        } else {
+          summaryContent = [
+            I18n.t('js.work_packages.table.text_sort_hint')
+          ]
         }
+
+        jQuery('#wp-table-sort-summary').text(summaryContent.join(" "));
       }
 
       function setActiveColumnClass() {


### PR DESCRIPTION
The WP table has a hidden label that informs blind users that the table can be sorted. This label was only shown when the table was sorted. Now it is shown when the page is loaded. 

https://community.openproject.com/work_packages/23503/activity
