### PR TITLE
[23785] Filter area looks incorrectly in Safari

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -88,10 +88,12 @@
   > .work-packages--filters-optional-container
     // not flex-item
     height: auto
-    flex-shrink: 0
 
   > .work-packages--split-view
     min-height: 100px
+
+  .work-packages--filters-optional-container
+    flex-shrink: 0
 
 .work-packages--split-view
   +display(flex)

--- a/frontend/app/components/filters/filter-container/filter-container.directive.ts
+++ b/frontend/app/components/filters/filter-container/filter-container.directive.ts
@@ -31,6 +31,7 @@ import {filtersModule} from '../../../angular-modules';
 function filterContainerDirective(wpFiltersService) {
   return {
     restrict: 'E',
+    replace: true,
     templateUrl: '/components/filters/filter-container/filter-container.directive.html',
 
     link: (scope) => {


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/4786 the scrolling bugs in safari were fixed. This PR takes care that the styling rule is really applied.

https://community.openproject.com/work_packages/23785/activity
