### PR TITLE
[23808] Border split screen missing when copying work package

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -188,7 +188,9 @@ openprojectModule
         controller: 'WorkPackageCopyController',
         controllerAs: '$ctrl',
         templateUrl: '/components/routing/wp-list/wp.list.new.html',
-        reloadOnSearch: false
+        reloadOnSearch: false,
+        onEnter: () => angular.element('body').addClass('action-details'),
+        onExit: () => angular.element('body').removeClass('action-details')
       })
       .state('work-packages.list.details', {
         url: '/details/{workPackageId:[0-9]+}',


### PR DESCRIPTION
This sets the action-class when copying a WP. Thus the styling in split screen is correct.

https://community.openproject.com/work_packages/23808/activity
