### PR TITLE
[23428] [1k] Ein- und Ausblenden von Ordnern und Dateien mit der Tastatur nicht möglich

### DIFF
--- a/app/assets/javascripts/repository_navigation.js
+++ b/app/assets/javascripts/repository_navigation.js
@@ -96,6 +96,7 @@
                 content.after(response);
                 content.removeClass('loading');
                 content.addClass('loaded open');
+                content.find('a.dir-expander')[0].title = I18n.t('js.label_collapse');
               }
             });
           }
@@ -116,6 +117,7 @@
       });
 
       content.toggleClass('open collapsed')
+      content.find('a.dir-expander')[0].title = I18n.t('js.label_expand');
     }
 
     /**
@@ -133,6 +135,7 @@
       });
 
       content.toggleClass('open collapsed')
+      content.find('a.dir-expander')[0].title = I18n.t('js.label_collapse');
     }
 
     /**

--- a/app/assets/stylesheets/scm.css.sass
+++ b/app/assets/stylesheets/scm.css.sass
@@ -207,7 +207,7 @@ div
     background: #bfb
 
 tr.dir
-  span
+  a
     &.dir-expander
       @include icon-common
       cursor: pointer
@@ -216,13 +216,13 @@ tr.dir
         margin-left: 5px
         padding: 0
   &.loading
-    span.dir-expander:before
+    .dir-expander:before
       @extend .icon-loading1:before
   &.collapsed
-    span.dir-expander:before
+    .dir-expander:before
       @extend .icon-plus:before
   &.open
-    span.dir-expander:before
+    .dir-expander:before
       @extend .icon-minus1:before
 
 tr

--- a/app/views/repositories/_dir_list_content.html.erb
+++ b/app/views/repositories/_dir_list_content.html.erb
@@ -34,7 +34,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <tr id="<%= tr_id %>" class="<%= h params[:parent_id] %> entry <%= h(entry.kind) %>">
     <td class="filename" style="padding-left: <%=18 * depth%>px;">
       <% if entry.dir? %>
-        <span class="icon-context dir-expander"
+        <a class="icon-context dir-expander"
+              title="<%= I18n.t('js.label_expand') %>"
+              href="javascript:"
               data-element="<%= "##{tr_id}" %>"
               data-url="<%= url_for(action: 'show',
                                     project_id: @project,
@@ -43,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
                                     depth: (depth + 1),
                                     parent_id: tr_id) %>">
           &nbsp
-        </span>
+        </a>
       <% end %>
       <%=  link_to h(ent_name),
           {action: (entry.dir? ? 'show' : 'changes'), project_id: @project, path: to_path_param(ent_path), rev: @rev},


### PR DESCRIPTION
This makes the icons to expand/collapse folders in the repo view focusable. Thus blind users can use them too.

https://community.openproject.com/work_packages/23428/activity
