### PR TITLE
[23495] [2l] Schalter ohne bzw. mit redundanter Beschriftung

### DIFF
--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -41,9 +41,6 @@
         </ul>
       </li>
       <li class="toolbar-item hidden-for-mobile">
-        <label for="work-packages-settings-button" class="hidden-for-sighted">
-          {{ I18n.t('js.button_settings') }}
-        </label>
         <button id="work-packages-settings-button"
                 ng-disabled="wpEditModeState.active"
                 title="{{ I18n.t('js.button_settings') }}"

--- a/frontend/app/components/wp-buttons/wp-button.template.html
+++ b/frontend/app/components/wp-buttons/wp-button.template.html
@@ -1,13 +1,8 @@
-<label for="{{ ::vm.buttonId }}"
-       ng-attr-accesskey="{{ ::vm.activeAccessKey }}"
-       class="hidden-for-sighted">
-
-  {{ vm.label }}
-</label>
 <button id="{{ ::vm.buttonId }}"
         class="button"
         title="{{ vm.label }}"
         ng-click="vm.performAction()"
+        ng-attr-accesskey="{{ ::vm.accessKey }}"
         ng-disabled="vm.disabled || vm.isActive()"
         ng-class="{ '-active': vm.isActive() }">
   <i class="{{ ::vm.iconClass }} button--icon"></i>

--- a/frontend/app/components/wp-buttons/wp-buttons.module.test.ts
+++ b/frontend/app/components/wp-buttons/wp-buttons.module.test.ts
@@ -139,7 +139,7 @@ describe('WP button directives', () => {
     });
 
     it('should not have a label with an access key', () => {
-      expect(label.attr('accesskey')).not.to.eq(controller.activeAccessKey);
+      expect(button.attr('accesskey')).not.to.eq(controller.activeAccessKey);
     });
 
     it("should have the button class set to '-active' ", () => {
@@ -155,11 +155,11 @@ describe('WP button directives', () => {
 
   describe('when not active', () => {
     it('should have a label with an access key attribute', () => {
-      expect(parseInt(label.attr('accesskey'))).to.eq(controller.activeAccessKey);
+      expect(parseInt(button.attr('accesskey'))).to.eq(controller.activeAccessKey);
     });
 
     it("should have the 'activate' prefix in the text values", () => {
-      expect(label.text()).to.contain('activate');
+      expect(button.text()).to.contain('activate');
     });
   });
 });

--- a/frontend/app/components/wp-buttons/wp-filter-button/wp-filter-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-filter-button/wp-filter-button.directive.html
@@ -1,15 +1,11 @@
-<label for="{{ ::vm.buttonId }}"
-       ng-attr-accesskey="{{ ::vm.accessKey }}"
-       class="hidden-for-sighted">
-
-  {{ vm.label }}
-</label>
 <button id="{{ ::vm.buttonId }}"
         class="button"
         title="{{ vm.label }}"
         ng-click="vm.performAction()"
+        ng-attr-accesskey="{{ ::vm.accessKey }}"
         ng-disabled="vm.disabled"
-        ng-class="{ '-active': vm.isActive() }">
+        ng-class="{ '-active': vm.isActive() }"
+        aria-label="{{ vm.label }}">
   <i class="{{ ::vm.iconClass }} button--icon"></i>
   <span class="button--text" ng-bind="::vm.buttonText"></span>
   <span class="badge -secondary">{{ vm.filterCount }}</span>

--- a/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.test.ts
+++ b/frontend/app/components/wp-buttons/wp-list-view-button/wp-list-view-button.directive.test.ts
@@ -68,6 +68,8 @@ describe('wpListViewButton directive', () => {
         projectIdentifier: controller.projectIdentifier
       };
 
+      console.log('BLUP:' + params.projectIdentifier);
+
       $state.params = {
         projectIdentifier: 'some-overwritten-value'
       };


### PR DESCRIPTION
This prevents the screenreader from reading some information in the WP toolbar twice.

https://community.openproject.com/work_packages/23495/activity
