### PR TITLE
[23477] [2g] Redundante Beschriftung interaktiver Elemente

### DIFF
--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -34,7 +34,6 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= new_timeline_link @project do %>
         <i class="button--icon icon-add"></i>
         <span class="button--text"><%= l('timelines.new_timeline') %></span>
-        <span class='hidden-for-sighted'><%= h(@timeline.name) %></span>
       <% end %>
     </li>
   <% end %>

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -143,7 +143,7 @@ module Redmine::MenuManager::MenuHelper
   end
 
   def render_drop_down_label_node(label, selected, options = {})
-    options[:title] ||= label
+    options[:title] ||= selected ? t(:description_current_position) + label : label
     options[:aria] = { haspopup: 'true' }
     options[:class] = "#{options[:class]} #{selected ? 'selected' : ''}"
 
@@ -209,7 +209,7 @@ module Redmine::MenuManager::MenuHelper
     link_text << you_are_here_info(selected)
     link_text << content_tag(:span, caption, lang: menu_item_locale(item))
     html_options = item.html_options(selected: selected)
-    html_options[:title] ||= caption
+    html_options[:title] ||= selected ? t(:description_current_position) + caption : caption
 
     link_to link_text, url, html_options
   end


### PR DESCRIPTION
This matches the title of selected menu items with their hidden label. Thus the title is not read twice. Further the timeline name was removed from the 'new-timeline' button.

https://community.openproject.com/work_packages/23477/activity
