### PR TITLE
clear cache before firing the settings callback

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -157,11 +157,11 @@ class Setting < ActiveRecord::Base
     if new_setting.save
       new_value = new_setting.value
 
-      # fire callbacks for name and pass as much information as possible
-      fire_callbacks(name, new_value, old_setting)
-
       # Delete the cache
       clear_cache(old_cache_key)
+
+      # fire callbacks for name and pass as much information as possible
+      fire_callbacks(name, new_value, old_setting)
 
       new_value
     else


### PR DESCRIPTION
Otherwise, callback listeners working on the change can not get the current value from querying Setting.
