### PR TITLE
Refactor/project authorization

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -42,12 +42,11 @@ class NewsController < ApplicationController
   accept_key_auth :index
 
   def index
-    scope = @project ? @project.news.visible : News.visible
+    scope = @project ? @project.news : News.all
 
-    @newss = scope.includes(:author, :project)
-             .order("#{News.table_name}.created_on DESC")
-             .page(params[:page])
-             .per_page(per_page_param)
+    @newss = scope.merge(News.latest_for(current_user, count: 0))
+                  .page(params[:page])
+                  .per_page(per_page_param)
 
     respond_to do |format|
       format.html do

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,12 +61,14 @@ class ProjectsController < ApplicationController
 
   # Lists visible projects
   def index
+    @projects = Project.visible
+
     respond_to do |format|
       format.html do
-        @projects = Project.visible.order('lft')
+        @projects = @projects.order('lft')
       end
       format.atom do
-        projects = Project.visible
+        projects = @projects
                    .order('created_on DESC')
                    .limit(Setting.feeds_limit.to_i)
         render_feed(projects, title: "#{Setting.app_title}: #{l(:label_project_latest)}")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,7 +67,8 @@ class UsersController < ApplicationController
 
   def show
     # show projects based on current user visibility
-    @memberships = @user.memberships.where(Project.visible_by(User.current))
+    @memberships = @user.memberships
+                        .visible(current_user)
 
     events = Redmine::Activity::Fetcher.new(User.current, author: @user).events(nil, nil, limit: 10)
     @events_by_day = events.group_by { |e| e.event_datetime.to_date }

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -53,6 +53,7 @@ class Changeset < ActiveRecord::Base
 
   scope :visible, -> (*args) {
     includes(repository: :project)
+      .references(:projects)
       .merge(Project.allowed_to(args.first || User.current, :view_changesets))
   }
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -46,6 +46,10 @@ class Member < ActiveRecord::Base
   after_save :save_notification
   after_destroy :destroy_notification
 
+  def self.visible(user)
+    where(project_id: Project.visible_by(user))
+  end
+
   def name
     principal.name
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -70,6 +70,7 @@ class Message < ActiveRecord::Base
 
   scope :visible, -> (*args) {
     includes(board: :project)
+      .references(:projects)
       .merge(Project.allowed_to(args.first || User.current, :view_messages))
   }
 

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -53,6 +53,7 @@ class News < ActiveRecord::Base
 
   scope :visible, -> (*args) {
     includes(:project)
+      .references(:projects)
       .merge(Project.allowed_to(args.first || User.current, :view_news))
   }
 
@@ -66,10 +67,15 @@ class News < ActiveRecord::Base
   end
 
   def self.latest_for(user, count: 5)
-    limit(count)
-      .newest_first
-      .includes(:project, :author)
-      .merge(Project.allowed_to(user, :view_news))
+    scope = newest_first
+            .includes(:author)
+            .visible(user)
+
+    if count > 0
+      scope.limit(count)
+    else
+      scope
+    end
   end
 
   # table_name shouldn't be needed :(

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -42,7 +42,8 @@ class ::Query::Results
 
   # Returns the work package count
   def work_package_count
-    WorkPackage.includes(:status, :project)
+    WorkPackage.visible
+               .includes(:status, :project)
                .where(query.statement)
                .references(:statuses, :projects)
                .count
@@ -57,7 +58,9 @@ class ::Query::Results
       if query.grouped?
         begin
           # Rails will raise an (unexpected) RecordNotFound if there's only a nil group value
-          r = WorkPackage.group(query.group_by_statement)
+          r = WorkPackage
+              .group(query.group_by_statement)
+              .visible
               .includes(:status, :project)
               .where(query.statement)
               .references(:statuses, :projects)
@@ -85,6 +88,7 @@ class ::Query::Results
       includes_for_columns(query.involved_columns) + (options[:include] || [])).uniq
 
     WorkPackage
+      .visible
       .where(::Query.merge_conditions(query.statement, options[:conditions]))
       .includes(includes)
       .joins((query.group_by_column ? query.group_by_column.join : nil))
@@ -101,9 +105,9 @@ class ::Query::Results
   end
 
   def versions
-    Version.includes(:project)
+    Version
+      .visible
       .where(::Query.merge_conditions(query.project_statement, options[:conditions]))
-      .references(:projects)
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)
   end

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -59,20 +59,9 @@ class TimeEntry < ActiveRecord::Base
     # switch projects. But as the time entry is still part of it's original
     # project, it is unclear, whether the time entry is actually visible if the
     # user lacks the view_work_packages permission in the moved to project.
-    includes(:project)
-      .references(:projects)
-      .where(visible_condition(args.first || User.current))
+    joins(:project)
+      .merge(Project.allowed_to(args.first || User.current, :view_time_entries))
   }
-
-  def self.visible_condition(user, table_alias: nil, project: nil)
-    options = {}
-    options[:project_alias] = table_alias if table_alias
-    options[:project] = project if project
-
-    Project.allowed_to_condition(user,
-                                 :view_time_entries,
-                                 options)
-  end
 
   scope :on_work_packages, ->(work_packages) { where(work_package_id: work_packages) }
 

--- a/app/models/user/project_authorization_cache.rb
+++ b/app/models/user/project_authorization_cache.rb
@@ -35,7 +35,13 @@ class User::ProjectAuthorizationCache
   end
 
   def cache(actions)
-    Array(actions).each do |action|
+    cached_actions = if actions.is_a?(Array)
+                       actions
+                     else
+                       [actions]
+                     end
+
+    cached_actions.each do |action|
       allowed_project_ids = Project.allowed_to(user, action).pluck(:id)
 
       projects_by_actions[normalized_permission_name(action)] = allowed_project_ids

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -51,7 +51,7 @@ class Version < ActiveRecord::Base
 
   scope :open, -> { where(status: 'open') }
   scope :visible, ->(*args) {
-    includes(:project)
+    joins(:project)
       .merge(Project.allowed_to(args.first || User.current, :view_work_packages))
   }
 

--- a/app/services/authorization/abstract_query.rb
+++ b/app/services/authorization/abstract_query.rb
@@ -29,6 +29,7 @@
 
 class Authorization::AbstractQuery
   class_attribute :model
+  class_attribute :base_table
 
   def self.query(*args)
     arel = transformed_query(*args)
@@ -36,6 +37,12 @@ class Authorization::AbstractQuery
     model.joins(joins(arel))
          .where(wheres(arel))
          .distinct
+  end
+
+  def self.base_query
+    Arel::SelectManager
+      .new(nil)
+      .from(base_table || model.arel_table)
   end
 
   def self.transformed_query(*args)

--- a/app/services/authorization/abstract_user_query.rb
+++ b/app/services/authorization/abstract_user_query.rb
@@ -28,20 +28,16 @@
 #++
 
 class Authorization::AbstractUserQuery < Authorization::AbstractQuery
-  def self.base_query
-    # It is unfortunate, that we have to have the first
-    # join statement as part of the base_scope.
-    #
-    # It would be better to simply start with the users_table
-    # and apply the join as a transformation. But a table
-    # can not be traversed by the visitor and wrapping
-    # the users_table in a Arel::SelectManager leads to invalid sql.
-    users_table
+  transformations.register :all,
+                           :users_members_join do |statement|
+    statement
       .outer_join(members_table)
       .on(users_members_join)
   end
 
-  transformations.register :all, :member_roles_join do |statement|
+  transformations.register :all,
+                           :member_roles_join,
+                           after: [:users_members_join] do |statement|
     statement.outer_join(member_roles_table)
              .on(members_member_roles_join)
   end

--- a/app/services/authorization/user_allowed_query.rb
+++ b/app/services/authorization/user_allowed_query.rb
@@ -45,7 +45,7 @@ class Authorization::UserAllowedQuery < Authorization::AbstractUserQuery
     if project.active? && project.allows_to?(action)
       statement.where(roles_table[:id].not_eq(nil).or(users_table[:admin].eq(true)))
     else
-      statement.where(Arel.sql('1 = 0'))
+      statement.where(Arel::Nodes::Equality.new(1, 0))
     end
   end
 

--- a/app/services/authorization/user_roles_query.rb
+++ b/app/services/authorization/user_roles_query.rb
@@ -29,6 +29,7 @@
 
 class Authorization::UserRolesQuery < Authorization::AbstractUserQuery
   self.model = Role
+  self.base_table = users_table
 
   def self.query(*args)
     arel = transformed_query(*args)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -158,6 +158,11 @@ Before do
   end
 end
 
+Before do
+  FactoryGirl.create(:non_member)
+  FactoryGirl.create(:anonymous_role)
+end
+
 # Capybara.register_driver :selenium do |app|
 #     Capybara::Selenium::Driver.new(app, browser: :chrome)
 # end

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -399,7 +399,12 @@ module OpenProject
                                class: 'attachment'
               end
             when 'project'
-              if p = Project.visible.where(['identifier = :s OR LOWER(name) = :s', { s: name.downcase }]).first
+              p = Project
+                  .visible
+                  .where(['projects.identifier = :s OR LOWER(projects.name) = :s',
+                          { s: name.downcase }])
+                  .first
+              if p
                 link = link_to_project(p, { only_path: only_path }, class: 'project')
               end
             end

--- a/lib/redmine/access_control.rb
+++ b/lib/redmine/access_control.rb
@@ -55,6 +55,12 @@ module Redmine
         perm ? perm.actions : []
       end
 
+      def allow_actions(action_hash)
+        action = "#{action_hash[:controller]}/#{action_hash[:action]}"
+
+        permissions.select { |p| p.actions.include? action }
+      end
+
       def public_permissions
         @public_permissions ||= @permissions.select(&:public?)
       end

--- a/spec/controllers/reportings_controller_spec.rb
+++ b/spec/controllers/reportings_controller_spec.rb
@@ -33,6 +33,7 @@ describe ReportingsController, type: :controller do
 
   before do
     allow(User).to receive(:current).and_return current_user
+    FactoryGirl.create(:non_member)
   end
 
   describe 'index.html' do

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -48,6 +48,8 @@ feature 'Top menu items', js: true, selenium: true do
 
   before do |ex|
     allow(User).to receive(:current).and_return user
+    FactoryGirl.create(:anonymous_role)
+    FactoryGirl.create(:non_member)
 
     if ex.metadata.key?(:allowed_to)
       allow(user).to receive(:allowed_to?).and_return(ex.metadata[:allowed_to])
@@ -90,6 +92,7 @@ feature 'Top menu items', js: true, selenium: true do
 
   context 'as an anonymous user' do
     let(:user) { FactoryGirl.create :anonymous }
+
     it 'displays only news' do
       has_menu_items news_item
     end

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -60,6 +60,7 @@ describe OpenProject::TextFormatting do
       @project = project
 
       allow(User).to receive(:current).and_return(project_member)
+      FactoryGirl.create(:non_member)
       allow(Setting).to receive(:text_formatting).and_return('textile')
     end
 

--- a/spec/models/project/allowed_to_scope_spec.rb
+++ b/spec/models/project/allowed_to_scope_spec.rb
@@ -1,0 +1,386 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Project, 'allowed to', type: :model do
+  let(:user) { FactoryGirl.build(:user) }
+  let(:anonymous) { FactoryGirl.build(:anonymous) }
+  let(:admin) { FactoryGirl.build(:admin) }
+
+  let(:private_project) do
+    FactoryGirl.build(:project,
+                      is_public: false,
+                      status: project_status)
+  end
+  let(:public_project) do
+    FactoryGirl.build(:project,
+                      is_public: true,
+                      status: project_status)
+  end
+  let(:project_status) { Project::STATUS_ACTIVE }
+
+  let(:role) do
+    FactoryGirl.build(:role,
+                      permissions: permissions)
+  end
+  let(:anonymous_role) do
+    FactoryGirl.build(:anonymous_role,
+                      permissions: anonymous_permissions)
+  end
+  let(:non_member_role) do
+    FactoryGirl.build(:non_member,
+                      permissions: non_member_permissions)
+  end
+  let(:permissions) { [action] }
+  let(:anonymous_permissions) { [action] }
+  let(:non_member_permissions) { [action] }
+  let(:action) { :view_work_packages }
+  let(:public_action) { :view_news }
+  let(:public_non_module_action) { :view_project }
+  let(:member) do
+    FactoryGirl.build(:member,
+                      user: user,
+                      roles: [role],
+                      project: project)
+  end
+
+  shared_examples_for 'includes the project' do
+    it 'includes the project' do
+      expect(Project.allowed_to(user, action)).to match_array [project]
+    end
+  end
+
+  shared_examples_for 'is empty' do
+    it 'is empty' do
+      expect(Project.allowed_to(user, action)).to be_empty
+    end
+  end
+
+  shared_examples_for 'member based allowed to check' do
+    before do
+      project.save!
+      user.save!
+    end
+
+    context 'w/ the user being member
+             w/ the role having the permission' do
+      before do
+        non_member_role.save!
+        member.save!
+      end
+
+      it_behaves_like 'includes the project'
+    end
+
+    context 'w/ the user being member
+             w/ the role having the permission
+             w/o the project being active' do
+      let(:project_status) { Project::STATUS_ARCHIVED }
+
+      before do
+        member.save!
+      end
+
+      it_behaves_like 'is empty'
+    end
+
+    context 'w/ the user being member
+             w/o the role having the permission' do
+      let(:permissions) { [] }
+
+      before do
+        member.save!
+      end
+
+      it_behaves_like 'is empty'
+    end
+
+    context 'w/o the user being member
+             w/ the role having the permission' do
+      it_behaves_like 'is empty'
+    end
+
+    context 'w/ the user being member
+             w/ the role having the permission
+             w/o the associated module being active' do
+      before do
+        member.save!
+        project.enabled_modules = []
+      end
+
+      it_behaves_like 'is empty'
+    end
+
+    context 'w/ the user being member
+             w/ the permission being public' do
+      before do
+        member.save!
+      end
+
+      it 'includes the project' do
+        expect(Project.allowed_to(user, public_action)).to match_array [project]
+      end
+    end
+
+    context 'w/ the user being member
+             w/ the permission being public
+             w/o the associated module being active' do
+      before do
+        member.save!
+        project.enabled_modules = []
+      end
+
+      it 'is empty' do
+        expect(Project.allowed_to(user, public_action)).to be_empty
+      end
+    end
+
+    context 'w/ the user being member
+             w/ the permission being public and not module bound
+             w/ no module bing active' do
+      before do
+        member.save!
+        project.enabled_modules = []
+      end
+
+      it 'includes the project' do
+        expect(Project.allowed_to(user, public_non_module_action)).to match_array [project]
+      end
+    end
+  end
+
+  shared_examples_for 'w/ an admin user' do
+    let(:user) { admin }
+
+    before do
+      project.save!
+      user.save!
+    end
+
+    context 'w/o the user being a member' do
+      it_behaves_like 'includes the project'
+    end
+
+    context 'w/o the project being active' do
+      let(:project_status) { Project::STATUS_ARCHIVED }
+
+      it_behaves_like 'is empty'
+    end
+
+    context 'w/o the project being active
+             w/ the permission being public' do
+      let(:project_status) { Project::STATUS_ARCHIVED }
+
+      it 'is empty' do
+        expect(Project.allowed_to(user, public_action)).to be_empty
+      end
+    end
+
+    context 'w/o the project module being active' do
+      before do
+        project.enabled_modules = []
+      end
+
+      it_behaves_like 'is empty'
+    end
+  end
+
+  context 'w/ the project being private' do
+    let(:project) { private_project }
+
+    it_behaves_like 'member based allowed to check'
+    it_behaves_like 'w/ an admin user'
+
+    context 'w/ the user not being logged in' do
+      before do
+        project.save!
+        anonymous.save!
+        anonymous_role.save!
+      end
+
+      context 'w/ the anonymous role having the permission' do
+        it 'is empty' do
+          expect(Project.allowed_to(anonymous, action)).to be_empty
+        end
+      end
+
+      context 'w/ the permission being public' do
+        it 'is empty' do
+          expect(Project.allowed_to(anonymous, public_action)).to be_empty
+        end
+      end
+    end
+  end
+
+  context 'w/ the project being public' do
+    let(:project) { public_project }
+
+    it_behaves_like 'member based allowed to check'
+    it_behaves_like 'w/ an admin user'
+
+    context 'w/ the user not being logged in' do
+      before do
+        project.save!
+        anonymous.save!
+        anonymous_role.save!
+      end
+
+      context 'w/ the anonymous role having the permission' do
+        it 'includes the project' do
+          expect(Project.allowed_to(anonymous, action)).to match_array [project]
+        end
+      end
+
+      context 'w/ the anonymous role having the permission
+               w/o the project being active' do
+        let(:project_status) { Project::STATUS_ARCHIVED }
+
+        it 'is empty' do
+          expect(Project.allowed_to(anonymous, action)).to be_empty
+        end
+      end
+
+      context 'w/o the anonymous role having the permission' do
+        let(:anonymous_permissions) { [] }
+
+        it 'is empty' do
+          expect(Project.allowed_to(anonymous, action)).to be_empty
+        end
+      end
+
+      context 'w/ the permission being public' do
+        it 'includes the project' do
+          expect(Project.allowed_to(anonymous, public_action)).to match_array [project]
+        end
+      end
+
+      context 'w/ the permission being public
+               w/ the associated module not being active' do
+        before do
+          project.enabled_modules = []
+        end
+
+        it 'is empty' do
+          expect(Project.allowed_to(anonymous, public_action)).to be_empty
+        end
+      end
+
+      context 'w/ the permission being public and not module bound
+               w/ no module being active' do
+        before do
+          project.enabled_modules = []
+        end
+
+        it 'includes the project' do
+          expect(Project.allowed_to(anonymous, public_non_module_action)).to match_array [project]
+        end
+      end
+    end
+
+    context 'w/ the user being member' do
+      before do
+        project.save!
+        user.save!
+        non_member_role.save!
+        member.save!
+      end
+
+      context 'w/ the role not having the permission
+               w/ non member having the permission' do
+        let(:permissions) { [] }
+        let(:non_member_permissions) { [action] }
+
+        it_behaves_like 'is empty'
+      end
+    end
+
+    context 'w/o the user being member' do
+      before do
+        project.save!
+        user.save!
+        non_member_role.save!
+      end
+
+      context 'w/ the non member role having the permission' do
+        it_behaves_like 'includes the project'
+      end
+
+      context 'w/ the non member role having the permission
+               w/o the project being active' do
+        let(:project_status) { Project::STATUS_ARCHIVED }
+
+        it_behaves_like 'is empty'
+      end
+
+      context 'w/ the permission being public and not module bound
+               w/o the project being active' do
+        let(:project_status) { Project::STATUS_ARCHIVED }
+
+        it 'is empty' do
+          expect(Project.allowed_to(user, public_non_module_action)).to be_empty
+        end
+      end
+
+      context 'w/o the non member role having the permission' do
+        let(:non_member_permissions) { [] }
+
+        it_behaves_like 'is empty'
+      end
+
+      context 'w/ the permission being public' do
+        it 'includes the project' do
+          expect(Project.allowed_to(user, public_action)).to match_array [project]
+        end
+      end
+
+      context 'w/ the permission being public
+               w/ the module not being active' do
+        before do
+          project.enabled_modules = []
+        end
+
+        it 'is empty' do
+          expect(Project.allowed_to(user, public_action)).to be_empty
+        end
+      end
+
+      context 'w/ the permission being public and not module bound
+               w/ no module active' do
+        before do
+          project.enabled_modules = []
+        end
+
+        it 'includes the project' do
+          expect(Project.allowed_to(user, public_non_module_action)).to match_array [project]
+        end
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -75,28 +75,6 @@ describe Project, type: :model do
     end
   end
 
-  describe '#find_visible' do
-    it 'should find the project by id if the user is project member' do
-      become_member_with_permissions(project, user, :view_work_packages)
-
-      expect(Project.find_visible(user, project.id)).to eq(project)
-    end
-
-    it 'should find the project by identifier if the user is project member' do
-      become_member_with_permissions(project, user, :view_work_packages)
-
-      expect(Project.find_visible(user, project.identifier)).to eq(project)
-    end
-
-    it 'should not find the project by identifier if the user is no project member' do
-      expect { Project.find_visible(user, project.identifier) }.to raise_error ActiveRecord::RecordNotFound
-    end
-
-    it 'should not find the project by id if the user is no project member' do
-      expect { Project.find_visible(user, project.id) }.to raise_error ActiveRecord::RecordNotFound
-    end
-  end
-
   context 'when the wiki module is enabled' do
     let(:project) { FactoryGirl.create(:project, disable_modules: 'wiki') }
 

--- a/spec_legacy/functional/projects_controller_spec.rb
+++ b/spec_legacy/functional/projects_controller_spec.rb
@@ -64,7 +64,7 @@ describe ProjectsController, type: :controller do
     assert_response :success
     assert_template 'common/feed'
     assert_select 'feed>title', text: 'OpenProject: Latest projects'
-    assert_select 'feed>entry', count: Project.where(Project.visible_by(User.current)).count
+    assert_select 'feed>entry', count: Project.visible(User.current).count
   end
 
   context '#index' do


### PR DESCRIPTION
The PR optimizes the db query for projects in which a given user has a requested permission (labeled query 3 in https://github.com/opf/openproject/pull/4778)
It should 
- no longer rely on the subquery used to filter out projects as this has poor performance in cases where a lot of projects exist and the user is admin. Especially because the query is used in the query for work packages which shows poor performance when applied to a project independent context
- adhere to the mechanisms introduced in https://github.com/opf/openproject/pull/4778 which will allow it to be adaptable by plugins which is currently very hard to do.
### Implementation approach

The implementation will work along the lines of what was introduced in https://github.com/opf/openproject/pull/4778.
### Alternatives

_Non considered_
### Out of scope
- Changes in functionality
### ToDo
- [x] Write integration tests for the existing functionality to ensure that the new implementation does not alter the functionality. The old query implementation has options like `project`, `with_subprojects` and `members` which are used to optimize the query. They should no longer be required and will thus not be tested.
- [x] Design a performant SQL query
- [x] Rewrite `Authorization::ProjectQuery.query` to follow that query
  - ~~Add unit tests if those would deviate from the integration tests~~
- [x] Fix integrational tests if any break
- [x] Check places where `Project.allowed_to_condition` or `Project.allowed` is used to ensure that everything is working
- [x] Adapt plugins to core
- [x] cleanup PR
### OP work package

https://community.openproject.com/work_packages/23783/activity
