### PR TITLE
[23829] Add "Cancel" button to wiki edit page

### DIFF
--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -49,6 +49,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <hr class="form--separator" />
   <%= f.button t(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
+  <%= link_to t(:button_cancel),
+      { controller: '/wiki', action: 'show', project_id: @project, id: @page },
+      class: 'button' %>
   <%= preview_link preview_project_wiki_path(@project, @page), 'wiki_form-preview' %>
   <%= wikitoolbar_for 'content_text' %>
 <% end %>


### PR DESCRIPTION
This adds a cancel button to the 'edit wiki' page.

https://community.openproject.com/work_packages/23829/activity
