### PR TITLE
[23820] Link to add additional attachments to wiki page not working

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -159,7 +159,7 @@ function addFileField() {
   var clone = $('attachment_template').cloneNode(true);
   clone.writeAttribute('id', '');
   clone.innerHTML = clone.innerHTML.replace(/\[1\]/g, '['+ fileFieldCount + ']');
-  jQuery('attachments_fields').appendChild(clone);
+  jQuery('#attachments_fields')[0].appendChild(clone);
 }
 
 function randomKey(size) {


### PR DESCRIPTION
This fixes the link to add more attachments in the wiki page.

https://community.openproject.com/work_packages/23820/activity
