### PR TITLE
[23834] Strange hove effects in WP fields

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -86,7 +86,7 @@
       display: inline-block
 
 // Style no-label fields (long text, description, ..) with padding
-.-editable.-no-label:not(.-active)
+.wp-edit-field.-no-label:not(.-active)
   margin-left: -0.375rem
 
   .wp-table--cell-span


### PR DESCRIPTION
When the user had no permission to edit a WP field the were strange hover effects caused by missing styling rules. This PR fixes this issue.

https://community.openproject.com/work_packages/23834/activity
