### PR TITLE
[23456] [7a] Unnötige und unsichtbare Tabschritte vor jedem Formularfeld

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -1,4 +1,5 @@
 <op-date-picker
+  tabindex="-1"
   on-change="vm.submit()"
   ng-model="vm.workPackage[vm.fieldName]">
 


### PR DESCRIPTION
This avoids that the date picker can be focused by tab. Since the date picker is not shown in accessibility mode unnecessary tab steps can be avoided.

https://community.openproject.com/work_packages/23456/activity
