### PR TITLE
[23464] [7h]  Element zum Einblenden eines interaktiven Elements erhält den Fokus

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
@@ -69,11 +69,6 @@ a.inplace-editing--trigger-link,
     img.avatar-mini
       float: inherit
 
-// Do not hover trigger-link when element is read-only
-.-read-only
-  .inplace-editing--trigger-link:hover .inplace-editing--container
-    border-color: transparent
-
 .inplace-edit--icon-wrapper
   display: inline-block
   text-align: center

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -85,3 +85,10 @@ body.accessibility-mode
   .skip-navigation-link:focus
     top: auto
     left: auto
+
+  // Show inplace-editing icons so that they can be accessed directly
+  .inplace-editing--trigger-link
+    .inplace-editing--container
+      border-color: $inplace-edit--border-color
+    .inplace-edit--icon-wrapper
+      visibility: visible


### PR DESCRIPTION
The icon to delete an attachment was only focusable when the attachment was focused. This is confusing for blind users. That is why the icons are now directly shown in the accessibility mode. (Further some duplicated code was removed.)

https://community.openproject.com/work_packages/23464/activity
