### PR TITLE
ensure using root members controller

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -274,7 +274,7 @@ Redmine::MenuManager.map :project_menu do |menu|
             html: { class: 'icon2 icon-cost-reports' }
 
   menu.push :members,
-            { controller: :members, action: :index },
+            { controller: '/members', action: 'index' },
             param: :project_id,
             caption: :label_member_plural,
             html: { class: 'icon2 icon-group' }


### PR DESCRIPTION
rails routing will construct a  path nested in the  current controller when a symbol is used. So wenn the user is e.g on the timelog controller, the path on the members menu item is time_entries/members instead of /members
