### PR TITLE
[23455] [4c] Fokusverlust an den Seitenanfang nach dem Registerkartenwechsel

### DIFF
--- a/app/assets/javascripts/tab_handling.js
+++ b/app/assets/javascripts/tab_handling.js
@@ -47,6 +47,10 @@ function showTab(name, url) {
   if ("replaceState" in window.history) {
     window.history.replaceState(null, document.title, url);
   }
+
+  window.setTimeout(function() {
+    jQuery('#tab-' + name).focus();
+  }, 100);
   return false;
 }
 

--- a/frontend/app/components/context-menus/column-context-menu/column-context-menu.controller.js
+++ b/frontend/app/components/context-menus/column-context-menu/column-context-menu.controller.js
@@ -70,8 +70,18 @@ function ColumnContextMenuController($scope, columnContextMenu, QueryService,
 
     $scope.hideColumn = function(columnName) {
       columnContextMenu.close();
+      var previousColumn = WorkPackagesTableHelper.getPreviousColumn($scope.columns, columnName);
+
       QueryService.hideColumns(new Array(columnName));
       QueryService.getQuery().dirty = true;
+
+      window.setTimeout(function() {
+        if(previousColumn.length !== 0) {
+          jQuery('#' + previousColumn[0].title).focus();
+        } else {
+          jQuery('th.checkbox a').focus();
+        }
+      }, 100);
     };
 
     $scope.insertColumns = function() {

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.html
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.html
@@ -26,7 +26,8 @@
             span-class="inplace-editing--container"
             link-class="inplace-editing--trigger-link"
             aria-label="{{ ::vm.text.editTitle }}"
-            execute="vm.activate()">
+            execute="vm.activate()"
+            focus="vm.shouldFocus()">
             <span class="inplace-edit--read-value -default">
               <span ng-bind="::vm.text.placeholder"></span>
             </span>

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
@@ -43,6 +43,7 @@ export class CommentFieldDirectiveController {
   protected editing = false;
   protected canAddComment:boolean;
   protected showAbove:boolean;
+  protected _forceFocus: boolean = false;
 
   constructor(protected $scope,
               protected $rootScope,
@@ -88,10 +89,11 @@ export class CommentFieldDirectiveController {
   }
 
   public shouldFocus() {
-    return true;
+    return this._forceFocus;
   }
 
   public activate(withText?:string) {
+    this._forceFocus = true;
     this.field.initializeFieldValue(withText);
     return this.editing = true;
   }
@@ -110,8 +112,7 @@ export class CommentFieldDirectiveController {
         this.workPackage.activities.$load(true).then(() => {
           this.wpCacheService.updateWorkPackage(this.workPackage);
         });
-
-        this.focusCommentField();
+        this._forceFocus = true;
       })
       .catch(error => {
         if (error.data instanceof ErrorResource) {
@@ -128,13 +129,7 @@ export class CommentFieldDirectiveController {
   public handleUserCancel() {
     this.editing = false;
     this.field.initializeFieldValue();
-    this.focusCommentField();
-  }
-
-  private focusCommentField() {
-    window.setTimeout(function(){
-      jQuery('.work-packages--activity--add-comment .inplace-editing--trigger-link')[0].focus();
-    }, 100);
+    this._forceFocus = true;
   }
 }
 

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
@@ -110,6 +110,8 @@ export class CommentFieldDirectiveController {
         this.workPackage.activities.$load(true).then(() => {
           this.wpCacheService.updateWorkPackage(this.workPackage);
         });
+
+        this.focusCommentField();
       })
       .catch(error => {
         if (error.data instanceof ErrorResource) {
@@ -126,6 +128,13 @@ export class CommentFieldDirectiveController {
   public handleUserCancel() {
     this.editing = false;
     this.field.initializeFieldValue();
+    this.focusCommentField();
+  }
+
+  private focusCommentField() {
+    window.setTimeout(function(){
+      jQuery('.work-packages--activity--add-comment .inplace-editing--trigger-link')[0].focus();
+    }, 100);
   }
 }
 

--- a/frontend/app/components/wp-activity/user/user-activity-directive.ts
+++ b/frontend/app/components/wp-activity/user/user-activity-directive.ts
@@ -132,7 +132,7 @@ function userActivity($uiViewScroll,
 
       scope.focusEditIcon = function () {
         // Find the according edit icon and focus it
-        jQuery('textarea.edit-comment-text').closest(".user-comment").siblings('.comments-number').find('.icon-edit').closest("a").focus();
+        jQuery('.edit-activity--' + scope.activityNo + ' a').focus();
       }
 
       scope.toggleCommentPreview = function () {

--- a/frontend/app/components/wp-activity/user/user-activity-directive.ts
+++ b/frontend/app/components/wp-activity/user/user-activity-directive.ts
@@ -112,6 +112,7 @@ function userActivity($uiViewScroll,
 
       scope.cancelEdit = function () {
         scope.inEdit = false;
+        this.focusEditIcon();
       };
 
       scope.quoteComment = function () {
@@ -126,7 +127,13 @@ function userActivity($uiViewScroll,
           wpCacheService.loadWorkPackageLinks(scope.workPackage, 'activities');
           scope.inEdit = false;
         });
+        this.focusEditIcon();
       };
+
+      scope.focusEditIcon = function () {
+        // Find the according edit icon and focus it
+        jQuery('textarea.edit-comment-text').closest(".user-comment").siblings('.comments-number').find('.icon-edit').closest("a").focus();
+      }
 
       scope.toggleCommentPreview = function () {
         scope.isPreview = !scope.isPreview;

--- a/frontend/app/components/wp-table/wp-table-helper/wp-table-helper.service.js
+++ b/frontend/app/components/wp-table/wp-table-helper/wp-table-helper.service.js
@@ -121,6 +121,16 @@ function WorkPackagesTableHelper(WorkPackagesHelper) {
         .indexOf(columnName);
     },
 
+    getPreviousColumn: function(columns, columnName) {
+      return columns.filter(function(column) {
+        var index = WorkPackagesTableHelper.getColumnIndexByName(columns, columnName);
+        var currentColumnIndex = WorkPackagesTableHelper.getColumnIndexByName(columns, column.name);
+        if(currentColumnIndex === index - 1) {
+          return column;
+        }
+      });
+    },
+
     detectColumnByName: function(columns, columnName) {
       return columns[WorkPackagesTableHelper.getColumnIndexByName(columns, columnName)];
     },

--- a/frontend/app/templates/work_packages/activities/_user.html
+++ b/frontend/app/templates/work_packages/activities/_user.html
@@ -30,7 +30,8 @@
       </accessible-by-keyboard>
       <accessible-by-keyboard ng-if="userCanEdit"
                               execute="editComment()"
-                              link-title="{{ I18n.t('js.label_edit_comment') }}">
+                              link-title="{{ I18n.t('js.label_edit_comment') }}"
+                              class="edit-activity--{{activityNo}}">
         <icon-wrapper icon-name="edit"
                       icon-title="{{ I18n.t('js.label_edit_comment') }}"
                       css-class="action-icon">


### PR DESCRIPTION
This sets the focus after various actions:
- Change tab in settings
- Remove column from WP table
- Adding a comment
- Cancel editing a comment

Related PR: https://github.com/finnlabs/reporting_engine/pull/80

https://community.openproject.com/work_packages/23455/activity
