### PR TITLE
[23854] Expire a user's sessions on login and logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -190,10 +190,10 @@ class ApplicationController < ActionController::Base
   # Sets the logged in user
   def logged_user=(user)
     reset_session
+
     if user && user.is_a?(User)
       User.current = user
-      session[:user_id] = user.id
-      session[:updated_at] = Time.now
+      InitializeSessionService.call(user, session)
     else
       User.current = User.anonymous
     end

--- a/app/services/initialize_session_service.rb
+++ b/app/services/initialize_session_service.rb
@@ -1,0 +1,55 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class InitializeSessionService
+  class << self
+    ##
+    # Initializes a new session for the given user.
+    # This services provides very little for what it is called,
+    # mainly caused due to the many ways a user can login.
+    def call(user, session)
+      session[:user_id] = user.id
+      session[:updated_at] = Time.now
+
+      if drop_old_sessions?
+        ::UserSession.where(user_id: user.id).delete_all
+      end
+    end
+
+    private
+
+    ##
+    # We can only drop old sessions if they're stored in the database
+    # and enabled by configuration.
+    def drop_old_sessions?
+      OpenProject::Configuration.session_store == :active_record_store &&
+        OpenProject::Configuration.drop_old_sessions_on_login?
+    end
+  end
+end

--- a/app/services/initialize_session_service.rb
+++ b/app/services/initialize_session_service.rb
@@ -40,6 +40,8 @@ class InitializeSessionService
       if drop_old_sessions?
         ::UserSession.where(user_id: user.id).delete_all
       end
+
+      ServiceResult.new(success: true, result: session)
     end
 
     private

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -208,6 +208,16 @@ default:
   # possible values are :cookie_store, :cache_store, :active_record_store
   session_store: :cache_store
 
+  # If the session store is :active_record_store, the following configuration settings
+  # are available
+
+  # Delete old sessions for the same user when logging in
+  # Disabled by default to allow multiple concurrent sessions.
+  # drop_old_sessions_on_login: false
+
+  # Delete old sessions for the same user when logging out. (Enabled by default)
+  # drop_old_sessions_on_logout: true
+
   # define your airbrake api key. optionally provide a different host and port
   # to connect to a different backend (e.g. a self-hosted errbit)
   # airbrake:

--- a/db/migrate/20160824121151_add_user_id_to_sessions.rb
+++ b/db/migrate/20160824121151_add_user_id_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddUserIdToSessions < ActiveRecord::Migration
+  def change
+    add_column :sessions, :user_id, :integer, index: true
+  end
+end

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -81,6 +81,8 @@ storage config above like this:
 * `scm_subversion_command` (default: 'svn')
 * `force_help_link` (default: nil)
 * `session_store`: `active_record_store`, `cache_store`, or `cookie_store` (default: cache_store)
+* `drop_old_sessions_on_logout` (default: true)
+* `drop_old_sessions_on_login` (default: false)
 * [`omniauth_direct_login_provider`](#omniauth-direct-login-provider) (default: nil)
 * [`disable_password_login`](#disable-password-login) (default: false)
 * [`attachments_storage`](#attachments-storage) (default: file)
@@ -88,6 +90,18 @@ storage config above like this:
 * [`disabled_modules`](#disabled-modules) (default: [])
 * [`blacklisted_routes`](#blacklisted-routes) (default: [])
 * [`global_basic_auth`](#global-basic-auth)
+
+## Setting session options
+
+Use `session_store` to define where session information is stored. In order to store sessions in the database and use the following options, set that configuration to `:active_record_store`.
+
+**Delete old sessions for the same user when logging in** (Disabled by default)
+
+To enable, set the configuration option `drop_old_sessions_on_login` to true.
+
+**Delete old sessions for the same user when logging out** (Enabled by default)
+
+To disable, set the configuration option `drop_old_sessions_on_logout` to false.
 
 ## Passing data structures
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -58,6 +58,7 @@ module OpenProject
       'session_cookie_name'     => '_open_project_session',
       # Destroy all sessions for current_user on logout
       'drop_old_sessions_on_logout' => true,
+      # Destroy all sessions for current_user on login
       'drop_old_sessions_on_login' => false,
       # url-path prefix
       'rails_relative_url_root' => '',

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -56,6 +56,9 @@ module OpenProject
       # where to store session data
       'session_store'           => :cache_store,
       'session_cookie_name'     => '_open_project_session',
+      # Destroy all sessions for current_user on logout
+      'drop_old_sessions_on_logout' => true,
+      'drop_old_sessions_on_login' => false,
       # url-path prefix
       'rails_relative_url_root' => '',
       'rails_force_ssl' => false,

--- a/spec/factories/user_session_factory.rb
+++ b/spec/factories/user_session_factory.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,21 +26,14 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Be sure to restart your server when you modify this file.
+FactoryGirl.define do
+  factory :user_session do
+    sequence(:session_id) do |n| "session_#{n}" end
+    association :user
 
-config = OpenProject::Configuration
-
-session_store     = config['session_store'].to_sym
-relative_url_root = config['rails_relative_url_root'].presence
-
-session_options = {
-  key:    config['session_cookie_name'],
-  path:   relative_url_root
-}
-
-OpenProject::Application.config.session_store session_store, session_options
-
-##
-# We use our own decorated session model to note the user_id
-# for each session.
-ActionDispatch::Session::ActiveRecordStore.session_class = ::UserSession
+    callback(:after_build) do |session|
+      session.data = {}
+      session.data['user_id'] = session.user.id if session.user.present?
+    end
+  end
+end

--- a/spec/features/security/expire_sessions.rb
+++ b/spec/features/security/expire_sessions.rb
@@ -1,0 +1,103 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Expire old user sessions', type: :feature do
+  let(:user) { FactoryGirl.create :admin }
+
+  before :all do
+    @session_store = OpenProject::Application.config.session_store
+    OpenProject::Application.config.session_store :active_record_store
+  end
+
+  after :all do
+    OpenProject::Application.config.session_store = @session_store
+  end
+
+  before do
+    login_with(user.login, user.password)
+
+    # Create a dangling session
+    Capybara.current_session.driver.browser.clear_cookies
+  end
+
+  describe 'logging in again' do
+    context 'with drop_old_sessions enabled', with_config: { drop_old_sessions_on_login: true } do
+      it 'destroys the old session' do
+        expect(UserSession.count).to eq(1)
+
+        first_session = UserSession.first
+        expect(first_session.user_id).to eq(user.id)
+
+        # Actually login now
+        login_with(user.login, user.password)
+
+        expect(UserSession.count).to eq(1)
+        second_session = UserSession.first
+
+        expect(second_session.user_id).to eq(user.id)
+        expect(second_session.session_id).not_to eq(first_session.session_id)
+      end
+    end
+
+    context 'with drop_old_sessions disabled', with_config: { drop_old_sessions_on_login: false } do
+      it 'keeps the old session' do
+        # Actually login now
+        login_with(user.login, user.password)
+
+        expect(UserSession.where(user_id: user.id).count).to eq(2)
+      end
+    end
+  end
+
+  describe 'logging out on another session', with_config: { drop_old_sessions_on_login: false } do
+    before do
+      # Actually login now
+      login_with(user.login, user.password)
+      expect(UserSession.where(user_id: user.id).count).to eq(2)
+      visit '/logout'
+    end
+
+    context 'with drop_old_sessions enabled', with_config: { drop_old_sessions_on_logout: true } do
+      it 'destroys the old session' do
+        # A fresh session is opened due to reset_session
+        expect(UserSession.where(user_id: user.id).count).to eq(0)
+        expect(UserSession.where(user_id: nil).count).to eq(1)
+      end
+    end
+
+    context 'with drop_old_sessions disabled',
+            with_config: { drop_old_sessions_on_logout: false } do
+      it 'keeps the old session' do
+        expect(UserSession.count).to eq(2)
+        expect(UserSession.where(user_id: user.id).count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -1,0 +1,78 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe UserSession do
+  subject { FactoryGirl.build(:user_session, user: user) }
+
+  shared_examples 'augments the user_id attribute' do
+    it do
+      subject.save
+      expect(subject.user_id).to eq(user_id)
+    end
+  end
+
+  describe 'when user_id is present' do
+    let(:user) { FactoryGirl.build_stubbed(:user) }
+    let(:user_id) { user.id }
+    it_behaves_like 'augments the user_id attribute'
+  end
+
+  describe 'when user_id is nil' do
+    let(:user) { nil }
+    let(:user_id) { nil }
+    it_behaves_like 'augments the user_id attribute'
+  end
+
+  describe 'delete other sessions on destroy' do
+    let(:user) { FactoryGirl.build_stubbed(:user) }
+    let!(:sessions) { FactoryGirl.create_list(:user_session, 2, user: user) }
+
+    context 'when config is enabled',
+            with_config: { drop_old_sessions_on_logout: true } do
+      it 'destroys both sessions' do
+        expect(UserSession.where(user_id: user.id).count).to eq(2)
+        sessions.first.destroy
+
+        expect(UserSession.count).to eq(0)
+      end
+    end
+
+    context 'when config is disabled',
+            with_config: { drop_old_sessions_on_logout: false } do
+      it 'destroys only the one session' do
+        expect(UserSession.where(user_id: user.id).count).to eq(2)
+        sessions.first.destroy
+
+        expect(UserSession.count).to eq(1)
+        expect(UserSession.first.session_id).to eq(sessions[1].session_id)
+      end
+    end
+  end
+end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -40,6 +40,15 @@ module AuthenticationHelpers
 
     allow(User).to receive(:current).and_return(user)
   end
+
+  def login_with(login, password)
+    visit '/login'
+    within('#login-form') do
+      fill_in 'username', with: login
+      fill_in 'password', with: password
+      click_button I18n.t(:button_login)
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -27,11 +27,26 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+def aggregate_mocked_configuration(example, config)
+  # We have to manually check parent groups for with_config:,
+  # since they are being ignored otherwise
+  example.example_group.parents.each do |parent|
+    if parent.respond_to?(:metadata) && parent.metadata[:with_config]
+      config.reverse_merge!(parent.metadata[:with_config])
+    end
+  end
+
+  config
+end
+
 RSpec.configure do |config|
   config.before(:each) do |example|
-    if example.metadata[:with_config]
+    config = example.metadata[:with_config]
+    if config.present?
+      config = aggregate_mocked_configuration(example, config)
+
       allow(OpenProject::Configuration).to receive(:[]).and_call_original
-      example.metadata[:with_config].each do |k,v|
+      config.each do |k,v|
         allow(OpenProject::Configuration)
           .to receive(:[])
           .with(k.to_s)


### PR DESCRIPTION
This PR extends the sessions table with a `user_id` column to find and
delete open sessions for a given user.
### Implementation

Extend the `Session` model of `activerecord-session_store` with a
separate :user_id attribute and synchronize this value on every update.

Destroy associated sessions in that decorated model.

Provides a simple service to initialize a setting and, if the configuration is set, drop old sessions for the same user. This will be disabled by default, since many uses will probably want two concurrent sessions.
### Alternatives

Do not extend the default `ActiveRecord::SessionStore::Session`, but the
`SqlBypass` class which manipulates the database directly for
a performance boost.

This will increase the complexitly of the change (we'll need to override
several methods instead of adding two save hooks), but it may be worth
it for the gainz.
### Out of scope
- Implement expiry of sessions for other types of session storage
  - **CookieStore**: We do not know all open sessions
  - **CacheStore**: Several cache implementations do not provide the
    means to iterate cache keys (e.g., memcached).
### Todos
- [x] Create Session model
  - [x] Store `user_id` attribute in before hook
  - [x] Delete other sessions in destroy hook
- [x] Create override configuration option
- [x] Check session implementation of saas (cache store, functionality is not available)
- [x] Integration tests

https://community.openproject.com/work_packages/23854
https://community.openproject.com/work_packages/23224
