### PR TITLE
avoid query initialization on html request

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -51,8 +51,10 @@ class WorkPackagesController < ApplicationController
   # before_filter :disable_api # TODO re-enable once API is used for any JSON request
   before_filter :authorize_on_work_package, only: :show
   before_filter :find_optional_project,
-                :protect_from_unauthorized_export,
-                :load_query, only: :index
+                :protect_from_unauthorized_export, only: :index
+
+  before_filter :load_query,
+                :load_work_packages, only: :index, unless: ->() { request.format.html? }
 
   def show
     respond_to do |format|
@@ -82,8 +84,6 @@ class WorkPackagesController < ApplicationController
   end
 
   def index
-    load_work_packages unless request.format.html?
-
     respond_to do |format|
       format.html do
         gon.settings = client_preferences

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -450,6 +450,7 @@ en:
         display_sums: "Display Sums"
         errors:
           unretrievable_query: "Unable to retrieve query from URL"
+          not_found: "There is no such query"
       table:
         summary: "Table with rows of work package and columns of work package attributes."
         text_inline_edit: "Most cells of this table are buttons that activate inline-editing functionality of that attribute."

--- a/frontend/app/components/work-packages/work-package.service.js
+++ b/frontend/app/components/work-packages/work-package.service.js
@@ -88,9 +88,15 @@ function WorkPackageService($http,
             return response.data;
           },
           function (failedResponse) {
-            NotificationsService.addError(
-                I18n.t('js.work_packages.query.errors.unretrievable_query')
-            );
+            var error = '';
+            if (failedResponse.status === 404) {
+              error = I18n.t('js.work_packages.query.errors.not_found');
+            }
+            else {
+              error = I18n.t('js.work_packages.query.errors.unretrievable_query');
+            }
+
+            NotificationsService.addError(error);
           }
       );
     },

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -88,6 +88,8 @@ describe 'work package export', type: :feature do
     select 'Progress (%)', from: 'add_filter_select'
     fill_in 'values-percentageDone', with: '25'
 
+    expect(page).not_to have_text(wp_2.description) # safeguard
+
     export!
 
     expect(page).to have_text(wp_1.description)
@@ -98,6 +100,8 @@ describe 'work package export', type: :feature do
   it 'shows only work packages of the filtered type', js: true do
     select 'Type', from: 'add_filter_select'
     select wp_3.type.name, from: 'values-type'
+
+    expect(page).not_to have_text(wp_2.description) # safeguard
 
     export!
 


### PR DESCRIPTION
The query is not required on the initial loading of the page. We load the query later on via api calls (experimental/v3).
