### PR TITLE
do not show pagination until we have backend information

### DIFF
--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
@@ -1,4 +1,4 @@
-<div class="pagination">
+<div class="pagination" ng-if="pageNumbers.length">
   <nav class="pagination--pages">
     <ul class="pagination--items">
 


### PR DESCRIPTION
I looked into also hiding the pagination upon query updating but then noticed that we also do not hide the rest of the results (work packages) so hiding only the pagination would not match the existing behaviour.

OP work package:

https://community.openproject.com/work_packages/23807/activity
