### PR TITLE
[23848] Show work package attributes in fullscreen view in two columns

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -301,10 +301,11 @@
     display: inline-block
 
 // Implement two column layout for WP full screen view
-@media screen and (min-width: 62rem)
+@media screen and (min-width: 90rem)
   .action-show .attributes-group
     .-columns-2
       column-count: 2
+      column-gap: 4rem
 
       .attributes-key-value
         -webkit-column-break-inside: avoid

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -299,3 +299,14 @@
   .work-package--attachments--filename
     width: rem-calc(354)
     display: inline-block
+
+// Implement two column layout for WP full screen view
+@media screen and (min-width: 62rem)
+  .action-show .attributes-group
+    .-columns-2
+      column-count: 2
+
+      .attributes-key-value
+        -webkit-column-break-inside: avoid
+        page-break-inside: avoid
+        break-inside: avoid

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -37,63 +37,65 @@
       </div>
     </div>
 
-    <div
-        class="attributes-key-value"
-        ng-repeat="field in group.attributes">
+    <div class="-columns-2">
       <div
-          class="attributes-key-value--key"
-          ng-hide="$ctrl.shouldHideField(field)"
-          ng-if="$ctrl.singleViewWp.isSingleField(field) && $ctrl.singleViewWp.isSpecified(field)"
-          wp-replacement-label="field">
-
-        {{$ctrl.singleViewWp.getLabel(field)}}
-
-        <span class="required" ng-if="$ctrl.singleViewWp.hasNiceStar(field)"> *</span>
-      </div>
-      <div
-          ng-hide="$ctrl.shouldHideField(field)"
-          ng-if="$ctrl.singleViewWp.isSingleField(field) && $ctrl.singleViewWp.isSpecified(field)"
-          wp-edit-field="field"
-          wp-edit-field-label="$ctrl.singleViewWp.getLabel(field)"
-          wp-edit-field-wrapper-classes="'-small'"
-          class="attributes-key-value--value-container">
-      </div>
-
-      <div
-          class="attributes-key-value--key"
-          ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
-                   $ctrl.shouldHideField(field.fields[1])"
-          ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
-                 $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
-                 $ctrl.singleViewWp.isSpecified(field.fields[1]) "
-          wp-replacement-label="field.label">
-
-        {{$ctrl.singleViewWp.getLabel(field.label)}}
-
-        <span class="required" ng-if="$ctrl.singleViewWp.hasNiceStar(field.label)"> *</span>
-      </div>
-      <div
-          ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
-                   $ctrl.shouldHideField(field.fields[1])"
-          ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
-                 $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
-                 $ctrl.singleViewWp.isSpecified(field.fields[1]) "
-          class="attributes-key-value--value-container -minimal">
-
+          class="attributes-key-value"
+          ng-repeat="field in group.attributes">
         <div
-            wp-edit-field="field.fields[0]"
-            wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[0])"
-            wp-edit-field-wrapper-classes="'-small -shrink'"
-            display-placeholder="::$ctrl.text.fields[field.label][field.fields[0]]">
+            class="attributes-key-value--key"
+            ng-hide="$ctrl.shouldHideField(field)"
+            ng-if="$ctrl.singleViewWp.isSingleField(field) && $ctrl.singleViewWp.isSpecified(field)"
+            wp-replacement-label="field">
+
+          {{$ctrl.singleViewWp.getLabel(field)}}
+
+          <span class="required" ng-if="$ctrl.singleViewWp.hasNiceStar(field)"> *</span>
+        </div>
+        <div
+            ng-hide="$ctrl.shouldHideField(field)"
+            ng-if="$ctrl.singleViewWp.isSingleField(field) && $ctrl.singleViewWp.isSpecified(field)"
+            wp-edit-field="field"
+            wp-edit-field-label="$ctrl.singleViewWp.getLabel(field)"
+            wp-edit-field-wrapper-classes="'-small'"
+            class="attributes-key-value--value-container">
         </div>
 
-        <span class="attributes-key-value--value-separator"></span>
-
         <div
-            wp-edit-field="field.fields[1]"
-            wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[1])"
-            wp-edit-field-wrapper-classes="'-small -shrink'"
-            display-placeholder="::$ctrl.text.fields[field.label][field.fields[1]]">
+            class="attributes-key-value--key"
+            ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
+                     $ctrl.shouldHideField(field.fields[1])"
+            ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
+                   $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
+                   $ctrl.singleViewWp.isSpecified(field.fields[1]) "
+            wp-replacement-label="field.label">
+
+          {{$ctrl.singleViewWp.getLabel(field.label)}}
+
+          <span class="required" ng-if="$ctrl.singleViewWp.hasNiceStar(field.label)"> *</span>
+        </div>
+        <div
+            ng-hide="$ctrl.shouldHideField(field.fields[0]) &&
+                     $ctrl.shouldHideField(field.fields[1])"
+            ng-if="!$ctrl.singleViewWp.isSingleField(field) &&
+                   $ctrl.singleViewWp.isSpecified(field.fields[0]) &&
+                   $ctrl.singleViewWp.isSpecified(field.fields[1]) "
+            class="attributes-key-value--value-container -minimal">
+
+          <div
+              wp-edit-field="field.fields[0]"
+              wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[0])"
+              wp-edit-field-wrapper-classes="'-small -shrink'"
+              display-placeholder="::$ctrl.text.fields[field.label][field.fields[0]]">
+          </div>
+
+          <span class="attributes-key-value--value-separator"></span>
+
+          <div
+              wp-edit-field="field.fields[1]"
+              wp-edit-field-label="$ctrl.singleViewWp.getLabel(field.fields[1])"
+              wp-edit-field-wrapper-classes="'-small -shrink'"
+              display-placeholder="::$ctrl.text.fields[field.label][field.fields[1]]">
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This includes a two column layout for the WP full screen view. Except form the description and files block all other blocks show their elements in two columns. The arrangement of the elements in the columns depends on their height.

https://community.openproject.com/work_packages/23848/activity
