### PR TITLE
[23866] Button overlapped in member screen

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -638,10 +638,10 @@ a.impaired--empty-link,
     .form--field
       margin-bottom: 1rem
 
-@media screen and (max-width: 970px) and (min-width: 681px)
+@media screen and (max-width: 87rem) and (min-width: 681px)
   #members_add_form .-flex.-with-button
     .form--field
-      max-width: 50%
+      max-width: 60%
       select
-        max-width: 66%
+        max-width: 60%
 

--- a/app/views/members/_member_form_non_impaired.html.erb
+++ b/app/views/members/_member_form_non_impaired.html.erb
@@ -57,7 +57,7 @@ See doc/COPYRIGHT.rdoc for more details.
                          class: "select2-select remote" %>
       </div>
     </div>
-    <div class="grid-content medium-7 small-12 -flex -with-button">
+    <div class="grid-content medium-8 small-12 -flex -with-button">
       <div class="form--field">
         <%= styled_label_tag :member_role_ids, l(:label_role_search) %>
         <div class="form--field-container">


### PR DESCRIPTION
In IE the button and select field to add a member in the new member page were overlapping on small screen sizes.

https://community.openproject.com/work_packages/23866/activity
