### PR TITLE
[23868] Long words in text field attributes not wrapped

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -64,6 +64,14 @@
     line-height: normal
     font-size: 14px
 
+  .wp-table--cell-span
+    display: inline-block
+    max-width: 100%
+
+    p
+      word-wrap: break-word
+      margin-bottom: 0
+
 // Editable fields cursor
 .-editable .wp-table--cell-span
   cursor: text
@@ -72,8 +80,7 @@
   border-radius: 2px
   border-width: 1px
   line-height: normal
-  display: inline-block
-  width: 100%
+
   &:hover,
   &:focus
     border-color: $inplace-edit--border-color
@@ -85,9 +92,6 @@
     width: 100%
     .error.macro-unavailable
       display: inline-block
-    p
-      word-wrap: break-word
-      margin-bottom: 0
 
 // Style no-label fields (long text, description, ..) with padding
 .wp-edit-field.-no-label:not(.-active)

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -72,7 +72,8 @@
   border-radius: 2px
   border-width: 1px
   line-height: normal
-
+  display: inline-block
+  width: 100%
   &:hover,
   &:focus
     border-color: $inplace-edit--border-color
@@ -84,6 +85,9 @@
     width: 100%
     .error.macro-unavailable
       display: inline-block
+    p
+      word-wrap: break-word
+      margin-bottom: 0
 
 // Style no-label fields (long text, description, ..) with padding
 .wp-edit-field.-no-label:not(.-active)

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -36,7 +36,7 @@ describe 'subject inplace editor', js: true, selenium: true do
 
   before do
     login_as(user)
-    work_packages_page.visit_index(work_package)
+    work_packages_page.visit_show(work_package)
     within '.panel-toggler' do
       find('a', text: 'Show all attributes').click
     end
@@ -44,6 +44,10 @@ describe 'subject inplace editor', js: true, selenium: true do
   end
 
   it 'renders hierarchical versions' do
+    expect(page).to have_selector('.inplace-edit.project span', text: 'Root')
+    expect(page).to have_selector('.attributes-key-value--key span', text: 'Version')
+
+    expect(page).to have_selector("#{field.field_selector}.-editable")
     expect(page).to have_selector("#{field.field_selector} select")
 
     options = page.all("#{field.field_selector} select option")

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -51,7 +51,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
 
   describe 'Work package row selection', js: true do
     def select_work_package_row(number, mouse_button_behavior = :left)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.id")
       loading_indicator_saveguard
       case mouse_button_behavior
       when :double
@@ -64,7 +64,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
     end
 
     def select_work_package_row_with_shift(number)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.id")
       loading_indicator_saveguard
 
       page.driver.browser.action.key_down(:shift)
@@ -74,7 +74,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
     end
 
     def select_work_package_row_with_ctrl(number)
-      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.status")
+      element = find(".work-package-table--container tr:nth-of-type(#{number}) .wp-table--cell.id")
       loading_indicator_saveguard
 
       page.driver.browser.action.key_down(:control)


### PR DESCRIPTION
This wraps long words in text fields in the WP overview.

 https://community.openproject.com/work_packages/23868/activity
