### PR TITLE
[23272] Show linked revisions from other projects if visible

### DIFF
--- a/doc/apiv3-documentation.apib
+++ b/doc/apiv3-documentation.apib
@@ -4910,6 +4910,7 @@ Gets a list of projects that are available as projects to which the work package
 ## Revisions [GET]
 
 Gets a list of revisions that are linked to this work package, e.g., because it is referenced in the commit message of the revision.
+Only linked revisions from repositories are shown if the user has the view changesets permission in the defining project.
 
 + Parameters
     + id (required, integer, `1`) ... work package id
@@ -4922,7 +4923,7 @@ Gets a list of revisions that are linked to this work package, e.g., because it 
 
     Returned if the client does not have sufficient permissions.
 
-    **Required permission:** view changesets of the project this work package is contained in
+    **Required permission:** view work packages for the project the work package is contained in.
 
     *Note that you will only receive this error, if you are at least allowed to see the corresponding work package.*
 

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -34,13 +34,13 @@ module API
       class RevisionsByWorkPackageAPI < ::API::OpenProjectAPI
         resources :revisions do
           before do
-            authorize(:view_changesets, context: work_package.project)
+            authorize(:view_work_packages, context: work_package.project)
           end
 
           get do
             self_path = api_v3_paths.work_package_revisions(work_package.id)
 
-            revisions = work_package.changesets
+            revisions = work_package.changesets.visible
             RevisionsCollectionRepresenter.new(revisions, self_path, current_user: current_user)
           end
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -168,7 +168,7 @@ module API
         link :revisions do
           {
             href: api_v3_paths.work_package_revisions(represented.id)
-          } if current_user_allowed_to(:view_changesets, context: represented.project)
+          }
         end
 
         link :watch do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -397,13 +397,6 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
             api_v3_paths.work_package_revisions(work_package.id)
           }
         end
-
-        context 'when the user lacks the view_changesets permission' do
-          let(:permissions) { all_permissions - [:view_changesets] }
-          it_behaves_like 'has no link' do
-            let(:link) { 'revisions' }
-          end
-        end
       end
 
       describe 'version' do


### PR DESCRIPTION
Revisions in other projects were not shown if the project containing the
linked work package did not have a repository itself.

The revision endpoint is now shown when the representer is accessible (similarly to activities) and instead, only changesets for which the user has permissions in the source repository are shown.

This has a downside: The revisions endpoint will now be requested at all times, even if mostly empty. I'm not sure what's worse: Checking for linked revisions in the backend (additional query) or an additional async request.

We could also decide to merge the activities+revisions requests into one that contains both, which would reduce effort on the frontend side to merge and order them correctly.

https://community.openproject.com/work_packages/23272
