### PR TITLE
[23881] Fix permission check in top-menu

### DIFF
--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -155,7 +155,8 @@ module Redmine::MenuManager::MenuHelper
   end
 
   def render_menu_node(node, project = nil)
-    return '' if project and not allowed_node?(node, User.current, project)
+    return '' unless allowed_node?(node, User.current, project)
+
     if node.has_children? || !node.child_menus.nil?
       render_menu_node_with_children(node, project)
     else

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -30,20 +30,17 @@ require 'spec_helper'
 
 feature 'Top menu items', js: true, selenium: true do
   let(:user) { FactoryGirl.create :user }
-  let(:modules) { find(:css, "[title=#{I18n.t('label_modules')}]") }
-
-  let(:news_item) { I18n.t('label_news_plural') }
-  let(:work_packages_item) { I18n.t('label_work_package_plural') }
-  let(:time_entries_item) { I18n.t('label_time_sheet_menu') }
-
-  let(:all_items) { [news_item, work_packages_item, time_entries_item] }
+  let(:open_menu) { true }
 
   def has_menu_items(*labels)
-    labels.each do |l|
-      expect(page).to have_link(l)
-    end
-    (all_items - labels).each do |l|
-      expect(page).not_to have_link(l)
+
+    within '#top-menu' do
+      labels.each do |l|
+        expect(page).to have_link(l)
+      end
+      (all_items - labels).each do |l|
+        expect(page).not_to have_link(l)
+      end
     end
   end
 
@@ -55,47 +52,105 @@ feature 'Top menu items', js: true, selenium: true do
     end
 
     visit root_path
-    modules.click
+    top_menu.click if open_menu
   end
 
-  context 'as an admin' do
-    let(:user) { FactoryGirl.create :admin }
-    it 'displays all items' do
-      has_menu_items(work_packages_item, time_entries_item, news_item)
+  describe 'Modules' do
+    let(:top_menu) { find(:css, "[title=#{I18n.t('label_modules')}]") }
+
+    let(:news_item) { I18n.t('label_news_plural') }
+    let(:work_packages_item) { I18n.t('label_work_package_plural') }
+    let(:time_entries_item) { I18n.t('label_time_sheet_menu') }
+
+    let(:all_items) { [news_item, work_packages_item, time_entries_item] }
+
+    context 'as an admin' do
+      let(:user) { FactoryGirl.create :admin }
+      it 'displays all items' do
+        has_menu_items(work_packages_item, time_entries_item, news_item)
+      end
+
+      it 'visits the work package page' do
+        click_link work_packages_item
+        expect(current_path).to eq(work_packages_path)
+      end
+
+      it 'visits the time sheet page' do
+        click_link time_entries_item
+        expect(current_path).to eq(time_entries_path)
+      end
+
+      it 'visits the work package page' do
+        click_link news_item
+        expect(current_path).to eq(news_index_path)
+      end
     end
 
-    it 'visits the work package page' do
-      click_link work_packages_item
-      expect(current_path).to eq(work_packages_path)
+    context 'as a regular user' do
+      it 'displays news only' do
+        has_menu_items news_item
+      end
     end
 
-    it 'visits the time sheet page' do
-      click_link time_entries_item
-      expect(current_path).to eq(time_entries_path)
+    context 'as a user with permissions', allowed_to: true do
+      it 'displays all options' do
+        has_menu_items(work_packages_item, time_entries_item, news_item)
+      end
     end
 
-    it 'visits the work package page' do
-      click_link news_item
-      expect(current_path).to eq(news_index_path)
+    context 'as an anonymous user' do
+      let(:user) { FactoryGirl.create :anonymous }
+      it 'displays only news' do
+        has_menu_items news_item
+      end
     end
   end
 
-  context 'as a regular user' do
-    it 'displays news only' do
-      has_menu_items news_item
-    end
-  end
+  describe 'Projects' do
+    let(:top_menu) { find(:css, '#projects-menu') }
 
-  context 'as a user with permissions', allowed_to: true do
-    it 'displays all options' do
-      has_menu_items(work_packages_item, time_entries_item, news_item)
-    end
-  end
+    let(:new_project) { I18n.t(:label_project_new) }
+    let(:all_projects) { I18n.t(:label_project_view_all) }
+    let(:all_items) { [new_project, all_projects] }
 
-  context 'as an anonymous user' do
-    let(:user) { FactoryGirl.create :anonymous }
-    it 'displays only news' do
-      has_menu_items news_item
+    context 'as an admin' do
+      let(:user) { FactoryGirl.create :admin }
+      it 'displays all items' do
+        has_menu_items(new_project, all_projects)
+      end
+
+      it 'visits the work package page' do
+        within '.drop-down--projects' do
+          click_link new_project
+        end
+
+        expect(current_path).to eq(new_project_path)
+      end
+
+      it 'visits the time sheet page' do
+        within '.drop-down--projects' do
+          click_link all_projects
+        end
+        expect(current_path).to eq(projects_path)
+      end
+    end
+
+    context 'as a user without project permission' do
+      before do
+        Role.non_member.update_attribute :permissions, [:view_project]
+      end
+      it 'does not display new_project' do
+        has_menu_items all_projects
+      end
+    end
+
+    context 'as an anonymous user' do
+      let(:user) { FactoryGirl.create :anonymous }
+      let(:open_menu) { false }
+
+      it 'does not show the menu' do
+        expect(page).to have_no_selector('#projects-menu')
+      end
     end
   end
 end


### PR DESCRIPTION
The global `new project` menu was always shown due to an incorrect authorization check.

https://community.openproject.com/work_packages/23881
