### PR TITLE
[23879] Fix editing a subject in the table after creation

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-form.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-form.directive.ts
@@ -30,6 +30,8 @@ import {ErrorResource} from '../api/api-v3/hal-resources/error-resource.service'
 import {WorkPackageEditModeStateService} from './wp-edit-mode-state.service';
 import {WorkPackageEditFieldController} from './wp-edit-field/wp-edit-field.directive';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
+import {scopedObservable} from '../../helpers/angular-rx-utils';
+import {WorkPackageResource} from '../api/api-v3/hal-resources/work-package-resource.service';
 
 export class WorkPackageEditFormController {
   public workPackage;
@@ -53,6 +55,11 @@ export class WorkPackageEditFormController {
     if (this.hasEditMode) {
       wpEditModeState.register(this);
     }
+
+    scopedObservable($scope, wpCacheService.loadWorkPackage(this.workPackage.id))
+      .subscribe((wp: WorkPackageResource) => {
+        this.workPackage = wp;
+      });
   }
 
   public isFieldRequired() {

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -189,6 +189,23 @@ describe 'new work package', js: true do
       save_work_package!
 
       expect(page).to have_selector('.wp--row input[type=checkbox]:checked')
+
+      # Editing the subject after creation
+      # Fix for WP #23879
+      new_wp = WorkPackage.last
+      new_subject = 'new subject'
+      table_subject = wp_table.edit_field(new_wp, :subject)
+      table_subject.activate!
+      table_subject.set_value new_subject
+      table_subject.submit_by_enter
+      table_subject.expect_state_text new_subject
+
+      new_wp.reload
+      expect(new_wp.subject).to eq(new_subject)
+
+      # Expect this to be synced
+      details_subject = wp_table.edit_field(new_wp, :subject)
+      details_subject.expect_state_text new_subject
     end
   end
 


### PR DESCRIPTION
The form controller was not subscribing the latest work package
and thus failed to receive the `$pristine` values set by the field
controller after initial creation.

https://community.openproject.com/work_packages/23879/activity
