### PR TITLE
[23859] Respect intermittent additions to WP pristine

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -268,12 +268,22 @@ export class WorkPackageResource extends HalResource {
     this.updateForm(this.$source)
       .then(form => {
         var payload = this.mergeWithForm(form);
+        const sentValues = Object.keys(this.$pristine);
 
         this.saveResource(payload)
           .then(workPackage => {
+
+            // Initialize any potentially new HAL values
             this.$initialize(workPackage);
-            this.$pristine = {};
+
+            // Remove only those pristine values that were submitted
+            angular.forEach(sentValues, (key) => {
+              delete this.$pristine[key];
+            });
+
+            // Forcefully refresh activities
             wpCacheService.loadWorkPackageLinks(this, 'activities');
+
             deferred.resolve(this);
           })
           .catch(error => {


### PR DESCRIPTION
When a user quickly saves a first attribute and opens a second attribute
before the first request has completed, the `$pristine` value stored for
the second is removed after the API request has completed and thus, the
second change is not saved.

A workaround is to remove only those pristine values that were known
before saving the resource.

https://community.openproject.com/work_packages/23859/activity
