### PR TITLE
[23853] Post the original form attributes when copying

### DIFF
--- a/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
+++ b/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
@@ -69,8 +69,8 @@ export class ApiWorkPackagesService {
    *
    * @returns An empty work package form resource.
    */
-  public emptyCreateForm(projectIdentifier?:string):ng.IPromise<HalResource> {
-    return this.halRequest.post(this.v3Path.wp.form({project: projectIdentifier}));
+  public emptyCreateForm(request:any, projectIdentifier?:string):ng.IPromise<HalResource> {
+    return this.halRequest.post(this.v3Path.wp.form(projectIdentifier), request);
   }
 
   /**

--- a/frontend/app/components/wp-create/wp-create.service.ts
+++ b/frontend/app/components/wp-create/wp-create.service.ts
@@ -41,21 +41,23 @@ export class WorkPackageCreateService {
   }
 
   public createNewWorkPackage(projectIdentifier) {
-    return this.getForm(projectIdentifier).then(form => {
+    return this.getEmptyForm(projectIdentifier).then(form => {
       return this.WorkPackageResource.fromCreateForm(form);
     });
   }
 
 
   public copyWorkPackage(copyFromForm, projectIdentifier?) {
-    return this.getForm(projectIdentifier).then(form => {
+    var request = copyFromForm.payload.$source;
+
+    return this.apiWorkPackages.emptyCreateForm(request, projectIdentifier).then(form => {
       return this.WorkPackageResource.copyFrom(copyFromForm, form);
     });
   }
 
-  private getForm(projectIdentifier):ng.IPromise<HalResource> {
+  private getEmptyForm(projectIdentifier):ng.IPromise<HalResource> {
     if (!this.form) {
-      this.form = this.apiWorkPackages.emptyCreateForm(projectIdentifier);
+      this.form = this.apiWorkPackages.emptyCreateForm({ project: projectIdentifier });
     }
 
     return this.form;

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -48,13 +48,15 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
                                      :add_work_packages,
                                      :edit_work_packages])
   end
-  let(:project) { FactoryGirl.create(:project) }
+  let(:type) { FactoryGirl.create(:type) }
+  let(:project) { FactoryGirl.create(:project, types: [type]) }
   let(:original_work_package) do
     FactoryGirl.build(:work_package,
                       project: project,
                       assigned_to: assignee,
                       responsible: responsible,
                       fixed_version: version,
+                      type: type,
                       author: author)
   end
   let(:role) { FactoryGirl.build(:role, permissions: [:view_work_packages]) }

--- a/spec/support/pages/abstract_work_package_create.rb
+++ b/spec/support/pages/abstract_work_package_create.rb
@@ -29,7 +29,7 @@
 require 'support/pages/page'
 
 module Pages
-  class AbstractWorkPackageCreate < Page
+  class AbstractWorkPackageCreate < AbstractWorkPackage
     attr_reader :original_work_package,
                 :parent_work_package
 


### PR DESCRIPTION
Previously, the copied work package would take over all attributes of
the original work package, but the form was an empty create form, which
results in only the default type and status being contained in the
schema.

We can instead post the attributes of the original WP form to retrieve a
matching form response.

https://community.openproject.com/work_packages/23853
