### PR TITLE
cache help menu

### DIFF
--- a/app/views/onboarding/_starting_video_modal.html.erb
+++ b/app/views/onboarding/_starting_video_modal.html.erb
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-  
+
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="onboarding--start-modal">
     <div class="onboarding--top-menu">
       <%= homescreen_user_avatar %>
-      <h2><%= I18n.t('onboarding.welcome', name: current_user.name) %></h2>
+      <h2><%= I18n.t('onboarding.welcome') %></h2>
     </div>
 
     <div class="onboarding--main">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1466,7 +1466,7 @@ en:
   onboarding:
     text_getting_started: "This video provides you an overview of OpenProject. It helps you to set up your first project and to start collaborating with your team members."
     text_show_again: "You can restart this video from the help menu"
-    welcome: "Hi %{name}, welcome to OpenProject"
+    welcome: "Welcome to OpenProject"
 
   permission_add_work_package_notes: "Add notes"
   permission_add_work_packages: "Add work packages (also allows to add attachments to all work packages)"

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -31,10 +31,12 @@ require 'open_project/static/links'
 
 module Redmine::MenuManager::TopMenu::HelpMenu
   def render_help_top_menu_node(item = help_menu_item)
-    if OpenProject::Static::Links.help_link_overridden?
-      render_menu_node(item)
-    else
-      render_help_dropdown
+    Rails.cache.fetch("help_top_menu_node/#{OpenProject::Static::Links.help_link}") do
+      if OpenProject::Static::Links.help_link_overridden?
+        render_menu_node(item)
+      else
+        render_help_dropdown
+      end
     end
   end
 


### PR DESCRIPTION
The help menu is costly to render mostly because of the onboarding menu which itself has a partial included.

When dropping the user name from that partial, we can however cache the menu which decreases the time required for rendering significantly.
