### PR TITLE
UserPasswords: Replace salted SHA-1 with bcrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ gem 'ruby-duration', '~> 3.2.0'
 # provide compatible filesystem information for available storage
 gem 'sys-filesystem', '~> 1.1.4', require: false
 
+gem 'bcrypt', '~> 3.1.6'
+
 # We rely on this specific version, which is the latest as of now (end of 2013),
 # because we have to apply to it a bugfix which could break things in other versions.
 # This can be removed as soon as said bugfix is integrated into rabl itself.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bourbon (4.2.6)
@@ -589,6 +590,7 @@ DEPENDENCIES
   airbrake (~> 5.1.0)
   autoprefixer-rails
   awesome_nested_set!
+  bcrypt (~> 3.1.6)
   bourbon (~> 4.2.0)
   capybara (~> 2.6.2)
   capybara-ng (~> 0.2.2)

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -103,7 +103,7 @@ class MyController < ApplicationController
     @user = User.current  # required by "my" layout
     @username = @user.login
     return if redirect_if_password_change_not_allowed_for(@user)
-    if @user.check_password?(params[:password])
+    if @user.check_password?(params[:password], update_legacy: false)
       @user.password = params[:new_password]
       @user.password_confirmation = params[:new_password_confirmation]
       @user.force_password_change = false

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -103,10 +103,6 @@ class UserPassword < ActiveRecord::Base
     raise NotImplementedError, 'Must be overridden by subclass'
   end
 
-  def generate_salt
-    raise NotImplementedError, 'Must be overridden by subclass'
-  end
-
   def derive_password!(_input)
     raise NotImplementedError, 'Must be overridden by subclass'
   end

--- a/app/models/user_password/bcrypt.rb
+++ b/app/models/user_password/bcrypt.rb
@@ -1,3 +1,4 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -26,28 +27,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-FactoryGirl.define do
-  factory :user_password, class: UserPassword.active_type do
-    association :user
-    plain_password 'adminADMIN!'
+##
+# Password hashing method using bcrypt
+class UserPassword::Bcrypt < UserPassword
+  protected
 
-    factory :old_user_password do
-      created_at 1.year.ago
-      updated_at 1.year.ago
-    end
+  ##
+  # Determines whether the hashed value of +plain+ matches the stored password hash.
+  def hash_matches?(plain)
+    BCrypt::Password.new(hashed_password) == plain
   end
 
-  factory :legacy_sha1_password, class: UserPassword::SHA1 do
-    association :user
-    type 'UserPassword::SHA1'
-    plain_password 'mylegacypassword!'
-
-    # Avoid going through the after_save hook
-    # As it's no longer possible for Sha1 passwords
-    after(:build) do |obj|
-      obj.salt = SecureRandom.hex(16)
-      obj.hashed_password = obj.send(:derive_password!, obj.plain_password)
-      obj.plain_password = nil
-    end
+  def derive_password!(input)
+    BCrypt::Password.create(input)
   end
 end

--- a/db/migrate/20160829225633_introduce_bcrypt_passwords.rb
+++ b/db/migrate/20160829225633_introduce_bcrypt_passwords.rb
@@ -1,0 +1,36 @@
+class IntroduceBcryptPasswords < ActiveRecord::Migration
+  def up
+    # Introduce type to UserPassword
+    add_column :user_passwords, :type, :string, null: true
+
+    # Increase hash limit due to bcrypt embedded salt
+    change_column :user_passwords, :hashed_password, :string, limit: 128, null: false
+
+    # All current passwords are assumed to be SHA-1 salted.
+    UserPassword.update_all(type: 'UserPassword::SHA1')
+
+    # Make type non-optional
+    change_column :user_passwords, :type, :string, null: false
+
+    # Make salt explicitly optional
+    change_column_null :user_passwords, :salt, true
+  end
+
+  def down
+    unless ENV['OPENPROJECT_CONFIRM_ROLLBACK'] == '20160829225633'
+      raise ActiveRecord::IrreversibleMigration, <<-EXC.strip_heredoc
+        WARNING
+
+        You cannot roll back this migration without losing passwords.
+        If you really want to do undo BCrypt passwords, set the following ENV variable:
+
+        export OPENPROJECT_CONFIRM_ROLLBACK="20160829225633"
+      EXC
+    end
+
+    UserPassword.where(type: 'UserPassword::Bcrypt').delete_all
+    remove_column :user_passwords, :type
+    change_column :user_passwords, :hashed_password, :string, limit: 40
+    # Salt was (implictly) optional
+  end
+end

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -84,6 +84,7 @@ module OpenProject
       'internal_password_confirmation' => true,
 
       'disable_password_choice' => false,
+      'override_bcrypt_cost_factor' => nil,
 
       'disabled_modules' => [], # allow to disable default modules
       'hidden_menu_items' => {},

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -81,6 +81,7 @@ describe UserPassword, type: :model do
       }.to_not change { user.passwords.count }
 
       expect(user.current_password).to be_a(UserPassword::Bcrypt)
+      expect(user.current_password.hashed_password).to start_with '$2a$'
     end
 
     it 'does not alter the password when invalid' do

--- a/spec_legacy/fixtures/user_passwords.yml
+++ b/spec_legacy/fixtures/user_passwords.yml
@@ -30,6 +30,7 @@
 user_passwords_004:
   created_at: 2006-07-19 19:34:07 +02:00
   # password = foo
+  type: UserPassword::SHA1
   salt: 3126f764c3c5ac61cbfc103f25f934cf
   hashed_password: 9e4dd7eeb172c12a0691a6d9d3a269f7e9fe671b
   updated_at: 2006-07-19 19:34:07 +02:00
@@ -38,6 +39,7 @@ user_passwords_004:
 user_passwords_001:
   created_at: 2006-07-19 19:12:21 +02:00
   # password = adminADMIN!
+  type: UserPassword::SHA1
   salt: a19f9743f4b7b043a2fd07b8eb13a1df
   hashed_password: b4596ce83c0e154e5ce9d3dd5636fde4d6f38b75
   updated_at: 2006-07-19 22:57:52 +02:00
@@ -46,6 +48,7 @@ user_passwords_001:
 user_passwords_002:
   created_at: 2006-07-19 19:32:09 +02:00
   # password = jsmith
+  type: UserPassword::SHA1
   salt: 67eb4732624d5a7753dcea7ce0bb7d7d
   hashed_password: bfbe06043353a677d0215b26a5800d128d5413bc
   updated_at: 2006-07-19 22:42:15 +02:00
@@ -54,6 +57,7 @@ user_passwords_002:
 user_passwords_003:
   created_at: 2006-07-19 19:33:19 +02:00
   # password = foo
+  type: UserPassword::SHA1
   salt: 7599f9963ec07b5a3b55b354407120c0
   hashed_password: 8f659c8d7c072f189374edacfa90d6abbc26d8ed
   updated_at: 2006-07-19 19:33:19 +02:00
@@ -63,28 +67,34 @@ user_passwords_005:
   id: 5
   user_id: 5
   created_at: 2006-07-19 19:33:19 +02:00
+  type: UserPassword::SHA1
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_006:
   id: 6
   user_id: 6
   created_at: 2006-07-19 19:33:19 +02:00
+  type: UserPassword::SHA1
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_007:
   id: 7
   user_id: 7
+  type: UserPassword::SHA1
+  hashed_password: 1
   created_at: 2006-07-19 19:33:19 +02:00
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_008:
   id: 8
   user_id: 8
+  type: UserPassword::SHA1
   created_at: 2006-07-19 19:33:19 +02:00
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00
 user_passwords_009:
   id: 9
   user_id: 9
+  type: UserPassword::SHA1
   created_at: 2006-07-19 19:33:19 +02:00
   hashed_password: 1
   updated_at: 2006-07-19 19:33:19 +02:00


### PR DESCRIPTION
This adds a typed `UserPassword` class for Bcrypt password hashes
that replace the previous default of salted SHA1.

It still provides a class for SHA1 passwords, however new passwords of
that type may no longer be created directly, and passwords are checked
whether to upgrade them on every login.

https://community.openproject.com/work_packages/22769
