### PR TITLE
Allow to customize the keys that are sent with remote-field-updater

### DIFF
--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -77,15 +77,14 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= styled_form_tag(members_of_group_path(@group), method: :post, remote: true) do |f| %>
         <fieldset class="form--fieldset">
           <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
-          <remote-field-updater
-             url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group) %>"
-             request-key="q">
+          <remote-field-updater url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group) %>">
             <div class="form--field -vertical">
               <%= styled_label_tag "user_search", l(:label_user_search) %>
               <div class="form--field-container">
                 <%= styled_text_field_tag 'user_search',
                                           nil,
-                                          class: 'remote-field--input' %>
+                                          class: 'remote-field--input',
+                                          data: { :'remote-field-key' =>'q' } %>
               </div>
             </div>
             <div class="form--field -vertical">

--- a/app/views/members/_member_form_impaired.html.erb
+++ b/app/views/members/_member_form_impaired.html.erb
@@ -34,9 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
              complete: 'jQuery(\'#member-add-submit\').enable(); activateFlashError();',
              html: {id: "members_add_form", class: "form -vertical"}) do |f| %>
   <div class="form--section">
-    <remote-field-updater
-       url="<%= url_for(controller: '/members', action: 'autocomplete_for_member', project_id: project) %>"
-       request-key="q">
+    <remote-field-updater url="<%= url_for(controller: '/members', action: 'autocomplete_for_member', project_id: project) %>">
       <div id="new-member-message"></div>
       <div class="grid-block">
         <div class="grid-block medium-6">
@@ -51,6 +49,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <%= styled_label_tag :principal_search, user_id_title %>
             <%= styled_text_field_tag :principal_search,
                                       nil,
+                                      data: { :'remote-field-key' => 'q' },
                                       class: 'remote-field--input' %>
           </div>
         </div>

--- a/frontend/app/components/common/remote/remote-field-updater.directive.test.ts
+++ b/frontend/app/components/common/remote/remote-field-updater.directive.test.ts
@@ -43,8 +43,8 @@ describe('remote-field-updater directive', function() {
     $httpBackend = _$httpBackend_;
 
     var template = `
-      <remote-field-updater url="/foo/bar" request-key="q">
-        <input type="text" class="remote-field--input" />
+      <remote-field-updater url="/foo/bar">
+        <input type="text" class="remote-field--input" data-remote-field-key="q"/>
         <div class="remote-field--target"></div>
       </remote-field-updater>`;
     element = $compile(template)($rootScope);

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -65,6 +65,8 @@ opApp
         $httpProvider.defaults.headers.common['X-CSRF-TOKEN'] = jQuery(
             'meta[name=csrf-token]').attr('content');
         $httpProvider.defaults.headers.common['X-Authentication-Scheme'] = 'Session';
+        // Add X-Requested-With for request.xhr?
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         // prepend a given base path to requests performed via $http
         //
         $httpProvider.interceptors.push(function($q) {


### PR DESCRIPTION
Extend the angular replacement for `observe_field` with means to specify which fields are used as parameters.
