### PR TITLE
[23941] Bump required ruby version to 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@
 language: ruby
 
 rvm:
-  - 2.2.3
+  - 2.3.1
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ ruby '2.3.1'
 gem 'rails', '~> 4.2.7', '>= 4.2.7.1'
 gem 'actionpack-action_caching'
 gem 'actionpack-xml_parser'
-gem 'activerecord-session_store'
+gem 'activerecord-session_store', '~> 1.0.0'
 gem 'rails-observers'
 gem 'responders', '~> 2.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@
 
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 gem 'rails', '~> 4.2.7', '>= 4.2.7.1'
 gem 'actionpack-action_caching'
 gem 'actionpack-xml_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,10 +125,12 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activerecord-session_store (0.1.2)
-      actionpack (>= 4.0.0, < 5)
-      activerecord (>= 4.0.0, < 5)
-      railties (>= 4.0.0, < 5)
+    activerecord-session_store (1.0.0)
+      actionpack (>= 4.0, < 5.1)
+      activerecord (>= 4.0, < 5.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.1)
     activerecord-tableless (1.3.4)
       activerecord (>= 2.3.0)
     activesupport (4.2.7.1)
@@ -583,7 +585,7 @@ DEPENDENCIES
   actionpack-xml_parser
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter
-  activerecord-session_store
+  activerecord-session_store (~> 1.0.0)
   activerecord-tableless (~> 1.0)
   acts_as_list (~> 0.7.2)
   airbrake (~> 5.1.0)
@@ -694,6 +696,9 @@ DEPENDENCIES
   warden-basic_auth (~> 0.2.1)
   webmock (~> 1.24.2)
   will_paginate (~> 3.1)
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
This is a quick test if we can move [23941](https://community.openproject.com/work_packages/23941/activity) to 6.1.
