### PR TITLE
[23835] Fix escaped display of wiki preview

### DIFF
--- a/frontend/app/components/common/has-preview/has-preview.directive.test.ts
+++ b/frontend/app/components/common/has-preview/has-preview.directive.test.ts
@@ -57,6 +57,3 @@ describe('hasPreview Directive', function() {
     });
   });
 });
-
-
-

--- a/frontend/app/components/common/has-preview/has-preview.directive.test.ts
+++ b/frontend/app/components/common/has-preview/has-preview.directive.test.ts
@@ -26,32 +26,37 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function() {
-  return {
-    restrict: 'A',
-    scope: {},
-    link: function(scope, element, attrs) {
-      var href = attrs.href;
-      var id = attrs.id;
-      var target = attrs.previewArea ||  '#preview';
-      element.on('click', function() {
-        jQuery.ajax({
-          url: href,
-          type: 'POST',
-          data: angular.element('#' + id.replace(/(-preview)/g, '')).serialize()
-            .replace(/_method=(patch|put)&/, ''),
-          success: function(data) {
-            angular.element(target).html(data);
-            angular.element('html, body').animate({
-                scrollTop: angular.element('#preview').offset()
-                  .top
-              },
-              'slow');
-          }
-        });
+describe('hasPreview Directive', function() {
+  var compile, element, scope;
 
-        return false;
-      });
-    }
-  };
-};
+  beforeEach(angular.mock.module('openproject.uiComponents'));
+  beforeEach(angular.mock.module('openproject.templates'));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    var html = '<a href="/preview-url" id="text-preview" has-preview>Preview</a>';
+
+    element = angular.element(html);
+    scope = $rootScope.$new();
+
+    compile = function() {
+      $compile(element)(scope);
+      scope.$digest();
+    };
+  }));
+
+  beforeEach(function() {
+    compile();
+  });
+
+  describe('link element', function() {
+    beforeEach(function() {
+      element.click();
+    });
+
+    xit('should load the preview', function() {
+    });
+  });
+});
+
+
+

--- a/frontend/app/components/common/has-preview/has-preview.directive.ts
+++ b/frontend/app/components/common/has-preview/has-preview.directive.ts
@@ -26,36 +26,41 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-/*jshint expr: true*/
+import {openprojectModule} from "../../../angular-modules";
 
-describe('hasPreview Directive', function() {
-  var compile, element, scope;
+function hasPreview($compile, $rootScope) {
+  return {
+    restrict: 'A',
+    scope: {},
+    link: function(scope, element, attrs) {
+      var href = attrs.href;
+      var id = attrs.id;
+      var target = attrs.previewArea ||  '#preview';
+      element.on('click', function() {
+        jQuery.ajax({
+          url: href,
+          type: 'POST',
+          data: angular.element('#' + id.replace(/(-preview)/g, '')).serialize()
+            .replace(/_method=(patch|put)&/, ''),
+          success: function(data) {
+            var el = angular.element(target);
+            scope.$apply(() => {
+              el.html(data);
+              $compile(el.contents())($rootScope);
+            });
 
-  beforeEach(angular.mock.module('openproject.uiComponents'));
-  beforeEach(angular.mock.module('openproject.templates'));
+            angular.element('html, body').animate({
+                scrollTop: angular.element('#preview').offset()
+                  .top
+              },
+              'slow');
+          }
+        });
 
-  beforeEach(inject(function($rootScope, $compile) {
-    var html = '<a href="/preview-url" id="text-preview" has-preview>Preview</a>';
+        return false;
+      });
+    }
+  };
+};
 
-    element = angular.element(html);
-    scope = $rootScope.$new();
-
-    compile = function() {
-      $compile(element)(scope);
-      scope.$digest();
-    };
-  }));
-
-  beforeEach(function() {
-    compile();
-  });
-
-  describe('link element', function() {
-    beforeEach(function() {
-      element.click();
-    });
-
-    xit('should load the preview', function() {
-    });
-  });
-});
+openprojectModule.directive('hasPreview', hasPreview);

--- a/frontend/app/ui_components/index.js
+++ b/frontend/app/ui_components/index.js
@@ -54,9 +54,6 @@ angular.module('openproject.uiComponents')
   .constant('FOCUSABLE_SELECTOR', 'a, button, :input, [tabindex], select')
   .service('FocusHelper', ['$timeout', 'FOCUSABLE_SELECTOR', require(
     './focus-helper')])
-  .directive('hasPreview', [
-    require('./has-preview-directive')
-  ])
   .service('I18n', [require('./i18n')])
   .directive('iconWrapper', [require('./icon-wrapper-directive')])
   .directive('inaccessibleByTab', [require('./inaccessible-by-tab-directive')])

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -115,7 +115,7 @@ module OpenProject
     # This will avoid arbitrary angular expressions to be evaluated in
     # formatted text marked html_safe.
     def escape_non_macros(text)
-      text.gsub!('{{', '{{ DOUBLE_LEFT_CURLY_BRACE }}')
+      text.gsub!(/\{\{(?! DOUBLE_LEFT_CURLY_BRACE)/, '{{ DOUBLE_LEFT_CURLY_BRACE }}')
     end
 
     def parse_non_pre_blocks(text)

--- a/spec/features/security/angular_xss_spec.rb
+++ b/spec/features/security/angular_xss_spec.rb
@@ -73,6 +73,33 @@ describe 'Angular expression escaping', type: :feature do
     end
   end
 
+  describe '#wiki edit previewing', js: true do
+    let(:user) { FactoryGirl.create :admin }
+    let(:project) { FactoryGirl.create :project, enabled_module_names: %w(wiki) }
+
+    let(:content) { find '#content_text' }
+    let(:preview) { find '#preview' }
+    let(:btn_preview) { find '#wiki_form-preview' }
+    let(:btn_cancel) { find '#wiki_form a.button', text: I18n.t(:button_cancel) }
+
+    before do
+      login_as(user)
+      visit project_wiki_path(project, project.wiki)
+    end
+
+    it 'properly escapes a macro in the preview functionality' do
+      content.set '{{macro_list(wiki)}}'
+      btn_preview.click
+
+      expect(preview.text).not_to include '{{ DOUBLE_LEFT_CURLY_BRACE }}'
+      expect(preview.text).to match /\{\{[\s\w]+\}\}/
+
+      btn_cancel.click
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_no_selector('#content_text')
+    end
+  end
+
   describe '#text_format' do
     let(:text) { '{{hello_world}} {{ 3 + 5 }}' }
     subject(:html) { format_text(text) }


### PR DESCRIPTION
**Compile contents retrieved through the has-preview directive**
The contents returned from Rails are escaped for angular, so we need to
present it to the scope.

**Avoid double escaping when using nested format_text**
Macros such as `macro_list(wiki)` will call format_text within the macro
expansion, which will cause escaped angular braces to be escaped twice.

https://community.openproject.com/work_packages/23835
