### PR TITLE
[23873] Collapse submenus when sidebar is collapsed

### DIFF
--- a/frontend/app/layout/controllers/main-menu-controller.js
+++ b/frontend/app/layout/controllers/main-menu-controller.js
@@ -27,11 +27,36 @@
 //++
 
 module.exports = function($rootScope, $window) {
+  var menuList = null;
 
   this.toggleNavigation = function() {
+    if ($rootScope.showNavigation) {
+      menuList = hideSubMenuEntries();
+    } else {
+      showSubMenuEntries(menuList);
+    }
     $rootScope.showNavigation = !$rootScope.showNavigation;
     $rootScope.$broadcast('openproject.layout.navigationToggled', $rootScope.showNavigation);
     $window.sessionStorage.setItem('openproject:navigation-toggle',
       !$rootScope.showNavigation ? 'collapsed' : 'expanded');
   };
 };
+
+function hideSubMenuEntries() {
+  var togglers = jQuery('#main-menu .main-item-wrapper.open .toggler');
+  toggleMenus(togglers);
+
+  return togglers;
+}
+
+function showSubMenuEntries(togglers) {
+  if (togglers !== null) {
+    toggleMenus(togglers);
+  }
+}
+
+function toggleMenus(togglers) {
+  togglers.each(function(index) {
+    jQuery(this).trigger('click');
+  });
+}


### PR DESCRIPTION
When the sidebar is collapsed all open sub menus in the sidebar shall be collapsed. Thus the sidebar is more compact and usable. When the sidebar is reopened all submenus that were open before shall be open too. This does not apply when the page is reloaded.

https://community.openproject.com/work_packages/23873/activity
