### PR TITLE
[23969] Improve space usage in WP full screen view

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -83,7 +83,10 @@ body.controller-work_packages.action-show {
     flex-shrink: 8;
     border-top: 1px solid #ccc;
     overflow: visible;
-    position: relative;
+    // Important for Safari
+    height: initial;
+    // Important for Firefox to let 'flex-shrink' work correctly.
+    min-height: 0;
 
     &[cg-busy] {
       overflow: visible;
@@ -204,6 +207,13 @@ body.controller-work_packages.action-show {
         display: block;
       }
     }
+  }
+}
+
+@media only screen and (max-width: 78rem) {
+  .work-packages--show-view {
+    // Important for Safari
+    height: initial;
   }
 }
 

--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -31,6 +31,9 @@ body.controller-work_packages.action-show {
 }
 
 .work-packages--show-view {
+  display: flex;
+  flex-direction: column;
+  height: inherit;
 
   #toolbar {
     display: flex;
@@ -42,6 +45,7 @@ body.controller-work_packages.action-show {
   .toolbar-container {
     @include clearfix;
     margin-bottom: 20px;
+    padding-right: 20px;
   }
 
 
@@ -76,15 +80,10 @@ body.controller-work_packages.action-show {
   }
 
   .work-packages--split-view {
-    height: auto;
+    flex-shrink: 8;
     border-top: 1px solid #ccc;
     overflow: visible;
-    position: absolute;
-    padding-right: 20px;
-    top: 139px;
-    left: 20px;
-    right: 0px;
-    bottom: 0px;
+    position: relative;
 
     &[cg-busy] {
       overflow: visible;
@@ -223,8 +222,6 @@ body.controller-work_packages.action-show {
 }
 
 .work-packages--show-view {
-  padding-right: 20px;
-
   .subject-header {
     margin: 0;
     padding: 0;

--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -33,6 +33,9 @@ body.controller-work_packages.action-show {
 .work-packages--show-view {
 
   #toolbar {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap-reverse;
     @include clearfix;
   }
 
@@ -41,13 +44,44 @@ body.controller-work_packages.action-show {
     margin-bottom: 20px;
   }
 
+
+  ul#toolbar-items {
+    @include clearfix;
+    order: 2;
+    margin: 0 0 1rem 2rem;
+
+    button {
+      margin-bottom: 0;
+    }
+
+    li {
+      float: left;
+      position: relative;
+
+      &.toolbar-item:first-of-type {
+        margin-left: 0;
+      }
+
+      .dropdown {
+        top: 100% !important;
+        right: 0px !important;
+        left: auto !important;
+        margin-top: 0;
+
+        ul li {
+          float: none;
+        }
+      }
+    }
+  }
+
   .work-packages--split-view {
     height: auto;
     border-top: 1px solid #ccc;
-    overflow: hidden;
+    overflow: visible;
     position: absolute;
     padding-right: 20px;
-    top: 76px;
+    top: 139px;
     left: 20px;
     right: 0px;
     bottom: 0px;
@@ -104,10 +138,6 @@ body.controller-work_packages.action-show {
     }
   }
 
-  .work-packages--split-view {
-    overflow: visible !important;
-  }
-
   .work-packages--right-panel {
     min-width: 420px;
     overflow-y: auto;
@@ -146,31 +176,6 @@ body.controller-work_packages.action-show {
     ul { padding-left: 2em; }
   }
 
-  ul#toolbar-items {
-    @include clearfix;
-    float: right;
-
-    button {
-      margin-bottom: 0;
-    }
-
-    li {
-      float: left;
-      position: relative;
-
-      .dropdown {
-        top: 100% !important;
-        right: 0px !important;
-        left: auto !important;
-        margin-top: 0;
-
-        ul li {
-          float: none;
-        }
-      }
-    }
-  }
-
   .activity-comment {
     margin-top: 15px;
   }
@@ -203,6 +208,14 @@ body.controller-work_packages.action-show {
   }
 }
 
+@media only screen and (max-width: 679px) {
+  #toolbar {
+    #toolbar-items {
+      margin-left: 0;
+    }
+  }
+}
+
 #work-packages-index {
   .wiki-anchor {
     display: none;
@@ -213,16 +226,16 @@ body.controller-work_packages.action-show {
   padding-right: 20px;
 
   .subject-header {
-    float: left;
-    margin-right: -470px;
-    margin-top: 0;
-    padding: 10px 470px 0 0;
-    width: 100%;
+    margin: 0;
+    padding: 0;
+    min-height: 50px;
+    width: initial;
+    align-self: center;
+    flex-grow: 1;
 
-    .subject-header-inner {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 100%;
+
+    .wp-table--cell-span {
+      white-space: normal;
     }
 
     li .inline-edit { width: 100%; }


### PR DESCRIPTION
WP with long headers take way too much space on smaller screens. This PR allow such headers to move below the toolbar and use the space like it is in mobile view.

https://community.openproject.com/work_packages/23969/activity
