### PR TITLE
[23883] Remove padding from drop down icons in top menu

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -115,7 +115,7 @@
       &:after
         @include icon-common
         font-size: 10px
-        padding: 0 2px 0 9px
+        padding: 0 0 0 9px
         @extend .icon-pulldown:before
     &:hover
       background-color: $header-item-bg-hover-color


### PR DESCRIPTION
This removes the padding from dropdown icons in the top menu.

https://community.openproject.com/work_packages/23883/activity
