### PR TITLE
[23911] Reduce width of WP table pagination

### DIFF
--- a/app/assets/stylesheets/content/_pagination.sass
+++ b/app/assets/stylesheets/content/_pagination.sass
@@ -89,11 +89,11 @@ $pagination--font-size: 0.8125rem
       background: #eaeaea
 
 .pagination--space
-  width: 25px
   background: #ffffff
   border: 1px solid #ffffff
   font-style: italic
   padding: 3px 0
+  margin: 0 5px 0 0
 
 .pagination--label
   +flex(1)

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
@@ -6,11 +6,10 @@
         <a ng-click="showPage(paginationOptions.page - 1)"
            rel="prev start"
            aria-label="{{ ::text.label_previous }}"
-           ng-bind="::text.previous"
            data-click-on-keypress="[13, 32]"
            id= "pagination--prev-link"
            role="link"
-           href=""></a>
+           href="">&#60;</a>
       </li>
 
       <li ng-if="prePageNumbers.length" ng-repeat="pageNumber in prePageNumbers"
@@ -55,10 +54,9 @@
            class="pagination--next-link"
            aria-label="{{ ::text.label_next }}"
            data-click-on-keypress="[13, 32]"
-           ng-bind="::text.next"
            id="pagination--next-link"
            role="link"
-           href=""></a>
+           href="">&#62;</a>
       </li>
 
       <li class="pagination--range">

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.js
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.js
@@ -44,9 +44,7 @@ function tablePagination(PaginationService) {
       scope.I18n = I18n;
       scope.paginationOptions = PaginationService.getPaginationOptions();
       scope.text = {
-        previous: I18n.t('js.label_previous'),
         label_previous: I18n.t('js.pagination.pages.previous'),
-        next: I18n.t('js.label_next'),
         label_next: I18n.t('js.pagination.pages.next'),
         per_page: I18n.t('js.label_per_page'),
         no_other_page: I18n.t('js.pagination.no_other_page')
@@ -99,16 +97,24 @@ function tablePagination(PaginationService) {
           pageNumbers.push(i);
         }
 
-        scope.prePageNumbers = truncatePageNums(pageNumbers, PaginationService.getPage() >= maxVisible, 0, Math.min(PaginationService.getPage() - Math.ceil(maxVisible / 2), pageNumbers.length - maxVisible), truncSize);
-        scope.postPageNumbers = truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible, pageNumbers.length, 0);
+        // This avoids a truncation when there are not enough elements to truncate for the first elements
+        var startingDiff = PaginationService.getPage() - 2 * truncSize;
+        if ( 0 <= startingDiff && startingDiff <= 1 ) {
+          scope.postPageNumbers = truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible + truncSize, pageNumbers.length, 0);
+        }
+        else {
+          scope.prePageNumbers = truncatePageNums(pageNumbers, PaginationService.getPage() >= maxVisible, 0, Math.min(PaginationService.getPage() - Math.ceil(maxVisible / 2), pageNumbers.length - maxVisible), truncSize);
+          scope.postPageNumbers = truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible, pageNumbers.length, 0);
+        }
+
         scope.pageNumbers = pageNumbers;
       }
 
       function truncatePageNums(pageNumbers, perform, disectFrom, disectLength, truncateFrom){
         if (perform){
-          var tuncationSize = PaginationService.getOptionsTruncationSize();
+          var truncationSize = PaginationService.getOptionsTruncationSize();
           var truncatedNums = pageNumbers.splice(disectFrom, disectLength);
-          if (truncatedNums.length >= tuncationSize * 2) truncatedNums.splice(truncateFrom, truncatedNums.length - tuncationSize);
+          if (truncatedNums.length >= truncationSize * 2) truncatedNums.splice(truncateFrom, truncatedNums.length - truncationSize);
           return truncatedNums;
         } else {
           return [];

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.js
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.js
@@ -104,7 +104,7 @@ describe('tablePagination Directive', function () {
 
       scope.tableEntries = 101;
       scope.$apply();
-      expect(numberOfPageNumberLinks()).to.eq(8);
+      expect(numberOfPageNumberLinks()).to.eq(7);
     });
   });
 

--- a/frontend/app/work_packages/config/index.js
+++ b/frontend/app/work_packages/config/index.js
@@ -77,5 +77,5 @@ angular.module('openproject.workPackages.config')
   perPage: 10,
   perPageOptions: [10, 100, 500, 1000],
   maxVisiblePageOptions: 6,
-  optionsTruncationSize: 2
+  optionsTruncationSize: 1
 });


### PR DESCRIPTION
This PR does two things:
1. A bug in the pagination is fixed: The truncation sign was shown although nothing was truncated. (This happened when being on page 6)
2. The overall width of the pagination is reduced. Thus the appearance of scrollbars is delayed.

https://community.openproject.com/work_packages/23911/activity
