### PR TITLE
Extending the backend with new relation types / methods

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -53,7 +53,7 @@ class Relation < ActiveRecord::Base
             TYPE_PRECEDES =>    { name: :label_precedes, sym_name: :label_follows, order: 6, sym: TYPE_FOLLOWS },
             TYPE_FOLLOWS =>     { name: :label_follows, sym_name: :label_precedes, order: 7, sym: TYPE_PRECEDES, reverse: TYPE_PRECEDES },
             TYPE_INCLUDES =>    { name: :label_includes, sym_name: :label_includes, order: 8, sym: TYPE_INCLUDES, reverse: TYPE_PARTOF },
-            TYPE_PARTOF =>      { name: :label_part_of, sym_name: :label_partof, order: 9, sym: TYPE_PARTOF, reverse: TYPE_INCLUDES },
+            TYPE_PARTOF =>      { name: :label_part_of, sym_name: :label_part_of, order: 9, sym: TYPE_PARTOF, reverse: TYPE_INCLUDES },
             TYPE_REQUIRES =>    { name: :label_requires, sym_name: :label_requires, order: 10, sym: TYPE_REQUIRES, reverse: TYPE_REQUIRED },
             TYPE_REQUIRED =>  { name: :label_required, sym_name: :label_required, order: 11, sym: TYPE_REQUIRED, reverse: TYPE_REQUIRES }
           }.freeze

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -40,6 +40,10 @@ class Relation < ActiveRecord::Base
   TYPE_BLOCKED      = 'blocked'
   TYPE_PRECEDES     = 'precedes'
   TYPE_FOLLOWS      = 'follows'
+  TYPE_INCLUDES     = 'includes'
+  TYPE_PARTOF       = 'partof'
+  TYPE_REQUIRES     = 'requires'
+  TYPE_REQUIRED     = 'required'
 
   TYPES = { TYPE_RELATES =>     { name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: TYPE_RELATES },
             TYPE_DUPLICATES =>  { name: :label_duplicates, sym_name: :label_duplicated_by, order: 2, sym: TYPE_DUPLICATED },
@@ -47,7 +51,11 @@ class Relation < ActiveRecord::Base
             TYPE_BLOCKS =>      { name: :label_blocks, sym_name: :label_blocked_by, order: 4, sym: TYPE_BLOCKED },
             TYPE_BLOCKED =>     { name: :label_blocked_by, sym_name: :label_blocks, order: 5, sym: TYPE_BLOCKS, reverse: TYPE_BLOCKS },
             TYPE_PRECEDES =>    { name: :label_precedes, sym_name: :label_follows, order: 6, sym: TYPE_FOLLOWS },
-            TYPE_FOLLOWS =>     { name: :label_follows, sym_name: :label_precedes, order: 7, sym: TYPE_PRECEDES, reverse: TYPE_PRECEDES }
+            TYPE_FOLLOWS =>     { name: :label_follows, sym_name: :label_precedes, order: 7, sym: TYPE_PRECEDES, reverse: TYPE_PRECEDES },
+            TYPE_INCLUDES =>    { name: :label_includes, sym_name: :label_includes, order: 8, sym: TYPE_INCLUDES, reverse: TYPE_PARTOF },
+            TYPE_PARTOF =>      { name: :label_part_of, sym_name: :label_partof, order: 9, sym: TYPE_PARTOF, reverse: TYPE_INCLUDES },
+            TYPE_REQUIRES =>    { name: :label_requires, sym_name: :label_requires, order: 10, sym: TYPE_REQUIRES, reverse: TYPE_REQUIRED },
+            TYPE_REQUIRED =>  { name: :label_required, sym_name: :label_required, order: 11, sym: TYPE_REQUIRED, reverse: TYPE_REQUIRES }
           }.freeze
 
   validates_presence_of :from, :to, :relation_type
@@ -84,7 +92,7 @@ class Relation < ActiveRecord::Base
   end
 
   def label_for(work_package)
-    TYPES[relation_type] ? TYPES[relation_type][(from_id == work_package.id) ? :name : :sym_name] : :unknow
+    TYPES[relation_type] ? TYPES[relation_type][(from_id == work_package.id) ? :name : :sym_name] : :unknown
   end
 
   def update_schedule

--- a/db/migrate/20160906113438_add_description_field_to_relations.rb
+++ b/db/migrate/20160906113438_add_description_field_to_relations.rb
@@ -1,0 +1,5 @@
+class AddDescriptionFieldToRelations < ActiveRecord::Migration
+  def change
+    add_column :relations, :description, :string, null: true
+  end
+end

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -67,7 +67,18 @@ module API
                                        context: represented.from.project)
         end
 
+        link :updateRelation do
+          {
+            href: api_v3_paths.work_package_relation(represented.id, represented.from.id),
+            method: :patch,
+            title: 'Update Relation'
+          } if current_user_allowed_to(:manage_work_package_relations,
+                                                  context: represented.from.project)
+        end
+
         property :delay, render_nil: true, if: -> (*) { relation_type == 'precedes' }
+
+        property :description, getter: -> (*) { description }
 
         def _type
           "Relation::#{relation_type}"

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -48,7 +48,9 @@ module API
             optional :to_id, desc: 'Id of related work package'
             optional :relation_type, desc: 'Type of relationship'
             optional :delay
+            optional :description
           end
+
           post do
             authorize(:manage_work_package_relations, context: @work_package.project)
             declared_params = declared(params).reject { |key, value| key.to_sym == :id || value.nil? }
@@ -57,6 +59,7 @@ module API
               r.to = WorkPackage.visible.find_by(id: declared_params[:to_id].match(/\d+/).to_s)
               r.relation_type = declared_params[:relation_type]
               r.delay = declared_params[:delay_id]
+              r.description = declared_params[:description]
             end
 
             if relation.valid? && relation.save
@@ -74,6 +77,27 @@ module API
               authorize(:manage_work_package_relations, context: @work_package.project)
               Relation.destroy(params[:relation_id])
               status 204
+            end
+
+            patch do
+              authorize(:manage_work_package_relations, context: @work_package.project)
+              # TODO: Jens, Oliver, Markus => please change this to allow :description and :relation_type
+              # as optional parameters and combine them in one single update query...
+
+              if params[:description].present?
+                if Relation.update(params[:relation_id], :description => params[:description])
+                  status 204
+                else
+                  fail ::API::Errors::Validation.new(nil, 'could not update description')
+                end
+              end
+              if params[:relation_type].present?
+                if Relation.update(params[:relation_id], :relation_type => params[:relation_type])
+                  status 204
+                else
+                  fail ::API::Errors::Validation.new(nil, 'could not update relation type')
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
This extends the available relations configuration with following types:
- includes / part of
- requires / required by

Furthermore it adds a patch method for updating relations.

@machisuji @ulferts 
