### PR TITLE
[23995] Apply multiple columns at Admin/Roles page (Core)

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -147,6 +147,9 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
     width: 1rem
     z-index: 2
 
+  .-columns-2
+    column-count: 2
+
 .form--separator
   border: 0
   border-bottom: 1px solid $content-form-separator-color

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -30,10 +30,10 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'role' %>
 
 <% unless @role.builtin? %>
-  <section class="form--section">
-    <div class="form--field"><%= f.text_field :name, required: true %></div>
-    <div class="form--field"><%= f.check_box :assignable %></div>
-    <% if @role.new_record? && @roles.any? %>
+  <div class="form--field"><%= f.text_field :name, required: true %></div>
+  <div class="form--field"><%= f.check_box :assignable %></div>
+  <% if @role.new_record? && @roles.any? %>
+    <div id="member_attributes">
       <div class="form--field">
         <%= styled_label_tag 'copy_workflow_from', l(:label_copy_workflow_from) %>
         <div class="form--field-container">
@@ -41,15 +41,15 @@ See doc/COPYRIGHT.rdoc for more details.
                 content_tag("option") + options_from_collection_for_select(@roles, :id, :name)) %>
         </div>
       </div>
-    <% end %>
-  </section>
+    </div>
+  <% end %>
 <% end %>
 
-<h3 class="form--section-title"><%= l(:label_permissions) %></h3>
-<section class="form--section" id="permissions">
-  <div class="grid-block small-up-2 medium-up-3 large-up-4">
-    <% perms_by_module = @permissions.group_by {|p| p.project_module.to_s} %>
-    <% perms_by_module.keys.sort.each do |mod| %>
+<div id="member_permissions">
+  <% perms_by_module = @permissions.group_by {|p| p.project_module.to_s} %>
+  <% perms_by_module.keys.sort.each do |mod| %>
+    <% module_name = mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>
+    <fieldset class="form--fieldset -collapsible" id="<%= module_name %>">
       <% module_name = mod.blank? ? "form--" + I18n.t('attributes.project') : "form--" + l_or_humanize(mod, prefix: 'project_module_').gsub(' ','_') %>
       <div class="grid-section">
         <fieldset class="form--fieldset -collapsible" id= "<%= module_name %>">
@@ -59,18 +59,20 @@ See doc/COPYRIGHT.rdoc for more details.
               (<%= check_all_links module_name %>)
             </span>
           </div>
-          <div class="autoscroll">
+          <div class="-columns-2">
             <% perms_by_module[mod].each do |permission| %>
-              <label class="form--label-with-check-box">
-                <%= styled_check_box_tag 'role[permissions][]', permission.name, (@role.permissions.include? permission.name) %>
-                <%= l_or_humanize(permission.name, prefix: 'permission_') %>
-              </label>
+              <div class="form--field autoscroll -trailing-label ">
+                <label class="form--label">
+                  <%= l_or_humanize(permission.name, prefix: 'permission_') %>
+                </label>
+                <div class="form--field-container">
+                  <%= styled_check_box_tag 'role[permissions][]', permission.name, (@role.permissions.include? permission.name) %>
+                </div>
+              </div>
             <% end %>
           </div>
         </fieldset>
       </div>
-    <% end %>
-  </div>
-  <%= check_all_links 'permissions' %>
-  <%= hidden_field_tag 'role[permissions][]', '' %>
-</section>
+    </fieldset>
+  <% end %>
+</div>


### PR DESCRIPTION
This adds the `-columns-2` class to enable a two column layout in forms. This was done in the scope of: https://github.com/finnlabs/openproject-global_roles/pull/66

Further the html structure of the core was adapted so that it is similar to the plugin.

https://community.openproject.com/work_packages/23995/activity
