### PR TITLE
improve query generated by spent time join

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -520,8 +520,10 @@ class WorkPackage < ActiveRecord::Base
   # patch in config/initializers/eager_load_with_hours, the value is
   # returned as the #hours attribute on each work package.
   def self.include_spent_hours(user)
-    WorkPackage::SpentTime.new(user).scope('time_per_wp')
-      .select('time_per_wp.hours')
+    WorkPackage::SpentTime
+      .new(user)
+      .scope
+      .select('SUM(time_entries.hours) AS hours')
   end
 
   # Returns the total number of hours spent on this work package and its descendants.
@@ -927,9 +929,9 @@ class WorkPackage < ActiveRecord::Base
   def compute_spent_hours(user)
     WorkPackage::SpentTime
       .new(user, self)
-      .scope('time_per_wp')
+      .scope
       .where(id: id)
-      .pluck('time_per_wp.hours')
+      .pluck('SUM(hours)')
       .first
   end
 end


### PR DESCRIPTION
The former query joined all work packages with their descendants which
resulted in a very poor performance.

Therefore, the query 

```
SELECT time_per_wp.hours, work_packages.*
FROM `work_packages` 
LEFT OUTER JOIN (SELECT `target`.`id`, SUM(`time_entries`.`hours`) AS hours FROM `work_packages` `target` 
    LEFT OUTER JOIN `work_packages` `descendants` ON `descendants`.`root_id` = `target`.`root_id` AND `descendants`.`lft` >= `target`.`lft` AND `descendants`.`rgt` <= `target`.`rgt` 
    INNER JOIN `projects` `descendants_projects` ON `descendants_projects`.`id` = `descendants`.`project_id` 
    INNER JOIN `time_entries` ON `time_entries`.`work_package_id` = `descendants`.`id` 
    WHERE `descendants_projects`.`id` IN (
        SELECT DISTINCT `projects`.`id` FROM `projects` 
        INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 
        WHERE `projects`.`status` = 1) 
    AND `time_entries`.`id` IN (
        SELECT `time_entries`.`id` FROM `time_entries` 
        WHERE (`time_entries`.`project_id` IN (
            SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) 
        OR `time_entries`.`project_id` IN (
            SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) 
        AND `time_entries`.`user_id` = 36)) 
    GROUP BY `target`.`id`) time_per_wp ON time_per_wp.`id` = `work_packages`.`id`  
WHERE `work_packages`.`id` IN (930, 929, 928, 927, 926, 925, 924, 923, 922, 921, 912, 851, 852, 842, 825, 824, 823, 826, 827, 822, 821, 820, 296)
```

would now be

```
SELECT work_packages.*, SUM(time_entries.hours) AS hours 
FROM `work_packages` 
LEFT OUTER JOIN `work_packages` `descendants` 
    ON `descendants`.`root_id` = `work_packages`.`root_id` 
    AND `descendants`.`lft` >= `work_packages`.`lft` AND `descendants`.`rgt` <= `work_packages`.`rgt`
    AND `descendants`.`project_id`IN (
        SELECT DISTINCT `projects`.`id` FROM `projects`
        INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 
        WHERE `projects`.`status` = 1) 
LEFT OUTER JOIN `time_entries` 
    ON `time_entries`.`work_package_id` = `descendants`.`id` 
    AND `time_entries`.`project_id` IN (
        SELECT DISTINCT `projects`.`id` FROM `projects` 
        INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 
        WHERE `projects`.`status` = 1) 
    AND `time_entries`.`user_id` = 36 
WHERE `work_packages`.`id` IN (930, 929, 928, 927, 926, 925, 924, 923, 922, 921, 912, 851, 852, 842, 825, 824, 823, 826, 827, 822, 821, 820, 296) 
GROUP BY `work_packages`.`id`
```

https://community.openproject.com/work_packages/23983/activity
