### PR TITLE
Fix/parent project relation copied

### DIFF
--- a/app/controllers/copy_projects_controller.rb
+++ b/app/controllers/copy_projects_controller.rb
@@ -32,27 +32,25 @@ class CopyProjectsController < ApplicationController
 
   before_action :disable_api
   before_action :find_project
-  before_action :authorize, only: [:copy, :copy_project]
-  before_action :prepare_for_copy_project, only: [:copy, :copy_project]
+  before_action :authorize
+  before_action :prepare_for_copy_project
 
   def copy
-    target_project_name = permitted_params.project[:name]
-    @copy_project = Project.new
-    @copy_project.attributes = permitted_params.project
+    @copy_project = project_copy
+
     if @copy_project.valid?
-      modules = permitted_params.project[:enabled_module_names] || params[:enabled_modules]
+      target_project_params = @copy_project.attributes.compact
 
       copy_project_job = CopyProjectJob.new(user_id: User.current.id,
                                             source_project_id: @project.id,
-                                            target_project_params: permitted_params.project.to_hash,
-                                            enabled_modules: modules,
+                                            target_project_params: target_project_params,
                                             associations_to_copy: params[:only],
                                             send_mails: params[:notifications] == '1')
 
       Delayed::Job.enqueue copy_project_job
       flash[:notice] = I18n.t('copy_project.started',
                               source_project_name: @project.name,
-                              target_project_name: target_project_name)
+                              target_project_name: permitted_params.project[:name])
       redirect_to origin
     else
       from = (['admin', 'settings'].include?(params[:coming_from]) ? params[:coming_from] : 'settings')
@@ -74,6 +72,18 @@ class CopyProjectsController < ApplicationController
   end
 
   private
+
+  def project_copy
+    copy_project = Project.new
+    copy_project.attributes = permitted_params.project
+
+    # cannot use set_allowed_parent! as it requires a persisted project
+    if copy_project.allowed_parent?(params['project']['parent_id'])
+      copy_project.parent_id = params['project']['parent_id']
+    end
+
+    copy_project
+  end
 
   def origin
     params[:coming_from] == 'admin' ? admin_projects_path : settings_project_path(@project.id)

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -278,7 +278,7 @@ class PermittedParams
                                  :comments_sorting, :warn_on_leaving_unsaved)
   end
 
-  def project(instance = nil)
+  def project
     whitelist = params.require(:project).permit(:name,
                                                 :description,
                                                 :is_public,
@@ -289,15 +289,6 @@ class PermittedParams
                                                 work_package_custom_field_ids: [],
                                                 type_ids: [],
                                                 enabled_module_names: [])
-
-    if instance &&
-       (instance.new_record? || current_user.allowed_to?(:select_project_modules, instance))
-      whitelist.permit(enabled_module_names: [])
-    end
-
-    if instance && current_user.allowed_to?(:add_subprojects, instance)
-      whitelist.permit(:parent_id)
-    end
 
     unless params[:project][:custom_field_values].nil?
       # Permit the sub-hash for custom_field_values

--- a/app/views/copy_projects/copy_from_admin.html.erb
+++ b/app/views/copy_projects/copy_from_admin.html.erb
@@ -36,10 +36,10 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <%= render partial: 'projects/form', locals: { f: f,
                                                  project: @copy_project,
-                                                 render_advanced: false,
-                                                 render_types: true,
-                                                 render_modules: true,
-                                                 render_custom_fields: true
+                                                 render_advanced: true,
+                                                 render_types: false,
+                                                 render_modules: false,
+                                                 render_custom_fields: false
                                                } %>
 
   <%= render partial: "copy_projects/copy_settings/copy_associations", locals: { project: @project } %>

--- a/app/views/copy_projects/copy_from_settings.html.erb
+++ b/app/views/copy_projects/copy_from_settings.html.erb
@@ -31,27 +31,15 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_project_new) %>
 
 <%= labelled_tabular_form_for @copy_project, url: { action: 'copy', coming_from: 'settings' } do |f| %>
-  <section class="form--section">
-    <%= render partial: "projects/form/attributes/name", locals: { form: f } %>
-    <%= render partial: "projects/form/attributes/identifier", locals: { form: f,
-                                                                               project: @copy_project } %>
-    <%= render partial: "projects/form/attributes/description", locals: { form: f } %>
-    <%= render partial: "customizable/form", locals: { project: @project, form: f, all_fields: true, only_required: false } %>
-    <%= render partial: "projects/form/attributes/responsible_id", locals: { form: f,
-                                                                                   project: @project } %>
-    <%= render partial: "projects/form/attributes/hidden_field",
-               locals: { form: f, name: :project_type_id, value: @project.project_type_id } %>
-    <%= render partial: "projects/form/attributes/hidden_field",
-               locals: { form: f, name: :parent_id, value: @project.parent_id } %>
-    <%= render partial: "projects/form/attributes/hidden_field",
-               locals: { form: f, name: :is_public, value: @project.is_public } %>
-    <%= render partial: "copy_projects/copy_settings/hidden_types",
-               locals: { form: f, types: @types, project: @project } %>
-    <%= render partial: "copy_projects/copy_settings/hidden_custom_fields",
-               locals: { form: f, project: @project, issue_custom_fields: @issue_custom_fields } %>
-    <%= render partial: "copy_projects/copy_settings/enabled_module_names",
-               locals: { project: @project } %>
-  </section>
+  <%= hidden_field_tag :coming_from, 'settings' %>
+
+  <%= render partial: 'projects/form', locals: { f: f,
+                                                 project: @copy_project,
+                                                 render_advanced: true,
+                                                 render_types: false,
+                                                 render_modules: false,
+                                                 render_custom_fields: false
+                                               } %>
 
   <%= render partial: "copy_projects/copy_settings/copy_associations", locals: { project: @project } %>
 

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -67,25 +67,7 @@ Feature: Project Settings
     And  I go to the members tab of the settings page of the project "project1"
     Then I should not see "Copy" within "#content"
 
-  Scenario: Check for differences in admin's and settings' copy
-    When I am already admin
-    And  I go to the admin page
-    And  I follow "Projects" within "#main-menu"
-    #just one project, so we should be fine
-    And  I click on "Copy" within "#content"
-    Then I should see "Modules" within "#content"
-    When I go to the settings page of the project "project1"
-    And  I follow "Copy" within "#content"
-    Then I should not see "Modules" within "#content"
-
-  Scenario: Check for presence and default status of the copying parameters
-    When I am already admin
-    When I go to the settings page of the project "project1"
-    And  I follow "Copy" within "#content"
-    Then the "Identifier" field should not contain "project1" within "#content"
-    And  the "Name" field should not contain "project1" within "#content"
-
-
+  @javascript
   Scenario: Copy a project with parent
     Given there are the following projects of type "Copy Project":
       | project2 |
@@ -95,13 +77,12 @@ Feature: Project Settings
     And  I click on "Save" within "#content"
     And  I follow "Copy" within "#content"
     And  I fill in "Name" with "Copied Project"
-    And  I fill in "Identifier" with "cp"
     And  I click on "Copy"
     Then I should see "Started to copy project"
-    And  I go to the settings page of the project "cp"
+    And  I go to the settings page of the project "copied-project"
     And  I should see "project2" within "#project_parent_id"
 
-
+  @javascript
   Scenario: Copy a project with types
     Given the following types are enabled for the project called "project1":
         | Name      |
@@ -111,15 +92,14 @@ Feature: Project Settings
     And  I go to the settings page of the project "project1"
     And  I follow "Copy" within "#content"
     And  I fill in "Name" with "Copied Project"
-    And  I fill in "Identifier" with "cp"
     And  I click on "Copy"
     Then I should see "Started to copy project"
-    And  I go to the settings page of the project "cp"
+    And  I go to the settings page of the project "copied-project"
     And  I follow "Types" within "#content"
     Then the "Phase1" checkbox should be checked
     And  the "Phase2" checkbox should be checked
 
-
+  @javascript
   Scenario: Copy a project with Custom Fields
     Given the following work package custom fields are defined:
       | name  | type | editable | is_for_all |
@@ -130,10 +110,9 @@ Feature: Project Settings
     And  I press "Save"
     And  I follow "Copy"
     And  I fill in "Name" with "Copied Project"
-    And  I fill in "Identifier" with "cp"
     And  I click on "Copy"
     Then I should see "Started to copy project"
-    And  I go to the custom_fields tab of the settings page of the project "cp"
+    And  I go to the custom_fields tab of the settings page of the project "copied-project"
     Then the "cfBug" checkbox should be checked
 
   @javascript
@@ -146,34 +125,12 @@ Feature: Project Settings
     And   I go to the settings page of the project "project1"
     And   I follow "Copy" within "#content"
     And   I fill in "Name" with "Copied Project"
-    And   I fill in "Identifier" with "cp"
     And   I check "Work packages"
     And   I click on "Copy"
     Then  I should see "Started to copy project"
     And   I go to the work packages index page for the project "Copied Project"
     Then  I should see "issue1" within "#content"
     And   I should see "issue2" within "#content"
-
-  @javascript
-  Scenario: Copying a project with some planning elements
-    Given there are the following work packages in project "project1":
-      | subject | start_date | due_date   |
-      | pe1     | 2013-01-01 | 2013-12-31 |
-    And   there are the following work packages in project "project1":
-      | subject | start_date | due_date   |
-      | pe2     | 2013-01-01 | 2013-12-31 |
-    When  I am already admin
-    And   I go to the settings page of the project "project1"
-    And   I follow "Copy" within "#content"
-    And   I fill in "Name" with "Copied Project"
-    And   I fill in "Identifier" with "cp"
-    And   I check "Work packages"
-    And   I click on "Copy"
-    Then  I should see "Started to copy project"
-    And   I go to the page of the planning element "pe1" of the project called "Copied Project"
-    Then  I should see "pe1" within "#content"
-    And   I go to the page of the planning element "pe2" of the project called "Copied Project"
-    Then  I should see "pe2" within "#content"
 
   @javascript
   Scenario: Copying a project with a complex issue
@@ -195,7 +152,6 @@ Feature: Project Settings
     And  I go to the settings page of the project "project1"
     And  I follow "Copy" within "#content"
     And  I fill in "Name" with "Copied Project"
-    And  I fill in "Identifier" with "cp"
     And  I check "Work packages"
     And  I click on "Copy"
     Then I should see "Started to copy project"

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -111,8 +111,9 @@ describe CopyProjectsController, type: :controller do
 
     it { expect(Project.count).to eq(2) }
 
-    it 'copied project enables modules specified in params' do
-      expect(Project.order(:id).last.enabled_modules.map(&:name)).to match_array(['work_package_tracking', 'boards'])
+    it 'copied project enables modules of source project' do
+      expect(Project.order(:id).last.enabled_modules.map(&:name))
+        .to match_array(project.enabled_modules.map(&:name))
     end
 
     it_behaves_like 'successful copy' do

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -48,7 +48,6 @@ describe CopyProjectJob, type: :model do
       CopyProjectJob.new user_id: user_de.id,
                          source_project_id: source_project.id,
                          target_project_params: target_project,
-                         enabled_modules: [],
                          associations_to_copy: []
     }
 
@@ -86,7 +85,6 @@ describe CopyProjectJob, type: :model do
       CopyProjectJob.new user_id: admin.id,
                          source_project_id: source_project.id,
                          target_project_params: params,
-                         enabled_modules: [],
                          associations_to_copy: [:work_packages]
     } # send mails
     let(:params) { { name: 'Copy', identifier: 'copy', type_ids: [type.id], work_package_custom_field_ids: [custom_field.id] } }
@@ -107,7 +105,6 @@ describe CopyProjectJob, type: :model do
       @copied_project, @errors = copy_job.send(:create_project_copy,
                                                source_project,
                                                params,
-                                               [], # enabled modules
                                                [:work_packages], # associations
                                                false)
     end
@@ -126,7 +123,6 @@ describe CopyProjectJob, type: :model do
       copy_project_job = CopyProjectJob.new(user_id: user.id,
                                             source_project_id: project_to_copy.id,
                                             target_project_params: params,
-                                            enabled_modules: [],
                                             associations_to_copy: [:members])
       copy_project_job.perform
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -188,4 +188,114 @@ describe Project, type: :model do
       expect(project.types_used_by_work_packages).to match_array [project_work_package.type]
     end
   end
+
+  describe '#allowed_parent?' do
+    let(:project) { FactoryGirl.build_stubbed(:project) }
+    let(:other_project) { FactoryGirl.build_stubbed(:project) }
+    let(:another_project) { FactoryGirl.build_stubbed(:project) }
+
+    it 'is false for nil on a persisted project with no allowed parents' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([])
+
+      expect(project.allowed_parent?(nil)).to be_falsey
+    end
+
+    it 'is true for nil on a persisted project with allowed parents' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return(['something'])
+
+      expect(project.allowed_parent?(nil)).to be_truthy
+    end
+
+    it 'is true for nil on an unpersisted project with no allowed parents' do
+      project = FactoryGirl.build(:project)
+
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([])
+
+      expect(project.allowed_parent?(nil)).to be_truthy
+    end
+
+    it 'is false for blank on a persisted project with no allowed parents' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([])
+
+      expect(project.allowed_parent?('')).to be_falsey
+    end
+
+    it 'is true for blank on a persisted project with allowed parents' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return(['something'])
+
+      expect(project.allowed_parent?('')).to be_truthy
+    end
+
+    it 'is true for blank on an unpersisted project with no allowed parents' do
+      project = FactoryGirl.build(:project)
+
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([])
+
+      expect(project.allowed_parent?('')).to be_truthy
+    end
+
+    it 'is true for an id pointing to a project in allowed_parents' do
+      allow(Project)
+        .to receive(:find_by)
+        .with(id: 1)
+        .and_return(other_project)
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([other_project])
+
+      expect(project.allowed_parent?(1)).to be_truthy
+    end
+
+    it 'is false for an id pointing to a project in allowed_parents' do
+      allow(Project)
+        .to receive(:find_by)
+        .with(id: 1)
+        .and_return(other_project)
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([another_project])
+
+      expect(project.allowed_parent?(1)).to be_falsey
+    end
+
+    it 'is false for a non existing project id' do
+      allow(Project)
+        .to receive(:find_by)
+        .with(id: 1)
+        .and_return(nil)
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([other_project])
+
+      expect(project.allowed_parent?(1)).to be_falsey
+    end
+
+    it 'is true for a project in allowed_projects' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([other_project])
+
+      expect(project.allowed_parent?(other_project)).to be_truthy
+    end
+
+    it 'is false for a project not in allowed_projects' do
+      allow(project)
+        .to receive(:allowed_parents)
+        .and_return([another_project])
+
+      expect(project.allowed_parent?(other_project)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Fixes having the parent project kept when copying a project:

https://community.openproject.com/work_packages/23979/activity

It also removes dead code from permitted params and reduces the heterogeneity on the copy project pages compared to the new project page.
