### PR TITLE
Close dropdowns on state change

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -240,6 +240,9 @@ openprojectModule
     });
 
     $rootScope.$on('$stateChangeStart', (event, toState, toParams) => {
+      // Close all open dropdowns, if any
+      $rootScope.$broadcast('openproject.dropdown.closeDropdowns');
+
       if (!toParams.projects && toParams.projectPath) {
         toParams.projects = 'projects';
         $state.go(toState, toParams);


### PR DESCRIPTION
Dropdowns are closed on all click events, but not when moving to a
different state with ui-sref (regular link movement).
