### PR TITLE
Fix: declared_params being initialized with empty values breaks the creation of relations

### DIFF
--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -51,7 +51,7 @@ module API
           end
           post do
             authorize(:manage_work_package_relations, context: @work_package.project)
-            declared_params = declared(params).reject { |key, value| key.to_sym == :id || value.nil? }
+            declared_params = declared(params).with_indifferent_access.reject { |key, value| key == :id || value.nil? }
 
             relation = @work_package.new_relation.tap do |r|
               r.to = WorkPackage.visible.find_by(id: declared_params[:to_id].match(/\d+/).to_s)

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -51,7 +51,9 @@ module API
           end
           post do
             authorize(:manage_work_package_relations, context: @work_package.project)
-            declared_params = declared(params).with_indifferent_access.reject { |key, value| key == :id || value.nil? }
+            declared_params = declared(params)
+                              .with_indifferent_access
+                              .reject { |key, value| key == :id || value.nil? }
 
             relation = @work_package.new_relation.tap do |r|
               r.to = WorkPackage.visible.find_by(id: declared_params[:to_id].match(/\d+/).to_s)


### PR DESCRIPTION
`declared_params` is initialized with empty values and therefore all operations including `declared_params[:any]` fail.

Making use of `.with_indifferent_access` solves the problem.
