### PR TITLE
[23865] 	Add separate display Field for WP resources

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-work-package-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-work-package-field.directive.html
@@ -1,0 +1,12 @@
+<span ng-if="!$ctrl.field.isEmpty()" title="{{ $ctrl.displayText }}">
+
+  <a role="link"
+     title='{{ ::$ctrl.field.text.linkTitle }}'
+     ui-sref="work-packages.show({workPackageId: $ctrl.field.wpId})">
+    {{ $ctrl.displayText }}
+  </a>
+</span>
+
+<span ng-if="$ctrl.field.isEmpty()" title="{{ $ctrl.displayText }}">
+  {{ $ctrl.displayText }}
+</span>

--- a/frontend/app/components/wp-display/field-types/wp-display-work-package-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-work-package-field.module.ts
@@ -1,0 +1,67 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {DisplayField} from "../wp-display-field/wp-display-field.module";
+import {WorkPackageResource} from "../../api/api-v3/hal-resources/work-package-resource.service";
+
+export class WorkPackageDisplayField extends DisplayField {
+  public template: string = '/components/wp-display/field-types/wp-display-work-package-field.directive.html';
+  public text: Object;
+
+
+  constructor(public resource:WorkPackageResource,
+              public name:string,
+              public schema) {
+    super(resource, name, schema);
+
+    this.text = {
+      linkTitle: this.I18n.t('js.work_packages.message_successful_show_in_fullscreen')
+    };
+  }
+
+  public get value() {
+    return this.resource[this.name];
+  }
+
+  public get wpId() {
+    if (this.value.$loaded) {
+      return this.value.id;
+    }
+
+    // Read WP ID from href
+    return this.value.href.match(/(\d+)$/)[0];
+  }
+
+  public get valueString() {
+    return "#" + this.wpId;
+  }
+
+  public isEmpty(): boolean {
+    return !this.value;
+  }
+}

--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.config.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.config.ts
@@ -40,7 +40,7 @@ import {ProgressDisplayField} from '../field-types/wp-display-progress-field.mod
 import {openprojectModule} from '../../../angular-modules';
 import {SpentTimeDisplayField} from '../field-types/wp-display-spent-time-field.module';
 import {IntegerDisplayField} from "../field-types/wp-display-integer-field.module";
-
+import {WorkPackageDisplayField} from "../field-types/wp-display-work-package-field.module";
 
 openprojectModule
   .run((wpDisplayField:WorkPackageDisplayFieldService) => {
@@ -62,6 +62,7 @@ openprojectModule
       .addFieldType(DateTimeDisplayField, 'datetime', ['DateTime'])
       .addFieldType(BooleanDisplayField, 'boolean', ['Boolean'])
       .addFieldType(ProgressDisplayField, 'progress', ['percentageDone'])
+      .addFieldType(WorkPackageDisplayField, 'work_package', ['WorkPackage'])
       .addFieldType(SpentTimeDisplayField, 'spentTime', ['spentTime'])
       .addFieldType(IdDisplayField, 'id', ['id']);
   });


### PR DESCRIPTION
Adds a new WorkPackageDisplayField to display actual work package
resources in properties (e.g., parent) to avoid showing `[object Object]`.

Uses the link title as a description.

![workpackages_parentbug](https://cloud.githubusercontent.com/assets/459462/19143460/65e57a0e-8ba4-11e6-9160-3b173c2141cf.jpeg)
