### PR TITLE
[23926] Horizontal scrolling bar in add member form (2)

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -618,6 +618,10 @@ a.impaired--empty-link,
       margin-bottom: 1px
       flex-basis: 50%
 
+    &:not(.-with-button)
+      .form--field
+        overflow: hidden
+
   // Override default margin to allow correct vertical alignment
   #add-member--submit-button
     margin-bottom: 0


### PR DESCRIPTION
The resizing of the select2 box in the add member screen is buggy in some case. To avoid the resulting (unnecessary) scrollbar, the overflow is hidden here.

https://community.openproject.com/work_packages/23926/activity
