### PR TITLE
[23995] Apply multiple columns at Admin/Roles page (Core)(2)

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -147,8 +147,9 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
     width: 1rem
     z-index: 2
 
-  .-columns-2
-    column-count: 2
+  @media screen and (min-width: 70rem)
+    .-columns-2
+      column-count: 2
 
 .form--separator
   border: 0

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -61,12 +61,12 @@ See doc/COPYRIGHT.rdoc for more details.
           </div>
           <div class="-columns-2">
             <% perms_by_module[mod].each do |permission| %>
-              <div class="form--field autoscroll -trailing-label ">
-                <label class="form--label">
-                  <%= l_or_humanize(permission.name, prefix: 'permission_') %>
-                </label>
+              <div class="form--field">
                 <div class="form--field-container">
-                  <%= styled_check_box_tag 'role[permissions][]', permission.name, (@role.permissions.include? permission.name) %>
+                  <label class="form--label-with-check-box">
+                    <%= styled_check_box_tag 'role[permissions][]', permission.name, (@role.permissions.include? permission.name) %>
+                    <%= l_or_humanize(permission.name, prefix: 'permission_') %>
+                  </label>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
With the new implementation of the checkboxes in Admin/Roles there were some minor styling issues. These occurred because of a false usage of the `trailing-label` class. This PR changes the implementation to the `label-with-checkbox` class. 

https://community.openproject.com/work_packages/23995/activity

**Related** https://github.com/finnlabs/openproject-global_roles/pull/69
