### PR TITLE
[24033] Text field changes are not saved

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -284,6 +284,7 @@ export class WorkPackageEditFieldController {
 
   public reset() {
     this.workPackage.restoreFromPristine(this.fieldName);
+    delete this.workPackage.$pristine[this.fieldName];
     this.fieldForm.$setPristine();
     this.deactivate();
   }


### PR DESCRIPTION
When editing the description or a CF-Text field changes were sometimes not saved. When the cancel button was pressed once, future changes were not submitted any more.

https://community.openproject.com/work_packages/24033/activity
