### PR TITLE
[24033] Text field changes are not saved

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -272,6 +272,7 @@ export class WorkPackageEditFieldController {
 
   public reset() {
     this.workPackage.restoreFromPristine(this.fieldName);
+    delete this.workPackage.$pristine[this.fieldName];
     this.fieldForm.$setPristine();
     this.deactivate();
   }

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -28,8 +28,23 @@ describe 'description inplace editor', js: true, selenium: true do
   end
 
   context 'with permission' do
-    it 'shows the description field' do
+    it 'allows editing description field' do
       field.expect_state_text(description_text)
+
+      # Regression test #24033
+      # Cancelling an edition several tiems properly resets the value
+      field.activate!
+
+      field.set_value "My intermittent edit 1"
+      field.cancel_by_escape
+
+      field.activate!
+      field.set_value "My intermittent edit 2"
+      field.cancel_by_click
+
+      field.activate!
+      field.expect_value description_text
+      field.cancel_by_click
     end
   end
 


### PR DESCRIPTION
When editing the description or a CF-Text field changes were sometimes not saved. When the cancel button was pressed once, future changes were not submitted any more.

https://community.openproject.com/work_packages/24033/activity
