### PR TITLE
[23910] Submit the field when the datepicker is closed

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -1,6 +1,7 @@
 <op-date-picker
   tabindex="-1"
   on-change="vm.submit()"
+  on-close="vm.submit()"
   ng-model="vm.workPackage[vm.fieldName]">
 
   <input ng-model="vm.workPackage[vm.fieldName]"

--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
@@ -28,6 +28,7 @@
 
 interface OpDatePickerScope extends ng.IScope {
   onChange:Function;
+  onClose?:Function;
 }
 
 function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, attrs, ngModel) {
@@ -40,6 +41,7 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
   let datePickerInstance;
   let DatePicker = this.Datepicker;
   let onChange = scope.onChange;
+  let onClose = scope.onClose;
 
   let unbindNgModelInitializationWatch = scope.$watch(() => ngModel.$viewValue !== NaN, () => {
     // This indirection is needed to prevent
@@ -57,7 +59,8 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
   });
 
   function showDatePicker() {
-    let options = { onSelect: (date) => {
+    let options = {
+      onSelect: (date) => {
         datePickerInstance.hide();
 
         let val = date;
@@ -67,7 +70,8 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
         }
         ngModel.$setViewValue(val);
         onChange();
-      }
+      },
+      onClose: onClose
     };
     datePickerInstance = new DatePicker(input, ngModel.$viewValue, options);
 
@@ -90,6 +94,7 @@ function opDatePicker(ConfigurationService, Datepicker) {
     require: 'ngModel',
     scope: {
       onChange: '&',
+      onClose: '&',
     }
   };
 }


### PR DESCRIPTION
When switching between the first and second date field, the first field
is not saved since `ng-blur` is not used outside accessibility mode.

**Issue:** When fixing this, quickly switching to the next date as in the gif in the ticket below no longer works, since the fields are temporarily blocked/marked busy when saving. This is annoying but consistent with how the other fields behave. Maybe we can find something to avoid it? I believe that adding some kind of 'changeset' policy as in [23899](https://community.openproject.com/work_packages/23899) should solve that.

https://community.openproject.com/work_packages/23910
