### PR TITLE
Fix/relations accessibility

### DIFF
--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -94,7 +94,7 @@ body.accessibility-mode
       visibility: visible
 
   .wp-relations-controls-section .-shown-in-accessibility-mode
-    display: block !important
+    display: inline-block !important
 
   .wp-relations-create-button .relation-create
     width: calc(100% - 6px)

--- a/app/assets/stylesheets/specific/accessibility.sass
+++ b/app/assets/stylesheets/specific/accessibility.sass
@@ -92,3 +92,11 @@ body.accessibility-mode
       border-color: $inplace-edit--border-color
     .inplace-edit--icon-wrapper
       visibility: visible
+
+  .wp-relations-controls-section .-shown-in-accessibility-mode
+    display: block !important
+
+  .wp-relations-create-button .relation-create
+    width: calc(100% - 6px)
+    padding: 0
+    margin: 3px

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -282,7 +282,7 @@ en:
       add_parent: "Add existing parent"
       add_new_child: "Create new child"
       add_existing_child: "Add existing child"
-      remove_child: "Remove child work package"
+      remove_child: "Remove child"
       add_new_relation: "Create new relation"
       remove: "Remove relation"
       save: "Save relation"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -271,6 +271,8 @@ en:
       precedes: "Precedes"
       follows: "Follows"
 
+      relation_type: "relation type"
+
     relations_hierarchy:
       hierarchy_headline: "hierarchy"
 

--- a/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.directive.ts
@@ -18,6 +18,7 @@ class WpRelationRowDirectiveController {
   public relation:RelationResource = this.relatedWorkPackage.relatedBy;
 
   constructor(protected $scope:ng.IScope,
+              protected $timeout,
               protected wpCacheService:WorkPackageCacheService,
               protected wpNotificationsService:WorkPackageNotificationService,
               protected wpRelationsService:WorkPackageRelationsService,
@@ -45,6 +46,9 @@ class WpRelationRowDirectiveController {
         this.$scope.$emit('wp-relations.removed', this.relation);
         this.wpCacheService.updateWorkPackage(this.relatedWorkPackage);
         this.wpNotificationsService.showSave(this.relatedWorkPackage);
+        this.$timeout(() => {
+          angular.element('#relation--add-relation').focus();
+        });
       })
       .catch(err => this.wpNotificationsService.handleErrorResponse(err, this.relatedWorkPackage));
   }

--- a/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -25,6 +25,7 @@
             <accessible-by-keyboard ng-show="$ctrl.showRelationControls"
                                     ng-if="$ctrl.relation.remove"
                                     execute="$ctrl.removeRelation($ctrl.relation)"
+                                    aria-hidden="false"
                                     class="-shown-in-accessibility-mode">
                 <icon-wrapper icon-name="remove"
                               icon-title="{{ ::$ctrl.text.removeButton }}">

--- a/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -3,14 +3,14 @@
      ng-mouseleave="$ctrl.showRelationControls = false">
     <div class="grid-block hierarchy-item">
 
-        <div class="grid-content medium-3 collapse">
+        <div class="grid-content medium-3 collapse" aria-hidden="true">
             {{ $ctrl.relationType }}
         </div>
 
         <div class="grid-content medium-5 collapse" wp-single-relation
              ng-if="$ctrl.relatedWorkPackage">
             <a href="{{ singleRelationCtrl.workPackagePath($ctrl.relatedWorkPackage.id) }}"
-               title="{{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage, true) }}">
+               aria-label="{{ $ctrl.relationType + ' ' + singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage, true) }}">
                 {{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage, true) }}
             </a>
         </div>

--- a/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -24,7 +24,8 @@
         <div class="grid-content medium-1 collapse wp-relations-controls-section">
             <accessible-by-keyboard ng-show="$ctrl.showRelationControls"
                                     ng-if="$ctrl.relation.remove"
-                    execute="$ctrl.removeRelation($ctrl.relation)">
+                                    execute="$ctrl.removeRelation($ctrl.relation)"
+                                    class="-shown-in-accessibility-mode">
                 <icon-wrapper icon-name="remove"
                               icon-title="{{ ::$ctrl.text.removeButton }}">
                 </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
@@ -1,17 +1,20 @@
 <div>
-    <div class="wp-inline-create-button wp-relations-create-button -full-width"
+    <div class="wp-relations-create-button -full-width"
          ng-if="!$ctrl.showRelationsCreateForm">
         <div class="grid-block">
             <div class="grid-content collapse">
                 <a class="wp-inline-create--add-link relation-create"
-                   ng-click="$ctrl.createNewChildWorkPackage()">
+                   ng-click="$ctrl.createNewChildWorkPackage()"
+                   href>
                     <i class="icon icon-add"></i>
                     <span>{{ ::$ctrl.text.addNewChild }}</span>
                 </a>
             </div>
             <div class="grid-content collapse">
-                <a class="wp-inline-create--add-link relation-create"
-                   ng-click="$ctrl.toggleRelationsCreateForm()">
+                <a class="wp-inline-create--add-link relation-create -focus-after-save"
+                   ng-click="$ctrl.toggleRelationsCreateForm()"
+                   href
+                   id="hierarchy--add-exisiting-child">
                     <i class="icon icon-add"></i>
                     <span>{{ ::$ctrl.text.addExistingChild }}</span>
                 </a>
@@ -23,7 +26,8 @@
             <wp-relations-autocomplete
                     work-package="$ctrl.workPackage"
                     selected-wp-id="$ctrl.selectedWpId"
-                    selected-relation-type="$ctrl.selectedRelationType">
+                    selected-relation-type="$ctrl.selectedRelationType"
+                    focus>
 
             </wp-relations-autocomplete>
         </div>

--- a/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
@@ -33,13 +33,15 @@
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
             <accessible-by-keyboard
-                    execute="$ctrl.createRelation()">
+                    execute="$ctrl.createRelation()"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="checkmark"
                               icon-title="{{ ::$ctrl.text.save }}">
                 </icon-wrapper>
             </accessible-by-keyboard>
             <accessible-by-keyboard
-                    execute="$ctrl.toggleRelationsCreateForm()">
+                    execute="$ctrl.toggleRelationsCreateForm()"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="remove"
                               icon-title="{{ ::$ctrl.text.abort }}">
                 </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
@@ -9,13 +9,15 @@
     </div>
     <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
         <accessible-by-keyboard
-                execute="$ctrl.createRelation()">
+                execute="$ctrl.createRelation()"
+                aria-hidden="false">
             <icon-wrapper icon-name="checkmark"
                           icon-title="{{ ::$ctrl.text.save }}">
             </icon-wrapper>
         </accessible-by-keyboard>
         <accessible-by-keyboard
-                execute="$ctrl.toggleRelationsCreateForm()">
+                execute="$ctrl.toggleRelationsCreateForm()"
+                aria-hidden="false">
             <icon-wrapper icon-name="remove"
                           icon-title="{{ ::$ctrl.text.abort }}">
             </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
@@ -3,7 +3,8 @@
     <div class="grid-content medium-10 collapse">
         <wp-relations-autocomplete
                 selected-wp-id="$ctrl.selectedWpId"
-                selected-relation-type="$ctrl.selectedRelationType">
+                selected-relation-type="$ctrl.selectedRelationType"
+                focus>
         </wp-relations-autocomplete>
     </div>
     <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">

--- a/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
@@ -1,10 +1,12 @@
 <div class="wp-relations-create">
-    <div class="wp-inline-create-button wp-relations-create-button"
+    <div class="wp-relations-create-button"
          ng-if="!$ctrl.showRelationsCreateForm">
         <div class="grid-block">
             <div class="grid-content collapse wp-inline-create-button">
-                <a class="wp-inline-create--add-link relation-create"
-                   ng-click="$ctrl.toggleRelationsCreateForm()">
+                <a class="wp-inline-create--add-link relation-create -focus-after-save"
+                   ng-click="$ctrl.toggleRelationsCreateForm()"
+                   href
+                   id="relation--add-relation">
                     <i class="icon icon-add"></i>
                     <span>{{ ::$ctrl.text.addNewRelation }}</span>
                 </a>
@@ -16,7 +18,8 @@
             <select
                     class="relationTypeSelect"
                     ng-model="$ctrl.selectedRelationType"
-                    ng-options="relationType.label for relationType in $ctrl.relationTypes">
+                    ng-options="relationType.label for relationType in $ctrl.relationTypes"
+                    focus>
             </select>
         </div>
         <div class="grid-content medium-7">

--- a/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
@@ -16,8 +16,8 @@
     <div class="grid-block v-align" ng-if="$ctrl.showRelationsCreateForm">
         <div class="grid-content collapse medium-3">
             <label class="hidden-for-sighted" for="relation-type--select">{{ ::$ctrl.text.relationType }}</label>
-            <select
-                    class="relationTypeSelect"
+            <select ng-init="$ctrl.selectedRelationType = $ctrl.relationTypes[0]"
+                    class="form--select relationTypeSelect"
                     id="relation-type--select"
                     ng-model="$ctrl.selectedRelationType"
                     ng-options="relationType.label for relationType in $ctrl.relationTypes"

--- a/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
@@ -15,8 +15,10 @@
     </div>
     <div class="grid-block v-align" ng-if="$ctrl.showRelationsCreateForm">
         <div class="grid-content collapse medium-3">
+            <label class="hidden-for-sighted" for="relation-type--select">{{ ::$ctrl.text.relationType }}</label>
             <select
                     class="relationTypeSelect"
+                    id="relation-type--select"
                     ng-model="$ctrl.selectedRelationType"
                     ng-options="relationType.label for relationType in $ctrl.relationTypes"
                     focus>
@@ -31,13 +33,15 @@
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
             <accessible-by-keyboard
-                    execute="$ctrl.createRelation()">
+                    execute="$ctrl.createRelation()"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="checkmark"
                               icon-title="{{ ::$ctrl.text.save }}">
                 </icon-wrapper>
             </accessible-by-keyboard>
             <accessible-by-keyboard
-                    execute="$ctrl.toggleRelationsCreateForm()">
+                    execute="$ctrl.toggleRelationsCreateForm()"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="remove"
                               icon-title="{{ ::$ctrl.text.abort }}">
                 </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
@@ -26,13 +26,15 @@
         <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
             <accessible-by-keyboard
                     execute="$ctrl.createRelation()"
-                    class="wp-relations--save">
+                    class="wp-relations--save"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="checkmark"
                               icon-title="{{ ::$ctrl.text.save }}">
                 </icon-wrapper>
             </accessible-by-keyboard>
             <accessible-by-keyboard
-                    execute="$ctrl.toggleRelationsCreateForm()">
+                    execute="$ctrl.toggleRelationsCreateForm()"
+                    aria-hidden="false">
                 <icon-wrapper icon-name="remove"
                               icon-title="{{ ::$ctrl.text.abort }}">
                 </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
@@ -1,10 +1,12 @@
 <div class="wp-relations-create">
-    <div class="wp-inline-create-button wp-relations-create-button -full-width"
+    <div class="wp-relations-create-button -full-width"
          ng-if="!$ctrl.showRelationsCreateForm">
         <div class="grid-block">
             <div class="grid-content collapse wp-inline-create-button">
-                <a class="wp-inline-create--add-link relation-create"
-                   ng-click="$ctrl.toggleRelationsCreateForm()">
+                <a class="wp-inline-create--add-link relation-create -focus-after-save"
+                   ng-click="$ctrl.toggleRelationsCreateForm()"
+                   href
+                   id="hierarchy--add-parent">
                     <i class="icon icon-add"></i>
                     <span>{{ ::$ctrl.text.addParent }}</span>
                 </a>
@@ -17,12 +19,14 @@
             <wp-relations-autocomplete
                     work-package="$ctrl.workPackage"
                     selected-wp-id="$ctrl.selectedWpId"
-                    selected-relation-type="$ctrl.selectedRelationType">
+                    selected-relation-type="$ctrl.selectedRelationType"
+                    focus>
             </wp-relations-autocomplete>
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
             <accessible-by-keyboard
-                    execute="$ctrl.createRelation()">
+                    execute="$ctrl.createRelation()"
+                    class="wp-relations--save">
                 <icon-wrapper icon-name="checkmark"
                               icon-title="{{ ::$ctrl.text.save }}">
                 </icon-wrapper>

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
@@ -20,6 +20,8 @@ export class WorkPackageRelationsCreateController {
   constructor(protected I18n,
               protected $scope:ng.IScope,
               protected $rootScope:ng.IRootScopeService,
+              protected $element,
+              protected $timeout,
               protected wpRelationsService:WorkPackageRelationsService,
               protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
               protected wpNotificationsService:WorkPackageNotificationService,
@@ -72,6 +74,7 @@ export class WorkPackageRelationsCreateController {
   }
 
   protected changeParent() {
+    this.toggleRelationsCreateForm();
     this.wpRelationsHierarchyService.changeParent(this.workPackage, this.selectedWpId)
       .then(updatedWp => {
         console.log("wp after update", updatedWp)
@@ -80,9 +83,11 @@ export class WorkPackageRelationsCreateController {
           parentId: this.selectedWpId
         });
         this.wpNotificationsService.showSave(this.workPackage);
+        this.$timeout(() => {
+          angular.element('#hierarchy--parent').focus();
+        });
       })
       .catch(err => this.wpNotificationsService.handleErrorResponse(err, this.workPackage))
-      .finally(this.toggleRelationsCreateForm());
   }
 
   protected createCommonRelation() {
@@ -100,6 +105,12 @@ export class WorkPackageRelationsCreateController {
   public toggleRelationsCreateForm() {
     this.showRelationsCreateForm = !this.showRelationsCreateForm;
     this.externalFormToggle = !this.externalFormToggle;
+
+    this.$timeout(() => {
+      if (!this.showRelationsCreateForm) {
+        this.$element.find('.-focus-after-save').first().focus();
+      }
+    });
   }
 }
 

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
@@ -41,7 +41,8 @@ export class WorkPackageRelationsCreateController {
     addNewChild: this.I18n.t('js.relation_buttons.add_new_child'),
     addExistingChild: this.I18n.t('js.relation_buttons.add_existing_child'),
     addNewRelation: this.I18n.t('js.relation_buttons.add_new_relation'),
-    addParent: this.I18n.t('js.relation_buttons.add_parent')
+    addParent: this.I18n.t('js.relation_buttons.add_parent'),
+    relationType: this.I18n.t('js.relation_labels.relation_type')
   };
 
   public createRelation() {

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
@@ -12,6 +12,7 @@ class WpRelationsHierarchyRowDirectiveController {
   public workPackagePath = this.PathHelper.workPackagePath;
 
   constructor(protected $scope:ng.IScope,
+              protected $timeout,
               protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
               protected wpCacheService:WorkPackageCacheService,
               protected wpNotificationsService:WorkPackageNotificationService,
@@ -47,6 +48,9 @@ class WpRelationsHierarchyRowDirectiveController {
       this.wpRelationsHierarchyService.removeChild(this.relatedWorkPackage).then(exChildWp => {
         this.$scope.$emit('wp-relations.removedChild', exChildWp);
         this.wpNotificationsService.showSave(this.workPackage);
+        this.$timeout(() => {
+          angular.element('#hierarchy--add-exisiting-child').focus();
+        });
       })
       .catch(err => this.wpNotificationsService.handleErrorResponse(err, this.relatedWorkPackage));
   }
@@ -59,8 +63,12 @@ class WpRelationsHierarchyRowDirectiveController {
           parentId: null
         });
         this.wpNotificationsService.showSave(this.workPackage);
+        this.$timeout(() => {
+          angular.element('#hierarchy--add-parent').focus();
+        });
       })
       .catch(err => this.wpNotificationsService.handleErrorResponse(err, this.relatedWorkPackage));
+
   }
 }
 

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
@@ -25,7 +25,7 @@ class WpRelationsHierarchyRowDirectiveController {
   };
 
   public text = {
-    changeParent: this.I18n.t('js.relation_buttons.change_parent'),
+    change_parent: this.I18n.t('js.relation_buttons.change_parent'),
     remove: this.I18n.t('js.relation_buttons.remove')
   };
 

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
@@ -26,7 +26,11 @@ class WpRelationsHierarchyRowDirectiveController {
 
   public text = {
     change_parent: this.I18n.t('js.relation_buttons.change_parent'),
-    remove: this.I18n.t('js.relation_buttons.remove')
+    remove_parent: this.I18n.t('js.relation_buttons.remove_parent'),
+    remove_child: this.I18n.t('js.relation_buttons.remove_child'),
+    remove: this.I18n.t('js.relation_buttons.remove'),
+    parent: this.I18n.t('js.relation_labels.parent'),
+    children: this.I18n.t('js.relation_labels.children')
   };
 
   public removeRelation() {
@@ -40,6 +44,12 @@ class WpRelationsHierarchyRowDirectiveController {
 
   public isCurrentElement() {
     if (this.relationType !== 'child' && this.relationType !== 'parent') {
+      return true;
+    }
+  }
+
+  public isParent() {
+    if (this.relationType === 'parent') {
       return true;
     }
   }

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.directive.ts
@@ -49,9 +49,7 @@ class WpRelationsHierarchyRowDirectiveController {
   }
 
   public isParent() {
-    if (this.relationType === 'parent') {
-      return true;
-    }
+    return this.relationType === 'parent';
   }
 
   protected removeChild() {

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
@@ -8,7 +8,8 @@
                   class="wp-relations-hierarchy-subject">
                 <a href="{{ singleRelationCtrl.workPackagePath($ctrl.relatedWorkPackage.id) }}"
                    title="{{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage) }}"
-                   ng-if="!$ctrl.isCurrentElement()">
+                   ng-if="!$ctrl.isCurrentElement()"
+                   ng-attr-id="{{ $ctrl.relationType === 'parent' ? 'hierarchy--parent' : ''}}">
                     {{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage) }}
                 </a>
                 <span ng-if="$ctrl.isCurrentElement()"
@@ -24,8 +25,9 @@
             </div>
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section">
-            <div ng-hide="!$ctrl.showRelationControls">
+            <div ng-hide="!$ctrl.showRelationControls" class="-shown-in-accessibility-mode">
                 <accessible-by-keyboard ng-hide="$ctrl.relationType !== 'parent'"
+                                        aria-label="{{ ::$ctrl.text.change_parent }}"
                                         execute="$ctrl.showEditForm = true">
                     <icon-wrapper icon-name="edit"
                                   icon-title="{{ ::$ctrl.text.change_parent }}">

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
@@ -25,22 +25,25 @@
             </div>
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section">
-            <div ng-hide="!$ctrl.showRelationControls" class="-shown-in-accessibility-mode">
-                <accessible-by-keyboard ng-hide="$ctrl.relationType !== 'parent'"
-                                        aria-label="{{ ::$ctrl.text.change_parent }}"
-                                        execute="$ctrl.showEditForm = true">
-                    <icon-wrapper icon-name="edit"
-                                  icon-title="{{ ::$ctrl.text.change_parent }}">
-                    </icon-wrapper>
-                </accessible-by-keyboard>
+          <accessible-by-keyboard ng-show="$ctrl.showRelationControls"
+                                  ng-if="$ctrl.relationType === 'parent'"
+                                  aria-hidden="false"
+                                  execute="$ctrl.showEditForm = true"
+                                  class="-shown-in-accessibility-mode">
+              <icon-wrapper icon-name="edit"
+                            icon-title="{{ ::$ctrl.text.change_parent }}">
+              </icon-wrapper>
+          </accessible-by-keyboard>
 
-                <accessible-by-keyboard ng-hide="!$ctrl.relationType"
-                        execute="$ctrl.removeRelation()">
-                    <icon-wrapper icon-name="remove"
-                                  icon-title="{{ ::$ctrl.text.remove }}">
-                    </icon-wrapper>
-                </accessible-by-keyboard>
-            </div>
+          <accessible-by-keyboard ng-show="$ctrl.showRelationControls"
+                                  ng-if="$ctrl.relationType"
+                                  aria-hidden="false"
+                                  execute="$ctrl.removeRelation()"
+                                  class="-shown-in-accessibility-mode">
+              <icon-wrapper icon-name="remove"
+                            icon-title="{{ ::$ctrl.text.remove }}">
+              </icon-wrapper>
+          </accessible-by-keyboard>
         </div>
     </div>
 

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy-row/wp-relations-hierarchy-row.template.html
@@ -7,9 +7,9 @@
             <span ng-style="{'padding-left': $ctrl.indentBy + 'px'}"
                   class="wp-relations-hierarchy-subject">
                 <a href="{{ singleRelationCtrl.workPackagePath($ctrl.relatedWorkPackage.id) }}"
-                   title="{{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage) }}"
                    ng-if="!$ctrl.isCurrentElement()"
-                   ng-attr-id="{{ $ctrl.relationType === 'parent' ? 'hierarchy--parent' : ''}}">
+                   aria-label="{{ ($ctrl.isParent() ? $ctrl.text.parent : $ctrl.text.children) + ' ' + singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage) }}"
+                   ng-attr-id="{{ $ctrl.isParent() ? 'hierarchy--parent' : ''}}">
                     {{ singleRelationCtrl.getFullIdentifier($ctrl.relatedWorkPackage) }}
                 </a>
                 <span ng-if="$ctrl.isCurrentElement()"
@@ -26,7 +26,7 @@
         </div>
         <div class="grid-content medium-2 collapse wp-relations-controls-section">
           <accessible-by-keyboard ng-show="$ctrl.showRelationControls"
-                                  ng-if="$ctrl.relationType === 'parent'"
+                                  ng-if="$ctrl.isParent()"
                                   aria-hidden="false"
                                   execute="$ctrl.showEditForm = true"
                                   class="-shown-in-accessibility-mode">
@@ -41,13 +41,13 @@
                                   execute="$ctrl.removeRelation()"
                                   class="-shown-in-accessibility-mode">
               <icon-wrapper icon-name="remove"
-                            icon-title="{{ ::$ctrl.text.remove }}">
+                            icon-title="{{ $ctrl.isParent() ? $ctrl.text.remove_parent : $ctrl.text.remove_child }}">
               </icon-wrapper>
           </accessible-by-keyboard>
         </div>
     </div>
 
-    <div ng-if="$ctrl.relationType === 'parent' && !$ctrl.relatedWorkPackage || $ctrl.showEditForm">
+    <div ng-if="$ctrl.isParent() && !$ctrl.relatedWorkPackage || $ctrl.showEditForm">
         <wp-relations-create template="empty-parents"
                              fixed-relation-type="parent"
                              external-form-toggle="$ctrl.showEditForm"

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
@@ -55,8 +55,6 @@ export class WorkPackageRelationsHierarchyController {
     if (this.workPackage.children) {
       this.loadChildren();
     }
-
-    console.log('wp hierarchy', this.workPackage.addRelation);
   }
 
   public text = {

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
@@ -55,6 +55,8 @@ export class WorkPackageRelationsHierarchyController {
     if (this.workPackage.children) {
       this.loadChildren();
     }
+
+    console.log('wp hierarchy', this.workPackage.addRelation);
   }
 
   public text = {

--- a/frontend/app/templates/components/accessible_by_keyboard.html
+++ b/frontend/app/templates/components/accessible_by_keyboard.html
@@ -4,6 +4,7 @@
    ng-disabled="isDisabled"
    title='{{ linkTitle }}'
    aria-label="{{ ariaLabel }}"
-   data-click-on-keypress="[13, 32]">
+   data-click-on-keypress="[13, 32]"
+   href>
    <span ng-transclude class='{{ spanClass }}'></span>
 </a>


### PR DESCRIPTION
related to: [22888](https://community.openproject.com/work_packages/22888)

this continues @HDinger 's work from [4891](https://github.com/opf/openproject/pull/4891) since I don't have write permissions on that repo.

**Quoted from the original pull:**
This does rudimentary accessibility improvements for the new relation tab. This includes 
- [x] All interactive elements shall be reachable by keyboard. 
- [x] The correct placement of the focus when opening/closing forms.
- [x] A support for blind users by screenreader 
