### PR TITLE
Avoid forcing ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@
 language: ruby
 
 rvm:
-  - 2.3.1
+  - 2.2.5
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@
 
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '>= 2.2.5'
 
 gem 'rails', '~> 5.0.0'
 gem 'actionpack-xml_parser', '~> 2.0.0'


### PR DESCRIPTION
This restores building / testing on ruby 2.2 due to the number of segfaults on our local machines and on travis.
