### PR TITLE
use common base class for jobs

### DIFF
--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -27,9 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class CopyProjectJob
+class CopyProjectJob < ApplicationJob
   include OpenProject::LocaleHelper
-  include OpenProject::BeforeDelayedJob
 
   attr_reader :user_id,
               :source_project_id,

--- a/app/workers/delete_user_job.rb
+++ b/app/workers/delete_user_job.rb
@@ -27,9 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class DeleteUserJob
-  include OpenProject::BeforeDelayedJob
-
+class DeleteUserJob < ApplicationJob
   def initialize(user_id)
     @user_id = user_id
   end

--- a/app/workers/deliver_invitation_job.rb
+++ b/app/workers/deliver_invitation_job.rb
@@ -27,9 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class DeliverInvitationJob
-  include OpenProject::BeforeDelayedJob
-
+class DeliverInvitationJob < ApplicationJob
   attr_reader :token_id
 
   def initialize(token_id)

--- a/app/workers/deliver_notification_job.rb
+++ b/app/workers/deliver_notification_job.rb
@@ -27,9 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class DeliverNotificationJob
-  include OpenProject::BeforeDelayedJob
-
+class DeliverNotificationJob < ApplicationJob
   def initialize(recipient_id, sender_id)
     @recipient_id = recipient_id
     @sender_id = sender_id

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -28,9 +28,7 @@
 #++
 
 # Enqueues
-class EnqueueWorkPackageNotificationJob
-  include OpenProject::BeforeDelayedJob
-
+class EnqueueWorkPackageNotificationJob < ApplicationJob
   def initialize(journal_id, author_id)
     @journal_id = journal_id
     @author_id = author_id

--- a/app/workers/scm/create_local_repository_job.rb
+++ b/app/workers/scm/create_local_repository_job.rb
@@ -34,9 +34,7 @@
 # We envision a repository management wrapper that covers transactional
 # creation and deletion of repositories BOTH on the database and filesystem.
 # Until then, a synchronous process is more failsafe.
-class Scm::CreateLocalRepositoryJob
-  include OpenProject::BeforeDelayedJob
-
+class Scm::CreateLocalRepositoryJob < ApplicationJob
   def initialize(repository)
     # Cowardly refusing to override existing local repository
     if File.directory?(repository.root_url)

--- a/app/workers/scm/delete_local_repository_job.rb
+++ b/app/workers/scm/delete_local_repository_job.rb
@@ -34,9 +34,7 @@
 # We envision a repository management wrapper that covers transactional
 # creation and deletion of repositories BOTH on the database and filesystem.
 # Until then, a synchronous process is more failsafe.
-class Scm::DeleteLocalRepositoryJob
-  include OpenProject::BeforeDelayedJob
-
+class Scm::DeleteLocalRepositoryJob < ApplicationJob
   def initialize(managed_path)
     @managed_path = managed_path
   end

--- a/app/workers/scm/remote_repository_job.rb
+++ b/app/workers/scm/remote_repository_job.rb
@@ -34,9 +34,7 @@
 # We envision a repository management wrapper that covers transactional
 # creation and deletion of repositories BOTH on the database and filesystem.
 # Until then, a synchronous process is more failsafe.
-class Scm::RemoteRepositoryJob
-  include OpenProject::BeforeDelayedJob
-
+class Scm::RemoteRepositoryJob < ApplicationJob
   attr_reader :repository
 
   ##

--- a/app/workers/scm/storage_updater_job.rb
+++ b/app/workers/scm/storage_updater_job.rb
@@ -27,9 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class Scm::StorageUpdaterJob
-  include OpenProject::BeforeDelayedJob
-
+class Scm::StorageUpdaterJob < ApplicationJob
   def initialize(repository)
     @id = repository.id
 

--- a/spec/workers/application_job_spec.rb
+++ b/spec/workers/application_job_spec.rb
@@ -28,10 +28,8 @@
 
 require 'spec_helper'
 
-describe OpenProject::BeforeDelayedJob do
-  class JobMock
-    include OpenProject::BeforeDelayedJob
-
+describe ApplicationJob do
+  class JobMock < ApplicationJob
     def initialize(callback)
       @callback = callback
     end


### PR DESCRIPTION
WP [#24049](https://community.openproject.com/work_packages/24049/activity)

This is the first step necessary to be able to remove resque from `openproject-multitenancy`.
