### PR TITLE
Fix AC::Parameters error in Rails 5 migration

### DIFF
--- a/db/migrate/20160913081236_type_attribute_visibility_to_hash.rb
+++ b/db/migrate/20160913081236_type_attribute_visibility_to_hash.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require_relative 'migration_utils/ar_parameter_patch'
+
 class TypeAttributeVisibilityToHash < ActiveRecord::Migration[5.0]
   class TypeWithWhatever < ActiveRecord::Base
     self.table_name = :types
@@ -41,6 +43,8 @@ class TypeAttributeVisibilityToHash < ActiveRecord::Migration[5.0]
   end
 
   def up
+    ArParametersPatch.load
+
     TypeWithWhatever.transaction do
       TypeWithWhatever.all.to_a.each do |type|
         visibility = type.attribute_visibility


### PR DESCRIPTION
== 20160913081236 TypeAttributeVisibilityToHash: migrating ====================
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

undefined method `[]=' for nil:NilClass
/opt/myproject/vendor/bundle/ruby/2.3.0/gems/actio
