### PR TITLE
[24051] Spent time link restricted to work package

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-spent-time-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-spent-time-field.module.ts
@@ -49,6 +49,7 @@ export class SpentTimeDisplayField extends DurationDisplayField {
         this.timeEntriesLink =
           URI
             .expand('/projects/{identifier}/time_entries', project)
+            .search({ work_package_id: resource.id })
             .toString();
       });
     }


### PR DESCRIPTION
This filters the Time entries and Cost report views for the current work
package when browsing the work package's spent time entries through the
attribute link introduced in https://github.com/opf/openproject/pull/4890

https://community.openproject.com/work_packages/24023
