### PR TITLE
[23715] Keep current project context as stateParam

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,6 +301,9 @@ OpenProject::Application.routes.draw do
       get '(/*state)' => 'work_packages#index', on: :collection, as: ''
       get '/create_new' => 'work_packages#index', on: :collection, as: 'new_split'
       get '/new' => 'work_packages#index', on: :collection, as: 'new'
+
+      # state for show view in project context
+      get '(/*state)' => 'work_packages#show', on: :member, as: ''
     end
 
     resources :activity, :activities, only: :index, controller: 'activities'

--- a/features/search/search.feature
+++ b/features/search/search.feature
@@ -44,4 +44,4 @@ Feature: Searching
     Then I should see "Overview" within "#main-menu"
      And I click on "wp1" within "#search-results"
     Then I should see "wp1" within ".wp-edit-field.subject"
-     And I should be on the page of the work package "wp1"
+     And I should be on the page of the work package "wp1" in project "project"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -147,7 +147,7 @@ module NavigationHelpers
       work_package = WorkPackage.find_by(subject: $1)
       project = Project.find_by(identifier: $2)
 
-      "/projects/#{project.identifier}/work_packages/#{work_package.id}"
+      "/projects/#{project.identifier}/work_packages/#{work_package.id}/activity"
 
     when /^the new work_package page (?:for|of) the project called "([^\"]+)"$/
       "/projects/#{$1}/work_packages/new"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -143,6 +143,12 @@ module NavigationHelpers
       work_package = WorkPackage.find_by(subject: $1)
       "/work_packages/#{work_package.id}/activity"
 
+    when /^the page (?:for|of) the work package "([^\"]+)" in project "([^\"]+)"$/
+      work_package = WorkPackage.find_by(subject: $1)
+      project = Project.find_by(identifier: $2)
+
+      "/projects/#{project.identifier}/work_packages/#{work_package.id}"
+
     when /^the new work_package page (?:for|of) the project called "([^\"]+)"$/
       "/projects/#{$1}/work_packages/new"
 

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -77,6 +77,7 @@ openprojectModule
   .config(($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) => {
 
     $urlRouterProvider.when('/work_packages/', '/work_packages')
+                      .when('/{projects}/{projectPath}/work_packages/', '/{projects}/{projectPath}/work_packages')
                       .when('/work_packages/{workPackageId:[0-9]+}?query_id&query_props', ($match, $state) => {
                         $state.go('work-packages.show.activity', $match, { location: 'replace' });
                         return true;

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -95,6 +95,12 @@ openprojectModule
       .state('work-packages', {
         url: '',
         abstract: true,
+        params: {
+          // value: null makes the parameter optional
+          // squash: true avoids duplicate slashes when the paramter is not provided
+          projectPath: {value: null, squash: true},
+          projects: {value: null, squash: true},
+        },
         templateUrl: '/components/routing/main/work-packages.html',
         controller: 'WorkPackagesController'
       })
@@ -107,12 +113,6 @@ openprojectModule
         reloadOnSearch: false,
         onEnter: () => angular.element('body').addClass('full-create'),
         onExit: () => angular.element('body').removeClass('full-create'),
-        params: {
-          // value: null makes the parameter optional
-          // squash: true avoids duplicate slashes when the paramter is not provided
-          projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true}
-        }
       })
 
       .state('work-packages.copy', {
@@ -128,11 +128,6 @@ openprojectModule
 
       .state('work-packages.edit', {
         url: '/{projects}/{projectPath}/work_packages/{workPackageId:[0-9]+}/edit',
-        params: {
-          projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true},
-        },
-
         onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
           // Transitioning to a new state may cause a reported issue
@@ -143,7 +138,7 @@ openprojectModule
       })
 
       .state('work-packages.show', {
-        url: '/work_packages/{workPackageId:[0-9]+}?query_id&query_props',
+        url: '/work_packages/{workPackageId:[0-9]+}',
         templateUrl: '/components/routing/wp-show/wp.show.html',
         controller: 'WorkPackageShowController',
         controllerAs: '$ctrl',
@@ -173,8 +168,6 @@ openprojectModule
         params: {
           // value: null makes the parameter optional
           // squash: true avoids duplicate slashes when the paramter is not provided
-          projectPath: {value: null, squash: true},
-          projects: {value: null, squash: true},
           query_id: {value: null},
           query_props: {value: null}
         },

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -73,28 +73,27 @@ const panels = {
   }
 };
 
+const redirectTo = (routeTo) => {
+  return ($match, $state) => {
+    $state.go(routeTo, $match, { location: 'replace' });
+    return true;
+  };
+};
+
 openprojectModule
   .config(($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) => {
+    $urlMatcherFactoryProvider.strictMode(false);
 
     $urlRouterProvider.when('/work_packages/', '/work_packages')
                       .when('/{projects}/{projectPath}/work_packages/', '/{projects}/{projectPath}/work_packages')
-                      .when('/work_packages/{workPackageId:[0-9]+}?query_id&query_props', ($match, $state) => {
-                        $state.go('work-packages.show.activity', $match, { location: 'replace' });
-                        return true;
-                      })
-                      .when('/work_packages/details/{workPackageId:[0-9]+}?query_id&query_props', ($match, $state) => {
-                        $state.go('work-packages.list.details.overview', $match, { location: 'replace' });
-                        return true;
-                      })
-                      .when('/{projects}/{projectPath}/work_packages/details/{workPackageId:[0-9]+}?query_id&query_props', ($match, $state) => {
-                        $state.go('work-packages.list.details.overview', $match, { location: 'replace' });
-                        return true;
-                      });
-    $urlMatcherFactoryProvider.strictMode(false);
+                      .when('/work_packages/details/{workPackageId:[0-9]+}?query_id&query_props', redirectTo('work-packages.list.details.overview'))
+                      .when('/{projects}/{projectPath}/work_packages/details/{workPackageId:[0-9]+}?query_id&query_props', redirectTo('work-packages.list.details.overview'))
+                      .when('/work_packages/{workPackageId:[0-9]+}?query_id&query_props', redirectTo('work-packages.show.activity'))
+                      .when('/{projects}/{projectPath}/work_packages/{workPackageId:[0-9]+}?query_id&query_props', redirectTo('work-packages.show.activity'))
 
     $stateProvider
       .state('work-packages', {
-        url: '/{projects}/{projectPath}',
+        url: '/{projects}/{projectPath}/work_packages?query_id&query_props',
         abstract: true,
         params: {
           // value: null makes the parameter optional
@@ -107,7 +106,7 @@ openprojectModule
       })
 
       .state('work-packages.new', {
-        url: '/work_packages/new?type&parent_id',
+        url: '/new?type&parent_id',
         templateUrl: '/components/routing/main/work-packages.new.html',
         controller: 'WorkPackageCreateController',
         controllerAs: '$ctrl',
@@ -117,7 +116,7 @@ openprojectModule
       })
 
       .state('work-packages.copy', {
-        url: '/work_packages/{copiedFromWorkPackageId:[0-9]+}/copy',
+        url: '/{copiedFromWorkPackageId:[0-9]+}/copy',
         controller: 'WorkPackageCopyController',
         controllerAs: '$ctrl',
         reloadOnSearch: false,
@@ -128,7 +127,7 @@ openprojectModule
       })
 
       .state('work-packages.edit', {
-        url: '/work_packages/{workPackageId:[0-9]+}/edit',
+        url: '/{workPackageId:[0-9]+}/edit',
         onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
           // Transitioning to a new state may cause a reported issue
@@ -139,7 +138,7 @@ openprojectModule
       })
 
       .state('work-packages.show', {
-        url: '/work_packages/{workPackageId:[0-9]+}',
+        url: '/{workPackageId:[0-9]+}',
         templateUrl: '/components/routing/wp-show/wp.show.html',
         controller: 'WorkPackageShowController',
         controllerAs: '$ctrl',
@@ -163,15 +162,9 @@ openprojectModule
       .state('work-packages.show.watchers', panels.watchers)
 
       .state('work-packages.list', {
-        url: '/work_packages?query_id&query_props',
+        url: '',
         controller: 'WorkPackagesListController',
         templateUrl: '/components/routing/wp-list/wp.list.html',
-        params: {
-          // value: null makes the parameter optional
-          // squash: true avoids duplicate slashes when the paramter is not provided
-          query_id: {value: null},
-          query_props: {value: null}
-        },
         reloadOnSearch: false,
         onEnter: () => angular.element('body').addClass('action-index'),
         onExit: () => angular.element('body').removeClass('action-index')

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -93,7 +93,7 @@ openprojectModule
 
     $stateProvider
       .state('work-packages', {
-        url: '',
+        url: '/{projects}/{projectPath}',
         abstract: true,
         params: {
           // value: null makes the parameter optional
@@ -106,7 +106,7 @@ openprojectModule
       })
 
       .state('work-packages.new', {
-        url: '/{projects}/{projectPath}/work_packages/new?type&parent_id',
+        url: '/work_packages/new?type&parent_id',
         templateUrl: '/components/routing/main/work-packages.new.html',
         controller: 'WorkPackageCreateController',
         controllerAs: '$ctrl',
@@ -127,7 +127,7 @@ openprojectModule
       })
 
       .state('work-packages.edit', {
-        url: '/{projects}/{projectPath}/work_packages/{workPackageId:[0-9]+}/edit',
+        url: '/work_packages/{workPackageId:[0-9]+}/edit',
         onEnter: ($state, $timeout, $stateParams, wpEditModeState:WorkPackageEditModeStateService) => {
           wpEditModeState.start();
           // Transitioning to a new state may cause a reported issue
@@ -162,7 +162,7 @@ openprojectModule
       .state('work-packages.show.watchers', panels.watchers)
 
       .state('work-packages.list', {
-        url: '/{projects}/{projectPath}/work_packages?query_id&query_props',
+        url: '/work_packages?query_id&query_props',
         controller: 'WorkPackagesListController',
         templateUrl: '/components/routing/wp-list/wp.list.html',
         params: {

--- a/spec/features/work_packages/create_child_spec.rb
+++ b/spec/features/work_packages/create_child_spec.rb
@@ -120,11 +120,12 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
 
     expect(child_work_package).to_not eql original_work_package
 
-    child_work_package_page = Pages::FullWorkPackage.new(child_work_package)
+    child_work_package_page = Pages::FullWorkPackage.new(child_work_package, project)
 
     child_work_package_page.ensure_page_loaded
     child_work_package_page.expect_subject
-    child_work_package_page.expect_current_path
+    expect(current_path)
+      .to eq("/projects/#{project.identifier}/work_packages/#{child_work_package.id}")
 
     child_work_package_page.expect_parent(original_work_package)
   end

--- a/spec/features/work_packages/create_child_spec.rb
+++ b/spec/features/work_packages/create_child_spec.rb
@@ -124,8 +124,7 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
 
     child_work_package_page.ensure_page_loaded
     child_work_package_page.expect_subject
-    expect(current_path)
-      .to eq("/projects/#{project.identifier}/work_packages/#{child_work_package.id}")
+    child_work_package_page.expect_current_path
 
     child_work_package_page.expect_parent(original_work_package)
   end

--- a/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/custom_field_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'features/work_packages/work_packages_page'
 require 'features/work_packages/details/inplace_editor/shared_examples'
 
-describe 'custom field inplace editor', js: true, selenium: true do
+describe 'custom field inplace editor', js: true do
   let(:user) { FactoryGirl.create :admin }
   let(:type) { FactoryGirl.create(:type_standard, custom_fields: custom_fields) }
   let(:project) {

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -91,9 +91,10 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     full_work_package.expect_subject
     full_work_package.expect_current_path
 
-    # Back to table
-    global_work_packages.visit!
+    # Back to table using the button
+    find('#work-packages-list-view-button').click
     global_work_packages.expect_work_package_listed(work_package)
+    expect(current_path).to eq "/projects/#{project.identifier}/work_packages"
 
     # Link to full screen from index
     global_work_packages.open_full_screen_by_link(work_package)

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     global_work_packages.open_full_screen_by_link(work_package)
 
     full_work_package.expect_subject
-    expect(current_path).to eq project_work_package_path(project, work_package)
+    full_work_package.expect_current_path
 
     # Safeguard: ensure spec to have finished loading everything before proceeding to the next spec
     full_work_package.ensure_page_loaded

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -89,18 +89,18 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     full_work_package = project_work_packages.open_full_screen_by_button(work_package)
 
     full_work_package.expect_subject
-    full_work_package.expect_current_path
+    expect(current_path).to eq project_work_package_path(project, work_package, 'activity')
 
     # Back to table using the button
     find('#work-packages-list-view-button').click
     global_work_packages.expect_work_package_listed(work_package)
-    expect(current_path).to eq "/projects/#{project.identifier}/work_packages"
+    expect(current_path).to eq project_work_packages_path(project)
 
     # Link to full screen from index
     global_work_packages.open_full_screen_by_link(work_package)
 
     full_work_package.expect_subject
-    full_work_package.expect_current_path
+    expect(current_path).to eq project_work_package_path(project, work_package)
 
     # Safeguard: ensure spec to have finished loading everything before proceeding to the next spec
     full_work_package.ensure_page_loaded

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -30,10 +30,11 @@ require 'support/pages/page'
 
 module Pages
   class AbstractWorkPackage < Page
-    attr_reader :work_package, :type_field_selector, :subject_field_selector
+    attr_reader :project, :work_package, :type_field_selector, :subject_field_selector
 
-    def initialize(work_package)
+    def initialize(work_package, project = nil)
       @work_package = work_package
+      @project = project
 
       @type_field_selector = '.wp-edit-field.type'
       @subject_field_selector = '.wp-edit-field.subject'

--- a/spec/support/pages/full_work_package.rb
+++ b/spec/support/pages/full_work_package.rb
@@ -42,7 +42,11 @@ module Pages
     end
 
     def path(tab = 'activity')
-      work_package_path(work_package.id, tab)
+      if project
+        project_work_package_path(project, work_package.id, tab)
+      else
+        work_package_path(work_package.id, tab)
+      end
     end
 
     def create_page(args)

--- a/spec/support/pages/split_work_package.rb
+++ b/spec/support/pages/split_work_package.rb
@@ -31,11 +31,10 @@ require 'support/pages/split_work_package_create'
 
 module Pages
   class SplitWorkPackage < Pages::AbstractWorkPackage
-    attr_reader :project, :selector
+    attr_reader :selector
 
     def initialize(work_package, project = nil)
-      super work_package
-      @project = project
+      super work_package, project
       @selector = '.work-packages--details'
     end
 

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -99,7 +99,7 @@ module Pages
       loading_indicator_saveguard
       page.driver.browser.mouse.double_click(row(work_package).native)
 
-      FullWorkPackage.new(work_package)
+      FullWorkPackage.new(work_package, project)
     end
 
     def open_full_screen_by_button(work_package)
@@ -108,7 +108,7 @@ module Pages
 
       click_button(I18n.t('js.label_activate') + ' ' + I18n.t('js.button_show_view'))
 
-      FullWorkPackage.new(work_package)
+      FullWorkPackage.new(work_package, project)
     end
 
     def open_full_screen_by_link(work_package)


### PR DESCRIPTION
This adds a global projectPath parameter to the router configuration,
which allows us to keep the current project context without explicitly
specifying it as a parameter.

We do not have frontend movements outside the project context without a
hard refresh. Should that come, one simply has to explictly specify
`projectPath: null` to the route request.

https://community.openproject.com/work_packages/23715/activity
