### PR TITLE
prevent circular dependency of 'from' relations

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -72,19 +72,19 @@ class Relation < ActiveRecord::Base
     },
     TYPE_INCLUDES => {
       name: :label_includes, sym_name: :label_includes, order: 8,
-      sym: TYPE_INCLUDES, reverse: TYPE_PARTOF
+      sym: TYPE_PARTOF
     },
     TYPE_PARTOF => {
       name: :label_part_of, sym_name: :label_part_of, order: 9,
-      sym: TYPE_PARTOF, reverse: TYPE_INCLUDES
+      sym: TYPE_INCLUDES, reverse: TYPE_INCLUDES
     },
     TYPE_REQUIRES => {
       name: :label_requires, sym_name: :label_requires, order: 10,
-      sym: TYPE_REQUIRES, reverse: TYPE_REQUIRED
+      sym: TYPE_REQUIRED
     },
     TYPE_REQUIRED => {
       name: :label_required, sym_name: :label_required, order: 11,
-      sym: TYPE_REQUIRED, reverse: TYPE_REQUIRES
+      sym: TYPE_REQUIRES, reverse: TYPE_REQUIRES
     }
   }.freeze
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -335,10 +335,12 @@ class WorkPackage < ActiveRecord::Base
   def all_dependent_packages(except = [])
     except << self
     dependencies = []
-    relations_from.each do |relation|
-      if relation.to && !except.include?(relation.to)
-        dependencies << relation.to
-        dependencies += relation.to.all_dependent_packages(except)
+    relations.includes(:from, :to).each do |relation|
+      work_package = relation.canonical_to
+
+      if work_package && !except.include?(work_package)
+        dependencies << work_package
+        dependencies += work_package.all_dependent_packages(except)
       end
     end
     dependencies

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -91,15 +91,32 @@ describe Relation, type: :model do
       FactoryGirl.build(:relation, from: to, to: otherwp, relation_type: Relation::TYPE_PRECEDES)
     }
 
-    let(:invalid_relation) {
+    let(:invalid_precedes_relation) {
       FactoryGirl.build(:relation, from: otherwp, to: from, relation_type: Relation::TYPE_PRECEDES)
     }
 
-    it do
+    let(:invalid_follows_relation) {
+      FactoryGirl.build(:relation, from: from, to: otherwp, relation_type: Relation::TYPE_FOLLOWS)
+    }
+
+    it 'prevents invalid precedes relations' do
       expect(relation.save).to eq(true)
       expect(relation2.save).to eq(true)
-      expect(invalid_relation.save).to eq(false)
-      expect(invalid_relation.errors[:base]).not_to be_empty
+      from.reload
+      to.reload
+      otherwp.reload
+      expect(invalid_precedes_relation.save).to eq(false)
+      expect(invalid_precedes_relation.errors[:base]).not_to be_empty
+    end
+
+    it 'prevents invalid follows relations' do
+      expect(relation.save).to eq(true)
+      expect(relation2.save).to eq(true)
+      from.reload
+      to.reload
+      otherwp.reload
+      expect(invalid_follows_relation.save).to eq(false)
+      expect(invalid_follows_relation.errors[:base]).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
The previous implementation to detect circular dependencies was limited to detecting those circles, that originated in the 'to' work package of a relation. It did not prevent circles where the 'from' work package is involved. Now, both branches are checked.

While this removes the immediate issue, it also increases the time required for saving a relation. As long as our database does not provide us the capacity for recursive queries, this cannot be helped.

Work package: https://community.openproject.com/work_packages/23276/activity
