### PR TITLE
Fix/22888 - Focus problems with ui-select autocomplete component

### DIFF
--- a/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
+++ b/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
@@ -40,11 +40,9 @@ function uiSelectFocusFix( $timeout ) {
     restrict: 'A',
     require: 'uiSelect',
     link: function(scope, element, attrs, $select) {
-      scope.$watch(() => { return $select.open; }, (isOpen) => {
+      scope.$watch(() => $select.open, isOpen => {
         if ( isOpen ) {
-          $timeout(() => {
-            $select.focusSearchInput();
-          });
+          $timeout( () => { $select.focusSearchInput(); } );
         }
       });
     }

--- a/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
+++ b/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
@@ -40,11 +40,21 @@ function uiSelectFocusFix( $timeout ) {
     restrict: 'A',
     require: 'uiSelect',
     link: function(scope, element, attrs, $select) {
+
+      element.on('keyup', keyEvent => {
+        if (keyEvent.keyCode === 27 && $select.open) {
+          keyEvent.preventDefault();
+          keyEvent.stopPropagation();
+          $select.close();
+        }
+      });
+
       scope.$watch(() => $select.open, isOpen => {
         if ( isOpen ) {
           $timeout( () => { $select.focusSearchInput(); } );
         }
       });
+
     }
   };
 }

--- a/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
+++ b/frontend/app/components/common/ui-select-focus-fix/ui-select-focus-fix.directive.ts
@@ -1,0 +1,55 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+/**
+ * The search input of ui-select fields doesn't get the focus when the
+ * field gets activated.
+ * This is a known issue and has not been solved yet (11.10.2016)
+ * Usage: add directive to <ui-select ...> element.
+ **/
+
+import {wpDirectivesModule} from '../../../angular-modules';
+
+function uiSelectFocusFix( $timeout ) {
+  return {
+    restrict: 'A',
+    require: 'uiSelect',
+    link: function(scope, element, attrs, $select) {
+      scope.$watch(() => { return $select.open; }, (isOpen) => {
+        if ( isOpen ) {
+          $timeout(() => {
+            $select.focusSearchInput();
+          });
+        }
+      });
+    }
+  };
+}
+
+wpDirectivesModule.directive('uiSelectFocusFix', uiSelectFocusFix);
+

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.template.html
@@ -1,6 +1,7 @@
 <form name="add_relation_form" class="form">
    <div class="dropdown-wrapper">
       <ui-select
+              ui-select-focus-fix
               class="inplace-edit--select -full-width"
               ng-model="selectedWpId"
               on-select="onSelect($model)"


### PR DESCRIPTION
This is related to [22888](https://community.openproject.com/work_packages/22888/activity) and fixes the issue that a user had to click twice on the autocomplete component to set the focus to its text-input field.

Setting the focus only by keyboard was not possible before.

The problem is know and addressed in several issues on https://github.com/angular-ui/ui-select/issues/ 

When the actual bug is fixed in the ui-select component this directive can be removed from op again.
