### PR TITLE
[24057] Add info row to WP show / split screen with more concise information

### DIFF
--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -36,10 +36,6 @@
   align-items: flex-end
 
 
-.attributes-group--header-container-right
-  font-size: 0.72rem
-  padding-bottom: 0.6rem
-
 .attributes-group--header-container
   @include grid-content
   padding: 0 1rem 0.4rem 0

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -32,6 +32,10 @@ $work-package-details--tab-height: 40px
   @include grid-visible-overflow
   padding: 0
 
+.work-packages--info-row
+  font-size: 0.8rem
+  padding: 5px 0
+
 .work-packages--details--title
   @include grid-block
   @include details-pane--form-field

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -101,6 +101,7 @@ en:
     label_board_locked: "Locked"
     label_board_sticky: "Sticky"
     label_create_work_package: "Create new work package"
+    label_created_by: "Created by"
     label_date: "Date"
     label_date_with_format: "Enter the %{date_attribute} using the following format: %{format}"
     label_deactivate: "Deactivate"
@@ -421,9 +422,9 @@ en:
       inline_create:
        title: 'Click here to add a new work package to this list'
       create:
-        header: 'New work package'
+        header: 'New %{type}'
+        header_with_parent: 'New %{type} (Child of %{type} #%{id})'
         button: 'Create'
-        header_with_parent: 'New work package (Child of %{type} #%{id})'
       no_results:
         title: No work packages to display.
         description: Either none have been created or all work packages are filtered out.

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -117,6 +117,7 @@ export class WorkPackageResource extends HalResource {
   public $pristine: { [attribute: string]: any } = {};
   public parentId: number;
   public subject: string;
+  public updatedAt: Date;
   public lockVersion: number;
   public description: any;
   public inFlight: boolean;

--- a/frontend/app/components/user/user-link/user-link.directive.html
+++ b/frontend/app/components/user/user-link/user-link.directive.html
@@ -1,0 +1,4 @@
+<a ng-href="{{ href }}"
+   ng-attr-title="::text.label"
+   ng-bind="::text.name">
+</a>

--- a/frontend/app/components/user/user-link/user-link.directive.test.ts
+++ b/frontend/app/components/user/user-link/user-link.directive.test.ts
@@ -1,0 +1,69 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('userLink Directive', function () {
+  var user, userLoadFn, link, $q, compile, element, scope;
+
+  beforeEach(angular.mock.module('openproject'));
+
+  beforeEach(inject(function ($rootScope, $compile, _$q_) {
+    $q = _$q_;
+    var html = '<user-link user="user"></user-link>';
+
+    userLoadFn = sinon.stub().returns($q.when(true));
+    user = {
+      name: 'First Last',
+      href: '/api/v3/users/1',
+      $load: userLoadFn,
+      showUser: {href: '/some/path'}
+    };
+
+    compile = function () {
+      element = angular.element(html);
+      scope = $rootScope.$new();
+      scope.user = user;
+
+      $compile(element)(scope);
+      scope.$digest();
+      link = element.find('a');
+    };
+  }));
+
+  describe('when loading', function () {
+    beforeEach(function () {
+      compile();
+    });
+
+    it('should render the user name', function () {
+      expect(link.text()).to.equal(user.name);
+      expect(userLoadFn).to.have.been.called;
+      expect(link.attr('href')).to.equal(user.showUser.href);
+    });
+  });
+});
+

--- a/frontend/app/components/user/user-link/user-link.directive.ts
+++ b/frontend/app/components/user/user-link/user-link.directive.ts
@@ -1,0 +1,57 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+import {openprojectModule} from '../../../angular-modules';
+import {UserResource} from '../../api/api-v3/hal-resources/user-resource.service';
+
+interface UserLinkScope {
+  user:UserResource;
+  href:string|null,
+  text:{};
+}
+
+function userLink(I18n) {
+  return {
+    restrict: 'E',
+    templateUrl: '/components/user/user-link/user-link.directive.html',
+    scope: {
+      user: '='
+    },
+    link: function(scope:UserLinkScope) {
+      scope.user.$load().then(() => {
+        scope.href = scope.user.showUser.href;
+      });
+      scope.text = {
+        name: scope.user.name,
+        label: I18n.t('js.label_author', { author: scope.user.name })
+      };
+    }
+  };
+};
+
+openprojectModule.directive('userLink', userLink);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -1,16 +1,19 @@
 <div ng-if="$ctrl.workPackage && $ctrl.formCtrl" class="work-package--single-view">
+  <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">
+    <span ng-bind="$ctrl.idLabel"/>:
+    <span ng-bind="$ctrl.text.infoRow.createdBy"/>
+    <user-link user="$ctrl.workPackage.author"></user-link>.
+    <span ng-bind="$ctrl.text.infoRow.lastUpdatedOn"/>
+    <op-date date-value="$ctrl.workPackage.updatedAt"></op-date>.
+  </div>
+
   <div class="attributes-group">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
-        <h3 class="attributes-group--header-text" ng-bind="$ctrl.text.idLabel"></h3>
-      </div>
-
-      <div class="attributes-group--header-container-right">
-        <span ng-bind="$ctrl.I18n.t('js.label_last_updated_on')"/>
-        <op-date date-value="$ctrl.workPackage.updatedAt"></op-date>
+        <h3 class="attributes-group--header-text"
+            ng-bind="$ctrl.text.fields.description"></h3>
       </div>
     </div>
-
     <div
         wp-edit-field="'description'"
         wp-attachments-formattable

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -4,7 +4,7 @@
     <span ng-bind="$ctrl.text.infoRow.createdBy"/>
     <user-link user="$ctrl.workPackage.author"></user-link>.
     <span ng-bind="$ctrl.text.infoRow.lastUpdatedOn"/>
-    <op-date date-value="$ctrl.workPackage.updatedAt"></op-date>.
+    <op-date-time date-time-value="$ctrl.workPackage.updatedAt"></op-date-time>.
   </div>
 
   <div class="attributes-group">

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -51,6 +51,7 @@ export class WorkPackageSingleViewController {
               protected I18n,
               protected wpCacheService,
               protected wpNotificationsService: WorkPackageNotificationService,
+              protected TimezoneService,
               protected WorkPackagesOverviewService,
               protected SingleViewWorkPackage) {
 
@@ -61,12 +62,16 @@ export class WorkPackageSingleViewController {
       dropFiles: I18n.t('js.label_drop_files'),
       dropFilesHint: I18n.t('js.label_drop_files_hint'),
       fields: {
+        description: I18n.t('js.work_packages.properties.description'),
         date: {
           startDate: I18n.t('js.label_no_start_date'),
           dueDate: I18n.t('js.label_no_due_date')
         }
       },
-      idLabel: ''
+      infoRow: {
+        createdBy: I18n.t('js.label_created_by'),
+        lastUpdatedOn: I18n.t('js.label_last_updated_on')
+      },
     };
 
     wpCacheService.loadWorkPackage(wpId).observe($scope).subscribe(wp => this.init(wp));
@@ -96,15 +101,19 @@ export class WorkPackageSingleViewController {
     }
   }
 
-  public setIdLabel() {
-    if (!this.workPackage.type) {
+  public get idLabel() {
+    var text;
+
+    if (!(this.workPackage && this.workPackage.type)) {
       return;
     }
 
-    this.text.idLabel = this.workPackage.type.name;
+    text = this.workPackage.type.name;
     if (!this.workPackage.isNew) {
-      this.text.idLabel += ' #' + this.workPackage.id;
+      text += ' #' + this.workPackage.id;
     }
+
+    return text;
   }
 
   private init(wp) {
@@ -147,10 +156,6 @@ function wpSingleViewDirective() {
                             controllers: [WorkPackageEditFormController, WorkPackageSingleViewController]) {
 
     controllers[1].formCtrl = controllers[0];
-
-    scope.$watch(_ => controllers[1].workPackage.type, _ => {
-      controllers[1].setIdLabel();
-    });
   }
 
   return {

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -41,10 +41,16 @@ export class WorkPackageCreateController {
 
   public get header():string {
     if (this.parentWorkPackage) {
-      return this.I18n.t('js.work_packages.create.header_with_parent',
-        {type: this.parentWorkPackage.type.name, id: this.parentWorkPackage.id});
+      return this.I18n.t(
+        'js.work_packages.create.header_with_parent',
+        { type: this.parentWorkPackage.type.name, id: this.parentWorkPackage.id }
+      );
     }
-    return this.I18n.t('js.work_packages.create.header');
+
+    return this.I18n.t(
+      'js.work_packages.create.header',
+      { type: this.newWorkPackage.type.name }
+    );
   }
 
   constructor(protected $state,


### PR DESCRIPTION
This PR adds some information to a separate info row below the WP title. It looks similar to the following, except `updated on by <user>` is excluded, since we need to grab the activities for that

![bildschirmfoto 2016-10-07 um 17 05 56](https://cloud.githubusercontent.com/assets/459462/19298940/84cc95a4-9051-11e6-82ab-2844fd851dfe.png)

**Out of scope** (will address in separate PR)
- hide project/type in project context
- hide author field

https://community.openproject.com/projects/openproject/work_packages/details/24057/overview
