### PR TITLE
Fix/23981 Adapt changes in wp-attachments to wp-attachments-formattable-field directive

### DIFF
--- a/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
+++ b/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
@@ -31,7 +31,7 @@ import IQService = angular.IQService;
 import IPromise = angular.IPromise;
 
 export interface UploadFile extends File {
-  description: string;
+  description?: string;
 }
 
 export interface UploadResult {

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
@@ -88,7 +88,7 @@ export class WpAttachmentsFormattableController {
           });
         }
         else {
-          this.insertDelayedAttachments(dropData, description);
+          this.insertDelayedAttachments(dropData, description, workPackage);
         }
       }
     }
@@ -125,12 +125,12 @@ export class WpAttachmentsFormattableController {
     }
   }
 
-  protected insertDelayedAttachments(dropData:DropModel, description):void {
+  protected insertDelayedAttachments(dropData:DropModel, description, workPackage: WorkPackageResourceInterface):void {
     for (var i = 0; i < dropData.files.length; i++) {
       var currentFile = new SingleAttachmentModel(dropData.files[i]);
       var insertMode = currentFile.isAnImage ? InsertMode.INLINE : InsertMode.ATTACHMENT;
       description.insertAttachmentLink(dropData.files[i].name.replace(/ /g, '_'), insertMode, true);
-      this.$rootScope.$broadcast('work_packages.attachment.add', dropData.files[i]);
+      workPackage.pendingAttachments.push((dropData.files[i] as UploadFile));
     }
 
     description.save();

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
@@ -130,7 +130,7 @@ export class WpAttachmentsFormattableController {
       var currentFile = new SingleAttachmentModel(dropData.files[i]);
       var insertMode = currentFile.isAnImage ? InsertMode.INLINE : InsertMode.ATTACHMENT;
       description.insertAttachmentLink(dropData.files[i].name.replace(/ /g, '_'), insertMode, true);
-      workPackage.pendingAttachments.push((dropData.files[i] as UploadFile));
+      workPackage.pendingAttachments.push((dropData.files[i]));
     }
 
     description.save();

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -108,7 +108,7 @@
 <div class="work-packages--attachments attributes-group">
   <div
       class="work-packages--atachments-container"
-      ng-if="!$ctrl.hideEmptyFields || $ctrl.workPackage.attachments.elements.length">
+      ng-if="!$ctrl.hideEmptyFields || $ctrl.workPackage.attachments.elements.length || $ctrl.workPackage.pendingAttachments">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
         <h3 class="attributes-group--header-text">


### PR DESCRIPTION
**Related to [23981](https://community.openproject.com/work_packages/23981/activity)**

This fixes several problems that came with the changes on handling attachments.
- [x]  add pending attachments via drag and drop in create mode
- [x] show attachments section when pending attachments are present
