### PR TITLE
Rails 5 no longer does autoload constants outside the global namespace constant

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -94,6 +94,7 @@ module OpenProject
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
+    config.enable_dependency_loading = true
     config.autoload_paths << Rails.root.join('lib')
 
     # Only load the plugins named here, in the order given (default is alphabetical).


### PR DESCRIPTION
Thus required files under lib/ are no longer correctly loaded at the moment.

There are two solutions:

Set config.enable_dependency_loading = true. This is not threadsafe and is not advised

Eagerly load what we need from lib/. Since this now requires everything in there, it throws for old code and embedded files we did not actually require before.

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#autoloading-is-disabled-after-booting-in-the-production-environment
