### PR TITLE
[24050] Unescape formattable html strings inserted as ng-bind-html

### DIFF
--- a/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.test.ts
+++ b/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.test.ts
@@ -1,0 +1,68 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+describe('bindUnescapedHtml Directive', function() {
+  var compile, element, scope;
+
+  beforeEach(angular.mock.module('openproject.uiComponents'));
+  beforeEach(angular.mock.module('openproject.services'));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    var html = '<span bind-unescaped-html="text"></span>';
+
+    element = angular.element(html);
+    scope = $rootScope.$new();
+
+    compile = function() {
+      $compile(element)(scope);
+      scope.$digest();
+    };
+  }));
+
+  describe('when content is unescaped', function() {
+    beforeEach(function() {
+      scope.text = '<p>Some unescaped {{ 3 + 5 }} angular expression</p>';
+      compile();
+    });
+
+    it('should not matter', function() {
+      expect(element.find('p').text()).to.equal('Some unescaped {{ 3 + 5 }} angular expression');
+    });
+  });
+
+  describe('when content is escaped', function() {
+    beforeEach(function() {
+      scope.text = '<p>Some escaped {{ DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }} angular expression</p>';
+      compile();
+    });
+
+    it('should not matter', function() {
+      expect(element.find('p').text()).to.equal('Some escaped {{ 3 + 5 }} angular expression');
+    });
+  });
+});

--- a/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.ts
+++ b/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.ts
@@ -1,0 +1,54 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+// Heavily borrows from foundation-apps ModalFactory. Copyright (c) 2014 ZURB, inc.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import ExpressionService from "../expression.service";
+function bindUnescapedHtml(ExpressionService:ExpressionService) {
+  var foundationModalLink = function (scope) {
+    scope.$watch('value', (value) => {
+      scope.escapedValue = '';
+
+      if (value) {
+        scope.escapedValue = ExpressionService.unescape(value.toString());
+      }
+    });
+  };
+
+  return {
+    restrict: 'A',
+    template: '<span ng-bind-html="escapedValue"></span>',
+    scope: {
+      value: '=bindUnescapedHtml',
+    },
+    link: foundationModalLink,
+  };
+}
+
+angular
+  .module('openproject.uiComponents')
+  .directive('bindUnescapedHtml', bindUnescapedHtml);

--- a/frontend/app/components/common/xss/expression.service.ts
+++ b/frontend/app/components/common/xss/expression.service.ts
@@ -26,33 +26,27 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {DisplayField} from "../wp-display-field/wp-display-field.module";
-import ExpressionService from "../../common/xss/expression.service";
-import {HalResource} from "../../api/api-v3/hal-resources/hal-resource.service";
+import {opServicesModule} from '../../../angular-modules';
 
-export class FormattableDisplayField extends DisplayField {
-  public template:string = '/components/wp-display/field-types/wp-display-formattable-field.directive.html'
+export default class ExpressionService {
 
-  protected ExpressionService:ExpressionService;
-
-  constructor(public resource: HalResource,
-              public name: string,
-              public schema) {
-    super(resource, name, schema);
-
-    this.ExpressionService = <ExpressionService>this.$injector.get('ExpressionService');
+  // This is what returned by rails-angular-xss when it discoveres double open curly braces
+  // See https://github.com/opf/rails-angular-xss for more information.
+  public get UNESCAPED_EXPRESSION() {
+    return '{{';
   }
 
-  public get value() {
-    if(!this.schema) {
-      return null;
-    }
-    return this.unescape(this.resource[this.name].html);
+  public get ESCAPED_EXPRESSION() {
+    return '{{ DOUBLE_LEFT_CURLY_BRACE }}';
   }
 
-  // Escape the given HTML string from the backend, which contains escaped Angular expressions.
-  // Since formattable fields are only binded to but never evaluated, we can safely remove these expressions.
-  protected unescape(html:string) {
-    return this.ExpressionService.unescape(html);
+  public escape(input:string) {
+    return input.replace(new RegExp(this.UNESCAPED_EXPRESSION, 'g'), this.ESCAPED_EXPRESSION);
+  }
+
+  public unescape(input:string) {
+    return input.replace(new RegExp(this.ESCAPED_EXPRESSION, 'g'), this.UNESCAPED_EXPRESSION);
   }
 }
+
+opServicesModule.service('ExpressionService', ExpressionService);

--- a/frontend/app/components/wp-activity/user/user-activity-directive.test.js
+++ b/frontend/app/components/wp-activity/user/user-activity-directive.test.js
@@ -138,7 +138,7 @@ describe('userActivity Directive', function() {
 
         describe('comment', function() {
           it('should render activity comment', function() {
-            var comment = element.find('span.user-comment > span.message').html();
+            var comment = element.find('span.user-comment > span.message > span').html();
 
             expect(comment).to.eq(scope.activity.comment.html);
           });

--- a/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-formattable-field.directive.html
@@ -1,4 +1,4 @@
 <span>
-   <span ng-bind-html="$ctrl.displayText" wp-display-formattable-field-helper></span>
+   <span bind-unescaped-html="$ctrl.displayText" wp-display-formattable-field-helper></span>
 </span>
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -15,7 +15,7 @@
           ng-model="vm.field.fieldVal.raw"
           ng-attr-id="{{vm.htmlId}}">  </textarea>
     <div class="inplace-edit--preview" ng-show="vm.field.isPreview && !vm.field.isBusy">
-        <span ng-bind-html="vm.field.previewHtml"></span>
+        <span bind-unescaped-html="vm.field.previewHtml"></span>
     </div>
     <wp-edit-field-controls ng-show="!vm.inEditMode"
                             field-controller="vm"

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -93,12 +93,14 @@ opApp
       '$rootScope',
       '$window',
       'TimezoneService',
+      'ExpressionService',
       'CacheService',
       'KeyboardShortcutService',
       function($http,
                $rootScope,
                $window,
                TimezoneService,
+               ExpressionService,
                CacheService,
                KeyboardShortcutService) {
         $http.defaults.headers.common.Accept = 'application/json';
@@ -106,7 +108,7 @@ opApp
         // Set the escaping target of opening double curly braces
         // This is what returned by rails-angular-xss when it discoveres double open curly braces
         // See https://github.com/opf/rails-angular-xss for more information.
-        $rootScope.DOUBLE_LEFT_CURLY_BRACE = '{{';
+        $rootScope.DOUBLE_LEFT_CURLY_BRACE = ExpressionService.UNESCAPED_EXPRESSION;
 
         $rootScope.showNavigation =
             $window.sessionStorage.getItem('openproject:navigation-toggle') !==

--- a/frontend/app/templates/work_packages/activities/_user.html
+++ b/frontend/app/templates/work_packages/activities/_user.html
@@ -53,7 +53,7 @@
                     required>
           </textarea>
           <div class="inplace-edit--preview" ng-if="isPreview">
-            <span ng-bind-html="previewHtml"></span>
+            <span bind-unescaped-html="previewHtml"></span>
           </div>
           <div class="inplace-edit--dashboard">
             <div class="inplace-edit--controls">
@@ -76,7 +76,7 @@
     <span ng-if="!inEdit"
           class="message"
           ng-show="activity._type == 'Activity::Comment'"
-          ng-bind-html="postedComment"/>
+          bind-unescaped-html="postedComment"/>
     <ul class="work-package-details-activities-messages" ng-if="!isInitial">
       <li ng-repeat="detail in details track by $index">
         <span class="message" ng-bind-html="detail"/>


### PR DESCRIPTION
The description and all other formattable fields are applied to the dom
with `ng-bind-html`. These directives never compile their contents, thus
any escaped expression `{{ ... }}` entered by the user is never evaluated (and thus, unescaped by angular)

We can either:
1. Compile the content needlessly just to remove escaped expressions.
2. Remove the escaped expression explicitly.

This PR implements the second approach.

https://community.openproject.com/work_packages/24050/activity
