### PR TITLE
[24069] [Accessibility] "You are here" shown twice on work package menu

### DIFF
--- a/frontend/app/layout/query-menu-item-factory.js
+++ b/frontend/app/layout/query-menu-item-factory.js
@@ -48,11 +48,6 @@ module.exports = function(menuItemFactory, $state, $stateParams, $animate, $time
         // No idea though, why these sometimes are null and sometimes are undefined.
         element.toggleClass('selected', $state.includes('work-packages') &&
                                         (scope.queryId == $stateParams.query_id));
-
-        // Add hidden info for blind users
-        element.prop('title', I18n.t('js.description_current_position') + element.prop('title'));
-        var hiddenLabel = jQuery("<span class='hidden-for-sighted'>" + I18n.t('js.description_current_position') + "</span>")[0];
-        element.prepend(hiddenLabel);
       }
       scope.$on('openproject.layout.activateMenuItem', setActiveState);
 


### PR DESCRIPTION
This removes the doubled position info from the WP menu entry. This info is now obsolete because the position info is already added in the `menu_helper`. 
**Note** To see the changed behavior you may have to clear the cache first.

https://community.openproject.com/work_packages/24069/activity
