### PR TITLE
Fix params deprecation in spec/controllers

### DIFF
--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -41,34 +41,49 @@ describe AccountController, type: :controller do
 
     describe 'User logging in with back_url' do
       it 'should redirect to a relative path' do
-        post :login, username: admin.login, password: 'adminADMIN!', back_url: '/'
+        post :login,
+             params: { username: admin.login, password: 'adminADMIN!', back_url: '/' }
         expect(response).to redirect_to root_path
       end
 
       it 'should redirect to an absolute path given the same host' do
         # note: test.host is the hostname during tests
-        post :login, username: admin.login,
-                     password: 'adminADMIN!',
-                     back_url: 'http://test.host/work_packages/show/1'
+        post :login,
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!',
+               back_url: 'http://test.host/work_packages/show/1'
+             }
         expect(response).to redirect_to '/work_packages/show/1'
       end
 
       it 'should not redirect to another host' do
-        post :login, username: admin.login,
-                     password: 'adminADMIN!',
-                     back_url: 'http://test.foo/work_packages/show/1'
+        post :login,
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!',
+               back_url: 'http://test.foo/work_packages/show/1'
+             }
         expect(response).to redirect_to my_page_path
       end
 
       it 'should not redirect to another host with a protocol relative url' do
-        post :login, username: admin.login,
-                     password: 'adminADMIN!',
-                     back_url: '//test.foo/fake'
+        post :login,
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!',
+               back_url: '//test.foo/fake'
+             }
         expect(response).to redirect_to my_page_path
       end
 
       it 'should not redirect to logout' do
-        post :login, username: admin.login, password: 'adminADMIN!', back_url: '/logout'
+        post :login,
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!',
+               back_url: '/logout'
+             }
         expect(response).to redirect_to my_page_path
       end
 
@@ -79,7 +94,7 @@ describe AccountController, type: :controller do
                                                                lastname: 'Smith',
                                                                mail: 'foo@bar.com',
                                                                auth_source_id: 66)
-        post :login, username: 'foo', password: 'bar'
+        post :login, params: { username: 'foo', password: 'bar' }
 
         expect(response).to redirect_to home_url(first_time_user: true)
         user = User.find_by_login('foo')
@@ -99,44 +114,62 @@ describe AccountController, type: :controller do
         end
 
         it 'should redirect to the same subdirectory with an absolute path' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: 'http://test.host/openproject/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: 'http://test.host/openproject/work_packages/show/1'
+               }
           expect(response).to redirect_to '/openproject/work_packages/show/1'
         end
 
         it 'should redirect to the same subdirectory with a relative path' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: '/openproject/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: '/openproject/work_packages/show/1'
+               }
           expect(response).to redirect_to '/openproject/work_packages/show/1'
         end
 
         it 'should not redirect to another subdirectory with an absolute path' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: 'http://test.host/foo/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: 'http://test.host/foo/work_packages/show/1'
+               }
           expect(response).to redirect_to my_page_path
         end
 
         it 'should not redirect to another subdirectory with a relative path' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: '/foo/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: '/foo/work_packages/show/1'
+               }
           expect(response).to redirect_to my_page_path
         end
 
         it 'should not redirect to another subdirectory by going up the path hierarchy' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: 'http://test.host/openproject/../foo/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: 'http://test.host/openproject/../foo/work_packages/show/1'
+               }
           expect(response).to redirect_to my_page_path
         end
 
         it 'should not redirect to another subdirectory with a protocol relative path' do
-          post :login, username: admin.login,
-                       password: 'adminADMIN!',
-                       back_url: '//test.host/foo/work_packages/show/1'
+          post :login,
+               params: {
+                 username: admin.login,
+                 password: 'adminADMIN!',
+                 back_url: '//test.host/foo/work_packages/show/1'
+               }
           expect(response).to redirect_to my_page_path
         end
       end
@@ -144,9 +177,12 @@ describe AccountController, type: :controller do
 
     describe 'for a user trying to log in via an API request' do
       before do
-        post :login, username: admin.login,
-                     password: 'adminADMIN!',
-                     format: :json
+        post :login,
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!'
+             },
+             format: :json
       end
 
       it 'should return a 410' do
@@ -184,7 +220,7 @@ describe AccountController, type: :controller do
 
     describe 'POST' do
       it 'redirects to some_provider' do
-        post :login, username: 'foo', password: 'bar'
+        post :login, params: { username: 'foo', password: 'bar' }
 
         expect(response).to redirect_to '/auth/some_provider'
       end
@@ -200,10 +236,13 @@ describe AccountController, type: :controller do
 
     describe "User who is not allowed to change password can't login" do
       before do
-        post 'change_password', username: admin.login,
-                                password: 'adminADMIN!',
-                                new_password: 'adminADMIN!New',
-                                new_password_confirmation: 'adminADMIN!New'
+        post 'change_password',
+             params: {
+               username: admin.login,
+               password: 'adminADMIN!',
+               new_password: 'adminADMIN!New',
+               new_password_confirmation: 'adminADMIN!New'
+             }
       end
 
       it 'should redirect to the login page' do
@@ -213,7 +252,7 @@ describe AccountController, type: :controller do
 
     describe 'User who is not allowed to change password, is not redirected to the login page' do
       before do
-        post 'login', username: admin.login, password: 'adminADMIN!'
+        post 'login', params: { username: admin.login, password: 'adminADMIN!' }
       end
 
       it 'should redirect ot the login page' do
@@ -297,14 +336,17 @@ describe AccountController, type: :controller do
         # expects `redirect_to_path`
         shared_examples 'automatic self registration succeeds' do
           before do
-            post :register, user: {
-              login: 'register',
-              password: 'adminADMIN!',
-              password_confirmation: 'adminADMIN!',
-              firstname: 'John',
-              lastname: 'Doe',
-              mail: 'register@example.com'
-            }
+            post :register,
+                 params: {
+                   user: {
+                     login: 'register',
+                     password: 'adminADMIN!',
+                     password_confirmation: 'adminADMIN!',
+                     firstname: 'John',
+                     lastname: 'Doe',
+                     mail: 'register@example.com'
+                   }
+                 }
           end
 
           it 'redirects to my page' do
@@ -341,14 +383,17 @@ describe AccountController, type: :controller do
       context 'with password login enabled' do
         before do
           Token.delete_all
-          post :register, user: {
-            login: 'register',
-            password: 'adminADMIN!',
-            password_confirmation: 'adminADMIN!',
-            firstname: 'John',
-            lastname: 'Doe',
-            mail: 'register@example.com'
-          }
+          post :register,
+               params: {
+                 user: {
+                   login: 'register',
+                   password: 'adminADMIN!',
+                   password_confirmation: 'adminADMIN!',
+                   firstname: 'John',
+                   lastname: 'Doe',
+                   mail: 'register@example.com'
+                 }
+               }
         end
 
         it 'redirects to the login page' do
@@ -391,7 +436,7 @@ describe AccountController, type: :controller do
 
       context 'without back_url' do
         before do
-          post :register, user: user_hash
+          post :register, params: { user: user_hash }
         end
 
         it 'redirects to the login page' do
@@ -405,7 +450,7 @@ describe AccountController, type: :controller do
 
       context 'with back_url' do
         before do
-          post :register, user: user_hash, back_url: 'https://example.net/some_back_url'
+          post :register, params: { user: user_hash, back_url: 'https://example.net/some_back_url' }
         end
 
         it 'preserves the back url' do
@@ -429,14 +474,17 @@ describe AccountController, type: :controller do
       before do
         allow(Setting).to receive(:self_registration).and_return('0')
         allow(Setting).to receive(:self_registration?).and_return(false)
-        post :register, user: {
-          login: 'register',
-          password: 'adminADMIN!',
-          password_confirmation: 'adminADMIN!',
-          firstname: 'John',
-          lastname: 'Doe',
-          mail: 'register@example.com'
-        }
+        post :register,
+             params: {
+               user: {
+                 login: 'register',
+                 password: 'adminADMIN!',
+                 password_confirmation: 'adminADMIN!',
+                 firstname: 'John',
+                 lastname: 'Doe',
+                 mail: 'register@example.com'
+               }
+             }
       end
 
       it_behaves_like 'registration disabled'
@@ -454,16 +502,21 @@ describe AccountController, type: :controller do
 
       context 'with password login enabled' do
         before do
-          post :login, username: 'foo', password: 'bar'
+          post :login, params: { username: 'foo', password: 'bar' }
         end
 
         it 'registers the user on-the-fly' do
           is_expected.to respond_with :success
           expect(response).to render_template :register
 
-          post :register, user: { firstname: 'Foo',
-                                  lastname: 'Smith',
-                                  mail: 'foo@bar.com' }
+          post :register,
+               params: {
+                 user: {
+                   firstname: 'Foo',
+                   lastname: 'Smith',
+                   mail: 'foo@bar.com'
+                 }
+               }
           expect(response).to redirect_to '/my/account'
 
           user = User.find_by_login('foo')
@@ -481,7 +534,7 @@ describe AccountController, type: :controller do
 
         describe 'login' do
           before do
-            post :login, username: 'foo', password: 'bar'
+            post :login, params: { username: 'foo', password: 'bar' }
           end
 
           it 'is not found' do
@@ -491,9 +544,14 @@ describe AccountController, type: :controller do
 
         describe 'registration' do
           before do
-            post :register, user: { firstname: 'Foo',
-                                    lastname: 'Smith',
-                                    mail: 'foo@bar.com' }
+            post :register,
+                 params: {
+                   user: {
+                     firstname: 'Foo',
+                     lastname: 'Smith',
+                     mail: 'foo@bar.com'
+                   }
+                 }
           end
 
           it_behaves_like 'registration disabled'

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -80,7 +80,9 @@ describe ActivitiesController, type: :controller do
       end
 
       describe 'empty filter selection' do
-        before do get 'index', apply: true end
+        before do
+          get 'index', params: { apply: true }
+        end
 
         it_behaves_like 'valid index response'
 
@@ -95,7 +97,7 @@ describe ActivitiesController, type: :controller do
       }
 
       it 'renders activity' do
-        get 'index', project_id: project.id
+        get 'index', params: { project_id: project.id }
         expect(response).to be_success
         expect(response).to render_template 'index'
       end
@@ -108,7 +110,7 @@ describe ActivitiesController, type: :controller do
       }
 
       it 'renders 403' do
-        get 'index', project_id: project.id
+        get 'index', params: { project_id: project.id }
         expect(response.status).to eq(403)
         expect(response).to render_template 'common/error'
       end
@@ -117,7 +119,7 @@ describe ActivitiesController, type: :controller do
     shared_context 'index with params' do
       let(:session_values) { defined?(session_hash) ? session_hash : {} }
 
-      before { get :index, params, session_values }
+      before { get :index, params: params, session: session_values }
     end
 
     describe '#atom_feed' do

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -22,10 +22,12 @@ describe AnnouncementsController, type: :controller do
     before do
       expect(announcement).to receive(:save).and_call_original
       put :update,
-          announcement: {
-            until_date: '2011-01-11',
-            text: 'announcement!!!',
-            active: 1
+          params: {
+            announcement: {
+              until_date: '2011-01-11',
+              text: 'announcement!!!',
+              active: 1
+            }
           }
     end
 

--- a/spec/controllers/api/experimental/queries_controller_spec.rb
+++ b/spec/controllers/api/experimental/queries_controller_spec.rb
@@ -98,7 +98,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'should respond with 403 to project scoped request' do
-        get :available_columns, format: :json, project_id: project.id
+        get :available_columns, format: :json, params: { project_id: project.id }
         expect(response.response_code).to eql(403)
       end
     end
@@ -126,7 +126,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'should respond with 403 to project scoped request' do
-        get :custom_field_filters, format: :json, project_id: project.id
+        get :custom_field_filters, format: :json, params: { id: project.id }
         expect(response.response_code).to eql(403)
       end
     end
@@ -135,7 +135,7 @@ describe Api::Experimental::QueriesController, type: :controller do
   describe '#grouped' do
     context 'within a project' do
       it 'responds with 200' do
-        get :grouped, format: :json, project_id: project.id
+        get :grouped, format: :json, params: { project_id: project.id }
       end
     end
 
@@ -154,7 +154,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'should respond with 403 to project scoped request' do
-        post :grouped, format: :json, project_id: project.id
+        post :grouped, format: :json, params: { project_id: project.id }
         expect(response.response_code).to eql(403)
       end
     end
@@ -175,7 +175,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'responds with 200' do
-        post :create, valid_params
+        post :create, params: valid_params
         expect(response.response_code).to eql(200)
       end
     end
@@ -193,7 +193,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'responds with 200' do
-        post :create, valid_params
+        post :create, params: valid_params
         expect(response.response_code).to eql(200)
       end
     end
@@ -207,7 +207,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'should respond with 403 to project scoped request' do
-        post :create, format: :json, project_id: project.id
+        post :create, format: :json, params: { project_id: project.id }
         expect(response.response_code).to eql(403)
       end
     end
@@ -218,7 +218,8 @@ describe Api::Experimental::QueriesController, type: :controller do
       let(:user) { FactoryGirl.create(:user) }
       let(:query) { FactoryGirl.create(:query, project: project, user: user) }
       let(:valid_params) do
-        { 'c' => ['type', 'status', 'priority', 'assigned_to'],
+        {
+          'c' => ['type', 'status', 'priority', 'assigned_to'],
           'f' => ['status'],
           'group_by' => '',
           'is_public' => 'false',
@@ -228,11 +229,12 @@ describe Api::Experimental::QueriesController, type: :controller do
           'query_id' => query.id,
           'id' => query.id,
           'project_id' => project.id,
-          'format' => 'json' }
+          'format' => 'json'
+        }
       end
 
       shared_examples_for 'valid query update' do
-        before { post :update, valid_params }
+        before { post :update, params: valid_params }
 
         it { expect(response.response_code).to eql(200) }
       end
@@ -333,7 +335,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'responds with 200' do
-        post :update, valid_params
+        post :update, params: valid_params
         expect(response.response_code).to eql(200)
       end
     end
@@ -374,7 +376,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'responds with 200' do
-        delete :destroy, valid_params
+        delete :destroy, params: valid_params
         expect(response.response_code).to eql(200)
       end
     end
@@ -398,7 +400,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'responds with 200' do
-        delete :destroy, valid_params
+        delete :destroy, params: valid_params
         expect(response.response_code).to eql(200)
       end
     end
@@ -412,7 +414,7 @@ describe Api::Experimental::QueriesController, type: :controller do
       end
 
       it 'should respond with 403 to project scoped request' do
-        delete :destroy, format: :json, project_id: project.id
+        delete :destroy, format: :json, params: { project_id: project.id }
         expect(response.response_code).to eql(403)
       end
     end

--- a/spec/controllers/api/experimental/users_controller_spec.rb
+++ b/spec/controllers/api/experimental/users_controller_spec.rb
@@ -61,7 +61,7 @@ describe Api::Experimental::UsersController, type: :controller do
 
     context 'with a project' do
       before do
-        get 'index', project_id: project.id, format: 'json'
+        get 'index', params: { project_id: project.id }, format: 'json'
       end
 
       context 'with the necessary permissions' do

--- a/spec/controllers/api/experimental/versions_controller_spec.rb
+++ b/spec/controllers/api/experimental/versions_controller_spec.rb
@@ -46,12 +46,12 @@ describe Api::Experimental::VersionsController, type: :controller do
     context 'within a project' do
       context 'with no versions available' do
         it 'assigns an empty versions array' do
-          get 'index', format: 'json', project_id: project.id
+          get 'index', format: 'json', params: { project_id: project.id }
           expect(assigns(:versions)).to eq []
         end
 
         it 'renders the index template' do
-          get 'index', format: 'json', project_id: project.id
+          get 'index', format: 'json', params: { project_id: project.id }
           expect(response).to render_template('api/experimental/versions/index')
         end
       end
@@ -63,7 +63,7 @@ describe Api::Experimental::VersionsController, type: :controller do
         end
 
         it 'assigns an array with 2 versions' do
-          get 'index', format: 'json', project_id: project.id
+          get 'index', format: 'json', params: { project_id: project.id }
           expect(assigns(:versions).size).to eq 2
         end
       end
@@ -72,7 +72,7 @@ describe Api::Experimental::VersionsController, type: :controller do
         let(:role)         { FactoryGirl.create(:role, permissions: []) }
 
         it 'should respond with 403' do
-          get 'index', format: 'json', project_id: project.id
+          get 'index', format: 'json', params: { project_id: project.id }
           expect(response.response_code).to eql(403)
         end
       end

--- a/spec/controllers/api/v2/authentication_spec.rb
+++ b/spec/controllers/api/v2/authentication_spec.rb
@@ -99,12 +99,12 @@ describe Api::V2::AuthenticationController, type: :controller do
     it 'should not expire' do
       session[:updated_at] = Time.now
 
-      get :index, format: 'xml', key: api_key
+      get :index, format: 'xml', params: { key: api_key }
       expect(response.status).to eq(200)
 
       Timecop.travel(Time.now + (ttl + 1).minutes) do
         # Now another request after a normal session would be expired
-        get :index, format: 'xml', key: api_key
+        get :index, format: 'xml', params: { key: api_key }
         expect(response.status).to eq(200)
       end
     end
@@ -121,7 +121,7 @@ describe Api::V2::AuthenticationController, type: :controller do
     end
 
     it 'has Basic auth_scheme per default' do
-      get :index, format: 'xml', key: api_key.reverse
+      get :index, format: 'xml', params: { key: api_key.reverse }
 
       expect(response.status).to eq 401
       expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="OpenProject API"'
@@ -133,7 +133,7 @@ describe Api::V2::AuthenticationController, type: :controller do
       end
 
       it 'has Session auth scheme' do
-        get :index, format: 'xml', key: api_key.reverse
+        get :index, format: 'xml', params: { key: api_key.reverse }
 
         expect(response.status).to eq 401
         expect(response.headers['WWW-Authenticate']).to eq 'Session realm="OpenProject API"'
@@ -147,7 +147,7 @@ describe Api::V2::AuthenticationController, type: :controller do
       end
 
       it 'has another realm' do
-        get :index, format: 'xml', key: api_key.reverse
+        get :index, format: 'xml', params: { key: api_key.reverse }
 
         expect(response.headers['WWW-Authenticate']).to eq 'Basic realm="Narnia"'
       end

--- a/spec/controllers/api/v2/pagination/pagination_spec_helper.rb
+++ b/spec/controllers/api/v2/pagination/pagination_spec_helper.rb
@@ -44,7 +44,7 @@ module Api
                 .with(params['q'])
                 .and_return(model)
 
-              get :index, params
+              get :index, params: params
             end
 
             it 'should be successful' do

--- a/spec/controllers/api/v2/planning_element_journals_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_element_journals_controller_spec.rb
@@ -36,9 +36,12 @@ describe Api::V2::PlanningElementJournalsController, type: :controller do
       planning_element = FactoryGirl.create(:work_package,
                                             project_id: project.id)
 
-      get 'index', project_id:          project.identifier,
-                   planning_element_id: planning_element.id,
-                   format:              'xml'
+      get 'index',
+          params: {
+            project_id: project.identifier,
+            planning_element_id: planning_element.id
+          },
+          format: 'xml'
     end
     let(:permission) { :view_work_packages }
 

--- a/spec/controllers/api/v2/planning_element_type_colors_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_element_type_colors_controller_spec.rb
@@ -78,13 +78,13 @@ describe Api::V2::PlanningElementTypeColorsController, type: :controller do
     describe 'with unknown color' do
       if false # would like to write it this way
         it 'returns status code 404' do
-          get 'show', id: '1337', format: 'xml'
+          get :show, params: { id: '1337' }, format: 'xml'
 
           expect(response.status).to eq('404 Not Found')
         end
 
         it 'returns an empty body' do
-          get 'show', id: '1337', format: 'xml'
+          get :show, params: { id: '1337' }, format: 'xml'
 
           expect(response.body).to be_empty
         end
@@ -92,7 +92,7 @@ describe Api::V2::PlanningElementTypeColorsController, type: :controller do
       else # but have to write it that way
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', id: '1337', format: 'xml'
+            get :show, params: { id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -104,17 +104,17 @@ describe Api::V2::PlanningElementTypeColorsController, type: :controller do
       end
 
       def fetch
-        get 'show', id: '1337', format: 'xml'
+        get :show, params: { id: '1337' }, format: 'xml'
       end
       it_should_behave_like 'a controller action with unrestricted access'
 
       it 'assigns the available color' do
-        get 'show', id: '1337', format: 'xml'
+        get :show, params: { id: '1337' }, format: 'xml'
         expect(assigns(:color)).to eq(@available_color)
       end
 
       it 'renders the show template' do
-        get 'show', id: '1337', format: 'xml'
+        get :show, params: { id: '1337' }, format: 'xml'
         expect(response).to render_template('planning_element_type_colors/show')
       end
     end

--- a/spec/controllers/api/v2/planning_element_types_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_element_types_controller_spec.rb
@@ -51,13 +51,13 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
       let(:permission) { :view_work_packages }
 
       def fetch
-        get 'index', project_id: project.identifier, format: 'xml'
+        get 'index', params: { project_id: project.identifier }, format: 'xml'
       end
       it_should_behave_like 'a controller action which needs project permissions'
 
       describe 'with unknown project' do
         it 'returns 404' do
-          get 'index', project_id: 'blah', format: 'xml'
+          get 'index', params: { project_id: 'blah' }, format: 'xml'
 
           expect(response.response_code).to eql 404
         end
@@ -65,12 +65,12 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
 
       describe 'with only the standard type available' do
         it 'assigns an type array including the standard type' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(assigns(:types)).to eq(project.types)
         end
 
         it 'renders the index builder template' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(response).to render_template('planning_element_types/index')
         end
       end
@@ -98,12 +98,12 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         end
 
         it 'assigns an array with all planning element types' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(assigns(:types).to_set).to eq(@all_types.to_set)
         end
 
         it 'renders the index template' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(response).to render_template('planning_element_types/index')
         end
       end
@@ -117,13 +117,13 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         @available_type = FactoryGirl.create(:type, id: '1337')
         enable_type(project, @available_type)
 
-        get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+        get 'show', params: { project_id: project.identifier, id: '1337' }, format: 'xml'
       end
       it_should_behave_like 'a controller action which needs project permissions'
 
       describe 'with unknown project' do
         it 'returns 404' do
-          get 'show', project_id: 'blah', id: '1337', format: 'xml'
+          get 'show', params: { project_id: 'blah', id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eql 404
         end
@@ -131,7 +131,7 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
 
       describe 'with unknown planning element type' do
         it 'returns 404' do
-          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+          get 'show', params: { project_id: project.identifier, id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eql 404
         end
@@ -143,7 +143,7 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         end
 
         it 'returns 404' do
-          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+          get 'show', params: { project_id: project.identifier, id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eql 404
         end
@@ -158,12 +158,12 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         end
 
         it 'assigns the available planning element type' do
-          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+          get 'show', params: { project_id: project.identifier, id: '1337' }, format: 'xml'
           expect(assigns(:type)).to eq(@available_planning_element_type)
         end
 
         it 'renders the show template' do
-          get 'show', project_id: project.identifier, id: '1337', format: 'xml'
+          get 'show', params: { project_id: project.identifier, id: '1337' }, format: 'xml'
           expect(response).to render_template('planning_element_types/show')
         end
       end
@@ -219,7 +219,7 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
 
       describe 'with unknown planning element type' do
         it 'returns 404' do
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eql 404
         end
@@ -231,17 +231,17 @@ describe Api::V2::PlanningElementTypesController, type: :controller do
         end
 
         def fetch
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
         end
         it_should_behave_like 'a controller action which needs project permissions'
 
         it 'assigns the available planning element type' do
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
           expect(assigns(:type)).to eq(@available_planning_element_type)
         end
 
         it 'renders the show template' do
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
           expect(response).to render_template('planning_element_types/show')
         end
       end

--- a/spec/controllers/api/v2/planning_elements_controller_spec.rb
+++ b/spec/controllers/api/v2/planning_elements_controller_spec.rb
@@ -123,7 +123,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
     describe 'w/ list of ids' do
       describe 'w/ an unknown work package id' do
         it 'renders an empty list' do
-          get 'index', ids: '4711', format: 'xml'
+          get 'index', params: { ids: '4711' }, format: 'xml'
 
           expect(assigns(:planning_elements)).to eq([])
         end
@@ -137,7 +137,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders an empty list' do
-            get 'index', ids: work_package.id.to_s, format: 'xml'
+            get 'index', params: { ids: work_package.id.to_s }, format: 'xml'
 
             expect(assigns(:planning_elements)).to eq([])
           end
@@ -147,7 +147,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_view_planning_element_permissions
 
           before do
-            get 'index', ids: '', format: 'xml'
+            get 'index', params: { ids: '' }, format: 'xml'
           end
 
           describe 'w/o any planning elements within the project' do
@@ -167,7 +167,9 @@ describe Api::V2::PlanningElementsController, type: :controller do
                 FactoryGirl.create(:work_package, project_id: project.id),
                 FactoryGirl.create(:work_package, project_id: project.id)
               ]
-              get 'index', ids: @created_planning_elements.map(&:id).join(','), format: 'xml'
+              get 'index',
+                  params: { ids: @created_planning_elements.map(&:id).join(',') },
+                  format: 'xml'
             end
 
             it 'assigns a planning_elements array containing all three elements' do
@@ -189,10 +191,13 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
               context 'with rewire_parents=false' do
                 before do
-                  get 'index', project_id: project.id,
-                               ids: wp_child.id.to_s,
-                               rewire_parents: 'false',
-                               format: 'xml'
+                  get 'index',
+                      params: {
+                        project_id: project.id,
+                        ids: wp_child.id.to_s,
+                        rewire_parents: 'false'
+                      },
+                      format: 'xml'
                 end
 
                 it "includes the child's parent_id" do
@@ -206,9 +211,12 @@ describe Api::V2::PlanningElementsController, type: :controller do
                 # without rewiring disabled.
                 # Passing a project_id here, so we can test this with rewiring enabled.
                 before do
-                  get 'index', project_id: project.id,
-                               ids: wp_child.id.to_s,
-                               format: 'xml'
+                  get 'index',
+                      params: {
+                        project_id: project.id,
+                        ids: wp_child.id.to_s
+                      },
+                      format: 'xml'
                 end
 
                 it "doesn't include child's parent_id" do
@@ -243,7 +251,11 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_admin { [project_a, project_b] }
 
           it 'renders only existing work packages' do
-            get 'index', ids: [@project_a_wps[0].id, @project_b_wps[0].id, '4171', '5555'].join(','), format: 'xml'
+            get 'index',
+                params: {
+                  ids: [@project_a_wps[0].id, @project_b_wps[0].id, '4171', '5555'].join(',')
+                },
+                format: 'xml'
 
             expect(assigns(:planning_elements)).to match_array([@project_a_wps[0], @project_b_wps[0]])
           end
@@ -254,13 +266,20 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member { [project_c] }
 
           it 'renders only accessable work packages' do
-            get 'index', ids: [@project_a_wps[0].id, @project_b_wps[0].id, @project_c_wps[0].id, @project_c_wps[1].id].join(','), format: 'xml'
+            get 'index',
+                params: {
+                  ids: [@project_a_wps[0].id, @project_b_wps[0].id,
+                        @project_c_wps[0].id, @project_c_wps[1].id].join(',')
+                },
+                format: 'xml'
 
             expect(assigns(:planning_elements)).to match_array([@project_a_wps[0], @project_b_wps[0]])
           end
 
           it 'renders only accessable work packages' do
-            get 'index', ids: [@project_c_wps[0].id, @project_c_wps[1].id].join(','), format: 'xml'
+            get 'index',
+                params: { ids: [@project_c_wps[0].id, @project_c_wps[1].id].join(',') },
+                format: 'xml'
 
             expect(assigns(:planning_elements)).to match_array([])
           end
@@ -270,7 +289,11 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_view_planning_element_permissions { [project_a, project_b, project_c] }
 
           it 'renders all work packages' do
-            get 'index', ids: (@project_a_wps + @project_b_wps + @project_c_wps).map(&:id).join(','), format: 'xml'
+            get 'index',
+                params: {
+                  ids: (@project_a_wps + @project_b_wps + @project_c_wps).map(&:id).join(',')
+                },
+                format: 'xml'
 
             expect(assigns(:planning_elements)).to match_array(@project_a_wps + @project_b_wps + @project_c_wps)
           end
@@ -295,7 +318,9 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
         context 'without rewire_parents' do  # equivalent to rewire_parents=true
           it 'rewires ancestors correctly' do
-            get 'index', project_id: project1.id, format: 'xml'
+            get 'index',
+                params: { project_id: project1.id },
+                format: 'xml'
 
             # the controller returns structs. We therefore have to filter for those
             ticket_f_struct = assigns(:planning_elements).detect { |pe| pe.id == ticket_f.id }
@@ -306,7 +331,9 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
         context 'with rewire_parents=false' do
           before do
-            get 'index', project_id: project1.id, format: 'xml', rewire_parents: 'false'
+            get 'index',
+                params: { project_id: project1.id, rewire_parents: 'false' },
+                format: 'xml'
           end
 
           it "doesn't rewire ancestors" do
@@ -338,7 +365,11 @@ describe Api::V2::PlanningElementsController, type: :controller do
         become_admin { [work_package.project] }
 
         shared_context 'get work packages changed since' do
-          before { get 'index', project_id: work_package.project_id, changed_since: timestamp,  format: 'xml' }
+          before do
+            get 'index',
+                params: { project_id: work_package.project_id, changed_since: timestamp },
+                format: 'xml'
+          end
         end
 
         describe 'valid timestamp' do
@@ -395,13 +426,21 @@ describe Api::V2::PlanningElementsController, type: :controller do
       become_admin { [project_a, project_b, work_package_c.project] }
 
       describe 'empty ids' do
-        before { get 'index', project_id: project_ids, ids: '', format: 'xml' }
+        before do
+          get 'index',
+              params: { project_id: project_ids, ids: '' },
+              format: 'xml'
+        end
 
         it { expect(assigns(:planning_elements)).to be_empty }
       end
 
       shared_examples_for 'valid ids request' do
-        before { get 'index', project_id: project_ids, ids: wp_ids.join(','), format: 'xml' }
+        before do
+          get 'index',
+              params: { project_id: project_ids, ids: wp_ids.join(',') },
+              format: 'xml'
+        end
 
         subject { assigns(:planning_elements).map(&:id) }
 
@@ -430,7 +469,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
     describe 'w/ list of projects' do
       describe 'w/ an unknown project' do
         it 'renders a 404 Not Found page' do
-          get 'index', project_id: 'project_x,project_b', format: 'xml'
+          get 'index', params: { project_id: 'project_x,project_b' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -443,7 +482,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders a 403 Forbidden page' do
-            get 'index', project_id: project.identifier, format: 'xml'
+            get 'index', params: { project_id: project.identifier }, format: 'xml'
 
             expect(response.response_code).to eq(403)
           end
@@ -453,7 +492,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_view_planning_element_permissions
 
           before do
-            get 'index', project_id: project.id, format: 'xml'
+            get 'index', params: { project_id: project.id }, format: 'xml'
           end
 
           describe 'w/o any planning elements within the project' do
@@ -475,7 +514,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
               ]
               @created_planning_elements = work_packages_to_structs(created_planning_elements)
 
-              get 'index', project_id: project.id, format: 'xml'
+              get 'index', params: { project_id: project.id }, format: 'xml'
             end
 
             it 'assigns a planning_elements array containing all three elements' do
@@ -498,8 +537,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_admin { [project_a, project_b] }
 
           it 'renders a 404 Not Found page' do
-            get 'index', project_id: 'project_x,project_b', format: 'xml'
-
+            get 'index', params: { project_id: 'project_x,project_b' }, format: 'xml'
             expect(response.response_code).to eq(404)
           end
         end
@@ -508,7 +546,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           before { project_a; project_b }
           become_non_member { [project_b] }
           before do
-            get 'index', project_id: 'project_a,project_b', format: 'xml'
+            get 'index', params: { project_id: 'project_a,project_b' }, format: 'xml'
           end
 
           it 'assigns an empty planning_elements array' do
@@ -524,7 +562,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_view_planning_element_permissions { [project_a, project_b] }
 
           before do
-            get 'index', project_id: 'project_a,project_b', format: 'xml'
+            get 'index', params: { project_id: 'project_a,project_b' }, format: 'xml'
           end
 
           describe 'w/o any planning elements within the project' do
@@ -550,7 +588,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
               # adding another planning element, just to make sure, that the
               # result set is properly filtered
               FactoryGirl.create(:work_package, project_id: project_c.id)
-              get 'index', project_id: 'project_a,project_b', format: 'xml'
+              get 'index', params: { project_id: 'project_a,project_b' }, format: 'xml'
             end
 
             it 'assigns a planning_elements array containing all three elements' do
@@ -578,9 +616,12 @@ describe Api::V2::PlanningElementsController, type: :controller do
       end
 
       def fetch
-        post 'create', project_id: project.identifier,
-                       format: 'xml',
-                       planning_element: planning_element.attributes
+        post 'create',
+             params: {
+               project_id: project.identifier,
+               planning_element: planning_element.attributes
+             },
+             format: 'xml'
       end
 
       def expect_redirect_to
@@ -612,10 +653,13 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       it 'creates a new planning element with the given custom field value' do
         post 'create',
-             project_id: project.identifier,
-             format: 'xml',
-             planning_element: planning_element.attributes.merge(custom_fields: [
-               { id: custom_field.id, value: 'Wurst' }])
+             params: {
+               project_id: project.identifier,
+               planning_element: planning_element.attributes.merge(
+                 custom_fields: [{ id: custom_field.id, value: 'Wurst' }]
+               )
+             },
+             format: 'xml'
         expect(response.response_code).to eq(303)
 
         id = response.headers['Location'].scan(/\d+/).last.to_i
@@ -639,7 +683,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
     describe 'w/o a valid planning element id' do
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: '4711', format: 'xml'
+          get 'show', params: { id: '4711' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -647,7 +691,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       describe 'w/ an unknown project' do
         it 'renders a 404 Not Found page' do
-          get 'show', project_id: '4711', id: '1337', format: 'xml'
+          get 'show', params: {  project_id: '4711', id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -660,7 +704,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders a 403 Forbidden page' do
-            get 'show', project_id: project.id, id: '1337', format: 'xml'
+            get 'show', params: { project_id: project.id, id: '1337' }, format: 'xml'
 
             expect(response.response_code).to be === 403
           end
@@ -671,7 +715,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
           it 'raises ActiveRecord::RecordNotFound errors' do
             expect {
-              get 'show', project_id: project.id, id: '1337', format: 'xml'
+              get 'show', params: {  project_id: project.id, id: '1337' }, format: 'xml'
             }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
@@ -686,7 +730,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: planning_element.id, format: 'xml'
+          get 'show', params: { id: planning_element.id }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -697,7 +741,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders a 403 Forbidden page' do
-            get 'show', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'show', params: { project_id: project.id, id: planning_element.id }, format: 'xml'
 
             expect(response.response_code).to eq(403)
           end
@@ -707,12 +751,12 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_view_planning_element_permissions
 
           it 'assigns the planning_element' do
-            get 'show', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'show', params: {  project_id: project.id, id: planning_element.id }, format: 'xml'
             expect(assigns(:planning_element)).to eq(planning_element)
           end
 
           it 'renders the show builder template' do
-            get 'show', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'show', params: {  project_id: project.id, id: planning_element.id }, format: 'xml'
             expect(response).to render_template('planning_elements/show')
           end
         end
@@ -740,7 +784,9 @@ describe Api::V2::PlanningElementsController, type: :controller do
       end
 
       it 'should render the custom field values' do
-        get 'show', project_id: project.identifier, id: planning_element.id, format: 'json'
+        get 'show',
+            params: { project_id: project.identifier, id: planning_element.id },
+            format: 'json'
 
         expect(response).to be_success
         expect(response.header['Content-Type']).to include 'application/json'
@@ -762,10 +808,13 @@ describe Api::V2::PlanningElementsController, type: :controller do
       }
 
       def fetch
-        post 'update', project_id:       project.identifier,
-                       id:               planning_element.id,
-                       planning_element: { name: 'blubs' },
-                       format: 'xml'
+        post 'update',
+             params: {
+               project_id: project.identifier,
+               id: planning_element.id,
+               planning_element: { name: 'blubs' }
+             },
+             format: 'xml'
       end
 
       def expect_no_content
@@ -778,8 +827,10 @@ describe Api::V2::PlanningElementsController, type: :controller do
     describe 'empty' do
       before do
         put :update,
-            project_id: work_package.project_id,
-            id: work_package.id,
+            params: {
+              project_id: work_package.project_id,
+              id: work_package.id
+            },
             format: :xml
       end
 
@@ -791,9 +842,11 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       before do
         put :update,
-            project_id: work_package.project_id,
-            id: work_package.id,
-            planning_element: { note: note },
+            params: {
+              project_id: work_package.project_id,
+              id: work_package.id,
+              planning_element: { note: note }
+            },
             format: :xml
       end
 
@@ -829,14 +882,16 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       it 'updates the custom field value' do
         put 'update',
-            project_id: project.identifier,
-            format: 'xml',
-            id: planning_element.id,
-            planning_element: {
-              custom_fields: [
-                { id: custom_field.id, value: 'Wurst' }
-              ]
-            }
+            params: {
+              project_id: project.identifier,
+              id: planning_element.id,
+              planning_element: {
+                custom_fields: [
+                  { id: custom_field.id, value: 'Wurst' }
+                ]
+              }
+            },
+            format: :xml
         expect(response.response_code).to eq(204)
 
         wp = WorkPackage.find planning_element.id
@@ -862,10 +917,12 @@ describe Api::V2::PlanningElementsController, type: :controller do
       shared_examples_for 'work package status change' do
         before do
           put 'update',
-              project_id: project.identifier,
-              format: 'xml',
-              id: planning_element.id,
-              planning_element: { status_id: status_b.id }
+              params: {
+                project_id: project.identifier,
+                id: planning_element.id,
+                planning_element: { status_id: status_b.id }
+              },
+              format: 'xml'
         end
 
         it { expect(response.response_code).to eq(expected_response_code) }
@@ -904,7 +961,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
     describe 'w/o a valid planning element id' do
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'destroy', id: '4711', format: 'xml'
+          get 'destroy', params: { id: '4711' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -912,7 +969,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       describe 'w/ an unknown project' do
         it 'renders a 404 Not Found page' do
-          get 'destroy', project_id: '4711', id: '1337', format: 'xml'
+          get 'destroy', params: {  project_id: '4711', id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -925,7 +982,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders a 403 Forbidden page' do
-            get 'destroy', project_id: project.id, id: '1337', format: 'xml'
+            get 'destroy', params: {  project_id: project.id, id: '1337' }, format: 'xml'
 
             expect(response.response_code).to eq(403)
           end
@@ -936,7 +993,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
           it 'raises ActiveRecord::RecordNotFound errors' do
             expect {
-              get 'destroy', project_id: project.id, id: '1337', format: 'xml'
+              get 'destroy', params: {  project_id: project.id, id: '1337' }, format: 'xml'
             }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
@@ -949,7 +1006,7 @@ describe Api::V2::PlanningElementsController, type: :controller do
 
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'destroy', id: planning_element.id, format: 'xml'
+          get 'destroy', params: { id: planning_element.id }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -960,7 +1017,9 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_non_member
 
           it 'renders a 403 Forbidden page' do
-            get 'destroy', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'destroy',
+                params: { project_id: project.id, id: planning_element.id },
+                format: :xml
 
             expect(response.response_code).to eq(403)
           end
@@ -970,19 +1029,25 @@ describe Api::V2::PlanningElementsController, type: :controller do
           become_member_with_delete_planning_element_permissions
 
           it 'assigns the planning_element' do
-            get 'destroy', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'destroy',
+                params: { project_id: project.id, id: planning_element.id },
+                format: :xml
 
             expect(assigns(:planning_element)).to eq(planning_element)
           end
 
           it 'renders the destroy builder template' do
-            get 'destroy', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'destroy',
+                params: { project_id: project.id, id: planning_element.id },
+                format: :xml
 
             expect(response).to render_template('planning_elements/destroy')
           end
 
           it 'deletes the record' do
-            get 'destroy', project_id: project.id, id: planning_element.id, format: 'xml'
+            get 'destroy',
+                params: { project_id: project.id, id: planning_element.id },
+                format: :xml
             expect {
               planning_element.reload
             }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/controllers/api/v2/project_associations_controller_spec.rb
+++ b/spec/controllers/api/v2/project_associations_controller_spec.rb
@@ -46,7 +46,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
 
     describe 'w/ an unknown project' do
       it 'renders a 404 Not Found page' do
-        get 'index', project_id: '4711', format: 'xml'
+        get 'index', params: { project_id: '4711' }, format: 'xml'
 
         expect(response.response_code).to eq(404)
       end
@@ -56,7 +56,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
       let(:project) { FactoryGirl.create(:project, identifier: 'test_project') }
 
       def fetch
-        get 'index', project_id: project.id, format: 'xml'
+        get 'index', params: { project_id: project.id }, format: 'xml'
       end
       let(:permission) { :view_project_associations }
 
@@ -65,12 +65,12 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
       describe 'w/ the current user being a member' do
         describe 'w/o any project_associations within the project' do
           it 'assigns an empty project_associations array' do
-            get 'index', project_id: project.id, format: 'xml'
+            get 'index', params: { project_id: project.id }, format: 'xml'
             expect(assigns(:project_associations)).to eq([])
           end
 
           it 'renders the index builder template' do
-            get 'index', project_id: project.id, format: 'xml'
+            get 'index', params: { project_id: project.id }, format: 'xml'
             expect(response).to render_template('project_associations/index')
           end
         end
@@ -88,12 +88,12 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
           end
 
           it 'assigns a project_associations array containing all three elements' do
-            get 'index', project_id: project.id, format: 'xml'
+            get 'index', params: { project_id: project.id }, format: 'xml'
             expect(assigns(:project_associations)).to eq(@created_project_associations)
           end
 
           it 'renders the index builder template' do
-            get 'index', project_id: project.id, format: 'xml'
+            get 'index', params: { project_id: project.id }, format: 'xml'
             expect(response).to render_template('project_associations/index')
           end
         end
@@ -105,7 +105,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
     describe 'w/o a valid project_association id' do
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: '4711', format: 'xml'
+          get 'show', params: { id: '4711' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -113,7 +113,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
 
       describe 'w/ an unknown project' do
         it 'renders a 404 Not Found page' do
-          get 'index', project_id: '4711', id: '1337', format: 'xml'
+          get 'index', params: { project_id: '4711', id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -125,7 +125,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
         describe 'w/ the current user being a member' do
           it 'raises ActiveRecord::RecordNotFound errors' do
             expect {
-              get 'show', project_id: project.id, id: '1337', format: 'xml'
+              get 'show', params: { project_id: project.id, id: '1337' }, format: 'xml'
             }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
@@ -138,7 +138,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
 
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: project_association.id, format: 'xml'
+          get 'show', params: { id: project_association.id }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -146,7 +146,7 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
 
       describe 'w/ a known project' do
         def fetch
-          get 'show', project_id: project.id, id: project_association.id, format: 'xml'
+          get 'show', params: { project_id: project.id, id: project_association.id }, format: 'xml'
         end
         let(:permission) { :view_project_associations }
 
@@ -154,12 +154,16 @@ describe Api::V2::ProjectAssociationsController, type: :controller do
 
         describe 'w/ the current user being a member' do
           it 'assigns the project_association' do
-            get 'show', project_id: project.id, id: project_association.id, format: 'xml'
+            get 'show',
+                params: { project_id: project.id, id: project_association.id },
+                format: 'xml'
             expect(assigns(:project_association)).to eq(project_association)
           end
 
           it 'renders the index builder template' do
-            get 'index', project_id: project.id, id: project_association.id, format: 'xml'
+            get 'index',
+                params: { project_id: project.id, id: project_association.id },
+                format: 'xml'
             expect(response).to render_template('project_associations/index')
           end
         end

--- a/spec/controllers/api/v2/project_types_controller_spec.rb
+++ b/spec/controllers/api/v2/project_types_controller_spec.rb
@@ -78,7 +78,7 @@ describe Api::V2::ProjectTypesController, type: :controller do
     describe 'with unknown project type' do
       it 'raises ActiveRecord::RecordNotFound errors' do
         expect {
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -89,17 +89,17 @@ describe Api::V2::ProjectTypesController, type: :controller do
       end
 
       def fetch
-        get 'show', id: '1337', format: 'xml'
+        get 'show', params: { id: '1337' }, format: 'xml'
       end
       it_should_behave_like 'a controller action with unrestricted access'
 
       it 'assigns the available project type' do
-        get 'show', id: '1337', format: 'xml'
+        get 'show', params: { id: '1337' }, format: 'xml'
         expect(assigns(:project_type)).to eq(@available_project_type)
       end
 
       it 'renders the show template' do
-        get 'show', id: '1337', format: 'xml'
+        get 'show', params: { id: '1337' }, format: 'xml'
         expect(response).to render_template('api/v2/project_types/show')
       end
     end

--- a/spec/controllers/api/v2/projects_controller_spec.rb
+++ b/spec/controllers/api/v2/projects_controller_spec.rb
@@ -89,7 +89,7 @@ describe Api::V2::ProjectsController, type: :controller do
       describe 'public project' do
         let(:project) { FactoryGirl.create(:project, is_public: true) }
         def fetch
-          get 'show', id: project.identifier, format: 'xml'
+          get 'show', params: { id: project.identifier }, format: 'xml'
         end
         it_should_behave_like 'a controller action with unrestricted access'
       end
@@ -100,7 +100,7 @@ describe Api::V2::ProjectsController, type: :controller do
 
         let(:project) { FactoryGirl.create(:project, is_public: false) }
         def fetch
-          get 'show', id: project.identifier, format: 'xml'
+          get 'show', params: { id: project.identifier }, format: 'xml'
         end
         it_should_behave_like 'a controller action which needs project permissions'
       end
@@ -108,7 +108,7 @@ describe Api::V2::ProjectsController, type: :controller do
       describe 'with unknown project' do
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', id: 'unknown_project', format: 'xml'
+            get 'show', params: { id: 'unknown_project' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -117,12 +117,12 @@ describe Api::V2::ProjectsController, type: :controller do
         let(:project) { FactoryGirl.create(:project, is_public: true) }
 
         it 'assigns the available project' do
-          get 'show', id: project.identifier, format: 'xml'
+          get 'show', params: { id: project.identifier }, format: 'xml'
           expect(assigns(:project)).to eq(project)
         end
 
         it 'renders the show template' do
-          get 'show', id: project.identifier, format: 'xml'
+          get 'show', params: { id: project.identifier }, format: 'xml'
           expect(response).to render_template('api/v2/projects/show')
         end
       end

--- a/spec/controllers/api/v2/reported_project_statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/reported_project_statuses_controller_spec.rb
@@ -46,7 +46,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
       describe 'with unknown project_type' do
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'index', project_type_id: '0', format: 'xml'
+            get 'index', params: { project_type_id: '0' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -54,12 +54,12 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
       describe 'with valid project_type' do
         describe 'with no reported_project_statuses available' do
           it 'assigns an empty reported_project_statuses array' do
-            get 'index', project_type_id: project_type.id, format: 'xml'
+            get 'index', params: { project_type_id: project_type.id }, format: 'xml'
             expect(assigns(:reported_project_statuses)).to eq([])
           end
 
           it 'renders the index builder template' do
-            get 'index', project_type_id: project_type.id, format: 'xml'
+            get 'index', params: { project_type_id: project_type.id }, format: 'xml'
             expect(response).to render_template('api/v2/reported_project_statuses/index')
           end
         end
@@ -89,12 +89,12 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
           end
 
           it 'assigns an array with all reported_project_statuses' do
-            get 'index', project_type_id: project_type.id, format: 'xml'
+            get 'index', params: { project_type_id: project_type.id }, format: 'xml'
             expect(assigns(:reported_project_statuses)).to eq(@created_reported_project_statuses)
           end
 
           it 'renders the index template' do
-            get 'index', project_type_id: project_type.id, format: 'xml'
+            get 'index', params: { project_type_id: project_type.id }, format: 'xml'
             expect(response).to render_template('api/v2/reported_project_statuses/index')
           end
         end
@@ -105,7 +105,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
       describe 'with unknown project_type' do
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', project_type_id: '0', id: '1337', format: 'xml'
+            get 'show', params: { project_type_id: '0', id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -113,7 +113,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
       describe 'with unknown reported_project_status' do
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', project_type_id: project_type.id, id: '1337', format: 'xml'
+            get 'show', params: { project_type_id: project_type.id, id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -132,7 +132,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
 
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', project_type_id: project_type.id, id: '1337', format: 'xml'
+            get 'show', params: { project_type_id: project_type.id, id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -141,7 +141,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
         it 'raises ActiveRecord::RecordNotFound errors' do
           available_reported_project_status
           expect {
-            get 'show', project_type_id: project_type.id, id: '1337', format: 'xml'
+            get 'show', params: { project_type_id: project_type.id, id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -154,12 +154,12 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
         end
 
         it 'assigns the available reported_project_status' do
-          get 'show', project_type_id: project_type.id, id: '1337', format: 'xml'
+          get 'show', params: { project_type_id: project_type.id, id: '1337' }, format: 'xml'
           expect(assigns(:reported_project_status)).to eq(available_reported_project_status)
         end
 
         it 'renders the show template' do
-          get 'show', project_type_id: project_type.id, id: '1337', format: 'xml'
+          get 'show', params: { project_type_id: project_type.id, id: '1337' }, format: 'xml'
           expect(response).to render_template('api/v2/reported_project_statuses/show')
         end
       end
@@ -206,7 +206,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
       describe 'with unknown reported_project_status' do
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', id: '1337', format: 'xml'
+            get 'show', params: { id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -220,7 +220,7 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
 
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', id: '1337', format: 'xml'
+            get 'show', params: { id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -232,12 +232,12 @@ describe Api::V2::ReportedProjectStatusesController, type: :controller do
         end
 
         it 'assigns the available reported_project_status' do
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
           expect(assigns(:reported_project_status)).to eq(@available_reported_project_status)
         end
 
         it 'renders the show template' do
-          get 'show', id: '1337', format: 'xml'
+          get 'show', params: { id: '1337' }, format: 'xml'
           expect(response).to render_template('api/v2/reported_project_statuses/show')
         end
       end

--- a/spec/controllers/api/v2/reportings_controller_spec.rb
+++ b/spec/controllers/api/v2/reportings_controller_spec.rb
@@ -46,7 +46,7 @@ describe Api::V2::ReportingsController, type: :controller do
 
     describe 'w/ an unknown project' do
       it 'renders a 404 Not Found page' do
-        get 'index', project_id: '4711', format: 'xml'
+        get 'index', params: { project_id: '4711' }, format: 'xml'
 
         expect(response.response_code).to eq(404)
       end
@@ -56,19 +56,19 @@ describe Api::V2::ReportingsController, type: :controller do
       let(:project) { FactoryGirl.create(:project, identifier: 'test_project') }
 
       def fetch
-        get 'index', project_id: project.identifier, format: 'xml'
+        get 'index', params: { project_id: project.identifier }, format: 'xml'
       end
       let(:permission) { :view_reportings }
       it_should_behave_like 'a controller action which needs project permissions'
 
       describe 'w/o any reportings within the project' do
         it 'assigns an empty reportings array' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(assigns(:reportings)).to eq([])
         end
 
         it 'renders the index builder template' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(response).to render_template('api/v2/reportings/index')
         end
       end
@@ -83,25 +83,29 @@ describe Api::V2::ReportingsController, type: :controller do
         end
 
         it 'assigns a reportings array containing all three elements' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(assigns(:reportings)).to match_array(@created_reportings)
         end
 
         it 'renders the index builder template' do
-          get 'index', project_id: project.identifier, format: 'xml'
+          get 'index', params: { project_id: project.identifier }, format: 'xml'
           expect(response).to render_template('api/v2/reportings/index')
         end
 
         describe 'w/ ?only=via_source' do
           it 'assigns a reportings array containg the two reportings where project.id is source' do
-            get 'index', project_id: project.identifier, format: 'xml', only: 'via_source'
+            get 'index',
+                params: { project_id: project.identifier, only: 'via_source' },
+                format: 'xml'
             expect(assigns(:reportings)).to match_array(@created_reportings[0..1])
           end
         end
 
         describe 'w/ ?only=via_target' do
           it 'assigns a reportings array containg the two reportings where project.id is source' do
-            get 'index', project_id: project.identifier, format: 'xml', only: 'via_target'
+            get 'index',
+                params: { project_id: project.identifier, only: 'via_target' },
+                format: 'xml'
             expect(assigns(:reportings)).to eq(@created_reportings[2..2])
           end
         end
@@ -113,7 +117,7 @@ describe Api::V2::ReportingsController, type: :controller do
     describe 'w/o a valid reporting id' do
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: '4711', format: 'xml'
+          get 'show', params: { id: '4711' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -121,7 +125,7 @@ describe Api::V2::ReportingsController, type: :controller do
 
       describe 'w/ an unknown project' do
         it 'renders a 404 Not Found page' do
-          get 'index', project_id: '4711', id: '1337', format: 'xml'
+          get 'index', params: { project_id: '4711', id: '1337' }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -132,7 +136,7 @@ describe Api::V2::ReportingsController, type: :controller do
 
         it 'raises ActiveRecord::RecordNotFound errors' do
           expect {
-            get 'show', project_id: project.id, id: '1337', format: 'xml'
+            get 'show', params: { project_id: project.id, id: '1337' }, format: 'xml'
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -144,7 +148,7 @@ describe Api::V2::ReportingsController, type: :controller do
 
       describe 'w/o a given project' do
         it 'renders a 404 Not Found page' do
-          get 'show', id: reporting.id, format: 'xml'
+          get 'show', params: { id: reporting.id }, format: 'xml'
 
           expect(response.response_code).to eq(404)
         end
@@ -152,18 +156,18 @@ describe Api::V2::ReportingsController, type: :controller do
 
       describe 'w/ a known project' do
         def fetch
-          get 'show', project_id: project.id, id: reporting.id, format: 'xml'
+          get 'show', params: { project_id: project.id, id: reporting.id }, format: 'xml'
         end
         let(:permission) { :view_reportings }
         it_should_behave_like 'a controller action which needs project permissions'
 
         it 'assigns the reporting' do
-          get 'show', project_id: project.id, id: reporting.id, format: 'xml'
+          get 'show', params: { project_id: project.id, id: reporting.id }, format: 'xml'
           expect(assigns(:reporting)).to eq(reporting)
         end
 
         it 'renders the index builder template' do
-          get 'index', project_id: project.id, id: reporting.id, format: 'xml'
+          get 'index', params: { project_id: project.id, id: reporting.id }, format: 'xml'
           expect(response).to render_template('api/v2/reportings/index')
         end
       end

--- a/spec/controllers/api/v2/statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/statuses_controller_spec.rb
@@ -40,11 +40,11 @@ describe Api::V2::StatusesController, type: :controller do
     let(:closed) { FactoryGirl.create(:status, name: 'Closed') }
 
     it 'that does not exist should raise an error' do
-      get 'show', id: '0', format: 'json'
+      get 'show', params: { id: '0' }, format: 'json'
       expect(response.response_code).to eq(404)
     end
     it 'that exists should return the proper status' do
-      get 'show', id: closed.id, format: 'json'
+      get 'show', params: { id: closed.id }, format: 'json'
       expect(assigns(:status)).to eql closed
     end
   end

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -54,19 +54,25 @@ describe Api::V2::UsersController, type: :controller do
       end
 
       context 'no scope' do
-        before do get 'index', format: :json end
+        before do
+          get 'index', format: :json
+        end
 
         it_behaves_like 'no scope provided'
       end
 
       context 'empty scope' do
-        before do get 'index', ids: '', format: :json end
+        before do
+          get 'index', params: { ids: '' }, format: :json
+        end
 
         it_behaves_like 'no scope provided'
       end
 
       context 'filled scope' do
-        before do get 'index', ids: '1', format: :json end
+        before do
+          get 'index', params: { ids: '1' }, format: :json
+        end
 
         it_behaves_like 'valid user API call' do
           let(:user_count) { 0 }
@@ -81,7 +87,9 @@ describe Api::V2::UsersController, type: :controller do
       context 'as an admin' do
         include_context 'As an admin'
 
-        before do get 'index', ids: ids, format: :json end
+        before do
+          get 'index', params: { ids: ids }, format: :json
+        end
 
         it_behaves_like 'valid user API call' do
           let(:user_count) { 1 }
@@ -97,7 +105,9 @@ describe Api::V2::UsersController, type: :controller do
       context 'as an admin' do
         include_context 'As an admin'
 
-        before do get 'index', ids: ids, format: :json end
+        before do
+          get 'index', params: { ids: ids }, format: :json
+        end
 
         it_behaves_like 'valid user API call' do
           let(:user_count) { 4 }
@@ -107,7 +117,9 @@ describe Api::V2::UsersController, type: :controller do
       context 'as a normal user' do
         include_context 'As a normal user'
 
-        before do get 'index', ids: ids, format: 'json' end
+        before do
+          get 'index', params: { ids: ids }, format: 'json'
+        end
 
         it_behaves_like 'valid user API call' do
           let(:user_count) { 4 }
@@ -123,7 +135,9 @@ describe Api::V2::UsersController, type: :controller do
 
       let!(:non_member) { FactoryGirl.create :user }
 
-      before do get 'index', project_id: project.to_param, format: :json end
+      before do
+        get 'index', params: { project_id: project.to_param }, format: :json
+      end
 
       it_behaves_like 'valid user API call' do
         let(:user_count) { 1 }
@@ -136,7 +150,9 @@ describe Api::V2::UsersController, type: :controller do
       let (:user_1) { FactoryGirl.create(:user) }
       let (:user_2) { FactoryGirl.create(:user) }
 
-      before do get 'index', ids: "#{user_1.id},#{user_2.id}", format: 'json' end
+      before do
+        get 'index', params: { ids: "#{user_1.id},#{user_2.id}" }, format: 'json'
+      end
 
       subject { assigns(:users) }
 

--- a/spec/controllers/api/v2/versions_controller_spec.rb
+++ b/spec/controllers/api/v2/versions_controller_spec.rb
@@ -34,7 +34,7 @@ describe Api::V2::VersionsController, type: :controller do
   let(:admin_user) { FactoryGirl.create(:admin) }
 
   shared_examples_for 'unauthorized access' do
-    before do get action, request_params end
+    before do get action, params: request_params end
 
     it { expect(response.status).to eq(401) }
   end
@@ -51,7 +51,7 @@ describe Api::V2::VersionsController, type: :controller do
       before do allow(User).to receive(:current).and_return admin_user end
 
       describe 'single project' do
-        before do get :index, project_id: project.id, format: :xml end
+        before do get :index, params: { project_id: project.id, format: :xml } end
 
         it { expect(assigns(:project)).to eq(project) }
 
@@ -68,7 +68,7 @@ describe Api::V2::VersionsController, type: :controller do
         shared_context 'request versions' do
           before do
             get :index,
-                project_id: projects.map(&:id).join(','),
+                params: { project_id: projects.map(&:id).join(',') },
                 format: :xml
           end
         end
@@ -129,7 +129,7 @@ describe Api::V2::VersionsController, type: :controller do
 
       describe 'ids' do
         shared_context 'request versions filtered' do
-          before { get :index, ids: ids, project_id: project.id, format: :json }
+          before { get :index, params: { ids: ids, project_id: project.id }, format: :json }
         end
 
         describe 'invalid version' do
@@ -153,7 +153,11 @@ describe Api::V2::VersionsController, type: :controller do
           let(:child_project) { FactoryGirl.create(:project, parent: project) }
           let(:shared_version) { FactoryGirl.create(:version, project: project, sharing: 'descendants') }
 
-          before do get :index, ids: shared_version.id.to_s, project_id: child_project.id, format: :json end
+          before do
+            get :index,
+                params: { ids: shared_version.id.to_s, project_id: child_project.id },
+                format: :json
+          end
 
           it { expect(assigns(:versions).map(&:id)).to match_array([shared_version.id]) }
 
@@ -170,7 +174,9 @@ describe Api::V2::VersionsController, type: :controller do
           before do
             allow(User).to receive(:current).and_return user
 
-            get :index, ids: shared_version.id.to_s, project_id: child_project.id, format: :json
+            get :index,
+                params: { ids: shared_version.id.to_s, project_id: child_project.id },
+                format: :json
           end
 
           it { expect(assigns(:versions).map(&:id)).to match_array([shared_version.id]) }

--- a/spec/controllers/api/v2/workflows_controller_spec.rb
+++ b/spec/controllers/api/v2/workflows_controller_spec.rb
@@ -33,7 +33,7 @@ describe Api::V2::WorkflowsController, type: :controller do
     describe 'unauthorized access' do
       let(:project) { FactoryGirl.create(:project) }
 
-      before do get :index, project_id: project.id, format: :xml end
+      before do get :index, params: { project_id: project.id }, format: :xml end
 
       it { expect(response.status).to eq(401) }
     end
@@ -71,7 +71,7 @@ describe Api::V2::WorkflowsController, type: :controller do
                              roles: [role_0, role_1])
         }
 
-        before do get :index, project_id: project.id, format: :xml end
+        before do get :index, params: { project_id: project.id }, format: :xml end
 
         it { expect(assigns(:workflows)).to be_empty }
 
@@ -144,7 +144,7 @@ describe Api::V2::WorkflowsController, type: :controller do
                                assignee: false)
           }
 
-          before do get :index, project_id: project.id, format: :xml end
+          before do get :index, params: { project_id: project.id }, format: :xml end
 
           it_behaves_like 'valid workflow index request'
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -74,7 +74,9 @@ describe AttachmentsController, type: :controller do
       }
       let(:redirect_path) { work_package_path(container) }
 
-      before do delete :destroy, id: attachment.id end
+      before do
+        delete :destroy, params: { id: attachment.id }
+      end
 
       it_behaves_like :deleted
 
@@ -91,7 +93,7 @@ describe AttachmentsController, type: :controller do
       before do
         project.reload # get wiki
 
-        delete :destroy, id: attachment.id
+        delete :destroy, params: { id: attachment.id }
       end
 
       it_behaves_like :deleted
@@ -131,7 +133,7 @@ describe AttachmentsController, type: :controller do
     end
 
     subject {
-      get :download, id: attachment.id
+      get :download, params: { id: attachment.id }
     }
 
     context 'with a local file' do

--- a/spec/controllers/auth_sources_controller_spec.rb
+++ b/spec/controllers/auth_sources_controller_spec.rb
@@ -64,7 +64,7 @@ describe AuthSourcesController, type: :controller do
 
   describe 'create' do
     before do
-      post :create, auth_source: { name: 'Test' }
+      post :create, params: { auth_source: { name: 'Test' } }
     end
 
     it { is_expected.to respond_with :redirect }
@@ -75,7 +75,7 @@ describe AuthSourcesController, type: :controller do
   describe 'edit' do
     before do
       @auth_source = FactoryGirl.create(:auth_source, name: 'TestEdit')
-      get :edit, id: @auth_source.id
+      get :edit, params: { id: @auth_source.id }
     end
 
     it { expect(assigns(:auth_source)).to eq @auth_source }
@@ -86,7 +86,7 @@ describe AuthSourcesController, type: :controller do
   describe 'update' do
     before do
       @auth_source = FactoryGirl.create(:auth_source, name: 'TestEdit')
-      post :update, id: @auth_source.id, auth_source: { name: 'TestUpdate' }
+      post :update, params: { id: @auth_source.id, auth_source: { name: 'TestUpdate' } }
     end
 
     it { is_expected.to respond_with :redirect }
@@ -101,7 +101,7 @@ describe AuthSourcesController, type: :controller do
 
     context 'without users' do
       before do
-        post :destroy, id: @auth_source.id
+        post :destroy, params: { id: @auth_source.id }
       end
 
       it { is_expected.to respond_with :redirect }
@@ -112,7 +112,7 @@ describe AuthSourcesController, type: :controller do
     context 'with users' do
       before do
         FactoryGirl.create(:user, auth_source: @auth_source)
-        post :destroy, id: @auth_source.id
+        post :destroy, params: { id: @auth_source.id }
       end
 
       it { is_expected.to respond_with :redirect }
@@ -141,25 +141,25 @@ describe AuthSourcesController, type: :controller do
     end
 
     it 'cannot find create' do
-      post :create, auth_source: { name: 'Test' }
+      post :create, params: { auth_source: { name: 'Test' } }
 
       expect(response.status).to eq 404
     end
 
     it 'cannot find edit' do
-      get :edit, id: 42
+      get :edit, params: { id: 42 }
 
       expect(response.status).to eq 404
     end
 
     it 'cannot find update' do
-      post :update, id: 42, auth_source: { name: 'TestUpdate' }
+      post :update, params: { id: 42, auth_source: { name: 'TestUpdate' } }
 
       expect(response.status).to eq 404
     end
 
     it 'cannot find destroy' do
-      post :destroy, id: 42
+      post :destroy, params: { id: 42 }
 
       expect(response.status).to eq 404
     end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -57,7 +57,9 @@ describe CategoriesController, type: :controller do
   end
 
   describe '#new' do
-    before do get :new, project_id: project.id end
+    before do
+      get :new, params: { project_id: project.id }
+    end
 
     subject { response }
 
@@ -71,9 +73,11 @@ describe CategoriesController, type: :controller do
 
     before do
       post :create,
-           project_id: project.id,
-           category: { name: category_name,
-                       assigned_to_id: user.id }
+           params: {
+             project_id: project.id,
+             category: { name: category_name,
+                         assigned_to_id: user.id }
+           }
     end
 
     describe '#categories' do
@@ -95,8 +99,7 @@ describe CategoriesController, type: :controller do
 
     subject { response }
     before do
-      get :edit,
-           id: category_id
+      get :edit, params: { id: category_id }
     end
 
 
@@ -123,8 +126,10 @@ describe CategoriesController, type: :controller do
 
       before do
         post :update,
-             id: category.id,
-             category: { name: name }
+             params: {
+               id: category.id,
+               category: { name: name }
+             }
       end
 
       subject { Category.find(category.id).name }
@@ -143,8 +148,10 @@ describe CategoriesController, type: :controller do
     context 'invalid category' do
       before do
         post :update,
-             id: 404,
-             category: { name: name }
+             params: {
+               id: 404,
+               category: { name: name }
+             }
       end
 
       subject { response.response_code }
@@ -173,7 +180,9 @@ describe CategoriesController, type: :controller do
     end
 
     context 'unused' do
-      before do delete :destroy, id: category.id end
+      before do
+        delete :destroy, params: { id: category.id }
+      end
 
       it_behaves_like :redirect
 
@@ -184,7 +193,7 @@ describe CategoriesController, type: :controller do
       before do
         work_package
 
-        delete :destroy, id: category.id
+        delete :destroy, params: { id: category.id }
       end
 
       subject { Category.find_by(id: category.id) }
@@ -209,9 +218,11 @@ describe CategoriesController, type: :controller do
         work_package
 
         delete :destroy,
-               id: category.id,
-               todo: 'reassign',
-               reassign_to_id: target.id
+               params: {
+                 id: category.id,
+                 todo: 'reassign',
+                 reassign_to_id: target.id
+               }
       end
 
       subject { work_package.reload.category_id }
@@ -228,8 +239,10 @@ describe CategoriesController, type: :controller do
         work_package
 
         delete :destroy,
-               id: category.id,
-               todo: 'nullify'
+               params: {
+                 id: category.id,
+                 todo: 'nullify'
+               }
       end
 
       subject { work_package.reload.category_id }

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -162,10 +162,15 @@ describe AccountController, type: :controller do
             omniauth: true,
             timestamp: Time.new)
           session[:auth_source_registration] = auth_source_registration
-          post :register, user: { login: 'login@bar.com',
-                                  firstname: 'Foo',
-                                  lastname: 'Smith',
-                                  mail: 'foo@bar.com' }
+          post :register,
+               params: {
+                 user: {
+                   login: 'login@bar.com',
+                   firstname: 'Foo',
+                   lastname: 'Smith',
+                   mail: 'foo@bar.com'
+                 }
+               }
           expect(response).to redirect_to home_url(first_time_user: true)
 
           user = User.find_by_login('login@bar.com')
@@ -183,9 +188,14 @@ describe AccountController, type: :controller do
           end
 
           it 'does not register the user when providing all the missing fields' do
-            post :register, user: { firstname: 'Foo',
-                                    lastname: 'Smith',
-                                    mail: 'foo@bar.com' }
+            post :register,
+                 params: {
+                   user: {
+                     firstname: 'Foo',
+                     lastname: 'Smith',
+                     mail: 'foo@bar.com'
+                   }
+                 }
 
             expect(response).to redirect_to signin_path
             expect(flash[:error]).to eq(I18n.t(:error_omniauth_registration_timed_out))
@@ -193,9 +203,14 @@ describe AccountController, type: :controller do
           end
 
           it 'does not register the user when providing all the missing fields' do
-            post :register, user: { firstname: 'Foo',
-                                    # lastname intentionally not provided
-                                    mail: 'foo@bar.com' }
+            post :register,
+                 params: {
+                   user: {
+                     firstname: 'Foo',
+                     # lastname intentionally not provided
+                     mail: 'foo@bar.com'
+                   }
+                 }
 
             expect(response).to redirect_to signin_path
             expect(flash[:error]).to eq(I18n.t(:error_omniauth_registration_timed_out))
@@ -478,7 +493,7 @@ describe AccountController, type: :controller do
 
       it 'should log a warn message' do
         expect(Rails.logger).to receive(:warn).with('invalid_credentials')
-        post :omniauth_failure, message: 'invalid_credentials'
+        post :omniauth_failure, params: { message: 'invalid_credentials' }
       end
     end
   end

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -55,7 +55,7 @@ describe CopyProjectsController, type: :controller do
 
   describe 'copy_from_settings uses correct project to copy from' do
     before do
-      get 'copy_project', id: project.id, coming_from: :settings
+      get 'copy_project', params: { id: project.id, coming_from: :settings }
     end
 
     it { expect(assigns(:project)).to eq(project) }
@@ -74,8 +74,7 @@ describe CopyProjectsController, type: :controller do
   describe 'copy_from_settings without name and identifier' do
     before {
       post 'copy',
-           id: project.id,
-           project: copy_project_params
+           params: { id: project.id, project: copy_project_params }
     }
 
     it { expect(response).to render_template('copy_from_settings') }
@@ -86,7 +85,7 @@ describe CopyProjectsController, type: :controller do
 
   describe 'copy_from_settings permissions' do
     def fetch
-      get 'copy_project', id: project.id, coming_from: :settings
+      get 'copy_project', params: { id: project.id, coming_from: :settings }
     end
 
     it_should_behave_like 'a controller action which needs project permissions'
@@ -98,8 +97,10 @@ describe CopyProjectsController, type: :controller do
 
   def copy_project(project)
     post 'copy',
-         id: project.id,
-         project: copy_project_params.merge(identifier: 'copy', name: 'copy')
+         params: {
+           id: project.id,
+           project: copy_project_params.merge(identifier: 'copy', name: 'copy')
+         }
   end
 
   describe 'copy creates a new project' do
@@ -127,8 +128,10 @@ describe CopyProjectsController, type: :controller do
   describe 'copy permissions' do
     def fetch
       post 'copy',
-           id: project.id,
-           project: copy_project_params.merge(identifier: 'copy', name: 'copy')
+           params: {
+             id: project.id,
+             project: copy_project_params.merge(identifier: 'copy', name: 'copy')
+           }
     end
 
     def expect_redirect_to

--- a/spec/controllers/custom_fields_controller_spec.rb
+++ b/spec/controllers/custom_fields_controller_spec.rb
@@ -53,7 +53,7 @@ describe CustomFieldsController, type: :controller do
       }
 
       before do
-        put :update, params
+        put :update, params: params
       end
 
       it { expect(response).to be_redirect }
@@ -70,7 +70,7 @@ describe CustomFieldsController, type: :controller do
       }
 
       before do
-        put :update, params
+        put :update, params: params
       end
 
       it { expect(response).to be_redirect }
@@ -94,7 +94,7 @@ describe CustomFieldsController, type: :controller do
                               'field_format' => 'string' } }
       }
       before do
-        post :create, params
+        post :create, params: params
       end
 
       it { expect(response).to render_template 'new' }
@@ -113,7 +113,7 @@ describe CustomFieldsController, type: :controller do
       }
 
       before do
-        post :create, params
+        post :create, params: params
       end
 
       it { expect(response.status).to eql(302) }
@@ -131,7 +131,7 @@ describe CustomFieldsController, type: :controller do
                               'field_format' => 'string' } }
       }
       before do
-        post :create, params
+        post :create, params: params
       end
 
       it { expect(response.status).to eql(302) }
@@ -152,7 +152,7 @@ describe CustomFieldsController, type: :controller do
                               'field_format' => 'string' } }
       }
       before do
-        post :create, params
+        post :create, params: params
       end
 
       around do |example|

--- a/spec/controllers/enumerations_controller.rb
+++ b/spec/controllers/enumerations_controller.rb
@@ -42,7 +42,9 @@ describe EnumerationsController, type: :controller do
       end
 
       describe 'not in use' do
-        before do post :destroy, id: enum_to_delete.id end
+        before do
+          post :destroy, params: { id: enum_to_delete.id }
+        end
 
         it_behaves_like 'successful delete'
       end
@@ -55,7 +57,9 @@ describe EnumerationsController, type: :controller do
         }
 
         describe 'no reassign' do
-          before do post :destroy, id: enum_to_delete.id end
+          before do
+            post :destroy, params: { id: enum_to_delete.id }
+          end
 
           it { expect(assigns(:enumerations)).to include(enum_to_reassign) }
 
@@ -66,8 +70,8 @@ describe EnumerationsController, type: :controller do
 
         describe 'reassign' do
           before do
-            post :destroy, id: enum_to_delete.id,
-                           reassign_to_id: enum_to_reassign.id
+            post :destroy,
+                 params: { id: enum_to_delete.id, reassign_to_id: enum_to_reassign.id }
           end
 
           it_behaves_like 'successful delete'

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -62,7 +62,9 @@ describe JournalsController, type: :controller do
     before do
       work_package.update_attribute :description, 'description'
 
-      xhr :get, :diff, params
+      get :diff,
+          xhr: true,
+          params: params
     end
 
     describe 'w/ authorization' do

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -53,10 +53,12 @@ describe MembersController, type: :controller do
 
     it 'should work for multiple users' do
       post :create,
-           project_id: project_2.identifier,
-           member: {
-             user_ids: [admin.id, user.id],
-             role_ids: [role.id]
+           params: {
+             project_id: project_2.identifier,
+             member: {
+               user_ids: [admin.id, user.id],
+               role_ids: [role.id]
+             }
            }
 
       expect(response.response_code).to be < 400
@@ -91,10 +93,12 @@ describe MembersController, type: :controller do
 
     it 'should, however, allow roles to be updated through mass assignment' do
       put 'update',
-          project_id: project.identifier,
-          id: member_2.id,
-          member: {
-            role_ids: [role_1.id, role_2.id]
+          params: {
+            project_id: project.identifier,
+            id: member_2.id,
+            member: {
+              role_ids: [role_1.id, role_2.id]
+            }
           }
 
       expect(Member.find(member_2.id).roles).to include(role_1, role_2)
@@ -117,14 +121,14 @@ describe MembersController, type: :controller do
       end
 
       it 'should be success' do
-        post :autocomplete_for_member, params, format: :xhr
+        post :autocomplete_for_member, xhr: true, params: params
         expect(response).to be_success
       end
     end
 
     describe 'WHEN the user is not authorized' do
       it 'should be forbidden' do
-        post :autocomplete_for_member, params, format: :xhr
+        post :autocomplete_for_member, xhr: true, params: params
         expect(response.response_code).to eq(403)
       end
     end
@@ -139,7 +143,11 @@ describe MembersController, type: :controller do
     context 'post :create' do
       context 'single member' do
         let(:action) do
-          post :create, project_id: project.id, member: { role_ids: [role.id], user_id: user2.id }
+          post :create,
+               params: {
+                 project_id: project.id,
+                 member: { role_ids: [role.id], user_id: user2.id }
+               }
         end
 
         it 'should add a member' do
@@ -152,8 +160,10 @@ describe MembersController, type: :controller do
       context 'multiple members' do
         let(:action) do
           post :create,
-               project_id: project.id,
-               member: { role_ids: [role.id], user_ids: [user2.id, user3.id, user4.id] }
+               params: {
+                 project_id: project.id,
+                 member: { role_ids: [role.id], user_ids: [user2.id, user3.id, user4.id] }
+               }
         end
 
         it 'should add all members' do
@@ -174,7 +184,7 @@ describe MembersController, type: :controller do
       }
 
       before do
-        post :create, invalid_params
+        post :create, params: invalid_params
       end
 
       it 'should not redirect to the members index' do
@@ -188,7 +198,7 @@ describe MembersController, type: :controller do
   end
 
   describe '#destroy' do
-    let(:action) { post :destroy, id: member.id }
+    let(:action) { post :destroy, params: { id: member.id } }
     before do
       member
     end
@@ -201,7 +211,13 @@ describe MembersController, type: :controller do
   end
 
   describe '#update' do
-    let(:action) { post :update, id: member.id, member: { role_ids: [role2.id], user_id: user.id } }
+    let(:action) {
+      post :update,
+           params: {
+             id: member.id,
+             member: { role_ids: [role2.id], user_id: user.id }
+           }
+    }
     let(:role2) { FactoryGirl.create(:role) }
 
     before do

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -59,9 +59,12 @@ describe MyController, type: :controller do
 
     describe 'with wrong confirmation' do
       before do
-        post :change_password, password: 'adminADMIN!',
-                               new_password: 'adminADMIN!New',
-                               new_password_confirmation: 'adminADMIN!Other'
+        post :change_password,
+             params: {
+               password: 'adminADMIN!',
+               new_password: 'adminADMIN!New',
+               new_password_confirmation: 'adminADMIN!Other'
+             }
       end
       it 'should show an error message' do
         assert_response :success
@@ -75,9 +78,12 @@ describe MyController, type: :controller do
       render_views
       before do
         @current_password = user.current_password.id
-        post :change_password, password: 'wrongpassword',
-                               new_password: 'adminADMIN!New',
-                               new_password_confirmation: 'adminADMIN!New'
+        post :change_password,
+             params: {
+               password: 'wrongpassword',
+               new_password: 'adminADMIN!New',
+               new_password_confirmation: 'adminADMIN!New'
+             }
       end
 
       it 'should show an error message' do
@@ -93,9 +99,12 @@ describe MyController, type: :controller do
 
     describe 'with good password and good confirmation' do
       before do
-        post :change_password, password: 'adminADMIN!',
-                               new_password: 'adminADMIN!New',
-                               new_password_confirmation: 'adminADMIN!New'
+        post :change_password,
+             params: {
+               password: 'adminADMIN!',
+               new_password: 'adminADMIN!New',
+               new_password_confirmation: 'adminADMIN!New'
+             }
       end
 
       it 'should redirect to the my password page' do
@@ -147,7 +156,7 @@ describe MyController, type: :controller do
         as_logged_in_user user do
           user.pref.self_notified = false
 
-          patch :settings, user: { language: 'en' }
+          patch :settings, params: { user: { language: 'en' } }
         end
       end
 

--- a/spec/controllers/news/comments_controller_spec.rb
+++ b/spec/controllers/news/comments_controller_spec.rb
@@ -40,7 +40,7 @@ describe News::CommentsController, type: :controller do
 
   describe '#create' do
     it 'assigns a comment to the news item and redirects to the news page' do
-      post :create, news_id: news.id, comment: { comments: 'This is a test comment' }
+      post :create, params: { news_id: news.id, comment: { comments: 'This is a test comment' } }
 
       expect(response).to redirect_to news_path(news)
 
@@ -52,7 +52,7 @@ describe News::CommentsController, type: :controller do
 
     it "doesn't create a comment when it is invalid" do
       expect {
-        post :create, news_id: news.id, comment: { comments: '' }
+        post :create, params: { news_id: news.id, comment: { comments: '' } }
         expect(response).to redirect_to news_path(news)
       }.not_to change { Comment.count }
     end
@@ -63,7 +63,7 @@ describe News::CommentsController, type: :controller do
       comment = FactoryGirl.create :comment, commented: news
 
       expect {
-        delete :destroy, id: comment.id
+        delete :destroy, params: { id: comment.id }
       }.to change { Comment.count }.by -1
 
       expect(response).to redirect_to news_path(news)

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -59,7 +59,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders index with project' do
-      get :index, project_id: project.id
+      get :index, params: { project_id: project.id }
 
       expect(response).to be_success
       expect(response).to render_template 'index'
@@ -69,7 +69,7 @@ describe NewsController, type: :controller do
 
   describe '#show' do
     it 'renders show' do
-      get :show, id: news.id
+      get :show, params: { id: news.id }
 
       expect(response).to be_success
       expect(response).to render_template 'show'
@@ -78,7 +78,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders show with slug' do
-      get :show, id: "#{news.id}-some-news-title"
+      get :show, params: { id: "#{news.id}-some-news-title" }
 
       expect(response).to be_success
       expect(response).to render_template 'show'
@@ -87,7 +87,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders error if news item is not found' do
-      get :show, id: -1
+      get :show, params: { id: -1 }
 
       expect(response).to be_not_found
     end
@@ -95,7 +95,7 @@ describe NewsController, type: :controller do
 
   describe '#new' do
     it 'renders new' do
-      get :new, project_id: project.id
+      get :new, params: { project_id: project.id }
 
       expect(response).to be_success
       expect(response).to render_template 'new'
@@ -108,9 +108,15 @@ describe NewsController, type: :controller do
       it 'persists a news item and delivers email notifications' do
         become_member_with_permissions(project, user)
 
-        post :create, project_id: project.id, news: { title: 'NewsControllerTest',
-                                                      description: 'This is the description',
-                                                      summary: '' }
+        post :create,
+             params: {
+               project_id: project.id,
+               news: {
+                 title: 'NewsControllerTest',
+                 description: 'This is the description',
+                 summary: ''
+               }
+             }
         expect(response).to redirect_to project_news_index_path(project)
 
         news = News.find_by!(title: 'NewsControllerTest')
@@ -124,9 +130,15 @@ describe NewsController, type: :controller do
     end
 
     it "doesn't persist if validations fail" do
-      post :create, project_id: project.id, news: { title: '',
-                                                    description: 'This is the description',
-                                                    summary: '' }
+      post :create,
+           params: {
+             project_id: project.id,
+             news: {
+               title: '',
+               description: 'This is the description',
+               summary: ''
+             }
+           }
 
       expect(response).to be_success
       expect(response).to render_template 'new'
@@ -139,7 +151,7 @@ describe NewsController, type: :controller do
 
   describe '#edit' do
     it 'renders edit' do
-      get :edit, id: news.id
+      get :edit, params: { id: news.id }
       expect(response).to be_success
       expect(response).to render_template 'edit'
     end
@@ -147,7 +159,8 @@ describe NewsController, type: :controller do
 
   describe '#update' do
     it 'updates the news element' do
-      put :update, id: news.id, news: { description: 'Description changed by test_post_edit' }
+      put :update,
+          params: { id: news.id, news: { description: 'Description changed by test_post_edit' } }
 
       expect(response).to redirect_to news_path(news)
 
@@ -158,7 +171,7 @@ describe NewsController, type: :controller do
 
   describe '#destroy' do
     it 'deletes the news element and redirects to the news overview page' do
-      delete :destroy, id: news.id
+      delete :destroy, params: { id: news.id }
 
       expect(response).to redirect_to project_news_index_path(news.project)
       expect { news.reload }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/controllers/planning_element_type_colors_controller_spec.rb
+++ b/spec/controllers/planning_element_type_colors_controller_spec.rb
@@ -51,7 +51,7 @@ describe PlanningElementTypeColorsController, type: :controller do
 
   describe 'create.html' do
     def fetch
-      post 'create', color: FactoryGirl.build(:color).attributes
+      post 'create', params: { color: FactoryGirl.build(:color).attributes }
     end
 
     def expect_redirect_to
@@ -63,7 +63,7 @@ describe PlanningElementTypeColorsController, type: :controller do
   describe 'edit.html' do
     def fetch
       @available_color = FactoryGirl.create(:color, id: '1337')
-      get 'edit', id: '1337'
+      get 'edit', params: { id: '1337' }
     end
     it_should_behave_like 'a controller action with require_admin'
   end
@@ -71,7 +71,7 @@ describe PlanningElementTypeColorsController, type: :controller do
   describe 'update.html' do
     def fetch
       @available_color = FactoryGirl.create(:color, id: '1337')
-      put 'update', id: '1337', color: { 'name' => 'blubs' }
+      put 'update', params: { id: '1337', color: { 'name' => 'blubs' } }
     end
 
     def expect_redirect_to
@@ -83,7 +83,7 @@ describe PlanningElementTypeColorsController, type: :controller do
   describe 'move.html' do
     def fetch
       @available_color = FactoryGirl.create(:color, id: '1337')
-      post 'move', id: '1337', color: { move_to: 'highest' }
+      post 'move', params: { id: '1337', color: { move_to: 'highest' } }
     end
 
     def expect_redirect_to
@@ -95,7 +95,7 @@ describe PlanningElementTypeColorsController, type: :controller do
   describe 'confirm_destroy.html' do
     def fetch
       @available_color = FactoryGirl.create(:color, id: '1337')
-      get 'confirm_destroy', id: '1337'
+      get 'confirm_destroy', params: { id: '1337' }
     end
     it_should_behave_like 'a controller action with require_admin'
   end
@@ -103,7 +103,7 @@ describe PlanningElementTypeColorsController, type: :controller do
   describe 'destroy.html' do
     def fetch
       @available_color = FactoryGirl.create(:color, id: '1337')
-      post 'destroy', id: '1337'
+      post 'destroy', params: { id: '1337' }
     end
 
     def expect_redirect_to

--- a/spec/controllers/project_associations_controller_spec.rb
+++ b/spec/controllers/project_associations_controller_spec.rb
@@ -38,7 +38,7 @@ describe ProjectAssociationsController, type: :controller do
   describe 'index.html' do
     let(:project) { FactoryGirl.create(:project, is_public: false) }
     def fetch
-      get 'index', project_id: project.identifier
+      get 'index', params: { project_id: project.identifier }
     end
     let(:permission) { :view_project_associations }
 
@@ -48,7 +48,7 @@ describe ProjectAssociationsController, type: :controller do
   describe 'new.html' do
     let(:project) { FactoryGirl.create(:project, is_public: false) }
     def fetch
-      get 'new', project_id: project.identifier
+      get 'new', params: { project_id: project.identifier }
     end
     let(:permission) { :edit_project_associations }
 
@@ -59,8 +59,11 @@ describe ProjectAssociationsController, type: :controller do
     let(:project)   { FactoryGirl.create(:project, is_public: false) }
     let(:project_b) { FactoryGirl.create(:project, is_public: true) }
     def fetch
-      post 'create', project_id: project.identifier,
-                     project_association: { project_b_id: project_b.id }
+      post 'create',
+           params: {
+             project_id: project.identifier,
+             project_association: { project_b_id: project_b.id }
+           }
     end
     let(:permission) { :edit_project_associations }
     def expect_redirect_to
@@ -79,8 +82,11 @@ describe ProjectAssociationsController, type: :controller do
                          project_b_id: project_b.id)
     }
     def fetch
-      get 'edit', project_id: project.identifier,
-                  id:         project_association.id
+      get 'edit',
+          params: {
+            project_id: project.identifier,
+            id: project_association.id
+          }
     end
     let(:permission) { :edit_project_associations }
 
@@ -96,9 +102,12 @@ describe ProjectAssociationsController, type: :controller do
                          project_b_id: project_b.id)
     }
     def fetch
-      post 'update', project_id: project.identifier,
-                     id:         project_association.id,
-                     project_association: {}
+      post 'update',
+           params: {
+             project_id: project.identifier,
+             id: project_association.id,
+             project_association: {}
+           }
     end
     let(:permission) { :edit_project_associations }
     def expect_redirect_to
@@ -117,9 +126,12 @@ describe ProjectAssociationsController, type: :controller do
                          project_b_id: project_b.id)
     }
     def fetch
-      get 'confirm_destroy', project_id: project.identifier,
-                             id:         project_association.id,
-                             project_association: {}
+      get 'confirm_destroy',
+          params: {
+            project_id: project.identifier,
+            id: project_association.id,
+            project_association: {}
+          }
     end
     let(:permission) { :delete_project_associations }
 
@@ -135,8 +147,11 @@ describe ProjectAssociationsController, type: :controller do
                          project_b_id: project_b.id)
     }
     def fetch
-      post 'destroy', project_id: project.identifier,
-                      id:         project_association.id
+      post 'destroy',
+           params: {
+             project_id: project.identifier,
+             id: project_association.id
+           }
     end
     let(:permission) { :delete_project_associations }
     def expect_redirect_to

--- a/spec/controllers/project_types_controller_spec.rb
+++ b/spec/controllers/project_types_controller_spec.rb
@@ -51,7 +51,7 @@ describe ProjectTypesController, type: :controller do
 
   describe 'create.html' do
     def fetch
-      post 'create', project_type: FactoryGirl.build(:project_type).attributes
+      post 'create', params: { project_type: FactoryGirl.build(:project_type).attributes }
     end
 
     def expect_redirect_to
@@ -63,7 +63,7 @@ describe ProjectTypesController, type: :controller do
   describe 'edit.html' do
     def fetch
       FactoryGirl.create(:project_type, id: '1337')
-      get 'edit', id: '1337'
+      get 'edit', params: { id: '1337' }
     end
     it_should_behave_like 'a controller action with require_admin'
   end
@@ -71,7 +71,7 @@ describe ProjectTypesController, type: :controller do
   describe 'update.html' do
     def fetch
       FactoryGirl.create(:project_type, id: '1337')
-      put 'update', id: '1337', project_type: { 'name' => 'blubs' }
+      put 'update', params: { id: '1337', project_type: { 'name' => 'blubs' } }
     end
 
     def expect_redirect_to
@@ -83,7 +83,7 @@ describe ProjectTypesController, type: :controller do
   describe 'move.html' do
     def fetch
       FactoryGirl.create(:project_type, id: '1337')
-      post 'move', id: '1337', project_type: { move_to: 'highest' }
+      post 'move', params: { id: '1337', project_type: { move_to: 'highest' } }
     end
 
     def expect_redirect_to
@@ -95,7 +95,7 @@ describe ProjectTypesController, type: :controller do
   describe 'confirm_destroy.html' do
     def fetch
       FactoryGirl.create(:project_type, id: '1337')
-      get 'confirm_destroy', id: '1337'
+      get 'confirm_destroy', params: { id: '1337' }
     end
     it_should_behave_like 'a controller action with require_admin'
   end
@@ -103,7 +103,7 @@ describe ProjectTypesController, type: :controller do
   describe 'destroy.html' do
     def fetch
       FactoryGirl.create(:project_type, id: '1337')
-      post 'destroy', id: '1337'
+      post 'destroy', params: { id: '1337' }
     end
 
     def expect_redirect_to

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -57,13 +57,13 @@ describe ProjectsController, type: :controller do
       end
 
       it 'renders show' do
-        get 'show', @params
+        get 'show', params: @params
         expect(response).to be_success
         expect(response).to render_template 'show'
       end
 
       it 'renders main menu without wiki menu item' do
-        get 'show', @params
+        get 'show', params: @params
 
         assert_select '#main-menu a.Wiki-menu-item', false # assert_no_select
       end
@@ -78,13 +78,13 @@ describe ProjectsController, type: :controller do
 
       describe 'without custom wiki menu items' do
         it 'renders show' do
-          get 'show', @params
+          get 'show', params: @params
           expect(response).to be_success
           expect(response).to render_template 'show'
         end
 
         it 'renders main menu with wiki menu item' do
-          get 'show', @params
+          get 'show', params: @params
 
           assert_select '#main-menu a.wiki-menu-item', 'Wiki'
         end
@@ -97,19 +97,19 @@ describe ProjectsController, type: :controller do
         end
 
         it 'renders show' do
-          get 'show', @params
+          get 'show', params: @params
           expect(response).to be_success
           expect(response).to render_template 'show'
         end
 
         it 'renders main menu with wiki menu item' do
-          get 'show', @params
+          get 'show', params: @params
 
           assert_select '#main-menu a.example-menu-item', 'Example Title'
         end
 
         it 'renders main menu with sub wiki menu item' do
-          get 'show', @params
+          get 'show', params: @params
 
           assert_select '#main-menu a.sub-menu-item', 'Sub Title'
         end
@@ -123,13 +123,13 @@ describe ProjectsController, type: :controller do
       end
 
       it 'renders show' do
-        get 'show', @params
+        get 'show', params: @params
         expect(response).to be_success
         expect(response).to render_template 'show'
       end
 
       it 'renders main menu with activity tab' do
-        get 'show', @params
+        get 'show', params: @params
         assert_select '#main-menu a.activity-menu-item'
       end
     end
@@ -141,13 +141,13 @@ describe ProjectsController, type: :controller do
       end
 
       it 'renders show' do
-        get 'show', @params
+        get 'show', params: @params
         expect(response).to be_success
         expect(response).to render_template 'show'
       end
 
       it 'renders main menu without activity tab' do
-        get 'show', @params
+        get 'show', params: @params
         expect(response.body).not_to have_selector '#main-menu a.activity-menu-item'
       end
     end
@@ -155,7 +155,7 @@ describe ProjectsController, type: :controller do
 
   describe 'new' do
     it "renders 'new'" do
-      get 'new', @params
+      get 'new', params: @params
       expect(response).to be_success
       expect(response).to render_template 'new'
     end
@@ -189,7 +189,7 @@ describe ProjectsController, type: :controller do
         before do
           expect(update_service).to receive(:call).with([1, 2, 3]).and_return true
 
-          patch :types, id: project.id, project: { 'type_ids' => ['1', '2', '3'] }
+          patch :types, params: { id: project.id, project: { 'type_ids' => ['1', '2', '3'] } }
         end
 
         it 'sets a flash message' do
@@ -209,7 +209,7 @@ describe ProjectsController, type: :controller do
 
           allow(project).to receive_message_chain(:errors, :full_messages).and_return(error_message)
 
-          patch :types, id: project.id, project: { 'type_ids' => ['1', '2', '3'] }
+          patch :types, params: { id: project.id, project: { 'type_ids' => ['1', '2', '3'] } }
         end
 
         it 'sets a flash message' do
@@ -228,9 +228,11 @@ describe ProjectsController, type: :controller do
       let(:custom_field_2) { FactoryGirl.create(:work_package_custom_field) }
       let(:request) do
         put :custom_fields,
-            id: project.id,
-            project: {
-              work_package_custom_field_ids: [custom_field_1.id, custom_field_2.id]
+            params: {
+              id: project.id,
+              project: {
+                work_package_custom_field_ids: [custom_field_1.id, custom_field_2.id]
+              }
             }
       end
 

--- a/spec/controllers/reportings_controller_spec.rb
+++ b/spec/controllers/reportings_controller_spec.rb
@@ -39,7 +39,7 @@ describe ReportingsController, type: :controller do
   describe 'index.html' do
     let(:project) { FactoryGirl.create(:project) }
     def fetch
-      get 'index', project_id: project.identifier
+      get 'index', params: { project_id: project.identifier }
     end
     let(:permission) { :view_reportings }
     it_should_behave_like 'a controller action which needs project permissions'
@@ -49,7 +49,7 @@ describe ReportingsController, type: :controller do
     let(:project)   { FactoryGirl.create(:project) }
     let(:reporting) { FactoryGirl.create(:reporting, project_id: project.id) }
     def fetch
-      get 'show', project_id: project.identifier, id: reporting.id
+      get 'show', params: { project_id: project.identifier, id: reporting.id }
     end
     let(:permission) { :view_reportings }
     it_should_behave_like 'a controller action which needs project permissions'
@@ -60,7 +60,7 @@ describe ReportingsController, type: :controller do
     def fetch
       FactoryGirl.create(:public_project) # reporting candidate
 
-      get 'new', project_id: project.identifier
+      get 'new', params: { project_id: project.identifier }
     end
     let(:permission) { :edit_reportings }
     it_should_behave_like 'a controller action which needs project permissions'
@@ -69,9 +69,11 @@ describe ReportingsController, type: :controller do
   describe 'create.html' do
     let(:project)   { FactoryGirl.create(:project) }
     def fetch
-      post 'create', project_id: project.identifier,
-                     reporting: FactoryGirl.build(:reporting,
-                                                  project_id: project.id).attributes
+      post 'create',
+           params: {
+             project_id: project.identifier,
+             reporting: FactoryGirl.build(:reporting, project_id: project.id).attributes
+           }
     end
     let(:permission) { :edit_reportings }
     def expect_redirect_to
@@ -81,12 +83,14 @@ describe ReportingsController, type: :controller do
 
     it 'should not create a reporting w/o a reporting project' do
       post :create,
-           project_id: project.identifier,
-           reporting: FactoryGirl.build(
-             :reporting,
-             project_id: project.id,
-             reporting_to_project_id: nil
-           ).attributes
+           params: {
+             project_id: project.identifier,
+             reporting: FactoryGirl.build(
+               :reporting,
+               project_id: project.id,
+               reporting_to_project_id: nil
+             ).attributes
+           }
 
       expect(response).to render_template(:new)
     end
@@ -97,8 +101,8 @@ describe ReportingsController, type: :controller do
     let(:reporting) { FactoryGirl.create(:reporting, project_id: project.id) }
 
     def fetch
-      get 'edit', project_id: project.identifier,
-                  id: reporting.id
+      get 'edit',
+          params: { project_id: project.identifier, id: reporting.id }
     end
     let(:permission) { :edit_reportings }
     it_should_behave_like 'a controller action which needs project permissions'
@@ -109,9 +113,8 @@ describe ReportingsController, type: :controller do
     let(:reporting) { FactoryGirl.create(:reporting, project_id: project.id) }
 
     def fetch
-      post 'update', project_id: project.identifier,
-                     id: reporting.id,
-                     reporting: {}
+      post 'update',
+           params: { project_id: project.identifier, id: reporting.id, reporting: {} }
     end
     let(:permission) { :edit_reportings }
     def expect_redirect_to
@@ -125,8 +128,8 @@ describe ReportingsController, type: :controller do
     let(:reporting) { FactoryGirl.create(:reporting, project_id: project.id) }
 
     def fetch
-      get 'confirm_destroy', project_id: project.identifier,
-                             id: reporting.id
+      get 'confirm_destroy',
+          params: { project_id: project.identifier, id: reporting.id }
     end
     let(:permission) { :delete_reportings }
     it_should_behave_like 'a controller action which needs project permissions'
@@ -137,8 +140,8 @@ describe ReportingsController, type: :controller do
     let(:reporting) { FactoryGirl.create(:reporting, project_id: project.id) }
 
     def fetch
-      post 'destroy', project_id: project.identifier,
-                      id: reporting.id
+      post 'destroy',
+           params: { project_id: project.identifier, id: reporting.id }
     end
     let(:permission) { :delete_reportings }
     def expect_redirect_to

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -81,7 +81,7 @@ describe RepositoriesController, type: :controller do
       before do
         xhr :get,
             :edit,
-            scm_vendor: 'subversion'
+            params: { scm_vendor: 'subversion' }
       end
 
       it_behaves_like 'successful settings response'
@@ -110,9 +110,11 @@ describe RepositoriesController, type: :controller do
       before do
         xhr :post,
             :create,
-            scm_vendor: 'subversion',
-            scm_type: 'local',
-            url: 'file:///tmp/repo.svn/'
+            params: {
+              scm_vendor: 'subversion',
+              scm_type: 'local',
+              url: 'file:///tmp/repo.svn/'
+            }
       end
 
       it 'renders a JS redirect' do
@@ -132,7 +134,7 @@ describe RepositoriesController, type: :controller do
 
     context 'with #show' do
       before do
-        get :show, project_id: project.identifier
+        get :show, params: { project_id: project.identifier }
       end
       it 'renders an empty warning view' do
         expect(response).to render_template 'repositories/empty'
@@ -154,7 +156,7 @@ describe RepositoriesController, type: :controller do
 
       before do
         allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
-        get :show, project_id: project.identifier
+        get :show, params: { project_id: project.identifier }
       end
 
       it 'renders an empty warning view' do
@@ -176,7 +178,7 @@ describe RepositoriesController, type: :controller do
 
       describe 'commits per author graph' do
         before do
-          get :graph, project_id: project.identifier, graph: 'commits_per_author'
+          get :graph, params: { project_id: project.identifier, graph: 'commits_per_author' }
         end
 
         context 'requested by an authorized user' do
@@ -233,7 +235,7 @@ describe RepositoriesController, type: :controller do
 
       describe 'stats' do
         before do
-          get :stats, project_id: project.identifier
+          get :stats, params: { project_id: project.identifier }
         end
 
         describe 'requested by a user with view_commit_author_statistics permission' do
@@ -268,7 +270,7 @@ describe RepositoriesController, type: :controller do
         let(:role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
 
         before do
-          get :show, project_id: project.identifier, path: path
+          get :show, params: { project_id: project.identifier, path: path }
         end
 
         context 'with brackets' do
@@ -287,7 +289,7 @@ describe RepositoriesController, type: :controller do
         let(:role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
 
         before do
-          get :changes, project_id: project.identifier, path: path
+          get :changes, params: { project_id: project.identifier, path: path }
           expect(response).to be_success
         end
 
@@ -317,7 +319,7 @@ describe RepositoriesController, type: :controller do
 
         before do
           allow(Setting).to receive(:repository_checkout_data).and_return(checkout_hash)
-          get :show, project_id: project.identifier, path: 'subversion_test'
+          get :show, params: { project_id: project.identifier, path: 'subversion_test' }
         end
 
         it 'renders an empty warning view' do

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -49,7 +49,7 @@ describe SettingsController, type: :controller do
     end
 
     it 'contains a check box for the activity module on the projects tab' do
-      get 'edit', tab: 'projects'
+      get 'edit', params: { tab: 'projects' }
 
       expect(response).to be_success
       expect(response).to render_template 'edit'
@@ -57,9 +57,13 @@ describe SettingsController, type: :controller do
     end
 
     it 'does not store the activity in the default_projects_modules if unchecked' do
-      post 'edit', tab: 'projects', settings: {
-        default_projects_modules: ['wiki']
-      }
+      post 'edit',
+           params: {
+             tab: 'projects',
+             settings: {
+               default_projects_modules: ['wiki']
+             }
+           }
 
       expect(response).to be_redirect
       expect(response).to redirect_to action: 'edit', tab: 'projects'
@@ -68,9 +72,13 @@ describe SettingsController, type: :controller do
     end
 
     it 'stores the activity in the default_projects_modules if checked' do
-      post 'edit', tab: 'projects', settings: {
-        default_projects_modules: ['activity', 'wiki']
-      }
+      post 'edit',
+           params: {
+             tab: 'projects',
+             settings: {
+               default_projects_modules: ['activity', 'wiki']
+             }
+           }
 
       expect(response).to be_redirect
       expect(response).to redirect_to action: 'edit', tab: 'projects'
@@ -84,7 +92,7 @@ describe SettingsController, type: :controller do
       end
 
       it 'contains a checked checkbox for activity' do
-        get 'edit', tab: 'projects'
+        get 'edit', params: { tab: 'projects' }
 
         expect(response).to be_success
         expect(response).to render_template 'edit'
@@ -99,7 +107,7 @@ describe SettingsController, type: :controller do
       end
 
       it 'contains an unchecked checkbox for activity' do
-        get 'edit', tab: 'projects'
+        get 'edit', params: { tab: 'projects' }
 
         expect(response).to be_success
         expect(response).to render_template 'edit'
@@ -154,7 +162,7 @@ describe SettingsController, type: :controller do
         before do
           allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(false)
 
-          post 'edit', tab: 'authentication', settings: new_settings
+          post 'edit', params: { tab: 'authentication', settings: new_settings }
         end
 
         it 'is successful' do
@@ -190,7 +198,7 @@ describe SettingsController, type: :controller do
         before do
           allow(OpenProject::Configuration).to receive(:disable_password_login?).and_return(true)
 
-          post 'edit', tab: 'authentication', settings: new_settings
+          post 'edit', params: { tab: 'authentication', settings: new_settings }
         end
 
         it 'is successful' do

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -75,7 +75,10 @@ describe StatusesController, type: :controller do
   describe '#create' do
     let(:name) { 'New Status' }
 
-    before do post :create, status: { name: name } end
+    before do
+      post :create,
+           params: { status: { name: name } }
+    end
 
     it_behaves_like :statuses
 
@@ -91,7 +94,10 @@ describe StatusesController, type: :controller do
                            is_default: true)
       }
 
-      before do get :edit, id: status_default.id end
+      before do
+        get :edit,
+            params: { id: status_default.id }
+      end
 
       it_behaves_like :response
 
@@ -109,7 +115,7 @@ describe StatusesController, type: :controller do
       before do
         status
 
-        get :edit, id: status.id
+        get :edit, params: { id: status.id }
       end
 
       it_behaves_like :response
@@ -132,8 +138,10 @@ describe StatusesController, type: :controller do
       status
 
       patch :update,
-            id: status.id,
-            status: { name: name }
+            params: {
+              id: status.id,
+              status: { name: name }
+            }
     end
 
     it_behaves_like :statuses
@@ -154,7 +162,7 @@ describe StatusesController, type: :controller do
       before do
         status
 
-        delete :destroy, id: status.id
+        delete :destroy, params: { id: status.id }
       end
 
       it_behaves_like :destroyed
@@ -171,7 +179,7 @@ describe StatusesController, type: :controller do
       before do
         work_package
 
-        delete :destroy, id: status.id
+        delete :destroy, params: { id: status.id }
       end
 
       it_behaves_like :statuses
@@ -186,7 +194,7 @@ describe StatusesController, type: :controller do
       }
 
       before do
-        delete :destroy, id: status_default.id
+        delete :destroy, params: { id: status_default.id }
       end
 
       it_behaves_like :statuses

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -219,7 +219,7 @@ describe TimelinesController, type: :controller do
 
   describe 'index.html' do
     def fetch(options = {})
-      get 'index', options
+      get 'index', params: options
     end
     it_should_behave_like 'all actions related to all timelines within a project'
 
@@ -259,7 +259,7 @@ describe TimelinesController, type: :controller do
 
   describe 'new.html' do
     def fetch(options = {})
-      get 'new', options
+      get 'new', params: options
     end
 
     it_should_behave_like 'all actions related to all timelines within a project'
@@ -285,7 +285,7 @@ describe TimelinesController, type: :controller do
 
   describe 'create.html' do
     def fetch(options = {})
-      post 'create', options
+      post 'create', params: options
     end
 
     it_should_behave_like 'all actions related to all timelines within a project'
@@ -342,7 +342,7 @@ describe TimelinesController, type: :controller do
 
   describe 'show.html' do
     def fetch(options = {})
-      get 'show', options
+      get 'show', params: options
     end
 
     it_should_behave_like 'all actions related to an existing timeline'
@@ -383,7 +383,7 @@ describe TimelinesController, type: :controller do
 
   describe 'edit.html' do
     def fetch(options = {})
-      get 'edit', options
+      get 'edit', params: options
     end
 
     it_should_behave_like 'all actions related to an existing timeline'
@@ -403,7 +403,7 @@ describe TimelinesController, type: :controller do
 
   describe 'update.html' do
     def fetch(options = {})
-      post 'update', options
+      post 'update', params: options
     end
 
     it_should_behave_like 'all actions related to an existing timeline'
@@ -461,7 +461,7 @@ describe TimelinesController, type: :controller do
 
   describe 'confirm_destroy.html' do
     def fetch(options = {})
-      get 'confirm_destroy', options
+      get 'confirm_destroy', params: options
     end
 
     it_should_behave_like 'all actions related to an existing timeline'
@@ -482,7 +482,7 @@ describe TimelinesController, type: :controller do
 
   describe 'destroy.html' do
     def fetch(options = {})
-      post 'destroy', options
+      post 'destroy', params: options
     end
 
     it_should_behave_like 'all actions related to an existing timeline'

--- a/spec/controllers/timelog_controller_spec.rb
+++ b/spec/controllers/timelog_controller_spec.rb
@@ -57,7 +57,7 @@ describe TimelogController, type: :controller do
 
     context 'project' do
       describe '#valid' do
-        before do post :create, params end
+        before do post :create, params: params end
 
         it_behaves_like 'successful timelog creation'
       end
@@ -65,7 +65,7 @@ describe TimelogController, type: :controller do
       describe '#invalid' do
         let(:project_id) { -1 }
 
-        before do post :create, params end
+        before do post :create, params: params end
 
         it { expect(response.status).to eq(404) }
       end
@@ -81,7 +81,7 @@ describe TimelogController, type: :controller do
           before do
             params[:time_entry][:custom_field_values] = { custom_field.id.to_s => 'wurst' }
 
-            post :create, params
+            post :create, params: params
           end
 
           it_behaves_like 'successful timelog creation'
@@ -93,7 +93,7 @@ describe TimelogController, type: :controller do
           before do
             params[:time_entry][:custom_field_values] = { "42" => 'wurst' }
 
-            post :create, params
+            post :create, params: params
           end
 
           it 'is rejected' do
@@ -111,7 +111,7 @@ describe TimelogController, type: :controller do
         }
         let(:work_package_id) { work_package.id }
 
-        before do post :create, params end
+        before do post :create, params: params end
 
         it_behaves_like 'successful timelog creation'
       end
@@ -119,7 +119,7 @@ describe TimelogController, type: :controller do
       describe '#invalid' do
         let(:work_package_id) { 'blub' }
 
-        before do post :create, params end
+        before do post :create, params: params end
 
         it { expect(response).to render_template(:edit) }
 

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -134,7 +134,7 @@ describe TypesController, type: :controller do
                                     } } }
 
         before do
-          post :create, params
+          post :create, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -150,7 +150,7 @@ describe TypesController, type: :controller do
                                    } } }
 
         before do
-          post :create, params
+          post :create, params: params
         end
 
         it { expect(response.status).to eq(200) }
@@ -175,7 +175,7 @@ describe TypesController, type: :controller do
         } }
 
         before do
-          post :create, params
+          post :create, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -191,7 +191,7 @@ describe TypesController, type: :controller do
       let(:type) { FactoryGirl.create(:type, name: 'My type', is_milestone: true, projects: [project]) }
 
       before do
-        get 'edit', id: type.id
+        get 'edit', params: { id: type.id }
       end
 
       it { expect(response).to be_success }
@@ -209,7 +209,7 @@ describe TypesController, type: :controller do
         let(:params) { { 'id' => type.id, 'type' => { name: 'My type renamed' } } }
 
         before do
-          put :update, params
+          put :update, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -223,7 +223,7 @@ describe TypesController, type: :controller do
         let(:params) { { 'id' => type.id, 'type' => { project_ids: [''] } } }
 
         before do
-          put :update, params
+          put :update, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -240,7 +240,7 @@ describe TypesController, type: :controller do
       let(:params) { { 'id' => type.id, 'type' => { move_to: 'lower' } } }
 
       before do
-        post :move, params
+        post :move, params: params
       end
 
       it { expect(response).to be_redirect }
@@ -259,7 +259,7 @@ describe TypesController, type: :controller do
         let(:params) { { 'id' => type.id } }
 
         before do
-          delete :destroy, params
+          delete :destroy, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -287,7 +287,7 @@ describe TypesController, type: :controller do
         let(:params) { { 'id' => type2.id } }
 
         before do
-          delete :destroy, params
+          delete :destroy, params: params
         end
 
         it { expect(response).to be_redirect }
@@ -304,7 +304,7 @@ describe TypesController, type: :controller do
         let(:params) { { 'id' => type3.id } }
 
         before do
-          delete :destroy, params
+          delete :destroy, params: params
         end
 
         it { expect(response).to be_redirect }

--- a/spec/controllers/users/memberships_controller_spec.rb
+++ b/spec/controllers/users/memberships_controller_spec.rb
@@ -42,10 +42,12 @@ describe Users::MembershipsController, type: :controller do
       # i.e. it should successfully add a user to a project's members
       as_logged_in_user admin do
         post :create,
-             user_id: user.id,
-             membership: {
-               project_id: project.id,
-               role_ids: [role.id]
+             params: {
+               user_id: user.id,
+               membership: {
+                 project_id: project.id,
+                 role_ids: [role.id]
+               }
              },
              format: 'js'
       end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -47,7 +47,7 @@ describe VersionsController, type: :controller do
     context 'without additional params' do
       before do
         login_as(user)
-        get :index, project_id: project.id
+        get :index, params: { project_id: project.id }
       end
 
       it { expect(response).to be_success }
@@ -68,7 +68,7 @@ describe VersionsController, type: :controller do
     context 'with showing completed versions' do
       before do
         login_as(user)
-        get :index, project_id: project, completed: '1'
+        get :index, params: { project_id: project, completed: '1' }
       end
 
       it { expect(response).to be_success }
@@ -93,7 +93,7 @@ describe VersionsController, type: :controller do
       before do
         login_as(user)
         version4
-        get :index, project_id: project, with_subprojects: '1'
+        get :index, params: { project_id: project, with_subprojects: '1' }
       end
 
       it { expect(response).to be_success }
@@ -118,7 +118,7 @@ describe VersionsController, type: :controller do
     before do
       login_as(user)
       version2
-      get :show, id: version2.id
+      get :show, params: { id: version2.id }
     end
 
     it { expect(response).to be_success }
@@ -134,7 +134,7 @@ describe VersionsController, type: :controller do
     # the `version` key in params, so visiting it without one failed.
     it 'renders correctly' do
       login_as(user)
-      get :new, project_id: project.id
+      get :new, params: { project_id: project.id }
       expect(response.status).to eq(200)
     end
   end
@@ -143,7 +143,7 @@ describe VersionsController, type: :controller do
     context 'with vaild attributes' do
       before do
         login_as(user)
-        post :create, project_id: project.id, version: { name: 'test_add_version' }
+        post :create, params: { project_id: project.id, version: { name: 'test_add_version' } }
       end
 
       it { expect(response).to redirect_to(settings_project_path(project, tab: 'versions')) }
@@ -161,7 +161,7 @@ describe VersionsController, type: :controller do
     before do
       login_as(user)
       version2
-      get :edit, id: version2.id
+      get :edit, params: { id: version2.id }
     end
 
     context 'when resource is found' do
@@ -176,7 +176,7 @@ describe VersionsController, type: :controller do
       version1.update_attribute :status, 'open'
       version2.update_attribute :status, 'open'
       version3.update_attribute :status, 'open'
-      put :close_completed, project_id: project.id
+      put :close_completed, params: { project_id: project.id }
     end
 
     it { expect(response).to redirect_to(settings_project_path(project, tab: 'versions')) }
@@ -185,11 +185,18 @@ describe VersionsController, type: :controller do
 
   describe '#update' do
     context 'with valid params' do
+      let(:params) {
+        {
+          id: version1.id,
+          version: {
+            name: 'New version name',
+            effective_date: Date.today.strftime('%Y-%m-%d')
+          }
+        }
+      }
       before do
         login_as(user)
-        patch :update, id: version1.id,
-                       version: { name: 'New version name',
-                                  effective_date: Date.today.strftime('%Y-%m-%d') }
+        patch :update, params: params
       end
 
       it { expect(response).to redirect_to(settings_project_path(project, tab: 'versions')) }
@@ -201,10 +208,13 @@ describe VersionsController, type: :controller do
              with a redirect url" do
       before do
         login_as(user)
-        patch :update, id: version1.id,
-                       version: { name: 'New version name',
-                                  effective_date: Date.today.strftime('%Y-%m-%d') },
-                       back_url: home_path
+        patch :update,
+              params: {
+                id: version1.id,
+                version: { name: 'New version name',
+                           effective_date: Date.today.strftime('%Y-%m-%d') },
+                back_url: home_path
+              }
       end
 
       it { expect(response).to redirect_to(home_path) }
@@ -213,9 +223,12 @@ describe VersionsController, type: :controller do
     context 'with invalid params' do
       before do
         login_as(user)
-        patch :update, id: version1.id,
-                       version: { name: '',
-                                  effective_date: Date.today.strftime('%Y-%m-%d') }
+        patch :update,
+              params: {
+                id: version1.id,
+                version: { name: '',
+                           effective_date: Date.today.strftime('%Y-%m-%d') }
+              }
       end
 
       it { expect(response).to be_success }
@@ -227,7 +240,7 @@ describe VersionsController, type: :controller do
     before do
       login_as(user)
       @deleted = version3.id
-      delete :destroy, id: @deleted
+      delete :destroy, params: { id: @deleted }
     end
 
     it 'redirects to projects versions and the version is deleted' do
@@ -243,7 +256,9 @@ describe VersionsController, type: :controller do
 
     context 'status by version' do
       before do
-        xhr :get, :status_by, id: version2.id, format: :js
+        get :status_by,
+            xhr: true,
+            params: { id: version2.id }, format: :js
       end
 
       it { expect(response).to be_success }
@@ -252,7 +267,10 @@ describe VersionsController, type: :controller do
 
     context 'status by version with status_by' do
       before do
-        xhr :get, :status_by, id: version2.id, format: :js, status_by: 'status'
+        get :status_by,
+            xhr: true,
+            params: { id: version2.id, status_by: 'status' },
+            format: :js
       end
 
       it { expect(response).to be_success }

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -87,13 +87,13 @@ describe WikiController, type: :controller do
     end
 
     describe 'new' do
-      let(:get_page) { get 'new', project_id: @project }
+      let(:get_page) { get 'new', params: { project_id: @project } }
 
       it_should_behave_like "a 'new' action"
     end
 
     describe 'new_child' do
-      let(:get_page) { get 'new_child', project_id: @project, id: @existing_page.title }
+      let(:get_page) { get 'new_child', params: { project_id: @project, id: @existing_page.title } }
 
       it_should_behave_like "a 'new' action"
 
@@ -104,7 +104,7 @@ describe WikiController, type: :controller do
       end
 
       it 'renders 404 if used with an unknown page title' do
-        get 'new_child', project_id: @project, id: 'foobar'
+        get 'new_child', params: { project_id: @project, id: 'foobar' }
 
         expect(response.status).to eq(404) # not found
       end
@@ -114,16 +114,20 @@ describe WikiController, type: :controller do
       describe 'successful action' do
         it 'redirects to the show action' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: 'abc' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: 'abc' } }
+               }
 
           expect(response).to redirect_to action: 'show', project_id: @project, id: 'abc'
         end
 
         it 'saves a new WikiPage with proper content' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: 'abc' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: 'abc' } }
+               }
 
           page = @project.wiki.pages.find_by title: 'abc'
           expect(page).not_to be_nil
@@ -134,24 +138,30 @@ describe WikiController, type: :controller do
       describe 'unsuccessful action' do
         it 'renders "wiki/new"' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: '' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: '' } }
+               }
 
           expect(response).to render_template('new')
         end
 
         it 'assigns project to work with new template' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: '' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: '' } }
+               }
 
           expect(assigns[:project]).to eq(@project)
         end
 
         it 'assigns wiki to work with new template' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: '' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: '' } }
+               }
 
           expect(assigns[:wiki]).to eq(@project.wiki)
           expect(assigns[:wiki]).not_to be_new_record
@@ -159,8 +169,10 @@ describe WikiController, type: :controller do
 
         it 'assigns page to work with new template' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: '' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: '' } }
+               }
 
           expect(assigns[:page]).to be_new_record
           expect(assigns[:page].wiki.project).to eq(@project)
@@ -170,8 +182,10 @@ describe WikiController, type: :controller do
 
         it 'assigns content to work with new template' do
           post 'create',
-               project_id: @project,
-               content: { text: 'h1. abc', page: { title: '' } }
+               params: {
+                 project_id: @project,
+                 content: { text: 'h1. abc', page: { title: '' } }
+               }
 
           expect(assigns[:content]).to be_new_record
           expect(assigns[:content].page.wiki.project).to eq(@project)
@@ -191,14 +205,14 @@ describe WikiController, type: :controller do
           end
 
           it 'redirects to wiki#index' do
-            delete :destroy, project_id: @project, id: @existing_page
+            delete :destroy, params: { project_id: @project, id: @existing_page }
             expect(response).to redirect_to action: 'index', project_id: @project, id: redirect_page_after_destroy
           end
         end
 
         context 'when it is the only wiki page' do
           it 'redirects to projects#show' do
-            delete :destroy, project_id: @project, id: @existing_page
+            delete :destroy, params: { project_id: @project, id: @existing_page }
             expect(response).to redirect_to project_path(@project)
           end
         end
@@ -274,7 +288,7 @@ describe WikiController, type: :controller do
 
       shared_examples_for 'all wiki menu items' do
         it 'is inactive, when an unrelated page is shown' do
-          get 'show', id: @unrelated_page.slug, project_id: @project.id
+          get 'show', params: { id: @unrelated_page.slug, project_id: @project.id }
 
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
@@ -284,7 +298,7 @@ describe WikiController, type: :controller do
         end
 
         it "is inactive, when another wiki menu item's page is shown" do
-          get 'show', id: @other_wiki_menu_item.name, project_id: @project.id
+          get 'show', params: { id: @other_wiki_menu_item.name, project_id: @project.id }
 
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
@@ -294,7 +308,7 @@ describe WikiController, type: :controller do
         end
 
         it 'is active, when the given wiki menu item is shown' do
-          get 'show', id: @wiki_menu_item.name, project_id: @project.id
+          get 'show', params: { id: @wiki_menu_item.name, project_id: @project.id }
 
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
@@ -306,7 +320,7 @@ describe WikiController, type: :controller do
       shared_examples_for 'all existing wiki menu items' do
         # TODO: Add tests for new and toc options within menu item
         it 'is active on parents item, when new page is shown' do
-          get 'new_child', id: @wiki_menu_item.name, project_id: @project.identifier
+          get 'new_child', params: { id: @wiki_menu_item.name, project_id: @project.identifier }
 
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
@@ -315,7 +329,7 @@ describe WikiController, type: :controller do
         end
 
         it 'is active, when a toc page is shown' do
-          get 'index', id: @wiki_menu_item.name, project_id: @project.id
+          get 'index', params: { id: @wiki_menu_item.name, project_id: @project.id }
 
           expect(response).to be_success
           assert_select '#content h2', text: 'Index by title'
@@ -327,7 +341,7 @@ describe WikiController, type: :controller do
 
       shared_examples_for 'all wiki menu items with child pages' do
         it 'is active, when the given wiki menu item is an ancestor of the shown page' do
-          get 'show', id: @child_page.slug, project_id: @project.id
+          get 'show', params: { id: @child_page.slug, project_id: @project.id }
 
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
@@ -374,7 +388,7 @@ describe WikiController, type: :controller do
         describe 'on a show page' do
           describe 'being authorized to configure menu items' do
             it 'is visible' do
-              get 'show', project_id: @project.id
+              get 'show', params: { project_id: @project.id }
 
               expect(response).to be_success
 
@@ -388,7 +402,7 @@ describe WikiController, type: :controller do
             end
 
             it 'is invisible' do
-              get 'show', project_id: @project.id
+              get 'show', params: { project_id: @project.id }
 
               expect(response).to be_success
 
@@ -402,7 +416,7 @@ describe WikiController, type: :controller do
         describe 'on an index page' do
           describe 'being authorized to edit wiki pages' do
             it 'is invisible' do
-              get 'index', project_id: @project.id
+              get 'index', params: { project_id: @project.id }
 
               expect(response).to be_success
 
@@ -416,7 +430,7 @@ describe WikiController, type: :controller do
             end
 
             it 'is invisible' do
-              get 'index', project_id: @project.id
+              get 'index', params: { project_id: @project.id }
 
               expect(response).to be_success
 
@@ -429,7 +443,8 @@ describe WikiController, type: :controller do
           describe 'being authorized to edit wiki pages' do
             describe 'with a wiki page present' do
               it 'is visible' do
-                get 'show', id: @page_with_content.title, project_id: @project.identifier
+                get 'show',
+                    params: { id: @page_with_content.title, project_id: @project.identifier }
 
                 expect(response).to be_success
 
@@ -439,7 +454,7 @@ describe WikiController, type: :controller do
 
             describe 'with no wiki page present' do
               it 'is invisible' do
-                get 'show', id: 'i-am-a-ghostpage', project_id: @project.identifier
+                get 'show', params: { id: 'i-am-a-ghostpage', project_id: @project.identifier }
 
                 expect(response).to be_success
 
@@ -455,7 +470,7 @@ describe WikiController, type: :controller do
             end
 
             it 'is invisible' do
-              get 'show', id: @page_with_content.title, project_id: @project.identifier
+              get 'show', params: { id: @page_with_content.title, project_id: @project.identifier }
 
               expect(response).to be_success
 
@@ -469,7 +484,7 @@ describe WikiController, type: :controller do
         describe 'on a show page' do
           describe 'being authorized to edit wiki pages' do
             it 'is visible' do
-              get 'show', project_id: @project.id
+              get 'show', params: { project_id: @project.id }
 
               expect(response).to be_success
 
@@ -483,7 +498,7 @@ describe WikiController, type: :controller do
             end
 
             it 'is invisible' do
-              get 'show', project_id: @project.id
+              get 'show', params: { project_id: @project.id }
 
               expect(response).to be_success
 

--- a/spec/controllers/wiki_menu_authentication_spec.rb
+++ b/spec/controllers/wiki_menu_authentication_spec.rb
@@ -50,7 +50,7 @@ describe WikiMenuItemsController, type: :controller do
       permission_role = FactoryGirl.create(:role, name: 'accessgranted', permissions: [:manage_wiki_menu])
       member = FactoryGirl.create(:member, principal: admin_user, user: admin_user, project: @project, roles: [permission_role])
 
-      get 'edit', @params
+      get 'edit', params: @params
 
       expect(response).to be_success
     end
@@ -60,7 +60,7 @@ describe WikiMenuItemsController, type: :controller do
     it 'be forbidden' do
       allow(User).to receive(:current).and_return FactoryGirl.create(:user)
 
-      get 'edit', @params
+      get 'edit', params: @params
 
       expect(response.status).to eq(403) # forbidden
     end

--- a/spec/controllers/wiki_menu_items_controller_spec.rb
+++ b/spec/controllers/wiki_menu_items_controller_spec.rb
@@ -59,7 +59,7 @@ describe WikiMenuItemsController, type: :controller do
 
     context 'when no parent wiki menu item has been configured yet' do
       context 'and it is a child page' do
-        before do get :edit, project_id: project.id, id: child_page.slug end
+        before do get :edit, params: { project_id: project.id, id: child_page.slug } end
         subject { response }
 
         it 'preselects the wiki menu item of the parent page as parent wiki menu item option' do
@@ -72,7 +72,7 @@ describe WikiMenuItemsController, type: :controller do
         before do
           # ensure the parent page of grand_child_page is not a main item
           child_page_wiki_menu_item.tap { |page| page.parent = top_level_wiki_menu_item }.save
-          get :edit, project_id: project.id, id: grand_child_page.slug
+          get :edit, params: { project_id: project.id, id: grand_child_page.slug }
         end
 
         subject { response }
@@ -84,7 +84,7 @@ describe WikiMenuItemsController, type: :controller do
     end
 
     context 'when a parent wiki menu item has already been configured' do
-      before do get :edit, project_id: project.id, id: another_child_page.slug end
+      before do get :edit, params: { project_id: project.id, id: another_child_page.slug } end
       subject { response }
 
       it 'preselects the parent wiki menu item that is already assigned' do
@@ -103,7 +103,7 @@ describe WikiMenuItemsController, type: :controller do
   describe '#select_main_menu_item' do
     include_context 'when there is one more wiki page with a child page'
 
-    before do get :select_main_menu_item, project_id: project, id: wiki_page.id end
+    before do get :select_main_menu_item, params: { project_id: project, id: wiki_page.id } end
     subject { assigns['possible_wiki_pages'] }
 
     context 'when selecting a new wiki page to replace the current main menu item' do
@@ -122,9 +122,12 @@ describe WikiMenuItemsController, type: :controller do
       let(:new_menu_item) { selected_page.menu_item }
 
       before do
-        post :replace_main_menu_item, project_id: project,
-                                      id: wiki_page.id,
-                                      wiki_page: { id: selected_page.id }
+        post :replace_main_menu_item,
+             params: {
+               project_id: project,
+               id: wiki_page.id,
+               wiki_page: { id: selected_page.id }
+             }
       end
 
       it 'destroys the current wiki menu item' do
@@ -145,9 +148,12 @@ describe WikiMenuItemsController, type: :controller do
       let!(:wiki_menu_item) { wiki_page.menu_item }
 
       before do
-        post :replace_main_menu_item, project_id: project,
-                                      id: wiki_page.id,
-                                      wiki_page: { id: wiki_page.id }
+        post :replace_main_menu_item,
+             params: {
+               project_id: project,
+               id: wiki_page.id,
+               wiki_page: { id: wiki_page.id }
+             }
       end
 
       it 'does not destroy the wiki menu item' do

--- a/spec/controllers/work_packages/auto_completes_controller_spec.rb
+++ b/spec/controllers/work_packages/auto_completes_controller_spec.rb
@@ -84,8 +84,10 @@ describe WorkPackages::AutoCompletesController, type: :controller do
 
       before do
         get :index,
-            project_id: project.id,
-            q: 'ReCiPe'
+            params: {
+              project_id: project.id,
+              q: 'ReCiPe'
+            }
       end
 
       it_behaves_like 'successful response'
@@ -98,8 +100,10 @@ describe WorkPackages::AutoCompletesController, type: :controller do
 
       before do
         get :index,
-            project_id: project.id,
-            q: work_package_1.id
+            params: {
+              project_id: project.id,
+              q: work_package_1.id
+            }
       end
 
       it_behaves_like 'successful response'
@@ -140,8 +144,10 @@ describe WorkPackages::AutoCompletesController, type: :controller do
 
       before do
         get :index,
-            project_id: project.id,
-            q: ids
+            params: {
+              project_id: project.id,
+              q: ids
+            }
       end
 
       it_behaves_like 'successful response'
@@ -168,8 +174,10 @@ describe WorkPackages::AutoCompletesController, type: :controller do
 
       before do
         get :index,
-            project_id: project.id,
-            q: work_package_4.id,
+            params: {
+              project_id: project.id,
+              q: work_package_4.id
+            },
             format: :json
       end
 
@@ -210,9 +218,11 @@ describe WorkPackages::AutoCompletesController, type: :controller do
           allow(Setting).to receive(:cross_project_work_package_relations?).and_return(true)
 
           get :index,
-              project_id: project_id,
-              q: work_package_4.id,
-              scope: scope
+              params: {
+                project_id: project_id,
+                q: work_package_4.id,
+                scope: scope
+              }
         end
 
         context 'with scope "relatable"' do
@@ -247,9 +257,11 @@ describe WorkPackages::AutoCompletesController, type: :controller do
           allow(Setting).to receive(:cross_project_work_package_relations?).and_return(false)
 
           get :index,
-              project_id: project.id,
-              q: work_package_4.id,
-              scope: scope
+              params: {
+                project_id: project.id,
+                q: work_package_4.id,
+                scope: scope
+              }
         end
 
         context 'with scope "relatable"' do

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -126,7 +126,7 @@ describe WorkPackages::BulkController, type: :controller do
     end
 
     context 'same project' do
-      before do get :edit, ids: [work_package_1.id, work_package_2.id] end
+      before do get :edit, params: { ids: [work_package_1.id, work_package_2.id] } end
 
       it_behaves_like :response
 
@@ -159,7 +159,7 @@ describe WorkPackages::BulkController, type: :controller do
       before do
         member1_p2
 
-        get :edit, ids: [work_package_1.id, work_package_2.id, work_package_3.id]
+        get :edit, params: { ids: [work_package_1.id, work_package_2.id, work_package_3.id] }
       end
 
       it_behaves_like :response
@@ -197,7 +197,7 @@ describe WorkPackages::BulkController, type: :controller do
       context 'in host' do
         let(:url) { '/work_packages' }
 
-        before do put :update, ids: work_package_ids, back_url: url end
+        before do put :update, params: { ids: work_package_ids, back_url: url } end
 
         subject { response }
 
@@ -209,7 +209,7 @@ describe WorkPackages::BulkController, type: :controller do
       context 'of host' do
         let(:url) { 'http://google.com' }
 
-        before do put :update, ids: work_package_ids, back_url: url end
+        before do put :update, params: { ids: work_package_ids, back_url: url } end
 
         subject { response }
 
@@ -249,7 +249,7 @@ describe WorkPackages::BulkController, type: :controller do
         member1_p2
         # let other_user perform the bulk update
         allow(User).to receive(:current).and_return other_user
-        put :update, ids: work_package_ids, work_package: work_package_params
+        put :update, params: { ids: work_package_ids, work_package: work_package_params }
       end
 
       it 'updates the description if whitelisted' do
@@ -269,12 +269,14 @@ describe WorkPackages::BulkController, type: :controller do
     shared_context 'update_request' do
       before do
         put :update,
-            ids: work_package_ids,
-            notes: 'Bulk editing',
-            work_package: { priority_id: priority.id,
-                            assigned_to_id: group_id,
-                            responsible_id: responsible_id,
-                            send_notification: send_notification }
+            params: {
+              ids: work_package_ids,
+              notes: 'Bulk editing',
+              work_package: { priority_id: priority.id,
+                              assigned_to_id: group_id,
+                              responsible_id: responsible_id,
+                              send_notification: send_notification }
+            }
       end
     end
 
@@ -408,8 +410,10 @@ describe WorkPackages::BulkController, type: :controller do
             workflow
 
             put :update,
-                ids: work_package_ids,
-                work_package: { status_id: closed_status.id }
+                params: {
+                  ids: work_package_ids,
+                  work_package: { status_id: closed_status.id }
+                }
           end
 
           subject { work_packages.map(&:status_id).uniq }
@@ -426,8 +430,10 @@ describe WorkPackages::BulkController, type: :controller do
 
           before do
             put :update,
-                ids: work_package_ids,
-                work_package: { parent_id: parent.id }
+                params: {
+                  ids: work_package_ids,
+                  work_package: { parent_id: parent.id }
+                }
           end
 
           subject { work_packages.map(&:parent_id).uniq }
@@ -459,8 +465,10 @@ describe WorkPackages::BulkController, type: :controller do
         describe '#unassign' do
           before do
             put :update,
-                ids: work_package_ids,
-                work_package: { assigned_to_id: 'none' }
+                params: {
+                  ids: work_package_ids,
+                  work_package: { assigned_to_id: 'none' }
+                }
           end
 
           subject { work_packages.map(&:assigned_to_id).uniq }
@@ -471,8 +479,10 @@ describe WorkPackages::BulkController, type: :controller do
         describe '#delete_responsible' do
           before do
             put :update,
-                ids: work_package_ids,
-                work_package: { responsible_id: 'none' }
+                params: {
+                  ids: work_package_ids,
+                  work_package: { responsible_id: 'none' }
+                }
           end
 
           subject { work_packages.map(&:responsible_id).uniq }
@@ -496,8 +506,10 @@ describe WorkPackages::BulkController, type: :controller do
 
             before do
               put :update,
-                  ids: work_package_ids,
-                  work_package: { fixed_version_id: version.id.to_s }
+                  params: {
+                    ids: work_package_ids,
+                    work_package: { fixed_version_id: version.id.to_s }
+                  }
             end
 
             subject { response }
@@ -523,8 +535,10 @@ describe WorkPackages::BulkController, type: :controller do
               # 'none' is a magic value, setting fixed_version_id to nil
               # will make the controller ignore that param
               put :update,
-                  ids: work_package_ids,
-                  work_package: { fixed_version_id: 'none' }
+                  params: {
+                    ids: work_package_ids,
+                    work_package: { fixed_version_id: 'none' }
+                  }
             end
             describe '#work_package' do
               describe '#fixed_version' do
@@ -572,7 +586,7 @@ describe WorkPackages::BulkController, type: :controller do
         expect(WorkPackage).to receive(:cleanup_associated_before_destructing_if_required).with([stub_work_package], user, params['to_do']).and_return true
 
         as_logged_in_user(user) do
-          delete :destroy, params
+          delete :destroy, params: params
         end
       end
 
@@ -586,7 +600,7 @@ describe WorkPackages::BulkController, type: :controller do
         expect(WorkPackage).to receive(:cleanup_associated_before_destructing_if_required).with([stub_work_package], user, params['to_do']).and_return false
 
         as_logged_in_user(user) do
-          delete :destroy, params
+          delete :destroy, params: params
         end
       end
 

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -67,7 +67,7 @@ describe WorkPackages::MovesController, type: :controller do
         become_non_member
 
         it 'renders a 404 page' do
-          get 'new', id: '1337'
+          get 'new', params: { id: '1337' }
 
           expect(response.response_code).to be === 404
         end
@@ -77,7 +77,7 @@ describe WorkPackages::MovesController, type: :controller do
         become_member_with_view_planning_element_permissions
 
         it 'raises ActiveRecord::RecordNotFound errors' do
-          get 'new', id: '1337'
+          get 'new', params: { id: '1337' }
 
           expect(response.response_code).to be === 404
         end
@@ -91,7 +91,7 @@ describe WorkPackages::MovesController, type: :controller do
         become_non_member
 
         it 'renders a 403 Forbidden page' do
-          get 'new', work_package_id: work_package.id
+          get 'new', params: { work_package_id: work_package.id }
 
           expect(response.response_code).to eq(403)
         end
@@ -101,7 +101,7 @@ describe WorkPackages::MovesController, type: :controller do
         become_member_with_move_work_package_permissions
 
         before do
-          get 'new', work_package_id: work_package.id
+          get 'new', params: { work_package_id: work_package.id }
         end
 
         it 'renders the new builder template' do
@@ -127,15 +127,17 @@ describe WorkPackages::MovesController, type: :controller do
       context 'w/o following' do
         subject do
           post :create,
-               work_package_id: work_package.id,
-               new_project_id: target_project.id,
-               type_id: '',
-               author_id: user.id,
-               assigned_to_id: '',
-               responsible_id: '',
-               status_id: '',
-               start_date: '',
-               due_date: ''
+               params: {
+                 work_package_id: work_package.id,
+                 new_project_id: target_project.id,
+                 type_id: '',
+                 author_id: user.id,
+                 assigned_to_id: '',
+                 responsible_id: '',
+                 status_id: '',
+                 start_date: '',
+                 due_date: ''
+               }
         end
 
         it "redirects to the project's work packages page" do
@@ -147,15 +149,17 @@ describe WorkPackages::MovesController, type: :controller do
       context 'with following' do
         subject do
           post :create,
-               work_package_id: work_package.id,
-               new_project_id: target_project.id,
-               new_type_id: target_project.types.first.id, # FIXME (see #1868) the validation on the work_package requires a proper target-type, other cases are not tested here
-               assigned_to_id: '',
-               responsible_id: '',
-               status_id: '',
-               start_date: '',
-               due_date: '',
-               follow: '1'
+               params: {
+                 work_package_id: work_package.id,
+                 new_project_id: target_project.id,
+                 new_type_id: target_project.types.first.id,
+                 assigned_to_id: '',
+                 responsible_id: '',
+                 status_id: '',
+                 start_date: '',
+                 due_date: '',
+                 follow: '1'
+               }
         end
 
         it 'redirects to the work package page' do
@@ -174,9 +178,10 @@ describe WorkPackages::MovesController, type: :controller do
           target_project.save
 
           post :create,
-               ids: [work_package.id, work_package_2.id],
-               new_project_id: target_project.id
-
+               params: {
+                 ids: [work_package.id, work_package_2.id],
+                 new_project_id: target_project.id
+               }
           work_package.reload
           work_package_2.reload
         end
@@ -195,9 +200,10 @@ describe WorkPackages::MovesController, type: :controller do
       context 'to another type' do
         before do
           post :create,
-               ids: [work_package.id, work_package_2.id],
-               new_type_id: type_2.id
-
+               params: {
+                 ids: [work_package.id, work_package_2.id],
+                 new_type_id: type_2.id
+               }
           work_package.reload
           work_package_2.reload
         end
@@ -211,9 +217,10 @@ describe WorkPackages::MovesController, type: :controller do
       context 'with another priority' do
         before do
           post :create,
-               ids: [work_package.id, work_package_2.id],
-               priority_id: target_priority.id
-
+               params: {
+                 ids: [work_package.id, work_package_2.id],
+                 priority_id: target_priority.id
+               }
           work_package.reload
           work_package_2.reload
         end
@@ -236,8 +243,10 @@ describe WorkPackages::MovesController, type: :controller do
         context 'w/o work package changes' do
           before do
             post :create,
-                 ids: [work_package.id],
-                 notes: note
+                 params: {
+                   ids: [work_package.id],
+                   notes: note
+                 }
           end
 
           it_behaves_like 'single note for moved work package' do
@@ -248,9 +257,11 @@ describe WorkPackages::MovesController, type: :controller do
         context 'w/o work package changes' do
           before do
             post :create,
-                 ids: [work_package.id],
-                 notes: note,
-                 priority_id: target_priority.id
+                 params: {
+                   ids: [work_package.id],
+                   notes: note,
+                   priority_id: target_priority.id
+                 }
           end
 
           it_behaves_like 'single note for moved work package' do
@@ -263,11 +274,13 @@ describe WorkPackages::MovesController, type: :controller do
         context 'follows to another project' do
           before do
             post :create,
-                 ids: [work_package.id],
-                 copy: '',
-                 new_project_id: target_project.id,
-                 new_type_id: target_project.types.first.id, # FIXME see #1868
-                 follow: ''
+                 params: {
+                   ids: [work_package.id],
+                   copy: '',
+                   new_project_id: target_project.id,
+                   new_type_id: target_project.types.first.id, # FIXME see #1868
+                   follow: ''
+                 }
           end
 
           it 'redirects to the work package copy' do
@@ -279,9 +292,11 @@ describe WorkPackages::MovesController, type: :controller do
         context "w/o changing the work package's attribute" do
           before do
             post :create,
-                 ids: [work_package.id],
-                 copy: '',
-                 new_project_id: target_project.id
+                 params: {
+                   ids: [work_package.id],
+                   copy: '',
+                   new_project_id: target_project.id
+                 }
           end
 
           subject { WorkPackage.order('id desc').where(project_id: project.id).first }
@@ -310,15 +325,17 @@ describe WorkPackages::MovesController, type: :controller do
 
           before do
             post :create,
-                 ids: [work_package.id, work_package_2.id],
-                 copy: '',
-                 new_project_id: target_project.id,
-                 new_type_id: target_project.types.first.id, # FIXME see #1868
-                 assigned_to_id: target_user.id,
-                 responsible_id: target_user.id,
-                 status_id: target_status,
-                 start_date: start_date,
-                 due_date: due_date
+                 params: {
+                   ids: [work_package.id, work_package_2.id],
+                   copy: '',
+                   new_project_id: target_project.id,
+                   new_type_id: target_project.types.first.id, # FIXME see #1868
+                   assigned_to_id: target_user.id,
+                   responsible_id: target_user.id,
+                   status_id: target_status,
+                   start_date: start_date,
+                   due_date: due_date
+                 }
           end
 
           subject { WorkPackage.limit(2).order('id desc').where(project_id: target_project.id) }
@@ -369,9 +386,11 @@ describe WorkPackages::MovesController, type: :controller do
 
           before do
             post :create,
-                 ids: [work_package.id],
-                 copy: '',
-                 notes: note
+                 params: {
+                   ids: [work_package.id],
+                   copy: '',
+                   notes: note
+                 }
           end
 
           subject { WorkPackage.limit(1).order('id desc').last.journals }
@@ -408,11 +427,13 @@ describe WorkPackages::MovesController, type: :controller do
 
             def self.copy_child_work_package
               post :create,
-                   ids: [child_wp.id],
-                   copy: '',
-                   new_project_id: to_project.id,
-                   work_package_id: child_wp.id,
-                   new_type_id: to_project.types.first.id
+                   params: {
+                     ids: [child_wp.id],
+                     copy: '',
+                     new_project_id: to_project.id,
+                     work_package_id: child_wp.id,
+                     new_type_id: to_project.types.first.id
+                   }
             end
           end
 

--- a/spec/controllers/work_packages/reports_controller_spec.rb
+++ b/spec/controllers/work_packages/reports_controller_spec.rb
@@ -71,7 +71,10 @@ describe WorkPackages::ReportsController, type: :controller do
 
   describe '#report' do
     describe 'w/o details' do
-      before do get :report, project_id: project.id end
+      before do
+        get :report,
+            params: { project_id: project.id }
+      end
 
       subject { response }
 
@@ -96,7 +99,10 @@ describe WorkPackages::ReportsController, type: :controller do
 
     describe 'with details' do
       shared_examples_for 'details view' do
-        before do get :report_details, project_id: project.id, detail: detail end
+        before do
+          get :report_details,
+              params: { project_id: project.id, detail: detail }
+        end
 
         subject { response }
 
@@ -162,7 +168,10 @@ describe WorkPackages::ReportsController, type: :controller do
       end
 
       context 'invalid detail' do
-        before do get :report_details, project_id: project.id, detail: 'invalid' end
+        before do
+          get :report_details,
+              params: { project_id: project.id, detail: 'invalid' }
+        end
 
         subject { response }
 

--- a/spec/support/shared/previews.rb
+++ b/spec/support/shared/previews.rb
@@ -30,7 +30,7 @@ shared_examples_for 'valid preview' do
   render_views
 
   before do
-    put :preview, preview_params
+    put :preview, params: preview_params
   end
 
   it { expect(response).to render_template('common/preview') }
@@ -48,7 +48,7 @@ shared_examples_for 'authorizes object access' do
   before do
     allow(User).to receive(:current).and_return(unauthorized_user)
 
-    put :preview, preview_params
+    put :preview, params: preview_params
   end
 
   it { expect(response.status).to eq(403) }


### PR DESCRIPTION
Fixes in spec/controllers:

```
DEPRECATION WARNING: ActionController::TestCase HTTP request methods will accept only
keyword arguments in future Rails versions.
```
