### PR TITLE
Feature: Relations CRUD

### DIFF
--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -39,8 +39,8 @@ module Relations
     attribute :from_id
     attribute :to_id
 
-    validate :user_allowed_to_manage_relations
     validate :user_allowed_to_access
+    validate :user_allowed_to_manage_relations
 
     attr_reader :user
 
@@ -55,19 +55,14 @@ module Relations
     ##
     # Allow the user only to create/update relations between work packages they are allowed to see.
     def user_allowed_to_access
-      if !work_packages_visible?
-        errors.add :base, :error_not_found
-      end
+      errors.add :from, :error_not_found unless visible_work_packages.exists? model.from_id
+      errors.add :to, :error_not_found unless visible_work_packages.exists? model.to_id
     end
 
     def user_allowed_to_manage_relations
       if !manage_relations?
         errors.add :base, :error_unauthorized
       end
-    end
-
-    def work_packages_visible?
-      visible_work_packages.exists?(model.from_id) && visible_work_packages.exists?(model.to_id)
     end
 
     def visible_work_packages

--- a/app/contracts/relations/create_contract.rb
+++ b/app/contracts/relations/create_contract.rb
@@ -31,6 +31,5 @@ require 'relations/base_contract'
 
 module Relations
   class CreateContract < BaseContract
-
   end
 end

--- a/app/contracts/relations/create_contract.rb
+++ b/app/contracts/relations/create_contract.rb
@@ -27,34 +27,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
+require 'relations/base_contract'
 
-module API
-  module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Relations::RelationsAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::UserPreferences::UserPreferencesAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+module Relations
+  class CreateContract < BaseContract
 
-      get '/' do
-        RootRepresenter.new({}, current_user: current_user)
-      end
-    end
   end
 end

--- a/app/contracts/relations/update_contract.rb
+++ b/app/contracts/relations/update_contract.rb
@@ -27,33 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
+require 'relations/base_contract'
 
-module API
-  module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Relations::RelationsAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::UserPreferences::UserPreferencesAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+module Relations
+  class UpdateContract < BaseContract
+    validate :links_immutable
 
-      get '/' do
-        RootRepresenter.new({}, current_user: current_user)
+    private
+
+    def links_immutable
+      if model.from_id_changed? || model.to_id_changed?
+        errors.add :base, :error_readonly
       end
     end
   end

--- a/app/contracts/relations/update_contract.rb
+++ b/app/contracts/relations/update_contract.rb
@@ -36,9 +36,8 @@ module Relations
     private
 
     def links_immutable
-      if model.from_id_changed? || model.to_id_changed?
-        errors.add :base, :error_readonly
-      end
+      errors.add :from, :error_readonly if model.from_id_changed?
+      errors.add :to, :error_readonly if model.to_id_changed?
     end
   end
 end

--- a/app/services/relations/update_relation_service.rb
+++ b/app/services/relations/update_relation_service.rb
@@ -27,34 +27,34 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
+class UpdateRelationService
+  include Concerns::Contracted
 
-module API
-  module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Relations::RelationsAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::UserPreferences::UserPreferencesAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+  attr_accessor :user, :relation
 
-      get '/' do
-        RootRepresenter.new({}, current_user: current_user)
+  self.contract = Relations::UpdateContract
+
+  def initialize(user:, relation:)
+    self.user = user
+    self.relation = relation
+    self.contract = self.class.contract.new relation, user
+  end
+
+  def call(attributes: {}, send_notifications: true)
+    User.execute_as user do
+      JournalManager.with_send_notifications send_notifications do
+        update attributes
       end
     end
+  end
+
+  private
+
+  def update(attributes)
+    relation.attributes = relation.attributes.merge attributes
+
+    save_result, save_errors = validate_and_save relation
+
+    ServiceResult.new success: save_result, errors: save_errors, result: relation
   end
 end

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -300,3 +300,6 @@ end
 
 # Patch acts_as_list before any class includes the module
 require 'open_project/patches/acts_as_list'
+
+# Backports some useful ruby 2.3 methods for Hash
+require 'open_project/patches/hash'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,18 @@ en:
 
   actionview_instancetag_blank_option: "Please select"
 
+  activemodel:
+    errors:
+      models:
+        "relations/base_contract":
+          attributes:
+            to:
+              error_not_found: "work package in `to` position not found or not visible"
+              error_readonly: "an existing relation's `to` link is immutable"
+            from:
+              error_not_found: "work package in `from` position not found or not visible"
+              error_readonly: "an existing relation's `from` link is immutable"
+
   activerecord:
     attributes:
       announcements:

--- a/db/migrate/20161017102547_add_description_to_relations.rb
+++ b/db/migrate/20161017102547_add_description_to_relations.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToRelations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :relations, :description, :text
+  end
+end

--- a/doc/apiv3/endpoints/work-packages.apib
+++ b/doc/apiv3/endpoints/work-packages.apib
@@ -1386,7 +1386,7 @@ If the request succeeds, the specified user is not watching the work package any
                 "message": "The specified work package does not exist."
             }
 
-## Available relation candidates [/api/v3/work_packages/{id}/available_relation_candidates{?filters,query,offset,pageSize}]
+## Available relation candidates [/api/v3/work_packages/{id}/available_relation_candidates{?filters,query,type,pageSize}]
 
 Lists work packages with which this work package can be in a relation.
 Only sound candidates are returned. For instance a work package cannot stand in relation to itself,
@@ -1403,6 +1403,9 @@ For instance to find all work packages with "rollout" in their subject:
 
 For convenience there is also a simple `query` parameter which is a shortcut for listing work packages
 whose ID or subject contain the given string.
+
+While the endpoint does support the pageSize parameter to limit the number of results it
+**does not** support the offset parameter.
 
 ```
 ?query=112
@@ -1446,14 +1449,14 @@ whose ID or subject contain the given string.
 ## Available relation candidates [GET]
 
 + Parameters
-    + offset = `1` (optional, integer, `25`) ... Page number inside the requested collection.
-
-    + pageSize (optional, integer, `25`) ... Number of elements to display per page.
+    + pageSize (optional, integer, `25`) ... Maximum number of candidates to list (default 10)
 
     + filters (optional, string, `[{ "status_id": { "operator": "o", "values": null }" }]`) ... JSON specifying filter conditions.
         Accepts the same format as returned by the [queries](#queries) endpoint.
 
     + query (optional, string, `"rollout"`) ... Shortcut for filtering by ID or subject
+
+    + type (optional, string, `"follows"`) ... Type of relation to find candidates for (default "relates")
 
 + Response 200 (application/hal+json)
 
@@ -2194,4 +2197,3 @@ Gets a list of users that can be assigned as the responsible of a work package i
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
                 "message": "The specified project does not exist."
             }
-

--- a/frontend/app/components/wp-relations/wp-relations.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations.directive.ts
@@ -82,7 +82,7 @@ export class WorkPackageRelationsController {
   }
 
   protected getRelatedWorkPackageId(relation) {
-    let direction = (relation.relatedTo.href === this.workPackage.href) ? 'relatedFrom' : 'relatedTo';
+    let direction = (relation.to.href === this.workPackage.href) ? 'from' : 'to';
     return parseInt(relation[direction].href.split('/').pop());
   }
 

--- a/lib/api/utilities/property_name_converter.rb
+++ b/lib/api/utilities/property_name_converter.rb
@@ -55,7 +55,8 @@ module API
           updated_on: 'updatedAt',
           remaining_hours: 'remainingTime',
           spent_hours: 'spentTime',
-          subproject: 'subprojectId'
+          subproject: 'subprojectId',
+          relation_type: 'type'
         }
 
         # Converts the attribute name as refered to by ActiveRecord to a corresponding API-conform

--- a/lib/api/v3/relations/relation_collection_representer.rb
+++ b/lib/api/v3/relations/relation_collection_representer.rb
@@ -33,28 +33,14 @@ module API
       class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
         element_decorator ::API::V3::Relations::RelationRepresenter
 
-        # TODO: we should not pass in the work_package here.  It is done,
-        # so that we can differentiate the relation type e.g.
-        # Relation::Follows vs. Relation::Precedes.  However, this causes
-        # the relation (a resource in it's own right) to change depending
-        # on the work package this is queried for.  We could either:
-        # * change the relation self href to only be valid within a work
-        #   package scope
-        # * remove the difference between the relation pairs
-        #   (e.g. Follows/Precedes) and by that remove the necessity to have
-        #   work package passed in.
-
-        def initialize(models, self_link, current_user:, work_package: nil)
-          @work_package = work_package
+        def initialize(models, self_link, current_user:)
           super(models, self_link, current_user: current_user)
         end
 
         collection :elements,
                    getter: -> (*) {
                      represented.map { |model|
-                       element_decorator.create(model,
-                                                current_user: current_user,
-                                                work_package: @work_package)
+                       element_decorator.new model, current_user: current_user
                      }
                    },
                    exec_context: :decorator,

--- a/lib/api/v3/relations/relation_helpers.rb
+++ b/lib/api/v3/relations/relation_helpers.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,33 +26,31 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
-
 module API
   module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Relations::RelationsAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::UserPreferences::UserPreferencesAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+    module Relations
+      module RelationHelpers
+        def filter_attributes(relation)
+          relation
+            .attributes
+            .with_indifferent_access
+            .reject { |_key, value| value.blank? }
+        end
 
-      get '/' do
-        RootRepresenter.new({}, current_user: current_user)
+        def representer
+          ::API::V3::Relations::RelationRepresenter
+        end
+
+        def project_id_for_relation(id)
+          relations = Relation.table_name
+          work_packages = WorkPackage.table_name
+
+          Relation
+            .joins(:from)
+            .where("#{relations}.id" => id)
+            .pluck("#{relations}.id, #{work_packages}.project_id")
+            .first
+        end
       end
     end
   end

--- a/lib/api/v3/relations/relation_helpers.rb
+++ b/lib/api/v3/relations/relation_helpers.rb
@@ -48,7 +48,7 @@ module API
           Relation
             .joins(:from)
             .where("#{relations}.id" => id)
-            .pluck("#{relations}.id, #{work_packages}.project_id")
+            .pluck("#{work_packages}.project_id")
             .first
         end
       end

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -97,8 +97,11 @@ module API
         ##
         # Used while parsing JSON to initialize `from` and `to` through the given links.
         def initialize_embedded_links!(data)
-          represented.from_id = parse_wp_id data, "from"
-          represented.to_id = parse_wp_id data, "to"
+          from_id = parse_wp_id data, "from"
+          to_id = parse_wp_id data, "to"
+
+          represented.from_id = from_id if from_id
+          represented.to_id = to_id if to_id
         end
 
         ##
@@ -112,11 +115,15 @@ module API
         end
 
         def parse_wp_id(data, link_name)
-          ::API::Utilities::ResourceLinkParser.parse_id(
-            data.dig("_links", link_name, "href"),
-            property: :from,
-            expected_version: "3",
-            expected_namespace: "work_packages")
+          value = data.dig("_links", link_name, "href")
+
+          if value
+            ::API::Utilities::ResourceLinkParser.parse_id(
+              value,
+              property: :from,
+              expected_version: "3",
+              expected_namespace: "work_packages")
+          end
         end
 
         def _type

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -122,7 +122,8 @@ module API
               value,
               property: :from,
               expected_version: "3",
-              expected_namespace: "work_packages")
+              expected_namespace: "work_packages"
+            )
           end
         end
 

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -34,7 +34,7 @@ module API
   module V3
     module Relations
       class RelationsAPI < ::API::OpenProjectAPI
-        helpers RelationHelpers
+        helpers ::API::V3::Relations::RelationsHelper
 
         resources :relations do
           get do

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -79,7 +79,7 @@ module API
 
               authorize :manage_work_package_relations, context: project
 
-              Relation.destroy! params[:id]
+              Relation.destroy params[:id]
               status 204
             end
           end

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -62,9 +62,7 @@ module API
             end
 
             if relation.valid? && relation.save
-              representer = RelationRepresenter.new(relation,
-                                                    work_package: relation.to,
-                                                    current_user: current_user)
+              representer = RelationRepresenter.new(relation, current_user: current_user)
               representer
             else
               fail ::API::Errors::Validation.new(nil, I18n.t('api_v3.errors.invalid_relation'))

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -83,19 +83,6 @@ module API
               status 204
             end
           end
-
-          post do
-            rep = representer.new Relation.new, current_user: current_user
-            relation = rep.from_json request.body.read
-            service = ::CreateRelationService.new user: current_user
-            call = service.call relation, send_notifications: !(params[:notify] == 'false')
-
-            if call.success?
-              representer.new call.result, current_user: current_user, embed_links: true
-            else
-              fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
-            end
-          end
         end
       end
     end

--- a/lib/api/v3/relations/relations_helper.rb
+++ b/lib/api/v3/relations/relations_helper.rb
@@ -29,7 +29,7 @@
 module API
   module V3
     module Relations
-      module RelationHelpers
+      module RelationsHelper
         def filter_attributes(relation)
           relation
             .attributes

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -57,6 +57,12 @@ module API
         }
       end
 
+      link :relations do
+        {
+          href: api_v3_paths.relations
+        }
+      end
+
       link :statuses do
         {
           href: api_v3_paths.statuses

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -83,6 +83,10 @@ module API
             "#{work_packages}/available_projects"
           end
 
+          def self.available_relation_candidates(work_package_id)
+            "#{work_package(work_package_id)}/available_relation_candidates"
+          end
+
           def self.categories(project_id)
             "#{project(project_id)}/categories"
           end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -139,6 +139,10 @@ module API
             "#{root}/relations/#{id}"
           end
 
+          def self.relations
+            "#{root}/relations"
+          end
+
           def self.revision(id)
             "#{root}/revisions/#{id}"
           end

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -34,6 +34,7 @@ module API
           params do
             requires :query, type: String # either WP ID or part of its subject
             optional :type, type: String, default: "relates" # relation type
+            optional :pageSize, type: Integer, default: 10
           end
           get do
             from = @work_package
@@ -41,7 +42,7 @@ module API
             query = WorkPackage
               .where("id = ? OR subject LIKE ?", params[:query].to_i, "%#{params[:query]}%")
               .where.not(id: from.id) # can't relate to itself
-              .limit(10)
+              .limit(params[:pageSize])
 
             if !Setting.cross_project_work_package_relations?
               query = query.where(project_id: from.project_id) # has to be same project

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      class AvailableRelationCandidatesAPI < ::API::OpenProjectAPI
+        resources :available_relation_candidates do
+          params do
+            requires :query, type: String # either WP ID or part of its subject
+            optional :type, type: String, default: "relates" # relation type
+          end
+          get do
+            from = @work_package
+
+            query = WorkPackage
+              .where("id = ? OR subject LIKE ?", params[:query].to_i, "%#{params[:query]}%")
+              .where.not(id: from.id) # can't relate to itself
+              .limit(10)
+
+            if !Setting.cross_project_work_package_relations?
+              query = query.where(project_id: from.project_id) # has to be same project
+            end
+
+            work_packages = query
+              .reject do |to|
+                rel = Relation.new(relation_type: params[:type], from: from, to: to)
+
+                rel.shared_hierarchy? || rel.circular_dependency?
+              end
+
+            ::API::V3::WorkPackages::WorkPackageListRepresenter.new(
+              work_packages,
+              "/api/v3/work_package/#{@work_package.id}/available_relation_candidates",
+              current_user: current_user
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -40,7 +40,7 @@ module API
           end
           get do
             from = @work_package
-            query = work_package_query params[:query], from, params[:type], params[:pageSize]
+            query = work_package_query params[:query], from, params[:pageSize]
             work_packages = filter_work_packages query, from, params[:type]
 
             ::API::V3::WorkPackages::WorkPackageListRepresenter.new(

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module WorkPackages
       class AvailableRelationCandidatesAPI < ::API::OpenProjectAPI
-        include API::V3::Utilities::PathHelper
+        helpers ::API::V3::WorkPackages::AvailableRelationCandidatesHelper
 
         resources :available_relation_candidates do
           params do
@@ -40,7 +40,7 @@ module API
           end
           get do
             from = @work_package
-            query = work_package_query from, params[:type], params[:pageSize]
+            query = work_package_query params[:query], from, params[:type], params[:pageSize]
             work_packages = filter_work_packages query, from, params[:type]
 
             ::API::V3::WorkPackages::WorkPackageListRepresenter.new(
@@ -49,37 +49,6 @@ module API
               current_user: current_user
             )
           end
-        end
-
-        private
-
-        ##
-        # Queries the compatible work package's to the given one as much as possible through the
-        # database.
-        #
-        # @param from [WorkPackage] The work package in the `from` position of a relation.
-        # @param type [String] The type of relation (e.g. follows, blocks, etc.) to be checked.
-        # @param limit [Integer] Maximum number of results to retrieve.
-        def work_package_query(from, type, limit)
-          WorkPackage.where("id = ? OR subject LIKE ?", params[:query].to_i, "%#{params[:query]}%")
-                     .where.not(id: from.id) # can't relate to itself
-                     .limit(limit)
-
-          if Setting.cross_project_work_package_relations?
-            query
-          else
-            query.where(project_id: from.project_id) # has to be same project
-          end
-        end
-
-        def filter_work_packages(work_packages, from, type)
-          work_packages.reject { |to| illegal_relation? type, from, to }
-        end
-
-        def illegal_relation?(type, from, to)
-          rel = Relation.new(relation_type: params[:type], from: from, to: to)
-
-          rel.shared_hierarchy? || rel.circular_dependency?
         end
       end
     end

--- a/lib/api/v3/work_packages/available_relation_candidates_helper.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_helper.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      module AvailableRelationCandidatesHelper
+        include API::V3::Utilities::PathHelper
+
+        ##
+        # Queries the compatible work package's to the given one as much as possible through the
+        # database.
+        #
+        # @param query [String] The ID or part of a subject to filter by
+        # @param from [WorkPackage] The work package in the `from` position of a relation.
+        # @param type [String] The type of relation (e.g. follows, blocks, etc.) to be checked.
+        # @param limit [Integer] Maximum number of results to retrieve.
+        def work_package_query(query, from, type, limit)
+          wps = WorkPackage.where("id = ? OR subject LIKE ?", query.to_i, "%#{query}%")
+                           .where.not(id: from.id) # can't relate to itself
+                           .limit(limit)
+
+          if Setting.cross_project_work_package_relations?
+            wps
+          else
+            wps.where(project_id: from.project_id) # has to be same project
+          end
+        end
+
+        def filter_work_packages(work_packages, from, type)
+          work_packages.reject { |to| illegal_relation? type, from, to }
+        end
+
+        def illegal_relation?(type, from, to)
+          rel = Relation.new(relation_type: type, from: from, to: to)
+
+          rel.shared_hierarchy? || rel.circular_dependency?
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/available_relation_candidates_helper.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_helper.rb
@@ -38,9 +38,8 @@ module API
         #
         # @param query [String] The ID or part of a subject to filter by
         # @param from [WorkPackage] The work package in the `from` position of a relation.
-        # @param type [String] The type of relation (e.g. follows, blocks, etc.) to be checked.
         # @param limit [Integer] Maximum number of results to retrieve.
-        def work_package_query(query, from, type, limit)
+        def work_package_query(query, from, limit)
           wps = WorkPackage.where("id = ? OR subject LIKE ?", query.to_i, "%#{query}%")
                            .where.not(id: from.id) # can't relate to itself
                            .limit(limit)

--- a/lib/api/v3/work_packages/work_package_list_representer.rb
+++ b/lib/api/v3/work_packages/work_package_list_representer.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'roar/decorator'
+require 'roar/json'
+require 'roar/json/collection'
+require 'roar/json/hal'
+
+module API
+  module V3
+    module WorkPackages
+      class WorkPackageListRepresenter < ::API::Decorators::UnpaginatedCollection
+        element_decorator ::API::V3::WorkPackages::WorkPackageRepresenter
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_package_relations_api.rb
+++ b/lib/api/v3/work_packages/work_package_relations_api.rb
@@ -30,6 +30,8 @@ module API
   module V3
     module WorkPackages
       class WorkPackageRelationsAPI < ::API::OpenProjectAPI
+        helpers ::API::V3::Relations::RelationHelpers
+
         resources :relations do
           ##
           # @todo Redirect to relations endpoint as soon as `list relations` API endpoint
@@ -44,6 +46,19 @@ module API
               api_v3_paths.work_package_relations(@work_package.id),
               current_user: current_user
             )
+          end
+
+          post do
+            rep = representer.new Relation.new, current_user: current_user
+            relation = rep.from_json request.body.read
+            service = ::CreateRelationService.new user: current_user
+            call = service.call relation, send_notifications: !(params[:notify] == 'false')
+
+            if call.success?
+              representer.new call.result, current_user: current_user, embed_links: true
+            else
+              fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
+            end
           end
         end
       end

--- a/lib/api/v3/work_packages/work_package_relations_api.rb
+++ b/lib/api/v3/work_packages/work_package_relations_api.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      class WorkPackageRelationsAPI < ::API::OpenProjectAPI
+        resources :relations do
+          ##
+          # @todo Redirect to relations endpoint as soon as `list relations` API endpoint
+          #       including filters is complete.
+          get do
+            relations = @work_package.relations.select do |relation|
+              relation.other_work_package(@work_package).visible?
+            end
+
+            ::API::V3::Relations::RelationCollectionRepresenter.new(
+              relations,
+              api_v3_paths.work_package_relations(@work_package.id),
+              current_user: current_user
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_package_relations_api.rb
+++ b/lib/api/v3/work_packages/work_package_relations_api.rb
@@ -30,16 +30,15 @@ module API
   module V3
     module WorkPackages
       class WorkPackageRelationsAPI < ::API::OpenProjectAPI
-        helpers ::API::V3::Relations::RelationHelpers
+        helpers ::API::V3::Relations::RelationsHelper
 
         resources :relations do
           ##
           # @todo Redirect to relations endpoint as soon as `list relations` API endpoint
           #       including filters is complete.
           get do
-            relations = @work_package.relations.select do |relation|
-              relation.other_work_package(@work_package).visible?
-            end
+            visible = ->(relation) { relation.other_work_package(@work_package).visible? }
+            relations = @work_package.relations.select(&visible)
 
             ::API::V3::Relations::RelationCollectionRepresenter.new(
               relations,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -400,7 +400,6 @@ module API
 
           ::API::V3::Relations::RelationCollectionRepresenter.new(visible_relations,
                                                                   self_path,
-                                                                  work_package: represented,
                                                                   current_user: current_user)
         end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -126,6 +126,13 @@ module API
           } if current_user_allowed_to(:export_work_packages, context: represented.project)
         end
 
+        link :available_relation_candidates do
+          {
+            href: "/api/v3/work_packages/#{represented.id}/available_relation_candidates",
+            title: "Potential work packages to relate to"
+          }
+        end
+
         linked_property :type, embed_as: ::API::V3::Types::TypeRepresenter
         linked_property :status, embed_as: ::API::V3::Statuses::StatusRepresenter
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -106,7 +106,6 @@ module API
             end
 
             mount ::API::V3::WorkPackages::WatchersAPI
-            mount ::API::V3::Relations::RelationsAPI
             mount ::API::V3::Activities::ActivitiesByWorkPackageAPI
             mount ::API::V3::Attachments::AttachmentsByWorkPackageAPI
             mount ::API::V3::Repositories::RevisionsByWorkPackageAPI

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -111,6 +111,8 @@ module API
             mount ::API::V3::Repositories::RevisionsByWorkPackageAPI
             mount ::API::V3::WorkPackages::UpdateFormAPI
             mount ::API::V3::WorkPackages::AvailableProjectsOnEditAPI
+            mount ::API::V3::WorkPackages::AvailableRelationCandidatesAPI
+            mount ::API::V3::WorkPackages::WorkPackageRelationsAPI
           end
 
           mount ::API::V3::WorkPackages::Schema::WorkPackageSchemasAPI

--- a/lib/open_project/patches/hash.rb
+++ b/lib/open_project/patches/hash.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,34 +26,29 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Root class of the API v3
-# This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
+# This patch adds a convenience method to models that are including acts_as_list.
+# After including it is possible to e.g. call
+#
+# including_instance.move_to = "highest"
+#
+# and the instance will be sorted to to the top of the list.
+#
+# This enables having the view send string that will be used for sorting.
 
-module API
-  module V3
-    class Root < ::API::OpenProjectAPI
-      mount ::API::V3::Activities::ActivitiesAPI
-      mount ::API::V3::Attachments::AttachmentsAPI
-      mount ::API::V3::Categories::CategoriesAPI
-      mount ::API::V3::Configuration::ConfigurationAPI
-      mount ::API::V3::Priorities::PrioritiesAPI
-      mount ::API::V3::Projects::ProjectsAPI
-      mount ::API::V3::Queries::QueriesAPI
-      mount ::API::V3::Render::RenderAPI
-      mount ::API::V3::Relations::RelationsAPI
-      mount ::API::V3::Repositories::RevisionsAPI
-      mount ::API::V3::Statuses::StatusesAPI
-      mount ::API::V3::StringObjects::StringObjectsAPI
-      mount ::API::V3::Types::TypesAPI
-      mount ::API::V3::Users::UsersAPI
-      mount ::API::V3::UserPreferences::UserPreferencesAPI
-      mount ::API::V3::Versions::VersionsAPI
-      mount ::API::V3::WorkPackages::WorkPackagesAPI
+# Needs to be applied before any of the models using acts_as_list get loaded.
 
-      get '/' do
-        RootRepresenter.new({}, current_user: current_user)
+module OpenProject
+  module Patches
+    module Hash
+      ##
+      # Becomes obsolete with ruby 2.3's Hash#dig but until then this will do.
+      def dig(*keys)
+        keys.inject(self) { |hash, key| hash && hash.is_a?(Hash) && hash[key] }
       end
     end
   end
+end
+
+if !Hash.instance_methods.include? :dig
+  Hash.prepend OpenProject::Patches::Hash
 end

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -32,5 +32,6 @@ FactoryGirl.define do
     to do FactoryGirl.build(:work_package, project: from.project) end
     relation_type 'relates' # "relates", "duplicates", "duplicated", "blocks", "blocked", "precedes", "follows"
     delay nil
+    description nil
   end
 end

--- a/spec/factories/role_factory.rb
+++ b/spec/factories/role_factory.rb
@@ -54,11 +54,12 @@ FactoryGirl.define do
       permissions []
 
       initialize_with do
-        if Role.where(name: name).exists?
-          role = Role.find_by(name: name)
-        else
-          role = Role.create name: name, assignable: assignable
-        end
+        role =
+          if Role.where(name: name).exists?
+            Role.find_by(name: name)
+          else
+            Role.create name: name, assignable: assignable
+          end
 
         role.add_permission!(*permissions.reject { |p| role.permissions.include?(p) })
 

--- a/spec/factories/role_factory.rb
+++ b/spec/factories/role_factory.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'digest'
+
 FactoryGirl.define do
   factory :role do
     permissions []
@@ -47,13 +49,20 @@ FactoryGirl.define do
     end
 
     factory :existing_role do
-      name { 'Role with ' + permissions.map(&:to_s).join('/') }
+      name { 'Role ' + Digest::MD5.hexdigest(permissions.map(&:to_s).join('/'))[0..4] }
       assignable true
       permissions []
 
       initialize_with do
-        Role.find_or_create_by(
-          name: name, assignable: assignable, permissions: permissions)
+        if Role.where(name: name).exists?
+          role = Role.find_by(name: name)
+        else
+          role = Role.create name: name, assignable: assignable
+        end
+
+        role.add_permission!(*permissions.reject { |p| role.permissions.include?(p) })
+
+        role
       end
     end
   end

--- a/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
@@ -52,7 +52,6 @@ describe ::API::V3::Relations::RelationCollectionRepresenter do
   let(:representer) {
     described_class.new(relations,
                         self_link,
-                        work_package: work_package,
                         current_user: user)
   }
 
@@ -62,6 +61,6 @@ describe ::API::V3::Relations::RelationCollectionRepresenter do
     it_behaves_like 'unpaginated APIv3 collection',
                     3,
                     'a link that is provided',
-                    'Relation::Relates'
+                    'Relation'
   end
 end

--- a/spec/lib/api/v3/relations/relation_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_representer_spec.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Relations::RelationRepresenter do
+  let(:user) { FactoryGirl.create :admin }
+
+  let(:from) { FactoryGirl.create :work_package }
+  let(:to) { FactoryGirl.create :work_package }
+
+  let(:type) { "precedes" }
+  let(:description) { "This first" }
+
+  let(:relation) do
+    FactoryGirl.create :relation, from: from, to: to, relation_type: type, description: description
+  end
+
+  let(:representer) { described_class.new relation, current_user: user }
+
+  let(:result) do
+    {
+      "_type" => "Relation",
+      "_links" => {
+        "self" => {
+          "href" => "/api/v3/relations/#{relation.id}"
+        },
+        "updateImmediately" => {
+          "href" => "/api/v3/relations/#{relation.id}",
+          "method" => "patch"
+        },
+        "delete" => {
+          "href" => "/api/v3/relations/#{relation.id}",
+          "method" => "delete",
+          "title" => "Remove relation"
+        },
+        "from" => {
+          "href" => "/api/v3/work_packages/#{from.id}",
+          "title" => "Show work package"
+        },
+        "to" => {
+          "href" => "/api/v3/work_packages/#{to.id}",
+          "title" => "Show work package"
+        }
+      },
+      "name" => "precedes",
+      "type" => "precedes",
+      "reverseType" => "follows",
+      "description" => description,
+      "delay" => 0
+    }
+  end
+
+  it 'serializes the relation correctly' do
+    data = JSON.parse representer.to_json
+
+    expect(data).to eq result
+  end
+end

--- a/spec/lib/api/v3/relations/relation_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_representer_spec.rb
@@ -36,9 +36,15 @@ describe ::API::V3::Relations::RelationRepresenter do
 
   let(:type) { "precedes" }
   let(:description) { "This first" }
+  let(:delay) { 3 }
 
   let(:relation) do
-    FactoryGirl.create :relation, from: from, to: to, relation_type: type, description: description
+    FactoryGirl.create :relation,
+                       from: from,
+                       to: to,
+                       relation_type: type,
+                       description: description,
+                       delay: delay
   end
 
   let(:representer) { described_class.new relation, current_user: user }
@@ -61,18 +67,19 @@ describe ::API::V3::Relations::RelationRepresenter do
         },
         "from" => {
           "href" => "/api/v3/work_packages/#{from.id}",
-          "title" => "Show work package"
+          "title" => from.subject
         },
         "to" => {
           "href" => "/api/v3/work_packages/#{to.id}",
-          "title" => "Show work package"
+          "title" => to.subject
         }
       },
+      "id" => relation.id,
       "name" => "precedes",
       "type" => "precedes",
       "reverseType" => "follows",
       "description" => description,
-      "delay" => 0
+      "delay" => delay
     }
   end
 
@@ -80,5 +87,17 @@ describe ::API::V3::Relations::RelationRepresenter do
     data = JSON.parse representer.to_json
 
     expect(data).to eq result
+  end
+
+  it 'deserializes the relation correctly' do
+    rep = ::API::V3::Relations::RelationRepresenter.new Relation.new, current_user: user
+    rel = rep.from_json result.except(:id).to_json
+
+    expect(rel.from).to eq from
+    expect(rel.to).to eq to
+    expect(rel.delay).to eq delay
+    expect(rel.relation_type).to eq type
+    expect(rel.description).to eq description
+    expect(rel.delay).to eq delay
   end
 end

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -1,0 +1,151 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Relations::RelationRepresenter, type: :request do
+  let(:user) { FactoryGirl.create :admin }
+
+  let!(:from) { FactoryGirl.create :work_package }
+  let!(:to) { FactoryGirl.create :work_package }
+
+  let(:type) { "precedes" }
+  let(:description) { "This first" }
+  let(:delay) { 3 }
+
+  let(:params) do
+    {
+      _links: {
+        from: {
+          href: "/api/v3/work_packages/#{from.id}"
+        },
+        to: {
+          href: "/api/v3/work_packages/#{to.id}"
+        }
+      },
+      type: type,
+      description: description,
+      delay: delay
+    }
+  end
+
+  before do
+    login_as user
+  end
+
+  describe "creating a relation" do
+    before do
+      expect(Relation.count).to eq 0
+
+      post "/api/v3/relations",
+           params: params.to_json,
+           headers: { "Content-Type": "application/json" }
+    end
+
+    it 'should return 201 (created)' do
+      expect(response.status).to eq(201)
+    end
+
+    it 'should have created a new relation' do
+      expect(Relation.count).to eq 1
+    end
+
+    it 'should have created the relation correctly' do
+      rel = described_class.new(Relation.new, current_user: user).from_json response.body
+
+      expect(rel.from).to eq from
+      expect(rel.to).to eq to
+      expect(rel.relation_type).to eq type
+      expect(rel.description).to eq description
+      expect(rel.delay).to eq delay
+    end
+  end
+
+  describe "updating a relation" do
+    let!(:relation) do
+      FactoryGirl.create :relation,
+                         from: from,
+                         to: to,
+                         relation_type: type,
+                         description: description,
+                         delay: delay
+    end
+
+    let(:new_description) { "This is another description" }
+    let(:new_delay) { 42 }
+
+    let(:update) do
+      {
+        description: new_description,
+        delay: new_delay
+      }
+    end
+
+    before do
+      patch "/api/v3/relations/#{relation.id}",
+            params: update.to_json,
+            headers: { "Content-Type": "application/json" }
+    end
+
+    it "should return 200 (ok)" do
+      expect(response.status).to eq 200
+    end
+
+    it "updates the relation's description" do
+      expect(relation.reload.description).to eq new_description
+    end
+
+    it "updates the relation's delay" do
+      expect(relation.reload.delay).to eq new_delay
+    end
+
+    it "should return the updated relation" do
+      rel = described_class.new(Relation.new, current_user: user).from_json response.body
+
+      expect(rel).to eq relation.reload
+    end
+
+    context "with invalid type" do
+      let(:update) do
+        {
+          type: "foobar"
+        }
+      end
+
+      it "should return 422" do
+        expect(response.status).to eq 422
+      end
+
+      it "should indicate an error with the type attribute" do
+        attr = JSON.parse(response.body).dig "_embedded", "details", "attribute"
+
+        expect(attr).to eq "type"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -231,6 +231,12 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
 
         expect(attr).to eq "to"
       end
+
+      it "should have a localized error message" do
+        message = JSON.parse(response.body)["message"]
+
+        expect(message).not_to include "translation missing"
+      end
     end
   end
 

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -62,7 +62,7 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
     before do
       expect(Relation.count).to eq 0
 
-      post "/api/v3/relations",
+      post "/api/v3/work_packages/#{from.id}/relations",
            params: params.to_json,
            headers: { "Content-Type": "application/json" }
     end
@@ -196,7 +196,7 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
     before do
       project.add_member! user, role
 
-      post "/api/v3/relations",
+      post "/api/v3/work_packages/#{from.id}/relations",
            params: params.to_json,
            headers: { "Content-Type": "application/json" }
     end

--- a/spec/requests/api/v3/relations_resource_spec.rb
+++ b/spec/requests/api/v3/relations_resource_spec.rb
@@ -86,7 +86,7 @@ describe 'API v3 Relation resource', type: :request do
         get path
       end
 
-      it_behaves_like 'API V3 collection response', 1, 1, 'Relation::Relates'
+      it_behaves_like 'API V3 collection response', 1, 1, 'Relation'
     end
 
     context 'when not having view_work_packages' do

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
@@ -34,10 +34,18 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
   let(:project_1) { FactoryGirl.create :project }
 
   let!(:wp_1) { FactoryGirl.create :work_package, project: project_1, subject: "WP 1" }
-  let!(:wp_1_1) { FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.1" }
-  let!(:wp_1_2) { FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.2" }
-  let!(:wp_1_2_1) { FactoryGirl.create :work_package, parent: wp_1_2, project: project_1, subject: "WP 1.2.1" }
 
+  let!(:wp_1_1) do
+    FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.1"
+  end
+
+  let!(:wp_1_2) do
+    FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.2"
+  end
+
+  let!(:wp_1_2_1) do
+    FactoryGirl.create :work_package, parent: wp_1_2, project: project_1, subject: "WP 1.2.1"
+  end
 
   let(:project_2) { FactoryGirl.create :project }
 
@@ -45,7 +53,9 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
   let!(:wp_2_1) { FactoryGirl.create :work_package, project: project_2, subject: "WP 2.1" }
   let!(:wp_2_2) { FactoryGirl.create :work_package, project: project_2, subject: "WP 2.2" }
 
-  let!(:relation_wp_2_1_to_wp_2_2) { FactoryGirl.create :relation, from: wp_2_1, to: wp_2_2, relation_type: "relates" }
+  let!(:relation_wp_2_1_to_wp_2_2) do
+    FactoryGirl.create :relation, from: wp_2_1, to: wp_2_2, relation_type: "relates"
+  end
 
   let(:result) { JSON.parse response.body }
 

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
@@ -1,0 +1,129 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Relations::RelationRepresenter, type: :request do
+  let(:user) { FactoryGirl.create :admin }
+
+  let(:project_1) { FactoryGirl.create :project }
+
+  let!(:wp_1) { FactoryGirl.create :work_package, project: project_1, subject: "WP 1" }
+  let!(:wp_1_1) { FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.1" }
+  let!(:wp_1_2) { FactoryGirl.create :work_package, parent: wp_1, project: project_1, subject: "WP 1.2" }
+  let!(:wp_1_2_1) { FactoryGirl.create :work_package, parent: wp_1_2, project: project_1, subject: "WP 1.2.1" }
+
+
+  let(:project_2) { FactoryGirl.create :project }
+
+  let!(:wp_2) { FactoryGirl.create :work_package, project: project_2, subject: "WP 2" }
+  let!(:wp_2_1) { FactoryGirl.create :work_package, project: project_2, subject: "WP 2.1" }
+  let!(:wp_2_2) { FactoryGirl.create :work_package, project: project_2, subject: "WP 2.2" }
+
+  let!(:relation_wp_2_1_to_wp_2_2) { FactoryGirl.create :relation, from: wp_2_1, to: wp_2_2, relation_type: "relates" }
+
+  let(:result) { JSON.parse response.body }
+
+  def work_packages
+    result["_embedded"]["elements"]
+  end
+
+  before do
+    login_as user
+  end
+
+  context "without cross project relations" do
+    before do
+      Setting.cross_project_work_package_relations = "0"
+    end
+
+    describe "relation candidates for wp_1 (in hierarchy)" do
+      before do
+        get "/api/v3/work_packages/#{wp_1.id}/available_relation_candidates?query=WP"
+      end
+
+      it "should return an empty list" do # as relations to ancestors or descendents is not allowed
+        expect(result["count"]).to eq 0
+      end
+    end
+
+    describe "relation candidates for wp_2" do
+      before do
+        get "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP"
+      end
+
+      it "should return WP 2.1 and 2.2" do
+        subjects = work_packages.map { |e| e["subject"] }
+
+        expect(subjects).to match_array ["WP 2.1", "WP 2.2"]
+      end
+    end
+
+    describe "relation candidates for WP 2.2 (circular dependency check)" do
+      before do
+        get "/api/v3/work_packages/#{wp_2_2.id}/available_relation_candidates?query=WP"
+      end
+
+      it "should return just WP 2, not WP 2.1" do
+        subjects = work_packages.map { |e| e["subject"] }
+
+        expect(subjects).to match_array ["WP 2"]
+      end
+    end
+  end
+
+  context "with cross project relations" do
+    before do
+      Setting.cross_project_work_package_relations = "1"
+    end
+
+    describe "relation candidates for wp_1 (in hierarchy)" do
+      before do
+        get "/api/v3/work_packages/#{wp_1.id}/available_relation_candidates?query=WP"
+      end
+
+      it "should return WP 2 and all WP 2.x" do
+        subjects = work_packages.map { |wp| wp["subject"] }
+
+        expect(subjects).to match_array ["WP 2", "WP 2.1", "WP 2.2"]
+      end
+    end
+
+    describe "relation candidates for wp_2" do
+      before do
+        get "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP"
+      end
+
+      it "should return WP 2.1 and 2.2, WP 1 and all WP 1.x" do
+        subjects = work_packages.map { |wp| wp["subject"] }
+
+        expect(subjects).to match_array ["WP 1", "WP 1.1", "WP 1.2", "WP 1.2.1", "WP 2.1", "WP 2.2"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
WP [#18884](https://community.openproject.com/work_packages/18884/activity)
### Implementation approach

Implement CRUD of relations through APIv3 according to the specification. Implementation-wise, this will take over the structure of the abstractions used in the POST /api/v3/work_packages endpoint including Services and Contracts where applicable.
### Alternatives
## 
### Out of scope
- This PR contains a "dumb" "list relations" endpoint. This endpoint will be extended to support filters for relations in a separate step.
### ToDos
- [x] **C**reate Relation (`POST /api/v3/work_packages/:id/relations`)
- [x] **R**ead Relation (`GET /api/v3/relations/:id`)
- [x] **U**pdate Relation (`PATCH /api/v3/relations/:id`)
- [x] **D**elete Relation (`DELETE /api/v3/relations/:id`)
- [x] also: available relation candidates endpoint for work packages
