### PR TITLE
[24063] Add PATCH api/v3/users

### DIFF
--- a/app/contracts/users/update_contract.rb
+++ b/app/contracts/users/update_contract.rb
@@ -1,0 +1,46 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'users/base_contract'
+
+module Users
+  class UpdateContract < BaseContract
+    validate :user_allowed_to_update
+
+    private
+
+    ##
+    # Users can only be updated by Admins
+    def user_allowed_to_update
+      unless current_user.admin?
+        errors.add :base, :error_unauthorized
+      end
+    end
+  end
+end

--- a/app/services/users/update_user_service.rb
+++ b/app/services/users/update_user_service.rb
@@ -1,0 +1,60 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Users
+  class UpdateUserService
+    include Concerns::Contracted
+
+    attr_accessor :current_user, :user
+
+    self.contract = Users::UpdateContract
+
+    def initialize(current_user:, user:)
+      self.current_user = current_user
+      self.user = user
+
+      self.contract = self.class.contract.new(user, current_user)
+    end
+
+    def call(attributes: {})
+      User.execute_as current_user do
+        set_attributes(attributes)
+
+        success, errors = validate_and_save(user)
+        ServiceResult.new(success: success, errors: errors, result: user)
+      end
+    end
+
+    private
+
+    def set_attributes(attributes)
+      user.attributes = attributes
+    end
+  end
+end

--- a/doc/apiv3/endpoints/users.apib
+++ b/doc/apiv3/endpoints/users.apib
@@ -159,7 +159,7 @@ When calling this endpoint the client provides a single object, containing at le
 
     Returned if the client does not have sufficient permissions.
 
-    **Required permission:** Administrators only (exception: users may update their own accounts)
+    **Required permission:** Administrators only
 
     + Body
 
@@ -182,6 +182,7 @@ When calling this endpoint the client provides a single object, containing at le
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
                 "message": "The specified user does not exist or you do not have permission to view them."
             }
+
 
 + Response 422 (application/hal+json)
 

--- a/lib/api/v3/users/update_user.rb
+++ b/lib/api/v3/users/update_user.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'api/v3/users/user_representer'
+require 'users/update_user_service'
+
+module API
+  module V3
+    module Users
+      module UpdateUser
+        ##
+        # Call the user create service for the current request
+        # and return the service result API representation
+        def update_user(request_body, current_user)
+          payload = ::API::V3::Users::UserRepresenter.create(@user, current_user: current_user)
+          updated_user = payload.from_hash(request_body)
+
+          result = call_service(updated_user, current_user)
+          represent_service_result(result, current_user)
+        end
+
+        private
+
+        def represent_service_result(result, current_user)
+          if result.success?
+            ::API::V3::Users::UserRepresenter.create(result.result, current_user: current_user)
+          else
+            fail ::API::Errors::ErrorBase.create_and_merge_errors(result.errors)
+          end
+        end
+
+        def call_service(updated_user, current_user)
+          create_service = ::Users::UpdateUserService.new(
+            current_user: current_user,
+            user: updated_user
+          )
+          create_service.call
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -53,6 +53,14 @@ module API
           }
         end
 
+        link :update do
+          {
+            href: api_v3_paths.user(represented.id),
+            title: "Update #{represented.login}",
+            method: :patch
+          } if current_user_is_admin
+        end
+
         link :lock do
           {
             href: api_v3_paths.user_lock(represented.id),

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -64,12 +64,19 @@ module API
             requires :id, desc: 'User\'s id'
           end
           route_param :id do
+            helpers ::API::V3::Users::UpdateUser
+
             before do
               @user  = User.find(params[:id])
             end
 
             get do
               UserRepresenter.new(@user, current_user: current_user)
+            end
+
+            patch do
+              allow_only_admin
+              update_user(request_body, current_user)
             end
 
             delete do

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -94,14 +94,16 @@ describe ::API::V3::Users::UserRepresenter do
         it 'should have no lock-related links' do
           expect(subject).not_to have_json_path('_links/lock/href')
           expect(subject).not_to have_json_path('_links/unlock/href')
+          expect(subject).not_to have_json_path('_links/update/href')
         end
       end
 
       context 'when current_user is admin' do
         let(:current_user) { FactoryGirl.build_stubbed(:admin) }
 
-        it 'should link to lock' do
+        it 'should link to lock and update' do
           expect(subject).to have_json_path('_links/lock/href')
+          expect(subject).to have_json_path('_links/update/href')
         end
 
         context 'when account is locked' do

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -1,0 +1,120 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+require 'rack/test'
+
+describe ::API::V3::Users::UsersAPI, type: :request do
+  include API::V3::Utilities::PathHelper
+
+  let(:path) { api_v3_paths.user(user.id) }
+  let(:current_user) { FactoryGirl.build(:admin) }
+
+  let(:user) { FactoryGirl.create(:user) }
+  let(:parameters) { {} }
+
+  before do
+    login_as(current_user)
+  end
+
+  def send_request
+    patch path, params: parameters.to_json, headers: { 'Content-Type' => 'application/json' }
+  end
+
+  shared_context 'successful update' do |expected_attributes|
+    it 'responds with the represented updated user' do
+      send_request
+
+      expect(response.status).to eq(200)
+      expect(response.body).to have_json_type(Object).at_path('_links')
+      expect(response.body)
+        .to be_json_eql('User'.to_json)
+        .at_path('_type')
+
+      updated_user = User.find(user.id)
+      (expected_attributes || {}).each do |key, val|
+        expect(updated_user.send(key)).to eq(val)
+      end
+    end
+  end
+
+  describe 'empty request body' do
+    it_behaves_like 'successful update'
+  end
+
+  describe 'attribute change' do
+    let(:parameters) { { email: 'foo@example.org' } }
+    it_behaves_like 'successful update', mail: 'foo@example.org'
+  end
+
+  describe 'password update' do
+    let(:password) { 'my!new!password123' }
+    let(:parameters) { { password: password } }
+
+    it 'updates the users password correctly' do
+      send_request
+      expect(response.status).to eq(200)
+
+      updated_user = User.find(user.id)
+      matches = updated_user.check_password?(password)
+      expect(matches).to eq(true)
+    end
+  end
+
+  describe 'attribute collision' do
+    let(:parameters) { { email: 'foo@example.org' } }
+    let(:collision) { FactoryGirl.create(:user, mail: 'foo@example.org') }
+    before do
+      collision
+    end
+
+    it 'returns an erroneous response' do
+      send_request
+
+      expect(response.status).to eq(422)
+
+      expect(response.body)
+        .to be_json_eql('email'.to_json)
+        .at_path('_embedded/details/attribute')
+
+      expect(response.body)
+        .to be_json_eql('urn:openproject-org:api:v3:errors:PropertyConstraintViolation'.to_json)
+        .at_path('errorIdentifier')
+    end
+  end
+
+  describe 'unauthorized user' do
+    let(:current_user) { FactoryGirl.build(:user) }
+    let(:parameters) { { email: 'new@example.org' } }
+
+    it 'returns an erroneous response' do
+      send_request
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -108,6 +108,16 @@ describe ::API::V3::Users::UsersAPI, type: :request do
     end
   end
 
+  describe 'unknown user' do
+    let(:parameters) { { email: 'foo@example.org' } }
+    let(:path) { api_v3_paths.user(666) }
+
+    it 'responds with 404' do
+      send_request
+      expect(response.status).to eql(404)
+    end
+  end
+
   describe 'unauthorized user' do
     let(:current_user) { FactoryGirl.build(:user) }
     let(:parameters) { { email: 'new@example.org' } }

--- a/spec/services/users/update_user_service_spec.rb
+++ b/spec/services/users/update_user_service_spec.rb
@@ -1,0 +1,134 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe Users::UpdateUserService do
+  let(:current_user) { FactoryGirl.build_stubbed(:admin) }
+  let(:update_user) { FactoryGirl.build_stubbed(:user) }
+  let(:instance) { described_class.new(user: update_user, current_user: current_user) }
+
+  describe '.contract' do
+    it 'uses the UpdateContract contract' do
+      expect(described_class.contract).to eql Users::UpdateContract
+    end
+  end
+
+  describe '.new' do
+    it 'takes a user which is available as a getter' do
+      expect(instance.current_user).to eql current_user
+    end
+  end
+
+  describe 'updating attributes' do
+    let(:update_user) { FactoryGirl.create(:user, mail: 'correct@example.org') }
+    subject { instance.call(attributes: attributes) }
+
+    context 'when invalid' do
+      let(:attributes) { { mail: 'invalid' } }
+
+      it 'fails to update' do
+        expect(subject).to_not be_success
+
+        update_user.reload
+        expect(update_user.mail).to eq('correct@example.org')
+
+        expect(subject.errors.symbols_for(:mail)).to match_array(%i[invalid])
+      end
+    end
+
+    context 'when valid' do
+      let(:attributes) { { mail: 'new@example.org' } }
+
+      it 'updates the user' do
+        expect(subject).to be_success
+
+        update_user.reload
+        expect(update_user.mail).to eq('new@example.org')
+      end
+
+      context 'if current_user is no admin' do
+        let(:current_user) { FactoryGirl.build_stubbed(:user) }
+        it 'is unsuccessful' do
+          expect(subject).to_not be_success
+        end
+      end
+    end
+  end
+
+  describe '#call' do
+    subject { instance.call() }
+    let(:validates) { true }
+    let(:saves) { true }
+
+    before do
+      allow(update_user).to receive(:save).and_return(saves)
+      allow_any_instance_of(Users::UpdateContract).to receive(:validate).and_return(validates)
+    end
+
+    context 'if contract validates and the user saves' do
+      it 'is successful' do
+        expect(subject).to be_success
+      end
+
+      it 'has no errors' do
+        expect(subject.errors).to be_empty
+      end
+
+      it 'returns the user as a result' do
+        result = subject.result
+        expect(result).to be_a User
+      end
+    end
+
+    context 'if contract does not validate' do
+      let(:validates) { false }
+
+      it 'is unsuccessful' do
+        expect(subject).to_not be_success
+      end
+    end
+
+    context 'if user does not save' do
+      let(:saves) { false }
+      let(:errors) { double('errors') }
+
+      it 'is unsuccessful' do
+        expect(subject).to_not be_success
+      end
+
+      it "returns the user's errors" do
+        allow(update_user)
+          .to receive(:errors)
+          .and_return errors
+
+        expect(subject.errors).to eql errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.com/work_packages/24063

(currently contains the code of #4950)
### Implementation approach

Implement creation of users through APIv3 according to the specification. Implementation-wise, this will take over the strcuture of the abstractions used in the POST /api/v3/users endpoint.

An open issue is the updating of a user's own account, since in OpenProject, that requires password confirmation to continue (when the user is internally authenticated).
### Alternatives
### Out of scope
- Migrate existing user update flows to the service.
### ToDos
- [x] Users API
  - [x] Add update helper
  - [x] Add route handler
- [x] Add UserUpdateService 
- [x] Add User UpdateContract
