### PR TITLE
Fix/24099 - Blank or broken page after click on tabs in edit mode

### DIFF
--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -80,16 +80,16 @@
           <ul class="tabrow">
             <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
             properly. Thus, don't remove the hrefs or the empty URLs! -->
-            <li ui-sref="work-packages.show.activity({})"
+            <li ui-sref="work-packages.show.activity({workPackageId: $ctrl.workPackage.id})"
                 ui-sref-active="selected">
               <a href="" ng-bind="::$ctrl.text.tabs.activity"/>
             </li>
-            <li ui-sref="work-packages.show.relations({})"
+            <li ui-sref="work-packages.show.relations({workPackageId: $ctrl.workPackage.id})"
                 ui-sref-active="selected">
               <a href="" ng-bind="::$ctrl.text.tabs.relations"/>
             </li>
             <li ng-if="$ctrl.canViewWorkPackageWatchers()"
-                ui-sref="work-packages.show.watchers({})"
+                ui-sref="work-packages.show.watchers({workPackageId: $ctrl.workPackage.id})"
                 ui-sref-active="selected">
               <a href="" ng-bind="::$ctrl.text.tabs.watchers"/>
             </li>


### PR DESCRIPTION
Related to [24099](https://community.openproject.com/work_packages/24099/activity)

The bug resulted from an empty `$stateParams['workPackageId']` param.
A click on any tab panel led to a broken / blank page since the wpCacheService could not return a workPackage without a valid id.

Manually adding the id to our `ui-srefs` in the `wp.show.html`-template solves the problem. 
I am not sure where exactly the id gets lost, so may be there is a better solution for this @oliverguenther ?
