### PR TITLE
[24121] Remove inline-block to allow text-overflow ellipsis

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -65,7 +65,6 @@
     font-size: 14px
 
   .wp-table--cell-span
-    display: inline-block
     max-width: 100%
 
     p


### PR DESCRIPTION
Fixes the `...` in Firefox long subjects:

![](https://community.openproject.com/attachments/8579/topicclipping.JPG)

https://community.openproject.com/work_packages/24121/activity
