### PR TITLE
[24079] Search icon in relations tab not in center of field

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -602,6 +602,12 @@ a.impaired--empty-link,
     .box-actions
       margin-top: -60px
 
+// Position the icon correctly which is strangely not done by select2 itself
+.ui-select-dropdown
+  .select2-search
+    &:before
+      top: 8px !important
+
 
 #members_add_form
   margin-bottom: 1rem

--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -45,11 +45,6 @@
   .choice .choice--select
     width: 100%
 
-  .ui-select-dropdown
-    .select2-search
-      &:before
-        top: 8px !important
-
-    &.select2-drop.select2-with-searchbox.select2-drop-active
-      margin-top: 0 !important
-      top: 1px !important
+  .ui-select-dropdown.select2-drop.select2-with-searchbox.select2-drop-active
+    margin-top: 0 !important
+    top: 1px !important


### PR DESCRIPTION
This changes the position of he search icon in the select2-search field. This was done before for mobile devices and is now applied to all screen sizes.

https://community.openproject.com/work_packages/24079/activity
