### PR TITLE
[24121] Topic clipping in work package list

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -28,10 +28,7 @@
 
 .wp-edit-field
   padding-left: 0
-
-  // Remove overflow with ellipsis
-  text-overflow: ellipsis
-  overflow: hidden
+  line-height: 1
 
   // Avoid jumping subject field
   &:first-of-type
@@ -67,6 +64,12 @@
   .wp-table--cell-span
     display: inline-block
     max-width: 100%
+
+    .inplace-edit--read-value--value-span
+      overflow: hidden
+      text-overflow: ellipsis
+      display: block
+      line-height: 1.6em
 
     p
       word-wrap: break-word


### PR DESCRIPTION
This avoids a complete content cut off when the content is too long. This happens only in Firefox with all kinds of inline-edit fields which content is so long that its truncated. It appears in the full screen view, split screen view and in the WP table. 

https://community.openproject.com/work_packages/24121/activity
