### PR TITLE
[24074] Allow previewMarkup without context

### DIFF
--- a/lib/api/v3/work_packages/create_form_representer.rb
+++ b/lib/api/v3/work_packages/create_form_representer.rb
@@ -46,10 +46,11 @@ module API
         end
 
         link :previewMarkup do
+          context = api_v3_paths.project(represented.project_id) if represented.project_id
           {
-            href: api_v3_paths.render_markup(link: api_v3_paths.project(represented.project_id)),
+            href: api_v3_paths.render_markup(link: context),
             method: :post
-          } if represented.project
+          }
         end
 
         link :commit do


### PR DESCRIPTION
When creating a work package without a project set, the previewMarkup is
not available despite a link being possible without setting the context.

https://community.openproject.com/work_packages/24074
