### PR TITLE
[24133] Serialize column_names as arrays

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -41,7 +41,7 @@ class Query < ActiveRecord::Base
           class_name: 'MenuItems::QueryMenuItem',
           dependent: :delete, foreign_key: 'navigatable_id'
   serialize :filters, Queries::WorkPackages::FilterSerializer
-  serialize :column_names
+  serialize :column_names, Array
   serialize :sort_criteria, Array
 
   validates :name, presence: true
@@ -291,7 +291,7 @@ class Query < ActiveRecord::Base
   end
 
   def has_default_columns?
-    column_names.nil? || column_names.empty?
+    column_names.empty?
   end
 
   ##

--- a/db/migrate/20161025135400_query_empty_column_names_to_array.rb
+++ b/db/migrate/20161025135400_query_empty_column_names_to_array.rb
@@ -1,0 +1,51 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require_relative 'migration_utils/ar_parameter_patch'
+
+class QueryEmptyColumnNamesToArray < ActiveRecord::Migration[5.0]
+  class QueryWithWhatever < ActiveRecord::Base
+    self.table_name = :queries
+    serialize :column_names
+  end
+
+  def up
+    ArParametersPatch.load
+
+    QueryWithWhatever.transaction do
+      empty = QueryWithWhatever.where(column_names: '')
+      null = QueryWithWhatever.where(column_names: nil)
+
+      empty.or(null).update_all(column_names: [])
+    end
+  end
+
+  # This migration does not need to be rolled back because
+  # it only harmonizes the possible values of the value attribute.
+end


### PR DESCRIPTION
https://community.openproject.com/work_packages/24133
Currently, column_names on production systems are either
1. YAML-serialized Arrays of column names (duh)
2. An empty string ''
3. nil

The two latter are invalid with Rails 5 and cause the following error:

```
NoMethodError (undefined method `map' for "":String):

app/controllers/api/experimental/concerns/v3_naming.rb:70:in `json_query_as_v3'
app/controllers/api/experimental/work_packages_controller.rb:85:in `query_as_json'
app/controllers/api/experimental/work_packages_controller.rb:51:in `index'
app/middleware/reset_current_user.rb:47:in `call'
```

This commit forces Array serialization and fixes previous queries with the empty values.
