### PR TITLE
[24083] Don't show the drop-down until the form and types are loaded

### DIFF
--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -59,6 +59,9 @@
   padding: 3px 0
   margin: 0
 
+.dropdown-menu.-empty
+  visibility: hidden
+
 .dropdown .dropdown-panel
   padding: 10px
 

--- a/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.html
+++ b/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.html
@@ -1,6 +1,6 @@
 <div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar"
      id="types-context-menu">
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.types.length === 0 }">
     <li ng-repeat="type in $ctrl.types">
       <a class="menu-item" ui-sref="{{$ctrl.stateName}}({type: type.id})">
         {{ type.name }}

--- a/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.ts
+++ b/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.ts
@@ -27,19 +27,18 @@
 //++
 
 import {opWorkPackagesModule} from '../../../angular-modules';
-import {ApiWorkPackagesService} from '../../api/api-work-packages/api-work-packages.service';
+import {WorkPackageCreateService} from '../../wp-create/wp-create.service';
 
 class TypesContextMenuController {
   public types = [];
 
-  constructor(protected $state, protected $scope, apiWorkPackages) {
+  constructor(protected $state, protected $scope, protected wpCreate:WorkPackageCreateService) {
     const project = $scope.projectIdentifier;
     $scope.$ctrl = this;
 
-    apiWorkPackages
-      .emptyCreateForm({}, project)
-      .then(form =>
-              this.types = form.schema.type.allowedValues);
+    wpCreate.getEmptyForm(project).then((form:any) => {
+      this.types = form.schema.type.allowedValues;
+    });
   }
 
   public get stateName() {

--- a/frontend/app/components/wp-create/wp-create.service.ts
+++ b/frontend/app/components/wp-create/wp-create.service.ts
@@ -60,7 +60,7 @@ export class WorkPackageCreateService {
     });
   }
 
-  private getEmptyForm(projectIdentifier):ng.IPromise<HalResource> {
+  public getEmptyForm(projectIdentifier):ng.IPromise<HalResource> {
     if (!this.form) {
       this.form = this.apiWorkPackages.emptyCreateForm({}, projectIdentifier);
     }


### PR DESCRIPTION
Currently, expanding the types drop down will initiate the form load and
shows a small part of the drop down despite it being empty.

Possible solutions:

~~1. Preload the form. Doesn't necessary fix the issue if the user is fast
enough and puts more initial effort on the page~~

**2. Don't show the dropdown until types are loaded.**

We can't remove it from the dom with `display: none` since it will mess with the
positioning, so we only use `visibility: hidden` to render, but not show
it.

We can also re-use the `wpCreate` persisted form.

https://community.openproject.com/work_packages/24083
