### PR TITLE
added translation for new wp status again

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1314,6 +1314,7 @@ en:
   label_work_package_plural: "Work packages"
   label_work_package_priority_updated: "Work package priority updated"
   label_work_package_status: "Work package status"
+  label_work_package_status_new: "New status"
   label_work_package_status_plural: "Work package statuses"
   label_work_package_types: "Work package types"
   label_work_package_updated: "Work package updated"


### PR DESCRIPTION
it was removed by mistake I reckon

WP [#24146](https://community.openproject.com/work_packages/24146/activity)
