### PR TITLE
WIP: [24151] Refactor lib/redmine/wiki_formatting/macros.rb 

### DIFF
--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -27,6 +27,9 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+# enable default wiki macros
+require 'open_project/wiki_formatting/macros/default'
+
 module OpenProject
   module TextFormatting
     extend ActiveSupport::Concern

--- a/lib/open_project/wiki_formatting/macros/default.rb
+++ b/lib/open_project/wiki_formatting/macros/default.rb
@@ -26,6 +26,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'redmine/wiki_formatting/macros'
+
 module OpenProject
   module WikiFormatting
     module Macros

--- a/lib/redmine/wiki_formatting/macros.rb
+++ b/lib/redmine/wiki_formatting/macros.rb
@@ -91,8 +91,6 @@ module Redmine
         def desc(txt)
           @@desc = txt
         end
-
-        include OpenProject::WikiFormatting::Macros::Default
       end
     end
   end


### PR DESCRIPTION
Refactor `lib/redmine/wiki_formatting/macros.rb` so that it will not include `OpenProject::WikiFormatting::Macros::Default`. Instead, `lib/open_project/text_formatting` will now require `open_project/wiki_formatting/macros/default`,. which in turn will require `redmine/wiki_formatting/macros`.

This will enable plugin authors to also provide new macros to the wiki by also simply requiring `redmine/wiki_formatting/macros` in their plugin modules.

https://community.openproject.com/work_packages/24151
