### PR TITLE
[24155] Fix wiki preview overflow

### DIFF
--- a/app/assets/stylesheets/content/_preview.sass
+++ b/app/assets/stylesheets/content/_preview.sass
@@ -30,6 +30,9 @@
   @extend %form--fieldset-or-section
   padding: 1rem
   background: image-url('draft.png')
+  min-width: 100%
+  overflow-wrap: break-word
+  word-wrap: break-word
 
 .preview--legend
   @extend %form--fieldset-legend-or-section-title


### PR DESCRIPTION
On chrome/chromium the wiki preview is overflowing the visible draw area and content will be cut off.

This fix will allow chrome/chromium and possibly other webkit based browsers to render the preview so that it will fit into the currently visible draw area.

https://community.openproject.com/work_packages/24155
