### PR TITLE
Enhance delayed_job to load full environment (including eager load)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,10 @@ OpenProject::Application.configure do
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both thread web servers
   # and those relying on copy on write to perform better.
+  #
   # Rake tasks automatically ignore this option for performance.
+  # We force some rake tasks to use eager_load through enhancing with environment:eager_load
+  # DISABLE those when you change this setting!
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.

--- a/lib/tasks/delayed_job.rake
+++ b/lib/tasks/delayed_job.rake
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+##
+# Enhance the delayed_job prerequisites rake task to load the environment
+unless Rake::Task.task_defined?('jobs:environment_options') &&
+       Rake::Task['jobs:work'].prerequisites == %w(environment_options)
+  raise "Trying to load the full environment for delayed_job, but jobs:work seems to have changed."
+end
+
+Rake::Task['jobs:environment_options']
+  .clear_prerequisites
+  .enhance(['environment:full'])

--- a/lib/tasks/environment.rake
+++ b/lib/tasks/environment.rake
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+namespace 'environment' do
+  desc 'Force application to eager load if configured (does not happen by default for rake tasks)'
+  task :full do
+    $stderr.puts "Forcefully loading the application. Use :environment to avoid eager loading."
+
+    ##
+    # Require the environment, bypassing the default :environment flag
+    Rails.application.require_environment!
+  end
+end


### PR DESCRIPTION
We use delayed_job's `jobs:work` rake task in packaged environments to
run the worker process.

As it turns out, Rails doesn't eager load on rake tasks by default:
https://github.com/rails/rails/blob/master/railties/lib/rails/application.rb#L451

But without eager_load and autoload, not all dependencies may be met and
this causes a nasty invalid constant in the documents plugin, where
`Document` becomes an auto-record from the table information but the
`app/models/document.rb` requirement has never been loaded.

The suggested solution is to load the full environment in a separate
rake task and point the prerequisites of `jobs:work` towards that.

Uses [ci skip] because nothing of it  is testable in travis.
