### PR TITLE
[24158] Fix wiki page view overflow

### DIFF
--- a/app/assets/stylesheets/content/_preview.sass
+++ b/app/assets/stylesheets/content/_preview.sass
@@ -30,6 +30,8 @@
   @extend %form--fieldset-or-section
   padding: 1rem
   background: image-url('draft.png')
+  min-width: 100%
+  overflow-wrap: break-word;
 
 .preview--legend
   @extend %form--fieldset-legend-or-section-title

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -166,6 +166,10 @@ h1:hover, h2:hover, h3:hover
     overflow: hidden
     text-overflow: ellipsis
 
+.wiki.wiki-content
+  overflow-wrap: break-word
+  word-wrap: break-word
+
 #wiki_form .attributes-group
   .attributes-group--header-text
     color: lighten($body-font-color, 10)


### PR DESCRIPTION
On chrome/chromium the wiki page view is overflowing the visible draw area and content will be cut off.

This fix will allow chrome/chromium and possibly other webkit based browsers to render the page view so that it will fit into the currently visible draw area.

https://community.openproject.com/work_packages/24158
