### PR TITLE
Feature/23777: Add Button to add attachments in work package create and edit form

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -357,7 +357,6 @@ export class WorkPackageResource extends HalResource {
     var deferred = $q.defer();
     this.inFlight = true;
     const wasNew = this.isNew;
-
     this.updateForm(this.$source)
       .then(form => {
         const payload = this.mergeWithForm(form);

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -22,7 +22,7 @@
           </button>
         </li>
         <li>
-          <wp-upload-button work-package="$ctrl.workPackage"></wp-upload-button>
+          <wp-upload-button template="wp-upload-button-toolbar" work-package="$ctrl.workPackage"></wp-upload-button>
         </li>
         <li class="toolbar-item" ng-if="$ctrl.displayWatchButton">
           <wp-watcher-button work-package="$ctrl.workPackage" disabled="$ctrl.wpEditModeState.active"></wp-watcher-button>

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -105,6 +105,11 @@
   </div>
 </div>
 
+<wp-upload-button
+        ng-hide="$ctrl.workPackage.attachments.elements.length > 0"
+        template="wp-upload-button-create"
+        work-package="$ctrl.workPackage"></wp-upload-button>
+
 <div class="work-packages--attachments attributes-group">
   <div
       class="work-packages--atachments-container"

--- a/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button-create.directive.html
+++ b/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button-create.directive.html
@@ -1,0 +1,8 @@
+<div class="wp-inline-create-button" aria-hidden="false">
+    <a class="wp-inline-create--add-link" wp-attachments-upload work-package="workPackage" role="link" aria-label="Add attachment" data-click-on-keypress="[13, 32]">
+        <i class="icon icon-attachment"></i>
+        <span ng-bind="::text.addAttachments" aria-hidden="true">Add attachments</span>
+    </a>
+</div>
+
+

--- a/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button-toolbar.directive.html
+++ b/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button-toolbar.directive.html
@@ -1,0 +1,7 @@
+<button
+        class="button"
+        wp-attachments-upload
+        work-package="workPackage"
+        title="{{ ::text.addAttachments }}">
+    <i class="icon-attachment"></i>
+</button>

--- a/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button.directive.test.ts
+++ b/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button.directive.test.ts
@@ -29,10 +29,12 @@
 import {opApiModule} from '../../../angular-modules';
 import IAugmentedJQuery = angular.IAugmentedJQuery;
 import IProvideService = angular.auto.IProvideService;
+import I18n = op.I18n;
 
 describe('wpUploadButton directive', () => {
   var workPackage;
 
+  var I18n;
   var compile;
   var scope;
 
@@ -40,6 +42,8 @@ describe('wpUploadButton directive', () => {
   var button: any;
 
   var uploadsDirectiveScope;
+
+  beforeEach(angular.mock.module('openproject.templates'));
 
   beforeEach(angular.mock.module(opApiModule.name, ($provide: IProvideService) => {
     $provide.decorator('wpAttachmentsUploadDirective', () => {
@@ -51,8 +55,9 @@ describe('wpUploadButton directive', () => {
     });
   }));
 
-  beforeEach(angular.mock.inject(function ($rootScope, $compile, I18n) {
-    const html = '<wp-upload-button work-package="workPackage"></wp-upload-button>';
+  beforeEach(angular.mock.inject(function ($rootScope, $compile, _I18n_) {
+    I18n = _I18n_;
+    const html = '<wp-upload-button template="wp-upload-button-toolbar" work-package="workPackage"></wp-upload-button>';
     workPackage = {};
     scope = $rootScope.$new();
     scope.workPackage = workPackage;
@@ -61,14 +66,18 @@ describe('wpUploadButton directive', () => {
 
     compile = () => {
       element = $compile(html)(scope);
-      button = element.find('.button').first();
+      scope.$digest();
+
+      button = element.find('.button');
       uploadsDirectiveScope = button.scope();
-      $rootScope.$digest();
     };
 
     compile();
-    I18n.t.restore();
   }));
+
+  afterEach(function() {
+    I18n.t.restore();
+  });
 
   it('should have the add attachment tooltip', () => {
     expect(button.attr('title')).to.equal('add attachments');

--- a/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button.directive.ts
+++ b/frontend/app/components/wp-attachments/wp-upload-button/wp-upload-button.directive.ts
@@ -32,21 +32,19 @@ import IDirective = angular.IDirective;
 function wpUploadButtonDirective(I18n): IDirective {
   return {
     restrict: 'E',
-    template: `
-      <button
-        class="button"
-        wp-attachments-upload
-        work-package="workPackage"
-        title="{{ ::text.addAttachments }}">
-        <i class="icon-attachment"></i>
-      </button>`,
+    templateUrl: (element, attrs) => {
+      return '/components/wp-attachments/wp-upload-button/' + attrs.template + '.directive.html';
+    },
 
     scope: {
-      workPackage: '='
+      workPackage: '=',
+      template: '@'
     },
 
     link(scope: any) {
-      scope.text = {addAttachments: I18n.t('js.label_add_attachments')};
+      scope.text = {
+        addAttachments: I18n.t('js.label_add_attachments')
+      };
     }
   };
 }

--- a/frontend/app/components/wp-details/wp-details-toolbar.directive.html
+++ b/frontend/app/components/wp-details/wp-details-toolbar.directive.html
@@ -11,7 +11,7 @@
                      ng-if="displayWatchButton">
   </wp-watcher-button>
 
-  <wp-upload-button work-package="workPackage"></wp-upload-button>
+  <wp-upload-button template="wp-upload-button-toolbar" work-package="workPackage"></wp-upload-button>
 
   <button class="button dropdown-relative"
           ng-disabled="!actionsAvailable"


### PR DESCRIPTION
related to [23777](https://community.openproject.com/projects/openproject/work_packages/details/23777/overview)

This adds a button similar to our `wp-create-button` to add attachments to the current work package.
