### PR TITLE
[24140] Layout error on work package fullscreen

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -93,8 +93,7 @@ body.controller-work_packages.action-show {
     flex-shrink: 8;
     border-top: 1px solid #ccc;
     overflow: visible;
-    // Important for Safari
-    height: initial;
+    height: 100%;
     // Important for Firefox to let 'flex-shrink' work correctly.
     min-height: 0;
 

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -73,6 +73,8 @@
         position: relative
         right: 0
         top: 0
+        // Important for safari
+        height: initial
 
         .tabrow
           height: auto


### PR DESCRIPTION
This increases the height of the outer container of the full screen WP view. Thus both panels have this size too. Now the border separating the two is also full at height. This was a problem when the panels where too short to scroll.

https://community.openproject.com/work_packages/24140/activity 
