### PR TITLE
[24168] Preview buttons are too large

### DIFF
--- a/app/assets/stylesheets/content/_preview.sass
+++ b/app/assets/stylesheets/content/_preview.sass
@@ -30,7 +30,10 @@
   @extend %form--fieldset-or-section
   padding: 1rem
   background: image-url('draft.png')
-  min-width: 100%
+  // Min-width has to be defined to avoid a content overflow
+  // of the preview window. Since this class is also applied to the buttons
+  // it should however not be too large.
+  min-width: 0
   overflow-wrap: break-word
   word-wrap: break-word
 


### PR DESCRIPTION
This reduces the `min-width` of the `preview`-class. The attribute is needed to avoid a content cutoff when there is a really long word in the text. Since this class is also applied for the buttons, it has to be much smaller than 100%.

https://community.openproject.com/work_packages/24168/activity
