### PR TITLE
[24170] Headline to much indented

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -257,14 +257,15 @@ fieldset.form--fieldset
   &:before
     @include icon-common
     font-size: 0.75rem
-    padding:   0.625rem 0.25rem 0 0.25rem
 
     .form--fieldset.-collapsible > &
       @extend .icon-arrow-up1:before
+      padding:   0.625rem 0.25rem 0 0.25rem
 
     .form--fieldset.-collapsible.-collapsed > &,
     .form--fieldset.-collapsible.collapsed  > &
       @extend .icon-arrow-down1:before
+      padding:   0.625rem 0.25rem 0 0.25rem
 
 #sidebar .form--fieldset-legend
   color: $main-menu-sidebar-font-color


### PR DESCRIPTION
This avoids a indentation for fieldset legends that are not collapsible.

https://community.openproject.com/work_packages/24170/activity
