### PR TITLE
Update installation-guide.md

### DIFF
--- a/doc/operation_guides/manual/installation-guide.md
+++ b/doc/operation_guides/manual/installation-guide.md
@@ -239,7 +239,7 @@ will seed the database in the french language.
 ### Secret Token
 
 You need to generate a secret key base for the production environment with `./bin/rake secret` and make that available through the environment variable `SECRET_KEY_BASE`.
-In this installation guide, we will use the local `.profile` of the OpenProject user. You may alternatively put set the environment variable in `/etc/environment` or pass it to the server upon start manually.
+In this installation guide, we will use the local `.profile` of the OpenProject user. You may alternatively set the environment variable in `/etc/environment` or pass it to the server upon start manually in '/etc/apache2/envvars'.
 
 ```bash
 [openproject@host] echo "export SECRET_KEY_BASE=$(./bin/rake secret)" >> ~/.profile


### PR DESCRIPTION
+Added file and path for manual pass of SECRET_KEY_BASE to Apache
-removed one unnecessary "put"

Just by following the existing guide me and at least one other person faced problems with SECRET_KEY_BASE visibility as explained on: https://community.openproject.com/topics/6896?r=6907

Based on that knowledge Apache does not see SECRET_KEY_BASE if that is defined on ~/.profile or /etc/environment. (This is true at least on our environments.) I guess the guide was trying to explain also this option to define SECRET_KEY_BASE on /etc/apache/envvars by text "or pass it to the server upon start manually" but that was not as explanatory as the rest of the guide. Proposing to at least add more explanation by this change.
