### PR TITLE
Help Menu Take I18n.locale into account for cache key

### DIFF
--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -31,7 +31,8 @@ require 'open_project/static/links'
 
 module Redmine::MenuManager::TopMenu::HelpMenu
   def render_help_top_menu_node(item = help_menu_item)
-    Rails.cache.fetch("help_top_menu_node/#{OpenProject::Static::Links.help_link}") do
+    cache_key = "help_top_menu_node/#{I18n.locale}/#{OpenProject::Static::Links.help_link}"
+    Rails.cache.fetch(cache_key) do
       if OpenProject::Static::Links.help_link_overridden?
         render_menu_node(item)
       else


### PR DESCRIPTION
The cache does not respect the current locale, thus all users see the same cached help menu.

/cc @wielinde 