### PR TITLE
[24080] Scroll bars shown for relations in full screen (Chrome, Edge)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -62,6 +62,10 @@
     padding: 4px
   .wp-edit-field
     width: 90%
+    // Similar to inner span's line-height
+    line-height: 1.6em
+    .wp-table--cell-span
+      vertical-align: middle
   .controls-container
     text-align: right
 


### PR DESCRIPTION
This adjusts the line-height of the relation elements. Thus scrollbars shall be avoided.

https://community.openproject.com/work_packages/24080/activity