### PR TITLE
[24221] Arrow for children work packages is too low

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -167,7 +167,7 @@ tr
       &.subject
         text-align: left
     &.idnt td.subject .icon-context:before
-      padding: 9px 0 0 5px
+      padding: 0px 0 0 5px
 
   &.entry
     border: 1px solid #f8f8f8

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -75,6 +75,12 @@
       word-wrap: break-word
       margin-bottom: 0
 
+  .inplace-edit--read-value
+    &:before
+      vertical-align: middle
+    .wp-table--cell-span
+      vertical-align: middle
+
 // Editable fields cursor
 .-editable .wp-table--cell-span
   cursor: text


### PR DESCRIPTION
This aligns the arrow indicating a child WP in the WP table.

https://community.openproject.com/work_packages/24221/activity