### PR TITLE
[24223] Unnecessary line when showing version details

### DIFF
--- a/app/views/versions/edit.html.erb
+++ b/app/views/versions/edit.html.erb
@@ -34,7 +34,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render partial: 'form', locals: { f: f,
                                               project: @project } %>
 
-  <hr class="form--separator" />
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 
 <% end %>


### PR DESCRIPTION
This removes an unnecessary line in the version overview.

https://community.openproject.com/work_packages/24223/activity