### PR TITLE
[24228] Remove headline border in Admin/Enumeration

### DIFF
--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -51,6 +51,9 @@ h3
   padding:            0 0 8px 0
   margin:             0 0 20px 0
 
+h3.-no-border
+  border: none
+
 h4
   color:              $h4-font-color
   font-weight:        normal

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title l(:label_administration), l(:label_enumerations) %>
 <%= toolbar title: l(:label_enumerations) %>
 <% Enumeration.descendants.each do |klass| %>
-  <h3><%= l(klass::OptionName) %></h3>
+  <h3 class="-no-border"><%= l(klass::OptionName) %></h3>
   <% enumerations = klass.shared %>
   <% if enumerations.any? %>
     <div class="generic-table--container">


### PR DESCRIPTION
This removes the headline border in Admin -> Enumeration. Therefore the styling class `-no-border` was introduced for h3-elements.

https://community.openproject.com/work_packages/24228/activity