### PR TITLE
[24193] Wrap the non-$http response into an Error Resource

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.test.ts
@@ -303,7 +303,7 @@ describe('WorkPackageResource service', () => {
 
         beforeEach(() => {
           uploadFilesDeferred.reject(error);
-          notificationStub = sinon.stub(wpNotificationsService, 'handleErrorResponse');
+          notificationStub = sinon.stub(wpNotificationsService, 'handleRawError');
           $rootScope.$apply();
         });
 

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -251,7 +251,7 @@ export class WorkPackageResource extends HalResource {
         return this.updateAttachments();
       })
       .catch(error => {
-        wpNotificationsService.handleErrorResponse(error, this);
+        wpNotificationsService.handleRawError(error, this);
       });
   }
 

--- a/frontend/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/app/components/wp-edit/wp-notification.service.ts
@@ -53,6 +53,15 @@ export class WorkPackageNotificationService {
     this.NotificationsService.addSuccess(message);
   }
 
+  public handleRawError(response, workPackage?:WorkPackageResource) {
+    if (response && response.data && response.data._type === 'Error') {
+      const resource = new ErrorResource(response.data);
+      return this.handleErrorResponse(resource, workPackage);
+    }
+
+    this.showGeneralError();
+  }
+
   public handleErrorResponse(errorResource, workPackage?:WorkPackageResource) {
     if (!(errorResource instanceof ErrorResource)) {
       return this.showGeneralError();


### PR DESCRIPTION
The result of `Upload.upload` is not transformed by our hal
resource response, even though an ErrorResponse is returned.

Fixes the remainder of https://community.openproject.com/work_packages/24193