### PR TITLE
[24251][24250] Reset selectedWpId after creating a relation and add error styling

### DIFF
--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -145,5 +145,15 @@
 .wp-relation--description-wrapper
   width: 100%
 
+// Disable create link until WP is selected
+.wp-create-relation--save[disabled]
+  color: $relations-save-button--disabled-color
+  cursor: not-allowed
 
+  .icon-button
+    cursor: not-allowed
 
+// Error highlighting
+input.wp-relations--autocomplete.-error
+  background: $nm-color-error-background
+  border-color: $nm-color-error-border

--- a/app/assets/stylesheets/open_project_global/_variables.sass
+++ b/app/assets/stylesheets/open_project_global/_variables.sass
@@ -212,6 +212,9 @@ $inplace-edit--selected-date-border-color:      $primary-color-dark
 $inplace-edit--color--disabled:                 #4d4d4d
 $inplace-edit--bg-color--disabled:              #eee
 
+
+$relations-save-button--disabled-color:         $gray-dark !default
+
 $table-row-border-color:                        #E7E7E7 !default
 $table-row-highlighting-color:                  #e4f7fb !default
 $table-header-border-color:                     #D7D7D7 !default

--- a/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
@@ -33,6 +33,7 @@
         <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
             <accessible-by-keyboard
                     execute="$ctrl.createRelation()"
+                    is-disabled="!$ctrl.selectedWpId"
                     link-class="wp-create-relation--save"
                     aria-hidden="false">
                 <icon-wrapper icon-name="checkmark"

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
@@ -77,6 +77,12 @@ function wpRelationsAutocompleteDirective($q, PathHelper, $http, I18n) {
           });
       };
 
+      scope.$watch('noResults', (noResults) => {
+        if (noResults) {
+          scope.selectedWpId = null;
+        }
+      });
+
       scope.$watch('autocompleteIsOpen', (isOpen) => {
         if (isOpen) {
           var searchInput = angular.element('input[uib-typeahead]');

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.template.html
@@ -1,9 +1,11 @@
 <form name="add_relation_form" class="form">
   <input type="text"
          class="wp-relations--autocomplete"
+         ng-class="{ '-error': noResults }"
          ng-model="selectedWp"
          typeahead-append-to-body="true"
          typeahead-on-select="onSelect($model)"
+         typeahead-no-results="noResults"
          typeahead-wait-ms="100"
          typeahead-input-formatter="getIdentifier($model)"
          typeahead-is-open="autocompleteIsOpen"

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
@@ -105,6 +105,8 @@ export class WorkPackageRelationsCreateController {
 
     this.$timeout(() => {
       if (!this.showRelationsCreateForm) {
+        // Reset value
+        this.selectedWpId = '';
         this.$element.find('.-focus-after-save').first().focus();
       }
     });


### PR DESCRIPTION
The last selected value was kept even when closing the edit form,
thus saving with an invalid value caused the selectedWpId to point to
the previously saved value.


**[24250] Provide some visual handling to invalid autocomplete** 

This adds an error styling to the input if no results matched / were
returned for the given input. Whenever that happens, the current
selected wpId is also reset.

Additionally, disable the save button unless a selectedWpId is set.

![anim3](https://cloud.githubusercontent.com/assets/459462/20099808/c37b34d0-a5ba-11e6-8376-382ebd375be2.gif)
