### PR TITLE
fix removing relations in cases where relations are not empty

### DIFF
--- a/frontend/app/components/wp-relations/wp-relations.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations.directive.ts
@@ -120,16 +120,14 @@ export class WorkPackageRelationsController {
     this.getRelatedWorkPackages(relatedWpIds)
       .take(1)
       .subscribe(relatedWorkPackages => {
-        if (angular.isArray(relatedWorkPackages)) {
-          this.currentRelations = relatedWorkPackages.map((wp) => {
-            wp.relatedBy = relations[wp.id];
-            return wp;
-          });
+        if (!angular.isArray(relatedWorkPackages)) {
+          relatedWorkPackages = [relatedWorkPackages];
         }
-        else {
-          relatedWorkPackages.relatedBy = relations[relatedWorkPackages.id];
-          this.currentRelations[0] = relatedWorkPackages;
-        }
+
+        this.currentRelations = relatedWorkPackages.map((wp) => {
+          wp.relatedBy = relations[wp.id];
+          return wp;
+        });
 
         this.buildRelationGroups();
       });


### PR DESCRIPTION
The code used to replace the first element in the currentRelations array with the response from the work package cache. The other elements where left unchanged causing e.g. 
https://community.openproject.com/projects/openproject/work_packages/24248
but also seemingly preventing the deletion of elements.

By harmonizing the code, such a special case behaviour should no longer occur.