### PR TITLE
fix title attributes on textarea inline edit controls

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -21,7 +21,7 @@
                             field-controller="vm"
                             on-save="vm.handleUserSubmit()"
                             on-cancel="vm.handleUserCancel()"
-                            save-title="{{ ::$ctrl.text.save }}"
-                            cancel-title="{{ ::$ctrl.text.cancel }}">
+                            save-title="{{ vm.field.text.save }}"
+                            cancel-title="{{ vm.field.text.cancel }}">
     </wp-edit-field-controls>
 </div>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -59,8 +59,8 @@ export class WikiTextareaEditField extends EditField {
     this.fieldVal = workPackage[fieldName];
     this.workPackage = workPackage;
     this.text = {
-      saveTitle: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
-      cancelTitle: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
+      save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
+      cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
     };
   }
 


### PR DESCRIPTION
This one is in fact curtesy of:
rspec ./spec/features/work_packages/edit_work_package_spec.rb:195

![tim-and-eric-mind-blown](https://cloud.githubusercontent.com/assets/617519/20101964/85c652dc-a5c4-11e6-9e73-5bbbdae76b4f.gif)
