### PR TITLE
Add simple cg-busy around wp-relation-create containers

### DIFF
--- a/app/assets/stylesheets/layout/_angular-busy.sass
+++ b/app/assets/stylesheets/layout/_angular-busy.sass
@@ -48,3 +48,8 @@
 .cg-busy-default-spinner
   top: 30px
   left: 30px
+
+// Remove top position for inline styles in grid-blocks
+.cg-busy-inline .cg-busy-default-spinner
+  top: 5px
+  left: 0

--- a/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-child.template.html
@@ -24,35 +24,38 @@
             </div>
         </div>
     </div>
-    <div class="grid-block v-align wp-relations--child-form" ng-if="$ctrl.showRelationsCreateForm">
-        <div class="grid-content medium-10">
-            <wp-relations-autocomplete
-                    work-package="$ctrl.workPackage"
-                    selected-wp-id="$ctrl.selectedWpId"
-                    selected-relation-type="$ctrl.selectedRelationType"
-                    filter-candidates-for="children"
-                    focus>
+    <div cg-busy="{promise: $ctrl.loadingPromise, wrapperClass: 'cg-busy-inline', message: ''}">
+      <div class="grid-block v-align wp-relations--child-form" ng-if="$ctrl.showRelationsCreateForm">
+          <div class="grid-content medium-10">
+              <wp-relations-autocomplete
+                      work-package="$ctrl.workPackage"
+                      loading-promise="$ctrl.loadingPromise"
+                      selected-wp-id="$ctrl.selectedWpId"
+                      selected-relation-type="$ctrl.selectedRelationType"
+                      filter-candidates-for="children"
+                      focus>
 
-            </wp-relations-autocomplete>
-        </div>
-        <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
-            <accessible-by-keyboard
-                    link-class="wp-create-relation--save"
-                    execute="$ctrl.createRelation()"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="checkmark"
-                              icon-title="{{ ::$ctrl.text.save }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
-            <accessible-by-keyboard
-                    link-class="wp-create-relation--cancel"
-                    execute="$ctrl.toggleRelationsCreateForm()"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="remove"
-                              icon-title="{{ ::$ctrl.text.abort }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
-        </div>
+              </wp-relations-autocomplete>
+          </div>
+          <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
+              <accessible-by-keyboard
+                      link-class="wp-create-relation--save"
+                      execute="$ctrl.createRelation()"
+                      aria-hidden="false">
+                  <icon-wrapper icon-name="checkmark"
+                                icon-title="{{ ::$ctrl.text.save }}">
+                  </icon-wrapper>
+              </accessible-by-keyboard>
+              <accessible-by-keyboard
+                      link-class="wp-create-relation--cancel"
+                      execute="$ctrl.toggleRelationsCreateForm()"
+                      aria-hidden="false">
+                  <icon-wrapper icon-name="remove"
+                                icon-title="{{ ::$ctrl.text.abort }}">
+                  </icon-wrapper>
+              </accessible-by-keyboard>
+          </div>
+      </div>
     </div>
 </div>
 

--- a/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/add-fixed-type.template.html
@@ -1,26 +1,29 @@
-<div class="grid-block v-align collapse  wp-relations-create"
-     ng-if="$ctrl.showRelationsCreateForm || $ctrl.externalFormToggle">
-    <div class="grid-content medium-10 collapse">
-        <wp-relations-autocomplete
-                selected-wp-id="$ctrl.selectedWpId"
-                selected-relation-type="$ctrl.selectedRelationType"
-                focus>
-        </wp-relations-autocomplete>
-    </div>
-    <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
-        <accessible-by-keyboard
-                execute="$ctrl.createRelation()"
-                aria-hidden="false">
-            <icon-wrapper icon-name="checkmark"
-                          icon-title="{{ ::$ctrl.text.save }}">
-            </icon-wrapper>
-        </accessible-by-keyboard>
-        <accessible-by-keyboard
-                execute="$ctrl.toggleRelationsCreateForm()"
-                aria-hidden="false">
-            <icon-wrapper icon-name="remove"
-                          icon-title="{{ ::$ctrl.text.abort }}">
-            </icon-wrapper>
-        </accessible-by-keyboard>
-    </div>
+<div cg-busy="{promise: $ctrl.loadingPromise, message: ''}">
+    <div class="grid-block v-align collapse  wp-relations-create"
+         ng-if="$ctrl.showRelationsCreateForm || $ctrl.externalFormToggle">
+        <div class="grid-content medium-10 collapse">
+            <wp-relations-autocomplete
+                    selected-wp-id="$ctrl.selectedWpId"
+                    loading-promise="$ctrl.loadingPromise"
+                    selected-relation-type="$ctrl.selectedRelationType"
+                    focus>
+            </wp-relations-autocomplete>
+        </div>
+        <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
+            <accessible-by-keyboard
+                    execute="$ctrl.createRelation()"
+                    aria-hidden="false">
+                <icon-wrapper icon-name="checkmark"
+                              icon-title="{{ ::$ctrl.text.save }}">
+                </icon-wrapper>
+            </accessible-by-keyboard>
+            <accessible-by-keyboard
+                    execute="$ctrl.toggleRelationsCreateForm()"
+                    aria-hidden="false">
+                <icon-wrapper icon-name="remove"
+                              icon-title="{{ ::$ctrl.text.abort }}">
+                </icon-wrapper>
+            </accessible-by-keyboard>
+        </div>
+</div>
 </div>

--- a/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/dynamic-relation-types.template.html
@@ -13,40 +13,42 @@
             </div>
         </div>
     </div>
-    <div class="grid-block v-align wp-relations-create--form" ng-if="$ctrl.showRelationsCreateForm">
-        <div class="grid-content collapse medium-3">
-            <label class="hidden-for-sighted" for="relation-type--select">{{ ::$ctrl.text.relationType }}</label>
-            <select class="form--select relationTypeSelect"
-                    id="relation-type--select"
-                    ng-model="$ctrl.selectedRelationType"
-                    ng-options="type.name as type.label for type in $ctrl.relationTypes"
-                    focus>
-            </select>
-        </div>
-        <div class="grid-content medium-7">
-            <wp-relations-autocomplete
-                    work-package="$ctrl.workPackage"
-                    selected-wp-id="$ctrl.selectedWpId"
-                    selected-relation-type="$ctrl.selectedRelationType">
-            </wp-relations-autocomplete>
-        </div>
-        <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
-            <accessible-by-keyboard
-                    execute="$ctrl.createRelation()"
-                    link-class="wp-create-relation--save"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="checkmark"
-                              icon-title="{{ ::$ctrl.text.save }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
-            <accessible-by-keyboard
-                    execute="$ctrl.toggleRelationsCreateForm()"
-                    link-class="wp-create-relation--cancel"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="remove"
-                              icon-title="{{ ::$ctrl.text.abort }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
+    <div cg-busy="{promise: $ctrl.loadingPromise, wrapperClass: 'cg-busy-inline', message: ''}">
+        <div class="grid-block v-align wp-relations-create--form" ng-if="$ctrl.showRelationsCreateForm">
+            <div class="grid-content collapse medium-3">
+                <label class="hidden-for-sighted" for="relation-type--select">{{ ::$ctrl.text.relationType }}</label>
+                <select class="form--select relationTypeSelect"
+                        id="relation-type--select"
+                        ng-model="$ctrl.selectedRelationType"
+                        ng-options="type.name as type.label for type in $ctrl.relationTypes"
+                        focus>
+                </select>
+            </div>
+            <div class="grid-content medium-7">
+                <wp-relations-autocomplete
+                        work-package="$ctrl.workPackage"
+                        selected-wp-id="$ctrl.selectedWpId"
+                        selected-relation-type="$ctrl.selectedRelationType">
+                </wp-relations-autocomplete>
+            </div>
+            <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
+                <accessible-by-keyboard
+                        execute="$ctrl.createRelation()"
+                        link-class="wp-create-relation--save"
+                        aria-hidden="false">
+                    <icon-wrapper icon-name="checkmark"
+                                  icon-title="{{ ::$ctrl.text.save }}">
+                    </icon-wrapper>
+                </accessible-by-keyboard>
+                <accessible-by-keyboard
+                        execute="$ctrl.toggleRelationsCreateForm()"
+                        link-class="wp-create-relation--cancel"
+                        aria-hidden="false">
+                    <icon-wrapper icon-name="remove"
+                                  icon-title="{{ ::$ctrl.text.abort }}">
+                    </icon-wrapper>
+                </accessible-by-keyboard>
+            </div>
         </div>
     </div>
 </div>

--- a/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-create/empty-parents.template.html
@@ -13,35 +13,38 @@
             </div>
         </div>
     </div>
-    <div class="grid-block v-align wp-relations--parent-form"
-         ng-if="$ctrl.showRelationsCreateForm || $ctrl.externalFormToggle">
-        <div class="grid-content medium-10 collapse">
-            <wp-relations-autocomplete
-                    work-package="$ctrl.workPackage"
-                    selected-wp-id="$ctrl.selectedWpId"
-                    selected-relation-type="$ctrl.selectedRelationType"
-                    filter-candidates-for="parent"
-                    focus>
-            </wp-relations-autocomplete>
-        </div>
-        <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
-            <accessible-by-keyboard
-                    link-class="wp-create-relation--save"
-                    execute="$ctrl.createRelation()"
-                    class="wp-relations--save"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="checkmark"
-                              icon-title="{{ ::$ctrl.text.save }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
-            <accessible-by-keyboard
-                    link-class="wp-create-relation--cancel"
-                    execute="$ctrl.toggleRelationsCreateForm()"
-                    aria-hidden="false">
-                <icon-wrapper icon-name="remove"
-                              icon-title="{{ ::$ctrl.text.abort }}">
-                </icon-wrapper>
-            </accessible-by-keyboard>
+    <div cg-busy="{promise: $ctrl.loadingPromise, wrapperClass: 'cg-busy-inline', message: ''}">
+        <div class="grid-block v-align wp-relations--parent-form"
+             ng-if="$ctrl.showRelationsCreateForm || $ctrl.externalFormToggle">
+            <div class="grid-content medium-10 collapse">
+                <wp-relations-autocomplete
+                        work-package="$ctrl.workPackage"
+                        loading-promise="$ctrl.loadingPromise"
+                        selected-wp-id="$ctrl.selectedWpId"
+                        selected-relation-type="$ctrl.selectedRelationType"
+                        filter-candidates-for="parent"
+                        focus>
+                </wp-relations-autocomplete>
+            </div>
+            <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
+                <accessible-by-keyboard
+                        link-class="wp-create-relation--save"
+                        execute="$ctrl.createRelation()"
+                        class="wp-relations--save"
+                        aria-hidden="false">
+                    <icon-wrapper icon-name="checkmark"
+                                  icon-title="{{ ::$ctrl.text.save }}">
+                    </icon-wrapper>
+                </accessible-by-keyboard>
+                <accessible-by-keyboard
+                        link-class="wp-create-relation--cancel"
+                        execute="$ctrl.toggleRelationsCreateForm()"
+                        aria-hidden="false">
+                    <icon-wrapper icon-name="remove"
+                                  icon-title="{{ ::$ctrl.text.abort }}">
+                    </icon-wrapper>
+                </accessible-by-keyboard>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Foundation doesn't really like stuff moving out of their grid-blocks,
but outside the grid-block for a relation create row, a simple cg-busy
can be added to add some basic feedback for the loading relation
candidates.

![anim3](https://cloud.githubusercontent.com/assets/459462/20102276/ddaba14a-a5c5-11e6-8637-2580f7fe81b3.gif)
