### PR TITLE
[24233] Fix deep link into work package project context

### DIFF
--- a/features/work_packages/work_package_textile_link.feature
+++ b/features/work_packages/work_package_textile_link.feature
@@ -63,7 +63,7 @@ Feature: Work package textile quickinfo links
     Then I should see a 1 hash work package quickinfo link to "January" within "div.wiki"
     When I follow the 1 hash work package quickinfo link to "January"
     Then I should see "January" within ".wp-edit-field.subject"
-     And I should be on the page of the work package "January"
+     And I should be on the page of the work package "January" in project "ecookbook"
 
   @javascript
   Scenario: Adding a work package quickinfo link
@@ -74,7 +74,7 @@ Feature: Work package textile quickinfo links
     Then I should see a 2 hashes work package quickinfo link to "January" within "div.wiki"
     When I follow the 2 hashes work package quickinfo link to "January"
     Then I should see "January" within ".wp-edit-field.subject"
-     And I should be on the page of the work package "January"
+     And I should be on the page of the work package "January" in project "ecookbook"
 
   @javascript
   Scenario: Adding a work package quickinfo link with description
@@ -85,7 +85,7 @@ Feature: Work package textile quickinfo links
     Then I should see a 3 hashes work package quickinfo link to "January" within "div.wiki"
     When I follow the 3 hashes work package quickinfo link to "January"
     Then I should see "January" within ".wp-edit-field.subject"
-     And I should be on the page of the work package "January"
+     And I should be on the page of the work package "January" in project "ecookbook"
 
 
   Scenario: Adding a work package quickinfo link without the right to see the work package

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -235,10 +235,13 @@ openprojectModule
     });
 
     $rootScope.$on('$stateChangeStart', (event, toState, toParams) => {
+      const projectIdentifier = toParams.projectPath || $rootScope.projectIdentifier;
+
       // Close all open dropdowns, if any
       $rootScope.$broadcast('openproject.dropdown.closeDropdowns');
 
-      if (!toParams.projects && toParams.projectPath) {
+      if (!toParams.projects && projectIdentifier) {
+        toParams.projectPath = projectIdentifier;
         toParams.projects = 'projects';
         $state.go(toState, toParams);
       }

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
     expect(copied_work_package).to_not eql original_work_package
 
-    work_package_page = Pages::FullWorkPackage.new(copied_work_package)
+    work_package_page = Pages::FullWorkPackage.new(copied_work_package, project)
 
     work_package_page.ensure_page_loaded
     work_package_page.expect_attributes Subject: original_work_package.subject,


### PR DESCRIPTION
When deep linking to a work package such as `/work_packages/:id`,
Rails renders a project context (project menu, etc.), but the frontend
does not respect the `projectIdentifier` setting as long as the
`projectPath` is missing from ui-router.

We can enforce the projectPath by looking at the root projectIdentifier.
If that is set, we're within the project context.

https://community.openproject.com/work_packages/24233