### PR TITLE
attempt to fix toppling export spec

### DIFF
--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -66,14 +66,7 @@ describe 'work package export', type: :feature do
 
   before do
     work_packages_page.visit_index
-    # ensure the page is loaded before expecting anything
-    find('.advanced-filters--filters select option', text: /\AAssignee\Z/,
-                                                     visible: false)
-
     work_packages_page.click_toolbar_button 'Activate Filter'
-    expect(work_packages_page.find_filter('status')).to have_content('Status')
-    expect(work_packages_page.find_filter('status'))
-      .to have_select('operators-status', selected: 'open')
 
     # render the CSV as plain text so we can run expectations against the output
     expect_any_instance_of(WorkPackagesController)
@@ -99,7 +92,6 @@ describe 'work package export', type: :feature do
   end
 
   it 'shows all work packages grouped by ', js: true, retry: 2 do
-    work_packages_page.ensure_loaded
     work_packages_page.open_settings!
 
     click_on 'Group by ...'
@@ -122,25 +114,25 @@ describe 'work package export', type: :feature do
     select 'Progress (%)', from: 'add_filter_select'
     fill_in 'values-percentageDone', with: '25'
 
-    expect(page).not_to have_text(wp_2.description) # safeguard
+    expect(page).to have_no_content(wp_2.description) # safeguard
 
     export!
 
     expect(subject).to have_text(wp_1.description)
-    expect(subject).to_not have_text(wp_2.description)
-    expect(subject).to_not have_text(wp_3.description)
+    expect(subject).not_to have_text(wp_2.description)
+    expect(subject).not_to have_text(wp_3.description)
   end
 
   it 'shows only work packages of the filtered type', js: true, retry: 2 do
     select 'Type', from: 'add_filter_select'
     select wp_3.type.name, from: 'values-type'
 
-    expect(page).not_to have_text(wp_2.description) # safeguard
+    expect(page).to have_no_content(wp_2.description) # safeguard
 
     export!
 
-    expect(subject).to_not have_text(wp_1.description)
-    expect(subject).to_not have_text(wp_2.description)
+    expect(subject).not_to have_text(wp_1.description)
+    expect(subject).not_to have_text(wp_2.description)
     expect(subject).to have_text(wp_3.description)
   end
 

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -143,9 +143,8 @@ class WorkPackagesPage
   def ensure_index_page_loaded
     if Capybara.current_driver == Capybara.javascript_driver
       extend ::Angular::DSL unless singleton_class.included_modules.include?(::Angular::DSL)
-      ng_wait
 
-      expect(page).to have_selector('.advanced-filters--filter', visible: false)
+      expect(page).to have_selector('.advanced-filters--filter', visible: false, wait: 8)
     end
   end
 end

--- a/spec/support/downloaded_file.rb
+++ b/spec/support/downloaded_file.rb
@@ -42,8 +42,9 @@ module DownloadedFile
     downloads.first
   end
 
-  def download_content
+  def download_content(ensure_content = true)
     wait_for_download
+    wait_for_download_content if ensure_content
     File.read(download)
   end
 
@@ -53,8 +54,18 @@ module DownloadedFile
     end
   end
 
+  def wait_for_download_content
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      sleep 0.1 until has_content?
+    end
+  end
+
   def downloaded?
     !downloading? && downloads.any?
+  end
+
+  def has_content?
+    !File.read(download).empty?
   end
 
   def downloading?


### PR DESCRIPTION
By:
* increasing the wait time for the page loaded safeguard
* removing ng_wait which failed constantly on my machine
* removing duplicate safeguards (ensure_loaded) as it is already part of the #visit method
* using a waiting safeguard (.to have_no_content) instead of a non waiting (.not_to have_content)