### PR TITLE
[24258] Reuse existing schema after updating work package

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -190,7 +190,11 @@ export class WorkPackageResource extends HalResource {
    * be done automatically, but the backend does not provide typed collections yet.
    */
   protected $initialize(source) {
+    const oldSchema = this.schema;
     super.$initialize(source);
+
+    // Take over previously loaded schema resource
+    this.setExistingSchema(oldSchema);
 
     var attachments = this.attachments || {$source: void 0, $loaded: void 0};
     this.attachments = new AttachmentCollectionResource(
@@ -458,6 +462,25 @@ export class WorkPackageResource extends HalResource {
         this[key] = formPayload[key];
       }
     });
+  }
+
+  private setExistingSchema(previous) {
+    // Only when existing schema was loaded
+    if (!(previous && previous.$loaded)) {
+      return;
+    }
+
+    // If old schema was a regular schema and both href match
+    // assume they are matching
+    if (previous.href === this.schema.href) {
+      this.schema = previous;
+    }
+
+    // If old schema was embedded into the WP form, decide
+    // based on its baseSchema href.
+    if (previous.baseSchema && previous.baseSchema.href === this.schema.href) {
+      this.schema = previous;
+    }
   }
 
   /**

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -49,8 +49,11 @@ module API
                  exec_context: :decorator,
                  getter: -> (*) {
                    schema = Schema::SpecificWorkPackageSchema.new(work_package: represented)
+                   schema_link = api_v3_paths.work_package_schema(represented.project_id,
+                                                                  represented.type_id)
                    Schema::WorkPackageSchemaRepresenter.create(schema,
                                                                form_embedded: true,
+                                                               base_schema_link: schema_link,
                                                                current_user: current_user,
                                                                action: action)
                  }

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -87,6 +87,7 @@ module API
 
           def initialize(schema, context)
             @self_link = context.delete(:self_link) || nil
+            @base_schema_link = context.delete(:base_schema_link) || nil
             @show_lock_version = !context.delete(:hide_lock_version)
             @action = context.delete(:action) || :update
             super(schema, context)
@@ -105,6 +106,10 @@ module API
 
           link :self do
             { href: @self_link } if @self_link
+          end
+
+          link :baseSchema do
+            { href: @base_schema_link } if @base_schema_link
           end
 
           schema :lock_version,

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -40,12 +40,15 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema.new(work_package: work_package)
   }
   let(:self_link) { '/a/self/link' }
+  let(:base_schema_link) { nil }
+  let(:hide_self_link) { false }
   let(:embedded) { true }
   let(:action) { :update }
   let(:representer) {
     described_class.create(schema,
                            form_embedded: embedded,
                            self_link: self_link,
+                           base_schema_link: base_schema_link,
                            current_user: current_user,
                            action: action)
   }
@@ -105,11 +108,21 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:href) { self_link }
       end
 
+      it_behaves_like 'has no link' do
+        let(:link) { 'baseSchema' }
+      end
+
       context 'embedded in a form' do
         let(:self_link) { nil }
+        let(:base_schema_link) { '/a/schema/link' }
 
         it_behaves_like 'has no link' do
           let(:link) { 'self' }
+        end
+
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'baseSchema' }
+          let(:href) { base_schema_link }
         end
       end
     end


### PR DESCRIPTION
When a work package is updated after a successful PATCH, its schema is
being reset to the linked value (and thus, `$loaded == false`).

Since this controls type attribute visibility, this always leads to a
small period of time where the schema is being retrieved from cache and
causes a visible reloading of an attribute section.

A workaround is to remember the previous schema and, if it matches either the self link or (in the form case, as no self link exists) a newly added schema link and replace that instead.

Here, again, the correct fix is to AVOID loading schemas as links (As per [#24227](https://community.openproject.com/work_packages/24227)), but
rather as a separate state where the referenced schema will always
reside unless the switch was made to a new type.

https://community.openproject.com/work_packages/24258