### PR TITLE
Fix reference to start/due date in calendar widget

### DIFF
--- a/app/helpers/my_helper.rb
+++ b/app/helpers/my_helper.rb
@@ -33,8 +33,12 @@ module MyHelper
   def calendar_items(startdt, enddt)
     WorkPackage.visible
       .where(project_id: User.current.projects.map(&:id))
-      .where('(start_date>=? and start_date<=?) or (due_date>=? and due_date<=?)', startdt, enddt, startdt, enddt)
+      .where("(#{WorkPackage.table_name}.start_date >= ? AND " \
+             "#{WorkPackage.table_name}.start_date <= ?)" \
+             "OR (#{WorkPackage.table_name}.due_date >= ? AND  " \
+             "#{WorkPackage.table_name}.due_date <= ? )", startdt, enddt, startdt, enddt)
       .includes(:project, :type, :priority, :assigned_to)
+      .references(:work_packages)
   end
 
   def wps_assigned_to_me


### PR DESCRIPTION
This should resolve the following error.
```
F, [2016-11-10T10:20:20.121294 #15771] FATAL -- : ActionView::Template::Error (Mysql2::Error: Column 'start_date' in where clause is ambiguous: SELECT DISTINCT `work_packages`.`id` AS t0_r0, `work_packages`.`type_id` AS t0_r1, `work_packages`.`project_id` AS t0_r2, `work_packages`.`subject` AS t0_r3, `work_packages`.`description` AS t0_r4, `work_packages`.`due_date` AS t0_r5, `work_packages`.`category_id` AS t0_r6, `work_packages`.`status_id` AS t0_r7, `work_packages`.`assigned_to_id` AS t0_r8, `work_packages`.`priority_id` AS t0_r9, `work_packages`.`fixed_version_id` AS t0_r10, `work_packages`.`author_id` AS t0_r11, `work_packages`.`lock_version` AS t0_r12, `work_packages`.`done_ratio` AS t0_r13, `work_packages`.`estimated_hours` AS t0_r14, `work_packages`.`created_at` AS t0_r15, `work_packages`.`updated_at` AS t0_r16, `work_packages`.`start_date` AS t0_r17, `work_packages`.`parent_id` AS t0_r18, `work_packages`.`responsible_id` AS t0_r19, `work_packages`.`root_id` AS t0_r20, `work_packages`.`lft` AS t0_r21, `work_packages`.`rgt` AS t0_r22, `work_packages`.`position` AS t0_r23, `work_packages`.`story_points` AS t0_r24, `work_packages`.`remaining_hours` AS t0_r25, `work_packages`.`cost_object_id` AS t0_r26, `projects`.`id` AS t1_r0, `projects`.`name` AS t1_r1, `projects`.`description` AS t1_r2, `projects`.`is_public` AS t1_r3, `projects`.`parent_id` AS t1_r4, `projects`.`created_on` AS t1_r5, `projects`.`updated_on` AS t1_r6, `projects`.`identifier` AS t1_r7, `projects`.`status` AS t1_r8, `projects`.`lft` AS t1_r9, `projects`.`rgt` AS t1_r10, `projects`.`project_type_id` AS t1_r11, `projects`.`responsible_id` AS t1_r12, `projects`.`work_packages_responsible_id` AS t1_r13, `types`.`id` AS t2_r0, `types`.`name` AS t2_r1, `types`.`position` AS t2_r2, `types`.`is_in_roadmap` AS t2_r3, `types`.`in_aggregation` AS t2_r4, `types`.`is_milestone` AS t2_r5, `types`.`is_default` AS t2_r6, `types`.`color_id` AS t2_r7, `types`.`created_at` AS t2_r8, `types`.`updated_at` AS t2_r9, `types`.`is_standard` AS t2_r10, `types`.`attribute_visibility` AS t2_r11, `enumerations`.`id` AS t3_r0, `enumerations`.`name` AS t3_r1, `enumerations`.`position` AS t3_r2, `enumerations`.`is_default` AS t3_r3, `enumerations`.`type` AS t3_r4, `enumerations`.`active` AS t3_r5, `enumerations`.`project_id` AS t3_r6, `enumerations`.`parent_id` AS t3_r7, `users`.`id` AS t4_r0, `users`.`login` AS t4_r1, `users`.`firstname` AS t4_r2, `users`.`lastname` AS t4_r3, `users`.`mail` AS t4_r4, `users`.`admin` AS t4_r5, `users`.`status` AS t4_r6, `users`.`last_login_on` AS t4_r7, `users`.`language` AS t4_r8, `users`.`auth_source_id` AS t4_r9, `users`.`created_on` AS t4_r10, `users`.`updated_on` AS t4_r11, `users`.`type` AS t4_r12, `users`.`identity_url` AS t4_r13, `users`.`terms_accepted` AS t4_r14, `users`.`force_password_reset` AS t4_r15, `users`.`failed_login_count` AS t4_r16, `users`.`last_failed_login_on` AS t4_r17, `users`.`guarantor_id` AS t4_r18, `users`.`mail_notification` AS t4_r19, `users`.`verified_phone` AS t4_r20, `users`.`unverified_phone` AS t4_r21, `users`.`first_login` AS t4_r22, `users`.`default_otp_channel` AS t4_r23, `users`.`force_password_change` AS t4_r24 FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `enumerations` ON `enumerations`.`id` = `work_packages`.`priority_id` AND `enumerations`.`type` IN ('IssuePriority') LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `members` ON `projects`.`id` = `members`.`project_id` AND `members`.`user_id` = 1238 AND `projects`.`status` = 1 INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 LEFT OUTER JOIN `role_assignment_intervals` ON `role_assignment_intervals`.`assignment_id` = `members`.`id` AND `role_assignment_intervals`.`assignment_type` = 'Member' INNER JOIN `role_permissions` ON `role_permissions`.`permission` IN ('view_work_packages') INNER JOIN `roles` `permission_roles` ON `permission_roles`.`id` = `role_permissions`.`role_id` LEFT OUTER JOIN `member_roles` ON `members`.`id` = `member_roles`.`member_id` LEFT OUTER JOIN `roles` `assigned_roles` ON `assigned_roles`.`id` = `permission_roles`.`id` AND `projects`.`status` = 1 AND ((`assigned_roles`.`id` = `member_roles`.`role_id` AND (`role_assignment_intervals`.`start_date` <= '2016-11-10' AND `role_assignment_intervals`.`end_date` >= '2016-11-10' OR `role_assignment_intervals`.`id` IS NULL)) OR `projects`.`is_public` = 1 AND `assigned_roles`.`builtin` = 1 AND (`member_roles`.`id` IS NULL OR (`role_assignment_intervals`.`start_date` > '2016-11-10' OR `role_assignment_intervals`.`end_date` < '2016-11-10'))) WHERE (`assigned_roles`.`id` IS NOT NULL) AND `work_packages`.`project_id` IN (2364, 2733, 582, 107, 1089, 470, 1120, 2358, 2618, 2517, 2519, 3054, 3572, 1324, 755, 838, 1238, 2544, 2506, 1943, 3698, 1267, 658, 813, 583, 601, 662, 702, 2725, 3737, 3024, 4747, 3877, 4148, 2588, 3533, 547, 2158, 4361, 6, 2063, 4208, 1560, 1156, 4516, 429, 18, 671) AND ((start_date>='2016-11-06' and start_date<='2016-11-12') or (due_date>='2016-11-06' and due_date<='2016-11-12'))):
F, [2016-11-10T10:20:20.122062 #15771] FATAL -- :     37: </h3>
F, [2016-11-10T10:20:20.122165 #15771] FATAL -- :     38:
F, [2016-11-10T10:20:20.122344 #15771] FATAL -- :     39: <% calendar = Redmine::Helpers::Calendar.new(Date.today, current_language, :week)
F, [2016-11-10T10:20:20.122475 #15771] FATAL -- :     40:    calendar.events = calendar_items(calendar.startdt, calendar.enddt) %>
F, [2016-11-10T10:20:20.122614 #15771] FATAL -- :     41:
F, [2016-11-10T10:20:20.122728 #15771] FATAL -- :     42: <%= render partial: 'common/calendar', locals: {calendar: calendar } %>
F, [2016-11-10T10:20:20.122837 #15771] FATAL -- :
F, [2016-11-10T10:20:20.122952 #15771] FATAL -- : lib/redmine/helpers/calendar.rb:62:in `group_by'
F, [2016-11-10T10:20:20.123029 #15771] FATAL -- : lib/redmine/helpers/calendar.rb:62:in `events='
F, [2016-11-10T10:20:20.123109 #15771] FATAL -- : app/views/my/blocks/_calendar.html.erb:40:in `_app_views_my_blocks__calendar_html_erb___758049655330408328_70034164793520'
F, [2016-11-10T10:20:20.123185 #15771] FATAL -- : app/views/my/_block_container.html.erb:8:in `block in _app_views_my__block_container_html_erb___3995601020402966656_70034165158760'
F, [2016-11-10T10:20:20.123272 #15771] FATAL -- : app/views/my/_block_container.html.erb:2:in `each'
F, [2016-11-10T10:20:20.123346 #15771] FATAL -- : app/views/my/_block_container.html.erb:2:in `_app_views_my__block_container_html_erb___3995601020402966656_70034165158760'
F, [2016-11-10T10:20:20.123380 #15771] FATAL -- : app/views/my/page.html.erb:41:in `_app_views_my_page_html_erb___1448889474268617509_70034165467820'
F, [2016-11-10T10:20:20.123410 #15771] FATAL -- : app/controllers/my_controller.rb:71:in `index'
F, [2016-11-10T10:20:20.123439 #15771] FATAL -- : app/middleware/reset_current_user.rb:47:in `call'
```