### PR TITLE
[24283] Wiki macros now accept an optional block of text for further processing

### DIFF
--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -59,11 +59,11 @@ See doc/COPYRIGHT.rdoc for more details.
     </style>
   </head>
   <body>
-    <span class="header"><%=raw Redmine::WikiFormatting.to_html(Setting.text_formatting, Setting.localized_emails_header) %></span>
+    <span class="header"><%=raw Redmine::WikiFormatting.to_html(Setting.localized_emails_header) %></span>
     <%= call_hook(:view_layouts_mailer_html_before_content, self.assigns) %>
     <%= yield %>
     <%= call_hook(:view_layouts_mailer_html_after_content, self.assigns) %>
     <hr />
-    <span class="footer"><%=raw Redmine::WikiFormatting.to_html(Setting.text_formatting, Setting.localized_emails_footer) %></span>
+    <span class="footer"><%=raw Redmine::WikiFormatting.to_html(Setting.localized_emails_footer) %></span>
   </body>
 </html>

--- a/app/views/wiki/_content.html.erb
+++ b/app/views/wiki/_content.html.erb
@@ -28,5 +28,5 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="wiki wiki-content">
-  <%= format_text content, :text, attachments: content.page.attachments %>
+  <%= format_text content, :text, attachments: content.page.attachments, headings: true %>
 </div>

--- a/lib/open_project/wiki_formatting/macros/default.rb
+++ b/lib/open_project/wiki_formatting/macros/default.rb
@@ -35,14 +35,14 @@ module OpenProject
 
           desc 'Sample macro.'
 
-          macro :hello_world do |obj, args|
+          macro :hello_world do |obj, args, **_options|
             "Hello world! Object: #{obj.class.name}, " + (args.empty? ? 'Called with no argument.' : "Arguments: #{args.join(', ')}")
           end
         end
 
         Redmine::WikiFormatting::Macros.register do
           desc 'Displays a list of all available macros, including description if available.'
-          macro :macro_list do |_obj, _args|
+          macro :macro_list do |_obj, _args, **_options|
             out = ''
             available_macros = Redmine::WikiFormatting::Macros.available_macros
 
@@ -60,7 +60,7 @@ module OpenProject
             "  !{{child_pages(Foo)}} -- lists all children of page Foo\n" +
             '  !{{child_pages(Foo, parent=1)}} -- same as above with a link to page Foo'
 
-          macro :child_pages do |obj, args|
+          macro :child_pages do |obj, args, **_options|
             args, options = extract_macro_options(args, :parent)
             page = nil
             if args.size > 0
@@ -78,15 +78,43 @@ module OpenProject
 
         Redmine::WikiFormatting::Macros.register do
           desc "Include a wiki page. Example:\n\n  !{{include(Foo)}}\n\nor to include a page of a specific project wiki:\n\n  !{{include(projectname:Foo)}}"
-          macro :include do |_obj, args|
-            page = Wiki.find_page(args.first.to_s, project: @project)
+          macro :include do |_obj, args, **options|
+            page = Wiki.find_page(args, project: options[:project])
             raise 'Page not found' if page.nil? || !User.current.allowed_to?(:view_wiki_pages, page.wiki.project)
             @included_wiki_pages ||= []
             raise 'Circular inclusion detected' if @included_wiki_pages.include?(page.title)
             @included_wiki_pages << page.title
-            out = format_text(page.content, :text, attachments: page.attachments, headings: false)
+            out = format_text(page.content, :text, attachments: page.attachments)
             @included_wiki_pages.pop
             out
+          end
+        end
+
+        Redmine::WikiFormatting::Macros.register do
+          desc "A PRE block. Example:\n\n  !{{pre\npre-block-content\n}}"
+          macro :pre do |_obj, args, block:, **_options|
+            attrs = []
+            unless args.empty?
+              attrs << ' '
+              args.scan(/([^,]+)/) do
+                attrs << $1
+              end
+            end
+            "<pre#{attrs.join(' ')}>#{block}</pre>".html_safe
+          end
+        end
+
+        Redmine::WikiFormatting::Macros.register do
+          desc "A CODE block. Example:\n\n  !{{code(options)\ncode-block-content\n}}"
+          macro :code do |_obj, args, block:, **_options|
+            attrs = []
+            unless args.empty?
+              attrs << ' '
+              args.scan(/([^,]+)/) do
+                attrs << $1
+              end
+            end
+            "<code#{attrs.join(' ')}>#{block}</code>".html_safe
           end
         end
 
@@ -95,7 +123,7 @@ module OpenProject
             Display a timeline report on the Wiki page.
           EOF
 
-          macro :timeline do |obj, args, options|
+          macro :timeline do |obj, args, **options|
             OpenProject::WikiFormatting::Macros::TimelinesWikiMacro.new.apply obj, args, options.merge(view: self)
           end
         end

--- a/lib/redmine/wiki_formatting.rb
+++ b/lib/redmine/wiki_formatting.rb
@@ -55,9 +55,12 @@ module Redmine
         @@formatters.keys.map
       end
 
-      def to_html(format, text, options = {}, &block)
-        edit = !!options[:edit]
-        text = if Setting.cache_formatted_text? && text.size > 2.kilobyte && cache_store && cache_key = cache_key_for(format, options[:object], options[:attribute], edit)
+      def to_html(text, options = {})
+        edit = options[:edit]
+        format = options[:format]
+        obj = options[:object]
+        text = if Setting.cache_formatted_text? && text.size > 2.kilobyte &&
+                  cache_store && cache_key = cache_key_for(format, obj, options[:attr], edit)
                  # Text retrieved from the cache store may be frozen
                  # We need to dup it so we can do in-place substitutions with gsub!
                  cache_store.fetch cache_key do

--- a/lib/redmine/wiki_formatting/macros.rb
+++ b/lib/redmine/wiki_formatting/macros.rb
@@ -31,14 +31,10 @@ module Redmine
   module WikiFormatting
     module Macros
       module Definitions
-        def exec_macro(name, obj, args, options = {})
+        def exec_macro(name, obj, args, block:, **options)
           method_name = "macro_#{name}"
           if respond_to?(method_name)
-            if method(method_name).arity == 2
-              send(method_name, obj, args)
-            else
-              send(method_name, obj, args, options)
-            end
+            send(method_name, obj, args, block: block, **options)
           end
         end
 
@@ -74,6 +70,10 @@ module Redmine
 
         def available_macros
           @@available_macros
+        end
+
+        def macro_exists?(name)
+          available_macros.key?(name.to_sym)
         end
 
         private


### PR DESCRIPTION
Wiki macros now accept an optional block of text for further processing

- This is basically a port of the same functionality from redmine to OP.
- Some refactoring was required to make this work. The interface of macro functions has changed. They must now expect a ``**options`` parameter. By default, a ``block:`` which represents the block of text from the parsed macro, will be passed as a named parameter to the macro.
- Additional refactoring was required to solve errors reported by codeclimate/rubocop.

Still working on test cases, so consider this a WIP.

https://community.openproject.com/work_packages/24283