### PR TITLE
[24274] Keep children menus closed if main menu is collpased

### DIFF
--- a/app/assets/javascripts/specific/main_menu.js.erb
+++ b/app/assets/javascripts/specific/main_menu.js.erb
@@ -39,11 +39,13 @@ function setExpandStatus(expanderObject) {
 }
 
 function initMainMenuExpandStatus() {
+  var wrapper = jQuery('#wrapper')
+
   jQuery('#main-menu .toggler').each(function(index) {
     var menu_expander = jQuery(this);
     var menu_item = menu_expander.closest('li').find('a.selected');
 
-    if (menu_item.length == 1) {
+    if (menu_item.length == 1 && !wrapper.hasClass('hidden-navigation')) {
       menu_expander.trigger('click');
     } else {
       setExpandStatus(menu_expander);

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -226,7 +226,8 @@ $toggler-width: 40px
       -ms-text-overflow: clip
     .toggler
       display: none
-  #sidebar
+  #sidebar,
+  .menu-children
     display: none
 
 #sidebar


### PR DESCRIPTION
Don't initially expand a child menu (e.g., work package queries) when the menu is collapsed.

![anim3](https://cloud.githubusercontent.com/assets/459462/20208483/cd279e5c-a7ee-11e6-8917-c36a9111de1f.gif)


https://community.openproject.com/projects/openproject/work_packages/24274