### PR TITLE
[24254] Star missing when renaming wiki page

### DIFF
--- a/app/views/wiki/rename.html.erb
+++ b/app/views/wiki/rename.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for @page, url: { id: @page, action: 'rename' }, as: :page do |f| %>
   <div class="box">
     <div class='form--field -required'>
-      <%= f.text_field :title %>
+      <%= f.text_field :title, required: true %>
     </div>
     <div class='form--field'>
       <%= f.check_box :redirect_existing_links %>


### PR DESCRIPTION
This adds the required attribute to the title field in the rename wiki form. 

https://community.openproject.com/work_packages/24254/activity