### PR TITLE
[24289] Toolbar misaligned on mobile taskboard

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -291,5 +291,7 @@
 
       .button
         width: 100%
-        margin-top: 0
         white-space: nowrap
+
+      .button, input, label, div
+        margin-top: 0


### PR DESCRIPTION
This removes the `top-margin` from possible toolbar elements. Thus they are correctly aligned.

https://community.openproject.com/work_packages/24289/activity