### PR TITLE
[24301] Add members button is not consistently named

### DIFF
--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -40,9 +40,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <% end %>
   <% if authorize_for(:members, :new) %>
     <li class="toolbar-item">
-      <button id="add-member-button" title="<%= I18n.t(:button_add_member) %>" onClick="showAddMemberForm()" class="button -alt-highlight">
+      <button id="add-member-button" aria-label="<%= I18n.t(:button_add_member) %>" title="<%= I18n.t(:button_add_member) %>" onClick="showAddMemberForm()" class="button -alt-highlight">
         <i class="button--icon icon-add"></i>
-        <span class="button--text"><%= I18n.t(:button_add_member) %></span>
+        <span class="button--text"><%= t('activerecord.models.member') %></span>
       </button>
     </li>
   <% end %>


### PR DESCRIPTION
This renames the add members button to make it more consistent to the rest of the system. 
Before: '+ Add member'
After: '+ Member'

https://community.openproject.com/projects/openproject/work_packages/24301/activity