### PR TITLE
[24291] Do not render the DOM element unless both conditions are met

### DIFF
--- a/frontend/app/templates/timelines/timeline_table.html
+++ b/frontend/app/templates/timelines/timeline_table.html
@@ -27,8 +27,7 @@
           'tl-last-row': $last,
           'tl-project-row': rowObjectType === 'Project'
         }"
-        ng-if="!(hideTreeRoot && $first || rowObjectType === 'Project' && excludeEmpty && !row.childNodes)"
-        ng-show="rowObjectType === 'Project' && row.level === 1 || (row.ancestors | ancestorsExpanded)">
+        ng-if="!(hideTreeRoot && $first || rowObjectType === 'Project' && (excludeEmpty && !row.childNodes)) && (rowObjectType === 'Project' && row.level === 1 || !!(row.ancestors | ancestorsExpanded))">
 
       <!-- tree node expansion toggle -->
 


### PR DESCRIPTION
The timeline rows have both an `ng-if` and `ng-show`, which causes the ng-if to evaluate to true during a digest, the ng-show to false but the latter not yet being evaluated.

This in turn causes more rows to be visible intermittently and breaks the height computation of the timeline.

Without trying to improve the conditions, moving both together fixes the issue.

https://community.openproject.com/projects/openproject/work_packages/details/24291/overview?query_id=892