### PR TITLE
[26266] Restore newlines in paragraphs within description

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -75,6 +75,9 @@
       word-wrap: break-word
       margin-bottom: 0
 
+    .read-value--html p
+      margin-bottom: 1em
+
   .inplace-edit--read-value
     &:before
       vertical-align: middle

--- a/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.ts
+++ b/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.ts
@@ -42,7 +42,7 @@ function bindUnescapedHtml(ExpressionService:ExpressionService, $sce) {
 
   return {
     restrict: 'A',
-    template: '<span ng-bind-html="escapedValue"></span>',
+    template: '<span class="read-value--html" ng-bind-html="escapedValue"></span>',
     scope: {
       value: '=bindUnescapedHtml',
     },


### PR DESCRIPTION
https://github.com/opf/openproject/commit/af430db688741f0c9704c3a1207de508f141543c#diff-4a5d02bdd648f4382bc7d0754cdb2851R73
introduced a margin-bottom of 0 for all paragraphs within an edit field.

As paragraphs are used to split apart, well, paragraphs in the textile, this causes all linebreaks to collapse.