### PR TITLE
[24290] Fix escaping angular expressions when in isolated scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem 'rack-protection', '~> 2.0.0.beta2'
 gem 'rack-attack', '~> 5.0.1'
 
 # Patch Rails HTML whitelisting for Angular curly braces
-gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: '5f5622e'
+gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: 'a45267d5'
 
 gem "syck", '~> 1.0.5', require: false
 gem 'gon', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,10 +71,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/rails-angular-xss
-  revision: 5f5622ec7b592e890e0d8ae8dbf786cf61ea2d24
-  ref: 5f5622e
+  revision: a45267d53d32610bad01f903e9f1b49a81b7c37b
+  ref: a45267d5
   specs:
-    rails-angular-xss (0.2.0.pre.pre)
+    rails-angular-xss (0.3.0.pre.pre)
       rails (>= 5.0.0, < 5.1)
 
 GIT

--- a/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.test.ts
+++ b/frontend/app/components/common/xss/bindUnescapedHtml/bindUnescapedHtml.directive.test.ts
@@ -57,7 +57,7 @@ describe('bindUnescapedHtml Directive', function() {
 
   describe('when content is escaped', function() {
     beforeEach(function() {
-      scope.text = '<p>Some escaped {{ DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }} angular expression</p>';
+      scope.text = '<p>Some escaped {{ $root.DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }} angular expression</p>';
       compile();
     });
 

--- a/frontend/app/components/common/xss/expression.service.ts
+++ b/frontend/app/components/common/xss/expression.service.ts
@@ -37,7 +37,7 @@ export default class ExpressionService {
   }
 
   public get ESCAPED_EXPRESSION() {
-    return '{{ DOUBLE_LEFT_CURLY_BRACE }}';
+    return '{{ \\$root\\.DOUBLE_LEFT_CURLY_BRACE }}';
   }
 
   public escape(input:string) {

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -115,7 +115,7 @@ module OpenProject
     # This will avoid arbitrary angular expressions to be evaluated in
     # formatted text marked html_safe.
     def escape_non_macros(text)
-      text.gsub!(/\{\{(?! DOUBLE_LEFT_CURLY_BRACE)/, '{{ DOUBLE_LEFT_CURLY_BRACE }}')
+      text.gsub!(/\{\{(?! \$root\.DOUBLE_LEFT_CURLY_BRACE)/, '{{ $root.DOUBLE_LEFT_CURLY_BRACE }}')
     end
 
     def parse_non_pre_blocks(text)

--- a/spec/features/security/angular_xss_spec.rb
+++ b/spec/features/security/angular_xss_spec.rb
@@ -48,7 +48,7 @@ describe 'Angular expression escaping', type: :feature do
       let(:login_string) { '{{ 3 + 5 }}' }
 
       it 'does not evaluate the expression' do
-        expect(login_field.value).to eq('{{ DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }}')
+        expect(login_field.value).to eq('{{ $root.DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }}')
       end
     end
 
@@ -127,7 +127,7 @@ describe 'Angular expression escaping', type: :feature do
       content.set '{{macro_list(wiki)}}'
       btn_preview.click
 
-      expect(preview.text).not_to include '{{ DOUBLE_LEFT_CURLY_BRACE }}'
+      expect(preview.text).not_to include '{{ $root.DOUBLE_LEFT_CURLY_BRACE }}'
       expect(preview.text).to match /\{\{[\s\w]+\}\}/
 
       btn_cancel.click
@@ -145,7 +145,7 @@ describe 'Angular expression escaping', type: :feature do
     end
 
     it 'escapes the expression' do
-      expect(html).to include('{{ DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }}')
+      expect(html).to include('{{ $root.DOUBLE_LEFT_CURLY_BRACE }} 3 + 5 }}')
     end
 
     it 'marks the string as safe' do

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
@@ -47,7 +47,7 @@ describe Redmine::WikiFormatting::Macros, type: :helper do
     assert format_text(text).match(/Hello world!/)
     # escaping
     text = '!{{hello_world}}'
-    assert_equal '<p>{{ DOUBLE_LEFT_CURLY_BRACE }}hello_world}}</p>', format_text(text)
+    assert_equal '<p>{{ $root.DOUBLE_LEFT_CURLY_BRACE }}hello_world}}</p>', format_text(text)
   end
 
   it 'should macro include' do


### PR DESCRIPTION
Isolated scopes do not inherit from rootScope and thus do not have
`DOUBLE_LEFT_CURLY_BRACE`.

However, every scope has a reference to the rootScope with
`scope.$root` (https://docs.angularjs.org/api/ng/type/$rootScope.Scope)

https://community.openproject.com/work_packages/24290/activity