### PR TITLE
Fix/avoid unnecessary ar model initialization

### DIFF
--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -30,7 +30,9 @@
 class CustomValue::UserStrategy < CustomValue::FormatStrategy
   def typed_value
     unless value.blank?
-      User.find_by(id: value)
+      RequestStore.fetch(:"user_custom_value_#{value}") do
+        User.find_by(id: value)
+      end
     end
   end
 

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -30,7 +30,9 @@
 class CustomValue::VersionStrategy < CustomValue::FormatStrategy
   def typed_value
     unless value.blank?
-      Version.find_by(id: value)
+      RequestStore.fetch(:"version_custom_value_#{value}") do
+        Version.find_by(id: value)
+      end
     end
   end
 

--- a/app/models/queries/work_packages/filter/custom_field_filter.rb
+++ b/app/models/queries/work_packages/filter/custom_field_filter.rb
@@ -100,9 +100,10 @@ class Queries::WorkPackages::Filter::CustomFieldFilter <
   def self.custom_fields(context)
     if context
       context
-        .all_work_package_custom_fields
+        .all_work_package_custom_fields(include: :translations)
     else
       WorkPackageCustomField
+        .includes(:translations)
         .filter
         .for_all
         .where.not(field_format: ['user', 'version'])

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -239,9 +239,9 @@ class Query < ActiveRecord::Base
     return @available_columns if @available_columns
     @available_columns = ::Query.available_columns
     @available_columns += if project
-                            project.all_work_package_custom_fields
+                            project.all_work_package_custom_fields(include: :translations)
                           else
-                            WorkPackageCustomField.all
+                            WorkPackageCustomField.includes(:translations).all
                           end.map { |cf| ::QueryCustomFieldColumn.new(cf) }
 
     # have to use this instead of

--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -45,11 +45,10 @@ module API
         @per_page = [per_page || self.class.per_page_default(models),
                      self.class.per_page_maximum].min
 
-        # FIXME: calling :to_a is a hack to circumvent a counting error in will_paginate
-        # see https://github.com/mislav/will_paginate/issues/449
-        page_models = models.page(@page).per_page(@per_page).to_a
         full_self_link = make_page_link(page: @page, page_size: @per_page)
-        super(page_models, models.count, full_self_link, current_user: current_user)
+        paged = paged_models(models)
+
+        super(paged, models.count, full_self_link, current_user: current_user)
       end
 
       link :jumpTo do
@@ -91,6 +90,12 @@ module API
       def make_page_link(page:, page_size:)
         query = @query.merge(offset: page, pageSize: page_size).to_query
         "#{@self_link_base}?#{query}"
+      end
+
+      def paged_models(models)
+        # FIXME: calling :to_a is a hack to circumvent a counting error in will_paginate
+        # see https://github.com/mislav/will_paginate/issues/449
+        models.page(@page).per_page(@per_page).to_a
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -57,11 +57,26 @@ module API
                 page: page,
                 per_page: per_page,
                 current_user: current_user)
+
+          # In order to optimize performance we
+          #   * override paged_models so that only the id is fetched from the
+          #     scope (typically a query with a couple of includes for e.g.
+          #     filtering), circumventing AR instantiation alltogether
+          #   * use the ids to fetch the actual work packages with all the fields
+          #     necessary for rendering the work packages in _elements
+          #
+          # This results in the weird flow where the scope is passed to super (models variable),
+          # which calls the overriden paged_models method fetching the ids. In order to have
+          # real AR objects again, we finally get the work packages we actually want to have
+          # and set those to be the represented collection.
+          # A potential ordering is reapplied to the work package collection in ruby.
+
+          @represented = full_work_packages(represented)
         end
 
         link :sumsSchema do
           {
-            href: api_v3_paths.work_package_sums_schema,
+            href: api_v3_paths.work_package_sums_schema
           } if total_sums || groups && groups.any?(&:has_sums?)
         end
 
@@ -81,20 +96,18 @@ module API
 
         collection :elements,
                    getter: -> (*) {
-                     work_packages = sorted_and_eager_loaded_work_packages
-
                      generated_classes = ::Hash.new do |hash, work_package|
-                       hit = hash.values.find { |klass|
+                       hit = hash.values.find do |klass|
                          klass.customizable.type_id == work_package.type_id &&
-                         klass.customizable.project_id == work_package.project_id
-                       }
+                           klass.customizable.project_id == work_package.project_id
+                       end
 
                        hash[work_package] = hit || element_decorator.create_class(work_package)
                      end
 
-                     work_packages.map { |model|
+                     represented.map do |model|
                        generated_classes[model].new(model, current_user: current_user)
-                     }
+                     end
                    },
                    exec_context: :decorator,
                    embedded: true
@@ -112,27 +125,26 @@ module API
                  },
                  render_nil: false
 
-        # Eager load elements used in the representer later
-        # to avoid n+1 queries triggered from each representer.
-        def sorted_and_eager_loaded_work_packages
-          ids_in_order = represented.map(&:id)
-          work_packages = eager_loaded_work_packages(ids_in_order)
-
-          work_packages.sort_by { |wp| ids_in_order.index(wp.id) }
-        end
-
-        def eager_loaded_work_packages(ids)
-          WorkPackage
-            .include_spent_hours(current_user)
-            .preload(element_decorator.to_eager_load)
-            .where(id: ids)
-            .select('work_packages.*')
-        end
-
         private
 
         def current_user_allowed_to_add_work_packages?
           current_user.allowed_to?(:add_work_packages, project, global: project.nil?)
+        end
+
+        def add_eager_loading(scope, current_user)
+          scope
+            .includes(element_decorator.to_eager_load)
+            .include_spent_hours(current_user)
+            .select('work_packages.*')
+        end
+
+        def paged_models(models)
+          models.page(@page).per_page(@per_page).pluck(:id).uniq
+        end
+
+        def full_work_packages(ids_in_order)
+          wps = add_eager_loading(WorkPackage.where(id: ids_in_order), current_user).to_a
+          wps.sort_by { |wp| ids_in_order.index(wp.id) }
         end
 
         attr_reader :project,


### PR DESCRIPTION
Consists of three optimizations:

* remove duplicate AR model initialization (please see 12d7761 for details)
* eager loads translations for custom fields
* Because there is no way yet to avoid n+1 queries when rendering work packages having user and version custom fields, the RequestStore is used to at least mitigate the situation.

All in all, the development log of an exemplary request to /api/v3/projects/[:identifier]/work_packages changes from:

```
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 26 LIMIT 1
   (0.3ms)  SELECT MAX(`settings`.`updated_on`) FROM `settings`
  Project Load (0.3ms)  SELECT  `projects`.* FROM `projects` WHERE `projects`.`identifier` = 'project3244' LIMIT 1
   (0.3ms)  SELECT `enabled_modules`.`name` FROM `enabled_modules` WHERE `enabled_modules`.`project_id` = 4516
  Type Load (3.6ms)  SELECT DISTINCT types.* FROM `types` INNER JOIN `projects_types` ON `projects_types`.`type_id` = `types`.`id` INNER JOIN `projects` ON `projects`.`id` = `projects_types`.`project_id` WHERE (projects.lft >= 5300 AND projects.rgt <= 5301 AND projects.status = 1) ORDER BY position ASC, types.position
  WorkPackageCustomField Load (0.6ms)  SELECT `custom_fields`.* FROM `custom_fields` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND (is_for_all=1) ORDER BY position
  WorkPackageCustomField Load (1.1ms)  SELECT `custom_fields`.* FROM `custom_fields` INNER JOIN `custom_fields_projects` ON `custom_fields`.`id` = `custom_fields_projects`.`custom_field_id` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `custom_fields_projects`.`project_id` = 4516 AND `custom_fields`.`type` IN ('WorkPackageCustomField') ORDER BY custom_fields.position
   (0.4ms)  SELECT COUNT(*) FROM `projects` WHERE (`projects`.`lft` >= 5300) AND (`projects`.`lft` < 5301) AND (`projects`.`id` != 4516) AND `projects`.`status` = 1
  SQL (11.2ms)  SELECT  DISTINCT `work_packages`.`id`,         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id, work_packages.lft AS alias_0 FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516)) ORDER BY         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id DESC, work_packages.lft ASC LIMIT 50 OFFSET 0
  SQL (56.0ms)  SELECT `work_packages`.`id` AS t0_r0, `work_packages`.`type_id` AS t0_r1, `work_packages`.`project_id` AS t0_r2, `work_packages`.`subject` AS t0_r3, `work_packages`.`description` AS t0_r4, `work_packages`.`due_date` AS t0_r5, `work_packages`.`category_id` AS t0_r6, `work_packages`.`status_id` AS t0_r7, `work_packages`.`assigned_to_id` AS t0_r8, `work_packages`.`priority_id` AS t0_r9, `work_packages`.`fixed_version_id` AS t0_r10, `work_packages`.`author_id` AS t0_r11, `work_packages`.`lock_version` AS t0_r12, `work_packages`.`done_ratio` AS t0_r13, `work_packages`.`estimated_hours` AS t0_r14, `work_packages`.`created_at` AS t0_r15, `work_packages`.`updated_at` AS t0_r16, `work_packages`.`start_date` AS t0_r17, `work_packages`.`parent_id` AS t0_r18, `work_packages`.`responsible_id` AS t0_r19, `work_packages`.`root_id` AS t0_r20, `work_packages`.`lft` AS t0_r21, `work_packages`.`rgt` AS t0_r22, `work_packages`.`position` AS t0_r23, `work_packages`.`story_points` AS t0_r24, `work_packages`.`remaining_hours` AS t0_r25, `work_packages`.`cost_object_id` AS t0_r26, `statuses`.`id` AS t1_r0, `statuses`.`name` AS t1_r1, `statuses`.`is_closed` AS t1_r2, `statuses`.`is_default` AS t1_r3, `statuses`.`position` AS t1_r4, `statuses`.`default_done_ratio` AS t1_r5, `projects`.`id` AS t2_r0, `projects`.`name` AS t2_r1, `projects`.`description` AS t2_r2, `projects`.`is_public` AS t2_r3, `projects`.`parent_id` AS t2_r4, `projects`.`created_on` AS t2_r5, `projects`.`updated_on` AS t2_r6, `projects`.`identifier` AS t2_r7, `projects`.`status` AS t2_r8, `projects`.`lft` AS t2_r9, `projects`.`rgt` AS t2_r10, `projects`.`project_type_id` AS t2_r11, `projects`.`responsible_id` AS t2_r12, `projects`.`work_packages_responsible_id` AS t2_r13, `types`.`id` AS t3_r0, `types`.`name` AS t3_r1, `types`.`position` AS t3_r2, `types`.`is_in_roadmap` AS t3_r3, `types`.`in_aggregation` AS t3_r4, `types`.`is_milestone` AS t3_r5, `types`.`is_default` AS t3_r6, `types`.`color_id` AS t3_r7, `types`.`created_at` AS t3_r8, `types`.`updated_at` AS t3_r9, `types`.`is_standard` AS t3_r10, `types`.`attribute_visibility` AS t3_r11, `users`.`id` AS t4_r0, `users`.`login` AS t4_r1, `users`.`firstname` AS t4_r2, `users`.`lastname` AS t4_r3, `users`.`mail` AS t4_r4, `users`.`admin` AS t4_r5, `users`.`status` AS t4_r6, `users`.`last_login_on` AS t4_r7, `users`.`language` AS t4_r8, `users`.`auth_source_id` AS t4_r9, `users`.`created_on` AS t4_r10, `users`.`updated_on` AS t4_r11, `users`.`type` AS t4_r12, `users`.`identity_url` AS t4_r13, `users`.`terms_accepted` AS t4_r14, `users`.`force_password_reset` AS t4_r15, `users`.`failed_login_count` AS t4_r16, `users`.`last_failed_login_on` AS t4_r17, `users`.`guarantor_id` AS t4_r18, `users`.`mail_notification` AS t4_r19, `users`.`verified_phone` AS t4_r20, `users`.`unverified_phone` AS t4_r21, `users`.`first_login` AS t4_r22, `users`.`default_otp_channel` AS t4_r23, `users`.`force_password_change` AS t4_r24, `parents_work_packages`.`id` AS t5_r0, `parents_work_packages`.`type_id` AS t5_r1, `parents_work_packages`.`project_id` AS t5_r2, `parents_work_packages`.`subject` AS t5_r3, `parents_work_packages`.`description` AS t5_r4, `parents_work_packages`.`due_date` AS t5_r5, `parents_work_packages`.`category_id` AS t5_r6, `parents_work_packages`.`status_id` AS t5_r7, `parents_work_packages`.`assigned_to_id` AS t5_r8, `parents_work_packages`.`priority_id` AS t5_r9, `parents_work_packages`.`fixed_version_id` AS t5_r10, `parents_work_packages`.`author_id` AS t5_r11, `parents_work_packages`.`lock_version` AS t5_r12, `parents_work_packages`.`done_ratio` AS t5_r13, `parents_work_packages`.`estimated_hours` AS t5_r14, `parents_work_packages`.`created_at` AS t5_r15, `parents_work_packages`.`updated_at` AS t5_r16, `parents_work_packages`.`start_date` AS t5_r17, `parents_work_packages`.`parent_id` AS t5_r18, `parents_work_packages`.`responsible_id` AS t5_r19, `parents_work_packages`.`root_id` AS t5_r20, `parents_work_packages`.`lft` AS t5_r21, `parents_work_packages`.`rgt` AS t5_r22, `parents_work_packages`.`position` AS t5_r23, `parents_work_packages`.`story_points` AS t5_r24, `parents_work_packages`.`remaining_hours` AS t5_r25, `parents_work_packages`.`cost_object_id` AS t5_r26, `custom_values`.`id` AS t6_r0, `custom_values`.`customized_type` AS t6_r1, `custom_values`.`customized_id` AS t6_r2, `custom_values`.`custom_field_id` AS t6_r3, `custom_values`.`value` AS t6_r4, `custom_fields`.`id` AS t7_r0, `custom_fields`.`type` AS t7_r1, `custom_fields`.`field_format` AS t7_r2, `custom_fields`.`regexp` AS t7_r3, `custom_fields`.`min_length` AS t7_r4, `custom_fields`.`max_length` AS t7_r5, `custom_fields`.`is_required` AS t7_r6, `custom_fields`.`is_for_all` AS t7_r7, `custom_fields`.`is_filter` AS t7_r8, `custom_fields`.`position` AS t7_r9, `custom_fields`.`searchable` AS t7_r10, `custom_fields`.`editable` AS t7_r11, `custom_fields`.`visible` AS t7_r12, `custom_fields`.`created_at` AS t7_r13, `custom_fields`.`updated_at` AS t7_r14 FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516)) AND `work_packages`.`id` IN (383332, 406393, 406390, 405445, 405439, 405346, 405319, 405316, 405313, 405310, 405304, 405301, 405295, 405292, 405286, 405283, 405277, 405238, 405217, 405214, 405208, 403474, 403420, 403414, 403339, 401050, 400981, 400972, 400969, 400960, 400939, 400921, 400492, 399802, 399778, 399775, 399163, 399139, 395626, 395581, 395350, 395347, 395344, 395341, 395338, 395335, 395332, 394705, 394678, 394672) ORDER BY         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id DESC, work_packages.lft ASC
   (20.4ms)  SELECT COUNT(DISTINCT `work_packages`.`id`) FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516))
  CACHE (0.0ms)  SELECT COUNT(DISTINCT `work_packages`.`id`) FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516))  [["customized_type", "WorkPackage"]]
  WorkPackage Load (4.5ms)  SELECT SUM(time_entries.hours) AS hours, work_packages.*, SUM(COALESCE(time_entries.overridden_costs, time_entries.costs)) AS time_entries_sum, SUM(COALESCE(cost_entries.overridden_costs, cost_entries.costs)) AS cost_entries_sum FROM `work_packages` LEFT OUTER JOIN `work_packages` `descendants` ON `descendants`.`root_id` = `work_packages`.`root_id` AND `descendants`.`lft` >= `work_packages`.`lft` AND `descendants`.`rgt` <= `work_packages`.`rgt` AND `descendants`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) LEFT OUTER JOIN `time_entries` ON `time_entries`.`work_package_id` = `descendants`.`id` AND `time_entries`.`id` IN (SELECT `time_entries`.`id` FROM `time_entries` WHERE (`time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) OR `time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) AND `time_entries`.`user_id` = 26)) LEFT OUTER JOIN `time_entries` `time_entry_labor` ON `time_entry_labor`.`work_package_id` = `work_packages`.`id` AND (`time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) OR `time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) AND `time_entries`.`user_id` = 26) AND (`time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('costs_module') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) OR `time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` WHERE `projects`.`status` = 1) AND `time_entries`.`user_id` = 26) LEFT OUTER JOIN `cost_entries` ON `cost_entries`.`work_package_id` = `work_packages`.`id` AND (`cost_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('costs_module') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) OR `cost_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('costs_module') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) AND `cost_entries`.`user_id` = 26) AND `cost_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('costs_module') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) WHERE `work_packages`.`id` IN (383332, 406393, 406390, 405445, 405439, 405346, 405319, 405316, 405313, 405310, 405304, 405301, 405295, 405292, 405286, 405283, 405277, 405238, 405217, 405214, 405208, 403474, 403420, 403414, 403339, 401050, 400981, 400972, 400969, 400960, 400939, 400921, 400492, 399802, 399778, 399775, 399163, 399139, 395626, 395581, 395350, 395347, 395344, 395341, 395338, 395335, 395332, 394705, 394678, 394672) GROUP BY `work_packages`.`id`, `work_packages`.`id`
  WorkPackage Load (0.8ms)  SELECT `work_packages`.* FROM `work_packages` WHERE `work_packages`.`parent_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY `work_packages`.`lft`
  Project Load (0.3ms)  SELECT `projects`.* FROM `projects` WHERE `projects`.`id` = 4516
  EnabledModule Load (0.3ms)  SELECT `enabled_modules`.* FROM `enabled_modules` WHERE `enabled_modules`.`project_id` = 4516
  SQL (1.8ms)  SELECT `custom_fields_projects`.`custom_field_id` AS t0_r0, `custom_fields_projects`.`project_id` AS t0_r1, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_fields_projects` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_fields_projects`.`custom_field_id` AND `custom_fields`.`type` IN ('WorkPackageCustomField') WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `custom_fields_projects`.`project_id` = 4516 ORDER BY custom_fields.position
  Status Load (0.3ms)  SELECT `statuses`.* FROM `statuses` WHERE `statuses`.`id` = 14 ORDER BY position ASC
  IssuePriority Load (0.3ms)  SELECT `enumerations`.* FROM `enumerations` WHERE `enumerations`.`type` IN ('IssuePriority') AND `enumerations`.`id` = 4 ORDER BY enumerations.position ASC
  Type Load (0.2ms)  SELECT `types`.* FROM `types` WHERE `types`.`id` = 215 ORDER BY position ASC
  SQL (1.1ms)  SELECT `custom_fields_types`.`custom_field_id` AS t0_r0, `custom_fields_types`.`type_id` AS t0_r1, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_fields_types` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_fields_types`.`custom_field_id` AND `custom_fields`.`type` IN ('WorkPackageCustomField') WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `custom_fields_types`.`type_id` = 215
  Version Load (0.3ms)  SELECT `versions`.* FROM `versions` WHERE `versions`.`id` IN (11161, 12484, 12412, 12238)
  SQL (23.5ms)  SELECT `custom_values`.`id` AS t0_r0, `custom_values`.`customized_type` AS t0_r1, `custom_values`.`customized_id` AS t0_r2, `custom_values`.`custom_field_id` AS t0_r3, `custom_values`.`value` AS t0_r4, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_values` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` WHERE `custom_values`.`customized_type` = 'WorkPackage' AND `custom_values`.`customized_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY custom_fields.position
  User Load (0.7ms)  SELECT `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` IN (2388, 140, 1752, 1185)
  SQL (1.5ms)  SELECT `watchers`.`id` AS t0_r0, `watchers`.`watchable_type` AS t0_r1, `watchers`.`watchable_id` AS t0_r2, `watchers`.`user_id` AS t0_r3, `users`.`id` AS t1_r0, `users`.`login` AS t1_r1, `users`.`firstname` AS t1_r2, `users`.`lastname` AS t1_r3, `users`.`mail` AS t1_r4, `users`.`admin` AS t1_r5, `users`.`status` AS t1_r6, `users`.`last_login_on` AS t1_r7, `users`.`language` AS t1_r8, `users`.`auth_source_id` AS t1_r9, `users`.`created_on` AS t1_r10, `users`.`updated_on` AS t1_r11, `users`.`type` AS t1_r12, `users`.`identity_url` AS t1_r13, `users`.`terms_accepted` AS t1_r14, `users`.`force_password_reset` AS t1_r15, `users`.`failed_login_count` AS t1_r16, `users`.`last_failed_login_on` AS t1_r17, `users`.`guarantor_id` AS t1_r18, `users`.`mail_notification` AS t1_r19, `users`.`verified_phone` AS t1_r20, `users`.`unverified_phone` AS t1_r21, `users`.`first_login` AS t1_r22, `users`.`default_otp_channel` AS t1_r23, `users`.`force_password_change` AS t1_r24 FROM `watchers` LEFT OUTER JOIN `users` ON `users`.`id` = `watchers`.`user_id` AND `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `watchers`.`watchable_type` = 'WorkPackage' AND `watchers`.`watchable_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  Attachment Load (1.2ms)  SELECT `attachments`.* FROM `attachments` WHERE `attachments`.`container_type` = 'WorkPackage' AND `attachments`.`container_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY attachments.filename
  TimeEntry Load (0.8ms)  SELECT `time_entries`.* FROM `time_entries` WHERE `time_entries`.`work_package_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  CostEntry Load (0.3ms)  SELECT `cost_entries`.* FROM `cost_entries` WHERE `cost_entries`.`work_package_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  CACHE (0.0ms)  SELECT `custom_fields`.* FROM `custom_fields` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND (is_for_all=1) ORDER BY position
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1
  UserPreference Load (0.5ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1  [["id", 917], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1  [["user_id", 917], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1400 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 118 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1400 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 118 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1237 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1237 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1
  UserPreference Load (0.5ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1  [["id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1  [["id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1  [["user_id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1  [["user_id", 917], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2069 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2069 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1  [["id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1  [["id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1  [["user_id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1  [["user_id", 917], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1045 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1045 LIMIT 1  [["id", 1045], ["LIMIT", 1]]
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1045 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1045 LIMIT 1  [["user_id", 1045], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1045 LIMIT 1  [["id", 1045], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1045 LIMIT 1  [["id", 1045], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1045 LIMIT 1  [["user_id", 1045], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1045 LIMIT 1  [["user_id", 1045], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1  [["id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1  [["user_id", 2958], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 508 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 508 LIMIT 1  [["id", 508], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 508 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 508 LIMIT 1  [["user_id", 508], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2069 LIMIT 1  [["id", 2069], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2069 LIMIT 1  [["user_id", 2069], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1  [["id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1  [["user_id", 911], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 375 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 375 LIMIT 1  [["id", 375], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 375 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 375 LIMIT 1  [["user_id", 375], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1454 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2322 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1454 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2322 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1309 LIMIT 1
  User Load (0.2ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2397 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1309 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2397 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 674 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 674 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 678 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 678 LIMIT 1  [["id", 678], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 678 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 678 LIMIT 1  [["user_id", 678], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 5201 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 5201 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1471 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1471 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1549 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 542 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1549 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 542 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 676 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 676 LIMIT 1  [["id", 676], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 676 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 676 LIMIT 1  [["user_id", 676], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 4379 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 989 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 4379 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 989 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 661 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 661 LIMIT 1
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1  [["id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1  [["id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1  [["user_id", 498], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1  [["user_id", 1593], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1400 LIMIT 1  [["id", 1400], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 542 LIMIT 1  [["id", 542], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1400 LIMIT 1  [["user_id", 1400], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 542 LIMIT 1  [["user_id", 542], ["LIMIT", 1]]
  CACHE (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1471 LIMIT 1  [["id", 1471], ["LIMIT", 1]]
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 300 LIMIT 1
  CACHE (0.0ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1471 LIMIT 1  [["user_id", 1471], ["LIMIT", 1]]
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 300 LIMIT 1
```

to

```
User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 26 LIMIT 1
   (0.2ms)  SELECT MAX(`settings`.`updated_on`) FROM `settings`
  Project Load (0.3ms)  SELECT  `projects`.* FROM `projects` WHERE `projects`.`identifier` = 'project3244' LIMIT 1
   (0.2ms)  SELECT `enabled_modules`.`name` FROM `enabled_modules` WHERE `enabled_modules`.`project_id` = 4516
  Type Load (2.7ms)  SELECT DISTINCT types.* FROM `types` INNER JOIN `projects_types` ON `projects_types`.`type_id` = `types`.`id` INNER JOIN `projects` ON `projects`.`id` = `projects_types`.`project_id` WHERE (projects.lft >= 5300 AND projects.rgt <= 5301 AND projects.status = 1) ORDER BY position ASC, types.position
  WorkPackageCustomField Load (0.5ms)  SELECT `custom_fields`.* FROM `custom_fields` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND (is_for_all=1) ORDER BY position
  WorkPackageCustomField Load (1.1ms)  SELECT `custom_fields`.* FROM `custom_fields` INNER JOIN `custom_fields_projects` ON `custom_fields_projects`.`custom_field_id` = `custom_fields`.`id` INNER JOIN `projects` ON `projects`.`id` = `custom_fields_projects`.`project_id` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `projects`.`id` = 4516
  CustomField::Translation Load (0.8ms)  SELECT `custom_field_translations`.* FROM `custom_field_translations` WHERE `custom_field_translations`.`custom_field_id` IN (158, 164, 170, 173, 176, 182, 268, 271, 292, 295, 298, 301, 304, 310, 328, 331, 334, 337, 346, 349, 352, 355, 358, 361, 364, 367, 370, 379, 382, 415, 418, 421, 427, 430, 433, 436, 439, 442, 445, 448, 454, 457, 505)
   (0.3ms)  SELECT COUNT(*) FROM `projects` WHERE (`projects`.`lft` >= 5300) AND (`projects`.`lft` < 5301) AND (`projects`.`id` != 4516) AND `projects`.`status` = 1
  SQL (7.3ms)  SELECT  DISTINCT `work_packages`.`id`,         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id, work_packages.lft AS alias_0 FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516)) ORDER BY         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id DESC, work_packages.lft ASC LIMIT 50 OFFSET 0
   (5.2ms)  SELECT `work_packages`.`id` FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516)) AND `work_packages`.`id` IN (383332, 406393, 406390, 405445, 405439, 405346, 405319, 405316, 405313, 405310, 405304, 405301, 405295, 405292, 405286, 405283, 405277, 405238, 405217, 405214, 405208, 403474, 403420, 403414, 403339, 401050, 400981, 400972, 400969, 400960, 400939, 400921, 400492, 399802, 399778, 399775, 399163, 399139, 395626, 395581, 395350, 395347, 395344, 395341, 395338, 395335, 395332, 394705, 394678, 394672) ORDER BY         COALESCE(    (SELECT cv_sort.value FROM custom_values cv_sort
        WHERE cv_sort.customized_type='WorkPackage'
        AND cv_sort.customized_id=work_packages.id
        AND cv_sort.custom_field_id=164 LIMIT 1)
, '')
, work_packages.root_id DESC, work_packages.lft ASC
   (16.1ms)  SELECT COUNT(DISTINCT `work_packages`.`id`) FROM `work_packages` INNER JOIN `projects` ON `projects`.`id` = `work_packages`.`project_id` LEFT OUTER JOIN `statuses` ON `statuses`.`id` = `work_packages`.`status_id` LEFT OUTER JOIN `types` ON `types`.`id` = `work_packages`.`type_id` LEFT OUTER JOIN `users` ON `users`.`id` = `work_packages`.`assigned_to_id` LEFT OUTER JOIN `work_packages` `parents_work_packages` ON `parents_work_packages`.`id` = `work_packages`.`parent_id` LEFT OUTER JOIN `custom_values` ON `custom_values`.`customized_id` = `work_packages`.`id` AND `custom_values`.`customized_type` = 'WorkPackage' LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1 AND (((work_packages.type_id IN ('215')) AND projects.id = 4516))
  WorkPackage Load (1.8ms)  SELECT SUM(time_entries.hours) AS hours, work_packages.* FROM `work_packages` LEFT OUTER JOIN `work_packages` `descendants` ON `descendants`.`root_id` = `work_packages`.`root_id` AND `descendants`.`lft` >= `work_packages`.`lft` AND `descendants`.`rgt` <= `work_packages`.`rgt` AND `descendants`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('work_package_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) LEFT OUTER JOIN `time_entries` ON `time_entries`.`work_package_id` = `descendants`.`id` AND `time_entries`.`id` IN (SELECT `time_entries`.`id` FROM `time_entries` WHERE (`time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) OR `time_entries`.`project_id` IN (SELECT DISTINCT `projects`.`id` FROM `projects` INNER JOIN `enabled_modules` ON `projects`.`id` = `enabled_modules`.`project_id` AND `enabled_modules`.`name` IN ('time_tracking') AND `projects`.`status` = 1 WHERE `projects`.`status` = 1) AND `time_entries`.`user_id` = 26)) WHERE `work_packages`.`id` IN (383332, 406393, 406390, 405445, 405439, 405346, 405319, 405316, 405313, 405310, 405304, 405301, 405295, 405292, 405286, 405283, 405277, 405238, 405217, 405214, 405208, 403474, 403420, 403414, 403339, 401050, 400981, 400972, 400969, 400960, 400939, 400921, 400492, 399802, 399778, 399775, 399163, 399139, 395626, 395581, 395350, 395347, 395344, 395341, 395338, 395335, 395332, 394705, 394678, 394672) GROUP BY `work_packages`.`id`
  WorkPackage Load (0.6ms)  SELECT `work_packages`.* FROM `work_packages` WHERE `work_packages`.`parent_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY `work_packages`.`lft`
  Project Load (0.3ms)  SELECT `projects`.* FROM `projects` WHERE `projects`.`id` = 4516
  EnabledModule Load (0.3ms)  SELECT `enabled_modules`.* FROM `enabled_modules` WHERE `enabled_modules`.`project_id` = 4516
  SQL (0.8ms)  SELECT `custom_fields_projects`.`custom_field_id` AS t0_r0, `custom_fields_projects`.`project_id` AS t0_r1, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_fields_projects` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_fields_projects`.`custom_field_id` AND `custom_fields`.`type` IN ('WorkPackageCustomField') WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `custom_fields_projects`.`project_id` = 4516 ORDER BY custom_fields.position
  Status Load (0.2ms)  SELECT `statuses`.* FROM `statuses` WHERE `statuses`.`id` = 14 ORDER BY position ASC
  IssuePriority Load (0.2ms)  SELECT `enumerations`.* FROM `enumerations` WHERE `enumerations`.`type` IN ('IssuePriority') AND `enumerations`.`id` = 4 ORDER BY enumerations.position ASC
  Type Load (0.2ms)  SELECT `types`.* FROM `types` WHERE `types`.`id` = 215 ORDER BY position ASC
  SQL (0.9ms)  SELECT `custom_fields_types`.`custom_field_id` AS t0_r0, `custom_fields_types`.`type_id` AS t0_r1, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_fields_types` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_fields_types`.`custom_field_id` AND `custom_fields`.`type` IN ('WorkPackageCustomField') WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND `custom_fields_types`.`type_id` = 215
  Version Load (0.4ms)  SELECT `versions`.* FROM `versions` WHERE `versions`.`id` IN (11161, 12484, 12412, 12238)
  SQL (17.0ms)  SELECT `custom_values`.`id` AS t0_r0, `custom_values`.`customized_type` AS t0_r1, `custom_values`.`customized_id` AS t0_r2, `custom_values`.`custom_field_id` AS t0_r3, `custom_values`.`value` AS t0_r4, `custom_fields`.`id` AS t1_r0, `custom_fields`.`type` AS t1_r1, `custom_fields`.`field_format` AS t1_r2, `custom_fields`.`regexp` AS t1_r3, `custom_fields`.`min_length` AS t1_r4, `custom_fields`.`max_length` AS t1_r5, `custom_fields`.`is_required` AS t1_r6, `custom_fields`.`is_for_all` AS t1_r7, `custom_fields`.`is_filter` AS t1_r8, `custom_fields`.`position` AS t1_r9, `custom_fields`.`searchable` AS t1_r10, `custom_fields`.`editable` AS t1_r11, `custom_fields`.`visible` AS t1_r12, `custom_fields`.`created_at` AS t1_r13, `custom_fields`.`updated_at` AS t1_r14 FROM `custom_values` LEFT OUTER JOIN `custom_fields` ON `custom_fields`.`id` = `custom_values`.`custom_field_id` WHERE `custom_values`.`customized_type` = 'WorkPackage' AND `custom_values`.`customized_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY custom_fields.position
  User Load (0.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` IN (2388, 140, 1752, 1185)
  SQL (0.9ms)  SELECT `watchers`.`id` AS t0_r0, `watchers`.`watchable_type` AS t0_r1, `watchers`.`watchable_id` AS t0_r2, `watchers`.`user_id` AS t0_r3, `users`.`id` AS t1_r0, `users`.`login` AS t1_r1, `users`.`firstname` AS t1_r2, `users`.`lastname` AS t1_r3, `users`.`mail` AS t1_r4, `users`.`admin` AS t1_r5, `users`.`status` AS t1_r6, `users`.`last_login_on` AS t1_r7, `users`.`language` AS t1_r8, `users`.`auth_source_id` AS t1_r9, `users`.`created_on` AS t1_r10, `users`.`updated_on` AS t1_r11, `users`.`type` AS t1_r12, `users`.`identity_url` AS t1_r13, `users`.`terms_accepted` AS t1_r14, `users`.`force_password_reset` AS t1_r15, `users`.`failed_login_count` AS t1_r16, `users`.`last_failed_login_on` AS t1_r17, `users`.`guarantor_id` AS t1_r18, `users`.`mail_notification` AS t1_r19, `users`.`verified_phone` AS t1_r20, `users`.`unverified_phone` AS t1_r21, `users`.`first_login` AS t1_r22, `users`.`default_otp_channel` AS t1_r23, `users`.`force_password_change` AS t1_r24 FROM `watchers` LEFT OUTER JOIN `users` ON `users`.`id` = `watchers`.`user_id` AND `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `watchers`.`watchable_type` = 'WorkPackage' AND `watchers`.`watchable_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  Attachment Load (0.7ms)  SELECT `attachments`.* FROM `attachments` WHERE `attachments`.`container_type` = 'WorkPackage' AND `attachments`.`container_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393) ORDER BY attachments.filename
  TimeEntry Load (0.6ms)  SELECT `time_entries`.* FROM `time_entries` WHERE `time_entries`.`work_package_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  CostEntry Load (0.3ms)  SELECT `cost_entries`.* FROM `cost_entries` WHERE `cost_entries`.`work_package_id` IN (383332, 394672, 394678, 394705, 395332, 395335, 395338, 395341, 395344, 395347, 395350, 395581, 395626, 399139, 399163, 399775, 399778, 399802, 400492, 400921, 400939, 400960, 400969, 400972, 400981, 401050, 403339, 403414, 403420, 403474, 405208, 405214, 405217, 405238, 405277, 405283, 405286, 405292, 405295, 405301, 405304, 405310, 405313, 405316, 405319, 405346, 405439, 405445, 406390, 406393)
  CACHE (0.0ms)  SELECT `custom_fields`.* FROM `custom_fields` WHERE `custom_fields`.`type` IN ('WorkPackageCustomField') AND (is_for_all=1) ORDER BY position
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 498 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1593 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 498 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1593 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 917 LIMIT 1
  UserPreference Load (0.4ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 917 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1400 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 118 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1400 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 118 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1237 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1237 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 911 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 911 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2069 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2069 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2958 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2958 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1045 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1045 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 508 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 508 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 375 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 375 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1454 LIMIT 1
  User Load (0.2ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2322 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1454 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2322 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1309 LIMIT 1
  User Load (0.2ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 2397 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1309 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 2397 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 674 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 674 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 678 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 678 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 5201 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 5201 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1471 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1471 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 1549 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 542 LIMIT 1
  UserPreference Load (0.2ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 1549 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 542 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 676 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 676 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 4379 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 989 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 4379 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 989 LIMIT 1
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 661 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 661 LIMIT 1
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User', 'AnonymousUser', 'DeletedUser') AND `users`.`id` = 300 LIMIT 1
  UserPreference Load (0.3ms)  SELECT  `user_preferences`.* FROM `user_preferences` WHERE `user_preferences`.`user_id` = 300 LIMIT 1
```

And the request time drops by one third.