### PR TITLE
[24272] Fix enabled_modules usage in project copy

### DIFF
--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -43,7 +43,7 @@ module Project::Copy
     def copy_attributes(project)
       super
       with_model(project) do |project|
-        self.enabled_modules = project.enabled_modules
+        self.enabled_module_names = project.enabled_module_names
         self.types = project.types
         self.custom_values = project.custom_values.map(&:clone)
         self.work_package_custom_fields = project.work_package_custom_fields

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -169,9 +169,12 @@ describe CopyProjectJob, type: :model do
 
         subject { Project.find_by(identifier: 'copy') }
 
-        it { expect(subject).not_to be_nil }
+        it 'copies the project' do
+          expect(subject).not_to be_nil
+          expect(subject.parent).to eql(project)
 
-        it { expect(subject.parent).to eql(project) }
+          expect(subproject.reload.enabled_module_names).not_to be_empty
+        end
       end
     end
   end

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -650,7 +650,7 @@ describe Project, type: :model do
 
     # Duplicated attributes
     assert_equal source_project.description, copied_project.description
-    assert_equal source_project.enabled_modules, copied_project.enabled_modules
+    assert_equal source_project.enabled_module_names.sort, copied_project.enabled_module_names.sort
     assert_equal source_project.types, copied_project.types
 
     # Default attributes


### PR DESCRIPTION
Fixes unselecting enabled_modules of the source project due to re-using the `enabled_modules` of it since they are updated to the new project_id upon saving.