### PR TITLE
Suggestion: Add gem to log the last trace to a SQL query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,6 +224,7 @@ group :development do
   gem 'pry-doc', '~> 0.9.0'
 
   gem 'rubocop'
+  gem 'active_record_query_trace'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_record_query_trace (1.5.4)
     activejob (5.0.0.1)
       activesupport (= 5.0.0.1)
       globalid (>= 0.3.6)
@@ -592,6 +593,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-xml_parser (~> 2.0.0)
+  active_record_query_trace
   activemodel-serializers-xml (~> 1.0.1)
   activerecord-jdbcmysql-adapter
   activerecord-jdbcpostgresql-adapter

--- a/config/initializers/active_record_query_trace.rb
+++ b/config/initializers/active_record_query_trace.rb
@@ -1,0 +1,5 @@
+if Rails.env.development?
+  ActiveRecordQueryTrace.enabled = true
+  ActiveRecordQueryTrace.lines = 1
+  ActiveRecordQueryTrace.colorize = 'light purple'
+end


### PR DESCRIPTION
I often find myself looking for a trace of a particular SQL query logged during development, which is exactly what the `active_record_query_trace` gem is doing. 

This adds a colored trace of the _last_ line an SQL line has been executed from, excluding rails gems.
![bildschirmfoto 2016-11-15 um 15 30 42](https://cloud.githubusercontent.com/assets/459462/20309524/8ac5a5a6-ab48-11e6-946e-408cd20a9774.png)
