### PR TITLE
[24262] Load broken queries to let the user fix it

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -40,6 +40,11 @@
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
+//
+.wp-table--faulty-query-icon
+  color: $nm-color-error-icon
+
+
 // Show details view button when hovering
 .wp-table--details-link
   .issue:hover &,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -431,6 +431,9 @@ en:
         header_no_type: 'New work package (Type not yet set)'
         header_with_parent: 'New %{type} (Child of %{parent_type} #%{id})'
         button: 'Create'
+      faulty_query:
+        title: Work packages could not be loaded.
+        description: Your query is erroneous and could not be processed.
       no_results:
         title: No work packages to display.
         description: Either none have been created or all work packages are filtered out.

--- a/frontend/app/components/filters/query-model/query-model.service.ts
+++ b/frontend/app/components/filters/query-model/query-model.service.ts
@@ -34,6 +34,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
 
     this.filters = [];
     this.groupBy = this.groupBy || '';
+    this.hasError = false;
 
     if(queryData.filters){
       if(options && options.rawFilters) {

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -78,6 +78,7 @@
                 columns="columns"
                 rows="rows"
                 query="query"
+                queryError="queryError"
                 group-by="query.groupBy"
                 group-headers="groupHeaders"
                 display-sums="query.displaySums"

--- a/frontend/app/components/wp-list/wp-list.service.ts
+++ b/frontend/app/components/wp-list/wp-list.service.ts
@@ -109,6 +109,10 @@ export class WorkPackagesListService {
           this.mergeApiResponses(json, workPackageCollection);
 
           deferred.resolve(json);
+        })
+        .catch((error) => {
+          this.mergeApiResponses(json, { elements: [], count: 0, total: 0 });
+          deferred.reject({ error: error, json: json });
         });
     });
 

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -46,14 +46,18 @@
         <!-- Empty row notification -->
         <tr id="empty-row-notification" ng-if="!rows.length">
           <td colspan="{{ numTableColumns }}">
-            <span>
+            <span ng-if="!query.hasError">
               <i class="icon-info1 icon-context"></i>
-              <strong ng-bind="text.noResults"></strong>
-              <span ng-bind="text.noResultsDescription"></span>
+              <strong ng-bind="text.noResults.title"></strong>
+              <span ng-bind="text.noResults.description"></span>
+            </span>
+            <span ng-if="query.hasError">
+              <i class="wp-table--faulty-query-icon icon-warning icon-context"></i>
+              <strong ng-bind="text.faultyQuery.title"></strong>
+              <span ng-bind="text.faultyQuery.description"></span>
             </span>
           </td>
         </tr>
-
         <!-- Group headers -->
 
         <tr wp-group-header

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -279,8 +279,14 @@ function WorkPackagesTableController($scope, $rootScope, I18n) {
     expand: I18n.t('js.label_expand'),
     sumFor: I18n.t('js.label_sum_for'),
     allWorkPackages: I18n.t('js.label_all_work_packages'),
-    noResults: I18n.t('js.work_packages.no_results.title'),
-    noResultsDescription: I18n.t('js.work_packages.no_results.description'),
+    noResults: {
+      title: I18n.t('js.work_packages.no_results.title'),
+      description: I18n.t('js.work_packages.no_results.description')
+    },
+    faultyQuery: {
+      title: I18n.t('js.work_packages.faulty_query.title'),
+      description: I18n.t('js.work_packages.faulty_query.description')
+    },
     tableSummary: I18n.t('js.work_packages.table.summary'),
     tableSummaryHints: [
       I18n.t('js.work_packages.table.text_inline_edit'),

--- a/spec/features/work_packages/table/invalid_query_spec.rb
+++ b/spec/features/work_packages/table/invalid_query_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'Invalid query spec', js: true do
+  let(:user) { FactoryGirl.create :admin }
+  let(:project) { FactoryGirl.create :project }
+
+  let(:wp_table) { ::Pages::WorkPackagesTable.new }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+
+  let(:query) {
+    query = FactoryGirl.create(:query,
+                               project: project,
+                               user: user)
+
+    query.add_filter('assigned_to_id', '=', [99999])
+    query.save!(validate: false)
+
+    query
+  }
+
+  before do
+    login_as(user)
+    wp_table.visit_query(query)
+  end
+
+  # Regression test for bug #24114 (broken watcher filter)
+  it 'should load the faulty query' do
+    expect(page).to have_selector(".notification-box.-error", wait: 10)
+    expect(page).to have_selector('#empty-row-notification .wp-table--faulty-query-icon')
+
+    filters.open
+    filters.expect_filter_count 2
+    expect(page).to have_select('values-assignee', selected: I18n.t('js.placeholders.selection'))
+  end
+end


### PR DESCRIPTION
When the API experimental returns a query that turns out to be invalid,
an error is returned from APIv3. This causes the filters to remain
hidden and thus leaves the user unable to correct the query.

Instead, we can render the query with a pseudo-empty response and create
a warning message similar to the no results row.

https://community.openproject.com/projects/openproject/work_packages/24262?query_id=892