### PR TITLE
[24335] Long filenames break the attachments styling

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
@@ -54,8 +54,9 @@ a.inplace-editing--trigger-link,
     display: inline-block
     span
       line-height: 2
-    i
-      vertical-align: middle
+
+  .inplace-editing--container
+    position: relative
 
 .work-package--details--long-field
   .inplace-edit--read .inplace-edit--read-value
@@ -70,15 +71,20 @@ a.inplace-editing--trigger-link,
       float: inherit
 
 .inplace-edit--icon-wrapper
-  display: inline-block
+  position: absolute
+  height: 100%
+  right: 0
   text-align: center
   width: 32px
-  line-height: 2.5
   background: $gray-light
   border-left: 1px solid $inplace-edit--border-color
   color: $body-font-color
   visibility: hidden
-  float: right
+
+  .icon-context
+    position: relative
+    // Position the icon in the middle
+    top: calc(50% - 0.5rem)
 
   .icon-context:before
     // HACK: overriding default padding here

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -221,14 +221,20 @@
     padding: 0.375rem 0.6rem
 
     i
-      margin-right: 0.6rem
       display: inline-block
+      &:before
+        vertical-align: middle
+        padding-top: 0
 
   .work-package--attachments--filename
     display: inline-block
     line-height: 1.4
+    // FF & IE
+    word-break: break-all
+    // Chrome & Safari
     word-break: break-word
     width: 90%
+    vertical-align: middle
 
 .work-package--attachments--drop-box
   border: 2px dashed $light-gray

--- a/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
+++ b/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
@@ -3,7 +3,7 @@
         ng-class="{'-focus': $ctrl.isFocused(attachment)}">
     <span class="inplace-editing--container">
       <span class="inplace-edit--read-value">
-        <i class="icon-attachment"></i>
+        <i class="icon-context icon-attachment"></i>
         <a
             class="work-package--attachments--filename"
             ng-href="{{ ::attachment.downloadLocation.href || '#' }}"


### PR DESCRIPTION
This fixes the styling errors within the attachments list. When an attachment has a very long name the styling was broken (see picture).

https://community.openproject.com/work_packages/24335/activity