### PR TITLE
[24339] Adapt left border distance in WP full screen view

### DIFF
--- a/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/_work_packages_show_view_overwrite.scss
@@ -31,11 +31,6 @@ body.controller-work_packages.action-show {
 
   #content {
     padding-left: 15px;
-
-    .work-packages--split-view {
-      margin-left: -5px;
-      width: calc(100% + 5px);
-    }
   }
 }
 


### PR DESCRIPTION
This equals the distance to the left of the left panel to the one of the right panel.

https://community.openproject.com/work_packages/24339/activity