### PR TITLE
[24174] Allow users to filter work packages by date or range of date

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -35,6 +35,27 @@
   &.collapsed
     display: none
 
+.advanced-filters--operator-value-container
+  display: flex
+  flex: 1 1 auto
+  flex-flow: row wrap
+  align-items: flex-start
+  min-width: 40%
+  max-width: 600px
+
+.advanced-filters--value-container
+  display: flex
+  align-items: flex-start
+  flex: 1 1 auto
+  flex-flow: row nowrap
+
+.advanced-filters--value-container > *
+  margin-right: 8px
+
+.advanced-filters--value-container
+  .advanced-filters--date-field
+    min-width: 100px
+
 @mixin advanced-filters--sizing()
   @include grid-block()
 

--- a/app/models/queries/base_filter.rb
+++ b/app/models/queries/base_filter.rb
@@ -40,25 +40,27 @@ class Queries::BaseFilter
   self.filter_params = [:operator, :values]
 
   self.operators = {
-    label_equals:               '=',
-    label_not_equals:           '!',
-    label_open_work_packages:   'o',
-    label_closed_work_packages: 'c',
-    label_none:                 '!*',
-    label_all:                  '*',
-    label_greater_or_equal:     '>=',
-    label_less_or_equal:        '<=',
-    label_in_less_than:         '<t+',
-    label_in_more_than:         '>t+',
-    label_in:                   't+',
-    label_today:                't',
-    label_this_week:            'w',
-    label_less_than_ago:        '>t-',
-    label_more_than_ago:        '<t-',
-    label_ago:                  't-',
-    label_contains:             '~',
-    label_not_contains:         '!~'
-  }.invert
+    '=': 'label_equals',
+    '!': 'label_not_equals',
+    'o': 'label_open_work_packages',
+    'c': 'label_closed_work_packages',
+    '!*': 'label_none',
+    '*': 'label_all',
+    '>=': 'label_greater_or_equal',
+    '<=': 'label_less_or_equal',
+    '<t+': 'label_in_less_than',
+    '>t+': 'label_in_more_than',
+    't+': 'label_in',
+    't': 'label_today',
+    'w': 'label_this_week',
+    '>t-': 'label_less_than_ago',
+    '<t-': 'label_more_than_ago',
+    't-': 'label_ago',
+    '~': 'label_contains',
+    '!~': 'label_not_contains',
+    '=d': 'label_on',
+    '<>d': 'label_between'
+  }
 
   self.operators_not_requiring_values = %w(o c !* * t w)
 
@@ -67,8 +69,8 @@ class Queries::BaseFilter
     list_status:      ['o', '=', '!', 'c', '*'],
     list_optional:    ['=', '!', '!*', '*'],
     list_subprojects: ['*', '!*', '='],
-    date:             ['<t+', '>t+', 't+', 't', 'w', '>t-', '<t-', 't-'],
-    date_past:        ['>t-', '<t-', 't-', 't', 'w'],
+    date:             ['<t+', '>t+', 't+', 't', 'w', '>t-', '<t-', 't-', '=d', '<>d'],
+    datetime_past:    ['>t-', '<t-', 't-', 't', 'w'],
     string:           ['=', '~', '!', '!~'],
     text:             ['~', '!~'],
     integer:          ['=', '>=', '<=', '!*', '*']
@@ -173,10 +175,20 @@ class Queries::BaseFilter
     return true if self.class.operators_not_requiring_values.include?(operator)
 
     case type
-    when :integer, :date, :date_past
-      validate_values_all_integer
+      when :integer, :date, :datetime_past
+        if operator == '=d' || operator == '<>d'
+          validate_values_all_date
+        else
+          validate_values_all_integer
+        end
     when :list, :list_optional
       validate_values_in_allowed_values_list
+    end
+  end
+
+  def validate_values_all_date
+    unless values.all? { |value| value != 'undefined' ? date?(value) : true }
+      errors.add(:values, I18n.t('activerecord.errors.messages.not_a_date'))
     end
   end
 
@@ -197,6 +209,12 @@ class Queries::BaseFilter
 
   def integer?(str)
     true if Integer(str)
+  rescue
+    false
+  end
+
+  def date?(str)
+    true if Date.parse(str)
   rescue
     false
   end

--- a/app/models/queries/sql_for_field.rb
+++ b/app/models/queries/sql_for_field.rb
@@ -37,84 +37,106 @@ module Queries::SqlForField
 
     sql = ''
     case operator
-    when '='
-      if values.present?
-        if values.include?('-1')
-          sql = "#{db_table}.#{db_field} IS NULL OR "
+      when '='
+        if values.present?
+          if values.include?('-1')
+            sql = "#{db_table}.#{db_field} IS NULL OR "
+          end
+
+          sql += "#{db_table}.#{db_field} IN (" + values.map { |val| "'#{connection.quote_string(val)}'" }.join(',') + ')'
+        else
+          # empty set of allowed values produces no result
+          sql = '0=1'
         end
-
-        sql += "#{db_table}.#{db_field} IN (" + values.map { |val| "'#{connection.quote_string(val)}'" }.join(',') + ')'
-      else
-        # empty set of allowed values produces no result
-        sql = '0=1'
-      end
-    when '!'
-      if values.present?
-        sql = "(#{db_table}.#{db_field} IS NULL OR #{db_table}.#{db_field} NOT IN (" + values.map { |val| "'#{connection.quote_string(val)}'" }.join(',') + '))'
-      else
-        # empty set of forbidden values allows all results
-        sql = '1=1'
-      end
-    when '!*'
-      sql = "#{db_table}.#{db_field} IS NULL"
-      sql << " OR #{db_table}.#{db_field} = ''" if is_custom_filter
-    when '*'
-      sql = "#{db_table}.#{db_field} IS NOT NULL"
-      sql << " AND #{db_table}.#{db_field} <> ''" if is_custom_filter
-    when '>='
-      if is_custom_filter
-        sql = "#{db_table}.#{db_field} != '' AND CAST(#{db_table}.#{db_field} AS decimal(60,4)) >= #{values.first.to_f}"
-      else
-        sql = "#{db_table}.#{db_field} >= #{values.first.to_f}"
-      end
-    when '<='
-      if is_custom_filter
-        sql = "#{db_table}.#{db_field} != '' AND CAST(#{db_table}.#{db_field} AS decimal(60,4)) <= #{values.first.to_f}"
-      else
-        sql = "#{db_table}.#{db_field} <= #{values.first.to_f}"
-      end
-    when 'o'
-      sql = "#{Status.table_name}.is_closed=#{connection.quoted_false}" if field == 'status_id'
-    when 'c'
-      sql = "#{Status.table_name}.is_closed=#{connection.quoted_true}" if field == 'status_id'
-    when '>t-'
-      sql = date_range_clause(db_table, db_field, - values.first.to_i, 0)
-    when '<t-'
-      sql = date_range_clause(db_table, db_field, nil, - values.first.to_i)
-    when 't-'
-      sql = date_range_clause(db_table, db_field, - values.first.to_i, - values.first.to_i)
-    when '>t+'
-      sql = date_range_clause(db_table, db_field, values.first.to_i, nil)
-    when '<t+'
-      sql = date_range_clause(db_table, db_field, 0, values.first.to_i)
-    when 't+'
-      sql = date_range_clause(db_table, db_field, values.first.to_i, values.first.to_i)
-    when 't'
-      sql = date_range_clause(db_table, db_field, 0, 0)
-    when 'w'
-      from = l(:general_first_day_of_week) == '7' ?
-      # week starts on sunday
-      ((Date.today.cwday == 7) ? Time.now.at_beginning_of_day : Time.now.at_beginning_of_week - 1.day) :
-        # week starts on monday (Rails default)
-        Time.now.at_beginning_of_week
-      sql = "#{db_table}.#{db_field} BETWEEN '%s' AND '%s'" % [connection.quoted_date(from), connection.quoted_date(from + 7.days)]
-    when '~'
-      sql = "LOWER(#{db_table}.#{db_field}) LIKE '%#{connection.quote_string(values.first.to_s.downcase)}%'"
-    when '!~'
-      sql = "LOWER(#{db_table}.#{db_field}) NOT LIKE '%#{connection.quote_string(values.first.to_s.downcase)}%'"
+      when '!'
+        if values.present?
+          sql = "(#{db_table}.#{db_field} IS NULL OR #{db_table}.#{db_field} NOT IN (" + values.map { |val| "'#{connection.quote_string(val)}'" }.join(',') + '))'
+        else
+          # empty set of forbidden values allows all results
+          sql = '1=1'
+        end
+      when '!*'
+        sql = "#{db_table}.#{db_field} IS NULL"
+        sql << " OR #{db_table}.#{db_field} = ''" if is_custom_filter
+      when '*'
+        sql = "#{db_table}.#{db_field} IS NOT NULL"
+        sql << " AND #{db_table}.#{db_field} <> ''" if is_custom_filter
+      when '>='
+        if is_custom_filter
+          sql = "#{db_table}.#{db_field} != '' AND CAST(#{db_table}.#{db_field} AS decimal(60,4)) >= #{values.first.to_f}"
+        else
+          sql = "#{db_table}.#{db_field} >= #{values.first.to_f}"
+        end
+      when '<='
+        if is_custom_filter
+          sql = "#{db_table}.#{db_field} != '' AND CAST(#{db_table}.#{db_field} AS decimal(60,4)) <= #{values.first.to_f}"
+        else
+          sql = "#{db_table}.#{db_field} <= #{values.first.to_f}"
+        end
+      when 'o'
+        sql = "#{Status.table_name}.is_closed=#{connection.quoted_false}" if field == 'status_id'
+      when 'c'
+        sql = "#{Status.table_name}.is_closed=#{connection.quoted_true}" if field == 'status_id'
+      when '>t-'
+        sql = relative_date_range_clause(db_table, db_field, - values.first.to_i, 0)
+      when '<t-'
+        sql = relative_date_range_clause(db_table, db_field, nil, - values.first.to_i)
+      when 't-'
+        sql = relative_date_range_clause(db_table, db_field, - values.first.to_i, - values.first.to_i)
+      when '>t+'
+        sql = relative_date_range_clause(db_table, db_field, values.first.to_i, nil)
+      when '<t+'
+        sql = relative_date_range_clause(db_table, db_field, 0, values.first.to_i)
+      when 't+'
+        sql = relative_date_range_clause(db_table, db_field, values.first.to_i, values.first.to_i)
+      when 't'
+        sql = relative_date_range_clause(db_table, db_field, 0, 0)
+      when 'w'
+        from = l(:general_first_day_of_week) == '7' ?
+        # week starts on sunday
+        ((Date.today.cwday == 7) ? Time.now.at_beginning_of_day : Time.now.at_beginning_of_week - 1.day) :
+          # week starts on monday (Rails default)
+          Time.now.at_beginning_of_week
+        sql = "#{db_table}.#{db_field} BETWEEN '%s' AND '%s'" % [connection.quoted_date(from), connection.quoted_date(from + 7.days)]
+      when '~'
+        sql = "LOWER(#{db_table}.#{db_field}) LIKE '%#{connection.quote_string(values.first.to_s.downcase)}%'"
+      when '!~'
+        sql = "LOWER(#{db_table}.#{db_field}) NOT LIKE '%#{connection.quote_string(values.first.to_s.downcase)}%'"
+      when '=d'
+        sql = date_range_clause(db_table, db_field, Date.parse(values.first), Date.parse(values.first))
+      when '<>d'
+        if (values.first != 'undefined')
+          from = Date.parse(values.first)
+        end
+        if (values.size == 2)
+          to = Date.parse(values.last)
+        end
+        sql = date_range_clause(db_table, db_field, from, to)
     end
-
     sql
   end
 
-  # Returns a SQL clause for a date or datetime field.
+  # Returns a SQL clause for a date or datetime field for a relative range from the end of the day of yesterday + from
+  # until the end of today + to.
+  def relative_date_range_clause(table, field, from, to)
+    if from
+      fromDate = Date.today + from
+    end
+    if to
+      toDate = Date.today + to
+    end
+    return date_range_clause(table, field, fromDate, toDate)
+  end
+
+  # Returns a SQL clause for date or datetime field for an exact range starting at the beginning of the day of from
+  # until the end of the day of to
   def date_range_clause(table, field, from, to)
     s = []
     if from
-      s << ("#{table}.#{field} > '%s'" % [connection.quoted_date((Date.yesterday + from).to_time.end_of_day)])
+      s << ("#{table}.#{field} > '%s'" % [connection.quoted_date(from.yesterday.to_time(:utc).end_of_day)])
     end
     if to
-      s << ("#{table}.#{field} <= '%s'" % [connection.quoted_date((Date.today + to).to_time.end_of_day)])
+      s << ("#{table}.#{field} <= '%s'" % [connection.quoted_date(to.to_time(:utc).end_of_day)])
     end
     s.join(' AND ')
   end

--- a/app/models/queries/work_packages/filter/created_at_filter.rb
+++ b/app/models/queries/work_packages/filter/created_at_filter.rb
@@ -29,7 +29,7 @@
 
 class Queries::WorkPackages::Filter::CreatedAtFilter < Queries::WorkPackages::Filter::WorkPackageFilter
   def type
-    :date_past
+    :datetime_past
   end
 
   def order

--- a/app/models/queries/work_packages/filter/updated_at_filter.rb
+++ b/app/models/queries/work_packages/filter/updated_at_filter.rb
@@ -29,7 +29,7 @@
 
 class Queries::WorkPackages::Filter::UpdatedAtFilter < Queries::WorkPackages::Filter::WorkPackageFilter
   def type
-    :date_past
+    :datetime_past
   end
 
   def order

--- a/config/application.rb
+++ b/config/application.rb
@@ -118,6 +118,7 @@ module OpenProject
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'UTC'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -913,6 +913,7 @@ en:
   label_available_project_versions: 'Available versions'
   label_available_project_repositories: 'Available repositories'
   label_api_documentation: "API documentation"
+  label_between: "between"
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_blog: "Blog"
@@ -1124,6 +1125,7 @@ en:
   label_not_contains: "doesn't contain"
   label_not_equals: "is not"
   label_notify_member_plural: "Email updates"
+  label_on: "on"
   label_open_menu: "Open menu"
   label_open_work_packages: "open"
   label_open_work_packages_plural: "open"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -98,6 +98,7 @@ en:
     label_all_work_packages: "all work packages"
     label_ascending: "Ascending"
     label_author: "Author: %{user}"
+    label_between: "between"
     label_board_locked: "Locked"
     label_board_sticky: "Sticky"
     label_create_work_package: "Create new work package"

--- a/frontend/app/components/filters/filter-model/filter-model.service.test.ts
+++ b/frontend/app/components/filters/filter-model/filter-model.service.test.ts
@@ -55,7 +55,7 @@ describe('Filter', function () {
     var filter, textValue;
 
     beforeEach(function () {
-      filter = Factory.build('Filter', {name: 'subject', values: []});
+      filter = Factory.build('Filter', {name: 'subject', type:'string', values: []});
     });
 
     describe('and the text value is set', function () {
@@ -70,6 +70,82 @@ describe('Filter', function () {
 
       it('should serialize the text value', function () {
         expect(filter.getValuesAsArray()).to.eql([textValue]);
+      });
+    });
+  });
+
+  describe('single date filter', function () {
+    var filter, dateValue;
+
+    beforeEach(function () {
+      filter = Factory.build('Filter', {name: 'createdAt', type: 'date', operator: '=d', values: []});
+    });
+
+    describe('and the date value is set', function () {
+      beforeEach(function () {
+        dateValue = '2016-12-01';
+        filter.dateValue = dateValue;
+      });
+
+      it('is considered to be configured', function () {
+        expect(filter.isConfigured()).to.be.true;
+      });
+
+      it('should serialize the date value', function () {
+        expect(filter.getValuesAsArray()).to.eql([dateValue]);
+      });
+    });
+  });
+
+  describe('date range filter', function () {
+    var filter, dateValues;
+
+    beforeEach(function () {
+      filter = Factory.build('Filter', {name: 'createdAt', type: 'date', operator: '<>d', values: []});
+    });
+
+    describe('and the values are set incl. both from and until', function () {
+      beforeEach(function () {
+        dateValues = ['2016-12-01', '2016-12-31'];
+        filter.values = {'0': dateValues[0], '1': dateValues[1]};
+      });
+
+      it('is considered to be configured', function () {
+        expect(filter.isConfigured()).to.be.true;
+      });
+
+      it('should serialize the date values', function () {
+        expect(filter.getValuesAsArray()).to.eql(dateValues);
+      });
+    });
+
+    describe('and the values are set incl. from excl. until', function () {
+      beforeEach(function () {
+        dateValues = ['2016-12-01'];
+        filter.values = {'0': dateValues[0], '1': dateValues[1]};
+      });
+
+      it('is considered to be configured', function () {
+        expect(filter.isConfigured()).to.be.true;
+      });
+
+      it('should serialize the date values', function () {
+        expect(filter.getValuesAsArray()).to.eql(dateValues);
+      });
+    });
+
+    describe('and the values are set excl. from incl. until', function () {
+      beforeEach(function () {
+        dateValues = ['undefined', '2016-12-31'];
+        filter.values = {'0': dateValues[0], '1': dateValues[1]};
+      });
+
+      it('is considered to be configured', function () {
+        expect(filter.isConfigured()).to.be.true;
+      });
+
+      it('should serialize the date values', function () {
+        expect(filter.getValuesAsArray()).to.eql(dateValues);
       });
     });
   });

--- a/frontend/app/components/filters/filters.constants.ts
+++ b/frontend/app/components/filters/filters.constants.ts
@@ -31,5 +31,6 @@ import {filtersModule} from '../../angular-modules';
 filtersModule
   .constant('ADD_FILTER_SELECT_INDEX', -1)
   .constant('OPERATORS_NOT_REQUIRING_VALUES', ['o', 'c', '!*', '*', 't', 'w'])
+  .constant('MULTIPLE_VALUE_FILTER_OPERATORS', '<>d')
   .constant('SELECTABLE_FILTER_TYPES',
     ['list', 'list_optional', 'list_status', 'list_subprojects', 'list_model']);

--- a/frontend/app/components/filters/query-filter/query-filter.directive.ts
+++ b/frontend/app/components/filters/query-filter/query-filter.directive.ts
@@ -34,6 +34,7 @@ function queryFilterDirective($timeout,
                               QueryService,
                               PaginationService,
                               I18n,
+                              TimezoneService,
                               OPERATORS_NOT_REQUIRING_VALUES) {
   var updateResultsJob;
 
@@ -78,18 +79,13 @@ function queryFilterDirective($timeout,
       });
 
       scope.$watch('filter', function (filter, oldFilter) {
-        var isEmptyText = filter.type === 'text' && filter.textValue === undefined;
-        var isEmptySelect = filter.type === 'list_status' && filter.values && filter.values[0] === 'undefined';
+        if (filter !== oldFilter && (filter.hasValues() || filter.isConfigured())
+          && (filterChanged(filter, oldFilter) || valueReset(filter, oldFilter))) {
 
-        if (filter !== oldFilter && !isEmptySelect) {
-          if ((isEmptyText || filter.isConfigured())
-            && (filterChanged(filter, oldFilter) || valueReset(filter, oldFilter))) {
-
-            PaginationService.resetPage();
-            scope.$emit('queryStateChange');
-            scope.$emit('workPackagesRefreshRequired');
-            scope.query.dirty = true;
-          }
+          PaginationService.resetPage();
+          scope.$emit('queryStateChange');
+          scope.$emit('workPackagesRefreshRequired');
+          scope.query.dirty = true;
         }
       }, true);
 

--- a/frontend/app/components/filters/query-filters/query-filters.directive.html
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.html
@@ -18,6 +18,8 @@
         {{ localisedFilterName(query.availableWorkPackageFilters[filter.name]) }}
       </label>
 
+      <div class="advanced-filters--operator-value-container">
+
       <!-- Operator -->
       <div class="advanced-filters--filter-operator">
          <label for="operators-{{filter.name}}" class="hidden-for-sighted">
@@ -33,7 +35,7 @@
                 style="vertical-align: top;"
                 ng-disabled="isLoading">
 
-          <option ng-repeat="option in operatorsAndLabelsByFilterType[filter.type]" value="{{ option[0] }}" ng-selected="option[0] == filter.operator" label="{{ I18n.t('js.' + option[1]) }}">{{ I18n.t('js.' + option[1]) }}</option>
+          <option ng-repeat="option in operatorsAndLabelsByFilterType[filter.type]" value="{{ option['op'] }}" ng-selected="option['op'] == filter.operator" label="{{ I18n.t('js.' + option['label']) }}">{{ I18n.t('js.' + option['label']) }}</option>
         </select>
       </div>
 
@@ -42,7 +44,7 @@
         <div id="div-values-{{filter.name}}"
              ng-if="!showValueOptionsAsSelect"
              ng-show="showValuesInput"
-             ng-switch="filter.type">
+             ng-switch="filter.type.startsWith('date') ? 'date' : filter.type">
 
           <input ng-switch-when="string"
                  ng-model="filter.textValue"
@@ -91,35 +93,62 @@
             {{ I18n.t('js.work_packages.description_enter_text') }}
           </label>
 
-          <span class="inline-label" ng-switch-when="date">
-            <input ng-model="filter.textValue"
-                   ng-model-options="::filterModelOptions"
-                   ng-required="true"
-                   class="advanced-filters--text-field"
-                   id="values-{{filter.name}}"
-                   name="v[{{filter.name}}]"
-                   size="3"
-                   type="text"
-                   ng-disabled="isLoading"/>
-            <label for="values_{{name}}" class="form-label -transparent">
-              {{ I18n.t('js.work_packages.time_relative.days') }}
-            </label>
-          </span>
-
-          <span class="inline-label" ng-switch-when="date_past">
-            <input ng-model="filter.textValue"
-                   ng-model-options="::filterModelOptions"
-                   ng-required="true"
-                   class="advanced-filters--text-field"
-                   id="values-{{filter.name}}"
-                   name="v[{{filter.name}}]"
-                   size="3"
-                   type="text"
-                   ng-disabled="isLoading"/>
-            <label ng-switch-when="date_past" for="values_{{name}}" class="form-label -transparent">
-              {{ I18n.t('js.work_packages.time_relative.days') }}
-            </label>
-          </span>
+          <ng-switch ng-switch-when="date" on="filter.operator">
+            <div ng-switch-when="=d">
+              <op-date-picker>
+                <input ng-model="filter.dateValue"
+                       ng-model-options="::filterModelOptions"
+                       ng-required="true"
+                       ng-disabled="isLoading"
+                       id="values-{{filter.name}}"
+                       name="v[{{filter.name}}]"
+                       class="advanced-filters--date-field"
+                       size="3"
+                       transform-date-value
+                       type="text"/>
+              </op-date-picker>
+            </div>
+            <div class="advanced-filters--value-container" ng-switch-when="<>d">
+              <op-date-picker>
+                <input ng-model="filter.values[0]"
+                       ng-model-options="::filterModelOptions"
+                       ng-required="true"
+                       ng-disabled="isLoading"
+                       id="values-{{filter.name}}-begin"
+                       name="v[{{filter.name}}]"
+                       class="advanced-filters--date-field"
+                       size="10"
+                       transform-date-value
+                       type="text"/>
+              </op-date-picker>
+              <op-date-picker>
+                <input ng-model="filter.values[1]"
+                       ng-model-options="::filterModelOptions"
+                       ng-required="true"
+                       ng-disabled="isLoading"
+                       id="values-{{filter.name}}-end"
+                       name="v[{{filter.name}}]"
+                       class="advanced-filters--date-field"
+                       size="10"
+                       transform-date-value
+                       type="text"/>
+              </op-date-picker>
+            </div>
+            <div ng-switch-default class="inline-label">
+              <input ng-model="filter.textValue"
+                     ng-model-options="::filterModelOptions"
+                     ng-required="true"
+                     class="advanced-filters--text-field"
+                     id="values-{{filter.name}}"
+                     name="v[{{filter.name}}]"
+                     size="3"
+                     type="text"
+                     ng-disabled="isLoading"/>
+              <label for="values-{{filter.name}}" class="form-label -transparent">
+                {{ I18n.t('js.work_packages.time_relative.days') }}
+              </label>
+            </div>
+          </ng-switch>
         </div>
 
         <div ng-if="showValueOptionsAsSelect"
@@ -128,8 +157,9 @@
                                filter="filter"
                                is-multiselect="false"
                                isDisabled="isLoading"/>
-
         </div>
+      </div>
+
       </div>
 
       <div class="advanced-filters--remove-filter">
@@ -140,6 +170,7 @@
         </accessible-by-keyboard>
         <!-- TODO I18n -->
       </div>
+
     </li>
 
     <li class="advanced-filters--spacer" ng-if="query.getActiveFilters().length > 0"></li>

--- a/frontend/app/components/filters/query-filters/query-filters.directive.test.ts
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.test.ts
@@ -42,7 +42,8 @@ describe('queryFilters', () => {
 
   beforeEach(angular.mock.module('openproject.templates', function ($provide) {
     $provide.constant('ConfigurationService', {
-      accessibilityModeEnabled: sinon.stub().returns(false)
+      accessibilityModeEnabled: sinon.stub().returns(false),
+      isTimezoneSet: sinon.stub().returns(false)
     });
   }));
 
@@ -90,6 +91,7 @@ describe('queryFilters', () => {
       var filter2 = Factory.build('Filter', {name: 'start_date'});
       var filter3 = Factory.build('Filter', {name: 'done_ratio'});
 
+      // TODO:unused
       var removeFilter = filterName => {
         var removeLinkElement = angular.element(element).find('#filter_' + filterName +
           ' .advanced-filters--remove-filter a');
@@ -111,7 +113,7 @@ describe('queryFilters', () => {
           context('does intersect with filter\'s operators', () => {
             beforeEach(() => {
               OPERATORS_AND_LABELS_BY_FILTER_TYPE['some_type'] = [
-                ['!*', 'label_none'], ['*', 'label_all']
+                [{op:'!*', label:'label_none'}, {op:'*', label:'label_all'}]
               ];
               scope.query.filters.push({
                 isSingleInputField: () => true,
@@ -121,8 +123,9 @@ describe('queryFilters', () => {
               });
               scope.$apply();
             });
-            it('should be undefined', () => {
-              expect(scope.operator).to.be.undefined;
+            it('should take the first one', () => {
+              var operatorValue = element.find('#operators-some_value').val();
+              expect(operatorValue).to.eq('!*');
             });
           });
 
@@ -139,7 +142,6 @@ describe('queryFilters', () => {
             it('should take the first one', () => {
               var operatorValue = element.find('#operators-some_value').val();
               expect(operatorValue).to.eq('=');
-              expect(operatorValue).to.eq(OPERATORS_AND_LABELS_BY_FILTER_TYPE['integer'][0][0]);
             });
           });
         });

--- a/frontend/app/components/filters/query-model/query-model.service.ts
+++ b/frontend/app/components/filters/query-model/query-model.service.ts
@@ -28,6 +28,7 @@
 
 import {filtersModule} from '../../../angular-modules';
 
+//function QueryModelService(FilterModelFactory, Sortation, UrlParamsHelper, PathHelper, INITIALLY_SELECTED_COLUMNS) {
 function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITIALLY_SELECTED_COLUMNS) {
   var Query = function (queryData, options) {
     angular.extend(this, queryData, options);
@@ -184,6 +185,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
         var self = this;
 
         this.filters = filters.map(function(filterData){
+          //return FilterModelFactory.createFilter(self.getExtendedFilterData(filterData));
           return new Filter(self.getExtendedFilterData(filterData));
         });
       }
@@ -195,6 +197,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
         var self = this;
 
         this.filters = filters.map(function(filterData){
+          //return FilterModelFactory.createFilter(filterData);
           return new Filter(filterData);
         });
       }
@@ -207,11 +210,18 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
     applyDefaultsFromFilters: function(workPackage) {
       angular.forEach(this.filters, function(filter) {
 
+        // FIXME:breaks on multi select
         // Ignore any filters except =
         if (filter.operator !== '=') {
           return;
         }
 
+        /* FIXME
+        if (!filter.hasValue()) {
+          return;
+        }
+         var value = filter.getValuesAsArray()[0];
+        */
         // Select the first value
         var value = filter.values;
         if (Array.isArray(filter.values)) {
@@ -256,6 +266,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
      * scoped to a project.
      * @returns {boolean} default
      */
+    // FIXME:unused
     isGlobal: function() {
       return !this.projectId;
     },
@@ -271,6 +282,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
      */
     setDefaultFilter: function() {
       var statusOpenFilterData = this.getExtendedFilterData({name: 'status', operator: 'o'});
+      //this.filters = [FilterModelFactory.createFilter(statusOpenFilterData)];
       this.filters = [new Filter(statusOpenFilterData)];
     },
 
@@ -332,6 +344,7 @@ function QueryModelService(Filter, Sortation, UrlParamsHelper, PathHelper, INITI
         filter.deactivated = false;
       } else {
         var filterData = this.getExtendedFilterData(angular.extend({name: filterName}, options));
+        //filter = FilterModelFactory.createNewFilter(filterData);
         filter = new Filter(filterData);
 
         this.filters.push(filter);

--- a/frontend/app/components/input/transformers/transform-date.directive.ts
+++ b/frontend/app/components/input/transformers/transform-date.directive.ts
@@ -32,9 +32,11 @@ function transformDate() {
     require: '^ngModel',
     link: function(scope, element, attrs, ngModelController) {
       ngModelController.$parsers.push(function(data) {
-        if (data === '') {
-          return null;
-        } else {
+        // TODO:coy test
+        if (!moment(data, 'YYYY-MM-DD', true).isValid()) {
+          return undefined;
+        }
+        else {
           return data;
         }
       });

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -1,8 +1,7 @@
 <op-date-picker
   tabindex="-1"
   on-change="vm.handleUserSubmit()"
-  on-change="vm.handleUserSubmit()"
-  ng-model="vm.workPackage[vm.fieldName]">
+  on-change="vm.handleUserSubmit()">
 
   <input ng-model="vm.workPackage[vm.fieldName]"
          type="text"

--- a/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
+++ b/frontend/app/components/wp-edit/op-date-picker/op-date-picker.directive.ts
@@ -27,11 +27,11 @@
 // ++
 
 interface OpDatePickerScope extends ng.IScope {
-  onChange:Function;
+  onChange?:Function;
   onClose?:Function;
 }
 
-function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, attrs, ngModel) {
+function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, _attrs) {
   // we don't want the date picker in the accessibility mode
   if (this.ConfigurationService.accessibilityModeEnabled()) {
     return;
@@ -40,16 +40,15 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
   let input = element.find('input');
   let datePickerInstance;
   let DatePicker = this.Datepicker;
-  let onChange = scope.onChange;
-  let onClose = scope.onClose;
 
-  let unbindNgModelInitializationWatch = scope.$watch(() => ngModel.$viewValue !== NaN, () => {
-    // This indirection is needed to prevent
-    // 'Missing instance data for this datepicker' errors.
-    input.focus( () => {
-      showDatePicker();
-    });
-    unbindNgModelInitializationWatch();
+  let defaultHandler = function () {
+    input.change();
+  };
+  let onChange = scope.onChange || defaultHandler;
+  let onClose = scope.onClose || defaultHandler;
+
+  input.focus( () => {
+    showDatePicker();
   });
 
   input.keydown((event) => {
@@ -68,12 +67,12 @@ function opDatePickerLink(scope:OpDatePickerScope, element:ng.IAugmentedJQuery, 
         if (input.val().trim() === '') {
           val = null;
         }
-        ngModel.$setViewValue(val);
+        input.val(val);
         onChange();
       },
       onClose: onClose
     };
-    datePickerInstance = new DatePicker(input, ngModel.$viewValue, options);
+    datePickerInstance = new DatePicker(input, input.val(), options);
 
     datePickerInstance.show();
   }
@@ -91,10 +90,9 @@ function opDatePicker(ConfigurationService, Datepicker) {
     templateUrl: '/components/wp-edit/op-date-picker/op-date-picker.directive.html',
     // http://stackoverflow.com/a/33614939/3206935
     link: angular.bind(dependencies, opDatePickerLink),
-    require: 'ngModel',
     scope: {
-      onChange: '&',
-      onClose: '&',
+      onChange: '&?',
+      onClose: '&?',
     }
   };
 }

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -71,17 +71,12 @@ module.exports = function(I18n, PaginationService, PathHelper) {
           return !filter.deactivated;
         })
         .map(function(filter) {
-          var filterData = {
+          return {
             n: filter.name,
             o: encodeURIComponent(filter.operator),
-            t: filter.type
+            t: filter.type,
+            v: filter.getValuesAsArray()
           };
-          if(filter.textValue) {
-            angular.extend(filterData, { v: filter.textValue });
-          } else if(filter.values) {
-            angular.extend(filterData, { v: filter.values });
-          }
-          return filterData;
         });
       }
       paramsData.pa = PaginationService.getPage();

--- a/frontend/app/services/timezone-service.js
+++ b/frontend/app/services/timezone-service.js
@@ -95,6 +95,50 @@ module.exports = function(ConfigurationService, I18n) {
 
     getTimeFormat: function() {
       return ConfigurationService.timeFormatPresent() ? ConfigurationService.timeFormat() : 'LT';
+    },
+
+    /**
+     * Returns the current date time adjusted to the user's local time zone or
+     * UTC if the user did not configure the time zone.
+     *
+     * @returns {Object} the current date time, a moment
+     */
+    now: function() {
+      var result = moment();
+      if (ConfigurationService.isTimezoneSet()) {
+        result.tz(ConfigurationService.timezone());
+      }
+      return result;
+    },
+
+    /**
+     * Returns the time zone offset based on either the user's configured time zone,
+     * or, if no time zone was configured, from the user agent's current time zone.
+     *
+     * @returns {int} time zone offset
+     */
+    getOffset: function() {
+      TimezoneService.now().utcOffset();
+    },
+
+    /**
+     * Returns the time zone offset based on either the user's configured time zone,
+     * or, if no time zone was configured, from the user agent's current time zone.
+     *
+     * @returns {string} time zone offset, e.g. +01:00
+     */
+    getOffsetAsString: function() {
+      return TimezoneService.now().format('Z');
+    },
+
+    /**
+     * Returns the time zone offset in a format that angular understands.
+     * This is intended to be used with ngModelOptions#timezone.
+     *
+     * @returns {string} timezone offset for use with angular model options
+     */
+    getOffsetAsStringNG: function() {
+      return this.getOffsetAsString().replace(':', '');
     }
   };
 

--- a/frontend/app/ui_components/authoring-directive.js
+++ b/frontend/app/ui_components/authoring-directive.js
@@ -36,6 +36,7 @@ module.exports = function(I18n, PathHelper, TimezoneService) {
     link: function(scope, element, attrs) {
       moment.locale(I18n.locale);
 
+      // TODO: requires UTC
       var createdOn = TimezoneService.parseDatetime(scope.createdOn);
       var timeago = createdOn.fromNow();
       var time = createdOn.format('LLL');
@@ -54,7 +55,7 @@ module.exports = function(I18n, PathHelper, TimezoneService) {
       scope.authorLink = '<a href="'+ PathHelper.userPath(scope.author.id) + '">' + scope.author.name + '</a>';
 
       if (scope.activity) {
-        scope.timestamp = '<a title="' + time + '" href="' + activityFromPath(scope.project, createdOn.format('YYYY-MM-DD')) + '">' + timeago + '</a>';
+        scope.timestamp = '<a title="' + time + '" href="' + activityFromPath(scope.project, TimezoneService.formattedISODate(createdOn)) + '">' + timeago + '</a>';
       } else {
         scope.timestamp = '<span class="timestamp" title="' + time + '">' + timeago + '</span>';
       }

--- a/frontend/app/ui_components/date/date-directive.js
+++ b/frontend/app/ui_components/date/date-directive.js
@@ -35,7 +35,7 @@ module.exports = function(TimezoneService) {
     link: function(scope, element, attrs) {
       function setDate(date) {
         if(date){
-          scope.date = TimezoneService.formattedDate(date);
+          scope.date = TimezoneService.formattedDate(TimezoneService.parseDate(date));
         } else {
           scope.date = scope.noDateText;
         }

--- a/frontend/app/ui_components/date/date-time-directive.js
+++ b/frontend/app/ui_components/date/date-time-directive.js
@@ -33,8 +33,9 @@ module.exports = function($compile, TimezoneService) {
     scope: { dateTimeValue: '=' },
     template: '<span title="{{ date }} {{ time }}"><op-date date-value="dateTimeValue" hide-title="true"></op-date> <op-time time-value="dateTimeValue" hide-title="true"></op-time></span>',
     link: function(scope, element, attrs) {
-      scope.date = TimezoneService.formattedDate(scope.dateTimeValue);
-      scope.time = TimezoneService.formattedTime(scope.dateTimeValue);
+      var datetime = TimezoneService.parseDatetime(scope.dateTimeValue);
+      scope.date = TimezoneService.formattedDate(datetime);
+      scope.time = TimezoneService.formattedTime(datetime);
 
       $compile(element.contents())(scope);
     }

--- a/frontend/app/ui_components/date/time-directive.js
+++ b/frontend/app/ui_components/date/time-directive.js
@@ -33,7 +33,7 @@ module.exports = function(TimezoneService) {
     scope: { timeValue: '=', hideTitle: '@' },
     template: '<span title="{{ timeTitle }}">{{time}}</span>',
     link: function(scope, element, attrs) {
-      scope.time = TimezoneService.formattedTime(scope.timeValue);
+      scope.time = TimezoneService.formattedTime(TimezoneService.parseDatetime(scope.timeValue));
       if (!scope.hideTitle) {
         scope.timeTitle = scope.time;
       }

--- a/frontend/app/work_packages/config/index.js
+++ b/frontend/app/work_packages/config/index.js
@@ -28,38 +28,114 @@
 
 /* jshint camelcase: false */
 
+// shared operator defs
+// TODO: requires validator, parser, view transformer
+const OP_NONE = {op:'!*', label:'label_none'};
+const OP_ALL = {op:'*', label:'label_all'};
+const OP_SEL_EQ = {op:'=', label:'label_equals'};
+const OP_SEL_NEQ = {op:'!', label:'label_not_equals'};
+const OP_TODAY = {op:'t', label:'label_today'};
+const OP_THIS_WEEK = {op:'w', label:'label_this_week'};
+const OP_AGO_LT = {op:'>t-', label:'label_less_than_ago'};
+const OP_AGO_GT = {op:'<t-', label:'label_more_than_ago'};
+const OP_AGO = {op:'t-', label:'label_ago'};
+const OP_DATE_EQ = {op:'=d', label:'label_on'};
+const OP_DATE_BETWEEN = {op:'<>d', label:'label_between'};
+const OP_CONTAINS = {op:'~', label:'label_contains'};
+const OP_NOT_CONTAINS = {op:'!~', label:'label_not_contains'};
+const OP_EQ = {op:'=', label:'label_equals'};
+const OP_NEQ = {op:'!', label:'label_not_equals'};
+const OP_LEQ = {op:'<=', label:'label_less_or_equal'};
+const OP_GEQ = {op:'>=', label:'label_greater_or_equal'};
+
+
 angular.module('openproject.workPackages.config')
 
-.constant('INITIALLY_SELECTED_COLUMNS', [{ name: 'id' }, { name: 'project' }, { name: 'type' }, { name: 'status' }, { name: 'priority' }, { name: 'subject' }, { name: 'assigned_to_id' }, { name: 'updated_at' }])
+.constant('INITIALLY_SELECTED_COLUMNS', [
+  { name: 'id' }, { name: 'project' }, { name: 'type' }, { name: 'status' },
+  { name: 'priority' }, { name: 'subject' }, { name: 'assigned_to_id' }, { name: 'updated_at' }
+])
 
 .constant('OPERATORS_AND_LABELS_BY_FILTER_TYPE', {
-  list: [['=', 'label_equals'], ['!', 'label_not_equals']],
-  list_model: [['=', 'label_equals'], ['!', 'label_not_equals']],
-  list_status: [['o', 'label_open_work_packages'], ['=', 'label_equals'], ['!', 'label_not_equals'], ['c', 'label_closed_work_packages'], ['*', 'label_all']],
-  list_optional: [['=', 'label_equals'], ['!', 'label_not_equals'], ['!*', 'label_none'], ['*', 'label_all']],
-  list_subprojects: [['*', 'label_all'], ['!*', 'label_none'], ['=', 'label_equals']],
-  date: [['<t+', 'label_in_less_than'], ['>t+', 'label_in_more_than'], ['t+', 'label_in'], ['t', 'label_today'], ['w', 'label_this_week'], ['>t-', 'label_less_than_ago'], ['<t-', 'label_more_than_ago'], ['t-', 'label_ago']],
-  date_past: [['>t-', 'label_less_than_ago'], ['<t-', 'label_more_than_ago'], ['t-', 'label_ago'], ['t', 'label_today'], ['w', 'label_this_week']],
-  string: [['=', 'label_equals'], ['~', 'label_contains'], ['!', 'label_not_equals'], ['!~', 'label_not_contains']],
-  text: [['~', 'label_contains'], ['!~', 'label_not_contains']],
-  integer: [['=', 'label_equals'], ['>=', 'label_greater_or_equal'], ['<=', 'label_less_or_equal'], ['!*', 'label_none'], ['*', 'label_all']]
+  list: [
+    OP_SEL_EQ,
+    OP_SEL_NEQ
+  ],
+  list_model: [
+    OP_SEL_EQ,
+    OP_SEL_NEQ
+  ],
+  list_status: [
+    {op:'o', label:'label_open_work_packages'},
+    OP_SEL_EQ,
+    OP_SEL_NEQ,
+    {op:'c', label:'label_closed_work_packages'},
+    OP_ALL
+  ],
+  list_optional: [
+    OP_SEL_EQ,
+    OP_SEL_NEQ,
+    OP_NONE,
+    OP_ALL
+  ],
+  list_subprojects: [
+    OP_SEL_EQ,
+    OP_NONE,
+    OP_ALL
+  ],
+  date: [
+    {op:'<t+', label:'label_in_less_than'},
+    {op:'>t+', label:'label_in_more_than'},
+    {op:'t+', label:'label_in'},
+    OP_TODAY,
+    OP_THIS_WEEK,
+    OP_AGO_LT,
+    OP_AGO_GT,
+    OP_AGO,
+    OP_DATE_EQ,
+    OP_DATE_BETWEEN
+  ],
+  datetime_past: [
+    OP_AGO_LT,
+    OP_AGO_GT,
+    OP_AGO,
+    OP_TODAY,
+    OP_THIS_WEEK
+  ],
+  string: [
+    OP_EQ,
+    OP_CONTAINS,
+    OP_NEQ,
+    OP_NOT_CONTAINS
+  ],
+  text: [
+    OP_CONTAINS,
+    OP_NOT_CONTAINS
+  ],
+  integer: [
+    OP_EQ,
+    OP_GEQ,
+    OP_LEQ,
+    OP_NONE,
+    OP_ALL
+  ]
 })
 
 .constant('AVAILABLE_WORK_PACKAGE_FILTERS', {
   status: { type: 'list_status', modelName: 'status' , order: 1, locale_name: 'status' },
   type: { type: 'list_model', modelName: 'type', order: 2, locale_name: 'type' },
-  priority: { type: 'list_model', modelName: 'priority', order: 3, locale_name: 'priority'},
+  priority: { type: 'list_model', modelName: 'priority', order: 3, locale_name: 'priority' },
   assignee: { type: 'list_optional', modelName: 'user' , order: 4, locale_name: 'assigned_to' },
   author: { type: 'list_model', modelName: 'user' , order: 5, locale_name: 'author' },
-  watcher: {type: 'list_model', modelName: 'user', order: 6, locale_name: 'watcher'},
-  responsible: {type: 'list_optional', modelName: 'user', order: 6, locale_name: 'responsible'},
-  version: {type: 'list_optional', modelName: 'version', order: 7, locale_name: 'fixed_version'},
+  watcher: {type: 'list_model', modelName: 'user', order: 6, locale_name: 'watcher' },
+  responsible: {type: 'list_optional', modelName: 'user', order: 6, locale_name: 'responsible' },
+  version: {type: 'list_optional', modelName: 'version', order: 7, locale_name: 'fixed_version' },
   category: { type: 'list_optional', modelName: 'category', order: 7, locale_name: 'category' },
-  memberOfGroup: {type: 'list_optional', modelName: 'group', order: 8, locale_name: 'member_of_group'},
-  assignedToRole: {type: 'list_optional', modelName: 'role', order: 9, locale_name: 'assigned_to_role'},
+  memberOfGroup: {type: 'list_optional', modelName: 'group', order: 8, locale_name: 'member_of_group' },
+  assignedToRole: {type: 'list_optional', modelName: 'role', order: 9, locale_name: 'assigned_to_role' },
   subject: { type: 'text', order: 10, locale_name: 'subject' },
-  createdAt: { type: 'date_past', order: 11, locale_name: 'created_at' },
-  updatedAt: { type: 'date_past', order: 12, locale_name: 'updated_at' },
+  createdAt: { type: 'datetime_past', order: 11, locale_name: 'created_at' },
+  updatedAt: { type: 'datetime_past', order: 12, locale_name: 'updated_at' },
   startDate: { type: 'date', order: 13, locale_name: 'start_date' },
   dueDate: { type: 'date', order: 14, locale_name: 'due_date' },
   estimatedTime: { type: 'integer', order: 15, locale_name: 'estimated_hours' },

--- a/frontend/app/work_packages/helpers/work-packages-helper.js
+++ b/frontend/app/work_packages/helpers/work-packages-helper.js
@@ -115,32 +115,20 @@ module.exports = function(TimezoneService, currencyFilter, CustomFieldHelper) {
     },
 
     formatValue: function(value, dataType) {
-      switch(dataType) {
+      switch(dataType ? dataType.toLowerCase() : null) {
         case 'datetime':
-          var dateTime;
-          if (value) {
-            dateTime = TimezoneService.formattedDatetime(value);
-          }
-          return dateTime || '';
-        case 'date':
-          return value ? TimezoneService.formattedDate(value) : '';
+          return value ? TimezoneService.formattedDatetime(TimezoneService.parseDatetime(value)) : '';
         case 'currency':
           return currencyFilter(value, 'EUR ');
-        case 'Duration':
+        case 'duration':
           return TimezoneService.formattedDuration(value);
-        case 'DateTime':
-          return TimezoneService.formattedDatetime(value);
-        case('Boolean'):
+        case('boolean'):
           return value ? I18n.t('js.general_text_yes') : I18n.t('js.general_text_no');
-        case 'Date':
-          return TimezoneService.formattedDate(value);
+        case 'date':
+          return value ? TimezoneService.formattedDate(TimezoneService.parseDate(value)) : '';
         default:
           return value;
       }
-    },
-
-    parseDateTime: function(value) {
-      return new Date(Date.parse(value.replace(/(A|P)M$/, '')));
     }
   };
 

--- a/frontend/tests/unit/factories/filter-factory.js
+++ b/frontend/tests/unit/factories/filter-factory.js
@@ -28,6 +28,7 @@
 
 (function(Filter) {
   Factory.define('Filter', Filter)
+    .attr('type', 'list_model')
     .attr('name', 'type_id')
     .attr('operator', '~')
     .attr('values', ['Bug', 'Feature']);

--- a/frontend/tests/unit/tests/helpers/url-params-helper-test.js
+++ b/frontend/tests/unit/tests/helpers/url-params-helper-test.js
@@ -71,7 +71,7 @@ describe('UrlParamsHelper', function() {
       };
       var filter2 = {
         name: 'created_at',
-        type: 'date_past',
+        type: 'datetime_past',
         operator: '<t-',
         textValue: '5'
       };
@@ -89,7 +89,7 @@ describe('UrlParamsHelper', function() {
 
     it('should encode query to params JSON', function() {
       var encodedJSON = UrlParamsHelper.encodeQueryJsonParams(query);
-      var expectedJSON = "{\"c\":[\"type\",\"status\",\"soße\"],\"s\":true,\"p\":2,\"g\":\"status\",\"t\":\"type:desc\",\"f\":[{\"n\":\"soße_id\",\"o\":\"%3D\",\"t\":\"list_model\",\"v\":[\"knoblauch\"]},{\"n\":\"created_at\",\"o\":\"%3Ct-\",\"t\":\"date_past\",\"v\":\"5\"}],\"pa\":1,\"pp\":10}";
+      var expectedJSON = "{\"c\":[\"type\",\"status\",\"soße\"],\"s\":true,\"p\":2,\"g\":\"status\",\"t\":\"type:desc\",\"f\":[{\"n\":\"soße_id\",\"o\":\"%3D\",\"t\":\"list_model\",\"v\":[\"knoblauch\"]},{\"n\":\"created_at\",\"o\":\"%3Ct-\",\"t\":\"datetime_past\",\"v\":[\"5\"]}],\"pa\":1,\"pp\":10}";
       expect(encodedJSON).to.eq(expectedJSON);
     });
   });
@@ -99,7 +99,7 @@ describe('UrlParamsHelper', function() {
     var queryId;
 
     beforeEach(function() {
-      params = "{\"c\":[\"type\",\"status\",\"soße\"],\"s\":true,\"p\":2,\"g\":\"status\",\"t\":\"type:desc\",\"f\":[{\"n\":\"soße_id\",\"o\":\"%3D\",\"t\":\"list_model\",\"v\":[\"knoblauch\"]},{\"n\":\"created_at\",\"o\":\"%3Ct-\",\"t\":\"date_past\",\"v\":\"5\"}]}";
+      params = "{\"c\":[\"type\",\"status\",\"soße\"],\"s\":true,\"p\":2,\"g\":\"status\",\"t\":\"type:desc\",\"f\":[{\"n\":\"soße_id\",\"o\":\"%3D\",\"t\":\"list_model\",\"v\":[\"knoblauch\"]},{\"n\":\"created_at\",\"o\":\"%3Ct-\",\"t\":\"datetime_past\",\"v\":[\"5\"]}]}";
       queryId = 2;
     });
 
@@ -120,7 +120,7 @@ describe('UrlParamsHelper', function() {
           values: ['knoblauch']
         },{
           name: 'created_at',
-          type: 'date_past',
+          type: 'datetime_past',
           operator: '<t-',
           values: ['5']
         }]

--- a/frontend/tests/unit/tests/services/timezone-service-test.js
+++ b/frontend/tests/unit/tests/services/timezone-service-test.js
@@ -82,4 +82,6 @@ describe('TimezoneService', function() {
       expect(time.format('HH:mm')).to.eq('00:00');
     });
   });
+
+  // TODO:coy
 });

--- a/frontend/tests/unit/tests/ui_components/date-time-directive-test.js
+++ b/frontend/tests/unit/tests/ui_components/date-time-directive-test.js
@@ -29,24 +29,17 @@
 /*jshint expr: true*/
 
 describe('date time Directives', function() {
-  var I18n, compile, element, scope, configurationService, TimezoneService;
+  var I18n, compile, element, scope, configurationService, TimezoneService, localDatetime;
 
   var formattedDate = function() {
     var formattedDateElement = element[0];
 
-    return formattedDateElement.innerText || formattedDateElement.textContent;
+    return (formattedDateElement.innerText || formattedDateElement.textContent || '').trim();
   };
 
   beforeEach(angular.mock.module('openproject.uiComponents', 'openproject.services'));
-  beforeEach(angular.mock.module('openproject.templates', function($provide) {
-    configurationService = {};
 
-    configurationService.isTimezoneSet = sinon.stub().returns(false);
-
-    $provide.constant('ConfigurationService', configurationService);
-  }));
-
-  beforeEach(inject(function($rootScope, $compile, _I18n_, _TimezoneService_) {
+  beforeEach(inject(function($rootScope, $compile, _I18n_, _ConfigurationService_, _TimezoneService_) {
     scope = $rootScope.$new();
 
     scope.testDateTime = "2013-02-08T09:30:26";
@@ -57,21 +50,21 @@ describe('date time Directives', function() {
     };
 
     TimezoneService = _TimezoneService_;
+    configurationService = _ConfigurationService_;
 
     I18n = _I18n_;
-
     I18n.locale = 'en';
-
     TimezoneService.setupLocale();
+
+    localDatetime = TimezoneService.parseDatetime(scope.testDateTime);
   }));
 
   afterEach(function() {
     I18n.locale = undefined;
-
     TimezoneService.setupLocale();
   });
 
-  var shouldBehaveLikeHashTitle = function(title) {
+  var shouldHaveTitle = function(title) {
     it('has title', function() {
       expect(angular.element(element)[0].title).to.eq(title);
     });
@@ -79,72 +72,67 @@ describe('date time Directives', function() {
 
   describe('date directive', function() {
     var html = '<op-date date-value="testDateTime"></op-date>';
+    var expected;
 
     describe('without configuration', function() {
       beforeEach(function() {
-        configurationService.dateFormatPresent = sinon.stub().returns(false);
-
         compile(html);
+        expected = TimezoneService.formattedDate(localDatetime);
       });
 
       it('should use default formatting', function() {
-        expect(formattedDate()).to.contain('02/08/2013');
+        expect(formattedDate()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('02/08/2013');
     });
 
     describe('with configuration', function() {
       beforeEach(function() {
-        configurationService.dateFormatPresent = sinon.stub().returns(true);
         configurationService.dateFormat = sinon.stub().returns("DD-MM-YYYY");
-
+        expected = TimezoneService.formattedDate(localDatetime);
         compile(html);
       });
 
       it('should use user specified formatting', function() {
-        expect(formattedDate()).to.contain('08-02-2013');
+        expect(formattedDate()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('08-02-2013');
     });
   });
 
   describe('time directive', function() {
     var html = '<op-time time-value="testDateTime"></op-time>';
+    var expected;
 
     describe('without configuration', function() {
       beforeEach(function() {
-        configurationService.timeFormatPresent = sinon.stub().returns(false);
-
+        expected = TimezoneService.formattedTime(localDatetime);
         compile(html);
       });
 
       it('should use default formatting', function() {
-        expect(formattedDate()).to.contain('9:30 AM');
+        expect(formattedDate()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('9:30 AM');
     });
 
     describe('with configuration', function() {
       beforeEach(function() {
-        configurationService.timeFormatPresent = sinon.stub().returns(true);
         configurationService.timeFormat = sinon.stub().returns("HH:mm a");
-
+        expected = TimezoneService.formattedTime(localDatetime);
         compile(html);
       });
 
       it('should use user specified formatting', function() {
-        expect(formattedDate()).to.contain('09:30 am');
+        expect(formattedDate()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('09:30 am');
     });
   });
 
   describe('date time directive', function() {
     var html = '<op-date-time date-time-value="testDateTime"></op-date-time>';
+    var expected;
 
     var formattedDateTime = function() {
       var formattedDateElements = [element.children()[0], element.children()[1]];
@@ -154,43 +142,35 @@ describe('date time Directives', function() {
         formattedDateTime += (formattedDateElements[x].innerText || formattedDateElements[x].textContent) + " ";
       }
 
-      return formattedDateTime;
+      return formattedDateTime.trim();
     };
 
     describe('without configuration', function() {
+
       beforeEach(function() {
-        configurationService.dateFormatPresent = sinon.stub().returns(false);
-        configurationService.timeFormatPresent = sinon.stub().returns(false);
-
-        scope.dateTimeValue = "2013-02-08T09:30:26";
-
+        expected = TimezoneService.formattedDatetime(localDatetime);
         compile(html);
       });
 
       it('should use default formatting', function() {
-        expect(formattedDateTime()).to.contain('02/08/2013');
-        expect(formattedDateTime()).to.contain('9:30 AM');
+        expect(formattedDateTime()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('02/08/2013 9:30 AM');
     });
 
     describe('with configuration', function() {
+
       beforeEach(function() {
-        configurationService.dateFormatPresent = sinon.stub().returns(true);
-        configurationService.timeFormatPresent = sinon.stub().returns(true);
         configurationService.dateFormat = sinon.stub().returns("DD-MM-YYYY");
         configurationService.timeFormat = sinon.stub().returns("HH:mm a");
-
+        expected = TimezoneService.formattedDatetime(localDatetime);
         compile(html);
       });
 
       it('should use user specified formatting', function() {
-        expect(formattedDateTime()).to.contain('08-02-2013');
-        expect(formattedDateTime()).to.contain('09:30 am');
+        expect(formattedDateTime()).to.eq(expected);
+        shouldHaveTitle(expected);
       });
-
-      shouldBehaveLikeHashTitle('08-02-2013 09:30 am');
     });
   });
 });

--- a/frontend/tests/unit/tests/work_packages/helpers/work-packages-helper-test.js
+++ b/frontend/tests/unit/tests/work_packages/helpers/work-packages-helper-test.js
@@ -29,20 +29,13 @@
 /*jshint expr: true*/
 
 describe('Work packages helper', function() {
-  var WorkPackagesHelper;
+  var WorkPackagesHelper, TimezoneService;
 
   beforeEach(angular.mock.module('openproject.helpers', 'openproject.services'));
-  beforeEach(angular.mock.module('openproject.templates', function($provide) {
-    var configurationService = {};
 
-    configurationService.isTimezoneSet = sinon.stub();
-    configurationService.dateFormatPresent = sinon.stub();
-    configurationService.timeFormatPresent = sinon.stub();
-
-    $provide.constant('ConfigurationService', configurationService);
-  }));
-  beforeEach(inject(function(_WorkPackagesHelper_) {
+  beforeEach(inject(function(_WorkPackagesHelper_, _TimezoneService_) {
     WorkPackagesHelper = _WorkPackagesHelper_;
+    TimezoneService = _TimezoneService_;
   }));
 
   describe('getRowObjectContent', function() {
@@ -97,34 +90,29 @@ describe('Work packages helper', function() {
   });
 
   describe('formatValue', function() {
-    var formatValue;
-
-    beforeEach(function() {
-      formatValue = WorkPackagesHelper.formatValue;
-    });
 
     it('should display a currency value', function() {
-      expect(formatValue(99,     'currency')).to.equal("EUR 99.00");
-      expect(formatValue(20.99,  'currency')).to.equal("EUR 20.99");
-      expect(formatValue("20",   'currency')).to.equal("EUR 20.00");
+      expect(WorkPackagesHelper.formatValue(99,     'currency')).to.equal("EUR 99.00");
+      expect(WorkPackagesHelper.formatValue(20.99,  'currency')).to.equal("EUR 20.99");
+      expect(WorkPackagesHelper.formatValue("20",   'currency')).to.equal("EUR 20.00");
     });
 
     it('should display empty strings for empty/undefined dates', function() {
-      expect(formatValue("", 'datetime')).to.equal("");
-      expect(formatValue(undefined, 'datetime')).to.equal("");
-      expect(formatValue(null, 'datetime')).to.equal("");
-      expect(formatValue("", 'date')).to.equal("");
-      expect(formatValue(undefined, 'date')).to.equal("");
-      expect(formatValue(null, 'date')).to.equal("");
+      expect(WorkPackagesHelper.formatValue("", 'datetime')).to.equal("");
+      expect(WorkPackagesHelper.formatValue(undefined, 'datetime')).to.equal("");
+      expect(WorkPackagesHelper.formatValue(null, 'datetime')).to.equal("");
+      expect(WorkPackagesHelper.formatValue("", 'date')).to.equal("");
+      expect(WorkPackagesHelper.formatValue(undefined, 'date')).to.equal("");
+      expect(WorkPackagesHelper.formatValue(null, 'date')).to.equal("");
     });
 
-    var TIME = '2014-01-01T00:00:00';
-    var EXPECTED_DATE = '01/01/2014';
-    var EXPECTED_DATETIME = '01/01/2014 12:00 AM';
-
     it('should display parsed dates and datetimes', function(){
-      expect(formatValue(TIME, 'date')).to.equal(EXPECTED_DATE);
-      expect(formatValue(TIME, 'datetime')).to.equal(EXPECTED_DATETIME);
+      var datetime = '2014-01-01T00:00:00';
+      var localDatetime = TimezoneService.parseDatetime(datetime);
+      var expectedDate = TimezoneService.formattedDate(localDatetime);
+      var expectedDatetime= TimezoneService.formattedDatetime(localDatetime);
+      expect(WorkPackagesHelper.formatValue(datetime, 'date')).to.equal(expectedDate);
+      expect(WorkPackagesHelper.formatValue(datetime, 'datetime')).to.equal(expectedDatetime);
     });
   });
 


### PR DESCRIPTION
This PR allows users to filter the work package list by an exact date or a range of dates (begin/end).

This applies to non custom fields such as created_at, updated_at, started_at and so on.

https://community.openproject.com/work_packages/24174
https://community.openproject.com/work_packages/24392