### PR TITLE
Use webpack.optimize plugins for test and production

### DIFF
--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -36,6 +36,9 @@ var autoprefixer = require('autoprefixer');
 var TypeScriptDiscruptorPlugin = require('./webpack/typescript-disruptor.plugin.js');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+var mode = (process.env['RAILS_ENV'] || 'production').toLowerCase();
+var uglify = (process.env['RAILS_ENV'] !== 'development');
+
 var pluginEntries = _.reduce(pathConfig.pluginNamesPaths, function (entries, path, name) {
   entries[name.replace(/^openproject\-/, '')] = name;
   return entries;
@@ -99,7 +102,7 @@ loaders.push({
 
 
 function getWebpackMainConfig() {
-  return {
+  config = {
     context: path.join(__dirname, '/app'),
 
     entry: _.merge({
@@ -195,6 +198,24 @@ function getWebpackMainConfig() {
       ])
     ]
   };
+
+  if (uglify) {
+    console.log("Applying webpack.optimize plugins for production.");
+    // Add compression and optimization plugins
+    // to the webpack build.
+    config.plugins.push(
+      new webpack.optimize.UglifyJsPlugin({
+        mangle: false,
+        compress: true,
+        compressor: { warnings: false },
+        sourceMap: false
+      }),
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.OccurenceOrderPlugin()
+    );
+  }
+
+  return config;
 }
 
 module.exports = getWebpackMainConfig;

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -89,7 +89,7 @@ for (var k in pathConfig.pluginNamesPaths) {
     loaders.push({
       test: new RegExp('templates/plugin-' + k.replace(/^openproject\-/, '') + '/.*\.html$'),
       loader: 'ngtemplate?module=openproject.templates&relativeTo=' +
-      path.join(pathConfig.pluginNamesPaths[k], 'frontend', 'app') + '!html'
+      path.join(pathConfig.pluginNamesPaths[k], 'frontend', 'app') + '!html?-minimize'
     });
   }
 }
@@ -97,7 +97,7 @@ for (var k in pathConfig.pluginNamesPaths) {
 loaders.push({
   test: /^((?!templates\/plugin).)*\.html$/,
   loader: 'ngtemplate?module=openproject.templates&relativeTo=' +
-  path.resolve(__dirname, './app') + '!html'
+  path.resolve(__dirname, './app') + '!html?-minimize'
 });
 
 

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -37,7 +37,7 @@ var TypeScriptDiscruptorPlugin = require('./webpack/typescript-disruptor.plugin.
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var mode = (process.env['RAILS_ENV'] || 'production').toLowerCase();
-var uglify = (process.env['RAILS_ENV'] !== 'development');
+var uglify = (mode !== 'development');
 
 var pluginEntries = _.reduce(pathConfig.pluginNamesPaths, function (entries, path, name) {
   entries[name.replace(/^openproject\-/, '')] = name;


### PR DESCRIPTION
This applies uglifyjs with compression (no name mangling) and other webpack.optimize plugins anytime the RAILS_ENV is not development.

I've tried this in the past but received errors due to uglifyjs causing the html-loader to also minify html, causing all sorts of errors. However, we can separately disable this minification.

This cuts the size output bundles by around half.

![bildschirmfoto 2016-11-25 um 08 50 42](https://cloud.githubusercontent.com/assets/459462/20618042/1a75426e-b2ed-11e6-8a38-280b3f8cd3b2.png)
![bildschirmfoto 2016-11-25 um 08 51 59](https://cloud.githubusercontent.com/assets/459462/20618043/1a79569c-b2ed-11e6-8356-ce473c3bb141.png)
