### PR TITLE
[24366] Show hidden fields as empty and forbid editing in table

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
@@ -88,6 +88,7 @@ describe('wpDisplayAttr directive', () => {
         sheep: 10,
         customField1: 'asdf1234',
         emptyField: null,
+        hiddenField: 'foobar',
         schema: {
           "$load": () => $q.when(true),
           "_type": "Schema",
@@ -130,6 +131,13 @@ describe('wpDisplayAttr directive', () => {
             "name": "empty field",
             "required": false,
             "writable": true
+          },
+          "hiddenField": {
+            "type": "String",
+            "name": "hidden field",
+            "required": false,
+            "writable": true,
+            "visibility": "hidden"
           }
         }
       }
@@ -247,6 +255,16 @@ describe('wpDisplayAttr directive', () => {
     describe('rendering an empty field', () => {
       beforeEach(() => {
         scope.attribute = 'emptyField';
+        compile();
+      });
+
+      it('should adorne the element with the -placeholder class', () => {
+        expect(element.find('.inplace-edit--read-value--value.-placeholder').length).to.eql(1);
+      });
+    });
+    describe('rendering a hidden field', () => {
+      beforeEach(() => {
+        scope.attribute = 'hiddenField';
         compile();
       });
 

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -73,7 +73,11 @@ export class WorkPackageDisplayAttributeController {
   }
 
   public get isEmpty(): boolean {
-    return !this.field || this.field.isEmpty();
+    return !this.field || this.field.isEmpty() || this.field.hidden;
+  }
+
+  public get isHidden(): boolean {
+    return !this.field || this.field.hidden;
   }
 
   /**
@@ -85,7 +89,7 @@ export class WorkPackageDisplayAttributeController {
   }
 
   public get displayText(): string {
-    if (this.isEmpty) {
+    if (this.isEmpty || this.isHidden) {
       return this.placeholder;
     }
     return this.field.valueString;

--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
@@ -51,14 +51,6 @@ export class DisplayField extends Field {
     return (this.constructor as typeof DisplayField).type;
   }
 
-  public get required(): boolean {
-    return this.schema.required;
-  }
-
-  public isEmpty(): boolean {
-    return !this.value;
-  }
-
   public get placeholder(): string {
     return this.I18n.t('js.work_packages.placeholders.default');
   }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -132,7 +132,7 @@ export class WorkPackageEditFieldController {
     this.workPackage.schema.$load().then(schema => {
       var fieldSchema = schema[this.fieldName];
 
-      this.editable = fieldSchema && fieldSchema.writable;
+      this.editable = fieldSchema && fieldSchema.writable && fieldSchema.visibility !== 'hidden';
       this.fieldType = fieldSchema && this.wpEditField.fieldType(fieldSchema.type);
 
       this.updateDisplayAttributes();

--- a/frontend/app/components/wp-field/wp-field.module.ts
+++ b/frontend/app/components/wp-field/wp-field.module.ts
@@ -48,6 +48,14 @@ export class Field {
     return this.schema.required;
   }
 
+  public get visibility():string {
+    return this.schema.visibility;
+  }
+
+  public get hidden():boolean {
+    return this.visibility === 'hidden';
+  } 
+
   public isEmpty():boolean {
     return !this.value;
   }

--- a/spec/features/work_packages/hidden_types_spec.rb
+++ b/spec/features/work_packages/hidden_types_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe 'Work package with hidden type', js: true do
+  let(:user) { FactoryGirl.create :admin }
+  let(:type) { FactoryGirl.create :type, attribute_visibility: attribute_visibility }
+
+  let(:attribute_visibility) do
+    {
+      'status' => 'hidden'
+    }
+  end
+
+  let(:project) { FactoryGirl.create(:project, types: [type]) }
+  let(:work_package) {
+    FactoryGirl.create(:work_package,
+                       project: project,
+                       type:    type,
+                       status:  FactoryGirl.build(:status),
+                       subject: 'Foobar')
+  }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let!(:query) do
+    query              = FactoryGirl.build(:query, user: user, project: project)
+    query.column_names = ['subject', 'status']
+
+    query.save!
+    query
+  end
+
+  before do
+    work_package
+    login_as(user)
+
+    wp_table.visit_query(query)
+    wp_table.expect_work_package_listed(work_package)
+  end
+
+  it 'hides the subject field on table and single view' do
+      status_field = wp_table.edit_field(work_package, :status)
+      status_field.expect_text('-')
+      expect(status_field).not_to be_editable
+
+      # Visit details
+      split_view = wp_table.open_split_view(work_package)
+      split_view.view_all_attributes
+      split_view.expect_hidden_field(:status)
+  end
+end

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -54,6 +54,12 @@ module Pages
       WorkPackageField.new(context, attribute)
     end
 
+    def expect_hidden_field(attribute)
+      within(container) do
+        expect(page).to have_no_selectro(".inplace-edit.#{attribute}")
+      end
+    end
+
     def expect_subject
       within(container) do
         expect(page).to have_content(work_package.subject)


### PR DESCRIPTION
This extends on the somewhat weird single-view service/display field usage on the field schema. I would like to refactor this into a `fieldSchema` that you access directly on the schema, but given the priority of the bug, this must suffice.

https://community.openproject.com/work_packages/24366