### PR TITLE
avoid define_method scope

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -203,9 +203,9 @@ class CustomField < ActiveRecord::Base
 
   # to move in project_custom_field
   def self.for_all(options = {})
-    where(['is_for_all=?', true])
+    where(is_for_all: true)
       .includes(options[:include])
-      .order('position')
+      .order("#{table_name}.position")
   end
 
   def self.filter

--- a/app/workers/deliver_work_package_notification_job.rb
+++ b/app/workers/deliver_work_package_notification_job.rb
@@ -28,7 +28,6 @@
 #++
 
 class DeliverWorkPackageNotificationJob < DeliverNotificationJob
-
   def initialize(journal_id, recipient_id, author_id)
     @journal_id = journal_id
     super(recipient_id, author_id)

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -43,6 +43,7 @@ module API
                    :type,
                    :id,
                    :milestone?,
+                   :available_custom_fields,
                    to: :@work_package
 
           def assignable_values(property, current_user)
@@ -69,13 +70,6 @@ module API
             when 'version'
               assignable_values(:version, nil)
             end
-          end
-
-          def available_custom_fields
-            # we might have received a (currently) invalid work package
-            return [] if project.nil? || type.nil?
-
-            project.all_work_package_custom_fields.to_a & type.custom_fields.to_a
           end
 
           def writable?(property)

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -114,35 +114,11 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
   end
 
   describe '#available_custom_fields' do
-    let(:cf1) { double }
-    let(:cf2) { double }
-    let(:cf3) { double }
+    it 'delegates to work_package' do
+      expect(work_package)
+        .to receive(:available_custom_fields)
 
-    it 'is expected to return custom fields available in project AND type' do
-      allow(type).to receive_message_chain(:custom_fields, :to_a).and_return([cf1, cf2])
-      allow(project).to receive_message_chain(:all_work_package_custom_fields, :to_a)
-        .and_return([cf2, cf3])
-
-      expect(subject.available_custom_fields).to eql([cf2])
-    end
-
-    context 'type missing' do
-      let(:type) { nil }
-      it 'returns an empty list' do
-        allow(project).to receive_message_chain(:all_work_package_custom_fields, :to_a)
-          .and_return([cf2, cf3])
-
-        expect(subject.available_custom_fields).to eql([])
-      end
-    end
-
-    context 'project missing' do
-      let(:project) { nil }
-      it 'returns an empty list' do
-        allow(type).to receive_message_chain(:custom_fields, :to_a).and_return([cf1, cf2])
-
-        expect(subject.available_custom_fields).to eql([])
-      end
+      subject.available_custom_fields
     end
   end
 


### PR DESCRIPTION
Mixed bag:
* removes method duplicated when it could be used right away (#available_custom_fields)
* prevents redefining custom_field getter/setter on a call to #respond_to?