### PR TITLE
Fix/only link for cv on wp collection

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-string-object-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-object-field.module.ts
@@ -34,7 +34,7 @@ export class StringObjectDisplayField extends DisplayField {
 
   public get value() {
     if(this.schema) {
-      return this.resource[this.name] && this.resource[this.name].value;
+      return this.resource[this.name] && (this.resource[this.name].value || this.resource[this.name].name);
     }
     else {
       return null;

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -64,10 +64,10 @@ module API
         }.freeze
 
         class << self
-          def create_value_representer(customizable, representer)
+          def create_value_representer(customizable, representer, embed_links: true)
             new_representer_class_with(representer, customizable) do |injector|
               customizable.available_custom_fields.each do |custom_field|
-                injector.inject_value(custom_field, embed_links: true)
+                injector.inject_value(custom_field, embed_links: embed_links)
               end
             end
           end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -257,16 +257,24 @@ module API
         end
 
         def link_value_getter_for(custom_field, path_method)
-          -> (*) {
+          -> (*) do
             # we can't use the generated accessor (e.g. represented.send :custom_field_1) here,
             # because we need to generate a link even if the id does not belong to an existing
             # object (that behaviour is only required for form payloads)
             custom_value = represented.custom_value_for(custom_field)
-            value = custom_value ? custom_value.value : nil
-            path = api_v3_paths.send(path_method, value) if value.present?
 
-            { href: path }
-          }
+            unless custom_value && custom_value.value.present?
+              return { href: nil, title: nil }
+            end
+
+            hash = { href: api_v3_paths.send(path_method, custom_value.value) }
+            hash[:title] = if custom_value.typed_value.respond_to?(:name)
+                             custom_value.typed_value.name
+                           else
+                             custom_value.typed_value
+                           end
+            hash
+          end
         end
 
         def link_value_setter_for(custom_field, property, expected_namespace)

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -35,16 +35,19 @@ module API
     module WorkPackages
       class WorkPackageRepresenter < ::API::Decorators::Single
         class << self
-          def create_class(work_package)
+          def create_class(work_package, embed_links: false)
             injector_class = ::API::V3::Utilities::CustomFieldInjector
             injector_class.create_value_representer(work_package,
-                                                    WorkPackageRepresenter)
+                                                    WorkPackageRepresenter,
+                                                    embed_links: embed_links)
           end
 
           def create(work_package, current_user:, embed_links: false)
-            create_class(work_package).new(work_package,
-                                           current_user: current_user,
-                                           embed_links: embed_links)
+            create_class(work_package,
+                         embed_links: embed_links)
+              .new(work_package,
+                   current_user: current_user,
+                   embed_links: embed_links)
           end
         end
 

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -226,8 +226,9 @@ describe ::API::V3::Utilities::CustomFieldInjector do
              available_custom_fields: [custom_field],
              custom_field.accessor_name => value)
     }
-    let(:custom_value) { double('CustomValue', value: raw_value) }
+    let(:custom_value) { double('CustomValue', value: raw_value, typed_value: typed_value) }
     let(:raw_value) { nil }
+    let(:typed_value) { raw_value }
     let(:value) { '' }
     let(:current_user) { FactoryGirl.build(:user) }
     subject { modified_class.new(represented, current_user: current_user).to_json }
@@ -240,11 +241,13 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     context 'user custom field' do
       let(:value) { FactoryGirl.build(:user, id: 2) }
       let(:raw_value) { value.id.to_s }
+      let(:typed_value) { value }
       let(:field_format) { 'user' }
 
-      it_behaves_like 'has an untitled link' do
+      it_behaves_like 'has a titled link' do
         let(:link) { cf_path }
         let(:href) { api_v3_paths.user 2 }
+        let(:title) { value.name }
       end
 
       it 'has the user embedded' do
@@ -263,13 +266,15 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'version custom field' do
-      let(:value) { FactoryGirl.build(:version, id: 2) }
+      let(:value) { FactoryGirl.build_stubbed(:version, id: 2) }
       let(:raw_value) { value.id.to_s }
+      let(:typed_value) { value }
       let(:field_format) { 'version' }
 
-      it_behaves_like 'has an untitled link' do
+      it_behaves_like 'has a titled link' do
         let(:link) { cf_path }
         let(:href) { api_v3_paths.version 2 }
+        let(:title) { value.name }
       end
 
       it 'has the version embedded' do
@@ -292,9 +297,10 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       let(:raw_value) { value }
       let(:field_format) { 'list' }
 
-      it_behaves_like 'has an untitled link' do
+      it_behaves_like 'has a titled link' do
         let(:link) { cf_path }
         let(:href) { api_v3_paths.string_object 'Foobar' }
+        let(:title) { value }
       end
 
       it 'has the string object embedded' do
@@ -381,8 +387,9 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       double('represented',
              available_custom_fields: [custom_field])
     }
-    let(:custom_value) { double('CustomValue', value: value) }
+    let(:custom_value) { double('CustomValue', value: value, typed_value: typed_value) }
     let(:value) { '' }
+    let(:typed_value) { value }
     subject { "{ \"_links\": #{modified_class.new(represented, current_user: nil).to_json} }" }
 
     before do
@@ -391,11 +398,13 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     context 'reading' do
       let(:value) { '2' }
+      let(:typed_value) { FactoryGirl.build_stubbed(:user) }
       let(:field_format) { 'user' }
 
-      it_behaves_like 'has an untitled link' do
+      it_behaves_like 'has a titled link' do
         let(:link) { cf_path }
         let(:href) { api_v3_paths.user 2 }
+        let(:title) { typed_value.name }
       end
 
       context 'value is nil' do


### PR DESCRIPTION
Avoids embedding custom values into the api/v3/work_packages response as:
* it is contrary to how other attributes are handled. We embed on the individual work package but do not embed on the collection.
* it is slower as way more needs to be processed by roar and more needs to be serialized.

As a substitute for the removal, a `title` attribute is added to every `customFieldX` link which again is consistent with how we handle the other attributes.

### ToDo
- [x] Tests 