### PR TITLE
fix selenium specs/cukes (broken on my machine)

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -37,10 +37,11 @@ Capybara.register_driver :selenium do |app|
 
   profile['browser.helperApps.neverAsk.saveToDisk'] = 'text/csv'
 
+  capabilities["firefox_profile"] = profile
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :firefox,
-    profile: profile,
     http_client: client,
     desired_capabilities: capabilities
   )


### PR DESCRIPTION
At least on my machine, passing the profile directly to the Selenium::Driver resulted in an error.

According to https://github.com/teamcapybara/capybara/issues/1710#issuecomment-226586643, the profile has to be passed as part of the capabilities