### PR TITLE
[24391] Missing horizontal scrolbar in work package description

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -143,3 +143,6 @@
     line-height: 0
     opacity: 0
 
+// Allow horizontal scrolling in descripton field
+.work-packages--details--description .wp-table--cell-span .inplace-edit--read-value--value-span
+  overflow-x: auto


### PR DESCRIPTION
This allows horizontal scrollbars in the WP description. Thus very broad content can be seen, too.

https://community.openproject.com/projects/openproject/work_packages/24391/activity