### PR TITLE
[24394] Long custom fields overlap input fields

### DIFF
--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -40,6 +40,8 @@
     padding: 0.375rem 0 !important
     font-weight: bold
     align-self: center
+    overflow: hidden
+    text-overflow: ellipsis
 
   .attributes-key-value--value-container
     @include grid-content(8)


### PR DESCRIPTION
This truncates too long words in the scope of `attributes-key-values`. Thus long words do not overlap the content of the attribute. 

https://community.openproject.com/projects/openproject/work_packages/24394/activity