### PR TITLE
New settings: email_login, registration_footer

### DIFF
--- a/app/assets/javascripts/settings.js.erb
+++ b/app/assets/javascripts/settings.js.erb
@@ -53,11 +53,17 @@ See doc/COPYRIGHT.rdoc for more details.
       }
     });
 
-    /** Toggle current email decorator fields */
-    var lang = jQuery("#emails_decorators_switch").val();
-    $(".emails_decorators").hide();
-    $("#emails_decorators_" + lang).show();
+    /* Javascript for Settings::TextSettingCell */
+    $(document).ready(function() {
+      $(".lang-select-switch").change(function() {
+        var self = $(this);
+        var id = self.attr("id");
+        var lang = self.val();
 
+        $("." + id).hide();
+        $("#" + id + "-" + lang).show();
+      });
+    });
 
     /** Toggle notification settings fields */
     $("#email_delivery_method_switch").on("change", function() {

--- a/app/assets/stylesheets/content/_accounts.sass
+++ b/app/assets/stylesheets/content/_accounts.sass
@@ -124,3 +124,7 @@
 
 #top-menu #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
+
+.registration-footer
+  display: block
+  margin-top: 2em

--- a/app/cells/settings/text_setting_cell.rb
+++ b/app/cells/settings/text_setting_cell.rb
@@ -1,0 +1,16 @@
+module Settings
+  ##
+  # A language switch and text area for updating a localized text setting.
+  class TextSettingCell < ::RailsCell
+    include ActionView::Helpers::JavaScriptHelper
+    include ActionView::Helpers::FormOptionsHelper
+    include OpenProject::FormTagHelper
+    include Redmine::WikiFormatting::Textile::Helper
+
+    options :name # name of setting and tag to differentiate between different language selects
+
+    def current_language
+      model
+    end
+  end
+end

--- a/app/cells/views/settings/text_setting/show.erb
+++ b/app/cells/views/settings/text_setting/show.erb
@@ -1,0 +1,38 @@
+<%# The javscript for this cell is included in `settings.js.erb`. %>
+
+<div class="form--field -vertical">
+  <div class="form--field-container">
+    <%=
+      styled_select_tag(
+        "lang",
+        options_for_select(lang_options_for_select(false), current_language.to_s),
+        id: "lang-for-#{name}",
+        class: "lang-select-switch"
+      )
+    %>
+  </div>
+</div>
+
+<% Setting.available_languages.each do |lang| %>
+  <div id="lang-for-<%= name %>-<%= lang %>"
+       <%= "style=\"display:none\"" unless lang == current_language.to_s %>
+       class="lang-select lang-for-<%= name %>"
+  >
+    <div class="form--field -vertical">
+      <%= styled_label_tag "settings[#{name}][#{lang}]", t("setting_#{name}") %>
+      <div class="form--field-container">
+        <%=
+          styled_text_area_tag(
+            "settings[#{name}][#{lang}]",
+            Setting.send(name)[lang],
+            label: false,
+            id: "settings-#{name}-#{lang}",
+            class: 'wiki-edit',
+            rows: 5
+          )
+        %>
+        <%= wikitoolbar_for "settings-#{name}-#{lang}" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -120,6 +120,10 @@ class AccountController < ApplicationController
     if request.get?
       registration_through_invitation!
     else
+      if Setting.email_login?
+        params[:user][:login] = params[:user][:mail]
+      end
+
       self_registration!
     end
   end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,0 +1,23 @@
+module AccountsHelper
+  def login_field(form)
+    form.text_field :login, size: 25, required: true
+  end
+
+  def email_field(form)
+    form.text_field :mail, required: true
+  end
+
+  ##
+  # Hide the email field in the registration form if the `email_login` setting
+  # is active. However, if an auth source is present, do show it independently from
+  # the `email_login` setting as we can't say if the auth source's login is the email address.
+  def registration_show_email?
+    !Setting.email_login? || @user.auth_source_id.present?
+  end
+
+  def registration_footer
+    footer = Setting.registration_footer[I18n.locale.to_s].presence
+
+    RedCloth3.new(footer).to_html if footer
+  end
+end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,4 +1,18 @@
 module AccountsHelper
+  class Footer
+    include OpenProject::TextFormatting
+
+    attr_reader :source
+
+    def initialize(source)
+      @source = source
+    end
+
+    def to_html
+      format_text source
+    end
+  end
+
   def login_field(form)
     form.text_field :login, size: 25, required: true
   end
@@ -18,6 +32,6 @@ module AccountsHelper
   def registration_footer
     footer = Setting.registration_footer[I18n.locale.to_s].presence
 
-    RedCloth3.new(footer).to_html if footer
+    Footer.new(footer).to_html if footer
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -127,7 +127,10 @@ module SettingsHelper
     label = options[:label]
     return ''.html_safe if label == false
 
-    styled_label_tag("settings_#{setting}", I18n.t(label || "setting_#{setting}"))
+    styled_label_tag(
+      "settings_#{setting}", I18n.t(label || "setting_#{setting}"),
+      options.slice(:title)
+    )
   end
 
   # Renders a notification field for a Redmine::Notifiable option

--- a/app/views/account/_footer.html.erb
+++ b/app/views/account/_footer.html.erb
@@ -1,3 +1,3 @@
 <% if footer = registration_footer %>
-  <span class="registration-footer"><%= footer.html_safe %></span>
+  <span class="registration-footer"><%= footer %></span>
 <% end %>

--- a/app/views/account/_footer.html.erb
+++ b/app/views/account/_footer.html.erb
@@ -1,0 +1,3 @@
+<% if footer = registration_footer %>
+  <span class="registration-footer"><%= footer.html_safe %></span>
+<% end %>

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <label class="form--label-with-check-box" for="autologin"><%= styled_check_box_tag 'autologin', 1, false %> <%= l(:label_stay_logged_in) %></label>
           <% elsif Setting.self_registration? %>
             <%# show here if autologin is disabled, otherwise below lost_password link %>
-            <%= link_to l(:label_register), { controller: '/account', action: 'register' } %>
+            <%= link_to t(:label_register), account_register_url %>
           <% end %>
         </div>
       </div>

--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -28,8 +28,8 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% disable_accessibility_css! %>
-<% html_title l(:label_register) %>
-<%= toolbar title: l(:label_register) %>
+<% html_title t(:label_register) %>
+<%= toolbar title: t(:label_register) %>
 
 <%= labelled_tabular_form_for(@user, url: url_for(action: 'register')) do |f| %>
   <%= back_url_hidden_field_tag %>
@@ -38,7 +38,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <section class="form--section">
     <% if @user.auth_source_id.nil? %>
       <div class="form--field">
-        <%= f.text_field :login, size: 25, required: true %>
+        <% if Setting.email_login? %>
+          <%= email_field(f) %>
+        <% else %>
+          <%= login_field(f) %>
+        <% end %>
       </div>
     <% end %>
 
@@ -68,9 +72,11 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= f.text_field :lastname,  required: true %>
     </div>
 
-    <div class="form--field">
-      <%= f.text_field :mail,      required: true %>
-    </div>
+    <% if registration_show_email? %>
+      <div class="form--field">
+        <%= email_field(f) %>
+      </div>
+    <% end %>
 
     <%= call_hook :view_account_register_after_basic_information, f: f %>
     <div class="form--field"><%= f.select(:language, lang_options_for_select) %></div>
@@ -86,4 +92,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= styled_button_tag l(:button_submit), class: '-highlight -with-icon icon-checkmark' %>
 
   <%= render partial: 'auth_providers', locals: { omniauth_title: I18n.t('account.signup_with_auth_provider'), wide: true } %>
+
+  <%= render partial: 'footer' %>
 <% end %>

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -39,6 +39,17 @@ See doc/COPYRIGHT.rdoc for more details.
                                                 [l(:label_registration_manual_activation), "2"],
                                                 [l(:label_registration_automatic_activation), "3"]] %>
       </div>
+
+      <div class="form--field">
+        <%= setting_check_box :email_login, title: I18n.t("tooltip.setting_email_login") %>
+      </div>
+    </fieldset>
+
+    <fieldset class="form--fieldset">
+      <fieldset id="registration_footer" class="form--fieldset">
+        <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
+        <%= cell Settings::TextSettingCell, I18n.locale, name: "registration_footer" %>
+      </fieldset>
     </fieldset>
 
     <fieldset class="form--fieldset">

--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -46,27 +46,8 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="form--field"><%= check_all_links('notified_events') %></div>
     </fieldset>
     <fieldset id="emails_decorators" class="form--fieldset"><legend class="form--fieldset-legend"><%= l(:setting_emails_header) %> & <%= l(:setting_emails_footer) %></legend>
-      <div class="form--field -vertical">
-        <div class="form--field-container">
-          <%= styled_select_tag 'lang', options_for_select(lang_options_for_select(false), current_language.to_s), id: 'emails_decorators_switch', onchange: "toggleEmailDecoratorFields()" %>
-        </div>
-      </div>
-      <% Setting.available_languages.each do |lang| %>
-        <div id="emails_decorators_<%= lang %>" style="display:none" class="emails_decorators">
-          <div class="form--field -vertical">
-            <%= styled_label_tag "settings[emails_header][#{lang}]", l(:setting_emails_header) %>
-            <div class="form--field-container">
-              <%= styled_text_area_tag("settings[emails_header][#{lang}]", Setting.emails_header[lang], label: false, class: 'wiki-edit', rows: 5) %>
-            </div>
-          </div>
-          <div class="form--field -vertical">
-            <%= styled_label_tag "settings[emails_footer][#{lang}]", l(:setting_emails_footer) %>
-            <div class="form--field-container">
-              <%= styled_text_area_tag("settings[emails_footer][#{lang}]", Setting.emails_footer[lang], label: false, class: 'wiki-edit', rows: 5) %>
-            </div>
-          </div>
-        </div>
-      <% end %>
+      <%= cell Settings::TextSettingCell, I18n.locale, name: "emails_header" %>
+      <%= cell Settings::TextSettingCell, I18n.locale, name: "emails_footer" %>
     </fieldset>
     <%= content_tag :fieldset, id: "mail_configuration", class: "form--fieldset" do %>
       <legend class="form--fieldset-legend"><%=l(:text_setup_mail_configuration)%></legend>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1738,6 +1738,7 @@ en:
   setting_display_subprojects_work_packages: "Display subprojects work packages on main projects by default"
   setting_emails_footer: "Emails footer"
   setting_emails_header: "Emails header"
+  setting_email_login: "Use e-mail as login"
   setting_enabled_scm: "Enabled SCM"
   setting_feeds_enabled: "Enable Feeds"
   setting_feeds_limit: "Feed content limit"
@@ -1772,6 +1773,7 @@ en:
   setting_per_page_options: "Objects per page options"
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
+  setting_registration_footer: "Registration footer"
   setting_repositories_automatic_managed_vendor: "Automatic repository vendor type"
   setting_repositories_encodings: "Repositories encodings"
   setting_repository_authentication_caching_enabled: "Enable caching for authentication request of version control software"
@@ -2119,6 +2121,10 @@ en:
       default: Show if not empty
       visible: Show even if empty
       hidden: Hide by default
+    setting_email_login: >
+      If enabled a user will be unable to chose a login during registration.
+      Instead their given e-mail address will serve as the login.
+      An administrator may still change the login separately.
 
   queries:
     apply_filter: Apply preconfigured filter

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -150,6 +150,8 @@ available_languages:
   - ru
 default_language:
   default: en
+email_login: # use email address as login, hide login in registration form
+  default: 0
 host_name:
   default: localhost:3000
 protocol:
@@ -319,6 +321,10 @@ users_deletable_by_self:
 journal_aggregation_time_minutes:
   default: 5
   format: int
+registration_footer:
+  serialized: true
+  default:
+    en:
 repository_storage_cache_minutes:
   default: 720
   format: int

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -45,11 +45,14 @@ module Redmine
                                     title: ::I18n.t('js.inplace.link_formatting_help')
 
           javascript_tag(<<-EOF)
-            var wikiToolbar = new jsToolBar(document.getElementById('#{field_id}'));
-            wikiToolbar.setHelpLink(jQuery('#{escape_javascript help_button}')[0]);
             // initialize the toolbar later, so that i18n-js has a chance to set the translations
             // for the wiki-buttons first.
-            jQuery(function(){ wikiToolbar.draw(); });
+            jQuery(document).ready(function(){
+              var wikiToolbar = new jsToolBar(document.getElementById('#{field_id}'));
+
+              wikiToolbar.setHelpLink(jQuery('#{escape_javascript help_button}')[0]);
+              wikiToolbar.draw();
+            });
           EOF
         end
 

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -29,25 +29,78 @@
 require 'spec_helper'
 
 describe 'account/register', type: :view do
-  before do
-    assign(:user, user)
-    render
-  end
+  let(:user) { FactoryGirl.build :user, auth_source: nil }
 
-  context 'with auth source' do
-    let(:auth_source) { FactoryGirl.create :auth_source }
-    let(:user)        { FactoryGirl.build :user, auth_source: auth_source }
+  context 'with the email_login setting disabled (default value)' do
+    before do
+      Setting.email_login = 0
 
-    it 'should not show a login field' do
-      expect(rendered).not_to include('user[login]')
+      assign(:user, user)
+      render
+    end
+
+    context 'with auth source' do
+      let(:auth_source) { FactoryGirl.create :auth_source }
+      let(:user)        { FactoryGirl.build :user, auth_source: auth_source }
+
+      it 'should not show a login field' do
+        expect(rendered).not_to include('user[login]')
+      end
+    end
+
+    context 'without auth source' do
+      it 'should show a login field' do
+        expect(rendered).to include('user[login]')
+      end
     end
   end
 
-  context 'without auth source' do
-    let(:user) { FactoryGirl.build :user, auth_source: nil }
+  context 'with the email_login setting enabled' do
+    before do
+      Setting.email_login = 1
 
-    it 'should show a login field' do
-      expect(rendered).to include('user[login]')
+      assign(:user, user)
+      render
+    end
+
+    context 'with auth source' do
+      let(:auth_source) { FactoryGirl.create :auth_source }
+      let(:user)        { FactoryGirl.build :user, auth_source: auth_source }
+
+      it 'should not show a login field' do
+        expect(rendered).not_to include('user[login]')
+      end
+
+      it 'should show an email field' do
+        expect(rendered).to include('user[mail]')
+      end
+    end
+
+    context 'without auth source' do
+      it 'should not show a login field' do
+        puts rendered
+
+        expect(rendered).not_to include('user[login]')
+      end
+
+      it 'should show an email field' do
+        expect(rendered).to include('user[mail]')
+      end
+    end
+  end
+
+  context 'with the registration_footer setting enabled' do
+    let(:footer) { "Some email footer" }
+
+    before do
+      Setting.registration_footer = { "en" => footer }
+
+      assign(:user, user)
+      render
+    end
+
+    it 'should render the emai footer' do
+      expect(rendered).to include(footer)
     end
   end
 end

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe 'account/register', type: :view do
 
   context 'with the email_login setting disabled (default value)' do
     before do
-      Setting.email_login = 0
+      allow(Setting).to receive(:email_login?).and_return(false)
 
       assign(:user, user)
       render
@@ -57,7 +57,7 @@ describe 'account/register', type: :view do
 
   context 'with the email_login setting enabled' do
     before do
-      Setting.email_login = 1
+      allow(Setting).to receive(:email_login?).and_return(true)
 
       assign(:user, user)
       render
@@ -93,7 +93,7 @@ describe 'account/register', type: :view do
     let(:footer) { "Some email footer" }
 
     before do
-      Setting.registration_footer = { "en" => footer }
+      allow(Setting).to receive(:registration_footer).and_return("en" => footer)
 
       assign(:user, user)
       render


### PR DESCRIPTION
WP [#24404](https://community.openproject.com/projects/openproject/work_packages/24404/activity)

As seen in the following screenshot this implements the following new settings:

* `email_login` - The user may not chose a login during registration. The email is used instead.
* `registration_footer` - A customizable message shown below the registration form, for instance to show TOS.

It also does the following:

* introduces a `Settings::TextSetting` cell which is now used to render both the email footer and header settings, and the registration footer setting
* through that it fixes the bug that you can't edit email headers/footers in other languages
* also fixes the wiki toolbar bug because of which no toolbar was displayed anywhere when used through the `wikitoolbar_for` helper

*Out of scope*

Although seen in the screenshot the modal registration dialog has been extracted into a separate [Work Package](https://community.openproject.com/projects/openproject/work_packages/24405/activity?query_id=895).

<img width="1282" alt="email_login_and_registration_footer" src="https://cloud.githubusercontent.com/assets/158871/20795770/cedfde30-b7ca-11e6-8b5c-c86c2ba53e85.png">
