### PR TITLE
[24398] Insert iframe into modal body instead of loading it on page load

### DIFF
--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 </div>
 
 <% if show_onboarding_modal? %>
-  <modal-wrapper initialize="true" modal-params="{ appendClassName: 'onboarding-modal' }">
+  <modal-wrapper initialize="true" iframe-url="<%= OpenProject::Configuration.onboarding_video_url %>" modal-params="{ appendClassName: 'onboarding-modal' }">
     <%= render partial: '/onboarding/starting_video_modal' %>
   </modal-wrapper>
 <% end %>

--- a/app/views/onboarding/_menu_item.html.erb
+++ b/app/views/onboarding/_menu_item.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<modal-wrapper modal-params="{ appendClassName: 'onboarding-modal' }">
+<modal-wrapper iframe-url="<%= OpenProject::Configuration.onboarding_video_url %>" modal-params="{ appendClassName: 'onboarding-modal' }">
   <li>
     <%= link_to l(:label_video),
                 '',

--- a/app/views/onboarding/_starting_video_modal.html.erb
+++ b/app/views/onboarding/_starting_video_modal.html.erb
@@ -40,8 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="onboarding--video-text">
           <span><%= I18n.t('onboarding.text_getting_started') %></span>
         </div>
-        <div class="onboarding--video">
-          <iframe src="<%= OpenProject::Configuration.onboarding_video_url %>" height="282" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+        <div class="onboarding--video iframe-target-wrapper">
         </div>
       </div>
     </div>

--- a/frontend/app/components/modals/modal-wrapper/modal-wrapper.directive.ts
+++ b/frontend/app/components/modals/modal-wrapper/modal-wrapper.directive.ts
@@ -35,6 +35,8 @@ export class ModalWrapperController {
   public modal: any;
   public modalParams: any;
 
+  public iframeSelector = '.iframe-target-wrapper';
+
   private modalOptions: any = {
     plain: true,
     closeByEscape: true,
@@ -51,6 +53,10 @@ export class ModalWrapperController {
     const wrappedElement = $element.find('.modal-wrapper--content');
     this.modalBody = wrappedElement.html();
 
+    if ($attrs['iframeUrl']) {
+      this.appendIframe($attrs['iframeUrl']);
+    }
+
     angular.extend(this.modalOptions, this.modalParams || {});
     this.modalOptions.template = this.modalBody;
 
@@ -64,6 +70,16 @@ export class ModalWrapperController {
 
   public initialize() {
     this.modal = this.ngDialog.open(this.modalOptions);
+  }
+
+  private appendIframe(url) {
+    let subdom = angular.element(this.modalBody);
+    let iframe = angular.element('<iframe frameborder="0" height="282" allowfullscreen>></iframe>');
+    iframe.attr('src', url);
+
+    subdom.find(this.iframeSelector).append(iframe);;
+
+    this.modalBody = subdom.html();
   }
 }
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -92,7 +92,7 @@ module OpenProject
 
       'apiv2_enable_basic_auth' => true,
 
-      'onboarding_video_url' => 'https://player.vimeo.com/video/163426858',
+      'onboarding_video_url' => 'https://player.vimeo.com/video/163426858?autoplay=1',
       'onboarding_enabled' => true
     }
 


### PR DESCRIPTION
Currently, the vimeo iframe is loaded on page load and causes some assets to be loaded on _every_ page, even on travis runs.

Fixes https://community.openproject.com/work_packages/24398/