### PR TITLE
[24395] Fix typo in version_setter

### DIFF
--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -43,7 +43,7 @@ class CustomValue::VersionStrategy < CustomValue::FormatStrategy
       self.memoized_typed_value = val
 
       val.id.to_s
-    elsif value.blank?
+    elsif val.blank?
       super(nil)
     else
       super


### PR DESCRIPTION
The check used the previous `value` instead of the parsed `val`.
If a version was nil previously, the new value was never set.

https://community.openproject.com/projects/openproject/work_packages/details/24395