### PR TITLE
[24433] Fix accumulating carrierwave cache_dirs

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -39,6 +39,7 @@ targets:
 before_precompile: "packaging/setup"
 crons:
   - packaging/cron/openproject-clear-old-sessions
+  - packaging/cron/openproject-clear-uploaded-files
 services:
   - postgres
 installer: https://github.com/pkgr/installer.git

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -49,15 +49,7 @@ module FileUploader
 
   module ClassMethods
     def cache_dir
-      @cache_dir ||= begin
-        tmp = Tempfile.new 'op_uploaded_files'
-        path = Pathname(tmp)
-
-        tmp.close! # delete temp file
-        path.mkdir # create temp directory
-
-        path.to_s
-      end
+      @cache_dir ||= File.join(Dir.tmpdir, 'op_uploaded_files')
     end
   end
 end

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -28,6 +28,12 @@
 #++
 
 namespace :attachments do
+  desc 'Clear all attachments created before yesterday'
+  task clear: [:environment] do
+    CarrierWave.clean_cached_files!
+  end
+
+
   desc 'Copies all attachments from the current to the given storage.'
   task :copy_to, [:to] => :environment do |_task, args|
     if args.empty?

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -33,7 +33,6 @@ namespace :attachments do
     CarrierWave.clean_cached_files!
   end
 
-
   desc 'Copies all attachments from the current to the given storage.'
   task :copy_to, [:to] => :environment do |_task, args|
     if args.empty?

--- a/packaging/cron/openproject-clear-uploaded-files
+++ b/packaging/cron/openproject-clear-uploaded-files
@@ -1,0 +1,3 @@
+APP_NAME="_APP_NAME_"
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+0 23 * * 5 root ${APP_NAME} run rake -s attachments:clear >> /var/log/${APP_NAME}/cron-clear-uploaded-files.log 2>&1


### PR DESCRIPTION
**Simplify tmpdir used by CarrierWave**
We don't need to create the cache dir for them, it will create it automatically.
We can use [`Dir.tmpdir`](https://ruby-doc.org/stdlib-2.0.0/libdoc/tmpdir/rdoc/Dir.html#method-c-tmpdir) to retrieve a reference to the OS's tempdir. It will also respect `TMPDIR` env variable, which users might want to override depening on their configuration.

Otherwise, we end up creating a new temporary file each time the file uploader is loaded. These were never closed and end up accumulating.

* For cancelled / failed upload requests, introduce a rake task to clean any remaining upload directory
* Use that cron job in the packager configuration. Note that this will not catch previously accumulated directories due to the changed tempfile creation.

https://community.openproject.com/work_packages/24433/activity