### PR TITLE
Filters for Relations API

### DIFF
--- a/app/models/queries/base_filter.rb
+++ b/app/models/queries/base_filter.rb
@@ -71,7 +71,7 @@ class Queries::BaseFilter
     date_past:        ['>t-', '<t-', 't-', 't', 'w'],
     string:           ['=', '~', '!', '!~'],
     text:             ['~', '!~'],
-    integer:          ['=', '>=', '<=', '!*', '*']
+    integer:          ['=', '!', '>=', '<=', '!*', '*']
   }
 
   attr_accessor :context,

--- a/app/models/queries/relations.rb
+++ b/app/models/queries/relations.rb
@@ -27,12 +27,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
-      end
-    end
+module Queries
+  module Relations
+    register = Queries::Register
+    filters = Queries::Relations::Filters
+    query = Queries::Relations::RelationQuery
+
+    register.filter query, filters::IdFilter
+    register.filter query, filters::FromFilter
+    register.filter query, filters::ToFilter
+    register.filter query, filters::InvolvedFilter
+    register.filter query, filters::TypeFilter
+
+    register.order query, Queries::Relations::Orders::DefaultOrder
   end
 end

--- a/app/models/queries/relations/filters/from_filter.rb
+++ b/app/models/queries/relations/filters/from_filter.rb
@@ -27,11 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      class FromFilter < ::Queries::Relations::Filters::RelationFilter
+        def type
+          :integer
+        end
+
+        def self.key
+          :from_id
+        end
       end
     end
   end

--- a/app/models/queries/relations/filters/id_filter.rb
+++ b/app/models/queries/relations/filters/id_filter.rb
@@ -27,11 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      class IdFilter < ::Queries::Relations::Filters::RelationFilter
+        def type
+          :integer
+        end
+
+        def self.key
+          :id
+        end
       end
     end
   end

--- a/app/models/queries/relations/filters/involved_filter.rb
+++ b/app/models/queries/relations/filters/involved_filter.rb
@@ -27,11 +27,31 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      ##
+      # Filters relations by work package ID in either `from` or `to` position of a relation.
+      # For instance:
+      #   Given relations [{ from_id: 3, to_id: 7 }, { from_id: 8, to_id: 3}]
+      #   filtering by involved=3 would yield both these relations.
+      class InvolvedFilter < ::Queries::Relations::Filters::RelationFilter
+        def type
+          :integer
+        end
+
+        def self.key
+          :involved
+        end
+
+        def where
+          case operator
+          when "="
+            ["from_id IN (?) OR to_id IN (?)", values.join(", "), values.join(", ")]
+          when "!"
+            ["from_id NOT IN (?) AND to_id NOT IN (?)", values.join(", "), values.join(", ")]
+          end
+        end
       end
     end
   end

--- a/app/models/queries/relations/filters/relation_filter.rb
+++ b/app/models/queries/relations/filters/relation_filter.rb
@@ -27,11 +27,15 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      class RelationFilter < ::Queries::BaseFilter
+        self.model = Relation
+
+        def human_name
+          Relation.human_attribute_name(name)
+        end
       end
     end
   end

--- a/app/models/queries/relations/filters/to_filter.rb
+++ b/app/models/queries/relations/filters/to_filter.rb
@@ -27,11 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      class ToFilter < ::Queries::Relations::Filters::RelationFilter
+        def type
+          :integer
+        end
+
+        def self.key
+          :to_id
+        end
       end
     end
   end

--- a/app/models/queries/relations/filters/type_filter.rb
+++ b/app/models/queries/relations/filters/type_filter.rb
@@ -27,11 +27,17 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Filters
+      class TypeFilter < ::Queries::Relations::Filters::RelationFilter
+        def type
+          :string
+        end
+
+        def self.key
+          :relation_type
+        end
       end
     end
   end

--- a/app/models/queries/relations/orders/default_order.rb
+++ b/app/models/queries/relations/orders/default_order.rb
@@ -27,11 +27,15 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    module Orders
+      class DefaultOrder < ::Queries::BaseOrder
+        self.model = Relation
+
+        def self.key
+          /id|from|to|involved|type/
+        end
       end
     end
   end

--- a/app/models/queries/relations/relation_query.rb
+++ b/app/models/queries/relations/relation_query.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -27,11 +26,15 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        element_decorator ::API::V3::Relations::RelationRepresenter
+module Queries
+  module Relations
+    class RelationQuery < ::Queries::BaseQuery
+      def self.model
+        Relation
+      end
+
+      def self.default_scope
+        Relation.all
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1180,6 +1180,7 @@ en:
   label_registration_automatic_activation: "automatic account activation"
   label_registration_manual_activation: "manual account activation"
   label_related_work_packages: "Related work packages"
+  label_relates: "related to"
   label_relates_to: "related to"
   label_relation_delete: "Delete relation"
   label_relation_new: "New relation"

--- a/doc/apiv3/endpoints/relations.apib
+++ b/doc/apiv3/endpoints/relations.apib
@@ -321,7 +321,7 @@ applicable for the other relations.
                 "message": "The specified relation type does not exist."
             }
 
-## Relations [/api/v3/relations{?offset,pageSize,filters,sortBy}]
+## Relations [/api/v3/relations{?filters,sortBy}]
 
 + Model
     + Body
@@ -391,10 +391,6 @@ Lists all relations according to the given (optional, logically conjunctive) fil
 The response only includes relations between work packages which the user is allowed to see.
 
 + Parameters
-    + offset = `0` (optional, integer, `5`) ... Page number inside the requested collection
-
-    + pageSize (optional, integer, `20`) ... Number of elements to display per page
-
     + filters (optional, string, `[{ "from": { "operator": "=", "values": 42 }" }]`) ... JSON specifying filter conditions.
     Accepts the same format as returned by the [queries](#queries) endpoint. Valid fields to filter by are:
     `from` (ID of work package from which the filtered relations emanates), `to` (ID of work package to which this related points),

--- a/doc/apiv3/endpoints/relations.apib
+++ b/doc/apiv3/endpoints/relations.apib
@@ -393,8 +393,11 @@ The response only includes relations between work packages which the user is all
 + Parameters
     + filters (optional, string, `[{ "from": { "operator": "=", "values": 42 }" }]`) ... JSON specifying filter conditions.
     Accepts the same format as returned by the [queries](#queries) endpoint. Valid fields to filter by are:
-    `from` (ID of work package from which the filtered relations emanates), `to` (ID of work package to which this related points),
-    `involved` (ID of either the `from` or the `to` work package.), `type` (The type of relation to filter by, e.g. "follows")
+      + id - ID of relation
+      + from - ID of work package from which the filtered relations emanates.
+      + to - ID of work package to which this related points.
+      + involved - ID of either the `from` or the `to` work package.
+      + type - The type of relation to filter by, e.g. "follows".
 
     + sortBy (optional, string, `[["type", "asc"]]`) ... JSON specifying sort criteria.
     Accepts the same format as returned by the [queries](#queries) endpoint.

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -170,6 +170,9 @@ module API
             embed_links: false
           )
         end
+
+        self.to_eager_load = [:to,
+                              from: { project: :enabled_modules }]
       end
     end
   end

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -27,6 +27,8 @@
 #++
 
 require 'api/v3/relations/relation_representer'
+require 'api/v3/relations/relation_collection_representer'
+
 require 'relations/create_relation_service'
 require 'relations/update_relation_service'
 
@@ -38,11 +40,17 @@ module API
 
         resources :relations do
           get do
-            relations = Relation.all
+            query = ::API::V3::ParamsToQueryService.new(Relation).call(params)
 
-            RelationCollectionRepresenter.new(relations,
-                                              api_v3_paths.relations,
-                                              current_user: current_user)
+            if query.valid?
+              RelationCollectionRepresenter.new(
+                query.results,
+                api_v3_paths.relations,
+                current_user: current_user
+              )
+            else
+              raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+            end
           end
 
           params do

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -44,7 +44,7 @@ module API
 
             if query.valid?
               RelationCollectionRepresenter.new(
-                query.results,
+                query.results.includes(::API::V3::Relations::RelationRepresenter.to_eager_load),
                 api_v3_paths.relations,
                 current_user: current_user
               )

--- a/lib/api/v3/relations/relations_helper.rb
+++ b/lib/api/v3/relations/relations_helper.rb
@@ -51,6 +51,10 @@ module API
             .pluck("#{work_packages}.project_id")
             .first
         end
+
+        def to_i_or_nil(string)
+          string ? string.to_i : nil
+        end
       end
     end
   end

--- a/spec/requests/api/v3/relations/relations_index_spec.rb
+++ b/spec/requests/api/v3/relations/relations_index_spec.rb
@@ -1,0 +1,100 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'GET /api/v3/relations', type: :request do
+  let(:user) { FactoryGirl.create :admin }
+
+  let(:work_package) { FactoryGirl.create :work_package }
+
+  let!(:relations) do
+    def new_relation(opts = {})
+      relation_type = opts.delete(:type)
+
+      FactoryGirl.create :relation, opts.merge(relation_type: relation_type)
+    end
+
+    def new_work_package
+      FactoryGirl.create :work_package
+    end
+
+    [
+      new_relation(id: 3, from: work_package, to: new_work_package, type: 'precedes'),
+      new_relation(id: 5, from: work_package, to: new_work_package, type: 'blocks'),
+      new_relation(id: 7, from: new_work_package, to: work_package, type: 'precedes'),
+      new_relation(id: 11, from: new_work_package, to: new_work_package, type: 'blocks')
+    ]
+  end
+
+  before do
+    login_as user
+  end
+
+  describe "filters" do
+    def filter_relations(name, operator, values)
+      filter = {
+        name => {
+          "operator" => operator,
+          "values" => values
+        }
+      }
+      params = {
+        filters: [filter].to_json
+      }
+
+      get "/api/v3/relations", params: params
+
+      json = JSON.parse response.body
+
+      Array(Hash(json).dig("_embedded", "elements")).map { |e| e["id"] }
+    end
+
+    ##
+    # We're testing all cases within one example to save a lot of time.
+    # Initializing the relations takes very long (about 2s) and it's unnecessary
+    # to repeat that step for every example as we are not mutating anything.
+    # This saves about 75% on the runtime (6s vs 24s on this machine) of the spec.
+    it 'work' do
+      expect(filter_relations("id", "=", [3, 7])).to eq [3, 7]
+      expect(filter_relations("id", "!", [3, 7])).to eq [5, 11]
+
+      expect(filter_relations("from", "=", [work_package.id])).to eq [3, 5]
+      expect(filter_relations("from", "!", [work_package.id])).to eq [7, 11]
+
+      expect(filter_relations("to", "=", [work_package.id])).to eq [7]
+      expect(filter_relations("to", "!", [work_package.id])).to eq [3, 5, 11]
+
+      expect(filter_relations("involved", "=", [work_package.id])).to eq [3, 5, 7]
+      expect(filter_relations("involved", "!", [work_package.id])).to eq [11]
+
+      expect(filter_relations("type", "=", ["blocks"])).to eq [5, 11]
+      expect(filter_relations("type", "!", ["blocks"])).to eq [3, 7]
+    end
+  end
+end


### PR DESCRIPTION
WP [#24436](https://community.openproject.com/projects/openproject/work_packages/24436/activity)

**Implementation Approach**

Implement filters according to [specification](http://opf.github.io/apiv3-doc/#relations-relations-get). Straightforward addition of RelationQueryFilter. 

**ToDos**

- [x] implement RelationQueryFilter to allow filtering by
  - [x] id
  - [x] from
  - [x] to
  - [x] involved
  - [x] type
