### PR TITLE
fix estimated time filters

### DIFF
--- a/app/controllers/api/experimental/concerns/query_loading.rb
+++ b/app/controllers/api/experimental/concerns/query_loading.rb
@@ -69,7 +69,7 @@ module Api::Experimental::Concerns::QueryLoading
       end
 
       if params[:fields] || params[:f] || params[:accept_empty_query_fields]
-        view_context.add_filter_from_params
+        view_context.add_filter_from_params(@query, filters: params)
       end
 
       @query.group_by = params[:group_by]

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -44,12 +44,13 @@ module QueriesHelper
     column.is_a?(QueryCustomFieldColumn) ? column.custom_field.name_locale : nil
   end
 
-  def add_filter_from_params
-    @query.filters = []
-    @query.add_filters(
-      fields_from_params(@query, params),
-      operators_from_params(@query, params),
-      values_from_params(@query, params))
+  def add_filter_from_params(query, filters: params)
+    query.filters = []
+    query.add_filters(
+      fields_from_params(query, filters),
+      operators_from_params(query, filters),
+      values_from_params(query, filters)
+    )
   end
 
   # Retrieve query from session or build a new query
@@ -59,7 +60,7 @@ module QueriesHelper
       cond << " OR project_id = #{@project.id}" if @project
       @query = Query.where(cond).find(params[:query_id])
       @query.project = @project
-      add_filter_from_params if params[:accept_empty_query_fields]
+      add_filter_from_params(@query) if params[:accept_empty_query_fields]
       session[:query] = { id: @query.id, project_id: @query.project_id }
       sort_clear
     else
@@ -68,7 +69,7 @@ module QueriesHelper
         @query = Query.new(name: '_')
         @query.project = @project
         if params[:fields] || params[:f]
-          add_filter_from_params
+          add_filter_from_params(@query)
         else
           @query.available_filters.map(&:name).each do |field|
             @query.add_short_filter(field, params[field]) if params[field]
@@ -115,7 +116,7 @@ module QueriesHelper
     if names
       context = WorkPackage.new
 
-      names.map { |name| API::Utilities::PropertyNameConverter.to_ar_name name, context: context }
+      names.map { |name| converter.to_ar_name name, context: context }
     end
   end
 
@@ -155,9 +156,9 @@ module QueriesHelper
 
     names = field_hash.keys
     entries = names
-      .zip(fix_field_array(query, names))
-      .select { |_name, field| field.present? }
-      .map { |name, field| [field, field_hash[name]] }
+              .zip(fix_field_array(query, names))
+              .select { |_name, field| field.present? }
+              .map { |name, field| [field, field_hash[name]] }
 
     Hash[entries]
   end
@@ -181,11 +182,16 @@ module QueriesHelper
   def fix_field_array(query, field_names)
     return [] if field_names.nil?
 
-    context = WorkPackage.new
+    # memoize to reduce overhead of WorkPackage.new
+    @fix_field_array_wp ||= WorkPackage.new
     available_keys = query.available_filters.map(&:name)
 
     field_names
-      .map { |name| API::Utilities::PropertyNameConverter.to_ar_name name, context: context }
-      .map { |name| available_keys.find { |k| k =~ /#{name}(_id)?$/ } }
+      .map { |name| converter.to_ar_name name, context: @fix_field_array_wp, refer_to_ids: true }
+      .map { |name| available_keys.find { |k| name =~ /#{k}(s|_id)?$/ } }
+  end
+
+  def converter
+    API::Utilities::PropertyNameConverter
   end
 end

--- a/lib/api/utilities/property_name_converter.rb
+++ b/lib/api/utilities/property_name_converter.rb
@@ -95,10 +95,10 @@ module API
         private
 
         def special_api_to_ar_conversions
-          @api_to_ar_conversions ||= WELL_KNOWN_AR_TO_API_CONVERSIONS.inject({}) { |result, (k, v)|
+          @api_to_ar_conversions ||= WELL_KNOWN_AR_TO_API_CONVERSIONS.inject({}) do |result, (k, v)|
             result[v.underscore] = k.to_s
             result
-          }
+          end
         end
 
         # Unifies different attributes refering to the same thing via a foreign key
@@ -107,19 +107,23 @@ module API
           attribute.to_s.sub(/(.+)_id\z/, '\1')
         end
 
-        # Adds _id suffix to field names that refer to foreign key relations,
+        # Adds _id(s) suffix to field names that refer to foreign key relations,
         # leaves other names untouched.
-        # e.g. status_id -> status
+        # e.g.
+        #   status -> status_id
+        #   watcher -> watcher_ids
         def denormalize_foreign_key_name(attribute, context)
           name, id_name = key_name_with_and_without_id attribute
 
           # When appending an ID is valid, the context object will understand that message
           # in case of a `belongs_to` relation (e.g. status => status_id). The second check is for
-          # `has_many` relations (e.g. watcher => watchers).
-          if context.respond_to?(id_name) || context.respond_to?(name.pluralize)
+          # `has_many` relations (e.g. watcher => watcher_ids).
+          if context.respond_to?(id_name)
             id_name
+          elsif context.respond_to?(id_name.pluralize)
+            id_name.pluralize
           else
-            attribute
+            name
           end
         end
 

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -31,6 +31,7 @@ module API
     module WorkPackages
       module WorkPackageListHelpers
         extend Grape::API::Helpers
+        include QueriesHelper
 
         def work_packages_by_params(project: nil)
           query = Query.new(name: '_', project: project)
@@ -81,21 +82,19 @@ module API
           values = {}
           filters.each do |filter|
             attribute = filter.keys.first # there should only be one attribute per filter
-            ar_attribute = convert_attribute attribute, append_id: true
-            operators[ar_attribute] = filter[attribute]['operator']
-            values[ar_attribute] = filter[attribute]['values']
+            operators[attribute] = filter[attribute]['operator']
+            values[attribute] = filter[attribute]['values']
           end
 
           {
-            attributes: values.keys,
+            fields: values.keys,
             operators: operators,
             values: values
           }
         end
 
         def set_filters(query, filters)
-          query.filters = []
-          query.add_filters(filters[:attributes], filters[:operators], filters[:values])
+          add_filter_from_params(query, filters: filters)
 
           bad_filter = query.filters.detect(&:invalid?)
           if bad_filter

--- a/spec/lib/api/utilities/property_name_converter_spec.rb
+++ b/spec/lib/api/utilities/property_name_converter_spec.rb
@@ -79,7 +79,7 @@ describe ::API::Utilities::PropertyNameConverter do
 
   describe '#to_ar_name' do
     let(:attribute_name) { 'anAttribute' }
-    let(:context) { FactoryGirl.build(:work_package) }
+    let(:context) { FactoryGirl.build_stubbed(:work_package) }
 
     subject { described_class.to_ar_name(attribute_name, context: context) }
 
@@ -97,8 +97,20 @@ describe ::API::Utilities::PropertyNameConverter do
       context 'requesting ids via refer_to_ids' do
         subject { described_class.to_ar_name(attribute_name, context: context, refer_to_ids: true) }
 
-        it 'adds an id suffix' do
-          is_expected.to eql('status_id')
+        context 'for keys refering to a belongs_to association' do
+          let(:attribute_name) { 'status' }
+
+          it 'adds an id suffix' do
+            is_expected.to eql('status_id')
+          end
+        end
+
+        context 'for keys refering to a has_many association' do
+          let(:attribute_name) { 'watcher' }
+
+          it 'adds an id suffix' do
+            is_expected.to eql('watcher_ids')
+          end
         end
 
         context 'for non-foreign keys' do
@@ -106,6 +118,14 @@ describe ::API::Utilities::PropertyNameConverter do
 
           it 'does not add an id suffix' do
             is_expected.to eql('subject')
+          end
+        end
+
+        context 'does not append an id to pluarlized attributes' do
+          let(:attribute_name) { 'estimatedTime' }
+
+          it 'does not add an id suffix' do
+            is_expected.to eql('estimated_hours')
           end
         end
       end
@@ -144,7 +164,7 @@ describe ::API::Utilities::PropertyNameConverter do
         end
 
         context 'in an apropriate context' do
-          let(:context) { FactoryGirl.build(:version) }
+          let(:context) { FactoryGirl.build_stubbed(:version) }
 
           it 'should be performed' do
             is_expected.to eql('updated_on')


### PR DESCRIPTION
Because estimatedTime is turned to estimatated_hours by the PropertyNameConverter, checking whether work package responds to `estimated_hours.pluralize` only to return estimated_hours_id does not make sense. That behaviour was introduced to cope with the watcher attribute which should have been turned into watcher_ids as watchers is a has_many relations.
But when that behaviour was fixed to work correctly with estimated_hours again, so that the name converter returns estimated_hours (no foreign key) and watcher_ids (foreign key) the watcher bug had to be fixed all over again.
For turning work package filter parameters from the external to the internal representation, the v3 now makes use of the same method, as employed by the experimental api.

https://community.openproject.com/projects/openproject/work_packages/24448