### PR TITLE
allow changing user's authentication method

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -219,6 +219,9 @@ class UsersController < ApplicationController
   end
 
   def resend_invitation
+    status = Principal::STATUSES[:invited]
+    @user.update status: status if @user.status != status
+
     token = UserInvitation.reinvite_user @user.id
 
     if token.persisted?

--- a/app/views/users/_toolbar.html.erb
+++ b/app/views/users/_toolbar.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <%= breadcrumb_toolbar(@user.new_record? ? l(:label_user_new) : @user.name) do %>
   <% unless @user.new_record? %>
-    <% if @user.invited? and current_user.admin? %>
+    <% if current_user.admin? || current_user.id == @user.id %>
       <li class="toolbar-item">
         <%= form_for(@user, html: { class: 'toolbar-item'},
                             url: { action: :resend_invitation },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2230,6 +2230,8 @@ en:
   tooltip_resend_invitation: >
     Sends another invitation email with a fresh token in
     case the old one expired or the user did not get the original email.
+    Can also be used for active users to choose a new authentication method.
+    When used with active users their status will be changed to 'invited'.
 
   tooltip:
     attribute_visibility:

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -102,8 +102,8 @@ describe 'users/edit', type: :view do
       render
     end
 
-    it 'does not render the resend invitation button' do
-      expect(rendered).not_to include I18n.t(:label_resend_invitation)
+    it 'also renders the resend invitation button' do
+      expect(rendered).to include I18n.t(:label_resend_invitation)
     end
   end
 


### PR DESCRIPTION
Allows users' authentication method to be changed by clicking on "Resend Invitation".
Can be done by admins and also by users themselves for their own account.