### PR TITLE
[24474] Allow users to be uniquely identified by login

### DIFF
--- a/app/models/mixins/unique_finder.rb
+++ b/app/models/mixins/unique_finder.rb
@@ -1,0 +1,46 @@
+module Mixins
+  module UniqueFinder
+    def self.prepended(model_class)
+      unless model_class.respond_to? :unique_attribute
+        raise "Missing :unique_attribute accessor on ##{model_class}"
+      end
+
+      model_class.singleton_class.prepend ClassMethods
+    end
+
+    module ClassMethods
+      ##
+      # Returns the first model that matches (in this order), either:
+      # 1. The given ID
+      # 2. The given unique attribute
+      def find_by_unique(unique_or_id)
+        matches = where(id: unique_or_id).or(where(unique_attribute => unique_or_id)).to_a
+
+        case matches.length
+        when 0
+          nil
+        when 1
+          matches.first
+        else
+          matches.find { |user| user.id.to_s == unique_or_id.to_s }
+        end
+      end
+
+      ##
+      # Returns the first model that matches (in this order), either:
+      # 1. The given ID
+      # 2. The given unique attribute
+      #
+      # Raise ActiveRecord::RecordNotFound when no match is found.
+      def find_by_unique!(unique_or_id)
+        match = find_by_unique(unique_or_id)
+
+        if match.nil?
+          raise ActiveRecord::RecordNotFound
+        else
+          match
+        end
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,6 +149,11 @@ class User < Principal
 
   scope :newest, -> { order(created_on: :desc) }
 
+  def self.unique_attribute
+    :login
+  end
+  prepend ::Mixins::UniqueFinder
+
   def sanitize_mail_notification_setting
     self.mail_notification = Setting.default_notification_option if mail_notification.blank?
     true
@@ -478,23 +483,6 @@ class User < Principal
       MAIL_NOTIFICATION_OPTIONS.reject { |option| option.first == 'selected' }
     else
       MAIL_NOTIFICATION_OPTIONS
-    end
-  end
-
-  ##
-  # Returns the first user that matches (in this order), either:
-  # 1. The given ID
-  # 2. The given login
-  def self.find_by_unique(login_or_id)
-    matches = where(id: login_or_id).or(where(login: login_or_id)).to_a
-
-    case matches.length
-    when 0
-      raise ActiveRecord::RecordNotFound
-    when 1
-      return matches.first
-    else
-      return matches.find { |user| user.id.to_s == login_or_id.to_s }
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -481,6 +481,23 @@ class User < Principal
     end
   end
 
+  ##
+  # Returns the first user that matches (in this order), either:
+  # 1. The given ID
+  # 2. The given login
+  def self.find_by_unique(login_or_id)
+    matches = where(id: login_or_id).or(where(login: login_or_id)).to_a
+
+    case matches.length
+    when 0
+      raise ActiveRecord::RecordNotFound
+    when 1
+      return matches.first
+    else
+      return matches.find { |user| user.id.to_s == login_or_id.to_s }
+    end
+  end
+
   # Find a user account by matching the exact login and then a case-insensitive
   # version.  Exact matches will be given priority.
   def self.find_by_login(login)

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -89,7 +89,7 @@ module API
             helpers ::API::V3::Users::UpdateUser
 
             before do
-              @user = User.find_by_unique(params[:id])
+              @user = User.find_by_unique!(params[:id])
             end
 
             get do

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -89,7 +89,7 @@ module API
             helpers ::API::V3::Users::UpdateUser
 
             before do
-              @user = User.find(params[:id])
+              @user = User.find_by_unique(params[:id])
             end
 
             get do

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -40,11 +40,11 @@ describe SettingsController, type: :controller do
   describe 'edit' do
     render_views
 
-    before(:all) do
+    before do
       @previous_projects_modules = Setting.default_projects_modules
     end
 
-    after(:all) do
+    after do
       Setting.default_projects_modules = @previous_projects_modules
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,21 +46,18 @@ describe User, type: :model do
   }
 
   describe 'a user with a long login (<= 256 chars)' do
+    let(:login) { 'a' * 256 }
     it 'is valid' do
-      user.login = 'a' * 256
+      user.login = login
       expect(user).to be_valid
     end
 
-    it 'may be stored in the database' do
-      user.login = 'a' * 256
-      expect(user.save).to be_truthy
-    end
-
     it 'may be loaded from the database' do
-      user.login = 'a' * 256
-      user.save
+      user.login = login
+      expect(user.save).to be_truthy
 
-      expect(User.find_by_login('a' * 256)).to eq(user)
+      expect(User.find_by_login(login)).to eq(user)
+      expect(User.find_by_unique(login)).to eq(user)
     end
   end
 

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -182,6 +182,22 @@ describe 'API v3 User resource', type: :request do
       end
     end
 
+    context 'get with login' do
+      let(:get_path) { api_v3_paths.user user.login }
+      before do
+        allow(User).to receive(:current).and_return current_user
+        get get_path
+      end
+
+      it 'should respond with 200' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'should respond with correct body' do
+        expect(subject.body).to be_json_eql(user.name.to_json).at_path('name')
+      end
+    end
+
     it_behaves_like 'handling anonymous user' do
       let(:path) { api_v3_paths.user user.id }
     end


### PR DESCRIPTION
Contributes to https://community.openproject.com/projects/ucs/work_packages/24474/activity

Doesn't use friendly_id due to issues with STI if not configured for the various descendants of `User`. This also does not change any other lookups (e.g, for the UserController).