### PR TITLE
[24497] [Design] System Settings double vertical scrollbars

### DIFF
--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -75,6 +75,7 @@
 
 #content .tab-content
   overflow-x: auto
+  overflow-y: hidden
 
 div.tabs-buttons
   position: absolute


### PR DESCRIPTION
This avoids doubled scrollbars for tab-contents. The content is still scrollable however over the body. 

https://community.openproject.com/work_packages/24497/activity