### PR TITLE
[24495] [Design] Administration>Workflow if language "German"

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -97,11 +97,8 @@ table
         white-space: nowrap
         transform: rotate(270deg)
         position: absolute
-        top: 130px
-        left: -40px
-        transform-origin: center center
-        margin-top: 8px
-        font-size: 0.875rem
+        top: 235px
+        transform-origin: 0 0
         text-transform: uppercase
         font-weight: bold
 


### PR DESCRIPTION
This changes the implementation of the turned headers in admin/workflows. Thus the position of the header is independent of the header length. As a consequence the text starts now at the lower end of the table and not at the top.

https://community.openproject.com/work_packages/24495/activity