### PR TITLE
[24407] Very long custom fields overlap checkboxes in settings

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -429,11 +429,11 @@ a.has-thumb
   padding-left: 3px
 
 
-
 /* Cut of text with '...' - working on all major browsers and IE6+
  * not working for Firefox < 7 */
 
-.ellipsis
+.ellipsis,
+.form--field.ellipsis .form--label
   white-space: nowrap
   overflow: hidden
   text-overflow: ellipsis

--- a/app/assets/stylesheets/content/_attributes_table.sass
+++ b/app/assets/stylesheets/content/_attributes_table.sass
@@ -53,6 +53,10 @@
   &.-hidden
     display: none
 
+  &.-two-options
+    .attributes-table--option
+      width: 25%
+
 .delete-item
   cursor: pointer
   float: right

--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
         css_classes[:lang] = custom_field.name_locale
       %>
 
-    <div class="form--field">
+    <div class="form--field -wide-label ellipsis">
       <%= form.collection_check_box :work_package_custom_field_ids,
                                     custom_field.id,
                                     @project.all_work_package_custom_fields.include?(custom_field),

--- a/app/views/types/_form.html.erb
+++ b/app/views/types/_form.html.erb
@@ -60,12 +60,12 @@ See doc/COPYRIGHT.rdoc for more details.
         </legend>
         <div>
           <p><%= I18n.t('text_form_configuration') %></p>
-          <table class="attributes-table">
+          <table class="attributes-table -two-options">
             <thead>
               <tr>
                 <th><%= I18n.t('label_attribute') %></th>
-                <th><%= I18n.t('label_active') %></th>
-                <th><%= I18n.t('label_always_visible') %></th>
+                <th class="attributes-table--option"><%= I18n.t('label_active') %></th>
+                <th class="attributes-table--option"><%= I18n.t('label_always_visible') %></th>
               </tr>
             </thead>
             <tbody>
@@ -87,7 +87,7 @@ See doc/COPYRIGHT.rdoc for more details.
                     <%= label_tag "type_attribute_visibility_#{name}",
                                   translated_attribute_name(name, attr),
                                   value: "type_attribute_visibility[#{name}]",
-                                  class: 'form--label' %>
+                                  class: 'ellipsis' %>
                   </td>
                   <td>
                     <input name="<%= "type[attribute_visibility][#{name}]" %>" type="hidden" value="hidden" />


### PR DESCRIPTION
CF with long names often break the layout since they overlap input that comes after them. This PR avoids this for project settings and Admin/WP-types. As suggested in the ticket the labels have more space now. In case this is still not enough, the labels are truncated.

https://community.openproject.com/projects/openproject/work_packages/24407/activity