### PR TITLE
[24539] Respect project_id identifier in search links

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -126,6 +126,7 @@ module SearchHelper
   def link_to_previous_search_page(pagination_previous_date)
     link_to_content_update(l(:label_previous),
                            @search_params.merge(previous: 1,
+                                                project_id: @project.try(:identifier),
                                                 offset: pagination_previous_date.to_r.to_s),
                            class: 'navigate-left')
   end
@@ -133,6 +134,7 @@ module SearchHelper
   def link_to_next_search_page(pagination_next_date)
     link_to_content_update(l(:label_next),
                            @search_params.merge(previous: nil,
+                                                project_id: @project.try(:identifier),
                                                 offset: pagination_next_date.to_r.to_s),
                            class: 'navigate-right')
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -31,6 +31,7 @@ require 'spec_helper'
 describe 'Search', type: :feature do
   describe 'pagination' do
     let(:project) { FactoryGirl.create :project }
+    let(:user) { FactoryGirl.create :admin }
 
     let!(:work_packages) do
       (1..23).map do |n|
@@ -41,24 +42,45 @@ describe 'Search', type: :feature do
 
     let(:query) { "Subject" }
 
-    before do
-      login_as FactoryGirl.create(:admin)
-
-      visit "/search?q=#{query}"
-    end
-
     def expect_range(a, b)
       (a..b).each { |n| expect(page.body).to include ("No. #{n}") }
     end
 
-    it "works" do
-      expect_range 14, 23
+    context 'project search' do
+      before do
+        login_as user
 
-      click_on "Next", match: :first
-      expect_range 4, 13
+        visit search_path(project, q: query)
+      end
+      it "works" do
+        expect_range 14, 23
 
-      click_on "Previous", match: :first
-      expect_range 14, 23
+        click_on "Next", match: :first
+        expect_range 4, 13
+        expect(current_path).to match "/projects/#{project.identifier}/search"
+
+        click_on "Previous", match: :first
+        expect_range 14, 23
+        expect(current_path).to match "/projects/#{project.identifier}/search"
+      end
+    end
+
+    context 'global search' do
+      before do
+        login_as user
+
+        visit "/search?q=#{query}"
+      end
+
+      it "works" do
+        expect_range 14, 23
+
+        click_on "Next", match: :first
+        expect_range 4, 13
+
+        click_on "Previous", match: :first
+        expect_range 14, 23
+      end
     end
   end
 end


### PR DESCRIPTION
The search route is special and thus `:project_id` needs to be merged manually to `link_to_content_update` if it exists.