### PR TITLE
[24534] Fix query for watched work packages as non-admin

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -449,7 +449,7 @@ class Query < ActiveRecord::Base
                WHERE #{db_table}.watchable_type='WorkPackage'
                  AND #{sql_for_field field, '=', values, db_table, db_field})
                  AND #{Project.table_name}.id IN
-                   (#{Project.allowed_to(User.current, :view_work_package_watchers).to_sql})
+                   (#{Project.allowed_to(User.current, :view_work_package_watchers).select("#{Project.table_name}.id").to_sql})
           SQL
           sql << "(#{sql_parts.join(' OR ')})"
         end


### PR DESCRIPTION
The `allowed_to` query returns a projection of all columns of `projects` table, but the `IN` subquery expects one column only.

```
ActiveRecord::StatementInvalid (PG::SyntaxError: ERROR:  subquery has too many columns
LINE 6:                  AND projects.id IN
                                         ^
: SELECT  "work_packages"."id" FROM "work_packages" LEFT OUTER JOIN "statuses" ON "statuses"."id" = "work_packages"."status_id" LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" LEFT OUTER JOIN "types" ON "types"."id" = "work_packages"."type_id" LEFT OUTER JOIN "users" ON "users"."id" = "work_packages"."assigned_to_id" WHERE "work_packages"."project_id" IN (SELECT DISTINCT "projects"."id" FROM "projects" LEFT OUTER JOIN "members" ON "projects"."id" = "members"."project_id" AND "members"."user_id" = 3 AND "projects"."status" = 1 INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."status" = 1 INNER JOIN "role_permissions" ON "role_permissions"."permission" IN ('view_work_packages') INNER JOIN "roles" "permission_roles" ON "permission_roles"."id" = "role_permissions"."role_id" LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id" LEFT OUTER JOIN "roles" "assigned_roles" ON "assigned_roles"."id" = "permission_roles"."id" AND "projects"."status" = 1 AND ("assigned_roles"."id" = "member_roles"."role_id" OR "projects"."is_public" = 't' AND "assigned_roles"."builtin" = 1 AND "member_roles"."id" IS NULL) WHERE ("assigned_roles"."id" IS NOT NULL)) AND (((work_packages.id IN (SELECT watchers.watchable_id FROM watchers WHERE watchers.watchable_type='WorkPackage' AND watchers.user_id IN ('3')) OR             work_packages.id IN
              (SELECT watchers.watchable_id
               FROM watchers
               WHERE watchers.watchable_type='WorkPackage'
                 AND 0=1)
                 AND projects.id IN
                   (SELECT DISTINCT "projects".* FROM "projects" LEFT OUTER JOIN "members" ON "projects"."id" = "members"."project_id" AND "members"."user_id" = 3 AND "projects"."status" = 1 INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."status" = 1 INNER JOIN "role_permissions" ON "role_permissions"."permission" IN ('view_work_package_watchers') INNER JOIN "roles" "permission_roles" ON "permission_roles"."id" = "role_permissions"."role_id" LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id" LEFT OUTER JOIN "roles" "assigned_roles" ON "assigned_roles"."id" = "permission_roles"."id" AND "projects"."status" = 1 AND ("assigned_roles"."id" = "member_roles"."role_id" OR "projects"."is_public" = 't' AND "assigned_roles"."builtin" = 1 AND "member_roles"."id" IS NULL) WHERE ("assigned_roles"."id" IS NOT NULL))
) AND (statuses.is_closed='f'))) ORDER BY work_packages.updated_at DESC LIMIT $1 OFFSET $2):

lib/api/v3/work_packages/work_package_collection_representer.rb:142:in `paged_models'
lib/api/decorators/offset_paginated_collection.rb:49:in `initialize'
lib/api/v3/work_packages/work_package_collection_representer.rb:59:in `initialize'
lib/api/v3/work_packages/work_package_list_helpers.rb:177:in `new'
lib/api/v3/work_packages/work_package_list_helpers.rb:177:in `collection_representer'
lib/api/v3/work_packages/work_package_list_helpers.rb:56:in `work_packages_by_params'
lib/api/v3/work_packages/work_packages_api.rb:47:in `block (2 levels) in <class:WorkPackagesAPI>'
```