### PR TITLE
API v3 GET /api/v3/work_packages/schemas?filter=...

### DIFF
--- a/app/services/parse_schema_filter_params_service.rb
+++ b/app/services/parse_schema_filter_params_service.rb
@@ -1,0 +1,112 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class ParseSchemaFilterParamsService
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call(filter)
+    error_message = check_error_in_filter(filter)
+
+    if error_message
+      error(error_message)
+    else
+      pairs = valid_project_type_pairs(filter)
+
+      success(pairs)
+    end
+  end
+
+  private
+
+  def check_error_in_filter(filter)
+    if !filter.first['id']
+      :id_filter_required
+    elsif filter.first['id']['operator'] != '='
+      :unsupported_operator
+    elsif filter.first['id']['values'].any? { |id_string| !id_string.match(/\d+-\d+/) }
+      :invalid_values
+    end
+  end
+
+  def parse_ids(filter)
+    ids_string = filter.first['id']['values']
+
+    ids_string.map do |id_string|
+      id_string.split('-')
+    end
+  end
+
+  def error(message)
+    errors = ActiveModel::Errors.new(self)
+    errors.add(:base, message)
+    ServiceResult.new(errors: errors)
+  end
+
+  def success(result)
+    ServiceResult.new(success: true, result: result)
+  end
+
+  def valid_project_type_pairs(filter)
+    ids = parse_ids(filter)
+
+    projects_map = projects_by_id(ids.map(&:first))
+    types_map = types_by_id(ids.map(&:last))
+
+    valid_ids = only_valid_pairs(ids, projects_map, types_map)
+
+    string_pairs_to_object_pairs(valid_ids, projects_map, types_map)
+  end
+
+  def projects_by_id(ids)
+    Project.visible(user).where(id: ids).group_by(&:id)
+  end
+
+  def types_by_id(ids)
+    Type.where(id: ids).group_by(&:id)
+  end
+
+  def only_valid_pairs(id_pairs, projects_map, types_map)
+    id_pairs.reject do |project_id, type_id|
+      projects_map[project_id.to_i].nil? || types_map[type_id.to_i].nil?
+    end
+  end
+
+  def string_pairs_to_object_pairs(string_pairs, projects_map, types_map)
+    string_pairs.map do |project_id, type_id|
+      [projects_map[project_id.to_i].first, types_map[type_id.to_i].first]
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,12 @@ en:
               invalid_on_create: "is not a valid status for new users."
             auth_source:
               error_not_found: "not found"
+        parse_schema_filter_params_service:
+          attributes:
+            base:
+              unsupported_operator: "The operator is not supported."
+              invalid_values: "A value is invalid."
+              id_filter_required: "An 'id' filter is required."
   activerecord:
     attributes:
       announcements:
@@ -2261,9 +2267,9 @@ en:
       invalid_user_status_transition: "The current user account status does not allow this operation."
       missing_content_type: "not specified"
       missing_request_body: "There was no request body."
+      missing_or_malformed_parameter: "The query parameter '%{parameter}' is missing or malformed."
       multipart_body_error: "The request body did not contain the expected multipart parts."
       multiple_errors: "Multiple field constraints have been violated."
-      writing_read_only_attributes: "You must not write a read-only attribute."
       render:
         context_not_parsable: "The context provided is not a link to a resource."
         unsupported_context: "The resource given is not supported as context."
@@ -2274,5 +2280,6 @@ en:
         estimated_hours: "Estimated hours cannot be set on parent work packages."
         invalid_user_assigned_to_work_package: "The chosen user is not allowed to be '%{property}' for this work package."
         start_date: "Start date cannot be set on parent work packages."
+      writing_read_only_attributes: "You must not write a read-only attribute."
     resources:
       schema: 'Schema'

--- a/doc/apiv3/endpoints/work-packages.apib
+++ b/doc/apiv3/endpoints/work-packages.apib
@@ -436,6 +436,82 @@ Deletes the work package, as well as:
                 "message": "The specified schema does not exist."
             }
 
+## Work Package Schemas [/api/v3/work_packages/schemas/{?filters}]
+
++ Model
+  + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/api/v3/work_packages/schemas" }
+                },
+                "total": 5,
+                "count": 2,
+                "_type": "Collection",
+                "_embedded": {
+                    "elements": [
+                        {
+                            "_type": "Schema",
+                            "_links": {
+                                "self": { "href": "/api/v3/work_packages/schemas/13-1" }
+                            }
+
+                            <snip>
+
+                        },
+                        {
+                            "_type": "Schema",
+                            "_links": {
+                                "self": { "href": "/api/v3/work_packages/schemas/7-6" }
+                            }
+
+                            <snip>
+
+                        }
+                    ]
+                }
+            }
+
+## List Work Package Schemas [GET]
+
+List work package schemas.
+
++ Parameters
+    + filters (required, string, `[{ "id": { "operator": "=", "values": ["12-1", "14-2"] } }]`) ... JSON specifying filter conditions.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported filters are:
+      + id: The schema's id
+
++ Response 200 (application/hal+json)
+
+    [Work Package Schemas][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": "Unknown filter."
+            }
+
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** View work packages in any project.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to list schemas."
+            }
+
 ## Work Package Edit Form [/api/v3/work_packages/{id}/form]
 
 This endpoint returns a form to allow a guided modification of an existing work package.

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -261,6 +261,10 @@ module API
             "#{root}/work_packages/schemas/#{project_id}-#{type_id}"
           end
 
+          def self.work_package_schemas
+            "#{root}/work_packages/schemas"
+          end
+
           def self.work_package_sums_schema
             "#{root}/work_packages/schemas/sums"
           end

--- a/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
@@ -1,0 +1,54 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      module Schema
+        class WorkPackageSchemaCollectionRepresenter <
+          ::API::Decorators::UnpaginatedCollection
+          element_decorator ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter
+
+          collection :elements,
+                     getter: ->(*) {
+                       represented.map do |model|
+                         self_link = api_v3_paths.work_package_schema(model.project.id,
+                                                                      model.type.id)
+                         element_decorator.create(model,
+                                                  self_link: self_link,
+                                                  current_user: current_user)
+                       end
+                     },
+                     exec_context: :decorator,
+                     embedded: true
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -41,6 +41,7 @@ module API
           # Otherwise, the matcher for the :id also seems to match available_projects.
           # This is also true when the :id param is declared to be of type: Integer.
           mount ::API::V3::WorkPackages::AvailableProjectsOnCreateAPI
+          mount ::API::V3::WorkPackages::Schema::WorkPackageSchemasAPI
 
           get do
             authorize(:view_work_packages, global: true)
@@ -52,7 +53,7 @@ module API
           end
 
           params do
-            requires :id, desc: 'Work package id'
+            requires :id, desc: 'Work package id', type: Integer
           end
           route_param :id do
             helpers WorkPackagesSharedHelpers
@@ -115,7 +116,6 @@ module API
             mount ::API::V3::WorkPackages::WorkPackageRelationsAPI
           end
 
-          mount ::API::V3::WorkPackages::Schema::WorkPackageSchemasAPI
           mount ::API::V3::WorkPackages::CreateFormAPI
         end
       end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -277,6 +277,12 @@ describe ::API::V3::Utilities::PathHelper do
       it_behaves_like 'api v3 path', '/work_packages/schemas/1-2'
     end
 
+    describe '#work_package_schemas' do
+      subject { helper.work_package_schemas }
+
+      it_behaves_like 'api v3 path', '/work_packages/schemas'
+    end
+
     describe '#work_package_sums_schema' do
       subject { helper.work_package_sums_schema }
 

--- a/spec/services/parse_schema_filter_params_service_spec.rb
+++ b/spec/services/parse_schema_filter_params_service_spec.rb
@@ -1,0 +1,153 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ParseSchemaFilterParamsService do
+  let(:current_user) { FactoryGirl.build_stubbed(:user) }
+  let(:instance) { described_class.new(user: current_user) }
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:type) { FactoryGirl.build_stubbed(:type) }
+
+  describe '#call' do
+    let(:filter) do
+      [{ 'id' => { 'values' => ["#{project.id}-#{type.id}"], 'operator' => '=' } }]
+    end
+    let(:result) { instance.call(filter) }
+
+    let(:found_projects) { [project] }
+    let(:found_types) { [type] }
+
+    before do
+      visible_projects = double('visible_projects')
+
+      allow(Project)
+        .to receive(:visible)
+        .with(current_user)
+        .and_return(visible_projects)
+
+      allow(visible_projects)
+        .to receive(:where)
+        .with(id: [project.id.to_s])
+        .and_return(found_projects)
+
+      allow(Type)
+        .to receive(:where)
+        .with(id: [type.id.to_s])
+        .and_return(found_types)
+    end
+
+    context 'valid' do
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns the [project, type] pair' do
+        expect(result.result).to match_array [[project, type]]
+      end
+    end
+
+    context 'for a non existing project' do
+      let(:found_projects) { [] }
+
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to match_array []
+      end
+    end
+
+    context 'for a non existing type' do
+      let(:found_types) { [] }
+
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to match_array []
+      end
+    end
+
+    context 'without the "=" operator' do
+      let(:filter) do
+        [{ 'id' => { 'values' => ["#{project.id}-#{type.id}"], 'operator' => '!' } }]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['The operator is not supported.']
+      end
+    end
+
+    context 'with an invalid value' do
+      let(:filter) do
+        [{ 'id' => { 'values' => ["bogus-1"], 'operator' => "=" } }]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['A value is invalid.']
+      end
+    end
+
+    context 'without an id filter' do
+      let(:filter) do
+        [{}]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['An \'id\' filter is required.']
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add an endpoint to fetch a set of work package schemas as specified by the filter. This will allow the front end to fetch multiple schemas with one request.

https://community.openproject.com/projects/openproject/work_packages/24487

### Implementation approach

Please see 591e1dc for the specification.

The filter will be required as it does not make sense to fetch all schemas. While the filter interface will look the same as for users and relations and the like, the implementation can not build on the existing query as schemas are not persisted. 

Instead, we:
* parse the filter values
* Load all projects and types that are referenced
* check if the user has permission in every project
* return the schemas for those projects that exist and for which the user has the view_work_packages permission 

### Out of scope

* Embedding the schemas inside the work package collection #5163
* renaming the work package collection #5163

### ToDos

- [x] Specify
- [x] Write end point and tests