### PR TITLE
fix filtering by subprojectId

### DIFF
--- a/app/controllers/api/experimental/concerns/v3_naming.rb
+++ b/app/controllers/api/experimental/concerns/v3_naming.rb
@@ -92,6 +92,6 @@ module Api::Experimental::Concerns::V3Naming
   def context_dummy
     # memorize the work package because
     # initializing a work package queries the db
-    @context_dummy ||= WorkPackage.new
+    @context_dummy ||= API::Utilities::PropertyNameConverterQueryContext.new
   end
 end

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -182,16 +182,19 @@ module QueriesHelper
   def fix_field_array(query, field_names)
     return [] if field_names.nil?
 
-    # memoize to reduce overhead of WorkPackage.new
-    @fix_field_array_wp ||= WorkPackage.new
     available_keys = query.available_filters.map(&:name)
 
     field_names
-      .map { |name| converter.to_ar_name name, context: @fix_field_array_wp, refer_to_ids: true }
+      .map { |name| converter.to_ar_name name, context: converter_context, refer_to_ids: true }
       .map { |name| available_keys.find { |k| name =~ /#{k}(s|_id)?$/ } }
   end
 
   def converter
     API::Utilities::PropertyNameConverter
+  end
+
+  def converter_context
+    # memoize to reduce overhead of WorkPackage.new
+    @fix_field_array_wp ||= API::Utilities::PropertyNameConverterQueryContext.new
   end
 end

--- a/lib/api/utilities/property_name_converter_query_context.rb
+++ b/lib/api/utilities/property_name_converter_query_context.rb
@@ -1,0 +1,48 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module Utilities
+    # The PropertyNameConverter checks whether the object responds to the attribute
+    # that is to be converted.
+    # If the context is Query (e.g. when filters are restored), a WorkPackage
+    # is used instead.  However, some of the methods a work package does not
+    # respond to are nevertheless valid for transformation.  We therefore
+    # delegate to a WorkPackage per default but also explicitly respond in some
+    # cases.
+    class PropertyNameConverterQueryContext < SimpleDelegator
+      def initialize
+        super(WorkPackage.new)
+      end
+
+      def subproject_id
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -185,7 +185,7 @@ module API
         end
 
         def convert_attribute(attribute, append_id: false)
-          @@conversion_wp ||= WorkPackage.new
+          @@conversion_wp ||= ::API::Utilities::PropertyNameConverterQueryContext.new
           ::API::Utilities::PropertyNameConverter.to_ar_name(attribute,
                                                              context: @@conversion_wp,
                                                              refer_to_ids: append_id)


### PR DESCRIPTION
A quick fix in order to get filtering by subprojectId working again. 

The problem is caused by checking whether all the filter names are responded to by WorkPackage. If the filter name is postfixed by `_id` and work package does not respond to the name, the postfix is removed. But as the filter name is still postfixed by `_id`, the filter is then not found later on.

Because the experimental API is going to be removed, I didn't see the point to invest in a more general solution right now. After the removal, there is hopefully less need for the translation between the different names.

https://community.openproject.com/projects/openproject/work_packages/24550