### PR TITLE
[24580] Improve timeline print

### DIFF
--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -115,6 +115,7 @@
 @import specific/announcements
 @import specific/onboarding
 @import specific/accessibility
+@import specific/print
 
 @import misc_legacy
 @import jstoolbar

--- a/app/assets/stylesheets/specific/print.sass
+++ b/app/assets/stylesheets/specific/print.sass
@@ -1,0 +1,61 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+@media print
+  //------------- Generic rules -------------------------
+
+  #top-menu, #main-menu, #breadcrumb, #footer
+    display: none
+
+
+  //------------- WP table specific ---------------------
+
+  .controller-work_packages.action-index,
+  .controller-work_packages.action-show,
+  .controller-work_packages.full-create
+    .work-packages--list-pagination-area,
+    .toolbar-items,
+    .icon-pulldown,
+    .wp-table--details-column
+      display: none
+    .wp-timeline--slider-wrapper
+      display: none !important
+    #content
+      margin: 0
+      width: 100%
+      height: 100%
+      padding: 10px
+    #main
+      top: 0
+      padding: 0
+      border: none
+    .work-packages--list-table-area
+      height: 100%
+    .work-package-table--container,
+    .generic-table--results-container
+      overflow: hidden


### PR DESCRIPTION
This PR defines styling rules for the WP table. This was done for a better view of the new timeline functionality (https://github.com/opf/openproject/pull/4927).

https://community.openproject.com/projects/openproject/work_packages/24580/activity