### PR TITLE
Feature/embed schemas in wp list

### DIFF
--- a/app/services/parse_schema_filter_params_service.rb
+++ b/app/services/parse_schema_filter_params_service.rb
@@ -1,0 +1,112 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class ParseSchemaFilterParamsService
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call(filter)
+    error_message = check_error_in_filter(filter)
+
+    if error_message
+      error(error_message)
+    else
+      pairs = valid_project_type_pairs(filter)
+
+      success(pairs)
+    end
+  end
+
+  private
+
+  def check_error_in_filter(filter)
+    if !filter.first['id']
+      :id_filter_required
+    elsif filter.first['id']['operator'] != '='
+      :unsupported_operator
+    elsif filter.first['id']['values'].any? { |id_string| !id_string.match(/\d+-\d+/) }
+      :invalid_values
+    end
+  end
+
+  def parse_ids(filter)
+    ids_string = filter.first['id']['values']
+
+    ids_string.map do |id_string|
+      id_string.split('-')
+    end
+  end
+
+  def error(message)
+    errors = ActiveModel::Errors.new(self)
+    errors.add(:base, message)
+    ServiceResult.new(errors: errors)
+  end
+
+  def success(result)
+    ServiceResult.new(success: true, result: result)
+  end
+
+  def valid_project_type_pairs(filter)
+    ids = parse_ids(filter)
+
+    projects_map = projects_by_id(ids.map(&:first))
+    types_map = types_by_id(ids.map(&:last))
+
+    valid_ids = only_valid_pairs(ids, projects_map, types_map)
+
+    string_pairs_to_object_pairs(valid_ids, projects_map, types_map)
+  end
+
+  def projects_by_id(ids)
+    Project.visible(user).where(id: ids).group_by(&:id)
+  end
+
+  def types_by_id(ids)
+    Type.where(id: ids).group_by(&:id)
+  end
+
+  def only_valid_pairs(id_pairs, projects_map, types_map)
+    id_pairs.reject do |project_id, type_id|
+      projects_map[project_id.to_i].nil? || types_map[type_id.to_i].nil?
+    end
+  end
+
+  def string_pairs_to_object_pairs(string_pairs, projects_map, types_map)
+    string_pairs.map do |project_id, type_id|
+      [projects_map[project_id.to_i].first, types_map[type_id.to_i].first]
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,12 @@ en:
               invalid_on_create: "is not a valid status for new users."
             auth_source:
               error_not_found: "not found"
+        parse_schema_filter_params_service:
+          attributes:
+            base:
+              unsupported_operator: "The operator is not supported."
+              invalid_values: "A value is invalid."
+              id_filter_required: "An 'id' filter is required."
   activerecord:
     attributes:
       announcements:
@@ -2261,9 +2267,9 @@ en:
       invalid_user_status_transition: "The current user account status does not allow this operation."
       missing_content_type: "not specified"
       missing_request_body: "There was no request body."
+      missing_or_malformed_parameter: "The query parameter '%{parameter}' is missing or malformed."
       multipart_body_error: "The request body did not contain the expected multipart parts."
       multiple_errors: "Multiple field constraints have been violated."
-      writing_read_only_attributes: "You must not write a read-only attribute."
       render:
         context_not_parsable: "The context provided is not a link to a resource."
         unsupported_context: "The resource given is not supported as context."
@@ -2274,5 +2280,6 @@ en:
         estimated_hours: "Estimated hours cannot be set on parent work packages."
         invalid_user_assigned_to_work_package: "The chosen user is not allowed to be '%{property}' for this work package."
         start_date: "Start date cannot be set on parent work packages."
+      writing_read_only_attributes: "You must not write a read-only attribute."
     resources:
       schema: 'Schema'

--- a/doc/apiv3/endpoints/work-packages.apib
+++ b/doc/apiv3/endpoints/work-packages.apib
@@ -436,6 +436,82 @@ Deletes the work package, as well as:
                 "message": "The specified schema does not exist."
             }
 
+## Work Package Schemas [/api/v3/work_packages/schemas/{?filters}]
+
++ Model
+  + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/api/v3/work_packages/schemas" }
+                },
+                "total": 5,
+                "count": 2,
+                "_type": "Collection",
+                "_embedded": {
+                    "elements": [
+                        {
+                            "_type": "Schema",
+                            "_links": {
+                                "self": { "href": "/api/v3/work_packages/schemas/13-1" }
+                            }
+
+                            <snip>
+
+                        },
+                        {
+                            "_type": "Schema",
+                            "_links": {
+                                "self": { "href": "/api/v3/work_packages/schemas/7-6" }
+                            }
+
+                            <snip>
+
+                        }
+                    ]
+                }
+            }
+
+## List Work Package Schemas [GET]
+
+List work package schemas.
+
++ Parameters
+    + filters (required, string, `[{ "id": { "operator": "=", "values": ["12-1", "14-2"] } }]`) ... JSON specifying filter conditions.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported filters are:
+      + id: The schema's id
+
++ Response 200 (application/hal+json)
+
+    [Work Package Schemas][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": "Unknown filter."
+            }
+
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** View work packages in any project.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not allowed to list schemas."
+            }
+
 ## Work Package Edit Form [/api/v3/work_packages/{id}/form]
 
 This endpoint returns a form to allow a guided modification of an existing work package.

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -118,7 +118,17 @@ export class HalResource {
       state.clear();
     }
 
-    return <ng.IPromise<HalResource>> state.get();
+    // If nobody has asked yet for the resource to be $loaded, do it ourselves.
+    // Otherwise, we risk returning a promise, that will never be resolved.
+    if (state.isPristine()) {
+      state.putFromPromise(this.$loadResource(force));
+    }
+
+    return <ng.IPromise<HalResource>> state.get().then(source => {
+      this.$initialize(source);
+      this.$loaded = true;
+      return source;
+    });
   }
 
   protected $loadResource(force = false):ng.IPromise<HalResource> {

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.test.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.test.ts
@@ -312,8 +312,10 @@ describe('WorkPackageResource service', () => {
 
       describe('when the upload succeeds', () => {
         var removeStub;
+        var updateWorkPackageStub;
 
         beforeEach(() => {
+          updateWorkPackageStub = sinon.stub(wpCacheService, 'updateWorkPackage');
           uploadFilesDeferred.resolve();
           removeStub = sinon.stub(NotificationsService, 'remove');
 
@@ -334,6 +336,11 @@ describe('WorkPackageResource service', () => {
         it('should return an attachment collection resource promise', () => {
           expect(uploadAttachmentsPromise).to.eventually.have.property('$href', 'attachments');
           $rootScope.$apply();
+        });
+
+        afterEach(() => {
+          updateWorkPackageStub.restore();
+          removeStub.restore();
         });
       });
     });

--- a/frontend/app/components/api/api-v3/hal-resources/wp-collection-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/wp-collection-resource.service.ts
@@ -1,4 +1,4 @@
-// -- copyright
+//-- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 //
@@ -24,44 +24,24 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // See doc/COPYRIGHT.rdoc for more details.
-// ++
+//++
 
+import {CollectionResource} from './collection-resource.service';
 import {opApiModule} from '../../../../angular-modules';
-import {HalResourceTypesService} from './hal-resource-types.service';
 
-function halResourceTypesConfig(halResourceTypes:HalResourceTypesService) {
-  halResourceTypes.setResourceTypeConfig({
-    WorkPackage: {
-      className: 'WorkPackageResource',
-      attrTypes: {
-        parent: 'WorkPackage',
-        children: 'WorkPackage',
-        relations: 'Relation',
-        schema: 'Schema'
-      }
-    },
-    Activity: {
-      user: 'User'
-    },
-    'Activity::Comment': {
-      user: 'User'
-    },
-    'Activity::Revision': {
-      user: 'User'
-    },
-    Relation: {
-      className: 'RelationResource',
-      attrTypes: {
-        from: 'WorkPackage',
-        to: 'WorkPackage'
-      }
-    },
-    Schema: 'SchemaResource',
-    Error: 'ErrorResource',
-    User: 'UserResource',
-    Collection: 'CollectionResource',
-    WorkPackageCollection: 'WorkPackageCollectionResource'
-  });
+interface WorkPackageCollectionResourceEmbedded {
+  schemas: CollectionResource;
 }
 
-opApiModule.run(halResourceTypesConfig);
+export class WorkPackageCollectionResource extends CollectionResource {
+  public schemas: CollectionResource;
+}
+
+export interface WorkPackageCollectionResourceInterface extends WorkPackageCollectionResourceEmbedded, WorkPackageCollectionResource {
+}
+
+function workPackageCollectionResource() {
+  return WorkPackageCollectionResource;
+}
+
+opApiModule.factory('WorkPackageCollectionResource', workPackageCollectionResource);

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -71,12 +71,12 @@ export class WorkPackageCacheService {
       // Ensure the schema is loaded
       // so that no consumer needs to call schema#$load manually
       if (wpForPublish.schema.$loaded) {
-        return wpState.put(wpForPublish);
+        wpState.put(wpForPublish);
+      } else {
+        wpState.putFromPromise(wpForPublish.schema.$load().then(() => {
+          return wpForPublish;
+        }));
       }
-
-      wpState.putFromPromise(wpForPublish.schema.$load().then(() => {
-        return wpForPublish;
-      }));
     }
   }
 
@@ -86,7 +86,7 @@ export class WorkPackageCacheService {
       state.clear();
     }
 
-    // Several services involved in the creation of work packages 
+    // Several services involved in the creation of work packages
     // use this method to resolve the latest created work package,
     // so let them just subscribe.
     if (workPackageId.toString() === 'new') {

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -261,6 +261,10 @@ module API
             "#{root}/work_packages/schemas/#{project_id}-#{type_id}"
           end
 
+          def self.work_package_schemas
+            "#{root}/work_packages/schemas"
+          end
+
           def self.work_package_sums_schema
             "#{root}/work_packages/schemas/sums"
           end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -261,8 +261,19 @@ module API
             "#{root}/work_packages/schemas/#{project_id}-#{type_id}"
           end
 
-          def self.work_package_schemas
-            "#{root}/work_packages/schemas"
+          def self.work_package_schemas(*args)
+            path = "#{root}/work_packages/schemas"
+            if args.empty?
+              path
+            else
+              values = args.map do |project_id, type_id|
+                "#{project_id}-#{type_id}"
+              end
+
+              filter = [{ id: { operator: '=', values: values } }]
+
+              path + "?filters=#{CGI.escape(filter.to_s)}"
+            end
           end
 
           def self.work_package_sums_schema

--- a/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
@@ -1,0 +1,54 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      module Schema
+        class WorkPackageSchemaCollectionRepresenter <
+          ::API::Decorators::UnpaginatedCollection
+          element_decorator ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter
+
+          collection :elements,
+                     getter: ->(*) {
+                       represented.map do |model|
+                         self_link = api_v3_paths.work_package_schema(model.project.id,
+                                                                      model.type.id)
+                         element_decorator.create(model,
+                                                  self_link: self_link,
+                                                  current_user: current_user)
+                       end
+                     },
+                     exec_context: :decorator,
+                     embedded: true
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -221,6 +221,10 @@ module API
           cvs
         end
 
+        def _type
+          'WorkPackageCollection'
+        end
+
         attr_reader :project,
                     :groups,
                     :total_sums,

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -96,6 +96,12 @@ module API
           } if current_user_allowed_to_add_work_packages?
         end
 
+        link :schemas do
+          {
+            href: schemas_path
+          } if represented.any?
+        end
+
         collection :elements,
                    getter: -> (*) {
                      generated_classes = ::Hash.new do |hash, work_package|
@@ -116,7 +122,7 @@ module API
 
         property :schemas,
                  exec_context: :decorator,
-                 if: ->(*) { embed_schemas },
+                 if: ->(*) { embed_schemas && represented.any? },
                  embedded: true,
                  render_nil: false
 

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -181,6 +181,7 @@ module API
             per_page: to_i_or_nil(params[:pageSize]),
             groups: groups,
             total_sums: sums,
+            embed_schemas: true,
             current_user: current_user
           )
         end

--- a/lib/api/v3/work_packages/work_package_list_helpers.rb
+++ b/lib/api/v3/work_packages/work_package_list_helpers.rb
@@ -113,9 +113,9 @@ module API
         end
 
         def parse_sorting_from_json(json)
-          JSON.parse(json).map { |(attribute, order)|
+          JSON.parse(json).map do |(attribute, order)|
             [convert_attribute(attribute), order]
-          }
+          end
         end
 
         def apply_and_generate_groups(query, query_params)
@@ -128,14 +128,14 @@ module API
         end
 
         def generate_groups(results)
-          results.work_package_count_by_group.map { |group, count|
+          results.work_package_count_by_group.map do |group, count|
             sums = nil
             if params[:showSums] == 'true'
               sums = format_query_sums results.all_sums_for_group(group)
             end
 
             ::API::Decorators::AggregationGroup.new(group, count, sums: sums)
-          }
+          end
         end
 
         def generate_total_sums(results, query_params)
@@ -151,7 +151,7 @@ module API
 
         def format_column_keys(hash_by_column)
           ::Hash[
-            hash_by_column.map { |column, value|
+            hash_by_column.map do |column, value|
               match = /cf_(\d+)/.match(column.name.to_s)
 
               column_name = if match
@@ -161,7 +161,7 @@ module API
                             end
 
               [column_name, value]
-            }
+            end
           ]
         end
 
@@ -177,11 +177,12 @@ module API
             self_link,
             project: project,
             query: query_params,
-            page: params[:offset] ? params[:offset].to_i : nil,
-            per_page: params[:pageSize] ? params[:pageSize].to_i : nil,
+            page: to_i_or_nil(params[:offset]),
+            per_page: to_i_or_nil(params[:pageSize]),
             groups: groups,
             total_sums: sums,
-            current_user: current_user)
+            current_user: current_user
+          )
         end
 
         def convert_attribute(attribute, append_id: false)
@@ -192,11 +193,15 @@ module API
         end
 
         def raise_invalid_query(errors)
-          api_errors = errors.full_messages.map { |message|
+          api_errors = errors.full_messages.map do |message|
             ::API::Errors::InvalidQuery.new(message)
-          }
+          end
 
           raise ::API::Errors::MultipleErrors.create_if_many api_errors
+        end
+
+        def to_i_or_nil(value)
+          value ? value.to_i : nil
         end
       end
     end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -41,6 +41,7 @@ module API
           # Otherwise, the matcher for the :id also seems to match available_projects.
           # This is also true when the :id param is declared to be of type: Integer.
           mount ::API::V3::WorkPackages::AvailableProjectsOnCreateAPI
+          mount ::API::V3::WorkPackages::Schema::WorkPackageSchemasAPI
 
           get do
             authorize(:view_work_packages, global: true)
@@ -52,7 +53,7 @@ module API
           end
 
           params do
-            requires :id, desc: 'Work package id'
+            requires :id, desc: 'Work package id', type: Integer
           end
           route_param :id do
             helpers WorkPackagesSharedHelpers
@@ -115,7 +116,6 @@ module API
             mount ::API::V3::WorkPackages::WorkPackageRelationsAPI
           end
 
-          mount ::API::V3::WorkPackages::Schema::WorkPackageSchemasAPI
           mount ::API::V3::WorkPackages::CreateFormAPI
         end
       end

--- a/spec/lib/api/v3/support/api_v3_collection.rb
+++ b/spec/lib/api/v3/support/api_v3_collection.rb
@@ -36,7 +36,8 @@ shared_examples_for 'generic APIv3 collection' do
   end
 
   it 'has a collection type' do
-    expect(collection).to be_json_eql('Collection'.to_json).at_path('_type')
+    expected_type = defined?(collection_type) ? collection_type : 'Collection'
+    expect(collection).to be_json_eql(expected_type.to_json).at_path('_type')
   end
 
   describe 'elements are typed correctly' do

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -283,6 +283,17 @@ describe ::API::V3::Utilities::PathHelper do
       it_behaves_like 'api v3 path', '/work_packages/schemas'
     end
 
+    describe '#work_package_schemas with filters' do
+      subject { helper.work_package_schemas [1, 2], [3, 4] }
+
+      def self.filter
+        CGI.escape([{ id: { operator: '=', values: ['1-2', '3-4'] } }].to_s)
+      end
+
+      it_behaves_like 'api v3 path',
+                      "/work_packages/schemas?filters=#{filter}"
+    end
+
     describe '#work_package_sums_schema' do
       subject { helper.work_package_sums_schema }
 

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -277,6 +277,12 @@ describe ::API::V3::Utilities::PathHelper do
       it_behaves_like 'api v3 path', '/work_packages/schemas/1-2'
     end
 
+    describe '#work_package_schemas' do
+      subject { helper.work_package_schemas }
+
+      it_behaves_like 'api v3 path', '/work_packages/schemas'
+    end
+
     describe '#work_package_sums_schema' do
       subject { helper.work_package_sums_schema }
 

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -44,8 +44,9 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   let(:page_size_parameter) { nil }
   let(:default_page_size) { 30 }
   let(:total) { 5 }
+  let(:embed_schemas) { false }
 
-  let(:representer) {
+  let(:representer) do
     described_class.new(
       work_packages,
       self_base_link,
@@ -55,8 +56,10 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
       total_sums: total_sums,
       page: page_parameter,
       per_page: page_size_parameter,
-      current_user: user)
-  }
+      current_user: user,
+      embed_schemas: embed_schemas
+    )
+  end
 
   before do
     FactoryGirl.create_list(:work_package, total)
@@ -232,6 +235,19 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
         }
 
         is_expected.to be_json_eql(expected.to_json).at_path('_links/sumsSchema')
+      end
+    end
+
+    context 'passing schemas' do
+      let(:embed_schemas) { true }
+
+      it 'embeds a schema collection' do
+        expected_path = api_v3_paths.work_package_schema(work_packages[0].project.id,
+                                                         work_packages[0].type.id)
+
+        is_expected
+          .to be_json_eql(expected_path.to_json)
+          .at_path('_embedded/schemas/_embedded/elements/0/_links/self/href')
       end
     end
   end

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -77,6 +77,18 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
       is_expected.not_to have_json_path('totalSums')
     end
 
+    it 'has a schemas link' do
+      ids = work_packages.map do |wp|
+        [wp.project_id, wp.type_id]
+      end
+
+      path = api_v3_paths.work_package_schemas *ids
+
+      is_expected
+        .to be_json_eql(path.to_json)
+        .at_path('_links/schemas/href')
+    end
+
     context 'when the user has the add_work_package permission in any project' do
       before do
         allow(user)

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -154,6 +154,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
           let(:page) { 1 }
           let(:page_size) { page_size_parameter }
           let(:actual_count) { page_size_parameter }
+          let(:collection_type) { 'WorkPackageCollection' }
 
           it_behaves_like 'links to next page by offset'
         end
@@ -170,6 +171,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
           let(:page) { 3 }
           let(:page_size) { page_size_parameter }
           let(:actual_count) { 1 }
+          let(:collection_type) { 'WorkPackageCollection' }
 
           it_behaves_like 'links to previous page by offset'
         end

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -219,7 +219,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
     end
 
     context 'passing sums' do
-      let(:total_sums) { OpenStruct.new({ estimated_hours: 1 }) }
+      let(:total_sums) { OpenStruct.new(estimated_hours: 1) }
 
       it 'renders the groups object as json' do
         expected = { 'estimatedTime': 'PT1H' }

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -88,6 +88,14 @@ describe 'API v3 Work package resource', type: :request do
       expect(subject.body).to be_json_eql(1.to_json).at_path('total')
     end
 
+    it 'embedds the work package schemas' do
+      FactoryGirl.create(:work_package, project: project)
+
+      expect(subject.body)
+        .to be_json_eql(api_v3_paths.work_package_schema(project.id, work_package.type.id).to_json)
+        .at_path('_embedded/schemas/_embedded/elements/0/_links/self/href')
+    end
+
     context 'user not seeing any work packages' do
       include_context 'with non-member permissions from non_member_permissions'
       let(:current_user) { FactoryGirl.create(:user) }

--- a/spec/requests/api/v3/work_package_resource_spec.rb
+++ b/spec/requests/api/v3/work_package_resource_spec.rb
@@ -55,7 +55,7 @@ describe 'API v3 Work package resource', type: :request do
   end
   let(:watcher) do
     FactoryGirl
-      .create(:user,  member_in_project: project, member_through_role: role)
+      .create(:user, member_in_project: project, member_through_role: role)
       .tap do |user|
         work_package.add_watcher(user)
       end

--- a/spec/services/parse_schema_filter_params_service_spec.rb
+++ b/spec/services/parse_schema_filter_params_service_spec.rb
@@ -1,0 +1,153 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ParseSchemaFilterParamsService do
+  let(:current_user) { FactoryGirl.build_stubbed(:user) }
+  let(:instance) { described_class.new(user: current_user) }
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:type) { FactoryGirl.build_stubbed(:type) }
+
+  describe '#call' do
+    let(:filter) do
+      [{ 'id' => { 'values' => ["#{project.id}-#{type.id}"], 'operator' => '=' } }]
+    end
+    let(:result) { instance.call(filter) }
+
+    let(:found_projects) { [project] }
+    let(:found_types) { [type] }
+
+    before do
+      visible_projects = double('visible_projects')
+
+      allow(Project)
+        .to receive(:visible)
+        .with(current_user)
+        .and_return(visible_projects)
+
+      allow(visible_projects)
+        .to receive(:where)
+        .with(id: [project.id.to_s])
+        .and_return(found_projects)
+
+      allow(Type)
+        .to receive(:where)
+        .with(id: [type.id.to_s])
+        .and_return(found_types)
+    end
+
+    context 'valid' do
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns the [project, type] pair' do
+        expect(result.result).to match_array [[project, type]]
+      end
+    end
+
+    context 'for a non existing project' do
+      let(:found_projects) { [] }
+
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to match_array []
+      end
+    end
+
+    context 'for a non existing type' do
+      let(:found_types) { [] }
+
+      it 'is a success' do
+        expect(result).to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to match_array []
+      end
+    end
+
+    context 'without the "=" operator' do
+      let(:filter) do
+        [{ 'id' => { 'values' => ["#{project.id}-#{type.id}"], 'operator' => '!' } }]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['The operator is not supported.']
+      end
+    end
+
+    context 'with an invalid value' do
+      let(:filter) do
+        [{ 'id' => { 'values' => ["bogus-1"], 'operator' => "=" } }]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['A value is invalid.']
+      end
+    end
+
+    context 'without an id filter' do
+      let(:filter) do
+        [{}]
+      end
+
+      it 'is a failure' do
+        expect(result).not_to be_success
+      end
+
+      it 'returns an empty array' do
+        expect(result.result).to be_nil
+      end
+
+      it 'returns an error message' do
+        expect(result.errors.messages[:base]).to match_array ['An \'id\' filter is required.']
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements the following parts of 

https://community.openproject.com/projects/openproject/work_packages/24487

that have not been implemented by #5158:

* have a dedicated name in the API for a collection of work packages: 'WorkPackageCollection'
* embed schemas in that collection
* avoid having to load schemas separately by placing them in the state upon receiving a 'WorkPackageCollection' 

In order to enable the last, some errors had to be fixed:
* the SchemaResource needs to be explicitly defined in the front end's type configuration
* loading a halResource from a state via $load should also initialize the object $load has been called on instead of only returning the state
*  the wp cache should not leave the loop in  `updateWorkPackageList` when a workPackage already has a schema loaded.

⚠️ contains commits of #5158 ⚠️ 