### PR TITLE
Remove invalid wiki menu children nodes if the slug already exists

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -371,12 +371,12 @@ class WikiController < ApplicationController
     end
   end
 
-  def current_menu_item_sym(page, symbol_postfix = '')
+  def current_menu_item_sym(page)
     menu_item = send(page).try(:nearest_menu_item)
 
-    menu_item.present? ?
-      :"#{menu_item.item_class}#{symbol_postfix}" :
-      nil
+    if menu_item.present?
+      menu_item.menu_identifier
+    end
   end
 
   protected

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -31,7 +31,7 @@ class WikiMenuItemsController < ApplicationController
   attr_reader :wiki_menu_item
 
   current_menu_item do |controller|
-    controller.wiki_menu_item.item_class.to_sym if controller.wiki_menu_item
+    controller.wiki_menu_item.menu_identifier if controller.wiki_menu_item
   end
 
   before_action :find_project_by_project_id

--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -44,6 +44,10 @@ class MenuItems::WikiMenuItem < MenuItem
     slug
   end
 
+  def menu_identifier
+    "wiki-#{slug}".to_sym
+  end
+
   def index_page
     !!options[:index_page]
   end

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -29,6 +29,7 @@
 
 module Redmine::MenuManager::MenuHelper
   include ::Redmine::MenuManager::TopMenuHelper
+  include ::Redmine::MenuManager::WikiMenuHelper
   include AccessibilityHelper
 
   # Returns the current menu item name
@@ -43,31 +44,6 @@ module Redmine::MenuManager::MenuHelper
       build_work_packages_menu(project)
     end
     render_menu((project && !project.new_record?) ? :project_menu : :application_menu, project)
-  end
-
-  def build_wiki_menus(project)
-    return unless project.enabled_module_names.include? 'wiki'
-    project_wiki = project.wiki
-
-    MenuItems::WikiMenuItem.main_items(project_wiki).each do |main_item|
-      Redmine::MenuManager.loose :project_menu do |menu|
-        menu.push "#{main_item.item_class}".to_sym,
-                  { controller: '/wiki', action: 'show', id: main_item.slug },
-                  param: :project_id,
-                  caption: main_item.title,
-                  after: :repository,
-                  html: { class: 'icon2 icon-wiki' }
-
-        main_item.children.each do |child|
-          menu.push "#{child.item_class}".to_sym,
-                    { controller: '/wiki', action: 'show', id: child.slug },
-                    param: :project_id,
-                    caption: child.title,
-                    html:    { class: 'icon2 icon-wiki2' },
-                    parent: "#{main_item.item_class}".to_sym
-        end
-      end
-    end
   end
 
   def build_work_packages_menu(_project)

--- a/lib/redmine/menu_manager/tree_node.rb
+++ b/lib/redmine/menu_manager/tree_node.rb
@@ -41,7 +41,7 @@ class Redmine::MenuManager::TreeNode < Tree::TreeNode
   # parent is set to be the receiver.  The child is added as the first child in
   # the current list of children for the receiver node.
   def prepend(child)
-    raise 'Child already added' if @children_hash.has_key?(child.name)
+    raise(ArgumentError, 'Child already added') if @children_hash.has_key?(child.name)
 
     @children_hash[child.name]  = child
     @children = [child] + @children
@@ -53,7 +53,7 @@ class Redmine::MenuManager::TreeNode < Tree::TreeNode
   # parent is set to be the receiver.  The child is added at the position
   # into the current list of children for the receiver node.
   def add_at(child, position)
-    raise 'Child already added' if @children_hash.has_key?(child.name)
+    raise(ArgumentError, 'Child already added') if @children_hash.has_key?(child.name)
 
     @children_hash[child.name]  = child
     @children = @children.insert(position, child)
@@ -62,7 +62,7 @@ class Redmine::MenuManager::TreeNode < Tree::TreeNode
   end
 
   def add_last(child)
-    raise 'Child already added' if @children_hash.has_key?(child.name)
+    raise(ArgumentError, 'Child already added') if @children_hash.has_key?(child.name)
 
     @children_hash[child.name]  = child
     @children << child
@@ -75,6 +75,8 @@ class Redmine::MenuManager::TreeNode < Tree::TreeNode
   # parent is set to be the receiver.  The child is added as the last child in
   # the current list of children for the receiver node.
   def add(child)
+    raise(ArgumentError, 'Child already added') if @children_hash.has_key?(child.name)
+
     @children_hash[key!(child)] = child
     position = @children.size - @last_items_count
     @children.insert(position, child)

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -1,0 +1,69 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Redmine::MenuManager::WikiMenuHelper
+  def build_wiki_menus(project)
+    return unless project.enabled_module_names.include? 'wiki'
+    project_wiki = project.wiki
+
+    MenuItems::WikiMenuItem.main_items(project_wiki).each do |main_item|
+      Redmine::MenuManager.loose :project_menu do |menu|
+        push_wiki_main_menu(menu, main_item)
+
+        main_item.children.each do |child|
+          push_wiki_menu_subitem(menu, main_item, child)
+        end
+      end
+    end
+  end
+
+  def push_wiki_main_menu(menu, main_item)
+    menu.push main_item.menu_identifier,
+              { controller: '/wiki', action: 'show', id: main_item.slug },
+              param: :project_id,
+              caption: main_item.title,
+              after: :repository,
+              html: { class: 'icon2 icon-wiki' }
+  rescue ArgumentError => e
+    Rails.logger.error "Failed to add wiki item #{main_item.slug} to wiki menu: #{e}. Deleting it."
+    main_item.destroy
+  end
+
+  def push_wiki_menu_subitem(menu, main_item, child)
+    menu.push child.menu_identifier,
+              { controller: '/wiki', action: 'show', id: child.slug },
+              param: :project_id,
+              caption: child.title,
+              html:    { class: 'icon2 icon-wiki2' },
+              parent: main_item.menu_identifier
+  rescue ArgumentError => e
+    Rails.logger.error "Failed to add wiki item #{child.slug} to wiki menu: #{e}. Deleting it."
+    child.destroy
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -65,7 +65,7 @@ describe ProjectsController, type: :controller do
       it 'renders main menu without wiki menu item' do
         get 'show', params: @params
 
-        assert_select '#main-menu a.Wiki-menu-item', false # assert_no_select
+        assert_select '#main-menu a.wiki-Wiki-menu-item', false # assert_no_select
       end
     end
 
@@ -86,7 +86,7 @@ describe ProjectsController, type: :controller do
         it 'renders main menu with wiki menu item' do
           get 'show', params: @params
 
-          assert_select '#main-menu a.wiki-menu-item', 'Wiki'
+          assert_select '#main-menu a.wiki-wiki-menu-item', 'Wiki'
         end
       end
 
@@ -105,13 +105,13 @@ describe ProjectsController, type: :controller do
         it 'renders main menu with wiki menu item' do
           get 'show', params: @params
 
-          assert_select '#main-menu a.example-menu-item', 'Example Title'
+          assert_select '#main-menu a.wiki-example-menu-item', 'Example Title'
         end
 
         it 'renders main menu with sub wiki menu item' do
           get 'show', params: @params
 
-          assert_select '#main-menu a.sub-menu-item', 'Sub Title'
+          assert_select '#main-menu a.wiki-sub-menu-item', 'Sub Title'
         end
       end
     end

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -293,8 +293,8 @@ describe WikiController, type: :controller do
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
 
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item"
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item.selected", false
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected", false
         end
 
         it "is inactive, when another wiki menu item's page is shown" do
@@ -303,8 +303,8 @@ describe WikiController, type: :controller do
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
 
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item"
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item.selected", false
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected", false
         end
 
         it 'is active, when the given wiki menu item is shown' do
@@ -313,7 +313,7 @@ describe WikiController, type: :controller do
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
 
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item.selected"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected"
         end
       end
 
@@ -325,7 +325,7 @@ describe WikiController, type: :controller do
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
 
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item.selected"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected"
         end
 
         it 'is active, when a toc page is shown' do
@@ -333,7 +333,7 @@ describe WikiController, type: :controller do
 
           expect(response).to be_success
           assert_select '#content h2', text: 'Index by title'
-          assert_select "#main-menu a.#{@wiki_menu_item.name}-menu-item.selected"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected"
 
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
         end
@@ -346,7 +346,7 @@ describe WikiController, type: :controller do
           expect(response).to be_success
           expect(response.body).to have_selector('#main-menu a.selected', count: 1)
 
-          assert_select "#main-menu a.#{@wiki_menu_item.item_class}-menu-item.selected"
+          assert_select "#main-menu a.#{@wiki_menu_item.menu_identifier}-menu-item.selected"
         end
       end
 

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -1,0 +1,70 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'features/page_objects/notification'
+require 'features/work_packages/shared_contexts'
+require 'features/work_packages/work_packages_page'
+
+feature 'Wiki menu items' do
+  let(:user) { FactoryGirl.create :admin }
+  let(:project) { FactoryGirl.create :project, enabled_module_names: %w[wiki] }
+  let(:wiki) { project.wiki }
+  let(:parent_menu) { wiki.wiki_menu_items.find_by(name: 'wiki') }
+
+  before do
+    allow(User).to receive(:current).and_return user
+  end
+
+  context 'with identical names' do
+    # Create two items with identical slugs (one with space, which is removed)
+    let(:item1) do
+      MenuItems::WikiMenuItem.new(navigatable_id: wiki.id,
+                                  parent: parent_menu, title: 'Item 1', name: 'slug')
+    end
+    let(:item2) do
+      MenuItems::WikiMenuItem.new(navigatable_id: wiki.id,
+                                  parent: parent_menu, title: 'Item 2', name: 'slug ')
+    end
+
+    it 'one is invalid and deleted during visit' do
+      expect(wiki.wiki_menu_items.count).to eq(1)
+
+      item1.save!
+      item2.save!
+      wiki.wiki_menu_items.reload
+      expect(wiki.wiki_menu_items.count).to eq(3)
+
+      visit project_wiki_path(project, project.wiki)
+
+      wiki.wiki_menu_items.reload
+      expect(wiki.wiki_menu_items.count).to eq(2)
+      expect(wiki.wiki_menu_items.pluck(:name).sort).to eq(%w(slug wiki))
+    end
+  end
+end


### PR DESCRIPTION
They will be unable to be selected and/or removed by hand anyway,
so we should just delete them.

https://community.openproject.com/projects/openproject/work_packages/24582/activity