### PR TITLE
[23467][2b] Autocomplete-Eintrage nicht wahrnehmbar (Members autocomplete)

### DIFF
--- a/app/views/members/_autocomplete_for_member.html.erb
+++ b/app/views/members/_autocomplete_for_member.html.erb
@@ -38,3 +38,16 @@ See doc/COPYRIGHT.rdoc for more details.
     <% end %>
   <% end %>
 </fieldset>
+<div class="hidden-for-sighted" aria-live="polite">
+  <% if principals.empty? %>
+    <label aria-role="alert"><%= l('notice_no_principals_found') %></label>
+  <% else %>
+    <% if principals.size > 20 %>
+      <label><%= l('notice_to_many_principals_to_display') %></label>
+    <% elsif principals.size == 1 %>
+      <label><%= l('notice_principals_found_single') %></label>
+    <% else %>
+      <label><%= l('notice_principals_found_multiple', number: principals.size) %></label>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1455,6 +1455,8 @@ en:
   notice_not_authorized: "You are not authorized to access this page."
   notice_not_authorized_archived_project: "The project you're trying to access has been archived."
   notice_password_confirmation_failed: "Your password is not correct. The changes were not saved."
+  notice_principals_found_multiple: "There are %{number} results found. \n Tab to focus the first result."
+  notice_principals_found_single: "There is one result. \n Tab to focus it."
   notice_project_not_deleted: "The project wasn't deleted."
   notice_successful_connection: "Successful connection."
   notice_successful_create: "Successful creation."


### PR DESCRIPTION
This adds a hidden text below the results of the add member form. Thus the screen reader notifies the user after each update about the found result. 
It was necessary to put the labels in a separate block to avoid that the screen reader reads the results itself aloud every time.

https://community.openproject.com/projects/telekom/work_packages/23467/activity