### PR TITLE
Do not allow `admin/enterprise` routes if configuration if `ee_mangager_visible` is FALSE

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -110,6 +110,7 @@ module OpenProject
     # config.autoload_paths += %W(#{config.root}/extras)
     config.enable_dependency_loading = true
     config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('lib/constraints')
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -378,7 +378,9 @@ OpenProject::Application.routes.draw do
 
   scope 'admin' do
     resource :announcements, only: [:edit, :update]
-    resource :enterprise, only: [:show, :create, :destroy]
+    constraints(Enterprise) do
+      resource :enterprise, only: [:show, :create, :destroy]
+    end
     resources :enumerations
 
     delete 'design/logo' => 'custom_styles#logo_delete', as: 'custom_style_logo_delete'

--- a/lib/constraints/enterprise.rb
+++ b/lib/constraints/enterprise.rb
@@ -1,0 +1,35 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+
+class Enterprise
+  def self.matches?(request)
+    OpenProject::Configuration.ee_manager_visible?
+  end
+end

--- a/spec/routing/enterprise_routing_spec.rb
+++ b/spec/routing/enterprise_routing_spec.rb
@@ -1,0 +1,50 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe EnterprisesController, type: :routing do
+  context "when `ee_manager_visible`" do
+    it 'should connect GET /admin/enterprise to enterprises#show' do
+      allow(OpenProject::Configuration).to receive(:ee_manager_visible?).and_return(true)
+      expect(get('/admin/enterprise')).to route_to(controller: 'enterprises',
+      action: 'show')
+    end
+  end
+
+  context "when NOT `ee_manager_visible`" do
+    it 'GET /admin/enterprise should not route to enterprise#show' do
+      # With such a configuration and in case a token is present, the might be a
+      # good reason not to reveal the enterpise token to the admin.
+      # Think of cloud solutions for instance.
+      allow(OpenProject::Configuration).to receive(:ee_manager_visible?).and_return(false)
+      expect(get('/admin/enterprise')).not_to route_to(controller: 'enterprises',
+      action: 'show')
+    end
+  end
+end


### PR DESCRIPTION
With such a configuration and in case a token is present, the might be
a good reason not to reveal the enterpise token to the admin. Think of
cloud solutions for instance.