### PR TITLE
[24648] Add ancestors information through separate grouped SQL

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -37,6 +37,7 @@ class WorkPackage < ActiveRecord::Base
   include WorkPackage::StatusTransitions
   include WorkPackage::AskBeforeDestruction
   include WorkPackage::TimeEntries
+  include WorkPackage::Ancestors
 
   include OpenProject::Journal::AttachmentHelper
 

--- a/app/models/work_package/ancestors.rb
+++ b/app/models/work_package/ancestors.rb
@@ -85,7 +85,6 @@ module WorkPackage::Ancestors
         .and(nested_set_lft_condition)
         .and(nested_set_rgt_condition)
         .and(in_given_work_packages)
-        .and(not_self_condition)
     end
 
     def in_given_work_packages
@@ -98,20 +97,16 @@ module WorkPackage::Ancestors
       )
     end
 
-    def not_self_condition
-      wp_ancestors[:id].not_eq(wp_table[:id])
-    end
-
     def nested_set_root_condition
       wp_ancestors[:root_id].eq(wp_table[:root_id])
     end
 
     def nested_set_lft_condition
-      wp_ancestors[:lft].lteq(wp_table[:lft])
+      wp_ancestors[:lft].lt(wp_table[:lft])
     end
 
     def nested_set_rgt_condition
-      wp_ancestors[:rgt].gteq(wp_table[:rgt])
+      wp_ancestors[:rgt].gt(wp_table[:rgt])
     end
 
     def wp_table

--- a/app/models/work_package/ancestors.rb
+++ b/app/models/work_package/ancestors.rb
@@ -1,0 +1,125 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module WorkPackage::Ancestors
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :work_package_ancestors
+
+    ##
+    # Retrieve stored eager loaded ancestors
+    # or use awesome_nested_set#ancestors reduced by visibility
+    def visible_ancestors(user)
+      work_package_ancestors.presence || WorkPackage.visible(user).merge(ancestors)
+    end
+  end
+
+  class_methods do
+    def aggregate_ancestors(work_package_ids, user)
+      ::WorkPackage::Ancestors::Aggregator.new(work_package_ids, user).results
+    end
+  end
+
+  ##
+  # Aggregate ancestor data for the given work package IDs.
+  # Ancestors visible to the given user are returned, grouped by each input ID.
+  class Aggregator
+    attr_accessor :user, :ids
+
+    def initialize(work_package_ids, user)
+      @user = user
+      @ids = work_package_ids
+    end
+
+    def results
+      with_work_package_ancestors.group_by(&:leaf_id)
+    end
+
+    private
+
+    def with_work_package_ancestors
+      query = join_ancestors(wp_table)
+
+      WorkPackage.joins(query.join_sources)
+                 .select("#{wp_table.name}.id AS leaf_id")
+                 .select('ancestors.*')
+                 .order('ancestors.lft ASC')
+    end
+
+    def join_ancestors(select)
+      select
+        .join(wp_ancestors)
+        .on(ancestors_condition)
+    end
+
+    def ancestors_condition
+      nested_set_root_condition
+        .and(allowed_to_view_work_packages)
+        .and(nested_set_lft_condition)
+        .and(nested_set_rgt_condition)
+        .and(in_given_work_packages)
+        .and(not_self_condition)
+    end
+
+    def in_given_work_packages
+      wp_table[:id].in(ids)
+    end
+
+    def allowed_to_view_work_packages
+      wp_ancestors[:project_id].in(
+        Project.allowed_to(user, :view_work_packages).select(:id).arel
+      )
+    end
+
+    def not_self_condition
+      wp_ancestors[:id].not_eq(wp_table[:id])
+    end
+
+    def nested_set_root_condition
+      wp_ancestors[:root_id].eq(wp_table[:root_id])
+    end
+
+    def nested_set_lft_condition
+      wp_ancestors[:lft].lteq(wp_table[:lft])
+    end
+
+    def nested_set_rgt_condition
+      wp_ancestors[:rgt].gteq(wp_table[:rgt])
+    end
+
+    def wp_table
+      @wp_table ||= WorkPackage.arel_table
+    end
+
+    def wp_ancestors
+      @wp_ancestors ||= wp_table.alias('ancestors')
+    end
+  end
+end

--- a/doc/apiv3/endpoints/work-packages.apib
+++ b/doc/apiv3/endpoints/work-packages.apib
@@ -21,11 +21,13 @@
 | :----------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------ | --------------------- | ----------------------------------------- |
 | self               | This work package                                                                                                                                     | WorkPackage  | not null     | READ                  |                                           |
 | schema             | The schema of this work package                                                                                                                       | Schema       | not null     | READ                  |                                           |
+| ancestors          | Array of all visible ancestors of the work package, with the root node being the first element                                                        | Collection   | not null     | READ                  | **Permission** view work packages         |
 | attachments        | The files attached to this work package                                                                                                               | Collection   | not null     | READ                  |                                           |
 | author             | The person that created the work package                                                                                                              | User         | not null     | READ                  |                                           |
 | assignee           | The person that is intended to work on the work package                                                                                               | User         |              | READ / WRITE          |                                           |
 | availableWatchers  | All users that can be added to the work package as watchers.                                                                                          | User         |              | READ                  | **Permission** add work package watchers  |
 | category           | The category of the work package                                                                                                                      | Category     |              | READ / WRITE          |                                           |
+| children           | Array of all visible children of the work package                                                                                                     | Collection   | not null     | READ                  | **Permission** view work packages         |
 | priority           | The priority of the work package                                                                                                                      | Priority     | not null     | READ / WRITE          |                                           |
 | project            | The project to which the work package belongs                                                                                                         | Project      | not null     | READ / WRITE          |                                           |
 | responsible        | The person that is responsible for the overall outcome                                                                                                | User         |              | READ / WRITE          |                                           |
@@ -203,6 +205,20 @@ the human readable name of custom fields.*
                         {
                             "href": "/api/v3/work_packages/1529",
                             "title": "Write API documentation"
+                        }
+                    ],
+                    "ancestors": [
+                        {
+                            "href": "/api/v3/work_packages/1290",
+                            "title": "Root node of hierarchy"
+                        },
+                        {
+                            "href": "/api/v3/work_packages/1291",
+                            "title": "Intermediate node of hierarchy"
+                        },
+                        {
+                            "href": "/api/v3/work_packages/1298",
+                            "title": "nisi eligendi officiis eos delectus quis voluptas dolores"
                         }
                     ],
                     "timeEntries": {

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -183,10 +183,19 @@ module API
         def full_work_packages(ids_in_order)
           wps = add_eager_loading(WorkPackage.where(id: ids_in_order), current_user).to_a
 
+          eager_load_ancestry(wps, ids_in_order)
           eager_load_user_custom_values(wps)
           eager_load_version_custom_values(wps)
 
           wps.sort_by { |wp| ids_in_order.index(wp.id) }
+        end
+
+        def eager_load_ancestry(work_packages, ids_in_order)
+          grouped = WorkPackage.aggregate_ancestors(ids_in_order, current_user)
+
+          work_packages.each do |wp|
+            wp.work_package_ancestors = grouped[wp.id] || []
+          end
         end
 
         def eager_load_user_custom_values(work_packages)

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -293,6 +293,15 @@ module API
           end unless visible_children.empty?
         end
 
+        links :ancestors do
+          represented.visible_ancestors(current_user).map do |ancestor|
+            {
+              href: api_v3_paths.work_package(ancestor.id),
+              title: ancestor.subject
+            }
+          end
+        end
+
         property :id, render_nil: true
         property :lock_version
         property :subject, render_nil: true

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -89,6 +89,19 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
         .at_path('_links/schemas/href')
     end
 
+    describe 'ancestors' do
+      before do
+        expect(WorkPackage).to receive(:aggregate_ancestors).and_call_original
+      end
+
+      it 'are being eager loaded' do
+        representer.represented.each do |wp|
+          expect(wp.work_package_ancestors).to be_kind_of(Array)
+          expect(wp.ancestors).to eq(wp.work_package_ancestors)
+        end
+      end
+    end
+
     context 'when the user has the add_work_package permission in any project' do
       before do
         allow(user)

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -746,14 +746,15 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         end
 
         context 'ancestors' do
-          let(:root) { FactoryGirl.create(:work_package, project: project) }
-          let(:work_package) do
-            FactoryGirl.create(:work_package, parent: intermediate, project: project)
+          let(:root) { FactoryGirl.build_stubbed(:work_package, project: project) }
+          let(:intermediate) do
+            FactoryGirl.build_stubbed(:work_package, parent: root, project: project)
           end
 
-          context 'when intermediate is visible' do
-            let(:intermediate) do
-              FactoryGirl.create(:work_package, parent: root, project: project)
+          context 'when ancestors are visible' do
+            before do
+              expect(work_package).to receive(:visible_ancestors)
+                .and_return([root, intermediate])
             end
 
             it 'renders two items in ancestors' do
@@ -765,14 +766,14 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
             end
           end
 
-          context 'when intermdiate is invisible' do
-            let(:intermediate) do
-              FactoryGirl.create(:work_package, parent: root, project: forbidden_project)
+          context 'when ancestors are invisible' do
+            before do
+              expect(work_package).to receive(:visible_ancestors)
+                .and_return([])
             end
 
             it 'renders the root node in ancestors' do
-              expect(subject).to have_json_size(1).at_path('_links/ancestors')
-              expect(parse_json(subject)['_links']['ancestors'][0]['title']).to eq(root.subject)
+              expect(subject).to have_json_size(0).at_path('_links/ancestors')
             end
           end
         end

--- a/spec/models/work_package/aggregate_ancestors_spec.rb
+++ b/spec/models/work_package/aggregate_ancestors_spec.rb
@@ -1,0 +1,159 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe WorkPackage::Ancestors, type: :model do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:project) { FactoryGirl.create :project }
+  let(:project2) { FactoryGirl.create :project }
+
+  let!(:root_work_package) do
+    FactoryGirl.create :work_package,
+                       project: project
+  end
+
+  let!(:intermediate) do
+    FactoryGirl.create :work_package,
+                       parent: root_work_package,
+                       project: project
+  end
+  let!(:intermediate_project2) do
+    FactoryGirl.create :work_package,
+                       parent: root_work_package,
+                       project: project2
+  end
+  let!(:leaf) do
+    FactoryGirl.create :work_package,
+                       parent: intermediate,
+                       project: project
+  end
+  let!(:leaf_project2) do
+    FactoryGirl.create :work_package,
+                       parent: intermediate_project2,
+                       project: project
+  end
+
+  let(:view_role) do
+    FactoryGirl.build(:role,
+                      permissions: [:view_work_packages])
+  end
+
+  let(:none_role) do
+    FactoryGirl.build(:role,
+                      permissions: [])
+  end
+
+  let(:leaf_ids) { [leaf.id, leaf_project2.id] }
+  let(:intermediate_ids) { [intermediate.id, intermediate_project2.id] }
+
+  subject { ::WorkPackage.aggregate_ancestors(ids, user) }
+
+  before do
+    allow(Setting).to receive(:cross_project_work_package_relations?).and_return(true)
+    login_as(user)
+  end
+
+  context 'with permission in the first project' do
+    before do
+      FactoryGirl.create :member,
+                         user: user,
+                         project: project,
+                         roles: [view_role]
+    end
+
+    describe 'using_awesome_nested_set#ancestors' do
+      it 'returns the same results' do
+        expect(leaf.visible_ancestors(user)).to eq([root_work_package, intermediate])
+      end
+    end
+
+    describe 'leaf ids' do
+      let(:ids) { leaf_ids }
+
+      it 'returns ancestors for the leaf in project 1' do
+        expect(subject).to be_kind_of(Hash)
+        expect(subject.keys.length).to eq(2)
+
+        expect(subject[leaf.id]).to eq([root_work_package, intermediate])
+        expect(subject[leaf_project2.id]).to eq([root_work_package])
+      end
+    end
+
+    describe 'intermediate ids' do
+      let(:ids) { intermediate_ids }
+
+      it 'returns all ancestors in project 1' do
+        expect(subject).to be_kind_of(Hash)
+        expect(subject.keys.length).to eq(2)
+
+        expect(subject[intermediate.id]).to eq([root_work_package])
+        expect(subject[intermediate_project2.id]).to eq([root_work_package])
+      end
+    end
+
+    context 'and permission in second project' do
+      before do
+        FactoryGirl.create :member,
+                           user: user,
+                           project: project2,
+                           roles: [view_role]
+      end
+
+      describe 'leaf ids' do
+        let(:ids) { leaf_ids }
+
+        it 'returns all ancestors' do
+          expect(subject).to be_kind_of(Hash)
+          expect(subject.keys.length).to eq(2)
+
+          expect(subject[leaf.id]).to eq([root_work_package, intermediate])
+          expect(subject[leaf_project2.id]).to eq([root_work_package, intermediate_project2])
+        end
+      end
+    end
+  end
+
+  context 'no permissions' do
+    before do
+      FactoryGirl.create :member,
+                         user: user,
+                         project: project,
+                         roles: [none_role]
+    end
+
+    describe 'leaf ids' do
+      let(:ids) { leaf_ids }
+
+      it 'returns no results for all ids' do
+        expect(subject).to be_kind_of(Hash)
+        expect(subject.keys.length).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds an eager loading mechanism to `awesome_nested_set#ancestors` for a set of ancestors work packages that are visible to the given user.

The work packages API is extended to provide this data as a new `ancestors` link sorted by hierarchy.

https://community.openproject.com/projects/openproject/work_packages/24648/