### PR TITLE
[24580] Improve timeline print (2)

### DIFF
--- a/app/assets/stylesheets/layout/_print.sass
+++ b/app/assets/stylesheets/layout/_print.sass
@@ -5,9 +5,10 @@
   #main-menu,
   #sidebar,
   #footer,
+  #breadcrumb,
   .contextual,
   .other-formats
-    display:none
+    display: none
 
   #main
     background: #fff
@@ -35,29 +36,11 @@
     th, td
       border: 1px solid #aaa
 
-//------------- WP table specific ---------------------
+  // Sizes from user agent stylesheet
+  h1
+    font-size: 2em
+  h2
+    font-size: 1.5em
+  h3
+    font-size: 1.17em
 
-.controller-work_packages.action-index,
-.controller-work_packages.action-show,
-.controller-work_packages.full-create
-  .work-packages--list-pagination-area,
-  .toolbar-items,
-  .icon-pulldown,
-  .wp-table--details-column
-    display: none
-  .wp-timeline--slider-wrapper
-    display: none !important
-  #content
-    margin: 0
-    width: 100%
-    height: 100%
-    padding: 10px
-  #main
-    top: 0
-    padding: 0
-    border: none
-  .work-packages--list-table-area
-    height: 100%
-  .work-package-table--container,
-  .generic-table--results-container
-    overflow: hidden

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -320,3 +320,27 @@
         -webkit-column-break-inside: avoid
         page-break-inside: avoid
         break-inside: avoid
+
+// Print styles for WP table
+@media print
+  .controller-work_packages.action-index,
+  .controller-work_packages.action-show,
+  .controller-work_packages.full-create
+    .wp-timeline--slider-wrapper
+      display: none !important
+    #content
+      margin: 0
+      width: 100%
+      height: 100%
+      padding: 10px
+    #main
+      top: 0
+      padding: 0
+      border: none
+    .work-packages--list-table-area
+      height: 100%
+    .work-package-table--container,
+    .generic-table--results-container
+      overflow: hidden
+    .wp-timeline--scroll-wrapper
+      border-left-width: 3px

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -110,7 +110,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= render(partial: "wiki/content", locals: {content: @content}) %>
 <%= link_to_attachments @page %>
 <% if @editable && authorize_for('wiki', 'add_attachment') %>
-  <div id="wiki_add_attachment">
+  <div id="wiki_add_attachment" class="hide-when-print">
     <p>
       <%= link_to_function l(:label_attachment_new),
                            %{

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -7,7 +7,7 @@
         transition-method="loadQuery">
     </selectable-title>
 
-    <ul class="toolbar-items">
+    <ul class="toolbar-items hide-when-print">
       <li class="toolbar-item">
         <wp-create-button
             allowed="!!resource.$links.createWorkPackage"
@@ -91,7 +91,7 @@
       </wp-table>
     </div>
 
-    <div class="work-packages--list-pagination-area">
+    <div class="work-packages--list-pagination-area hide-when-print">
       <table-pagination>
       </table-pagination>
     </div>

--- a/frontend/app/components/wp-table/timeline/controls/wp-timeline.dummy-controls.directive.html
+++ b/frontend/app/components/wp-table/timeline/controls/wp-timeline.dummy-controls.directive.html
@@ -1,4 +1,4 @@
-<div class="wp-timeline--dummy-controls" ng-if="$ctrl.wpTimeline.visible">
+<div class="wp-timeline--dummy-controls hide-when-print" ng-if="$ctrl.wpTimeline.visible">
   <div class="timeline-controls--zoom-buttons">
     <button class="button -transparent"
             ng-disabled="$ctrl.currentZoom == $ctrl.maxZoomLevel"

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -26,7 +26,7 @@
                           query="query"
                           ng-class="column.name == 'id' && '-short' ">
           </th>
-          <th class="wp-table--details-column -short">
+          <th class="wp-table--details-column -short hide-when-print">
             <div class="generic-table--sort-header-outer">
               <accessible-by-keyboard
                           execute="openColumnsModal()"

--- a/frontend/app/templates/components/selectable_title.html
+++ b/frontend/app/templates/components/selectable_title.html
@@ -6,7 +6,7 @@
             collision-container="#content"
             locals="selectedTitle,groups,transitionMethod">
         <accessible-by-keyboard link-title="{{ I18n.t('js.toolbar.search_query_title') }}" >
-          <i class="icon-pulldown icon-button icon-small">
+          <i class="icon-pulldown icon-button icon-small hide-when-print">
           </i>
           {{ selectedTitle | characters:50 }}
         </accessible-by-keyboard>


### PR DESCRIPTION
This adds further improvements to the timeline print view. The details can be seen in the ticket: https://community.openproject.com/projects/openproject/work_packages/24580/activity.

Additionally the class `hide-when-print` was used to avoid unnecessary styling rules and the rules were assigned to the correct files. 

This PR is only useful in the scope of: https://github.com/opf/openproject/pull/4927