### PR TITLE
Experiment: Extract a webpack DLL bundle with all large vendors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ npm-debug.log*
 /.sass-cache/
 # Frontend debug log
 /frontend/npm-debug.log*
+/frontend/dist/
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ cache:
   directories:
     - frontend/node_modules
 
-bundler_args: --without development production docker
-
 branches:
   only:
     - master
@@ -90,13 +88,16 @@ before_install:
   # We need npm 4.0 for a bugfix in cross-platform shrinkwrap
   # https://github.com/npm/npm/issues/14042
   - npm install npm@4.0
-  - travis_retry npm install
 
   # We need phantomjs 2.0 to get tests passing
   - mkdir travis-phantomjs
   - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs:$PATH
+
+install:
+  - bundle install --without development production docker
+  - travis_retry npm install
 
 before_script:
   - sh script/ci_setup.sh $DB

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -26,11 +26,11 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-//= require ./bundles/openproject-global
-
 //= require i18n
 
-//# require jquery_noconflict
+//= require ./bundles/openproject-vendors
+//= require ./bundles/openproject-core-app
+//= require_tree ./bundles
 
 //= require lib/jquery.colorcontrast
 //= require lib/jquery.trap
@@ -52,9 +52,6 @@
 //= require openproject_plugins
 //= require versions
 //= require_tree ./specific
-
-//= require ./bundles/openproject-core-app
-//= require_tree ./bundles
 
 //= require custom-fields
 //= require date-range

--- a/app/assets/stylesheets/default.css.sass
+++ b/app/assets/stylesheets/default.css.sass
@@ -25,7 +25,7 @@
  *
  * See doc/COPYRIGHT.rdoc for more details.  ++
  */
-//= require bundles/openproject-global
+//= require bundles/openproject-core-app
 
 //= require print
 //= require scm

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -26,6 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+
 import {scopedObservable} from "../../helpers/angular-rx-utils";
 import {KeepTabService} from "../wp-panels/keep-tab/keep-tab.service";
 import * as MouseTrap from "mousetrap";

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -26,22 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-require('angular-animate');
-require('angular-aria');
-require('angular-modal');
+// Globally exposed dependencies
+require('./vendors');
 
-// depends on the html element having a 'lang' attribute
-var documentLang = (angular.element('html').attr('lang') || 'en').toLowerCase();
-require('angular-i18n/angular-locale_' + documentLang + '.js');
-
-require('angular-ui-router');
-
-require('angular-truncate');
-
-require('angular-context-menu');
-require('angular-elastic');
-require('angular-cache');
-require('ngFileUpload');
+// Styles for global dependencies
+require('at.js/jquery.atwho.min.css');
+require('select2/select2.css');
+require('ui-select/dist/select.min.css');
+require('ng-dialog/css/ngDialog.min.css');
+require('jquery-ui/themes/base/core.css');
+require('jquery-ui/themes/base/datepicker.css');
+require('jquery-ui/themes/base/dialog.css');
 
 var opApp = require('./angular-modules.ts').default;
 

--- a/frontend/app/vendors.js
+++ b/frontend/app/vendors.js
@@ -34,18 +34,32 @@
 // See: https://github.com/webpack/style-loader/issues/31
 require('phantomjs-polyfill');
 
-// Globally exposed dependencies
+// jQuery
 require('expose-loader?jQuery!jquery');
-require('expose-loader?angular!angular');
-require('expose-loader?dragula!dragula');
-require('expose-loader?moment!moment');
-require('expose-loader?Mousetrap!mousetrap');
-require('expose-loader?URI!URIjs');
-
 require('jquery-ujs');
 
-require('angular-dragula');
+require('expose-loader?mousetrap!mousetrap/mousetrap.min.js');
 
+// Angular dependencies
+require('expose-loader?angular!angular');
+require('expose-loader?dragula!dragula/dist/dragula.min.js');
+require('angular-animate/angular-animate.min.js');
+require('angular-aria/angular-aria.min.js');
+require('angular-cache/dist/angular-cache.min.js');
+require('angular-context-menu/dist/angular-context-menu.min.js');
+require('angular-dragula/dist/angular-dragula.min.js');
+require('angular-elastic');
+require('angular-modal/modal.min.js');
+require('angular-sanitize/angular-sanitize.min.js');
+require('angular-truncate/src/truncate.js');
+require('angular-ui-router/release/angular-ui-router.min.js');
+require('ng-file-upload/dist/ng-file-upload.min.js');
+
+// depends on the html element having a 'lang' attribute
+var documentLang = (angular.element('html').attr('lang') || 'en').toLowerCase();
+require('angular-i18n/angular-locale_' + documentLang + '.js');
+
+// Jquery UI
 require('jquery-ui/ui/core.js');
 require('jquery-ui/ui/position.js');
 require('jquery-ui/ui/widgets/datepicker.js');
@@ -57,30 +71,23 @@ require('./misc/datepicker-defaults');
 require('jquery-ui/ui/i18n/datepicker-en-GB.js');
 require('jquery-ui/ui/i18n/datepicker-de.js');
 
-require('jquery-ui/themes/base/core.css');
-require('jquery-ui/themes/base/datepicker.css');
-// TODO: move require to backlogs plugin
 require('jquery-ui/ui/widgets/dialog.js');
-require('jquery-ui/themes/base/dialog.css');
 
+require('expose-loader?moment!moment');
 require('moment/locale/en-gb.js');
 require('moment/locale/de.js');
 
 require('jquery.caret');
 require('at.js/jquery.atwho.min.js');
-require('at.js/jquery.atwho.min.css');
+
 
 require('moment-timezone/builds/moment-timezone-with-data.min.js');
 
 require('select2/select2.min.js');
-require('select2/select2.css');
-
-require('angular-sanitize');
 
 require('ui-select/dist/select.min.js');
-require('ui-select/dist/select.min.css');
 
 require('ng-dialog/js/ngDialog.min.js');
-require('ng-dialog/css/ngDialog.min.css');
 
+require('expose-loader?URI!URIjs');
 require('URIjs/src/URITemplate');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,10 +89,12 @@
     "webpack": "^2.2.0"
   },
   "scripts": {
-    "pretest": "npm run webpack",
+    "pretest": "npm run webpack-with-test",
     "test": "npm run karma",
     "karma": "./scripts/karma-runner.js",
     "webpack": "./node_modules/.bin/webpack --colors --progress",
-    "webpack-watch": "npm run webpack -- --watch --cache"
+    "webpack-with-test": "./node_modules/.bin/webpack --colors --progress --env.testconfig 1",
+    "webpack-watch": "npm run webpack -- --watch --cache",
+    "webpack-watch-with-test": "npm run webpack -- --watch --cache --env.testconfig 1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "webpack": "^2.2.0"
   },
   "scripts": {
+    "postinstall": "./node_modules/.bin/webpack --colors --progress  --debug --config webpack-vendors-config.js",
     "pretest": "npm run webpack-with-test",
     "test": "npm run karma",
     "karma": "./scripts/karma-runner.js",

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -99,7 +99,6 @@ function getWebpackMainConfig() {
     context: path.resolve(__dirname, 'app'),
 
     entry: _.merge({
-      'global': './global',
       'core-app': './openproject-app'
     }, pluginEntries),
 
@@ -127,10 +126,6 @@ function getWebpackMainConfig() {
 
         'at.js': path.resolve(__dirname, 'vendor', 'at.js'),
         'select2': path.resolve(__dirname, 'vendor', 'select2'),
-        'angular-truncate': 'angular-truncate/src/truncate',
-        'angular-context-menu': 'angular-context-menu/dist/angular-context-menu.js',
-        'mousetrap': 'mousetrap/mousetrap.js',
-        'ngFileUpload': 'ng-file-upload/dist/ng-file-upload.min.js',
         'lodash': path.resolve(node_root, 'lodash', 'dist', 'lodash.min.js'),
         // prevents using crossvent from dist and by that
         // reenables debugging in the browser console.
@@ -153,6 +148,10 @@ function getWebpackMainConfig() {
       new webpack.DefinePlugin({
         DEBUG: !!debug_output,
         PRODUCTION: !!production
+      }),
+      new webpack.DllReferencePlugin({
+          context: path.resolve(__dirname),
+          manifest: require('./dist/vendors-dll-manifest.json')
       }),
 
       // Extract CSS into its own bundle

--- a/frontend/webpack-main-config.js
+++ b/frontend/webpack-main-config.js
@@ -42,8 +42,8 @@ var debug_output = (!production || !!process.env['OP_FRONTEND_DEBUG_OUTPUT']);
 
 var node_root = path.resolve(__dirname, 'node_modules');
 
-var pluginEntries = _.reduce(pathConfig.pluginNamesPaths, function (entries, path, name) {
-  entries[name.replace(/^openproject\-/, '')] = name;
+var pluginEntries = _.reduce(pathConfig.pluginNamesPaths, function (entries, pluginPath, name) {
+  entries[name.replace(/^openproject\-/, '')] = path.resolve(pluginPath, 'frontend', 'app', name + '-app.js');
   return entries;
 }, {});
 
@@ -63,7 +63,13 @@ fs.readdirSync(translations).forEach(function (file) {
 });
 
 var loaders = [
-  { test: /\.tsx?$/, loader: 'ng-annotate-loader!ts-loader'},
+  { test: /\.tsx?$/,
+    loader: 'ts-loader',
+    options: {
+      logLevel: 'info',
+      configFileName: path.resolve(__dirname, 'tsconfig.json')
+    }
+  },
   {
     test: /\.css$/,
     loader: ExtractTextPlugin.extract({
@@ -113,7 +119,7 @@ function getWebpackMainConfig() {
     },
 
     resolve: {
-      modules: ['node_modules'].concat(pathConfig.pluginDirectories),
+      modules: ['node_modules'],
 
       extensions: ['.ts', '.tsx', '.js'],
 
@@ -149,6 +155,8 @@ function getWebpackMainConfig() {
         DEBUG: !!debug_output,
         PRODUCTION: !!production
       }),
+
+      // Reference the vendors bundle
       new webpack.DllReferencePlugin({
           context: path.resolve(__dirname),
           manifest: require('./dist/vendors-dll-manifest.json')

--- a/frontend/webpack-vendors-config.js
+++ b/frontend/webpack-vendors-config.js
@@ -1,0 +1,114 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+var webpack = require('webpack');
+var fs = require('fs');
+var path = require('path');
+var _ = require('lodash');
+var pathConfig = require('./rails-plugins.conf');
+var autoprefixer = require('autoprefixer');
+
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var mode = (process.env['RAILS_ENV'] || 'production').toLowerCase();
+var uglify = (mode !== 'development');
+
+var node_root = path.resolve(__dirname, 'node_modules');
+
+
+/** Extract available locales from openproject-translations plugin */
+var translations = path.resolve(pathConfig.allPluginNamesPaths['openproject-translations'], 'config', 'locales');
+var localeIds = ['en'];
+fs.readdirSync(translations).forEach(function (file) {
+  var matches = file.match( /^js-(.+)\.yml$/);
+  if (matches && matches.length > 1) {
+    localeIds.push(matches[1]);
+  }
+});
+
+function getWebpackVendorsConfig() {
+  config = {
+    entry: {
+      vendors: [path.resolve(__dirname, 'app', 'vendors.js')]
+    },
+
+    output: {
+      path: path.resolve(__dirname, '..', 'app', 'assets', 'javascripts', 'bundles'),
+      filename: 'openproject-[name].js',
+      library: '[name]'
+    },
+
+    resolve: {
+      modules: ['node_modules'],
+      alias: {
+        'at.js': path.resolve(__dirname, 'vendor', 'at.js'),
+        'select2': path.resolve(__dirname, 'vendor', 'select2'),
+      }
+    },
+
+    plugins: [
+      new webpack.DllPlugin({
+        path: path.join(__dirname, "dist", "[name]-dll-manifest.json"),
+        name: "[name]",
+        context: '.'
+      }),
+
+      // Restrict loaded ngLocale locales to the ones we load from translations
+      new webpack.ContextReplacementPlugin(
+        /angular\-i18n/,
+        new RegExp('angular\-locale\_(' + localeIds.join('|') + ')\.js$', 'i')
+      ),
+
+      // Restrict loaded moment locales to the ones we load from translations
+      new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp('(' + localeIds.join('|') + ')\.js$', 'i'))
+    ]
+  };
+
+  if (uglify) {
+    console.log("Applying webpack.optimize plugins for production.");
+    // Add compression and optimization plugins
+    // to the webpack build.
+    config.plugins.push(
+      new webpack.optimize.UglifyJsPlugin({
+        mangle: true,
+        compress: true,
+        compressor: { warnings: false },
+        sourceMap: false,
+        exclude: /\.min\.js$/
+      }),
+      new webpack.LoaderOptionsPlugin({
+        // Let loaders know that we're in minification mode
+        minimize: true
+      })
+    );
+  }
+
+  return config;
+}
+
+module.exports = getWebpackVendorsConfig;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -29,7 +29,13 @@
 var getWebpackMainConfig = require('./webpack-main-config');
 var getWebpackTestConfig = require('./webpack-test-config');
 
-module.exports = [
-    getWebpackMainConfig(),
-    getWebpackTestConfig()
-];
+module.exports = function(env) {
+    var configs = [getWebpackMainConfig()];
+
+    if (env && env.testconfig) {
+        console.log("Adding test config to build");
+        configs.push(getWebpackTestConfig());
+    }
+
+    return configs;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "cd frontend && npm test && cd ..",
     "karma": "cd frontend && npm run karma && cd ..",
     "webpack": "cd frontend && npm run webpack && cd ..",
-    "webpack-watch": "cd frontend && npm run webpack-watch"
+    "webpack-watch": "cd frontend && npm run webpack-watch",
+    "webpack-watch-with-test": "cd frontend && npm run webpack-watch-with-test"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
This PR suggests to add a DLL `vendors` bundle (previously 'openproject-global.js' that is **built through a separate webpack process as a post step of `npm install`**. It will always be compiled during that step and takes about 10s with minification.

**Pros**
- The usual webpack watch during development then can reference vendors from the prebuilt bundle, resulting in drastically improved initial (from 30s down to ~12 on my machine) and incremental builds (~1-1.5s).

- We can mangle the output of the vendors file, which shaves off a substantial amount of the vendor file.

**Cons**

- Debugging within the previous 'openproject-globals' is now minified in dev mode. We can introduce a flag to disable this, though.