### PR TITLE
[24477] Breadcrumbs partially hidden when linking on activity

### DIFF
--- a/app/assets/stylesheets/_misc_legacy.sass
+++ b/app/assets/stylesheets/_misc_legacy.sass
@@ -382,9 +382,13 @@ div.issue hr
   ol, ul
     margin-bottom: 6px
 
-#content
+// The min-height takes care that menus within the toolbar can be seen.
+// On the full screen view the min-height crashes the complete view
+// when anchors in the url were used on small sreens, because there the body is not scrollable.
+body:not(.action-show) #content
   min-height: 300px
 
+#content
   h3
     margin: 12px 0 6px
   h2 + h3


### PR DESCRIPTION
On small screens the content overlaps the breadcrumb when there is a link to an activity. 
This occurs because of two facts: First the `#content` has a minimum height to assure that a menu within the toolbar is also visible on small screens. Second the `body` on the WP page is set `overflow: hidden`. When the browser tries to bring the activity into view, it clips the some parts (because it was said that overflow can be hidden and the minimum height shall be satisfied).
http://stackoverflow.com/questions/8240967/why-is-this-page-layout-breaking-when-an-anchor-link-is-used

With the solution provided it is obviusly not possible to access all entries of the toolbar menu on such small screens. Since this did not work before neither (because of the hidden overflow), I opened a separate WP for this issue (https://community.openproject.com/projects/openproject/work_packages/24679/activity - https://github.com/opf/openproject/pull/5198).


Ticket: https://community.openproject.com/projects/openproject/work_packages/24477/activity