### PR TITLE
[24679] WP toolbar menu not visible on small screens

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -306,6 +306,16 @@
     width: rem-calc(354)
     display: inline-block
 
+// Workaround to make the toolbar menu accessible even on very small screens
+@media screen and (max-height: 25em)
+  .controller-work_packages.action-show,
+  .controller-work_packages.action-details,
+  .controller-work_packages.action-index
+    #main
+      overflow: overlay
+    #content
+      overflow-y: auto
+
 // Implement two column layout for WP full screen view
 @media screen and (min-width: 90rem)
   .action-show .attributes-group,


### PR DESCRIPTION
On screens with very little height, the toolbar menu on the WP pages cannot be seen. This happens because the body is not scrollable there and the overflow is hidden. This PR introduces a breakpoint to make the body scrollable again once the screen is too small.

https://community.openproject.com/projects/openproject/work_packages/24679/activity