### PR TITLE
Fix selected columns

### DIFF
--- a/frontend/app/components/modals/columns-modal/columns-modal.controller.ts
+++ b/frontend/app/components/modals/columns-modal/columns-modal.controller.ts
@@ -70,7 +70,7 @@ function ColumnsModalController(this:any,
 
       var availableColumnNames = getColumnNames(availableColumns);
       selectedColumns.forEach((column:api.ex.Column) => {
-        if (_.find(availableColumnNames, column.name)) {
+        if (_.find(availableColumnNames, (available:string) => (available === column.name))) {
           vm.selectedColumns.push(column);
           vm.selectedColumnMap[column.name] = true;
           vm.oldSelectedColumns.push(column);


### PR DESCRIPTION
Fixes an empty column selection modal due to invalid `_.find` syntax.