### PR TITLE
disable a forced password change for pull preview

### DIFF
--- a/app/seeders/admin_user_seeder.rb
+++ b/app/seeders/admin_user_seeder.rb
@@ -56,7 +56,21 @@ class AdminUserSeeder < Seeder
       user.mail_notification = User::USER_MAIL_OPTION_ONLY_MY_EVENTS.first
       user.language = I18n.locale.to_s
       user.status = User::STATUSES[:active]
-      user.force_password_change = Rails.env != 'development'
+      user.force_password_change = force_password_change?
     end
+  end
+
+  def force_password_change?
+    Rails.env != 'development' && !force_password_change_disabled?
+  end
+
+  def force_password_change_disabled?
+    off_values = ["off", "false", "no", "0"]
+
+    off_values.include? ENV[force_password_change_env_switch_name]
+  end
+
+  def force_password_change_env_switch_name
+    "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE"
   end
 end

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -22,6 +22,7 @@ worker: &ruby
     - "SECRET_KEY_BASE=d4e74f017910ac56c6ebad01165b7e1b37f4c9c02e9716836f8670cdc8d65a231e64e4f6416b19c8"
     - "RAILS_ENV=production"
     - "HEROKU=true"
+    - "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off"
   command: "./docker/wait-for-it.sh -t 60 -h db -p 5432 --strict -- bundle exec rake db:migrate db:seed jobs:work"
   memory: 384
 


### PR DESCRIPTION
Configures the admin user seeder so that it does not force a password change on pullpreview.