### PR TITLE
Introduce position: sticky to work package table

### DIFF
--- a/app/assets/stylesheets/content/_table.lsg
+++ b/app/assets/stylesheets/content/_table.lsg
@@ -101,7 +101,7 @@
         </tr>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 
@@ -223,7 +223,7 @@
         </tr>
       </tfoot>
     </table>
-    <div class="generic-table--header-background"></div>
+    
     <div class="generic-table--footer-background"></div>
   </div>
 </div>

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -53,7 +53,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 .generic-table--results-container
   height:       100%
   overflow:
-    x: hidden
+    x: auto
     y: auto
 
 .generic-table--action-buttons

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -43,7 +43,6 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 .generic-table--container
   position:     relative
   height:       100%
-  padding-top:    $generic-table--header-height
   overflow:
     x: auto
     y: hidden
@@ -82,6 +81,12 @@ table.generic-table
       background:   #f8f8f8
 
   thead
+    height: $generic-table--header-height
+
+    &.-sticky
+      position: sticky
+      top: 0
+
     tr
       &:hover
         background: none
@@ -191,11 +196,14 @@ table.generic-table
     z-index:      1
 
   .generic-table--header-outer,
-  .generic-table--sort-header-outer
-    position:     absolute
-    top:          0
+  .generic-table--sort-header-outer,
+  .generic-table--empty-header
+    width:        100%
+    background:   $body-background
+    border-bottom: 1px solid $table-header-border-color
     padding:      0 6px
     line-height:  $generic-table--header-height
+    height: $generic-table--header-height
     z-index:      1
 
     &:hover,
@@ -238,16 +246,6 @@ table.generic-table
 
   .generic-table--cell-controls
     white-space: nowrap
-
-.generic-table--header-background
-  position:     absolute
-  top:          0
-  width:        100%
-  height:       $generic-table--header-height
-  background:   $body-background
-  border-bottom: 1px solid $table-header-border-color
-  box-shadow:   0 5px 3px -4px $table-header-shadow-color
-  z-index:      0
 
   &.-no-border
     border: none

--- a/app/assets/stylesheets/content/work_packages/_table_content.lsg
+++ b/app/assets/stylesheets/content/work_packages/_table_content.lsg
@@ -145,7 +145,7 @@
         </tr>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 ```

--- a/app/cells/views/table/show.erb
+++ b/app/cells/views/table/show.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table">
+    <table class="generic-table">
       <colgroup>
         <% headers.each do |_name, _options| %>
           <col highlight-col>
@@ -52,7 +52,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end -%>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 <%= pagination_links_full rows %>

--- a/app/views/admin/plugins.html.erb
+++ b/app/views/admin/plugins.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @plugins.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table plugins">
+      <table class="generic-table plugins">
         <colgroup>
           <col>
           <col>
@@ -52,7 +52,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
 <% else %>

--- a/app/views/admin/projects.html.erb
+++ b/app/views/admin/projects.html.erb
@@ -68,7 +68,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @projects.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -84,7 +84,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <%= sort_header_tag('required_disk_space', caption: I18n.t(:label_required_disk_storage)) %>
             <%= sort_header_tag('created_on', caption: Project.human_attribute_name(:created_on)) %>
             <%= sort_header_tag('latest_activity_at', caption: Project.human_attribute_name(:latest_activity_at)) %>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -120,7 +120,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
       <%= pagination_links_full @projects %>
     </div>
   </div>

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @auth_sources.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -89,7 +89,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -111,7 +111,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <%= pagination_links_full @auth_sources %>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_board_plural) %>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table boards">
+    <table class="generic-table boards">
       <colgroup>
         <col highlight-col>
         <col highlight-col>
@@ -96,7 +96,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 <%= other_formats_links do |f| %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -72,7 +72,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @topics.any? %>
     <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table class="generic-table">
+          <table class="generic-table">
             <colgroup>
               <col highlight-col>
               <col highlight-col>
@@ -155,7 +155,7 @@ See doc/COPYRIGHT.rdoc for more details.
             </tr>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
      </div>
     <table-pagination total-entries="totalMessageCount" update-results="loadMessages()"></table-pagination>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -95,6 +95,6 @@
         </tr>
       <% end %>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if (@custom_fields_by_type[tab[:name]] || []).any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -100,7 +100,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -121,7 +121,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <div class="generic-table--action-buttons">

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if enumerations.any? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -98,7 +98,7 @@ See doc/COPYRIGHT.rdoc for more details.
             </tr>
           <% end %>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
   <% end %>

--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if @group.memberships.any? %>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table class="generic-table memberships">
+          <table class="generic-table memberships">
             <colgroup>
               <col highlight-col>
               <col highlight-col>
@@ -60,7 +60,7 @@ See doc/COPYRIGHT.rdoc for more details.
                     </div>
                   </div>
                 </th>
-                <th></th>
+                <th><div class="generic-table--empty-header"></div></th>
               </tr>
             </thead>
             <tbody>
@@ -96,7 +96,7 @@ See doc/COPYRIGHT.rdoc for more details.
             </tbody>
             <% end %>
           </table>
-          <div class="generic-table--header-background"></div>
+          
         </div>
       </div>
     <% else %>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <% if @group.users.any? %>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table class="generic-table users">
+          <table class="generic-table users">
             <colgroup>
               <col highlight-col>
               <col>
@@ -47,7 +47,7 @@ See doc/COPYRIGHT.rdoc for more details.
                       </span>
                     </div>
                   </div></th>
-                <th></th>
+                <th><div class="generic-table--empty-header"></div></th>
               </tr>
             </thead>
             <tbody>
@@ -64,7 +64,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <% end %>
             </tbody>
           </table>
-          <div class="generic-table--header-background"></div>
+          
         </div>
       </div>
     <% else %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -42,7 +42,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @groups.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -68,7 +68,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -81,7 +81,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
 <% else %>

--- a/app/views/help/wiki_syntax.html.erb
+++ b/app/views/help/wiki_syntax.html.erb
@@ -65,7 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <td><del>Deleted</del></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>??Quote??</td>
     <td><cite>Quote</cite></td>
   </tr>
@@ -142,12 +142,12 @@ See doc/COPYRIGHT.rdoc for more details.
     <th colspan="3">Links</th>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>http://foo.bar</td>
     <td><a href="#">http://foo.bar</a></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>"Foo":http://foo.bar</td>
     <td><a href="#">Foo</a></td>
   </tr>
@@ -166,17 +166,17 @@ See doc/COPYRIGHT.rdoc for more details.
     <td><a href="#">Wiki page</a> (On the Sandbox project)</td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>WorkPackage #12</td>
     <td>WorkPackage <a href="#">#12</a></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>WorkPackage ##12</td>
     <td>WorkPackage <a href="#">Bug #12: WorkPackage Subject</a> 2012-06-06 – 2013-06-06</td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>WorkPackage ###12</td>
     <td>WorkPackage <a href="#">Bug #12: WorkPackage Subject</a> 2012-06-06 – 2013-06-06
 
@@ -190,17 +190,17 @@ See doc/COPYRIGHT.rdoc for more details.
     </td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>Revision r43</td>
     <td>Revision <a href="#">r43</a></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>commit:f30e13e43</td>
     <td><a href="#">f30e13e4</a></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>source:some/file</td>
     <td><a href="#">source:some/file</a></td>
   </tr>
@@ -214,7 +214,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <td></td>
   </tr>
   <tr>
-    <th></th>
+    <th><div class="generic-table--empty-header"></div></th>
     <td>!<em>attached_image</em>!</td>
     <td></td>
   </tr>

--- a/app/views/my/access_token.html.erb
+++ b/app/views/my/access_token.html.erb
@@ -160,7 +160,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <%= call_hook(:view_access_tokens_table, user: @user) %>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
 <% else %>

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -51,7 +51,7 @@ entries_by_day = entries.group_by(&:spent_on)
 <% if entries.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table time-entries">
+      <table class="generic-table time-entries">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -97,7 +97,7 @@ entries_by_day = entries.group_by(&:spent_on)
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -136,7 +136,7 @@ entries_by_day = entries.group_by(&:spent_on)
           <% end -%>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
 <% end %>

--- a/app/views/planning_element_type_colors/index.html.erb
+++ b/app/views/planning_element_type_colors/index.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @colors.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -80,7 +80,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -103,7 +103,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
 <% else %>

--- a/app/views/project_associations/index.html.erb
+++ b/app/views/project_associations/index.html.erb
@@ -52,7 +52,7 @@ See doc/COPYRIGHT.rdoc for more details.
       </h3>
       <div class="generic-table--container">
         <div class="generic-table--results-container">
-          <table interactive-table class="generic-table timelines-project_associations">
+          <table class="generic-table timelines-project_associations">
             <colgroup>
               <col highlight-col>
               <col highlight-col>
@@ -150,7 +150,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <% end %>
             </tbody>
           </table>
-          <div class="generic-table--header-background"></div>
+          
       </div>
     </div>
     </div>

--- a/app/views/project_types/index.html.erb
+++ b/app/views/project_types/index.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @project_types.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -80,7 +80,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -106,7 +106,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
 <% else %>

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -105,7 +105,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end %>
           <% end %>
         </table>
-        <div class="generic-table--header-background"></div>
+        
     </div>
   </div>
   <% if withControlls == true %>

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table types" id="types-form">
+      <table class="generic-table types" id="types-form">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -132,7 +132,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <% if withControlls == true %>

--- a/app/views/projects/settings/_boards.html.erb
+++ b/app/views/projects/settings/_boards.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -70,7 +70,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   </div>
                 </div>
               </th>
-              <th></th>
+              <th><div class="generic-table--empty-header"></div></th>
             </tr>
           </thead>
           <tbody>
@@ -101,7 +101,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end %>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
     <% if @project.boards.any? %>

--- a/app/views/projects/settings/_categories.html.erb
+++ b/app/views/projects/settings/_categories.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -59,7 +59,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   </div>
                 </div>
               </th>
-              <th></th>
+              <th><div class="generic-table--empty-header"></div></th>
             </tr>
           </thead>
           <tbody>
@@ -84,7 +84,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end %>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
     <% if @project.categories.any? %>

--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </legend>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -109,7 +109,7 @@ See doc/COPYRIGHT.rdoc for more details.
                   </div>
                 </div>
               </th>
-              <th></th>
+              <th><div class="generic-table--empty-header"></div></th>
             </tr>
           </thead>
           <tbody>
@@ -147,7 +147,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end %>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
     <div class="generic-table--action-buttons">

--- a/app/views/reportings/index.html.erb
+++ b/app/views/reportings/index.html.erb
@@ -45,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @reportings.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col highlight-col>
@@ -91,7 +91,7 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </div>
           </th>
-          <th></th>
+          <th><div class="generic-table--empty-header"></div></th>
         </tr>
       </thead>
       <tbody>
@@ -130,7 +130,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 <% else %>

--- a/app/views/repositories/_dir_list.html.erb
+++ b/app/views/repositories/_dir_list.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table entries" id="browser">
+    <table class="generic-table entries" id="browser">
       <colgroup>
         <col highlight-col>
         <col highlight-col>
@@ -99,6 +99,6 @@ See doc/COPYRIGHT.rdoc for more details.
         <%= render partial: 'dir_list_content' %>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= form_tag({controller: '/repositories', action: 'diff', project_id: @project, path: to_path_param(path)}, method: :get) do %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table changesets">
+      <table class="generic-table changesets">
         <colgroup>
           <col highlight-col>
           <col>
@@ -135,7 +135,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <% if show_diff %>

--- a/app/views/repositories/committers.html.erb
+++ b/app/views/repositories/committers.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag({}) do %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -75,7 +75,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end -%>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
     <hr class="form--separator" />

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= render partial: 'layouts/action_menu_specific' %>
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table">
+    <table class="generic-table">
       <colgroup>
         <col highlight-col>
         <col highlight-col>
@@ -70,7 +70,7 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </div>
           </th>
-          <th></th>
+          <th><div class="generic-table--empty-header"></div></th>
         </tr>
       </thead>
       <tbody>
@@ -92,7 +92,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>
 <%= pagination_links_full @roles %>

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -45,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="autoscroll">
         <div class="generic-table--container">
           <div class="generic-table--results-container">
-            <table interactive-table class="generic-table">
+            <table class="generic-table">
               <colgroup>
                 <col highlight-col>
                 <col highlight-col>
@@ -101,7 +101,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 <% end %>
               </tbody>
             </table>
-            <div class="generic-table--header-background"></div>
+            
           </div>
         </div>
       </div>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -51,7 +51,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @statuses.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <% if WorkPackage.use_status_for_done_ratio? %>
@@ -111,7 +111,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -131,7 +131,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <%= pagination_links_full @statuses %>

--- a/app/views/time_entries/reports/show.html.erb
+++ b/app/views/time_entries/reports/show.html.erb
@@ -84,7 +84,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% unless @hours.empty? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table" id="time-report">
+        <table class="generic-table" id="time-report">
           <colgroup>
             <% @criterias.each do |criteria| %>
               <col highlight-col>
@@ -143,7 +143,7 @@ See doc/COPYRIGHT.rdoc for more details.
             </tr>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
 

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table">
+    <table class="generic-table">
       <colgroup>
         <col highlight-col>
         <col highlight-col>
@@ -118,7 +118,7 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </div>
           </th>
-          <th></th>
+          <th><div class="generic-table--empty-header"></div></th>
         </tr>
       </thead>
       <tbody>
@@ -148,6 +148,6 @@ See doc/COPYRIGHT.rdoc for more details.
         </tr>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
 </div>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% if @types.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
           <col highlight-col>
           <col>
@@ -65,7 +65,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
              <!-- Missing workflow warning -->
             <th>
               <div class="generic-table--sort-header-outer">
@@ -112,7 +112,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -137,7 +137,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <%= pagination_links_full @types %>

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if @user.memberships.any? %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table memberships">
+        <table class="generic-table memberships">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -62,7 +62,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </th>
               <%= call_hook(:view_users_memberships_table_header, user: @user )%>
-              <th></th>
+              <th><div class="generic-table--empty-header"></div></th>
             </tr>
           </thead>
           <tbody>
@@ -107,7 +107,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <% end %>
             </tbody>
           </table>
-          <div class="generic-table--header-background"></div>
+          
         </div>
       </div>
     <% else %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= form_tag({action: "diff"}, method: :get) do %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table wiki-page-versions">
+      <table class="generic-table wiki-page-versions">
         <colgroup>
           <col highlight-col>
           <col>
@@ -107,7 +107,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 </div>
               </div>
             </th>
-            <th></th>
+            <th><div class="generic-table--empty-header"></div></th>
           </tr>
         </thead>
         <tbody>
@@ -137,7 +137,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      <div class="generic-table--header-background"></div>
+      
     </div>
   </div>
   <div class="generic-table--action-buttons">

--- a/app/views/work_packages/_list_simple.html.erb
+++ b/app/views/work_packages/_list_simple.html.erb
@@ -30,7 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= form_tag({}) do %>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table work_packages">
+        <table class="generic-table work_packages">
           <colgroup>
             <col highlight-col>
             <col highlight-col>
@@ -93,7 +93,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end %>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
   <% end %>

--- a/app/views/work_packages/reports/_report.html.erb
+++ b/app/views/work_packages/reports/_report.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% column_names = report.statuses.map(&:name) + [l(:label_open_work_packages), l(:label_closed_work_packages), l(:label_total)] %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table class="generic-table">
+      <table class="generic-table">
         <colgroup>
          <% column_names.each do |name| %>
             <col highlight-col>
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </colgroup>
       <thead>
         <tr>
-          <th></th>
+          <th><div class="generic-table--empty-header"></div></th>
           <% column_names.each do |name| %>
             <th>
               <div class="generic-table--sort-header-outer">
@@ -102,7 +102,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <% end %>
       </tbody>
     </table>
-    <div class="generic-table--header-background"></div>
+    
   </div>
  </div>
 <% end

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -28,7 +28,7 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <div id="workflow_form_<%= name %>" class="generic-table--container">
   <div class="generic-table--results-container">
-    <table interactive-table class="generic-table workflow-table transitions-<%= name %>">
+    <table class="generic-table workflow-table transitions-<%= name %>">
       <colgroup>
         <col>
         <col>
@@ -37,7 +37,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <thead>
         <tr>
           <th class="-short"></th>
-          <th></th>
+          <th><div class="generic-table--empty-header"></div></th>
           <th colspan="<%= @statuses.length%>">
             <div class="generic-table--sort-header-outer -border">
               <div class="generic-table--sort-header workflow-table--header">

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -32,7 +32,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="autoscroll">
     <div class="generic-table--container">
       <div class="generic-table--results-container">
-        <table interactive-table class="generic-table">
+        <table class="generic-table">
           <colgroup>
             <col>
             <col highlight-col>
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
           </colgroup>
           <thead>
             <tr>
-              <th></th>
+              <th><div class="generic-table--empty-header"></div></th>
               <% @workflow_counts.first.last.each do |role, count| %>
                 <th>
                   <div class="generic-table--sort-header-outer">
@@ -69,7 +69,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <% end -%>
           </tbody>
         </table>
-        <div class="generic-table--header-background"></div>
+        
       </div>
     </div>
   </div>

--- a/features/roles/role_crud.feature
+++ b/features/roles/role_crud.feature
@@ -34,7 +34,7 @@ Feature: As an admin
   Scenario: Normal Role creation with existing role with same name
     And I am already admin
     When I go to the new page of "Role"
-    Then I should see "Work packages can be assigned to this role"
+    Then I should see "Work packages can be assigned to users and groups in possession of this role in the respective project"
     When I fill in "Name" with "Manager"
     And I click on "Create"
     Then I should see "Successful creation."
@@ -44,7 +44,7 @@ Feature: As an admin
     And there is a role "Manager"
     And I am already admin
     When I go to the new page of "Role"
-    Then I should see "Work packages can be assigned to this role"
+    Then I should see "Work packages can be assigned to users and groups in possession of this role in the respective project"
     When I fill in "Name" with "Manager"
     And I click on "Create"
     Then I should see "Name has already been taken"

--- a/frontend/app/components/common/interactive-table/interactive-table.directive.ts
+++ b/frontend/app/components/common/interactive-table/interactive-table.directive.ts
@@ -225,7 +225,7 @@ function interactiveTable() {
 
     link: function(scope:ng.IScope, element:ng.IAugmentedJQuery) {
       if (element.filter('table').length === 0) {
-        throw 'interactive-table needs to be defined on a \'table\' tag';
+        throw 'needs to be defined on a \'table\' tag';
       }
     }
   };

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -1,7 +1,7 @@
 <div class="generic-table--container work-package-table--container"
   ng-class="{ '-with-footer': displaySums }">
   <div class="generic-table--results-container">
-    <table interactive-table class="keyboard-accessible-list generic-table work-package-table">
+    <table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
         <col highlight-col />
         <col highlight-col ng-repeat="column in columns" />
@@ -11,7 +11,7 @@
         <span id="wp-table-sort-summary"></span>
         <span ng-bind="::text.tableSummaryHints"></span>
       </caption>
-      <thead>
+      <thead class="-sticky">
         <tr>
           <th sort-header ng-repeat="column in columns"
                           has-dropdown-menu
@@ -71,7 +71,6 @@
         </tr>
       </tfoot>
     </table>
-    <div class="generic-table--header-background"></div>
     <div class="generic-table--footer-background" ng-if="sumsLoaded()"></div>
   </div>
 </div>


### PR DESCRIPTION
This revisits the `position: sticky` header as a retina bug I experienced seems to be fixed in canary.

This proposes:

- The removal of all usages `interactive-table`
- The removal of all absolute table backgrounds.


This branch originally based on timeline branch to verify that the header positioning still works.