### PR TITLE
[24707] Close icon is missing in onboarding modal

### DIFF
--- a/app/assets/stylesheets/openproject/_onboarding.sass
+++ b/app/assets/stylesheets/openproject/_onboarding.sass
@@ -29,8 +29,8 @@
 // Align ngDialog's close button
 .onboarding-modal .ngdialog-close,
 .ngdialog-theme-openproject .ngdialog-close
-  line-height: $header-height
-  color: $header-item-font-color
+  @include varprop(line-height, header-height)
+  @include varprop(color, header-item-font-color)
 
 .onboarding--top-menu
   display: flex
@@ -45,7 +45,7 @@
   .icon-context
     margin-left: 1.5em
   h2
-    color: $header-item-font-color
+    @include varprop(color, header-item-font-color)
     padding: 0 0.5em
     font-size: 1.25rem
 
@@ -54,7 +54,7 @@
     top: 1rem
     right: 0.5rem
     z-index: 1000
-    color: $header-item-font-color
+    @include varprop(color, header-item-font-color)
 
 
 .onboarding--main

--- a/app/assets/stylesheets/vendor/_ng_dialog.sass
+++ b/app/assets/stylesheets/vendor/_ng_dialog.sass
@@ -60,6 +60,6 @@
     top: 0
 
     &:before
-      @include icon-common
+      @include icon-font-common
       @extend .icon-context
       @extend .icon-close:before


### PR DESCRIPTION
The close icon was not visible in the onboarding modal. 

https://community.openproject.com/projects/openproject/work_packages/24707/activity