### PR TITLE
[24656] Rework structure of main navigation (Part 2)

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -309,6 +309,8 @@ input.top-menu-search--input
     overflow: hidden
     text-overflow: ellipsis
     padding-right: 34px
+    font-size: 16px
+    font-weight: bold
 
     &:after
       position: absolute

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -27,9 +27,11 @@
 //++
 
 #logo
-  float: left
-  width: $main-menu-width
-  height: $header-height
+  @include varprop(width, main-menu-width)
+  @include varprop(height, header-height)
+  position: absolute
+  left: calc(50% - #{$main-menu-width} / 2)
+
   .home-link
     margin-top: 13px
     display: block
@@ -104,11 +106,6 @@
     position: relative
     top: 0
     z-index: 21
-  li.last-child > ul,
-  ul.drop-down--help,
-  ul.drop-down--modules
-    left: auto
-    right: 0
 
   li.drop-down
     select
@@ -126,9 +123,6 @@
       @include varprop(background-color, header-item-bg-hover-color)
       color: $header-item-font-hover-color
       &:after
-        @include icon-font-common
-        font-size: 10px
-        padding: 0 0 0 9px
         @extend .icon-pulldown-up:before
 
     li
@@ -145,6 +139,12 @@
     &.-hide-icon
       > a:after
         display: none
+
+  li.last-child > ul,
+  .drop-down--help,
+  .drop-down--modules
+    left: auto
+    right: 0
 
   .drop-down--projects
     > li
@@ -300,6 +300,20 @@ input.top-menu-search--input
       padding: 0 9px 0
     > ul > li
       max-width: 350px
+
+#account-nav-left
+  .drop-down
+    max-width: 230px
+
+  #projects-menu
+    overflow: hidden
+    text-overflow: ellipsis
+    padding-right: 34px
+
+    &:after
+      position: absolute
+      right: 15px
+      top: calc(50% - 10px / 2)
 
 #account-nav-right
   .drop-down.last-child

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -75,9 +75,6 @@ See doc/COPYRIGHT.rdoc for more details.
       <% if show_decoration %>
         <div id="top-menu">
           <div id="header">
-            <div id="logo">
-              <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
-            </div>
             <div id="top-menu-items">
               <h1 class="hidden-for-sighted">
                 <%= l(:label_top_menu) %>
@@ -87,6 +84,9 @@ See doc/COPYRIGHT.rdoc for more details.
                 <%= render partial: 'search/mini_form' %>
                 <%= render_top_menu_right %>
               </div>
+            </div>
+            <div id="logo">
+              <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
           </div>
         </div>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -67,18 +67,18 @@ Redmine::MenuManager.map :top_menu do |menu|
 end
 
 Redmine::MenuManager.map :account_menu do |menu|
-  menu.push :administration,
-            { controller: '/admin', action: 'projects' },
-            html: { class: 'hidden-for-mobile' },
-            if: Proc.new { User.current.admin? }
-  menu.push :my_account,
-            { controller: '/my', action: 'account' },
-            html: { class: 'hidden-for-mobile' },
-            if: Proc.new { User.current.logged? }
   menu.push :my_page,
             { controller: '/my', action: 'page' },
             html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.logged? }
+  menu.push :my_account,
+            { controller: '/my', action: 'account' },
+            html: { class: 'hidden-for-mobile' },
+            if: Proc.new { User.current.logged? }
+  menu.push :administration,
+            { controller: '/admin', action: 'projects' },
+            html: { class: 'hidden-for-mobile' },
+            if: Proc.new { User.current.admin? }
   menu.push :logout, :signout_path,
             if: Proc.new { User.current.logged? }
 end

--- a/lib/redmine/menu_manager/top_menu/projects_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/projects_menu.rb
@@ -47,9 +47,10 @@ module Redmine::MenuManager::TopMenu::ProjectsMenu
   end
 
   def render_projects_dropdown
+    label = @project ? @project.name : t(:label_project_plural)
     render_menu_dropdown_with_items(
-      label: l(:label_project_plural),
-      label_options: { id: 'projects-menu', class: 'icon3 icon-projects' },
+      label: label,
+      label_options: { id: 'projects-menu' },
       items: project_items,
       options: {
         drop_down_class: 'drop-down--projects'


### PR DESCRIPTION
This is the second part of the restructuring of the main navigation. 

* The logo is in the middle.
* The project menu is on the left.
* Instead of 'Projects' the actual project name is shown.
* 'My Page' and 'Administration' switch position in the right side menu.

https://community.openproject.com/projects/openproject/work_packages/24656/activity