### PR TITLE
[24751] Icons are missing on homescreen

### DIFF
--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -98,7 +98,7 @@ $widget-box--enumeration-width: 20px
         margin-bottom: 0
 
       li:before
-        @include icon-common
+        @include icon-font-common
         @extend .icon-context
         @extend .icon-arrow-right1:before
         display: inline-block


### PR DESCRIPTION
On the home screen the list arrows were not visible. This happens because of a wrong heritage (similar to https://github.com/opf/openproject/pull/5217).

https://community.openproject.com/projects/openproject/work_packages/24751/activity