### PR TITLE
[24750] Styling changes on WP page

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -20,8 +20,10 @@
     display: inline
 
 .wp-table--hierarchy-span
-  text-align: center
+  text-align: end
   display: inline-block
+  margin-left: 5px
+  padding-right: 8px
 
 .wp-table--hierarchy-indicator-icon
   @include icon-common
@@ -61,6 +63,9 @@
 // Padding for the hierarchy mode
 .wp-table--cell-td.subject:not(.-with-hierarchy)
   padding-left: 25px !important
+
+.wp-table--cell-td.subject.-with-hierarchy .wp-table--cell-span
+  padding-left: 0
 
 .hierarchy-header--icon
   display: inline-block

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -36,7 +36,7 @@
     margin-top: 13px
     display: block
     background: $header-home-link-bg
-    background-size: 150px
+    background-size: 140px
     height: 42px
     text-indent: -9999em
 
@@ -309,7 +309,7 @@ input.top-menu-search--input
     overflow: hidden
     text-overflow: ellipsis
     padding-right: 34px
-    font-size: 16px
+    font-size: 18px
     font-weight: bold
 
     &:after

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -297,6 +297,9 @@
     .form--field-container
       max-width: 400px
 
+  #breadcrumb
+    display: none
+
 %flex-grow-shrink-zero
   flex-grow: 0
   flex-shrink: 0

--- a/features/work_packages/moves/work_package_moves_new_copy.feature
+++ b/features/work_packages/moves/work_package_moves_new_copy.feature
@@ -87,7 +87,7 @@ Feature: Copying a work package
     When I click "Copy and follow"
     Then I should see "Successful creation."
     Then I should see "issue1" within ".wp-edit-field.subject"
-     And I should see "project_2" within ".breadcrumb"
+     And I should see "project_2" within "#projects-menu"
 
   @javascript @selenium
   Scenario: Issue children are moved
@@ -97,7 +97,7 @@ Feature: Copying a work package
     When I click "Move and follow"
     #Then I should see "Successful update."
     Then I should see "issue1" within ".wp-edit-field.subject"
-     And I should see "project_2" within ".breadcrumb"
+     And I should see "project_2" within "#projects-menu"
 
 
   Scenario: Move an issue to project with missing type

--- a/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-create-button/wp-create-button.directive.html
@@ -12,7 +12,7 @@
     <span class="button--text"
           ng-bind="::$ctrl.text.createWithDropdown"
           aria-hidden="true"></span>
-    <i class="button--icon icon-pulldown"></i>
+    <i class="button--icon icon-small icon-pulldown"></i>
   </button>
   <button class="button -alt-highlight add-work-package"
           ng-if="!$ctrl.projectIdentifier"

--- a/frontend/app/components/wp-fast-table/builders/rows/hierarchy-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/hierarchy-rows-builder.ts
@@ -114,7 +114,7 @@ export class HierarchyRowsBuilder extends PlainRowsBuilder {
       const hierarchyIndicator = document.createElement('span');
       const collapsed = this.wpTableHierarchy.collapsed(workPackage.id);
       hierarchyIndicator.classList.add(hierarchyCellClassName);
-      hierarchyIndicator.style.width = 25 + (15 * level) + 'px';
+      hierarchyIndicator.style.width = 25 + (20 * level) + 'px';
 
       if (workPackage.$loaded && workPackage.isLeaf) {
         hierarchyIndicator.innerHTML = `

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -31,7 +31,7 @@
               <accessible-by-keyboard
                           execute="openColumnsModal()"
                           link-class="wp-table--columns-selection">
-                <span class="icon-button icon-columns"></span>
+                <span class="icon-button icon-small icon-add"></span>
               </accessible-by-keyboard>
             </div>
           </th>


### PR DESCRIPTION
This makes some minor changes in the styling of the WP page. In detail:

* Decrease icon size on create button
* Column icon is replaced by add-icon
* Breadcrumb is hidden
* The distances of the hierarchy mode were adapted
* The logo was decreased
* 'Projects' in top menu was increased

https://community.openproject.com/projects/openproject/work_packages/24750/activity