### PR TITLE
[24656] Rework structure of main navigation (Part 3)

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -56,14 +56,13 @@
     padding: 20px !important
     width: 100% !important
 
-  #breadcrumb
+  #breadcrumb,
+  .hidden-for-mobile
     display: none !important
 
   h2
     font-size: 1.4rem
 
-  .hidden-for-mobile
-    display: none !important
-
-  .jstElements
+  .jstElements,
+  #sidebar
     display: none

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -56,7 +56,6 @@
     padding: 20px !important
     width: 100% !important
 
-  #main-menu,
   #breadcrumb
     display: none !important
 

--- a/app/assets/stylesheets/layout/_footer.sass
+++ b/app/assets/stylesheets/layout/_footer.sass
@@ -49,3 +49,8 @@
     a
       text-decoration: underline
       @include default-font($footer-content-link-color)
+
+@include breakpoint(680px down)
+  #footer
+    // Below #main so that the main menu can overlap the footer
+    z-index: 19

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -217,30 +217,6 @@ $toggler-width: 40px
   .sub-menu-heading
     float: left
 
-  #toggle-project-menu
-    border: $main-menu-item-border-width solid $main-menu-item-border-color
-    border-left: none
-    height: $main-menu-item-height
-    width: $main-menu-width
-    background-color: $main-menu-bg-color
-    @include default-transition
-    &:hover
-      @include varprop(background, main-menu-bg-hover-background)
-    &.show
-      width: $main-menu-folded-width
-      a.navigation-toggler
-        height: 100%
-        padding: 0 10px 0 0
-        &:before
-          @extend .icon-double-arrow-right:before
-    a.navigation-toggler
-      @include default-transition
-      position: relative
-      height: $main-menu-item-height
-      text-align: right
-      padding: 0 6px 0 0
-      &:hover
-        color: $main-menu-navigation-toggler-font-hover-color
   .toggle-follow
     position: absolute
     width: 140px
@@ -250,13 +226,14 @@ $toggler-width: 40px
 
 .hidden-navigation
   #main-menu
-    width: $main-menu-folded-width
+    @include varprop(width, main-menu-folded-width)
     .ellipsis
       text-overflow: clip
       -o-text-overflow: clip
       -ms-text-overflow: clip
     .toggler
       display: none
+  #menu-sidebar,
   #sidebar,
   .menu-children
     display: none

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -117,7 +117,6 @@ $toggler-width: 40px
             @extend .small-10
             border-right: 1px solid $main-menu-toggler-separator-color
 
-
         .open .toggler
           .icon-toggler:before
             @extend .icon-arrow-up1:before
@@ -132,6 +131,8 @@ $toggler-width: 40px
           // explicitly reset to zero to avoid selector precedence problems
           padding-left: 0
 
+      &:first-of-type
+        border-top: 1px solid $main-menu-item-border-color
 
       // all menu items
       li
@@ -282,3 +283,8 @@ $toggler-width: 40px
       border: none
     li a
       padding: 0
+
+@include breakpoint(680px down)
+  #main-menu
+    position: absolute !important
+    z-index: 11

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -27,6 +27,8 @@
 //++
 
 @include breakpoint(680px down)
+  #logo
+    background-color: transparent
   #top-menu
     position: relative !important
 
@@ -70,7 +72,7 @@
 
   #account-nav-left,
   #account-nav-right
-    > li a[class*="icon-"]
+    > li > a[class*="icon-"]
       padding-top: 4px
       &:before
         font-size: 1.5rem

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -27,9 +27,6 @@
 //++
 
 @include breakpoint(680px down)
-  #logo
-    background-color: transparent
-
   #top-menu
     position: relative !important
 
@@ -63,28 +60,17 @@
         display: block
 
       &.last-child
-        > a
-          display: block
-          padding: 0
-          position: relative
-          text-indent: -10000px
-          width: 68px
+        > a + ul
+          width: 100vw
+          box-shadow: 1px 1px 4px #cccccc
+          border: solid 1px rgba(0, 0, 0, 0.2)
 
-          &:before
-            content: "\e0d0" !important
-            display: block
-            font-size: 1.5rem !important
-            position: absolute
-            right: 20px
-            text-indent: 0
-            top: 16px
-            z-index: 1000
-            @include icon-common
+          li
+            max-width: none
 
-          + ul
-            width: 100vw
-            box-shadow: 1px 1px 4px #cccccc
-            border: solid 1px rgba(0, 0, 0, 0.2)
-
-            li
-              max-width: none
+  #account-nav-left,
+  #account-nav-right
+    > li a[class*="icon-"]
+      padding-top: 4px
+      &:before
+        font-size: 1.5rem

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -85,7 +85,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 <%= render_top_menu_right %>
               </div>
             </div>
-            <div id="logo" class="hidden-for-mobile">
+            <div id="logo">
               <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
             <%= call_hook :view_layouts_base_top_menu %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -85,7 +85,7 @@ See doc/COPYRIGHT.rdoc for more details.
                 <%= render_top_menu_right %>
               </div>
             </div>
-            <div id="logo">
+            <div id="logo" class="hidden-for-mobile">
               <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
             <%= call_hook :view_layouts_base_top_menu %>
@@ -96,14 +96,7 @@ See doc/COPYRIGHT.rdoc for more details.
            class="<%= initial_classes %>"
            ng-class="{ 'hidden-navigation': !showNavigation }">
         <% if (side_displayed && show_decoration) %>
-          <div id="main-menu" ng-controller="MainMenuController as mainMenu">
-            <h1 class="hidden-for-sighted"><%= l(:label_main_menu) %></h1>
-            <div id="toggle-project-menu"
-          ng-class="{ 'show': !showNavigation }">
-              <a href="javascript:;" title="<%= l(:show_hide_project_menu) %>"
-            ng-click="mainMenu.toggleNavigation()"
-            class="navigation-toggler icon4 icon-double-arrow-left"></a>
-            </div>
+          <div id="main-menu">
             <div id="menu-sidebar">
               <%= main_menu %>
               <%= content_for :main_menu %>

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -82,7 +82,7 @@ module OpenProject
       'footer-content-line-height'                           => "55px",
       'footer-content-link-color'                            => "$font-color-on-primary",
       'main-menu-width'                                      => "230px",
-      'main-menu-folded-width'                               => "50px",
+      'main-menu-folded-width'                               => "0px",
       'main-menu-border-color'                               => "#E7E7E7",
       'main-menu-border-width'                               => "1px",
       'main-menu-item-height'                                => "40px",

--- a/lib/redmine/menu_manager/top_menu/projects_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/projects_menu.rb
@@ -53,6 +53,7 @@ module Redmine::MenuManager::TopMenu::ProjectsMenu
       label_options: { id: 'projects-menu' },
       items: project_items,
       options: {
+        menu_item_class: 'hidden-for-mobile',
         drop_down_class: 'drop-down--projects'
       }
     ) do

--- a/lib/redmine/menu_manager/top_menu/projects_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/projects_menu.rb
@@ -53,7 +53,6 @@ module Redmine::MenuManager::TopMenu::ProjectsMenu
       label_options: { id: 'projects-menu' },
       items: project_items,
       options: {
-        menu_item_class: 'hidden-for-mobile',
         drop_down_class: 'drop-down--projects'
       }
     ) do

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -114,17 +114,21 @@ module Redmine::MenuManager::TopMenuHelper
     )
   end
 
-  def render_sidebar_top_menu_node()
+  def render_sidebar_top_menu_node
     show_decoration = params["layout"].nil?
     main_menu = render_main_menu(@project)
     side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank?
 
-    if (side_displayed && show_decoration)
+    if side_displayed && show_decoration
       content_tag(:li,
                   id: 'toggle-project-menu',
                   "ng-class" => "{ 'show': !showNavigation }",
                   "ng-controller" => 'MainMenuController as mainMenu') do
-        link_to '', '', title: l(:show_hide_project_menu), class: 'navigation-toggler icon-hamburger', "ng-click" => 'mainMenu.toggleNavigation()'
+        link_to '',
+                '',
+                title: l(:show_hide_project_menu),
+                class: 'navigation-toggler icon-hamburger',
+                "ng-click" => 'mainMenu.toggleNavigation()'
       end
     end
   end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -33,8 +33,9 @@ module Redmine::MenuManager::TopMenuHelper
   include Redmine::MenuManager::TopMenu::ProjectsMenu
 
   def render_top_menu_left
-    content_tag :ul, id: 'account-nav-left', class: 'menu_root account-nav hidden-for-mobile' do
+    content_tag :ul, id: 'account-nav-left', class: 'menu_root account-nav' do
       [render_main_top_menu_nodes,
+       render_sidebar_top_menu_node,
        render_projects_top_menu_node].join.html_safe
     end
   end
@@ -109,8 +110,23 @@ module Redmine::MenuManager::TopMenuHelper
       label: '',
       label_options: { class: 'icon-menu', title: I18n.t('label_modules') },
       items: items,
-      options: { drop_down_id: 'more-menu', drop_down_class: 'drop-down--modules ', menu_item_class: '-hide-icon' }
+      options: { drop_down_id: 'more-menu', drop_down_class: 'drop-down--modules', menu_item_class: '-hide-icon' }
     )
+  end
+
+  def render_sidebar_top_menu_node()
+    show_decoration = params["layout"].nil?
+    main_menu = render_main_menu(@project)
+    side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank?
+
+    if (side_displayed && show_decoration)
+      content_tag(:li,
+                  id: 'toggle-project-menu',
+                  "ng-class" => "{ 'show': !showNavigation }",
+                  "ng-controller" => 'MainMenuController as mainMenu') do
+        link_to '', '', title: l(:show_hide_project_menu), class: 'navigation-toggler icon-hamburger', "ng-click" => 'mainMenu.toggleNavigation()'
+      end
+    end
   end
 
   def render_main_top_menu_nodes(items = main_top_menu_items)


### PR DESCRIPTION
This is the final part of the restructuring of the main navigation. This PR changes the sidebar behavior.

**Details**
- [x] The sidebar shall completely vanish when collapsed.
- [x] The trigger shall be a burger icon next to the project menu.
- [x] The old icon in the sidebar to toggle the collapse will be removed.
- [x] When switching the page, the sidebar state stays the same.
- [x] On mobile screens the sidebar shall be visible too.
- [x] Accessibility check.
- [ ] TBD: Should this be merged?

https://community.openproject.com/projects/openproject/work_packages/24656/activity