### PR TITLE
[24699] Split screen view on mobile messed up (Safari)

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -197,6 +197,11 @@
         margin: 0
         padding: 0
 
+    // Workaround to assure that safari has the correct height
+    &.action-index #content .work-packages--split-view,
+    &.action-details #content .work-packages--split-view
+      height: 100vh
+
   .toolbar-items
     background: #fff
     display: flex


### PR DESCRIPTION
This adds a workaround to assure that the split screen can be seen in safari too.

https://community.openproject.com/projects/openproject/work_packages/24699/activity