### PR TITLE
Fix/various api shortcomings

### DIFF
--- a/app/models/queries/principals.rb
+++ b/app/models/queries/principals.rb
@@ -34,4 +34,5 @@ module Queries::Principals
 
   register.filter query, filters::TypeFilter
   register.filter query, filters::MemberFilter
+  register.filter query, filters::StatusFilter
 end

--- a/app/models/queries/principals/filters/status_filter.rb
+++ b/app/models/queries/principals/filters/status_filter.rb
@@ -27,27 +27,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Queries
-      module Schemas
-        class UserFilterDependencyRepresenter <
-          PrincipalFilterDependencyRepresenter
-
-          private
-
-          def filter_query
-            params = [{ type: { operator: '=', values: ['User'] } },
-                      { status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
-
-            if filter.context
-              params << { member: { operator: '=', values: [filter.context.id.to_s] } }
-            end
-
-            params
-          end
-        end
-      end
+class Queries::Principals::Filters::StatusFilter < Queries::Principals::Filters::PrincipalFilter
+  def allowed_values
+    ::Principal::STATUSES.map do |key, value|
+      [key, value]
     end
+  end
+
+  def type
+    :list
+  end
+
+  def self.key
+    :status
   end
 end

--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -46,7 +46,7 @@ module API
         parsed_params[:display_sums] = sums_from_params(params)
 
         ServiceResult.new(success: true,
-                          result: without_empty(parsed_params))
+                          result: without_empty(parsed_params, params.keys))
       end
 
       def group_by_from_params(params)
@@ -159,8 +159,9 @@ module API
         return result
       end
 
-      def without_empty(hash)
-        hash.select { |_, v| v.present? || v == false }
+      def without_empty(hash, exceptions)
+        exceptions = exceptions.map(&:to_sym)
+        hash.select { |k, v| v.present? || v == false || exceptions.include?(k) }
       end
     end
   end

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -63,7 +63,6 @@ module API
 
       property :value,
                exec_context: :decorator,
-               getter: -> (*) { represented ? represented.to_s : nil },
                render_nil: true
 
       property :count,
@@ -122,6 +121,14 @@ module API
 
       def link_options(query, group_key)
         query.group_by_column.custom_field.custom_options.where(id: group_key.to_s.split("."))
+      end
+
+      def value
+        if represented == true || represented == false
+          represented
+        else
+          represented ? represented.to_s : nil
+        end
       end
 
       def convert_attribute(attribute)

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -52,6 +52,15 @@ module API
         end
       end
 
+      link :groupBy do
+        converted_name = convert_attribute(query.group_by_column.name)
+
+        {
+          href: api_v3_paths.query_group_by(converted_name),
+          title: query.group_by_column.caption
+        }
+      end
+
       property :value,
                exec_context: :decorator,
                getter: -> (*) { represented ? represented.to_s : nil },
@@ -80,7 +89,8 @@ module API
       private
 
       attr_reader :sums,
-                  :count
+                  :count,
+                  :query
 
       ##
       # Initializes the links collection for this group if the query is being grouped by
@@ -112,6 +122,10 @@ module API
 
       def link_options(query, group_key)
         query.group_by_column.custom_field.custom_options.where(id: group_key.to_s.split("."))
+      end
+
+      def convert_attribute(attribute)
+        ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
       end
     end
   end

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -71,13 +71,29 @@ module API
                    exec_context: :decorator
 
           property :values,
-                   if: ->(*) { !ar_object_filter? },
+                   if: ->(*) { !represented.ar_object_filter? },
+                   exec_context: :decorator,
                    show_nil: true
 
           private
 
           def name
             represented.human_name
+          end
+
+          def values
+            if represented.respond_to?(:custom_field) &&
+               represented.custom_field.field_format == 'bool'
+              represented.values.map do |value|
+                if value == CustomValue::BoolStrategy::DB_VALUE_TRUE
+                  true
+                else
+                  false
+                end
+              end
+            else
+              represented.values
+            end
           end
 
           def _type

--- a/lib/api/v3/queries/filters/query_filter_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_representer.rb
@@ -36,7 +36,7 @@ module API
                     title_getter: ->(*) { represented.human_name },
                     path: :query_filter
 
-          def initialize(model)
+          def initialize(model, *_)
             super(model, current_user: nil, embed_links: true)
           end
 

--- a/lib/api/v3/queries/helpers/query_representer_response.rb
+++ b/lib/api/v3/queries/helpers/query_representer_response.rb
@@ -40,6 +40,7 @@ module API
               QueryRepresenter.new(query,
                                    current_user: current_user,
                                    results: representer.result,
+                                   embed_links: true,
                                    params: params)
             else
               raise ::API::Errors::InvalidQuery.new(representer.errors.full_messages)

--- a/lib/api/v3/queries/operators/query_operator_representer.rb
+++ b/lib/api/v3/queries/operators/query_operator_representer.rb
@@ -35,7 +35,7 @@ module API
           self_link id_attribute: ->(*) { represented },
                     title_getter: ->(*) { name }
 
-          def initialize(model)
+          def initialize(model, *_)
             super(model.to_sym, current_user: nil, embed_links: true)
           end
 

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -37,7 +37,7 @@ module API
           private
 
           def filter_query
-            params = []
+            params = [{ status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
 
             unless Setting.work_package_group_assignment?
               params << { type: { operator: '=', values: ['User'] } }

--- a/lib/api/v3/queries/schemas/boolean_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/boolean_filter_dependency_representer.rb
@@ -1,0 +1,48 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Queries
+      module Schemas
+        class BooleanFilterDependencyRepresenter <
+          FilterDependencyRepresenter
+
+          def href_callback; end
+
+          private
+
+          def type
+            '[1]Boolean'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb
@@ -83,8 +83,10 @@ module API
             format = filter.custom_field.field_format
 
             case format
-            when 'list', 'bool'
+            when 'list'
               'API::V3::Queries::Schemas::StringObjectFilterDependencyRepresenter'
+            when 'bool'
+              'API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter'
             when 'user', 'version', 'float'
               "API::V3::Queries::Schemas::#{format.camelize}FilterDependencyRepresenter"
             when 'string'

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
@@ -30,21 +30,11 @@
 require 'roar/decorator'
 require 'roar/json/hal'
 
-# This schema's structure deviates from the one of other schemas.
-# The reason for this is the dependency between the operator
-# and the allowed values.
 module API
   module V3
     module Queries
       module Schemas
         class QueryFilterInstanceSchemaRepresenter < ::API::Decorators::SchemaRepresenter
-          link :filter do
-            {
-              href: api_v3_paths.query_filter(convert_attribute(filter.name)),
-              title: filter.human_name
-            }
-          end
-
           schema :name,
                  type: 'String',
                  writable: false,
@@ -52,14 +42,54 @@ module API
                  required: true,
                  visibility: false
 
-          schema_with_allowed_link :filter,
-                                   type: 'QueryFilter',
-                                   required: true,
-                                   writable: true,
-                                   visibility: false,
-                                   href_callback: ->(*) {
-                                     api_v3_paths.query_filter(convert_attribute(filter.name))
-                                   }
+          def self.filter_representer
+            ::API::V3::Queries::Filters::QueryFilterRepresenter
+          end
+
+          def self.filter_link_factory
+            ->(*) do
+              {
+                href: api_v3_paths.query_filter(convert_attribute(filter.name)),
+                title: filter.human_name
+              }
+            end
+          end
+
+          schema_with_allowed_collection :filter,
+                                         type: 'QueryFilter',
+                                         required: true,
+                                         writable: true,
+                                         visibility: false,
+                                         values_callback: -> {
+                                           [filter]
+                                         },
+                                         value_representer: filter_representer,
+                                         link_factory: filter_link_factory
+
+          def self.operator_representer
+            ::API::V3::Queries::Operators::QueryOperatorRepresenter
+          end
+
+          def self.operator_link_factory
+            ->(operator) do
+              {
+                href: api_v3_paths.query_operator(operator),
+                title: I18n.t(::Queries::BaseFilter.operators[operator.to_sym])
+              }
+            end
+          end
+
+          schema_with_allowed_collection :operator,
+                                         type: 'QueryOperator',
+                                         writable: true,
+                                         has_default: false,
+                                         required: true,
+                                         visibility: false,
+                                         values_callback: -> {
+                                           filter.available_operators
+                                         },
+                                         value_representer: operator_representer,
+                                         link_factory: operator_link_factory
 
           # While this is not actually the represented class,
           # this is what the superclass expects in order to have the

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -193,6 +193,7 @@ module API
 
             QueryFilterInstanceSchemaCollectionRepresenter.new(filters,
                                                                filter_instance_schemas_href,
+                                                               form_embedded: form_embedded,
                                                                current_user: current_user)
           end
 

--- a/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -112,5 +112,44 @@ describe ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
           .at_path('values')
       end
     end
+
+    context 'with a bool custom field filter' do
+      let(:bool_cf) { FactoryGirl.build_stubbed(:bool_wp_custom_field) }
+      let(:filter) do
+        filter = Queries::WorkPackages::Filter::CustomFieldFilter.new(operator: operator, values: values)
+        filter.custom_field = bool_cf
+        filter
+      end
+
+      context "with 't' as filter value" do
+        let(:values) { [CustomValue::BoolStrategy::DB_VALUE_TRUE] }
+
+        it "has `true` for 'values'" do
+          is_expected
+            .to be_json_eql([true].to_json)
+            .at_path('values')
+        end
+      end
+
+      context "with 'f' as filter value" do
+        let(:values) { [CustomValue::BoolStrategy::DB_VALUE_FALSE] }
+
+        it "has `true` for 'values'" do
+          is_expected
+            .to be_json_eql([false].to_json)
+            .at_path('values')
+        end
+      end
+
+      context "with something as filter value" do
+        let(:values) { ['blubs'] }
+
+        it "has `true` for 'values'" do
+          is_expected
+            .to be_json_eql([false].to_json)
+            .at_path('values')
+        end
+      end
+    end
   end
 end

--- a/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
@@ -73,7 +73,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
 
         context 'within a project with group assignment' do
           let(:filter_query) do
-            [{ member: { operator: '=', values: [project.id.to_s] } }]
+            [{ status: { operator: '=', values: ['1'] } },
+             { member: { operator: '=', values: [project.id.to_s] } }]
           end
           let(:group_assignment_enabled) { true }
 
@@ -92,7 +93,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
 
         context 'within a project without group assignment' do
           let(:filter_query) do
-            [{ type: { operator: '=', values: ['User'] } },
+            [{ status: { operator: '=', values: ['1'] } },
+             { type: { operator: '=', values: ['User'] } },
              { member: { operator: '=', values: [project.id.to_s] } }]
           end
 
@@ -112,7 +114,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
         context 'global with no group assignments' do
           let(:project) { nil }
           let(:filter_query) do
-            [{ type: { operator: '=', values: ['User'] } },
+            [{ status: { operator: '=', values: ['1'] } },
+             { type: { operator: '=', values: ['User'] } },
              { member: { operator: '*', values: [] } }]
           end
 
@@ -132,7 +135,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
         context 'global with group assignments' do
           let(:project) { nil }
           let(:filter_query) do
-            [{ member: { operator: '*', values: [] } }]
+            [{ status: { operator: '=', values: ['1'] } },
+             { member: { operator: '*', values: [] } }]
           end
           let(:group_assignment_enabled) { true }
 

--- a/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
@@ -1,0 +1,74 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:bool_cf) { FactoryGirl.build_stubbed(:bool_wp_custom_field) }
+  let(:filter) do
+    filter = Queries::WorkPackages::Filter::CustomFieldFilter.new(context: project)
+
+    filter.custom_field = bool_cf
+
+    filter
+  end
+
+  let(:form_embedded) { false }
+
+  let(:instance) do
+    described_class.new(filter,
+                        operator,
+                        form_embedded: form_embedded)
+  end
+
+  subject(:generated) { instance.to_json }
+
+  context 'generation' do
+    context 'properties' do
+      describe 'values' do
+        let(:path) { 'values' }
+        let(:type) { '[1]Boolean' }
+
+        context "for operator '='" do
+          let(:operator) { "=" }
+
+          it_behaves_like 'filter dependency'
+        end
+
+        context "for operator '!'" do
+          let(:operator) { '!' }
+
+          it_behaves_like 'filter dependency'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
@@ -137,7 +137,7 @@ describe ::API::V3::Queries::Schemas::FilterDependencyRepresenterFactory do
         let(:custom_field) { FactoryGirl.build_stubbed(:bool_wp_custom_field) }
 
         it 'is the string object dependency' do
-          is_expected.to be_a(::API::V3::Queries::Schemas::StringObjectFilterDependencyRepresenter)
+          is_expected.to be_a(::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter)
         end
       end
 

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -78,34 +78,6 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
           let(:href) { self_link }
         end
       end
-
-      describe 'filter' do
-        it_behaves_like 'has a titled link' do
-          let(:link) { 'filter' }
-          let(:href) { api_v3_paths.query_filter 'status' }
-          let(:title) { 'Status' }
-        end
-      end
-
-      context 'for an assigned_to filter' do
-        let(:filter) { assigned_to_filter }
-
-        it_behaves_like 'has a titled link' do
-          let(:link) { 'filter' }
-          let(:href) { api_v3_paths.query_filter 'assignee' }
-          let(:title) { 'Assignee' }
-        end
-      end
-
-      context 'for a custom field filter' do
-        let(:filter) { custom_field_filter }
-
-        it_behaves_like 'has a titled link' do
-          let(:link) { 'filter' }
-          let(:href) { api_v3_paths.query_filter "customField#{custom_field.id}" }
-          let(:title) { custom_field.name }
-        end
-      end
     end
 
     context 'properties' do
@@ -148,15 +120,44 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
         context 'when embedding' do
           let(:form_embedded) { true }
 
-          it_behaves_like 'links to allowed values via collection link' do
-            let(:href) { api_v3_paths.query_filter('status') }
+          it_behaves_like 'links to and embeds allowed values directly' do
+            let(:hrefs) { [api_v3_paths.query_filter('status')] }
           end
 
           context 'with a custom field filter' do
             let(:filter) { custom_field_filter }
 
-            it_behaves_like 'links to allowed values via collection link' do
-              let(:href) { api_v3_paths.query_filter("customField#{custom_field.id}") }
+            it_behaves_like 'links to and embeds allowed values directly' do
+              let(:hrefs) { [api_v3_paths.query_filter("customField#{custom_field.id}")] }
+            end
+          end
+        end
+      end
+
+      describe 'operator' do
+        let(:path) { 'operator' }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'QueryOperator' }
+          let(:name) { Query.human_attribute_name('operator') }
+          let(:required) { true }
+          let(:writable) { true }
+        end
+
+        it_behaves_like 'has no visibility property'
+
+        it_behaves_like 'does not link to allowed values'
+
+        context 'when embedding' do
+          let(:form_embedded) { true }
+
+          it_behaves_like 'links to and embeds allowed values directly' do
+            let(:hrefs) do
+              [api_v3_paths.query_operator('o'),
+               api_v3_paths.query_operator('='),
+               api_v3_paths.query_operator('!'),
+               api_v3_paths.query_operator('c'),
+               api_v3_paths.query_operator('*')]
             end
           end
         end

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -50,6 +50,7 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
         let(:type) { '[]User' }
         let(:filter_query) do
           [{ type: { operator: '=', values: ['User'] } },
+           { status: { operator: '=', values: ['1'] } },
            { member: { operator: '=', values: [project.id.to_s] } }]
         end
         let(:href) do
@@ -71,7 +72,8 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
         context 'global' do
           let(:project) { nil }
           let(:filter_query) do
-            [{ type: { operator: '=', values: ['User'] } }]
+            [{ type: { operator: '=', values: ['User'] } },
+             { status: { operator: '=', values: ['1'] } }]
           end
 
           context "for operator '='" do

--- a/spec/services/api/v3/parse_query_params_service_spec.rb
+++ b/spec/services/api/v3/parse_query_params_service_spec.rb
@@ -213,6 +213,17 @@ describe ::API::V3::ParseQueryParamsService,
               .to end_with(message)
           end
         end
+
+        context 'with an empty array (in JSON)' do
+          it_behaves_like 'transforms' do
+            let(:params) do
+              { filters: JSON::dump([]) }
+            end
+            let(:expected) do
+              { filters: [] }
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Fixes a variety of shortcomings in the api that became apparent when working on #5219:

* Only active principals are now returned for filter parameters of the user filters.
* It is now possible to provide an empty set of filters. Doing that will remove the status filter that would otherwise be added by default.
* The groupBy resource is now present in a group object. It was simply more convenient to do that.
* Bool custom fields now return boolean values instead of 't', and 'f'.
* The Filter that is employed in a FilterInstance is now embedded in the FilterInstanceSchema which makes working with the FilterInstance easier. As it will always be only one value, that change should not be costly.
* The operator was missing from the FilterInstanceSchema.
* The FilterInstanceSchema was not embedding any values at all because of a faulty parameter.