### PR TITLE
[24773] Move "Buy now" button from breadcrumb to main navigation (Core)

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -88,6 +88,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <div id="logo">
               <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>
             </div>
+            <%= call_hook :view_layouts_base_top_menu %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
This PR calls a hook to include the buy now teaser in the top menu. (Belongs to: https://github.com/finnlabs/openproject-zacero/pull/76)

https://community.openproject.com/projects/saas/work_packages/24773/activity