### PR TITLE
Fix catching work package query menu clicks

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -225,22 +225,18 @@ openprojectModule
         || event.which === 2) {
 
         return;
+
       }
 
       // NOTE: making use of event delegation, thus jQuery-only.
       var elm = jQuery(event.target);
       var absHref = elm.prop('href');
-      // TODO this doesn't seem right
-      var rewrittenUrl = ($location as any).$$rewrite(absHref);
 
-      if (absHref && !elm.attr('target') && rewrittenUrl && !event.isDefaultPrevented()) {
+      if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
         event.preventDefault();
-
-        if (rewrittenUrl !== $location.url()) {
-          // update location manually
-          ($location as any).$$parse(rewrittenUrl);
-          $rootScope.$apply();
-        }
+        var targetUrl = URI(absHref);
+        $location.url(targetUrl.path() + targetUrl.search());
+        $rootScope.$apply();
       }
     });
 

--- a/frontend/app/layout/query-menu-item-factory.js
+++ b/frontend/app/layout/query-menu-item-factory.js
@@ -51,6 +51,13 @@ module.exports = function(menuItemFactory, $state, $stateParams, $animate, $time
       }
       scope.$on('openproject.layout.activateMenuItem', setActiveState);
 
+      scope.$watchCollection(function(){
+        return {
+          query_id: $stateParams['query_id'],
+        };
+      }, setActiveState);
+
+
       function removeItem() {
         $animate.leave(element.parent(), function () {
           scope.$destroy();

--- a/frontend/tests/unit/tests/layout/query-menu-item-factory-test.js
+++ b/frontend/tests/unit/tests/layout/query-menu-item-factory-test.js
@@ -108,9 +108,9 @@ describe('queryMenuItemFactory', function() {
     });
 
     describe('when the query id matches the query id of the state params', function() {
-      beforeEach(inject(function($timeout) {
+      beforeEach(inject(function() {
         stateParams['query_id'] = objectId;
-        $timeout.flush();
+        $rootScope.$apply();
       }));
 
       it('marks the new item as selected', function() {
@@ -127,9 +127,9 @@ describe('queryMenuItemFactory', function() {
     });
 
     describe('when the query id is undefined', function(){
-      beforeEach(inject(function($timeout) {
-        stateParams['query_id'] = objectId;
-        $timeout.flush();
+      beforeEach(inject(function() {
+        stateParams['query_id'] = undefined;
+        $rootScope.$apply();
       }));
 
       it('marks the new item as unselected', function() {
@@ -163,9 +163,9 @@ describe('queryMenuItemFactory', function() {
     describe('on a work_package page', function() {
 
       describe('for an undefined query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = undefined;
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('marks the item as selected', function() {
@@ -175,9 +175,9 @@ describe('queryMenuItemFactory', function() {
       });
 
       describe('for a null query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = null;
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('marks the item as selected', function() {
@@ -187,9 +187,9 @@ describe('queryMenuItemFactory', function() {
       });
 
       describe('for an integer query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = 1;
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('does not mark the item as selected', function() {
@@ -198,9 +198,9 @@ describe('queryMenuItemFactory', function() {
       });
 
       describe('for a string query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = "1";
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('does not mark the item as selected', function() {
@@ -216,9 +216,9 @@ describe('queryMenuItemFactory', function() {
       });
 
       describe('for an undefined query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = undefined;
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('marks the item as selected', function() {
@@ -227,9 +227,9 @@ describe('queryMenuItemFactory', function() {
       });
 
       describe('for a null query_id', function() {
-        beforeEach(inject(function($timeout) {
+        beforeEach(inject(function() {
           stateParams['query_id'] = null;
-          $timeout.flush();
+          $rootScope.$apply();
         }));
 
         it('marks the item as selected', function() {


### PR DESCRIPTION
This will result in staying in the frontend for changing a query
and result in much faster subsequent queries.