### PR TITLE
[23210] Show sidebar on mobile devices

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -42,7 +42,8 @@
     top: 0 !important
 
   #main
-    overflow: visible
+    height: initial !important
+    overflow: auto !important
 
   #header
     min-width: 0 !important
@@ -55,16 +56,17 @@
     margin: 0 !important
     padding: 20px !important
     width: 100% !important
+  #main-menu ~ #content
+    padding: 2rem 20px 0 20px !important
+    margin-bottom: 20px !important
 
-  #main-menu,
-  #breadcrumb
+  #breadcrumb,
+  #sidebar,
+  .hidden-for-mobile
     display: none !important
 
   h2
     font-size: 1.4rem
-
-  .hidden-for-mobile
-    display: none !important
 
   .jstElements
     display: none

--- a/app/assets/stylesheets/layout/_footer.sass
+++ b/app/assets/stylesheets/layout/_footer.sass
@@ -49,3 +49,8 @@
     a
       text-decoration: underline
       @include default-font($footer-content-link-color)
+
+@include breakpoint(680px down)
+  #footer
+    // Below #main so that the main menu can overlap the footer
+    z-index: 19

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -85,7 +85,6 @@ $toggler-width: 40px
               @include varprop(background, main-menu-bg-hover-background)
 
 
-
           // left item border hover / selected effect
           &:hover
             &> a:not(.toggler)
@@ -122,7 +121,6 @@ $toggler-width: 40px
           .icon-toggler:before
             @extend .icon-arrow-up1:before
 
-
         // padding for placeholder for highlighted left-item-border
         a
           // work around due to dom manipulation on document: ready:
@@ -131,7 +129,6 @@ $toggler-width: 40px
         a.toggler
           // explicitly reset to zero to avoid selector precedence problems
           padding-left: 0
-
 
       // all menu items
       li

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -26,23 +26,15 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@import layout/accessibility
-@import layout/base
-@import layout/base_mobile
-@import layout/grid
-@import layout/top_shelf
-@import layout/top_menu
-@import layout/top_menu_mobile
-@import layout/breadcrumb
-@import layout/main_menu
-@import layout/main_menu_mobile
-@import layout/footer
-@import layout/drop_down
-@import layout/drop_down_mobile
-@import layout/toolbar
-@import layout/work_package
-@import layout/work_package_mobile
+@include breakpoint(680px down)
+  #toggle-project-menu.show + #menu-sidebar
+    display: none
 
+  #main-menu
+    position: absolute !important
+    height: initial !important
+    overflow: auto !important
+    z-index: 11
 
-// Print layout
-@import layout/print
+  .main-item-wrapper a
+    width: 100%

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -287,7 +287,6 @@ input.top-menu-search--input
         @include varprop(color, drop-down-hover-font-color, !important)
 
 #header
-  height: $header-height
   min-width: 840px
   .chzn-container .chzn-results .highlighted
     background-color:  #24b3e7

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -32,6 +32,7 @@
 
   #top-menu
     position: relative !important
+    height: $header-height-mobile
 
     #nav-login-content
       float: none
@@ -53,6 +54,13 @@
 
       .button
         margin-right: 0
+    ul,
+    li > a
+      height: $header-height-mobile
+      line-height: $header-height-mobile
+    li > a:before
+      font-size: 1.25rem !important
+      vertical-align: text-bottom
 
   #account-nav-right
     > li
@@ -65,26 +73,24 @@
       &.last-child
         > a
           display: block
-          padding: 0
-          position: relative
-          text-indent: -10000px
-          width: 68px
+          text-align: center
 
           &:before
             content: "\e0d0" !important
-            display: block
-            font-size: 1.5rem !important
-            position: absolute
-            right: 20px
-            text-indent: 0
-            top: 16px
-            z-index: 1000
-            @include icon-common
+            padding: 0.25rem
+            @include icon-font-common
 
           + ul
+            top: $header-height-mobile
             width: 100vw
             box-shadow: 1px 1px 4px #cccccc
             border: solid 1px rgba(0, 0, 0, 0.2)
 
             li
               max-width: none
+          > img
+            display: none
+
+  #account-nav-left
+    #projects-menu
+      font-size: 15px

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -56,6 +56,7 @@ module OpenProject
       'h4-font-size'                                         => "calc($h3-font-size * 0.75)",
       'h4-font-color'                                        => "$body-font-color",
       'header-height'                                        => "55px",
+      'header-height-mobile'                                 => "45px",
       'header-bg-color'                                      => "$primary-color",
       'header-home-link-bg'                                  => '#{image-url("logo_openproject_white_big.png") no-repeat 20px 0}',
       'header-border-bottom-color'                           => "$primary-color",


### PR DESCRIPTION
This makes the sidebar on mobile pages visible again. To save space, only the toggler is shown when the sidebar is collapsed. 
The state is still memorized, so when switching the page over the sidebar, it is still expanded. This is not the optimal behavior which would be a menu which disappears on click. However this is a quick win. Since the main navigation may be changed soon, it is good for now.

https://community.openproject.com/projects/openproject/work_packages/23210/activity