### PR TITLE
[24803] Add advice text for accessibility mode

### DIFF
--- a/app/views/users/_preferences.html.erb
+++ b/app/views/users/_preferences.html.erb
@@ -41,6 +41,12 @@ See doc/COPYRIGHT.rdoc for more details.
                            container_class: (defined? input_size) ? "-#{input_size}" : '' %>
   </div>
   <div class="form--field"><%= pref_fields.check_box :warn_on_leaving_unsaved %></div>
-  <div class="form--field"><%= pref_fields.check_box :impaired %></div>
+  <div class="form--field">
+    <%= pref_fields.check_box :impaired, aria: {labelledby: 'accessibility-instructions'} %>
+    <div class="form--field-instructions" id="accessibility-instructions">
+      <span class="hidden-for-sighted"><%= t('activerecord.attributes.user_preference.impaired') + '. ' %></span>
+      <%= t(:text_accessibility_hint) %>
+    </div>
+  </div>
   <div class="form--field"><%= pref_fields.check_box :auto_hide_popups %></div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1901,6 +1901,7 @@ en:
       sentence_connector: "and"
       skip_last_comma: "false"
 
+  text_accessibility_hint: "The accessibility mode is designed for users who are blind, motorically handicaped or have a bad eyesight. For the latter focused elements are specially highlighted. Please notice, that the Backlogs module is not available in this mode."
   text_access_token_hint: "Access tokens allow you to grant external applications access to resources in OpenProject."
   text_analyze: "Further analyze: %{subject}"
   text_are_you_sure: "Are you sure?"


### PR DESCRIPTION
This adds a hint for the accessibility mode, which is also read by a screenreader.

https://community.openproject.com/projects/openproject/work_packages/24803/activity