### PR TITLE
[23426] Truncate too long labels

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -346,8 +346,10 @@ fieldset.form--fieldset
 
 .form--label
   @include grid-content(2)
-  @include grid-visible-overflow
   @extend %label-style
+  overflow-x: hidden
+  overflow-y: visible
+  text-overflow: ellipsis
   padding:      0 1rem 0 0
   font-size:    $form-label-fontsize
   line-height:  $base-line-height


### PR DESCRIPTION
This shall truncate too long labels. Since the `form--label`-class is globally used, this may cause some errors which I did not notice yet. 

https://community.openproject.com/projects/telekom/work_packages/23426/activity