### PR TITLE
Improve performance of CF values migration

### DIFF
--- a/db/migrate/20170308120915_migrate_missed_list_custom_values.rb
+++ b/db/migrate/20170308120915_migrate_missed_list_custom_values.rb
@@ -9,8 +9,7 @@ class MigrateMissedListCustomValues < ActiveRecord::Migration[5.0]
   def up
     migration = AddCustomOptions.new
 
-    migration.migrate_values!
-    migration.migrate_journals!
+    migration.migrate_all_values!
   end
 
   def down


### PR DESCRIPTION
This reduces the migration time on our dev instance from over 1,5 hours to ~10minutes at the cost of smaller transactions instead of one big one.