### PR TITLE
[23658] Remember and set cursor position when opening input fields

### DIFF
--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -86,19 +86,20 @@ export class WorkPackageEditForm {
    * Active the edit field upon user's request.
    * @param fieldName
    */
-  public activate(fieldName:string) {
-    if (this.activeFields[fieldName]) {
-      return;
+  public activate(fieldName:string):ng.IPromise<ng.IAugmentedJQuery> {
+    const activeField = this.activeFields[fieldName];
+    if (activeField) {
+      return this.$q.when(activeField.element);
     }
 
-    this.workPackage.loadFormSchema().then((schema:SchemaResource) => {
+    return this.workPackage.loadFormSchema().then((schema:SchemaResource) => {
       const field = this.wpEditField.getField(
         this.workPackage,
         fieldName,
         schema[fieldName]
       ) as EditField;
       this.workPackage.storePristine(fieldName);
-      this.buildField(fieldName, field);
+      return this.buildField(fieldName, field);
     });
   }
 
@@ -206,7 +207,7 @@ export class WorkPackageEditForm {
     }
   }
 
-  private buildField(fieldName:string, field:EditField) {
+  private buildField(fieldName:string, field:EditField):ng.IPromise<ng.IAugmentedJQuery> {
 
     // Let the context find the element
     const cell = this.editContext.find(fieldName);
@@ -219,7 +220,7 @@ export class WorkPackageEditForm {
       this.errorsPerAttribute[fieldName] || []
     );
 
-    this.templateRenderer.renderIsolated(
+    const promise = this.templateRenderer.renderIsolated(
       // Replace the current cell
       cell[0],
       '/components/wp-edit-form/wp-edit-form.template.html',
@@ -230,6 +231,7 @@ export class WorkPackageEditForm {
 
     this.activeFields[fieldName] = fieldHandler;
     this.lastActiveField = fieldName;
+    return promise;
   }
 }
 

--- a/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -53,13 +53,36 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
     let state = this.editState(workPackageId);
     let form = state.getCurrentValue() || this.startEditing(state, workPackageId);
 
+    // Get the position where the user clicked.
+    const positionOffset = this.getClickPosition(evt);
+
     // Set editing context to table
     form.editContext = new TableRowEditContext(workPackageId);
 
     // Activate the field
-    form.activate(fieldName);
+    form.activate(fieldName).then((fieldElement:ng.IAugmentedJQuery) => {
+      this.setClickPosition(fieldElement.find('input'), positionOffset);
+    });
 
     return false;
+  }
+
+  private setClickPosition(element:ng.IAugmentedJQuery, offset:number) {
+    if (element.length) {
+      (element[0] as HTMLInputElement).setSelectionRange(offset, offset);
+    } else {
+      debugLog('Unable to set position on Element.', element);
+    }
+  }
+
+  private getClickPosition(evt:JQueryEventObject):number {
+    try {
+      const range = document.caretRangeFromPoint(evt.clientX, evt.clientY);
+      return range.startOffset;
+    } catch(e) {
+      debugLog('Failed to get click position for edit field.', e);
+      return 0;
+    }
   }
 
   private startEditing(state:State<WorkPackageEditForm>, workPackageId:string):WorkPackageEditForm {


### PR DESCRIPTION
This adds a callback to the edit field rendering process to allow
modifying the now-in-dom edit field.

Using the Range/Selection API, we can now find out where the user
clicked and forward that information to the field.

**Note:** This will only work in the table due to the work the edit fields are compiled there. We need to port this behavior over to the split view when refactoring for the Type/Groups configuration.

https://community.openproject.com/projects/openproject/work_packages/23658