### PR TITLE
[23443] [10a] Elementgruppen können nicht übersprungen werden.

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -256,6 +256,18 @@
 
 }(jQuery));
 
+function skipMenu() {
+  // Skip to the breadcrumb or the first link in the toolbar or the first link in the content (homescreen)
+  const selectors = '.first-breadcrumb-element a, .toolbar-container a:first-of-type, #content a:first-of-type';
+  const visibleLink = jQuery(selectors)
+                        .not(':hidden')
+                        .first();
+
+ if (visibleLink.length) {
+   visibleLink.focus();
+ }
+}
+
 jQuery(document).ready(function($) {
   $("#top-menu-items").top_menu();
 });

--- a/app/assets/stylesheets/content/_links.sass
+++ b/app/assets/stylesheets/content/_links.sass
@@ -83,8 +83,6 @@ a.icon:hover, a.icon-context:hover
 .skip-navigation-link
   &:focus
     position: absolute
-    left: 0
-    top: 0
     width: auto
     height: auto
     overflow: visible

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -182,6 +182,11 @@
     table td
       padding: 3px
 
+  .skip-navigation-link:focus
+    top: 40px
+    left: 220px
+    @include varprop(color, font-color-on-primary)
+
 .top-menu-search
   display: inline-block
   &:not(.-collapsed) > div

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -79,6 +79,11 @@ See doc/COPYRIGHT.rdoc for more details.
               <h1 class="hidden-for-sighted">
                 <%= l(:label_top_menu) %>
               </h1>
+              <a href="" onclick="skipMenu();"
+                  class="hidden-for-sighted skip-navigation-link"
+                  aria-label="<%= I18n.t('js.work_packages.jump_marks.label_content') %>">
+                    <%= I18n.t('js.work_packages.jump_marks.content') %>
+              </a>
               <%= render_top_menu_left %>
               <div id="logo" class="hidden-for-mobile">
                 <%= link_to(I18n.t('label_home'), home_url, class: 'home-link') %>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -487,6 +487,8 @@ en:
       jump_marks:
         pagination: "Jump to table pagination"
         label_pagination: "Click here to skip over the work packages table and go to pagination"
+        content: "Jump to content"
+        label_content: "Click here to skip over the menu and go to the content"
       placeholders:
         default: "-"
         description: "Click to enter description..."


### PR DESCRIPTION
This adds a skip mark in the top menu to jump over the top menu and the sidebar. If activated the first link in the content is focussed.

https://community.openproject.com/projects/telekom/work_packages/23443/activity