### PR TITLE
[24809] Multi-select custom fields should open as a normal single-select menu by default

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -82,6 +82,9 @@
     .wp-table--cell-span
       vertical-align: middle
 
+  &.inplace-edit .custom-option
+    display: inline
+
 // Editable fields cursor
 .-editable .wp-table--cell-span,
 .wp-table--cell-span.-editable
@@ -101,6 +104,7 @@
 
   .inplace-edit--read-value--value-span
     width: 100%
+    white-space: nowrap
     .error.macro-unavailable
       display: inline-block
 

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -82,7 +82,7 @@
     .wp-table--cell-span
       vertical-align: middle
 
-  &.inplace-edit .custom-option
+  &.inplace-edit .custom-option:not(.-multiple-lines)
     display: inline
 
 // Editable fields cursor

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
@@ -59,6 +59,9 @@
       display: inline-flex
       justify-content: center
 
+  &.inline-label .inplace-edit--controls
+    right: 33px
+
 // Styles for the Save | Cancel controls below textareas
 .inplace-edit--controls
   position: absolute

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -433,6 +433,10 @@ en:
       label_filter_add: "Add filter"
       label_options: "Options"
       label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
+      label_switch_to_single_select: "Stwich to single select"
+      label_switch_to_multi_select: "Stwich to multi select"
+      label_table_multiple_values_plural: "%{value_1} and %{number} others"
+      label_table_multiple_values_single: "%{value} and 1 other"
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       message_successful_show_in_fullscreen: "Click here to open this work package in fullscreen view."

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -32,6 +32,7 @@ import {wpDirectivesModule} from "../../../angular-modules";
 import {WorkPackageEditFieldController} from "../../wp-edit/wp-edit-field/wp-edit-field.directive";
 import {WorkPackageCacheService} from "../work-package-cache.service";
 import {DisplayField} from "../../wp-display/wp-display-field/wp-display-field.module";
+import {MultipleLinesStringObjectsDisplayField} from '../../wp-display/field-types/wp-display-multiple-lines-string-objects-field.module';
 import {WorkPackageDisplayFieldService} from "../../wp-display/wp-display-field/wp-display-field.service";
 import {
   WorkPackageResource,
@@ -106,7 +107,12 @@ export class WorkPackageDisplayAttributeController {
 
   protected updateAttribute(wp:WorkPackageResourceInterface) {
     this.workPackage = wp;
-    this.field = this.wpDisplayField.getField(this.workPackage, this.attribute, this.schema[this.attribute]) as DisplayField;
+
+    if (this.schema[this.attribute].type === '[]StringObject') {
+      this.field = new MultipleLinesStringObjectsDisplayField(this.workPackage, this.attribute, this.schema[this.attribute])
+    } else {
+      this.field = this.wpDisplayField.getField(this.workPackage, this.attribute, this.schema[this.attribute]) as DisplayField;
+    }
 
     this.__d__renderer = this.__d__renderer || this.$element.find(".__d__renderer");
     this.field.render(this.__d__renderer[0], this.displayText);

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -108,7 +108,7 @@ export class WorkPackageDisplayAttributeController {
   protected updateAttribute(wp:WorkPackageResourceInterface) {
     this.workPackage = wp;
 
-    if (this.schema[this.attribute].type === '[]StringObject') {
+    if (this.schema[this.attribute] && (this.schema[this.attribute].type === '[]StringObject' || this.schema[this.attribute].type === '[]User')) {
       this.field = new MultipleLinesStringObjectsDisplayField(this.workPackage, this.attribute, this.schema[this.attribute])
     } else {
       this.field = this.wpDisplayField.getField(this.workPackage, this.attribute, this.schema[this.attribute]) as DisplayField;

--- a/frontend/app/components/wp-display/field-types/wp-display-multiple-lines-string-objects-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-multiple-lines-string-objects-field.directive.html
@@ -1,0 +1,9 @@
+<span>
+  <div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option -multiple-lines">
+    {{  value }}
+  </div>
+
+  <div title="I18n.t('js.work_packages.no_value')" ng-if="vm.field.value.length == 0" class="custom-option -empty">
+    -
+  </div>
+</span>

--- a/frontend/app/components/wp-display/field-types/wp-display-multiple-lines-string-objects-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-multiple-lines-string-objects-field.module.ts
@@ -1,0 +1,33 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {StringObjectsDisplayField} from "./wp-display-string-objects-field.module";
+
+export class MultipleLinesStringObjectsDisplayField extends StringObjectsDisplayField {
+  public template: string = '/components/wp-display/field-types/wp-display-multiple-lines-string-objects-field.directive.html';
+}

--- a/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
@@ -1,8 +1,10 @@
-<div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option">
-  <span ng-if="$first && vm.field.value.length > 1"> {{ value }} and {{ vm.field.value.length - 1}} others </span>
-  <span ng-if="$first && vm.field.value.length == 1"> {{ value }} </span>
-</div>
+<span>
+  <div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option">
+    <span ng-if="$first && vm.field.value.length > 1"> {{ value }} and {{ vm.field.value.length - 1}} others </span>
+    <span ng-if="$first && vm.field.value.length == 1"> {{ value }} </span>
+  </div>
 
-<div title="no value" ng-if="vm.field.value.length == 0" class="custom-option -empty">
-  -
-</div>
+  <div title="I18n.t('js.work_packages.no_value')" ng-if="vm.field.value.length == 0" class="custom-option -empty">
+    -
+  </div>
+</span>

--- a/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
@@ -1,6 +1,7 @@
 <span>
   <div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option">
-    <span ng-if="$first && vm.field.value.length > 1"> {{ value }} and {{ vm.field.value.length - 1}} others </span>
+    <span ng-if="$first && vm.field.value.length > 2"> {{ I18n.t('js.work_packages.label_table_multiple_values_plural', {value_1: value, number: vm.field.value.length - 1}) }} </span>
+    <span ng-if="$first && vm.field.value.length == 2"> {{ I18n.t('js.work_packages.label_table_multiple_values_single', {value: value}) }} </span>
     <span ng-if="$first && vm.field.value.length == 1"> {{ value }} </span>
   </div>
 

--- a/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
@@ -1,7 +1,8 @@
 <div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option">
-  {{ value }}
+  <span ng-if="$first && vm.field.value.length > 1"> {{ value }} and {{ vm.field.value.length - 1}} others </span>
+  <span ng-if="$first && vm.field.value.length == 1"> {{ value }} </span>
 </div>
 
 <div title="no value" ng-if="vm.field.value.length == 0" class="custom-option -empty">
   -
-</divn>
+</div>

--- a/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
@@ -105,6 +105,13 @@ export class WorkPackageEditFieldHandler {
   }
 
   /**
+   * Cancel edit
+   */
+  public handleUserCancel() {
+    this.reset();
+  }
+
+  /**
    * Cancel any pending changes
    */
   public reset() {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -1,5 +1,31 @@
-<div class="textarea-wrapper">
+<div ng-class="vm.field.isMultiselect ? 'textarea-wrapper' : 'inline-label'">
+
   <select
+    ng-if="!vm.field.isMultiselect"
+    ng-model="vm.workPackage[vm.fieldName]"
+    class="focus-input wp-inline-edit--field inplace-edit--textarea -animated form--select"
+    wp-edit-field-requirements="vm.field.schema"
+    ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
+    ng-required="vm.field.required"
+    ng-focus="vm.handleUserFocus()"
+    ng-disabled="vm.workPackage.inFlight"
+    focus="vm.shouldFocus()"
+    focus-priority="vm.shouldFocus()"
+    ng-attr-id="{{vm.htmlId}}"
+    ng-change="vm.handleUserSubmit()"
+  >
+    <option
+      value=""
+      ng-bind="vm.field.text.requiredPlaceholder"
+      ng-if="vm.field.currentValueInvalid || vm.field.options.length == 0"
+      ng-selected="vm.field.currentValueInvalid || vm.field.options.length == 0"
+      disabled
+    >
+    </option>
+  </select>
+
+  <select
+    ng-if="vm.field.isMultiselect"
     ng-model="vm.workPackage[vm.fieldName]"
     class="focus-input wp-inline-edit--field inplace-edit--textarea -animated form--select"
     wp-edit-field-requirements="vm.field.schema"
@@ -23,7 +49,20 @@
     </option>
   </select>
 
+  <a href class="form-label no-decoration-on-hover -transparent" ng-click="vm.field.toggleMultiselect()">
+    <icon-wrapper icon-name="minus2"
+                  ng-if="vm.field.isMultiselect"
+                  css-class="icon4">
+    </icon-wrapper>
+
+    <icon-wrapper icon-name="add"
+                  ng-if="!vm.field.isMultiselect"
+                  css-class="icon4">
+    </icon-wrapper>
+  </a>
+
   <wp-edit-field-controls ng-show="!vm.inEditMode"
+                          ng-if="vm.field.isMultiselect"
                           field-controller="vm"
                           on-save="vm.handleUserSubmit()"
                           on-cancel="vm.handleUserCancel()"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -1,4 +1,5 @@
-<div ng-class="vm.field.isMultiselect ? 'textarea-wrapper' : 'inline-label'">
+<div ng-class="vm.field.isMultiselect ? 'textarea-wrapper' : ''"
+    class="inline-label">
 
   <select
     ng-if="!vm.field.isMultiselect"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -3,8 +3,8 @@
 
   <select
     ng-if="!vm.field.isMultiselect"
-    ng-model="vm.workPackage[vm.fieldName]"
-    class="focus-input wp-inline-edit--field inplace-edit--textarea -animated form--select"
+    ng-model="vm.field.value"
+    class="focus-input wp-inline-edit--field inplace-edit--field -animated form--select"
     wp-edit-field-requirements="vm.field.schema"
     ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
     ng-required="vm.field.required"
@@ -27,7 +27,7 @@
 
   <select
     ng-if="vm.field.isMultiselect"
-    ng-model="vm.workPackage[vm.fieldName]"
+    ng-model="vm.field.value"
     class="focus-input wp-inline-edit--field inplace-edit--textarea -animated form--select"
     wp-edit-field-requirements="vm.field.schema"
     ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -52,11 +52,13 @@
 
   <a href class="form-label no-decoration-on-hover -transparent" ng-click="vm.field.toggleMultiselect()">
     <icon-wrapper icon-name="minus2"
+                  icon-title="{{I18n.t('js.work_packages.label_switch_to_single_select')}}"
                   ng-if="vm.field.isMultiselect"
                   css-class="icon4">
     </icon-wrapper>
 
     <icon-wrapper icon-name="add"
+                  icon-title="{{I18n.t('js.work_packages.label_switch_to_multi_select')}}"
                   ng-if="!vm.field.isMultiselect"
                   css-class="icon4">
     </icon-wrapper>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -34,6 +34,7 @@ export class MultiSelectEditField extends EditField {
   public options:any[];
   public template:string = '/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html';
   public text:{requiredPlaceholder:string, placeholder:string, save:string, cancel:string};
+  public isMultiselect: boolean;
 
   // Dependencies
   protected I18n:op.I18n = <op.I18n> MultiSelectEditField.$injector.get('I18n');
@@ -42,6 +43,8 @@ export class MultiSelectEditField extends EditField {
 
   constructor(workPackage:WorkPackageResourceInterface, fieldName:string, schema:op.FieldSchema) {
     super(workPackage, fieldName, schema);
+
+    this.isMultiselect = false;
 
     const I18n:any = this.$injector.get('I18n');
     this.text = {
@@ -66,6 +69,12 @@ export class MultiSelectEditField extends EditField {
       this.setValues([]);
     }
   }
+
+  public toggleMultiselect() {
+    console.log(this.isMultiselect);
+    this.isMultiselect = !this.isMultiselect;
+    console.log(this.isMultiselect);
+  };
 
   private setValues(availableValues:any[], sortValuesByName:boolean = false) {
     if (sortValuesByName) {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -92,12 +92,6 @@ export class MultiSelectEditField extends EditField {
   }
 
   public toggleMultiselect() {
-    if (this.isMultiselect) {
-      this.switchToSingleSelect();
-    } else {
-      this.switchToMultiSelect();
-    }
-
     this.isMultiselect = !this.isMultiselect;
   };
 
@@ -147,22 +141,4 @@ export class MultiSelectEditField extends EditField {
       });
     }
   }
-
-  public get isArray() {
-    return Array.isArray(this.value);
-  }
-
-  private switchToMultiSelect() {
-    if (!this.isArray) {
-      this.value = [this.value];
-    }
-  }
-
-  private switchToSingleSelect() {
-    if (this.isArray) {
-      this.value = this.value[0];
-    }
-  }
-
-
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -44,7 +44,7 @@ export class MultiSelectEditField extends EditField {
   constructor(workPackage:WorkPackageResourceInterface, fieldName:string, schema:op.FieldSchema) {
     super(workPackage, fieldName, schema);
 
-    this.isMultiselect = false;
+    this.isMultiselect = this.isValueMulti();
 
     const I18n:any = this.$injector.get('I18n');
     this.text = {
@@ -70,10 +70,16 @@ export class MultiSelectEditField extends EditField {
     }
   }
 
+  public get isArray() {
+    return Array.isArray(this.value);
+  }
+
+  public isValueMulti() {
+    return this.isArray && this.value.length > 1;
+  }
+
   public toggleMultiselect() {
-    console.log(this.isMultiselect);
     this.isMultiselect = !this.isMultiselect;
-    console.log(this.isMultiselect);
   };
 
   private setValues(availableValues:any[], sortValuesByName:boolean = false) {

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -21,6 +21,7 @@ describe "multi select custom values", js: true do
   end
 
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
+  let(:wp_table) { Pages::WorkPackagesTable.new }
   let(:user) { FactoryGirl.create :admin }
 
   context "with existing custom values" do
@@ -41,6 +42,8 @@ describe "multi select custom values", js: true do
       wp_page.visit!
       wp_page.ensure_page_loaded
     end
+
+    include_context 'work package table helpers'
 
     it "should be shown and allowed to be updated" do
       expect(page).to have_text custom_field.name
@@ -63,6 +66,14 @@ describe "multi select custom values", js: true do
       expect(page).to have_text "ham"
       expect(page).not_to have_text "pineapple"
       expect(page).to have_text "mushrooms"
+    end
+
+    it 'should have a different representation in the WP table' do
+      wp_table.visit!
+      wp_table.expect_work_package_listed(wp_page)
+      add_wp_table_column(custom_field.name)
+
+      expect(page).to have_text "ham and 1 other"
     end
   end
 end

--- a/spec/features/support/work_package_table.rb
+++ b/spec/features/support/work_package_table.rb
@@ -41,6 +41,19 @@ shared_context 'work package table helpers' do
     click_button('Apply')
   end
 
+  def add_wp_table_column(column_name)
+    click_button('Settings')
+    click_link('Columns ...')
+
+    input = find '.select2-search-field input'
+    input.set column_name
+
+    result = find '.select2-result-label'
+    result.click
+
+    click_button('Apply')
+  end
+
   def sort_wp_table_by(column_name, order: :desc)
     click_button('Settings')
     click_link('Sort by ...')


### PR DESCRIPTION
The multi-select CF should open per default as single-select fields. Only on click on a `+` the multi-select fields opens (similar to the filter behavior).

**Visual**:
- [x] List (View): The values shall be listed in the following form: `First value and X others`.
- [x] Details/Fullscreen (View): The values shall be listed below each other (like before).
- [x] List (Edit): Standard is the single-select field. 
-- Next to it is a plus icon to change to the multi-select field. (*Note* This will break the design of the Timeline, which we accept, as long as it is great again once the edit mode is left.)
-- When seeing the multi-select field there should be a minus icon to switch back to the single-select field.
--The design of the plus/minus icon should be the same as in the filters.
- [x] Details/Fullscreen (Edit): Similar to table edit

**Further ToDos**
- [x] Accessibility check
- [x] Changes are saved.

https://community.openproject.com/projects/openproject/work_packages/24809/activity