### PR TITLE
Fix #24417 force login for new WP in public project

### DIFF
--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -40,6 +40,7 @@ import {WorkPackageTableSelection} from '../wp-fast-table/state/wp-table-selecti
 import {States} from '../states.service';
 
 export class WorkPackageCreateController {
+
   public newWorkPackage:WorkPackageResource|any;
   public parentWorkPackage:WorkPackageResource|any;
   public successState:string;
@@ -74,6 +75,7 @@ export class WorkPackageCreateController {
               protected $scope:ng.IScope,
               protected $rootScope:IRootScopeService,
               protected $q:ng.IQService,
+              protected $location:ng.ILocationService,
               protected I18n:op.I18n,
               protected wpNotificationsService:WorkPackageNotificationService,
               protected states:States,
@@ -97,7 +99,15 @@ export class WorkPackageCreateController {
             });
         }
       })
-      .catch(error => this.wpNotificationsService.handleErrorResponse(error));
+      .catch(error => {
+        if (error.errorIdentifier == "urn:openproject-org:api:v3:errors:MissingPermission") {
+          let url: string = $location.absUrl();
+          $location.path('/login').search({back_url: url});
+          let loginUrl: string = $location.absUrl();
+          window.location.href = loginUrl;
+        };
+        this.wpNotificationsService.handleErrorResponse(error);
+      });
   }
 
   public switchToFullscreen() {

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -32,6 +32,9 @@ import {
   WorkPackageResource,
   WorkPackageResourceInterface
 } from '../api/api-v3/hal-resources/work-package-resource.service';
+import {
+  HalResource
+} from '../api/api-v3/hal-resources/hal-resource.service';
 import {WorkPackageCacheService} from "../work-packages/work-package-cache.service";
 import IRootScopeService = angular.IRootScopeService;
 import {WorkPackageEditModeStateService} from "../wp-edit/wp-edit-mode-state.service";
@@ -83,7 +86,9 @@ export class WorkPackageCreateController {
               protected wpCreate:WorkPackageCreateService,
               protected wpEditModeState:WorkPackageEditModeStateService,
               protected wpTableSelection:WorkPackageTableSelection,
-              protected wpCacheService:WorkPackageCacheService) {
+              protected wpCacheService:WorkPackageCacheService,
+              protected halRequest:any,
+              protected v3Path:any) {
 
     this.newWorkPackageFromParams($state.params)
       .then(wp => {
@@ -101,12 +106,17 @@ export class WorkPackageCreateController {
       })
       .catch(error => {
         if (error.errorIdentifier == "urn:openproject-org:api:v3:errors:MissingPermission") {
-          let url: string = $location.absUrl();
-          $location.path('/login').search({back_url: url});
-          let loginUrl: string = $location.absUrl();
-          window.location.href = loginUrl;
+          this.halRequest.get(this.v3Path.root()).then((root:HalResource) => {
+            if (!root.user) {
+              // Not logged in
+              let url: string = $location.absUrl();
+              $location.path('/login').search({back_url: url});
+              let loginUrl: string = $location.absUrl();
+              window.location.href = loginUrl;
+            };
+          });
+          this.wpNotificationsService.handleErrorResponse(error);
         };
-        this.wpNotificationsService.handleErrorResponse(error);
       });
   }
 

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -32,9 +32,8 @@ import {
   WorkPackageResource,
   WorkPackageResourceInterface
 } from '../api/api-v3/hal-resources/work-package-resource.service';
-import {
-  HalResource
-} from '../api/api-v3/hal-resources/hal-resource.service';
+import {RootDmService} from '../api/api-v3/hal-resource-dms/root-dm.service';
+import {RootResource} from '../api/api-v3/hal-resources/root-resource.service';
 import {WorkPackageCacheService} from "../work-packages/work-package-cache.service";
 import IRootScopeService = angular.IRootScopeService;
 import {WorkPackageEditModeStateService} from "../wp-edit/wp-edit-mode-state.service";
@@ -87,7 +86,7 @@ export class WorkPackageCreateController {
               protected wpEditModeState:WorkPackageEditModeStateService,
               protected wpTableSelection:WorkPackageTableSelection,
               protected wpCacheService:WorkPackageCacheService,
-              protected halRequest:any,
+              protected RootDm:RootDmService,
               protected v3Path:any) {
 
     this.newWorkPackageFromParams($state.params)
@@ -106,7 +105,7 @@ export class WorkPackageCreateController {
       })
       .catch(error => {
         if (error.errorIdentifier == "urn:openproject-org:api:v3:errors:MissingPermission") {
-          this.halRequest.get(this.v3Path.root()).then((root:HalResource) => {
+          this.RootDm.load().then((root:RootResource) => {
             if (!root.user) {
               // Not logged in
               let url: string = $location.absUrl();

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -290,4 +290,25 @@ describe 'new work package', js: true do
       end
     end
   end
+
+  context 'a anonymous user is prompted to login' do
+    let(:user) { FactoryGirl.create(:anonymous) }
+    let(:wp_page) { ::Pages::Page.new }
+
+    let(:paths) {
+      [
+        new_work_packages_path,
+        new_split_work_packages_path,
+        new_project_work_packages_path(project),
+        new_split_project_work_packages_path(project)
+      ]
+    }
+
+    it 'shows a 403 error on creation paths' do
+      paths.each do |path|
+        visit path
+        expect(wp_page.current_url).to match /#{signin_path}\?back_url=/
+      end
+    end
+  end
 end


### PR DESCRIPTION
Quick and not very holistic solution.

It uses a direct redirect to the sign in page.

It might be better to already check the authorization within Rails and before rendering the WP index page.

However, given the low risk of that feature and the relatively small value I opted for a quick solution