### PR TITLE
correctly filter involved relations

### DIFF
--- a/frontend/app/components/wp-table/timeline/wp-timeline-global.directive.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-global.directive.ts
@@ -97,7 +97,7 @@ export class WpTimelineGlobalService {
         halRequest.get(
           '/api/v3/relations',
           {
-            filter: [{ involved: {operator: '=', values: this.workPackageIdOrder } }]
+            filters: JSON.stringify([{ involved: {operator: '=', values: this.workPackageIdOrder } }])
           }).then((collection: CollectionResource) => {
             this.removeAllElements();
             collection.elements.forEach((relation: RelationResource) => {


### PR DESCRIPTION
Currently, all relations are returned as the filter is not applied (`filter` instead of `filters`). Once the key is correct, one also has to `stringify` the filter object to avoid a backend error.