### PR TITLE
Remove link to FAQ

### DIFF
--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -8,9 +8,6 @@
     <%= static_link_to :user_guides %>
   </li>
   <li>
-    <%= static_link_to :faq %>
-  </li>
-  <li>
     <a title="<%= l('homescreen.links.shortcuts') %>"
        onClick="modalHelperInstance.createModal('/help/keyboard_shortcuts');">
       <%= l('homescreen.links.shortcuts') %>

--- a/config/initializers/homescreen.rb
+++ b/config/initializers/homescreen.rb
@@ -57,11 +57,6 @@ OpenProject::Static::Homescreen.manage :links do |links|
       url: static_links[:user_guides][:href]
     },
     {
-      label: :faq,
-      icon: 'icon-context icon-faq',
-      url: static_links[:faq][:href]
-    },
-    {
       label: :glossary,
       icon: 'icon-context icon-glossar',
       url: static_links[:glossary][:href]

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -84,7 +84,6 @@ module Redmine::MenuManager::TopMenu::HelpMenu
                   title: l('top_menu.help_and_support')
     }
     result << static_link_item(:user_guides)
-    result << static_link_item(:faq)
     result << content_tag(:li) {
       link_to l('homescreen.links.shortcuts'),
               '',


### PR DESCRIPTION
This is a cherry-pick of https://github.com/opf/openproject/pull/5229  necessary to make the release-branch work again, since the faq link has been removed here.