### PR TITLE
[24809] Change representation of multiSelect CF

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -433,10 +433,8 @@ en:
       label_filter_add: "Add filter"
       label_options: "Options"
       label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
-      label_switch_to_single_select: "Stwich to single select"
-      label_switch_to_multi_select: "Stwich to multi select"
-      label_table_multiple_values_plural: "%{value_1} and %{number} others"
-      label_table_multiple_values_single: "%{value} and 1 other"
+      label_switch_to_single_select: "Switch to single select"
+      label_switch_to_multi_select: "Switch to multi select"
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       message_successful_show_in_fullscreen: "Click here to open this work package in fullscreen view."

--- a/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
+++ b/frontend/app/components/wp-display/field-types/wp-display-string-objects-field.directive.html
@@ -1,8 +1,10 @@
-<span>
-  <div ng-repeat="value in vm.field.value" title="{{ value }}" class="custom-option">
-    <span ng-if="$first && vm.field.value.length > 2"> {{ I18n.t('js.work_packages.label_table_multiple_values_plural', {value_1: value, number: vm.field.value.length - 1}) }} </span>
-    <span ng-if="$first && vm.field.value.length == 2"> {{ I18n.t('js.work_packages.label_table_multiple_values_single', {value: value}) }} </span>
+<span title="{{vm.field.value.join(', ')}}">
+  <div ng-repeat="value in vm.field.value" class="custom-option">
+    <span ng-if="$index < 2 && vm.field.value.length > 1"> {{ value }} </span>
     <span ng-if="$first && vm.field.value.length == 1"> {{ value }} </span>
+    <span ng-if="$index == 2 && vm.field.value.length > 2">... </span>
+    <span ng-if="$index == 2 && vm.field.value.length > 2" class="badge -secondary"> {{vm.field.value.length}} </span>
+    <span ng-if="$index < 2 && vm.field.value.length > 2 || $index == 0 && vm.field.value.length == 2">,</span>
   </div>
 
   <div title="I18n.t('js.work_packages.no_value')" ng-if="vm.field.value.length == 0" class="custom-option -empty">

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -29,7 +29,7 @@ describe "multi select custom values", js: true do
       wp = FactoryGirl.create :work_package, project: project, type: type
 
       wp.custom_field_values = {
-        custom_field.id => ["ham", "pineapple"].map { |s| custom_value_for(s) }
+        custom_field.id => ["ham", "pineapple", "onions"].map { |s| custom_value_for(s) }
       }
 
       wp.save
@@ -49,6 +49,7 @@ describe "multi select custom values", js: true do
       expect(page).to have_text custom_field.name
       expect(page).to have_text "ham"
       expect(page).to have_text "pineapple"
+      expect(page).to have_text "onions"
 
       page.find("div.custom-option", text: "ham").click
 
@@ -59,21 +60,23 @@ describe "multi select custom values", js: true do
 
       click_on "Ingredients: Save"
 
-      expect(page).to have_selector('.custom-option', count: 2)
+      expect(page).to have_selector('.custom-option.-multiple-lines', count: 3)
       expect(page).to have_text "Successful update"
 
       expect(page).to have_text custom_field.name
       expect(page).to have_text "ham"
       expect(page).not_to have_text "pineapple"
+      expect(page).to have_text "onions"
       expect(page).to have_text "mushrooms"
     end
 
-    it 'should have a different representation in the WP table' do
+    it 'should truncate the field in the WP table' do
       wp_table.visit!
       wp_table.expect_work_package_listed(wp_page)
       add_wp_table_column(custom_field.name)
 
-      expect(page).to have_text "ham and 1 other"
+      expect(page).to have_text "ham , pineapple , ... 3"
+      expect(page).not_to have_text "onions"
     end
   end
 end


### PR DESCRIPTION
This changes the representation of the multiSelectCF in the WP table. Further a spelling mistake was fixed.

https://community.openproject.com/projects/openproject/work_packages/24809/activity