### PR TITLE
[24874] Two scrollbars displayed in cost report (Core)

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -47,7 +47,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 .generic-table--results-container
   height:       100%
   overflow:
-    x: auto
+    x: hidden
     y: auto
 
 .generic-table--action-buttons
@@ -138,6 +138,7 @@ table.generic-table
       padding:
         top:    0
         bottom: 0
+      font-weight: bold
 
   tbody
     tr

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -47,6 +47,11 @@
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
+// Allow inner scrolling in the WP table which is necessary because of the timeline
+.work-package-table--container .generic-table--results-container
+  overflow:
+    x: auto
+
 //
 .wp-table--faulty-query-icon
   color: $nm-color-error-icon


### PR DESCRIPTION
This avoids doubled scrollbars in tables. This behavior occurred because the inner container shall be scrollable for the WP table (because of timelines).

**According Plugin PR**: https://github.com/finnlabs/openproject-reporting/pull/114

https://community.openproject.com/projects/openproject/work_packages/24874/activity