### PR TITLE
[24883] Table border missing for unsortable headers (Core)

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -218,6 +218,11 @@ table.generic-table
   &.hover
     background:   #f8f8f8
 
+  &.-hidden-content
+    .generic-table--header,
+    .generic-table--sort-header
+      visibility: hidden
+
 .generic-table--empty-header
   padding:       0 6px
   height:        calc(#{$generic-table--header-height} + 1px)
@@ -231,6 +236,7 @@ table.generic-table
   height:       0px
   line-height:  0px
 
+.generic-table--header,
 .generic-table--sort-header
   white-space: nowrap
   width:   100%

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -34,7 +34,10 @@
               </div>
             </div>
           </th>
-          <th style="max-width:200px;"></th>
+          <th style="max-width:200px;">
+            <div class="generic-table--empty-header">
+            </div>
+          </th>
         </tr>
       </thead>
       <% custom_options = [OpenStruct.new(id: 0, value: "", default_value: false)] if custom_options.empty? %>

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -59,8 +59,8 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--sort-header-outer hidden-for-sighted">
-                <div class="generic-table--sort-header">
+              <div class="generic-table--header-outer -hidden-content">
+                <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_from) + ' ' + t(:label_changeset) %>
                   </span>
@@ -68,8 +68,8 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--sort-header-outer hidden-for-sighted">
-                <div class="generic-table--sort-header">
+              <div class="generic-table--header-outer -hidden-content">
+                <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_to) + ' ' + t(:label_changeset) %>
                   </span>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -63,8 +63,8 @@ See doc/COPYRIGHT.rdoc for more details.
             </th>
             </th>
             <th>
-              <div class="generic-table--sort-header-outer hidden-for-sighted">
-                <div class="generic-table--sort-header">
+              <div class="generic-table--header-outer -hidden-content">
+                <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_from) + ' ' + t(:label_version) %>
                   </span>
@@ -72,8 +72,8 @@ See doc/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--sort-header-outer hidden-for-sighted">
-                <div class="generic-table--sort-header">
+              <div class="generic-table--header-outer -hidden-content">
+                <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_to) + ' ' + t(:label_version) %>
                   </span>


### PR DESCRIPTION
This takes care that the border of the last table header column is shown again.

According Plugin PR: https://github.com/finnlabs/openproject-reporting/pull/115

https://community.openproject.com/projects/openproject/work_packages/24883/activity