### PR TITLE
Provide configuration option for basic auth API access

### DIFF
--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -340,6 +340,11 @@ default:
   # Uncomment the following line to restrict APIv2 access to API tokens
   # apiv2_enable_basic_auth: false
 
+  # By default, the legacy APIv2 allows authentication through basic auth.
+  # Uncomment the following line to restrict APIv3 access to session.
+  # apiv3_enable_basic_auth: false
+
+
 # specific configuration options for production environment
 # that overrides the default ones
 # production:

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -340,7 +340,7 @@ default:
   # Uncomment the following line to restrict APIv2 access to API tokens
   # apiv2_enable_basic_auth: false
 
-  # By default, the legacy APIv2 allows authentication through basic auth.
+  # By default, the APIv3 allows authentication through basic auth.
   # Uncomment the following line to restrict APIv3 access to session.
   # apiv3_enable_basic_auth: false
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -61,6 +61,7 @@ storage config above like this:
 * [`disabled_modules`](#disabled-modules) (default: [])
 * [`blacklisted_routes`](#blacklisted-routes) (default: [])
 * [`global_basic_auth`](#global-basic-auth)
+* [`apiv3_enable_basic_auth`](#apiv3_enable_basic_auth)
 
 ## Setting session options
 
@@ -257,6 +258,16 @@ The option to use a string is mostly relevant for when you want to override the 
 
 ```
 OPENPROJECT_DISABLED__MODULES='backlogs meetings'
+```
+
+### APIv3 basic auth control
+
+**default: true**
+
+You can enable basic auth access to the APIv3 with the following configuration option:
+
+```
+apiv3_enable_basic_auth: true
 ```
 
 ### global basic auth

--- a/lib/open_project/authentication/strategies/warden/global_basic_auth.rb
+++ b/lib/open_project/authentication/strategies/warden/global_basic_auth.rb
@@ -70,7 +70,12 @@ module OpenProject
           ##
           # Only valid if global basic auth is configured and tried.
           def valid?
-            self.class.configuration? && super && username == self.class.user
+            (
+              OpenProject::Configuration.apiv3_enable_basic_auth? &&
+              self.class.configuration? &&
+              super &&
+              username == self.class.user
+            )
           end
 
           def authenticate_user(username, password)

--- a/lib/open_project/authentication/strategies/warden/user_basic_auth.rb
+++ b/lib/open_project/authentication/strategies/warden/user_basic_auth.rb
@@ -17,7 +17,11 @@ module OpenProject
           end
 
           def valid?
-            super && username == self.class.user
+            (
+              OpenProject::Configuration.apiv3_enable_basic_auth? &&
+              super &&
+              username == self.class.user
+            )
           end
 
           def authenticate_user(_, api_key)

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -91,6 +91,7 @@ module OpenProject
       'blacklisted_routes' => [],
 
       'apiv2_enable_basic_auth' => true,
+      'apiv3_enable_basic_auth' => true,
 
       'onboarding_video_url' => 'https://player.vimeo.com/video/163426858?autoplay=1',
       'onboarding_enabled' => true,


### PR DESCRIPTION
This adds:

1. A configuration option `apiv3_enable_basic_auth` to determine whether v3 may use the basic auth strategies
2. Extensions to the warden strategies to disable them unless configured