### PR TITLE
[24889] Button to order Enterprise Edition still shown when purchased

### DIFF
--- a/app/views/enterprises/show.html.erb
+++ b/app/views/enterprises/show.html.erb
@@ -1,6 +1,7 @@
 <% html_title t(:label_administration), t(:label_enterprise_edition) %>
 
 <%= toolbar title: t(:label_enterprise_edition) do %>
+  <% if EnterpriseToken.show_banners? %>
     <li class="toolbar-item">
       <%= link_to( "#{OpenProject::Static::Links.links[:upsale][:href]}?utm_source=ce-token-admin",
             { class: 'button -alt-highlight',
@@ -9,6 +10,7 @@
         <span class="button--text"><%= t('admin.enterprise.order') %></span>
       <% end %>
     </li>
+  <% end %>
 <% end %>
 
 <%= error_messages_for 'token' %>


### PR DESCRIPTION
This hides the enterprise button when the edition was already purchased.

https://community.openproject.com/projects/openproject/work_packages/24889/activity