### PR TITLE
[24898] Wrong cursor displayed on project overview page

### DIFF
--- a/app/assets/stylesheets/content/_my_page.sass
+++ b/app/assets/stylesheets/content/_my_page.sass
@@ -66,12 +66,12 @@
     #left
       margin-bottom: 0
 
-.handle
-  cursor: move
-
 div.box-actions
   float: right
   z-index: 500
+
+#my_project_blocks .handle
+  cursor: move
 
 #visible-grid
   .handle


### PR DESCRIPTION
This avoids a drag'n'drop cursor on the overview page, when there is no drag'n'drop enabled.

https://community.openproject.com/projects/openproject/work_packages/24898/activity