### PR TITLE
[24899] Hide breadcrumb when not necessary

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -30,6 +30,7 @@
   @include default-font($breadcrumb-font-color, $breadcrumb-font-size, bold)
 
 #breadcrumb
+  display: none
   @include default-transition
   height: $breadcrumb-height
   overflow: hidden
@@ -60,6 +61,9 @@
     &.cutme
       max-width: $breadcrumb-height
 
+  &.-show
+    display: block
+
 ul.breadcrumb
   margin: 0 0 0 13px
   padding: 0
@@ -83,3 +87,7 @@ ul.breadcrumb
   float: left
   margin: 0 0 0 10px
   padding: 0
+
+// Hide projects in normal mode
+body:not(.accessibility-mode) .breadcrumb .breadcrumb-project-element
+  display: none

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -297,9 +297,6 @@
     .form--field-container
       max-width: 400px
 
-  #breadcrumb
-    display: none
-
 %flex-grow-shrink-zero
   flex-grow: 0
   flex-shrink: 0

--- a/app/assets/stylesheets/openproject/_accessibility.sass
+++ b/app/assets/stylesheets/openproject/_accessibility.sass
@@ -115,3 +115,5 @@ body.accessibility-mode
     &:focus
       color: $body-font-color
 
+  #breadcrumb
+    display: block

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -118,4 +118,8 @@ class AdminController < ApplicationController
       l(:label_information)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -24,6 +24,10 @@ class AnnouncementsController < ApplicationController
     t(:label_announcement)
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def announcement_params
     params.require(:announcement).permit('text', 'show_until', 'active')
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -624,6 +624,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :default_breadcrumb
 
+  def show_local_breadcrumb
+    false
+  end
+  helper_method :show_local_breadcrumb
+
   def disable_everything_except_api
     unless api_request?
       head 410

--- a/app/controllers/auth_sources_controller.rb
+++ b/app/controllers/auth_sources_controller.rb
@@ -111,6 +111,10 @@ class AuthSourcesController < ApplicationController
     end
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def block_if_password_login_disabled
     render_404 if OpenProject::Configuration.disable_password_login?
   end

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -200,4 +200,8 @@ class CustomFieldsController < ApplicationController
       ActionController::Base.helpers.link_to(t('label_custom_field_plural'), custom_fields_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -103,6 +103,10 @@ class CustomStylesController < ApplicationController
     redirect_to action: :show
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   private
 
   def require_ee_token

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -64,4 +64,8 @@ class EnterprisesController < ApplicationController
   def default_breadcrumb
     t(:label_enterprise)
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/enumerations_controller.rb
+++ b/app/controllers/enumerations_controller.rb
@@ -101,6 +101,10 @@ class EnumerationsController < ApplicationController
     end
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def find_enumeration
     @enumeration = Enumeration.find(params[:id])
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -176,4 +176,8 @@ class GroupsController < ApplicationController
       ActionController::Base.helpers.link_to(t('label_group_plural'), groups_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -255,6 +255,10 @@ class MyController < ApplicationController
     l(:label_my_account)
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   private
 
   def redirect_if_password_change_not_allowed_for(user)

--- a/app/controllers/planning_element_type_colors_controller.rb
+++ b/app/controllers/planning_element_type_colors_controller.rb
@@ -127,6 +127,10 @@ class PlanningElementTypeColorsController < ApplicationController
     end
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def require_admin_unless_readonly_api_request
     require_admin unless %w[index show].include? params[:action] and
                          api_request?

--- a/app/controllers/project_types_controller.rb
+++ b/app/controllers/project_types_controller.rb
@@ -121,6 +121,10 @@ class ProjectTypesController < ApplicationController
     end
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def check_permissions
     render_403 unless readonly_api_request or User.current.allowed_to_globally?(:edit_timelines)
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -145,4 +145,8 @@ class RolesController < ApplicationController
       ActionController::Base.helpers.link_to(t('label_role_plural'), roles_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -87,6 +87,10 @@ class SettingsController < ApplicationController
     l(:label_system_settings)
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   private
 
   ##

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -109,4 +109,8 @@ class StatusesController < ApplicationController
       ActionController::Base.helpers.link_to(t(:label_work_package_status_plural), statuses_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -140,4 +140,8 @@ class TypesController < ApplicationController
       ActionController::Base.helpers.link_to(t(:label_type_plural), types_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -306,4 +306,8 @@ class UsersController < ApplicationController
       ActionController::Base.helpers.link_to(t('label_user_plural'), users_path)
     end
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -442,6 +442,10 @@ class WikiController < ApplicationController
     Wiki.name.humanize
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   def redirect_to_show
     redirect_to action: :show, project_id: @project, id: @page
   end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -109,6 +109,10 @@ class WorkflowsController < ApplicationController
     end
   end
 
+  def show_local_breadcrumb
+    true
+  end
+
   private
 
   def find_roles

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -45,7 +45,14 @@ module BreadcrumbHelper
     breadcrumb_elements = [content_tag(:li, elements.shift.to_s, class: 'first-breadcrumb-element', style: 'list-style-image:none;')]
 
     breadcrumb_elements += elements.map { |element|
-      content_tag(:li, h(element.to_s), class: 'icon-context icon-small icon-arrow-right5') if element
+      if element
+        css_class = if element.include? 'breadcrumb-project-title'
+                      'breadcrumb-project-element '
+                    end
+        content_tag(:li,
+                    h(element.to_s),
+                    class: "#{css_class} icon-context icon-small icon-arrow-right5")
+      end
     }
 
     content_tag(:ul, breadcrumb_elements.join.html_safe, class: 'breadcrumb')
@@ -62,6 +69,14 @@ module BreadcrumbHelper
     end
   end
 
+  def show_breadcrumb
+    if !!(defined? show_local_breadcrumb)
+      show_local_breadcrumb
+    else
+      false
+    end
+  end
+
   private
 
   def link_to_project_ancestors(project)
@@ -72,7 +87,7 @@ module BreadcrumbHelper
         if p == project
           link_to_project(p, { only_path: false }, title: p, class: 'breadcrumb-project-title nocut').html_safe
         else
-          link_to_project(p, { jump: current_menu_item }, title: p).html_safe
+          link_to_project(p, { jump: current_menu_item }, title: p, class: 'breadcrumb-project-title').html_safe
         end
       end
     end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,6 +30,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% local_assigns[:additional_breadcrumb].nil? ? (breadcrumb_paths(link_to(l(:label_administration), controller: '/admin'),
                      default_breadcrumb)) : (breadcrumb_paths(link_to(l(:label_administration), controller: '/admin'),
                      default_breadcrumb, local_assigns[:additional_breadcrumb])) %>
+
 <% @page_header_title = l(:label_administration) %>
 <% content_for :main_menu do %>
   <%= render partial: 'admin/menu' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -114,7 +114,7 @@ See doc/COPYRIGHT.rdoc for more details.
           </div>
         <% end %>
         <% if show_decoration %>
-          <div id="breadcrumb" class="<%= initial_classes %>"
+          <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>"
                ng-class="{ 'hidden-navigation': !showNavigation }">
             <%= you_are_here_info %>
             <%= full_breadcrumb %>


### PR DESCRIPTION
This hides the breadcrumb per default. The only places left, where it shall be seen is the wiki page, the admin page and the my page. In accessibility mode it is visible again.

According Plugin PRs:
* https://github.com/finnlabs/openproject-costs/pull/281
* https://github.com/finnlabs/openproject-pdf_export/pull/60
* https://github.com/finnlabs/openproject-zacero/pull/77

https://community.openproject.com/projects/openproject/work_packages/24899/activity