### PR TITLE
Clarify the project settings custom_fields tab

### DIFF
--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -35,18 +35,83 @@ See doc/COPYRIGHT.rdoc for more details.
     </span>
   </div>
 
-    <% work_package_custom_fields.each do |custom_field| %>
-      <%
-        css_classes = custom_field.is_for_all? ? { disabled:  "disabled" } : {}
-        css_classes[:lang] = custom_field.name_locale
-      %>
 
-    <div class="form--field -wide-label ellipsis">
-      <%= form.collection_check_box :work_package_custom_field_ids,
-                                    custom_field.id,
-                                    @project.all_work_package_custom_fields.include?(custom_field),
-                                    custom_field.name,
-                                    css_classes %>
+  <div class="generic-table--container">
+    <div class="generic-table--results-container">
+      <table class="generic-table">
+        <colgroup>
+          <col highlight-col>
+          <col highlight-col>
+          <col highlight-col>
+          </colgroup>
+          <thead>
+            <tr>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= CustomField.model_name.human %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= t('custom_fields.enabled_in_project') %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+              <th>
+                <div class="generic-table--sort-header-outer">
+                  <div class="generic-table--sort-header">
+                    <span>
+                      <%= t('custom_fields.contained_in_type') %>
+                    </span>
+                  </div>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% all_custom_fields = @project.all_work_package_custom_fields.pluck(:id) %>
+            <% work_package_custom_fields.includes(:types).each do |custom_field| %>
+            <%
+              options = {
+                lang: custom_field.name_locale,
+                label_options: { class: 'hidden-for-sighted' }
+              }
+            %>
+              <tr>
+                <td>
+                  <%= custom_field.name %>
+                </td>
+                <td>
+                  <% if custom_field.is_for_all? %>
+                    <%= t('custom_fields.is_enabled_globally') %>
+                  <% else %>
+                  <%= form.collection_check_box :work_package_custom_field_ids,
+                                                custom_field.id,
+                                                all_custom_fields.include?(custom_field.id),
+                                                custom_field.name,
+                                                options %>
+                  <% end %>
+                </td>
+                <td>
+                  <% if current_user.admin? %>
+                    <% custom_field.types.each do |type| %>
+                      <%= link_to type.name, edit_type_tab_path(id: type.id, tab: 'form_configuration') %>
+                    <% end %>
+                  <% else %>
+                    <%= custom_field.types.map(&:name).join(', ') %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
     </div>
-  <% end %>
+  </div>
 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,9 @@ en:
       no_results_title_text: There are currently no posts for the board.
 
   custom_fields:
+    is_enabled_globally: 'Is enabled globally'
+    enabled_in_project: 'Enabled in project'
+    contained_in_type: 'Contained in type'
     tab:
       no_results_title_text: There are currently no custom fields.
       no_results_content_text: Create a new custom field

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -202,6 +202,12 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     text = get_localized_field(field, options[:label])
     label_options = { class: 'form--label', title: text }
 
+    if options[:class].is_a?(Array)
+      label_options[:class] << " #{options[:class].join(' ')}"
+    elsif options[:class].is_a?(String)
+      label_options[:class] << " #{options[:class]}"
+    end
+
     content = h(text)
     label_for_field_errors(content, label_options, field)
     label_for_field_required(content, label_options, options[:required])
@@ -349,8 +355,10 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def extract_from(options)
-    label_options = options.dup
+    label_options = options.dup.except(:class)
     input_options = options.dup.except(:for, :label, :no_label, :prefix, :suffix)
+
+    label_options.merge!(options.delete(:label_options) || {})
 
     if options[:suffix]
       options[:suffix_id] ||= SecureRandom.uuid


### PR DESCRIPTION
- Use a table to show which types are enabled for the CF
- Avoid disabled check box, and provide text for globally enabled CF.
- Adds links to form configuration in activated types when admin