### PR TITLE
[24827] Unsticky footer in the work packages list

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -106,7 +106,6 @@
 
 .work-packages--list-table-area
   position: relative // required for loading indicator
-  height: calc(100% - 55px)
 
   table
     tr

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
@@ -70,7 +70,7 @@
     </ul>
   </nav>
 
-  <div class="pagination--options">
+  <div class="pagination--options" ng-if="totalEntries > paginationOptions.perPageOptions[0]">
     <ul class="pagination--items">
       <li class="pagination--label" ng-bind="::text.per_page" title="{{ ::text.per_page }}"></li>
 

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
@@ -177,10 +177,23 @@ describe('tablePagination Directive', function () {
       });
     });
 
-    describe('with entries', function() {
+    describe('with few entries', function() {
       beforeEach(function() {
         compile();
-        scope.setTotalResults(1);
+        scope.setTotalResults(5);
+      });
+
+      it('should have no perPage options', function () {
+        var perPageOptions = element.find('.pagination--options');
+
+        expect(perPageOptions.text()).to.not.include('Per page:');
+      });
+    });
+
+    describe('with multiple entries', function() {
+      beforeEach(function() {
+        compile();
+        scope.setTotalResults(20);
       });
 
       it('should render perPage options', function () {


### PR DESCRIPTION
This makes the pagination of the WP table unsticky. It is now simply below the WP table.

https://community.openproject.com/projects/openproject/work_packages/24827/activity