### PR TITLE
[24925] Project selection is cut off in German (and other languages with long words)

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -307,7 +307,7 @@ input.top-menu-search--input
 
 #account-nav-left
   .drop-down
-    max-width: 186px
+    max-width: 300px
 
   #projects-menu
     overflow: hidden

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -99,3 +99,5 @@
   #account-nav-left
     #projects-menu
       font-size: 15px
+    .drop-down
+      max-width: 140px


### PR DESCRIPTION
This increases them-width of the project selector in the top menu. Thus a content cut off in German is avoided.

https://community.openproject.com/projects/openproject/work_packages/24925/activity