### PR TITLE
[24926] Edit hover shown in work package list for user without permission to edit

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/cell-builder.ts
@@ -44,7 +44,7 @@ export class CellBuilder {
       td.classList.add('-short');
     }
 
-    if (fieldSchema.writable && !field.hidden) {
+    if (fieldSchema.writable && !field.hidden && workPackage.isEditable) {
       span.classList.add(editableClassName);
     } else {
       span.classList.add(readOnlyClassName);


### PR DESCRIPTION
This takes care that the `read-only` class in the WP table is set correctly.

https://community.openproject.com/projects/openproject/work_packages/24926/activity