### PR TITLE
[24928] Split screen header looks strange when not logged in

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
@@ -91,18 +91,6 @@ body.controller-work_packages.action-show {
     height: 100%;
     // Important for Firefox to let 'flex-shrink' work correctly.
     min-height: 0;
-
-    .tabrow {
-      display: table;
-      margin: 0;
-      width: 100%;
-      height: 32px;
-
-      li {
-        display: table-cell;
-        margin-right: 15px;
-      }
-    }
   }
 
   .work-packages--left-panel {

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -112,6 +112,7 @@ i
 
 
 .tabrow
+  display: table
   text-align: left
   list-style: none
   margin: 0 0 0 10px
@@ -126,7 +127,7 @@ i
 
   li
     background: #ffffff
-    display: inline-block
+    display: table-cell
     position: relative
     margin: 0
     padding: 0


### PR DESCRIPTION
This takes care that the split screen/right panel header always spans the whole width, unaffected by whether there are 2, 3 or 4 elements.

https://community.openproject.com/projects/openproject/work_packages/24928/activity