### PR TITLE
[24905, 24919] Change table footer implementation

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -48,7 +48,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 .generic-table--results-container
   height:       100%
   overflow:
-    x: hidden
+    x: auto
     y: auto
 
 .generic-table--action-buttons
@@ -130,6 +130,7 @@ table.generic-table
 
   tfoot
     tr
+      background: #f6f7f8
       border:
         top:    0
         bottom: 0
@@ -203,11 +204,10 @@ table.generic-table
       margin: 0
 
 .generic-table--footer-outer
-  position:     absolute
-  bottom:       0
   padding:      0 6px
   line-height:  $generic-table--footer-height
-  z-index:      1
+  width:        100%
+  height:       $generic-table--footer-height
 
 .generic-table--header-outer,
 .generic-table--sort-header-outer,
@@ -265,14 +265,6 @@ table.generic-table
 
   &:hover > .dropdown-indicator
     visibility: visible
-
-.generic-table--footer-background
-  position:     absolute
-  bottom:       0
-  width:        100%
-  height:       $generic-table--footer-height
-  background:   #f6f7f8
-  z-index:      0
 
 .generic-table--no-results-container
   background:   $gray-light

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -47,11 +47,6 @@
   &:hover .wp-edit-field.-error:hover
     border-color: $nm-color-error-border
 
-// Allow inner scrolling in the WP table which is necessary because of the timeline
-.work-package-table--container .generic-table--results-container
-  overflow:
-    x: auto
-
 //
 .wp-table--faulty-query-icon
   color: $nm-color-error-icon

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -91,9 +91,11 @@
             </wp-display-attr>
           </div>
         </td>
+        <td>
+          <div class="generic-table--footer-outer"></div>
+        </td>
       </tr>
       </tfoot>
     </table>
-    <div class="generic-table--footer-background" ng-if="sumsLoaded()"></div>
   </div>
 </div>


### PR DESCRIPTION
This changes the implementation of the footer styling. Thus two problems are fixed:
* There are no longer two scrollbars displayed (one for the table and one for the footer) --> 
https://community.openproject.com/projects/openproject/work_packages/24905/activity
* The content of the cost reports table is not cut off when the user has to scroll --> https://community.openproject.com/projects/openproject/work_packages/24919/activity . According plugin PR: https://github.com/finnlabs/openproject-reporting/pull/117

Please note, that the footer is not absolutely positioned anymore. Thus you have to scroll the table to see the footer.