### PR TITLE
Cache all_work_package_form_attributes

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -246,6 +246,7 @@ describe ProjectsController, type: :controller do
 
         before do
           expect(type.attribute_visibility.keys).not_to include "custom_field_#{custom_field_1.id}"
+          RequestStore.clear!
 
           request
         end

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -32,6 +32,11 @@ require 'spec_helper'
 describe ::Type, type: :model do
   let(:type) { FactoryGirl.build(:type) }
 
+  before do
+    # Clear up the request store cache for all_work_package_attributes
+    RequestStore.clear!
+  end
+
   describe "#attribute_groups" do
     it 'returns #default_attribute_groups if not yet set' do
       expect(type.read_attribute(:attribute_groups)).to be_empty


### PR DESCRIPTION
Especially with lots of custom fields, this is otherwise called once per
represented WP and is quite costly.


PR: https://community.openproject.com/projects/openproject/work_packages/24942