### PR TITLE
Fix/schema caching

### DIFF
--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -99,12 +99,9 @@ module API
           def attribute_group_map(key)
             return nil if type.nil?
             @attribute_group_map ||= begin
-              mapping = {}
-              attribute_groups.each do |group, attributes|
-                attributes.each { |prop| mapping[prop] = group }
+              attribute_groups.each_with_object({}) do |(group, attributes), hash|
+                attributes.each { |prop| hash[prop] = group }
               end
-
-              mapping
             end
 
             @attribute_group_map[key]
@@ -134,7 +131,6 @@ module API
           def convert_property(prop)
             ::API::Utilities::PropertyNameConverter.from_ar_name(prop)
           end
-
 
           def percentage_done_writable?
             Setting.work_package_done_ratio == 'field'

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -71,7 +71,7 @@ module API
             # the same visibility lambda for all properties by default
 
             def schema(property, *args)
-              opts, _ = args
+              opts, = args
               opts[:visibility] = visibility property
               opts[:attribute_group] = attribute_group property
 
@@ -79,7 +79,7 @@ module API
             end
 
             def schema_with_allowed_link(property, *args)
-              opts, _ = args
+              opts, = args
               opts[:visibility] = visibility property
               opts[:attribute_group] = attribute_group property
 
@@ -87,7 +87,7 @@ module API
             end
 
             def schema_with_allowed_collection(property, *args)
-              opts, _ = args
+              opts, = args
               opts[:visibility] = visibility property
               opts[:attribute_group] = attribute_group property
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -105,12 +105,11 @@ module API
           def cache_key
             custom_fields = represented.project.all_work_package_custom_fields
 
-            custom_fields_key = ActiveSupport::Cache.expand_cache_key custom_fields
-
-            ["api/v3/work_packages/schema/#{represented.project.id}-#{represented.type.id}",
-             I18n.locale,
-             represented.type.updated_at,
-             Digest::SHA2.hexdigest(custom_fields_key)]
+            OpenProject::Cache::CacheKey.key('api/v3/work_packages/schemas',
+                                             "#{represented.project.id}-#{represented.type.id}",
+                                             I18n.locale,
+                                             represented.type.updated_at,
+                                             OpenProject::Cache::CacheKey.expand(custom_fields))
           end
 
           link :baseSchema do

--- a/lib/open_project/cache/cache_key.rb
+++ b/lib/open_project/cache/cache_key.rb
@@ -1,0 +1,44 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module Cache
+    module CacheKey
+      def self.key(*parts)
+        ['openproject',
+         OpenProject::VERSION] + parts
+      end
+
+      def self.expand(ar_models)
+        key = ActiveSupport::Cache.expand_cache_key ar_models
+
+        Digest::SHA2.hexdigest(key)
+      end
+    end
+  end
+end

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -64,11 +64,11 @@ module Redmine::MenuManager::TopMenu::HelpMenu
   private
 
   def render_onboarding(result)
-    result << content_tag(:li) {
+    result << content_tag(:li) do
       content_tag(:span, l('top_menu.getting_started'),
                   class: 'drop-down--help-headline',
                   title: l('top_menu.getting_started'))
-    }
+    end
     result << render_onboarding_menu_item
     result << content_tag(:hr, '', class: 'form--separator')
   end
@@ -78,11 +78,11 @@ module Redmine::MenuManager::TopMenu::HelpMenu
   end
 
   def render_help_and_support(result)
-    result << content_tag(:li) {
+    result << content_tag(:li) do
       content_tag :span, l('top_menu.help_and_support'),
                   class: 'drop-down--help-headline',
                   title: l('top_menu.help_and_support')
-    }
+    end
     if EnterpriseToken.show_banners?
       result << static_link_item(:upsale, href_suffix: "?utm_source=ce-helpmenu")
     end
@@ -99,12 +99,12 @@ module Redmine::MenuManager::TopMenu::HelpMenu
   end
 
   def render_additional_resources(result)
-    result << content_tag(:li) {
+    result << content_tag(:li) do
       content_tag :span,
                   l('top_menu.additional_resources'),
                   class: 'drop-down--help-headline',
                   title: l('top_menu.additional_resources')
-    }
+    end
     result << static_link_item(:blog)
     result << static_link_item(:release_notes)
     result << static_link_item(:report_bug)

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -31,7 +31,9 @@ require 'open_project/static/links'
 
 module Redmine::MenuManager::TopMenu::HelpMenu
   def render_help_top_menu_node(item = help_menu_item)
-    cache_key = "openproject/#{OpenProject::VERSION}/help_top_menu_node/#{I18n.locale}/#{OpenProject::Static::Links.help_link}"
+    cache_key = OpenProject::Cache::CacheKey.key('help_top_menu_node',
+                                                 I18n.locale,
+                                                 OpenProject::Static::Links.help_link)
     Rails.cache.fetch(cache_key) do
       if OpenProject::Static::Links.help_link_overridden?
         render_menu_node(item)


### PR DESCRIPTION
Contains:
* code climate fixes
* includes the op version into the cache key (functionality extracted) so that changes to the representer are present in a new version. Without it, the `attribute_group` property will not be present as an outdated representer is delivered in existing installations.  