### PR TITLE
[24946] Select project menu shall span whole width in mobile view

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -101,3 +101,14 @@
       font-size: 15px
     .drop-down
       max-width: 140px
+      ul
+        width: 100vw
+        left: -50px
+        border: none
+
+  #select2-drop.project-search-results
+    width: 100vw !important
+    left: 0 !important
+    .select2-search:before
+      right: 44px
+


### PR DESCRIPTION
This lets the menu to select a project span the whole width on mobile screens.

https://community.openproject.com/projects/openproject/work_packages/24946/activity