### PR TITLE
Fix/outdated query column information

### DIFF
--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -54,8 +54,6 @@ class WorkPackageCustomField < CustomField
   end
 
   def type_name
-    # TODO
-    # this needs to be renamed to label_work_package_plural
     :label_work_package_plural
   end
 end


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/24458

The first call determined the available columns which depended on the project. If e.g. the project was set/altered after the first call, the outdated information from the first call would still be worked with.