### PR TITLE
Fix table header no longer being sticky

### DIFF
--- a/app/assets/stylesheets/content/_pagination.sass
+++ b/app/assets/stylesheets/content/_pagination.sass
@@ -36,7 +36,7 @@ $pagination--font-size: 0.8125rem
 .pagination--pages
   +flex-grow(2)
   +flex-shrink(2)
-  margin: 10px 5px 0 0
+  margin: 10px 5px 10px 0
 
 .pagination--options
   +flex-grow(1)

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -103,6 +103,8 @@
 .work-packages--list
   +flex(2)
   overflow-x: auto
+  display: flex
+  flex-direction: column
 
 .work-packages--list-table-area
   position: relative // required for loading indicator

--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -106,6 +106,7 @@
 
 .work-packages--list-table-area
   position: relative // required for loading indicator
+  height: 100%
 
   table
     tr


### PR DESCRIPTION
Due to the removed height in https://github.com/opf/openproject/pull/5287, the table header is no longer sticky.

Re-adding the 100% height looks weird when the table isn't spanning the entire height . @HDinger could you have a look?