### PR TITLE
avoid n+1 queries by using already loaded columns

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -419,6 +419,17 @@ class Query < ActiveRecord::Base
     sort_criteria && sort_criteria[arg] && sort_criteria[arg].last
   end
 
+  def sort_criteria_columns
+    sort_criteria.map do |attribute, direction|
+      attribute = attribute.to_sym
+
+      column = sortable_columns
+               .detect { |candidate| candidate.name == attribute }
+
+      [column, direction]
+    end
+  end
+
   def sorted?
     sort_criteria.any?
   end

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -113,7 +113,7 @@ module API
         end
 
         links :sortBy do
-          map_with_sort_by_as_decorated(represented.sort_criteria) do |sort_by|
+          map_with_sort_by_as_decorated(represented.sort_criteria_columns) do |sort_by|
             {
               href: api_v3_paths.query_sort_by(sort_by.converted_name, sort_by.direction_name),
               title: sort_by.name

--- a/lib/api/v3/queries/query_serialization.rb
+++ b/lib/api/v3/queries/query_serialization.rb
@@ -71,7 +71,7 @@ module API
         def sort_by
           return unless represented.sort_criteria
 
-          map_with_sort_by_as_decorated(represented.sort_criteria) do |sort_by|
+          map_with_sort_by_as_decorated(represented.sort_criteria_columns) do |sort_by|
             ::API::V3::Queries::SortBys::QuerySortByRepresenter.new(sort_by)
           end
         end
@@ -127,7 +127,7 @@ module API
           href = query_attributes.dig("_links", "project", "href")
           id = id_from_href "projects", href
 
-          if id.to_i != 0
+          if id.to_i.nonzero?
             id # return numerical ID
           else
             Project.where(identifier: id).pluck(:id).first # lookup Project by identifier
@@ -180,8 +180,8 @@ module API
         end
 
         def map_with_sort_by_as_decorated(sort_criteria)
-          sort_criteria.map do |attribute, order|
-            decorated = ::API::V3::Queries::SortBys::SortByDecorator.new(attribute, order)
+          sort_criteria.map do |column, order|
+            decorated = ::API::V3::Queries::SortBys::SortByDecorator.new(column, order)
 
             yield decorated
           end

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -152,8 +152,8 @@ module API
                                          visibility: false,
                                          values_callback: -> do
                                            values = represented.sortable_columns.map do |column|
-                                             [SortBys::SortByDecorator.new(column.name, 'asc'),
-                                              SortBys::SortByDecorator.new(column.name, 'desc')]
+                                             [SortBys::SortByDecorator.new(column, 'asc'),
+                                              SortBys::SortByDecorator.new(column, 'desc')]
                                            end
 
                                            values.flatten

--- a/lib/api/v3/queries/sort_bys/query_sort_bys_api.rb
+++ b/lib/api/v3/queries/sort_bys/query_sort_bys_api.rb
@@ -36,6 +36,14 @@ module API
               def convert_to_ar(attribute)
                 ::API::Utilities::WpPropertyNameConverter.to_ar_name(attribute)
               end
+
+              def find_column(attribute)
+                ar_id = convert_to_ar(attribute).to_sym
+
+                Query
+                  .sortable_columns
+                  .detect { |candidate| candidate.name == ar_id }
+              end
             end
 
             params do
@@ -49,10 +57,10 @@ module API
 
             namespace ':id-:direction' do
               get do
-                ar_id = convert_to_ar(params[:id])
+                column = find_column(params[:id])
 
                 begin
-                  decorator = ::API::V3::Queries::SortBys::SortByDecorator.new(ar_id,
+                  decorator = ::API::V3::Queries::SortBys::SortByDecorator.new(column,
                                                                                params[:direction])
                   ::API::V3::Queries::SortBys::QuerySortByRepresenter.new(decorator)
                 rescue ArgumentError

--- a/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
+++ b/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
@@ -32,22 +32,16 @@ module API
     module Queries
       module SortBys
         class SortByDecorator
-          def initialize(column_name, direction)
+          def initialize(column, direction)
             if !['asc', 'desc'].include?(direction)
               raise ArgumentError, "Invalid direction. Only 'asc' and 'desc' are supported."
             end
 
-            self.direction = direction
-
-            column_sym = column_name.to_sym
-            column = Query
-                     .sortable_columns
-                     .detect { |candidate| candidate.name == column_sym }
-
             if column.nil?
-              raise ArgumentError, "Invalid column name."
+              raise ArgumentError, "Column needs to be set"
             end
 
+            self.direction = direction
             self.column = column
           end
 

--- a/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
@@ -31,8 +31,9 @@ require 'spec_helper'
 describe ::API::V3::Queries::SortBys::QuerySortByRepresenter do
   include ::API::V3::Utilities::PathHelper
 
-  let(:column) { 'status' }
+  let(:column_name) { 'status' }
   let(:direction) { 'desc' }
+  let(:column) { QueryColumn.new(column_name) }
   let(:representer) do
     described_class
       .new(::API::V3::Queries::SortBys::SortByDecorator.new(column, direction))
@@ -104,7 +105,7 @@ describe ::API::V3::Queries::SortBys::QuerySortByRepresenter do
     end
 
     context 'for a translated column' do
-      let(:column) { 'assigned_to' }
+      let(:column_name) { 'assigned_to' }
 
       describe '_links' do
         it_behaves_like 'has a titled link' do


### PR DESCRIPTION
Avoids n+1 query in form representer for sort by.

By that, it addresses part one of https://community.openproject.com/projects/openproject/work_packages/24947