### PR TITLE
bump nokogiri and rubyzip from vulnerable versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ gem 'cocaine', '~> 0.5.8'
 # also, better than thin since we can control worker concurrency.
 gem 'unicorn'
 
-gem 'nokogiri', '~> 1.6.8'
+gem 'nokogiri', '~> 1.7.1'
 
 # carrierwave 0.11.3 should allow to use fog-aws without the rest of the
 # fog dependency chain. We only need aws here, so we can avoid it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (3.16.2.321)
     nio4r (1.2.1)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     oj (2.17.4)
     openproject-token (1.0.0)
@@ -504,7 +504,7 @@ GEM
     rubytree (0.9.7)
       json (~> 1.8)
       structured_warnings (~> 0.2)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.5.0.pre.rc.1)
       sass-listen (~> 3.0.7)
@@ -648,7 +648,7 @@ DEPENDENCIES
   mysql2 (~> 0.4.4)
   net-ldap (~> 0.14.0)
   newrelic_rpm
-  nokogiri (~> 1.6.8)
+  nokogiri (~> 1.7.1)
   oj (~> 2.17.4)
   omniauth!
   openproject-token (~> 1.0.0)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/617519/24695002/67f60a10-19e4-11e7-9d77-a7702c20fcb6.png)
