### PR TITLE
Fix CF translations with non-matching locales

### DIFF
--- a/db/migrate/20170330084810_remove_translations_from_custom_fields.rb
+++ b/db/migrate/20170330084810_remove_translations_from_custom_fields.rb
@@ -8,10 +8,33 @@ class RemoveTranslationsFromCustomFields < ActiveRecord::Migration[5.0]
     translates :name
   end
 
+  class NewCustomField < ActiveRecord::Base
+    self.table_name = :custom_fields
+    self.inheritance_column = nil
+  end
+
+  def get_globalize_fallbacks
+    first_defined_locale = {}
+    OldCustomField::Translation.pluck(:custom_field_id, :name).each do |id, name|
+      next if first_defined_locale[id]
+      first_defined_locale[id] = name
+    end
+
+    first_defined_locale
+  end
+
   def change
     reversible do |dir|
       dir.up do
+        names = get_globalize_fallbacks
         OldCustomField.drop_translation_table! migrate_data: true
+
+        NewCustomField.transaction do
+          NewCustomField.where(name: nil).each do |cf|
+            say "Custom field #{cf.id} is missing translation for #{I18n.locale}: Falling back to #{names[cf.id]}"
+            cf.update_attribute(:name, names[cf.id] || "Custom field #{cf.id}")
+          end
+        end
       end
 
       dir.down do


### PR DESCRIPTION
While `globalize` provides fallbacks, we allow custom fields with _any_ set of locales being translated. So it could be that a CF exists with only a german (or any other locale) translation.

Globalize will not automatically take the first available translation as a fallback, so we have to implement that ourselves:

1. Remember the first saved translation for any CF (defined by its order, which matches the appearance of fields).

2. Use the globalize's own `drop_translation_table!` helper to move back the current locale.

3. For any CFs with their name being `null` now, update it with the first available value.

Found the issue + re-tested on the MyProject dump