### PR TITLE
[24965] Try to fix missing filter class

### DIFF
--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -27,26 +27,48 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require_dependency 'app/models/queries/work_packages/filter/assigned_to_filter'
+require_dependency 'app/models/queries/work_packages/filter/author_filter'
+require_dependency 'app/models/queries/work_packages/filter/category_filter'
+require_dependency 'app/models/queries/work_packages/filter/created_at_filter'
+require_dependency 'app/models/queries/work_packages/filter/custom_field_filter'
+require_dependency 'app/models/queries/work_packages/filter/done_ratio_filter'
+require_dependency 'app/models/queries/work_packages/filter/due_date_filter'
+require_dependency 'app/models/queries/work_packages/filter/estimated_hours_filter'
+require_dependency 'app/models/queries/work_packages/filter/group_filter'
+require_dependency 'app/models/queries/work_packages/filter/priority_filter'
+require_dependency 'app/models/queries/work_packages/filter/project_filter'
+require_dependency 'app/models/queries/work_packages/filter/responsible_filter'
+require_dependency 'app/models/queries/work_packages/filter/role_filter'
+require_dependency 'app/models/queries/work_packages/filter/start_date_filter'
+require_dependency 'app/models/queries/work_packages/filter/status_filter'
+require_dependency 'app/models/queries/work_packages/filter/subject_filter'
+require_dependency 'app/models/queries/work_packages/filter/subproject_filter'
+require_dependency 'app/models/queries/work_packages/filter/type_filter'
+require_dependency 'app/models/queries/work_packages/filter/updated_at_filter'
+require_dependency 'app/models/queries/work_packages/filter/version_filter'
+require_dependency 'app/models/queries/work_packages/filter/watcher_filter'
+
 module Queries::WorkPackages
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::AssignedToFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::AuthorFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CategoryFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CreatedAtFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CustomFieldFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::DoneRatioFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::DueDateFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::EstimatedHoursFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::GroupFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::PriorityFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::ProjectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::ResponsibleFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::RoleFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::StartDateFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::StatusFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::SubjectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::SubprojectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::TypeFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::UpdatedAtFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::VersionFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::WatcherFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::AssignedToFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::AuthorFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::CategoryFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::CreatedAtFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::CustomFieldFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::DoneRatioFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::DueDateFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::EstimatedHoursFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::GroupFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::PriorityFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::ProjectFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::ResponsibleFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::RoleFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::StartDateFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::StatusFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::SubjectFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::SubprojectFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::TypeFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::UpdatedAtFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::VersionFilter
+  Queries::Register.filter Query, ::Queries::WorkPackages::Filter::WatcherFilter
 end


### PR DESCRIPTION
I _believe_ this fixed the following error on dev environment.

https://community.openproject.com/projects/openproject/work_packages/24965/

```
ArgumentError (Filter Queries::WorkPackages::Filter::StatusFilter does
        not map to a dependency representer.):

    lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb:104:in
    `custom_representer_class'
    lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb:59:in
    `representer_class'
    lib/api/v3/queries/schemas/filter_dependency_representer_factory.rb:38:in
    `create'
    lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb:128:in
    `block in dependencies'
    lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb:126:in
    `each'
    lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb:126:in
    `each_with_object'
    lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb:126:in
    `dependencies'
    lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb:115:in
    `_dependencies'
    lib/api/root.rb:45:in `call'
```