### PR TITLE
[19714] Make priority part of form configuration

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -43,7 +43,8 @@ module Type::AttributeGroups
         assignee: :people,
         responsible: :people,
         estimated_time: :estimates_and_time,
-        spent_time: :estimates_and_time
+        spent_time: :estimates_and_time,
+        priority: :details
       }
     end
 
@@ -53,7 +54,7 @@ module Type::AttributeGroups
         people: :label_people,
         estimates_and_time: :label_estimates_and_time,
         details: :label_details,
-        other: :label_other,
+        other: :label_other
       }
     end
   end

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -160,7 +160,7 @@ export class WorkPackageSingleViewController {
     this.setFocus();
 
     // Accept the fields you always need to show.
-    this.specialFields = this.getFields(['project', 'status', 'priority']);
+    this.specialFields = this.getFields(['project', 'status']);
 
     // Get attribute groups if they are available (in project context)
     const attributeGroups = this.workPackage.schema._attributeGroups;

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -267,6 +267,7 @@ module API
                                              title: priority.name
                                            }
                                          },
+                                         required: false,
                                          has_default: true
         end
       end

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -181,6 +181,7 @@ describe 'form configuration', type: :feature, js: true do
                    { key: :category, checked: false, translation: 'Category' },
                    { key: :date, checked: false, translation: 'Date' },
                    { key: :percentage_done, checked: false, translation: 'Progress (%)' },
+                   { key: :priority, checked: false, translation: 'Priority' },
                    { key: :version, checked: false, translation: 'Version' }
 
 

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -581,7 +581,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:path) { 'priority' }
         let(:type) { 'Priority' }
         let(:name) { I18n.t('activerecord.attributes.work_package.priority') }
-        let(:required) { true }
+        let(:required) { false }
         let(:writable) { true }
         let(:has_default) { true }
       end
@@ -601,7 +601,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:path) { 'priority' }
           let(:type) { 'Priority' }
           let(:name) { I18n.t('activerecord.attributes.work_package.priority') }
-          let(:required) { true }
+          let(:required) { false }
           let(:writable) { false }
           let(:has_default) { true }
         end


### PR DESCRIPTION
This allows users to completely disable the priority, if they wish.
As it will always receive a default value, it is internally still a
required field.