### PR TITLE
[24988] Remove minimal column widths

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -93,7 +93,6 @@ table.generic-table
       text-align: left
       line-height: 34px
       padding: 0
-      min-width: 150px
 
       &.active-column
         background: #f8f8f8
@@ -103,9 +102,6 @@ table.generic-table
         &:hover, &:active
           text-decoration: none
           color: $body-font-color
-
-      &.-short
-        min-width: 0
 
       .-required:after
         @include default-transition
@@ -150,7 +146,6 @@ table.generic-table
     td
       border-bottom: 1px solid $table-row-border-color
       max-width: 300px
-      min-width: 150px
       overflow:  hidden
       text-overflow: ellipsis
       text-align: left
@@ -169,10 +164,6 @@ table.generic-table
 
       input[type="checkbox"], input[type="radio"]
         margin-top: -0.25rem
-
-      &.-short
-        min-width: 50px
-        width: 50px
 
       // In the interactive table the behaviour is like this:
       // * if there is more space available than is required to render

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -54,6 +54,8 @@
 
 // Shrink column of details / inline-create icons
 .wp-table--details-column
+  // Set a minimum width for the cell to avoid movement
+  width: 25px
   // Center the th icon
   text-align: center !important
 


### PR DESCRIPTION
With the interactive-table gone, the browser can now decide how
small a column may become, so we won't need the `min-width` anymore.

Exceptions are the subject (which is set to prefer a certain width)
and the details icon.

https://community.openproject.com/projects/openproject/work_packages/24988