### PR TITLE
[24995] Type selector is not correctly aligned

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
@@ -250,13 +250,9 @@ body.controller-work_packages.action-show {
       line-height: 34px;
     }
 
-    .work-packages--type-selector .wp-inline-edit--field {
-      line-height: 34px;
-    }
-
     .work-packages--subject-element .wp-inline-edit--field {
-      height: auto;
-      padding: 0;
+      height: 1.75rem;
+      margin-top: 11px;
     }
   }
 }


### PR DESCRIPTION
This aligns the type selector box with the rest of the header content.

https://community.openproject.com/projects/openproject/work_packages/24995/activity