### PR TITLE
[24996] ID is truncated in WP table

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -235,6 +235,7 @@ table.generic-table
   width:   100%
   clear:   both
   display: block
+  min-width: 40px
 
   & > a,
   & > span

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -20,8 +20,7 @@
                           target="columnContextMenu"
                           locals="columns, column"
                           locale="column.custom_field && columns.custom_field.name_locale || locale"
-                          header-column="column"
-                          ng-class="column.name == 'id' && '-short' ">
+                          header-column="column">
           </th>
           <th class="wp-table--details-column -short hide-when-print">
             <div class="generic-table--sort-header-outer" aria-hidden="true">


### PR DESCRIPTION
This adds a min-width for table header cells. Thus a truncation of very short headers, like the ID field is avoided. 

https://community.openproject.com/projects/openproject/work_packages/24996/activity