### PR TITLE
[24998] Top bar is split on global WP page

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -203,7 +203,7 @@
 
 #wrapper.nosidebar #top-menu
   margin-left: 0
-  width: initial
+  width: 100%
 
 .top-menu-search
   display: inline-block


### PR DESCRIPTION
This sets the width of the top menu to let is span the whole width.

https://community.openproject.com/projects/openproject/work_packages/24998/activity