### PR TITLE
[24999] User icon not displayed on mobile pages

### DIFF
--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -225,7 +225,7 @@
 
 .icon-work_package-edit
   @extend .icon-ticket-edit
-  content: "\e023"
+  content: "\f1a7"
 
 .icon-work_package-note
   @extend .icon-ticket-note

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -76,7 +76,7 @@
           text-align: center
 
           &:not(.login):before
-            content: "\e0be" !important
+            content: "\f1d7" !important
             padding: 0.25rem
             @include icon-font-common
 


### PR DESCRIPTION
Since the icon codes have changed the some icons were not correctly displayed. This concerns all icons which are directly set within the css and not with the help of the according class.

https://community.openproject.com/projects/openproject/work_packages/24999/activity