### PR TITLE
[24997] 2 vertical scroll bars shown when activating split screen

### DIFF
--- a/app/assets/stylesheets/layout/_work_package.sass
+++ b/app/assets/stylesheets/layout/_work_package.sass
@@ -103,12 +103,10 @@
 .work-packages--list
   +flex(2)
   overflow-x: auto
-  display: flex
-  flex-direction: column
 
 .work-packages--list-table-area
   position: relative // required for loading indicator
-  height: 100%
+  height: calc(100% - 55px)
 
   table
     tr


### PR DESCRIPTION
This makes the pagination of the WP table sticky again. Thus the two scrollbars can be avoided.

https://community.openproject.com/projects/openproject/work_packages/24997/activity