### PR TITLE
[25001] Styling wrong for back/up-button in work packages view

### DIFF
--- a/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
+++ b/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
@@ -1,8 +1,12 @@
 .wp-show--back-button
-  width: 100px
-  padding: 0 10px
+  width: 90px
+  padding: 0 10px 0 0
   align-self: center
 
   a
     margin: 0
+    padding: 4px
     width: 75px
+
+    .button--icon:before
+      font-size: 1rem


### PR DESCRIPTION
This changes the styling of the WP back button.


https://community.openproject.com/projects/openproject/work_packages/25001/activity