### PR TITLE
[25002] Wrong margins to the right in work packages module

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
+++ b/app/assets/stylesheets/content/work_packages/_work_packages_show_view_overwrite.scss
@@ -28,9 +28,12 @@
 
 body.controller-work_packages.action-show {
   overflow-x: auto;
+}
 
+body.controller-work_packages {
   #content {
     padding-left: 15px;
+    padding-right: 15px;
   }
 }
 
@@ -50,7 +53,6 @@ body.controller-work_packages.action-show {
   .toolbar-container {
     @include clearfix;
     margin-bottom: 10px;
-    padding-right: 20px;
   }
 
 
@@ -135,7 +137,7 @@ body.controller-work_packages.action-show {
     width: 40%;
 
     .work-packages--panel-inner {
-      padding: 2px 15px 20px 15px;
+      padding: 2px 0 20px 15px;
     }
   }
 
@@ -303,8 +305,4 @@ body.controller-work_packages.action-show {
   .work-packages--details--title, .work-packages--details--description {
     margin-left: 0;
   }
-}
-
-.work-packages--page-container {
-  .toolbar { padding-right: 20px; }
 }

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -87,7 +87,6 @@ body
     position:   absolute
     width:      calc(100% - #{$main-menu-width})
     height:     100%
-    padding:    10px 0 0 20px
 
   &.hidden-navigation
     margin-left: $main-menu-folded-width


### PR DESCRIPTION
This corrects the margin values so that the WP table and full screen view are correctly aligned.

https://community.openproject.com/projects/openproject/work_packages/25002/activity