### PR TITLE
Never refresh the timeline before its visible

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -55,7 +55,7 @@
 // Shrink column of details / inline-create icons
 .wp-table--details-column
   // Set a minimum width for the cell to avoid movement
-  width: 25px
+  min-width: 40px
   // Center the th icon
   text-align: center !important
 
@@ -64,17 +64,15 @@
 .wp-table--details-link
   .issue:hover &,
   &:focus
+    // override the hidden-for-sighted definition
     position: relative
     left: 0
-    width: 1.5rem
-    height: 1.5rem
+    width: initial
+    height: initial
 
-    .icon
-      position: relative
-      left: 0.25rem
-      &:before
-        color: $body-font-color
-        padding: 0 0 0 0.25rem
+    .icon:before
+      color: $body-font-color
+      padding: 0 0 0 0.25rem
   &:hover
     text-decoration: none
 

--- a/frontend/app/components/wp-table/timeline/wp-timeline-container.directive.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-container.directive.ts
@@ -48,6 +48,7 @@ import IDirective = angular.IDirective;
 import IScope = angular.IScope;
 import {WorkPackageRelationsService} from "../../wp-relations/wp-relations.service";
 import {HalRequestService} from "../../api/api-v3/hal-request/hal-request.service";
+import {WorkPackageTableTimelineService} from '../../wp-fast-table/state/wp-table-timeline.service';
 
 export class WorkPackageTimelineTableController {
 
@@ -70,6 +71,7 @@ export class WorkPackageTimelineTableController {
               private TypeResource:any,
               private states:States,
               private halRequest:HalRequestService,
+              private wpTableTimeline:WorkPackageTableTimelineService,
               private wpRelations:WorkPackageRelationsService) {
 
     "ngInject";
@@ -109,6 +111,11 @@ export class WorkPackageTimelineTableController {
   }
 
   refreshView() {
+    if (!this.wpTableTimeline.isVisible) {
+      debugLog('refreshView() requested, but TL is invisible.');
+      return;
+    }
+
     if (!this.refreshViewRequested) {
       debugLog('refreshView() in timeline container');
       setTimeout(() => {

--- a/frontend/app/components/wp-table/timeline/wp-timeline.header.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline.header.ts
@@ -202,7 +202,7 @@ export class WpTimelineHeader {
       this.setupScrollbar();
     }
 
-    this.containerHeight = jQuery(cssClassTableContainer).outerHeight() + this.headerHeight;
+    this.containerHeight = jQuery(cssClassTableContainer).outerHeight();
     this.globalHeight = jQuery(cssClassTableBody).outerHeight();
     this.marginTop = this.headerHeight;
 


### PR DESCRIPTION
While not 100% sure, the `setTimeout` in the timline container seems to accumulate with moving queries. This is an additional fix to avoid refreshing the timeline unless its open, but there must be additional issues involved somewhere that cause the page to get really sluggish.

Also fixes https://community.openproject.com/projects/openproject/work_packages/24977
https://community.openproject.com/projects/openproject/work_packages/25004