### PR TITLE
Fix/filter add and remove

### DIFF
--- a/frontend/app/components/filters/filter-string-value/filter-string-value.directive.html
+++ b/frontend/app/components/filters/filter-string-value/filter-string-value.directive.html
@@ -12,5 +12,4 @@
          class="hidden-for-sighted">
     {{ ::$ctrl.I18n.t('js.work_packages.description_enter_text') }}
   </label>
-
 </div>

--- a/frontend/app/components/filters/query-filter/query-filter.directive.ts
+++ b/frontend/app/components/filters/query-filter/query-filter.directive.ts
@@ -58,9 +58,7 @@ function queryFilterDirective($animate:any,
       });
 
       function putStateIfComplete() {
-        if (scope.filter.isCompletelyDefined()) {
-          wpTableFilters.replace(scope.filters);
-        }
+        wpTableFilters.replaceIfComplete(scope.filters);
       }
     }
   };

--- a/frontend/app/components/filters/query-filters/query-filters.directive.html
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.html
@@ -63,6 +63,10 @@
                                filter="filter">
           </filter-string-value>
 
+          <filter-string-value ng-switch-when="[1]Float"
+                               filter="filter">
+          </filter-string-value>
+
           <filter-boolean-value ng-switch-when="[1]Boolean"
                                 filter="filter">
           </filter-boolean-value>

--- a/frontend/app/components/filters/query-filters/query-filters.directive.ts
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.ts
@@ -64,16 +64,18 @@ function queryFiltersDirective($timeout:ng.ITimeoutService,
               updateFilterFocus(index);
               updateRemainingFilters();
 
-              if (newFilter.isCompletelyDefined()) {
-                wpTableFilters.replace(scope.filters);
-              }
+              wpTableFilters.replaceIfComplete(scope.filters);
             }
           });
 
           scope.deactivateFilter = function (removedFilter:QueryFilterInstanceResource) {
             let index = scope.filters.current.indexOf(removedFilter);
 
-            wpTableFilters.remove(removedFilter);
+            if (removedFilter.isCompletelyDefined()) {
+              wpTableFilters.remove(removedFilter);
+            } else {
+              scope.filters.remove(removedFilter);
+            }
 
             updateFilterFocus(index);
 

--- a/frontend/app/components/filters/query-filters/query-filters.directive.ts
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.ts
@@ -62,6 +62,7 @@ function queryFiltersDirective($timeout:ng.ITimeoutService,
               let newFilter = scope.filters.add(filter);
               var index = currentFilterLength();
               updateFilterFocus(index);
+              updateRemainingFilters();
 
               if (newFilter.isCompletelyDefined()) {
                 wpTableFilters.replace(scope.filters);

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -182,9 +182,9 @@ function WorkPackagesListController($scope:any,
     }
   }
 
-  $scope.allowed = function(model:string, permission: string) {
+  $scope.allowed = function(model:string, permission:string) {
     return AuthorisationService.can(model, permission);
-  }
+  };
 
   initialSetup();
 
@@ -209,7 +209,7 @@ function WorkPackagesListController($scope:any,
 
       wpListChecksumService.executeIfOutdated(newId,
                                               newChecksum,
-                                              loadQuery)
+                                              loadQuery);
     });
 
   // The combineLatest retains the last value of each observable regardless of

--- a/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -75,6 +75,12 @@ export class WorkPackageTableFiltersService extends WorkPackageTableBaseService 
     this.state.putValue(newState);
   }
 
+  public replaceIfComplete(newState:WorkPackageTableFilters) {
+    if (newState.isComplete()) {
+      this.state.putValue(newState);
+    }
+  }
+
   public remove(removedFilter:QueryFilterInstanceResource) {
     this.currentState.remove(removedFilter);
 

--- a/frontend/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-filters.ts
@@ -70,6 +70,10 @@ export class WorkPackageTableFilters {
     return _.remove(this.availableFilters, filter => activeFilterHrefs.indexOf(filter.href) === -1);
   }
 
+  public isComplete():boolean {
+    return _.every(this.current, filter => filter.isCompletelyDefined());
+  }
+
   private get currentFilters() {
     return this.current.map((filter:QueryFilterInstanceResource) => filter.filter);
   }

--- a/frontend/app/components/wp-list/wp-list.service.ts
+++ b/frontend/app/components/wp-list/wp-list.service.ts
@@ -1,4 +1,3 @@
-import { WorkPackageTableHierarchiesService } from './../wp-fast-table/state/wp-table-hierarchy.service';
 // -- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -50,6 +49,7 @@ import {WorkPackageTableSumService} from '../wp-fast-table/state/wp-table-sum.se
 import {WorkPackageTablePaginationService} from '../wp-fast-table/state/wp-table-pagination.service';
 import {WorkPackagesListInvalidQueryService} from './wp-list-invalid-query.service';
 import {WorkPackageTableTimelineService} from './../wp-fast-table/state/wp-table-timeline.service';
+import { WorkPackageTableHierarchiesService } from './../wp-fast-table/state/wp-table-hierarchy.service';
 
 export class WorkPackagesListService {
   constructor(protected NotificationsService:any,


### PR DESCRIPTION
* update available filters list after adding one (https://community.openproject.com/projects/openproject/work_packages/25028) 
* only remove filters for which the 'x'  is clicked as opposed to all up to the last completed one https://community.openproject.com/projects/openproject/work_packages/25016
* Only send filters to backend that are complete which prevents sending invalid filters
* Show text input for float values. Might want to change this into a `type=number step=any` but this recreates the existing behaviour. 