### PR TITLE
[25042] Show no results for member search

### DIFF
--- a/app/cells/user_filter_cell.rb
+++ b/app/cells/user_filter_cell.rb
@@ -14,6 +14,10 @@ class UserFilterCell < RailsCell
         .first
     end
 
+    def is_filtered(params)
+      [:name, :status, :group_id, :role_id].any? { |name| params[name].present? }
+    end
+
     ##
     # Returns the selected status from the parameters
     # or the default status to be filtered by (active)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -190,6 +190,7 @@ class MembersController < ApplicationController
   def set_index_data!
     set_roles_and_principles!
 
+    @is_filtered = Members::UserFilterCell.is_filtered params
     @members = Members::UserFilterCell.filter index_members(@project), params
     @members_table_options = members_table_options @roles
     @members_filter_options = members_filter_options @roles

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -65,10 +65,11 @@ See doc/COPYRIGHT.rdoc for more details.
 </div>
 
 <div>
+  <%= cell Members::UserFilterCell, params, @members_filter_options %>
   <% if any_members %>
-    <%= cell Members::UserFilterCell, params, @members_filter_options %>
-    &nbsp;
     <%= cell Members::TableCell, @members, @members_table_options %>
+  <% elsif @is_filtered %>
+    <%= no_results_box custom_title: t(:notice_no_principals_found) %>
   <% else %>
     <%= no_results_box %>
   <% end %>


### PR DESCRIPTION
Instead of showing the general 'No results' view as if the project
had no members, show a notice that no results where found for the search
and also show the filter cell at all times.

https://community.openproject.com/projects/openproject/work_packages/25042