### PR TITLE
[25059] Do not restrict relations when setting new parent

### DIFF
--- a/lib/api/v3/work_packages/available_relation_candidates_helper.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_helper.rb
@@ -59,9 +59,11 @@ module API
         end
 
         def illegal_relation?(type, from, to)
-          rel = Relation.new(relation_type: type, from: from, to: to)
+          if type != 'parent'
+            rel = Relation.new(relation_type: type, from: from, to: to)
 
-          rel.shared_hierarchy? || rel.circular_dependency?
+            rel.shared_hierarchy? || rel.circular_dependency?
+          end
         end
       end
     end


### PR DESCRIPTION
Assuming the following situation

```
Grand parent
  > Parent
    > Child
```

You couldn't set 'Grand parent' as a new parent of child due to the
restrictions. It should be possible however.