### PR TITLE
Fix/query saving

### DIFF
--- a/app/models/queries/operators/base.rb
+++ b/app/models/queries/operators/base.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -65,6 +66,10 @@ module Queries::Operators
 
     def self.human_name
       I18n.t(label_key)
+    end
+
+    def self.to_query
+      CGI.escape(symbol.to_s)
     end
   end
 end

--- a/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-resource.service.ts
@@ -79,18 +79,25 @@ export class QueryFilterInstanceResource extends HalResource {
   public static fromSchema(schema:QueryFilterInstanceSchemaResource):QueryFilterInstanceResource {
     let operator = (schema.operator.allowedValues as HalResource[])[0];
     let filter = (schema.filter.allowedValues as HalResource[])[0];
+    let source:any = {
+                        name: filter.name,
+                       _links: {
+                         filter: filter.$plain()._links.self,
+                         schema: schema.$plain()._links.self,
+                         operator: operator.$plain()._links.self
+                       }
+                     }
 
-    let newFilter = new QueryFilterInstanceResource({
-                                                       name: filter.name,
-                                                      _links: {
-                                                        filter: filter.$plain()._links.self,
-                                                        schema: schema.$plain()._links.self,
-                                                        operator: operator.$plain()._links.self,
-                                                        values: []
-                                                      }
-                                                   });
+    if (this.definesAllowedValues(schema)) {
+      source._links['values'] = [];
+    } else {
+      source['values'] = [];
+    }
+
+    let newFilter = new QueryFilterInstanceResource(source);
 
     newFilter.schema = schema;
+
 
     return newFilter;
   }
@@ -101,6 +108,11 @@ export class QueryFilterInstanceResource extends HalResource {
 
   public $copy() {
     return this.constructor(this.$source);
+  }
+
+  private static definesAllowedValues(schema:QueryFilterInstanceSchemaResource) {
+    return _.some(schema._dependencies[0].dependencies,
+                  (dependency:any) => dependency.values && dependency.values._links && dependency.values._links.allowedValues );
   }
 }
 

--- a/frontend/app/components/api/api-v3/hal-resources/query-operator-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-operator-resource.service.ts
@@ -47,7 +47,7 @@ export class QueryOperatorResource extends HalResource {
 
   public get idFromLink():string {
     if (this.href) {
-      return this.href.split('/').pop()!;
+      return decodeURIComponent(this.href.split('/').pop()!);
     }
 
     return '';

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -80,8 +80,7 @@ module.exports = function(I18n, PaginationService, PathHelper) {
                        .map(function(filter) {
                          var id = filter.id;
 
-                         var operator = filter.operator.$href
-                         operator = operator.substring(operator.lastIndexOf('/') + 1, operator.length);
+                         var operator = filter.operator.id;
 
                          return {
                            n: id,
@@ -176,8 +175,7 @@ module.exports = function(I18n, PaginationService, PathHelper) {
         var id = filter.filter.$href;
         id = id.substring(id.lastIndexOf('/') + 1, id.length);
 
-        var operator = filter.operator.$href
-        operator = operator.substring(operator.lastIndexOf('/') + 1, operator.length);
+        var operator = filter.operator.id;
 
         var values = _.map(filter.values, UrlParamsHelper.queryFilterValueToParam);
 

--- a/frontend/tests/unit/tests/helpers/url-params-helper-test.js
+++ b/frontend/tests/unit/tests/helpers/url-params-helper-test.js
@@ -67,7 +67,7 @@ describe('UrlParamsHelper', function() {
         name: 'soße_id',
         type: 'list_model',
         operator: {
-          $href: '/api/operator/='
+          id: '='
         },
         filter: {
           $href: '/api/filter/soße'
@@ -78,7 +78,7 @@ describe('UrlParamsHelper', function() {
         id: 'created_at',
         type: 'datetime_past',
         operator: {
-          $href: '/api/operator/<t-'
+          id: '<t-'
         },
         filter: {
           $href: '/api/filter/created_at'
@@ -163,7 +163,7 @@ describe('UrlParamsHelper', function() {
         name: 'soße_id',
         type: 'list_model',
         operator: {
-          $href: '/api/operator/='
+          id: '='
         },
         filter: {
           $href: '/api/filter/soße'
@@ -174,7 +174,7 @@ describe('UrlParamsHelper', function() {
         id: 'created_at',
         type: 'datetime_past',
         operator: {
-          $href: '/api/operator/<t-'
+          id: '<t-'
         },
         filter: {
           $href: '/api/filter/created_at'
@@ -237,7 +237,7 @@ describe('UrlParamsHelper', function() {
       var filter1 = {
         id: 'customField1',
         operator: {
-          $href: '/api/operator/='
+          id: '='
         },
         filter: {
           $href: '/api/filter/customField1'

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -45,7 +46,7 @@ module API
 
           link :operator do
             {
-              href: api_v3_paths.query_operator(represented.operator),
+              href: api_v3_paths.query_operator(CGI.escape(represented.operator)),
               title: operator_name
             }
           end

--- a/lib/api/v3/queries/operators/query_operator_representer.rb
+++ b/lib/api/v3/queries/operators/query_operator_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,7 +33,7 @@ module API
     module Queries
       module Operators
         class QueryOperatorRepresenter < ::API::Decorators::Single
-          self_link id_attribute: ->(*) { id },
+          self_link id_attribute: ->(*) { represented.to_query },
                     title_getter: ->(*) { name }
 
           def initialize(model, *_)

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -75,7 +76,7 @@ module API
           def self.operator_link_factory
             ->(operator) do
               {
-                href: api_v3_paths.query_operator(operator.to_sym),
+                href: api_v3_paths.query_operator(operator.to_query),
                 title: operator.human_name
               }
             end
@@ -126,7 +127,7 @@ module API
 
           def dependencies
             filter.available_operators.each_with_object({}) do |operator, hash|
-              path = api_v3_paths.query_operator(operator.to_sym)
+              path = api_v3_paths.query_operator(operator.to_query)
               value = FilterDependencyRepresenterFactory.create(filter,
                                                                 operator,
                                                                 form_embedded: form_embedded)

--- a/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -60,7 +60,7 @@ describe ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
 
       it_behaves_like 'has a titled link' do
         let(:link) { 'operator' }
-        let(:href) { api_v3_paths.query_operator '=' }
+        let(:href) { api_v3_paths.query_operator(CGI.escape('=')) }
         let(:title) { 'is' }
       end
 

--- a/spec/lib/api/v3/queries/operators/query_operator_representer_spec.rb
+++ b/spec/lib/api/v3/queries/operators/query_operator_representer_spec.rb
@@ -40,7 +40,7 @@ describe ::API::V3::Queries::Operators::QueryOperatorRepresenter do
     describe '_links' do
       it_behaves_like 'has a titled link' do
         let(:link) { 'self' }
-        let(:href) { api_v3_paths.query_operator operator.to_sym }
+        let(:href) { api_v3_paths.query_operator operator.to_query }
         let(:title) { I18n.t(:label_not_contains) }
       end
     end

--- a/spec/lib/api/v3/queries/query_representer_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_spec.rb
@@ -489,7 +489,7 @@ describe ::API::V3::Queries::QueryRepresenter do
               "title": "Status"
             },
             "operator": {
-              "href": "/api/v3/queries/operators/=",
+              "href": api_v3_paths.query_operator(CGI.escape('=')),
               "title": "is"
             },
             "values": [
@@ -512,7 +512,7 @@ describe ::API::V3::Queries::QueryRepresenter do
               "title": "Assignee"
             },
             "operator": {
-              "href": "/api/v3/queries/operators/!",
+              "href": api_v3_paths.query_operator(CGI.escape('!')),
               "title": "is not"
             },
             "values": [

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -153,11 +153,11 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
 
           it_behaves_like 'links to and embeds allowed values directly' do
             let(:hrefs) do
-              [api_v3_paths.query_operator('o'),
-               api_v3_paths.query_operator('='),
-               api_v3_paths.query_operator('c'),
-               api_v3_paths.query_operator('!'),
-               api_v3_paths.query_operator('*')]
+              [api_v3_paths.query_operator(CGI.escape('o')),
+               api_v3_paths.query_operator(CGI.escape('=')),
+               api_v3_paths.query_operator(CGI.escape('c')),
+               api_v3_paths.query_operator(CGI.escape('!')),
+               api_v3_paths.query_operator(CGI.escape('*'))]
             end
           end
         end
@@ -183,11 +183,11 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
         describe 'dependencies' do
           it 'is the hash' do
             expected = {
-              api_v3_paths.query_operator('=') => { "lorem": "ipsum" },
-              api_v3_paths.query_operator('c') => { "lorem": "ipsum" },
-              api_v3_paths.query_operator('!') => { "lorem": "ipsum" },
-              api_v3_paths.query_operator('*') => { "lorem": "ipsum" },
-              api_v3_paths.query_operator('o') => { "lorem": "ipsum" }
+              api_v3_paths.query_operator(CGI.escape('=')) => { "lorem": "ipsum" },
+              api_v3_paths.query_operator(CGI.escape('c')) => { "lorem": "ipsum" },
+              api_v3_paths.query_operator(CGI.escape('!')) => { "lorem": "ipsum" },
+              api_v3_paths.query_operator(CGI.escape('*')) => { "lorem": "ipsum" },
+              api_v3_paths.query_operator(CGI.escape('o')) => { "lorem": "ipsum" }
             }
 
             expect(subject)
@@ -200,8 +200,8 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
 
             it 'is the hash' do
               expected = {
-                api_v3_paths.query_operator('=') => { "lorem": "ipsum" },
-                api_v3_paths.query_operator('!') => { "lorem": "ipsum" }
+                api_v3_paths.query_operator(CGI.escape('=')) => { "lorem": "ipsum" },
+                api_v3_paths.query_operator(CGI.escape('!')) => { "lorem": "ipsum" }
               }
 
               expect(subject)

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -118,7 +118,7 @@ describe "POST /api/v3/queries/form", type: :request do
                 href: "/api/v3/queries/filters/status"
               },
               operator: {
-                "href": "/api/v3/queries/operators/="
+                "href": "/api/v3/queries/operators/%3D"
               },
               values: [
                 {
@@ -182,7 +182,7 @@ describe "POST /api/v3/queries/form", type: :request do
         {
           "_links" => {
             "filter" => { "href" => "/api/v3/queries/filters/status" },
-            "operator" => { "href" => "/api/v3/queries/operators/=" },
+            "operator" => { "href" => "/api/v3/queries/operators/%3D" },
             "values" => [
               { "href" => "/api/v3/statuses/#{status.id}" }
             ]

--- a/spec/requests/api/v3/queries/operators/query_operators_resource_spec.rb
+++ b/spec/requests/api/v3/queries/operators/query_operators_resource_spec.rb
@@ -34,7 +34,7 @@ describe 'API v3 Query Operator resource', type: :request do
   include API::V3::Utilities::PathHelper
 
   describe '#get queries/operators/:id' do
-    let(:path) { api_v3_paths.query_operator(operator) }
+    let(:path) { api_v3_paths.query_operator(CGI.escape(operator)) }
     let(:operator) { '=' }
     let(:project) { FactoryGirl.create(:project) }
     let(:role) { FactoryGirl.create(:role, permissions: permissions) }

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -125,7 +125,7 @@ describe "POST /api/v3/queries/form", type: :request do
                 href: "/api/v3/queries/filters/status"
               },
               operator: {
-                "href": "/api/v3/queries/operators/="
+                "href": "/api/v3/queries/operators/%3D"
               },
               values: [
                 {
@@ -189,7 +189,7 @@ describe "POST /api/v3/queries/form", type: :request do
         {
           "_links" => {
             "filter" => { "href" => "/api/v3/queries/filters/status" },
-            "operator" => { "href" => "/api/v3/queries/operators/=" },
+            "operator" => { "href" => "/api/v3/queries/operators/%3D" },
             "values" => [
               { "href" => "/api/v3/statuses/#{status.id}" }
             ]


### PR DESCRIPTION
Fixes two problems with query saving:
* The operator symbols (e.g. '=', '!') need to be URI escaped for the backend to parse them correctly. Therefore, all links in the backend are changed accordingly.
* Fixes building the source object used for creating a filter instance in the front end. As this object is later relied upon when saving, the `values` property has to be placed correctly. https://community.openproject.com/projects/openproject/work_packages/25058