### PR TITLE
[25007] Column width too small / overlap on WP page with activated timeline

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -246,14 +246,16 @@ table.generic-table
 
   & > a
     float: left
-    width: calc(100% - 18px)
+    width: 100%
+    padding-right: 30px
 
   & > .dropdown-indicator
     width: 1em
-    text-align: right
     overflow: visible
     min-width: 1em
     visibility: hidden
+    position: relative
+    right: 15px
 
   &:hover > .dropdown-indicator
     visibility: visible


### PR DESCRIPTION
This removes the width restriction for the header elements of tables. Thus the content will not be cut off. The width calculation for the table columns will be done by the browser. 

https://community.openproject.com/projects/telekom/work_packages/25007/activity