### PR TITLE
[25084, 25085] Fix alignments within WP views

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -85,6 +85,11 @@
   &.inplace-edit .custom-option:not(.-multiple-lines)
     display: inline
 
+  .inline-label
+    .form-label,
+    .icon-context:before
+      padding-right: 0
+
 // Full width container
 .wp-table--cell-container
   display: inline-block

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -61,11 +61,13 @@ $work-package-details--tab-height: 40px
     textarea
       overflow: hidden
 
-// Make elements in split and full view span the entire width
 .work-package--single-view
+  // Make elements in split and full view span the entire width
   .wp-edit-field
     width: 100%
 
+  .panel-toggler .button
+    margin-right: 0
 
 div[class*='work-packages--details--']
   width: calc(100% + 0.375rem)


### PR DESCRIPTION
This corrects the alignment within WP views. The 'Show More/Less' and the MultiSelect Togglers were moved to the right. 

https://community.openproject.com/projects/openproject/work_packages/25084/activity
https://community.openproject.com/projects/openproject/work_packages/25085/activity