### PR TITLE
Fix/filter context

### DIFF
--- a/app/models/queries/available_filters.rb
+++ b/app/models/queries/available_filters.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/role_filter.rb
+++ b/app/models/queries/work_packages/filter/role_filter.rb
@@ -92,7 +92,7 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   def user_ids_for_filtering
     scope = if ['*', '!*'].include?(operator)
               user_ids_for_filtering_scope
-            elsif context
+            elsif project
               user_ids_for_filter_project_scope
             else
               user_ids_for_filter_non_project_scope
@@ -109,7 +109,7 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   def user_ids_for_filter_project_scope
     user_ids_for_filtering_scope
       .where(id: values)
-      .where(members: { project_id: context.id })
+      .where(members: { project_id: project.id })
   end
 
   def user_ids_for_filter_non_project_scope

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -46,8 +46,9 @@ class Queries::WorkPackages::Filter::WorkPackageFilter < ::Queries::Filters::Bas
     WorkPackage.human_attribute_name(name)
   end
 
-  alias :project :context
-  alias :project= :context=
+  def project
+    context.project
+  end
 
   def attributes
     { name: name, operator: operator, values: values }

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -55,13 +55,11 @@ class ::Query::Results
   # Returns the work package count by group or nil if query is not grouped
   def work_package_count_by_group
     @work_package_count_by_group ||= begin
-      r = nil
       if query.grouped?
         r = groups_grouped_by_column(query)
 
-        r = transform_group_keys(query, r)
+        transform_group_keys(query, r)
       end
-      r
     end
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -41,11 +42,11 @@ module Concerns::Contracted
 
     def validate_and_save(object)
       if !contract.validate
-        return false, contract.errors
+        [false, contract.errors]
       elsif !object.save
-        return false, object.errors
+        [false, object.errors]
       else
-        return true, object.errors
+        [true, object.errors]
       end
     end
   end

--- a/app/services/queries/create_query_service.rb
+++ b/app/services/queries/create_query_service.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -57,7 +57,7 @@ module API
           end
 
           get do
-            authorize_any [:view_work_packages, :manage_public_queries], global: true
+            authorize_any %i(view_work_packages manage_public_queries), global: true
 
             queries_scope = Query.all.includes(QueryRepresenter.to_eager_load)
 

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -44,8 +44,8 @@ module API
               params << { type: { operator: '=', values: ['User'] } }
             end
 
-            params << if filter.context
-                        { member: { operator: '=', values: [filter.context.id.to_s] } }
+            params << if filter.project
+                        { member: { operator: '=', values: [filter.project.id.to_s] } }
                       else
                         { member: { operator: '*', values: [] } }
                       end

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -37,7 +37,7 @@ module API
 
           def href_callback
             # This filter is only available inside projects
-            api_v3_paths.categories(filter.context.identifier)
+            api_v3_paths.categories(filter.project.identifier)
           end
 
           def type

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -40,8 +40,8 @@ module API
           def filter_query
             params = [{ type: { operator: '=', values: ['Group'] } }]
 
-            params << if filter.context
-                        { member: { operator: '=', values: [filter.context.id.to_s] } }
+            params << if filter.project
+                        { member: { operator: '=', values: [filter.project.id.to_s] } }
                       else
                         { member: { operator: '*', values: [] } }
                       end

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -212,8 +212,8 @@ module API
           end
 
           def filter_instance_schemas_href
-            if represented.context
-              api_v3_paths.query_project_filter_instance_schemas(represented.context.id)
+            if represented.project
+              api_v3_paths.query_project_filter_instance_schemas(represented.project.id)
             else
               api_v3_paths.query_filter_instance_schemas
             end

--- a/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
@@ -35,7 +35,7 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            params = [ancestor: { operator: '=', values: [filter.context.id.to_s] }]
+            params = [ancestor: { operator: '=', values: [filter.project.id.to_s] }]
             escaped = CGI.escape(::JSON.dump(params))
 
             "#{api_v3_paths.projects}?filters=#{escaped}"

--- a/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
@@ -35,10 +35,10 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            if filter.context.nil?
+            if filter.project.nil?
               api_v3_paths.types
             else
-              api_v3_paths.types_by_project(filter.context.id)
+              api_v3_paths.types_by_project(filter.project.id)
             end
           end
 

--- a/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
@@ -40,8 +40,8 @@ module API
             params = [{ type: { operator: '=', values: ['User'] } },
                       { status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
 
-            if filter.context
-              params << { member: { operator: '=', values: [filter.context.id.to_s] } }
+            if filter.project
+              params << { member: { operator: '=', values: [filter.project.id.to_s] } }
             end
 
             params

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -36,12 +36,12 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            if filter.context.nil?
+            if filter.project.nil?
               filter_params = [{ sharing: { operator: '=', values: ['system'] } }]
 
               "#{api_v3_paths.types}?filters=#{CGI.escape(::JSON.dump(filter_params))}"
             else
-              api_v3_paths.versions_by_project(filter.context.id)
+              api_v3_paths.versions_by_project(filter.project.id)
             end
           end
 

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -37,7 +38,7 @@ module API
           before do
             @versions = @project.shared_versions
 
-            authorize_any [:view_work_packages, :manage_versions], projects: @project
+            authorize_any %i(view_work_packages manage_versions), projects: @project
           end
 
           get do

--- a/spec/features/timelines/filter_custom_fields_spec.rb
+++ b/spec/features/timelines/filter_custom_fields_spec.rb
@@ -157,7 +157,7 @@ describe Timeline, 'filtering custom fields', type: :feature, js: true do
     it_behaves_like 'filtering by bool custom field'
   end
 
-  context 'with a global bool custom field' do
+  context 'with a project bool custom field' do
     let(:cf) { bool_cf_local }
     it_behaves_like 'filtering by bool custom field'
   end
@@ -248,7 +248,7 @@ describe Timeline, 'filtering custom fields', type: :feature, js: true do
     it_behaves_like 'filtering by list custom field'
   end
 
-  context 'with a global list custom field' do
+  context 'with a project list custom field' do
     let(:cf) { list_cf_local }
     it_behaves_like 'filtering by list custom field'
   end

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -1,39 +1,112 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 require 'spec_helper'
 
-describe 'filter by watcher', js: true do
+describe 'filter work packages', js: true do
   let(:user) { FactoryGirl.create :admin }
   let(:watcher) { FactoryGirl.create :user }
   let(:project) { FactoryGirl.create :project }
   let(:role) { FactoryGirl.create :existing_role, permissions: [:view_work_packages] }
-
-  let(:work_packages) { FactoryGirl.create_list :work_package, 10, project: project }
-  let(:watched_wps) { [work_packages[3], work_packages[5], work_packages[7]] }
-
-  let(:wp_table) { ::Pages::WorkPackagesTable.new }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }
 
   before do
     project.add_member! watcher, role
-
-    watched_wps.each_with_index do |wp, i|
-      wp.add_watcher watcher
-      wp.subject = "Watched WP ##{i}"
-      wp.save!
-    end
-
     login_as(user)
-    wp_table.visit!
   end
 
-  # Regression test for bug #24114 (broken watcher filter)
-  it 'should only filter work packages by watcher' do
-    filters.open
-    loading_indicator_saveguard
+  context 'by watchers' do
+    let(:work_package_with_watcher) do
+      wp = FactoryGirl.build :work_package, project: project
+      wp.add_watcher watcher
+      wp.save!
 
-    filters.filter_by_watcher watcher.name
-    loading_indicator_saveguard
+      wp
+    end
+    let(:work_package_without_watcher) { FactoryGirl.create :work_package, project: project }
 
-    expect(wp_table).to have_work_packages_listed watched_wps
-    expect(wp_table).not_to have_work_packages_listed (work_packages - watched_wps)
+    before do
+      work_package_with_watcher
+      work_package_without_watcher
+
+      wp_table.visit!
+    end
+
+    # Regression test for bug #24114 (broken watcher filter)
+    it 'should only filter work packages by watcher' do
+      filters.open
+      loading_indicator_saveguard
+
+      filters.filter_by_watcher watcher.name
+      loading_indicator_saveguard
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_watcher]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_watcher]
+    end
+  end
+
+  context 'by version in project' do
+    let(:version) { FactoryGirl.create :version, project: project }
+    let(:work_package_with_version) { FactoryGirl.create :work_package, project: project, fixed_version: version }
+    let(:work_package_without_version) { FactoryGirl.create :work_package, project: project }
+
+    before do
+      work_package_with_version
+      work_package_without_version
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving the saved filter' do
+      filters.open
+
+      filters.add_filter_by('Version', 'is', version.name)
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_version]
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'version'
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version, work_package_without_version]
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_version]
+
+      filters.open
+
+      filters.expect_filter_by('Version', 'is', version.name)
+    end
   end
 end

--- a/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.new(context: query) }
   let(:form_embedded) { false }
   let(:group_assignment_enabled) { false }
 

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::GroupFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::GroupFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::TypeFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::TypeFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed :project }
-  let(:filter) { Queries::WorkPackages::Filter::AuthorFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::AuthorFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::VersionFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::VersionFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
@@ -30,11 +30,12 @@ require 'spec_helper'
 
 describe Queries::WorkPackages::Filter::CustomFieldFilter, type: :model do
   let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
   let(:instance) do
     filter = described_class.new
     filter.name = "cf_#{custom_field.id}"
     filter.operator = '='
-    filter.context = project
+    filter.context = query
     filter
   end
   let(:instance_key) { nil }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -205,11 +205,7 @@ describe Query, type: :model do
       end
 
       it 'has the context set' do
-        expect(subject.context).to eql query.project
-
-        query.project = nil
-
-        expect(query.filter_for('status_id').context).to be_nil
+        expect(subject.context).to eql query
       end
 
       it 'reuses an existing filter' do
@@ -224,7 +220,7 @@ describe Query, type: :model do
 
       query.reload
       query.filters.each do |filter|
-        expect(filter.context).to eql(query.project)
+        expect(filter.context).to eql(query)
       end
     end
   end

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -54,6 +54,23 @@ module Components
         select name, from: "values-watcher"
       end
 
+      # limited to select fields for now
+      def add_filter_by(name, operator, value, selector = nil)
+        id = selector || name.downcase
+
+        select name, from: "add_filter_select"
+        select operator, from: "operators-#{id}"
+        select value, from: "values-#{id}"
+      end
+
+      # limited to select fields for now
+      def expect_filter_by(name, operator, value, selector = nil)
+        id = selector || name.downcase
+
+        expect(page).to have_select("operators-#{id}", selected: operator)
+        expect(page).to have_select("values-#{id}", selected: value)
+      end
+
       def remove_filter(field)
         page.within(filters_selector) do
           find("#filter_#{field} .advanced-filters--remove-filter-icon").click

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -138,6 +138,17 @@ module Pages
       find('#settingsDropdown .menu-item', text: label).click
     end
 
+    def save_as(name)
+      click_setting_item 'Save as'
+
+      fill_in 'save-query-name', with: name
+
+      click_button 'Save'
+
+      expect_notification message: 'Successful creation.'
+      expect_title name
+    end
+
     def open_filter_section
       unless page.has_selector?('#work-packages-filter-toggle-button.-active')
         click_button('work-packages-filter-toggle-button')

--- a/spec/support/pages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages_timeline.rb
@@ -27,10 +27,10 @@
 #++
 
 require 'support/pages/page'
+require 'support/pages/work_packages_table'
 
 module Pages
   class WorkPackagesTimeline < WorkPackagesTable
-
     def toggle_timeline
       find('#work-packages-timeline-toggle-button').click
     end

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -44,7 +44,7 @@ end
 shared_examples_for 'basic query filter' do
   include_context 'filter tests'
 
-  let(:context) { project }
+  let(:context) { FactoryGirl.build_stubbed(:query, project: project) }
   let(:project) { FactoryGirl.build_stubbed(:project) }
   let(:instance_key) { nil }
   let(:class_key) { raise 'needs to be defined' }

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,7 +27,7 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Project, type: :model do
   fixtures :all
@@ -880,8 +881,8 @@ describe Project, type: :model do
       # group role
       (Member.new.tap do |m|
         m.attributes = { project_id: @source_project.id,
-                               principal: group,
-                               role_ids: [2] }
+                         principal: group,
+                         role_ids: [2] }
       end).save!
 
       member = Member.find_by(user_id: user.id, project_id: @source_project.id)

--- a/spec_legacy/unit/query_spec.rb
+++ b/spec_legacy/unit/query_spec.rb
@@ -337,7 +337,8 @@ describe Query, type: :model do
     c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
     assert c
     assert c.sortable
-    issues = WorkPackage.includes(:assigned_to, :status, :type, :project, :priority)
+    issues = WorkPackage
+             .includes(:assigned_to, :status, :type, :project, :priority)
              .where(q.statement)
              .order(Array(c.sortable).map { |s| "#{s} ASC" }.join(', '))
              .references(:projects)
@@ -369,7 +370,6 @@ describe Query, type: :model do
     expect(count_by_group.keys.map { |k| k.class.name }.uniq)
       .to match_array(%w(CustomOption NilClass))
     assert_equal %w(Fixnum), count_by_group.values.map { |k| k.class.name }.uniq
-    puts count_by_group
     expect(count_by_group.any? { |k, v| k.is_a?(CustomOption) && k.id == 1 && v == 1 })
       .to be_truthy
   end


### PR DESCRIPTION
For some reason that is beyond the filters of a query lost their associated project between the `after_save` and the `after_commit` callback.

This PR therefore sets the filter context again after a commit. 

It additionally changes the context from the project to the query which should be more robust with regards to sequence when a filter is added before the project has been assigned as happens e.g. in the api.