### PR TITLE
[25096] Fix initial positioning of dropdown

### DIFF
--- a/app/assets/stylesheets/content/_context_menu.sass
+++ b/app/assets/stylesheets/content/_context_menu.sass
@@ -30,6 +30,12 @@
   &.action-menu
     position: absolute
     z-index: 1000
+    // initial styles
+    // are overridden immediately on first reposition
+    // by contextMenuService
+    top: 0
+    left: 0
+    visibility: hidden
 
 #work-package-context-menu.action-menu
   position: fixed

--- a/frontend/app/components/context-menus/context-menu.service.ts
+++ b/frontend/app/components/context-menus/context-menu.service.ts
@@ -79,9 +79,6 @@ export class ContextMenuService {
     // Open the menu
     contextMenu.open(target, locals).then((menuElement) => {
 
-      // Hide menu until rendered
-      menuElement.css('visibility', 'hidden');
-
       contextMenu.menuElement = menuElement;
       this.active_menu = contextMenu;
       (menuElement as any).trap();

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -15,7 +15,7 @@
         <tr>
           <th sort-header ng-repeat="column in columns track by column.href"
                           has-dropdown-menu
-                          position-relative-to=".generic-table--sort-header-outer"
+                          class="wp-table--table-header"
                           collision-container=".work-packages--list"
                           target="columnContextMenu"
                           locals="columns, column"


### PR DESCRIPTION
The default position of the dropdown right before positioning caused it
to be inside the normal dom flow, resulting in a temporary scroll bar,
which shifted the total width of the container.

If we instead set a default top/left value which is immediately cleared
on the first reposition, the position is correct.