### PR TITLE
remove legacy tables

### DIFF
--- a/db/migrate/20170420082944_remove_legacy_tables.rb
+++ b/db/migrate/20170420082944_remove_legacy_tables.rb
@@ -1,0 +1,13 @@
+class RemoveLegacyTables < ActiveRecord::Migration[5.0]
+  def up
+    drop_table(:legacy_default_planning_element_types, if_exists: true)
+    drop_table(:legacy_enabled_planning_element_types, if_exists: true)
+    drop_table(:legacy_issues, if_exists: true)
+    drop_table(:legacy_journals, if_exists: true)
+    drop_table(:legacy_planning_element_types, if_exists: true)
+    drop_table(:legacy_planning_elements, if_exists: true)
+    drop_table(:legacy_user_identity_urls, if_exists: true)
+  end
+
+  # Down migration is not interesting as the data has been lost already
+end


### PR DESCRIPTION
The information in those tables is no longer needed for potential backup scenarios as it would be quite stale now.

As it is, it just clutters backups.