### PR TITLE
bump required ruby to 2.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@
 language: ruby
 
 rvm:
-  - 2.2.5
+  - 2.3.4
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,8 @@
 
 source 'https://rubygems.org'
 
-ruby '>= 2.2.5'
+# We do not yet support 2.4
+ruby '~> 2.3.4'
 
 gem 'rails', '~> 5.0.2'
 gem 'actionpack-xml_parser', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,7 +716,7 @@ DEPENDENCIES
   will_paginate (~> 3.1.0)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.4p301
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
For whatever reasons (e.g. ruby being mature enough, having updated the right gems) running on 2.3.4 seems to be stable now on my machine.

