### PR TITLE
Fix/assigned responsible filter values

### DIFF
--- a/app/models/queries/work_packages/filter/principal_loader.rb
+++ b/app/models/queries/work_packages/filter/principal_loader.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -55,7 +56,7 @@ class Queries::WorkPackages::Filter::PrincipalLoader
       project.principals.sort
     elsif visible_projects.any?
       user_or_principal = Setting.work_package_group_assignment? ? Principal : User
-      user_or_principal.active.in_project(visible_projects).sort
+      user_or_principal.active_or_registered.in_project(visible_projects).sort
     else
       []
     end

--- a/lib/api/v3/principals/principals_api.rb
+++ b/lib/api/v3/principals/principals_api.rb
@@ -34,6 +34,7 @@ module API
           get do
             scope = Principal.includes(:preference, :members)
                              .where(members: { project_id: Project.visible(current_user) })
+                             .order_by_name
 
             representer = Users::UserCollectionRepresenter
 

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -37,7 +38,9 @@ module API
           private
 
           def filter_query
-            params = [{ status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
+            params = [{ status: { operator: '!',
+                                  values: [Principal::STATUSES[:builtin].to_s,
+                                           Principal::STATUSES[:locked].to_s] } }]
 
             unless Setting.work_package_group_assignment?
               params << { type: { operator: '=', values: ['User'] } }

--- a/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -37,8 +38,11 @@ module API
           private
 
           def filter_query
-            params = [{ type: { operator: '=', values: ['User'] } },
-                      { status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
+            params = [{ type: { operator: '=',
+                                values: ['User'] } },
+                      { status: { operator: '!',
+                                  values: [Principal::STATUSES[:builtin].to_s,
+                                           Principal::STATUSES[:locked].to_s] } }]
 
             if filter.context
               params << { member: { operator: '=', values: [filter.context.id.to_s] } }

--- a/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
@@ -73,7 +73,7 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
 
         context 'within a project with group assignment' do
           let(:filter_query) do
-            [{ status: { operator: '=', values: ['1'] } },
+            [{ status: { operator: '!', values: ['0', '3'] } },
              { member: { operator: '=', values: [project.id.to_s] } }]
           end
           let(:group_assignment_enabled) { true }
@@ -93,7 +93,7 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
 
         context 'within a project without group assignment' do
           let(:filter_query) do
-            [{ status: { operator: '=', values: ['1'] } },
+            [{ status: { operator: '!', values: ['0', '3'] } },
              { type: { operator: '=', values: ['User'] } },
              { member: { operator: '=', values: [project.id.to_s] } }]
           end
@@ -114,7 +114,7 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
         context 'global with no group assignments' do
           let(:project) { nil }
           let(:filter_query) do
-            [{ status: { operator: '=', values: ['1'] } },
+            [{ status: { operator: '!', values: ['0', '3'] } },
              { type: { operator: '=', values: ['User'] } },
              { member: { operator: '*', values: [] } }]
           end
@@ -135,7 +135,7 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
         context 'global with group assignments' do
           let(:project) { nil }
           let(:filter_query) do
-            [{ status: { operator: '=', values: ['1'] } },
+            [{ status: { operator: '!', values: ['0', '3'] } },
              { member: { operator: '*', values: [] } }]
           end
           let(:group_assignment_enabled) { true }

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -50,7 +50,7 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
         let(:type) { '[]User' }
         let(:filter_query) do
           [{ type: { operator: '=', values: ['User'] } },
-           { status: { operator: '=', values: ['1'] } },
+           { status: { operator: '!', values: ['0', '3'] } },
            { member: { operator: '=', values: [project.id.to_s] } }]
         end
         let(:href) do
@@ -73,7 +73,7 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
           let(:project) { nil }
           let(:filter_query) do
             [{ type: { operator: '=', values: ['User'] } },
-             { status: { operator: '=', values: ['1'] } }]
+             { status: { operator: '!', values: ['0', '3'] } }]
           end
 
           context "for operator 'Queries::Operators::Equals'" do

--- a/spec/models/queries/work_packages/filter/principal_loader_spec.rb
+++ b/spec/models/queries/work_packages/filter/principal_loader_spec.rb
@@ -73,6 +73,7 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
   context 'without a project' do
     let(:project) { nil }
     let(:visible_projects) { [FactoryGirl.build_stubbed(:project)] }
+    let(:matching_principals) { [user_1, group_1] }
 
     before do
       allow(Project)
@@ -80,9 +81,9 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
         .and_return visible_projects
 
       allow(Principal)
-        .to receive_message_chain(:active, :in_project)
+        .to receive_message_chain(:active_or_registered, :in_project)
         .with(visible_projects)
-        .and_return([user_1, group_1])
+        .and_return(matching_principals)
     end
 
     describe '#user_values' do
@@ -90,13 +91,12 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
         expect(instance.user_values).to match_array([[user_1.name, user_1.id.to_s]])
       end
 
-      it 'is empty if no user exists' do
-        allow(Principal)
-          .to receive_message_chain(:active, :in_project)
-          .with(visible_projects)
-          .and_return([group_1])
+      context 'no user exists' do
+        let(:matching_principals) { [group_1] }
 
-        expect(instance.user_values).to be_empty
+        it 'is empty' do
+          expect(instance.user_values).to be_empty
+        end
       end
     end
 
@@ -105,13 +105,12 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
         expect(instance.group_values).to match_array([[group_1.name, group_1.id.to_s]])
       end
 
-      it 'is empty if no group exists' do
-        allow(Principal)
-          .to receive_message_chain(:active, :in_project)
-          .with(visible_projects)
-          .and_return([user_1])
+      context 'no group exists' do
+        let(:matching_principals) { [user_1] }
 
-        expect(instance.group_values).to be_empty
+        it 'is empty' do
+          expect(instance.group_values).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
* allows active, registered and invited users to be used as filter values (e.g. assigned to, responsible) 
https://community.openproject.com/projects/openproject/work_packages/25081
* returns the values of the principals.api sorted by name which results in the filter values being sorted.