### PR TITLE
Fix/subproject default setting filtering

### DIFF
--- a/app/controllers/work_packages/calendars_controller.rb
+++ b/app/controllers/work_packages/calendars_controller.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -37,34 +38,14 @@ class WorkPackages::CalendarsController < ApplicationController
   include SortHelper
 
   def index
-    if params[:year] and params[:year].to_i > 1900
-      @year = params[:year].to_i
-      if params[:month] and params[:month].to_i > 0 and params[:month].to_i < 13
-        @month = params[:month].to_i
-      end
-    end
-    @year ||= Date.today.year
-    @month ||= Date.today.month
+    @year, @month = set_timeframe(params)
 
-    @calendar = Redmine::Helpers::Calendar.new(Date.civil(@year, @month, 1), current_language, :month)
+    @calendar = new_calendar(@year, @month)
+
     retrieve_query
     @query.group_by = nil
-    if @query.valid?
-      events = @query.results(
-        conditions: [
-          "((#{WorkPackage.table_name}.start_date BETWEEN ? AND ?) OR
-            (#{WorkPackage.table_name}.due_date BETWEEN ? AND ?))",
-          @calendar.startdt, @calendar.enddt,
-          @calendar.startdt, @calendar.enddt
-        ]).work_packages
-      events += @query.results(conditions: [
-        "#{Version.table_name}.effective_date BETWEEN ? AND ?",
-        @calendar.startdt,
-        @calendar.enddt
-      ]).versions
 
-      @calendar.events = events
-    end
+    @calendar.events = events_in_timeframe_and_filter(@query, @calendar)
 
     render layout: !request.xhr?
   end
@@ -73,5 +54,65 @@ class WorkPackages::CalendarsController < ApplicationController
 
   def default_breadcrumb
     l(:label_calendar)
+  end
+
+  def events_in_timeframe_and_filter(query, calendar)
+    if query.valid?
+      events = work_packages_in_timeframe(query, calendar)
+
+      events += versions_in_timeframe(query, calendar)
+
+      events
+    else
+      []
+    end
+  end
+
+  def work_packages_in_timeframe(query, calendar)
+    query.results(
+      conditions: [
+        "((#{WorkPackage.table_name}.start_date BETWEEN ? AND ?) OR
+          (#{WorkPackage.table_name}.due_date BETWEEN ? AND ?))",
+        calendar.startdt, calendar.enddt,
+        calendar.startdt, calendar.enddt
+      ]
+    ).work_packages
+  end
+
+  def versions_in_timeframe(query, calendar)
+    query.results(
+      conditions: [
+        "#{Version.table_name}.effective_date BETWEEN ? AND ?",
+        calendar.startdt,
+        calendar.enddt
+      ]
+    ).versions
+  end
+
+  def set_timeframe(params)
+    if valid_year_string?(params[:year])
+      year = params[:year].to_i
+
+      if valid_month_string?(params[:month])
+        month = params[:month].to_i
+      end
+    end
+
+    year ||= Date.today.year
+    month ||= Date.today.month
+
+    [year, month]
+  end
+
+  def valid_year_string?(year)
+    year && year.to_i > 1900
+  end
+
+  def valid_month_string?(month)
+    month && month.to_i > 0 && month.to_i < 13
+  end
+
+  def new_calendar(year, month)
+    Redmine::Helpers::Calendar.new(Date.civil(year, month, 1), current_language, :month)
   end
 end

--- a/app/models/queries/available_filters.rb
+++ b/app/models/queries/available_filters.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/role_filter.rb
+++ b/app/models/queries/work_packages/filter/role_filter.rb
@@ -92,7 +92,7 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   def user_ids_for_filtering
     scope = if ['*', '!*'].include?(operator)
               user_ids_for_filtering_scope
-            elsif context
+            elsif project
               user_ids_for_filter_project_scope
             else
               user_ids_for_filter_non_project_scope
@@ -109,7 +109,7 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   def user_ids_for_filter_project_scope
     user_ids_for_filtering_scope
       .where(id: values)
-      .where(members: { project_id: context.id })
+      .where(members: { project_id: project.id })
   end
 
   def user_ids_for_filter_non_project_scope

--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -71,6 +72,20 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
     value_ints = values.map(&:to_i)
 
     visible_subprojects.select { |p| value_ints.include?(p.id) }
+  end
+
+  def where
+    ids = [project.id]
+
+    case operator
+    when '='
+      # include the selected subprojects
+      ids += values.each(&:to_i)
+    when '*'
+      ids += project.descendants.pluck(:id)
+    end
+
+    "#{Project.table_name}.id IN (%s)" % ids.join(',')
   end
 
   private

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -46,8 +46,9 @@ class Queries::WorkPackages::Filter::WorkPackageFilter < ::Queries::Filters::Bas
     WorkPackage.human_attribute_name(name)
   end
 
-  alias :project :context
-  alias :project= :context=
+  def project
+    context.project
+  end
 
   def attributes
     { name: name, operator: operator, values: values }

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -231,14 +231,6 @@ class Query < ActiveRecord::Base
     end
   end
 
-  def editable_by?(user)
-    return false unless user
-    # Admin can edit them all and regular users can edit their private queries
-    return true if user.admin? || (!is_public && user_id == user.id)
-    # Members can not edit public queries that are for all project (only admin is allowed to)
-    is_public && !for_all? && user.allowed_to?(:manage_public_queries, project)
-  end
-
   def add_filter(field, operator, values)
     filter = filter_for(field)
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -55,13 +55,11 @@ class ::Query::Results
   # Returns the work package count by group or nil if query is not grouped
   def work_package_count_by_group
     @work_package_count_by_group ||= begin
-      r = nil
       if query.grouped?
         r = groups_grouped_by_column(query)
 
-        r = transform_group_keys(query, r)
+        transform_group_keys(query, r)
       end
-      r
     end
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -56,9 +56,9 @@ class ::Query::Results
   def work_package_count_by_group
     @work_package_count_by_group ||= begin
       if query.grouped?
-        r = groups_grouped_by_column(query)
+        r = groups_grouped_by_column
 
-        transform_group_keys(query, r)
+        transform_group_keys(r)
       end
     end
   rescue ::ActiveRecord::StatementInvalid => e
@@ -75,7 +75,8 @@ class ::Query::Results
 
     WorkPackage
       .visible
-      .where(::Query.merge_conditions(query.statement, options[:conditions]))
+      .where(query.statement)
+      .where(options[:conditions])
       .includes(includes)
       .joins((query.group_by_column ? query.group_by_column.join : nil))
       .order(order_option)
@@ -91,11 +92,15 @@ class ::Query::Results
   end
 
   def versions
-    Version
-      .visible
-      .where(::Query.merge_conditions(query.project_statement, options[:conditions]))
-  rescue ::ActiveRecord::StatementInvalid => e
-    raise ::Query::StatementInvalid.new(e.message)
+    scope = Version
+            .visible
+            .where(options[:conditions])
+
+    if query.project
+      scope.where(query.project_limiting_filter.where)
+    end
+
+    scope
   end
 
   def column_total_sums
@@ -151,20 +156,20 @@ class ::Query::Results
     name.to_s =~ /\Acf_\d+\z/
   end
 
-  def groups_grouped_by_column(query)
+  def groups_grouped_by_column
     # Rails will raise an (unexpected) RecordNotFound if there's only a nil group value
     WorkPackage
       .group(query.group_by_statement)
       .visible
       .includes(:status, :project)
-      .where(query.statement)
       .references(:statuses, :projects)
+      .where(query.statement)
       .count
   rescue ActiveRecord::RecordNotFound
     { nil => work_package_count }
   end
 
-  def transform_group_keys(query, groups)
+  def transform_group_keys(groups)
     column = query.group_by_column
 
     if column.is_a?(QueryCustomFieldColumn) && column.custom_field.list?

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -107,7 +107,7 @@ class WorkPackage < ActiveRecord::Base
   }
 
   scope :with_query, ->(query) {
-    where(::Query.merge_conditions(query.statement))
+    where(query.statement)
   }
 
   scope :with_author, ->(author) {
@@ -854,12 +854,13 @@ class WorkPackage < ActiveRecord::Base
   def self.update_versions(conditions = nil)
     # Only need to update issues with a fixed_version from
     # a different project and that is not systemwide shared
-    WorkPackage.where(
-      merge_conditions(
+    WorkPackage
+      .where(
         "#{WorkPackage.table_name}.fixed_version_id IS NOT NULL" +
         " AND #{WorkPackage.table_name}.project_id <> #{Version.table_name}.project_id" +
-        " AND #{Version.table_name}.sharing <> 'system'",
-        conditions))
+        " AND #{Version.table_name}.sharing <> 'system'"
+      )
+      .where(conditions)
       .includes(:project, :fixed_version)
       .references(:versions).each do |issue|
       next if issue.project.nil? || issue.fixed_version.nil?

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -41,11 +42,11 @@ module Concerns::Contracted
 
     def validate_and_save(object)
       if !contract.validate
-        return false, contract.errors
+        [false, contract.errors]
       elsif !object.save
-        return false, object.errors
+        [false, object.errors]
       else
-        return true, object.errors
+        [true, object.errors]
       end
     end
   end

--- a/app/services/queries/create_query_service.rb
+++ b/app/services/queries/create_query_service.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -268,22 +268,6 @@ ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
 end
 
 module ActiveRecord
-  class Base
-    # active record 2.3 backport, was removed in 3.0, only used in Query
-    def self.merge_conditions(*conditions)
-      segments = []
-
-      conditions.each do |condition|
-        unless condition.blank?
-          sql = sanitize_sql(condition)
-          segments << sql unless sql.blank?
-        end
-      end
-
-      "(#{segments.join(') AND (')})" unless segments.empty?
-    end
-  end
-
   class Errors
     #  def on_with_id_handling(attribute)
     #    attribute = attribute.to_s

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -57,7 +57,7 @@ module API
           end
 
           get do
-            authorize_any [:view_work_packages, :manage_public_queries], global: true
+            authorize_any %i(view_work_packages manage_public_queries), global: true
 
             queries_scope = Query.all.includes(QueryRepresenter.to_eager_load)
 

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -44,8 +44,8 @@ module API
               params << { type: { operator: '=', values: ['User'] } }
             end
 
-            params << if filter.context
-                        { member: { operator: '=', values: [filter.context.id.to_s] } }
+            params << if filter.project
+                        { member: { operator: '=', values: [filter.project.id.to_s] } }
                       else
                         { member: { operator: '*', values: [] } }
                       end

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -37,7 +37,7 @@ module API
 
           def href_callback
             # This filter is only available inside projects
-            api_v3_paths.categories(filter.context.identifier)
+            api_v3_paths.categories(filter.project.identifier)
           end
 
           def type

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -40,8 +40,8 @@ module API
           def filter_query
             params = [{ type: { operator: '=', values: ['Group'] } }]
 
-            params << if filter.context
-                        { member: { operator: '=', values: [filter.context.id.to_s] } }
+            params << if filter.project
+                        { member: { operator: '=', values: [filter.project.id.to_s] } }
                       else
                         { member: { operator: '*', values: [] } }
                       end

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -212,8 +212,8 @@ module API
           end
 
           def filter_instance_schemas_href
-            if represented.context
-              api_v3_paths.query_project_filter_instance_schemas(represented.context.id)
+            if represented.project
+              api_v3_paths.query_project_filter_instance_schemas(represented.project.id)
             else
               api_v3_paths.query_filter_instance_schemas
             end

--- a/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
@@ -35,7 +35,7 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            params = [ancestor: { operator: '=', values: [filter.context.id.to_s] }]
+            params = [ancestor: { operator: '=', values: [filter.project.id.to_s] }]
             escaped = CGI.escape(::JSON.dump(params))
 
             "#{api_v3_paths.projects}?filters=#{escaped}"

--- a/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
@@ -35,10 +35,10 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            if filter.context.nil?
+            if filter.project.nil?
               api_v3_paths.types
             else
-              api_v3_paths.types_by_project(filter.context.id)
+              api_v3_paths.types_by_project(filter.project.id)
             end
           end
 

--- a/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
@@ -40,8 +40,8 @@ module API
             params = [{ type: { operator: '=', values: ['User'] } },
                       { status: { operator: '=', values: [Principal::STATUSES[:active].to_s] } }]
 
-            if filter.context
-              params << { member: { operator: '=', values: [filter.context.id.to_s] } }
+            if filter.project
+              params << { member: { operator: '=', values: [filter.project.id.to_s] } }
             end
 
             params

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -36,12 +36,12 @@ module API
           FilterDependencyRepresenter
 
           def href_callback
-            if filter.context.nil?
+            if filter.project.nil?
               filter_params = [{ sharing: { operator: '=', values: ['system'] } }]
 
               "#{api_v3_paths.types}?filters=#{CGI.escape(::JSON.dump(filter_params))}"
             else
-              api_v3_paths.versions_by_project(filter.context.id)
+              api_v3_paths.versions_by_project(filter.project.id)
             end
           end
 

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -37,7 +38,7 @@ module API
           before do
             @versions = @project.shared_versions
 
-            authorize_any [:view_work_packages, :manage_versions], projects: @project
+            authorize_any %i(view_work_packages manage_versions), projects: @project
           end
 
           get do

--- a/spec/features/timelines/filter_custom_fields_spec.rb
+++ b/spec/features/timelines/filter_custom_fields_spec.rb
@@ -157,7 +157,7 @@ describe Timeline, 'filtering custom fields', type: :feature, js: true do
     it_behaves_like 'filtering by bool custom field'
   end
 
-  context 'with a global bool custom field' do
+  context 'with a project bool custom field' do
     let(:cf) { bool_cf_local }
     it_behaves_like 'filtering by bool custom field'
   end
@@ -248,7 +248,7 @@ describe Timeline, 'filtering custom fields', type: :feature, js: true do
     it_behaves_like 'filtering by list custom field'
   end
 
-  context 'with a global list custom field' do
+  context 'with a project list custom field' do
     let(:cf) { list_cf_local }
     it_behaves_like 'filtering by list custom field'
   end

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -1,39 +1,112 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
 require 'spec_helper'
 
-describe 'filter by watcher', js: true do
+describe 'filter work packages', js: true do
   let(:user) { FactoryGirl.create :admin }
   let(:watcher) { FactoryGirl.create :user }
   let(:project) { FactoryGirl.create :project }
   let(:role) { FactoryGirl.create :existing_role, permissions: [:view_work_packages] }
-
-  let(:work_packages) { FactoryGirl.create_list :work_package, 10, project: project }
-  let(:watched_wps) { [work_packages[3], work_packages[5], work_packages[7]] }
-
-  let(:wp_table) { ::Pages::WorkPackagesTable.new }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }
 
   before do
     project.add_member! watcher, role
-
-    watched_wps.each_with_index do |wp, i|
-      wp.add_watcher watcher
-      wp.subject = "Watched WP ##{i}"
-      wp.save!
-    end
-
     login_as(user)
-    wp_table.visit!
   end
 
-  # Regression test for bug #24114 (broken watcher filter)
-  it 'should only filter work packages by watcher' do
-    filters.open
-    loading_indicator_saveguard
+  context 'by watchers' do
+    let(:work_package_with_watcher) do
+      wp = FactoryGirl.build :work_package, project: project
+      wp.add_watcher watcher
+      wp.save!
 
-    filters.filter_by_watcher watcher.name
-    loading_indicator_saveguard
+      wp
+    end
+    let(:work_package_without_watcher) { FactoryGirl.create :work_package, project: project }
 
-    expect(wp_table).to have_work_packages_listed watched_wps
-    expect(wp_table).not_to have_work_packages_listed (work_packages - watched_wps)
+    before do
+      work_package_with_watcher
+      work_package_without_watcher
+
+      wp_table.visit!
+    end
+
+    # Regression test for bug #24114 (broken watcher filter)
+    it 'should only filter work packages by watcher' do
+      filters.open
+      loading_indicator_saveguard
+
+      filters.filter_by_watcher watcher.name
+      loading_indicator_saveguard
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_watcher]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_watcher]
+    end
+  end
+
+  context 'by version in project' do
+    let(:version) { FactoryGirl.create :version, project: project }
+    let(:work_package_with_version) { FactoryGirl.create :work_package, project: project, fixed_version: version }
+    let(:work_package_without_version) { FactoryGirl.create :work_package, project: project }
+
+    before do
+      work_package_with_version
+      work_package_without_version
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving the saved filter' do
+      filters.open
+
+      filters.add_filter_by('Version', 'is', version.name)
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_version]
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter 'version'
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version, work_package_without_version]
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_version]
+      expect(wp_table).not_to have_work_packages_listed [work_package_without_version]
+
+      filters.open
+
+      filters.expect_filter_by('Version', 'is', version.name)
+    end
   end
 end

--- a/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::AssignedToFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::AssignedToFilter.new(context: query) }
   let(:form_embedded) { false }
   let(:group_assignment_enabled) { false }
 

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::GroupFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::GroupFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::TypeFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::TypeFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed :project }
-  let(:filter) { Queries::WorkPackages::Filter::AuthorFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::AuthorFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::VersionFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::VersionFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do

--- a/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
@@ -30,11 +30,12 @@ require 'spec_helper'
 
 describe Queries::WorkPackages::Filter::CustomFieldFilter, type: :model do
   let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
   let(:instance) do
     filter = described_class.new
     filter.name = "cf_#{custom_field.id}"
     filter.operator = '='
-    filter.context = project
+    filter.context = query
     filter
   end
   let(:instance_key) { nil }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -205,11 +205,7 @@ describe Query, type: :model do
       end
 
       it 'has the context set' do
-        expect(subject.context).to eql query.project
-
-        query.project = nil
-
-        expect(query.filter_for('status_id').context).to be_nil
+        expect(subject.context).to eql query
       end
 
       it 'reuses an existing filter' do
@@ -224,7 +220,7 @@ describe Query, type: :model do
 
       query.reload
       query.filters.each do |filter|
-        expect(filter.context).to eql(query.project)
+        expect(filter.context).to eql(query)
       end
     end
   end

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -54,6 +54,23 @@ module Components
         select name, from: "values-watcher"
       end
 
+      # limited to select fields for now
+      def add_filter_by(name, operator, value, selector = nil)
+        id = selector || name.downcase
+
+        select name, from: "add_filter_select"
+        select operator, from: "operators-#{id}"
+        select value, from: "values-#{id}"
+      end
+
+      # limited to select fields for now
+      def expect_filter_by(name, operator, value, selector = nil)
+        id = selector || name.downcase
+
+        expect(page).to have_select("operators-#{id}", selected: operator)
+        expect(page).to have_select("values-#{id}", selected: value)
+      end
+
       def remove_filter(field)
         page.within(filters_selector) do
           find("#filter_#{field} .advanced-filters--remove-filter-icon").click

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -138,6 +138,17 @@ module Pages
       find('#settingsDropdown .menu-item', text: label).click
     end
 
+    def save_as(name)
+      click_setting_item 'Save as'
+
+      fill_in 'save-query-name', with: name
+
+      click_button 'Save'
+
+      expect_notification message: 'Successful creation.'
+      expect_title name
+    end
+
     def open_filter_section
       unless page.has_selector?('#work-packages-filter-toggle-button.-active')
         click_button('work-packages-filter-toggle-button')

--- a/spec/support/pages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages_timeline.rb
@@ -27,10 +27,10 @@
 #++
 
 require 'support/pages/page'
+require 'support/pages/work_packages_table'
 
 module Pages
   class WorkPackagesTimeline < WorkPackagesTable
-
     def toggle_timeline
       find('#work-packages-timeline-toggle-button').click
     end

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -44,7 +44,7 @@ end
 shared_examples_for 'basic query filter' do
   include_context 'filter tests'
 
-  let(:context) { project }
+  let(:context) { FactoryGirl.build_stubbed(:query, project: project) }
   let(:project) { FactoryGirl.build_stubbed(:project) }
   let(:instance_key) { nil }
   let(:class_key) { raise 'needs to be defined' }

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,7 +27,7 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Project, type: :model do
   fixtures :all
@@ -880,8 +881,8 @@ describe Project, type: :model do
       # group role
       (Member.new.tap do |m|
         m.attributes = { project_id: @source_project.id,
-                               principal: group,
-                               role_ids: [2] }
+                         principal: group,
+                         role_ids: [2] }
       end).save!
 
       member = Member.find_by(user_id: user.id, project_id: @source_project.id)

--- a/spec_legacy/unit/query_spec.rb
+++ b/spec_legacy/unit/query_spec.rb
@@ -310,9 +310,9 @@ describe Query, type: :model do
     assert c
     assert c.sortable
     issues = WorkPackage.includes(:assigned_to, :status, :type, :project, :priority)
-             .where(q.statement)
-             .order(Array(c.sortable).map { |s| "#{s} ASC" }.join(', '))
-             .references(:projects)
+                        .where(q.statement)
+                        .order(Array(c.sortable).map { |s| "#{s} ASC" }.join(', '))
+                        .references(:projects)
     values = issues.map { |i| i.custom_value_for(c.custom_field).to_s }
     assert !values.empty?
     assert_equal values.sort, values
@@ -355,7 +355,10 @@ describe Query, type: :model do
   end
 
   it 'should issue count by association group' do
-    q = Query.new(name: '_', group_by: 'assigned_to')
+    q = Query.new(name: '_',
+                  group_by: 'assigned_to',
+                  show_hierarchies: false)
+
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     assert_equal %w(NilClass User), count_by_group.keys.map { |k| k.class.name }.uniq.sort
@@ -364,7 +367,10 @@ describe Query, type: :model do
   end
 
   it 'should issue count by list custom field group' do
-    q = Query.new(name: '_', group_by: 'cf_1')
+    q = Query.new(name: '_',
+                  group_by: 'cf_1',
+                  show_hierarchies: false)
+
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     expect(count_by_group.keys.map { |k| k.class.name }.uniq)
@@ -375,7 +381,10 @@ describe Query, type: :model do
   end
 
   it 'should issue count by date custom field group' do
-    q = Query.new(name: '_', group_by: 'cf_8')
+    q = Query.new(name: '_',
+                  group_by: 'cf_8',
+                  show_hierarchies: false)
+
     count_by_group = q.results.work_package_count_by_group
     assert_kind_of Hash, count_by_group
     assert_equal %w(Date NilClass), count_by_group.keys.map { |k| k.class.name }.uniq.sort

--- a/spec_legacy/unit/query_spec.rb
+++ b/spec_legacy/unit/query_spec.rb
@@ -391,36 +391,6 @@ describe Query, type: :model do
     assert_equal %w(Fixnum), count_by_group.values.map { |k| k.class.name }.uniq
   end
 
-  it 'should editable by' do
-    admin = User.find(1)
-    manager = User.find(2)
-    developer = User.find(3)
-
-    # Public query on project 1
-    q = Query.find(1)
-    assert q.editable_by?(admin)
-    assert q.editable_by?(manager)
-    assert !q.editable_by?(developer)
-
-    # Private query on project 1
-    q = Query.find(2)
-    assert q.editable_by?(admin)
-    assert !q.editable_by?(manager)
-    assert q.editable_by?(developer)
-
-    # Private query for all projects
-    q = Query.find(3)
-    assert q.editable_by?(admin)
-    assert !q.editable_by?(manager)
-    assert q.editable_by?(developer)
-
-    # Public query for all projects
-    q = Query.find(4)
-    assert q.editable_by?(admin)
-    assert !q.editable_by?(manager)
-    assert !q.editable_by?(developer)
-  end
-
   context '#filter_for' do
     before do
       @query = Query.new(name: '_')

--- a/spec_legacy/unit/query_spec.rb
+++ b/spec_legacy/unit/query_spec.rb
@@ -337,7 +337,8 @@ describe Query, type: :model do
     c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
     assert c
     assert c.sortable
-    issues = WorkPackage.includes(:assigned_to, :status, :type, :project, :priority)
+    issues = WorkPackage
+             .includes(:assigned_to, :status, :type, :project, :priority)
              .where(q.statement)
              .order(Array(c.sortable).map { |s| "#{s} ASC" }.join(', '))
              .references(:projects)
@@ -369,7 +370,6 @@ describe Query, type: :model do
     expect(count_by_group.keys.map { |k| k.class.name }.uniq)
       .to match_array(%w(CustomOption NilClass))
     assert_equal %w(Fixnum), count_by_group.values.map { |k| k.class.name }.uniq
-    puts count_by_group
     expect(count_by_group.any? { |k, v| k.is_a?(CustomOption) && k.id == 1 && v == 1 })
       .to be_truthy
   end


### PR DESCRIPTION
:warning: 
Includes commits of #5378.
Only the last two commits are unique to this PR.
:warning:

Fixes the effect of the suproject setting
![image](https://cloud.githubusercontent.com/assets/617519/25265766/e4901aca-266e-11e7-88bc-8d72010b33d5.png)
as requested by https://community.openproject.com/projects/openproject/work_packages/25106

It additionally removes code from the query by using the subproject filter just like any other filter with the sole exception of it being added under the hood when the filter has not yet been selected by the user. This is necessary as the work packages have to be scoped to the current project if the query is project related.