### PR TITLE
Do not load schemas within each work package

### DIFF
--- a/frontend/app/components/schemas/schema-cache.service.ts
+++ b/frontend/app/components/schemas/schema-cache.service.ts
@@ -1,0 +1,92 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+import {opWorkPackagesModule} from "../../angular-modules";
+import {State} from "reactivestates";
+import {Observable, Subject} from "rxjs";
+import {WorkPackageResource} from "../api/api-v3/hal-resources/work-package-resource.service";
+import {ApiWorkPackagesService} from "../api/api-work-packages/api-work-packages.service";
+import {States} from "../states.service";
+import { WorkPackageNotificationService } from "./../wp-edit/wp-notification.service";
+import { SchemaResource } from "../api/api-v3/hal-resources/schema-resource.service";
+import IScope = angular.IScope;
+import IPromise = angular.IPromise;
+
+export class SchemaCacheService {
+
+  /*@ngInject*/
+  constructor(private states:States, private $q:ng.IQService) {
+  }
+
+  /**
+   * Ensure the given schema identified by its href is currently loaded.
+   * @param href The schema's href.
+   * @return A promise with the loaded schema.
+   */
+  ensureLoaded(workPackage:WorkPackageResource):PromiseLike<any> {
+    if (workPackage.hasOverriddenSchema) {
+      return this.$q.resolve();
+    }
+
+    const state = this.state(workPackage);
+
+    if (!state.hasValue()) {
+      this.load(workPackage);
+    }
+
+    return state.valuesPromise();
+  }
+
+  /**
+   * Get the associated schema state of the work package
+   *  without initializing a new resource.
+  */
+  state(workPackage:WorkPackageResource) {
+    const schema = workPackage.$links.schema;
+    return this.states.schemas.get(schema.href!);
+  }
+
+  /**
+   * Load the associated schema for the given work package, if needed.
+   */
+  load(workPackage:WorkPackageResource, forceUpdate = false):State<SchemaResource> {
+    const state = this.state(workPackage);
+
+    if (forceUpdate) {
+      state.clear();
+    }
+
+    state.putFromPromiseIfPristine(() => {
+      const resource = workPackage.createLinkedResource('schema', workPackage.$links.schema.$link);
+      return resource.$load();
+    });
+
+    return state;
+  }
+}
+
+opWorkPackagesModule.service('schemaCacheService', SchemaCacheService);

--- a/frontend/app/components/work-packages/work-package-cache.service.test.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.test.ts
@@ -40,11 +40,13 @@ describe('WorkPackageCacheService', () => {
 
   beforeEach(angular.mock.module('openproject'));
 
-  beforeEach(angular.mock.inject((_$q_:any, _$rootScope_:any, _wpCacheService_:any, _WorkPackageResource_:any) => {
+  beforeEach(angular.mock.inject((_$q_:any, _$rootScope_:any, _wpCacheService_:any, _WorkPackageResource_:any, schemaCacheService:any) => {
     $rootScope = _$rootScope_;
     $q = _$q_;
     wpCacheService = _wpCacheService_;
     WorkPackageResource = _WorkPackageResource_;
+
+    sinon.stub(schemaCacheService, 'ensureLoaded').returns($q.when(true));
 
     // dummy 1
     const workPackage1 = new _WorkPackageResource_({
@@ -53,10 +55,6 @@ describe('WorkPackageCacheService', () => {
         self: ""
       }
     });
-    workPackage1.schema = {
-      '$load': () => { return $q.when(true) }
-    };
-
 
     dummyWorkPackages = [workPackage1];
   }));
@@ -94,9 +92,6 @@ describe('WorkPackageCacheService', () => {
     let expected = 0;
     let workPackage: any = new WorkPackageResource({id: '1', _links: {self: ""}});
     workPackage.dummy = 0;
-    workPackage.schema = {
-      '$load': () => { return $q.when(true) }
-    };
 
     wpCacheService.updateWorkPackageList([workPackage]);
     $rootScope.$apply();

--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.test.ts
@@ -96,6 +96,7 @@ describe('wpDisplayAttr directive', () => {
         customField1: 'asdf1234',
         emptyField: null,
         hiddenField: 'foobar',
+        hasOverriddenSchema: true,
         schema: {
           "$load": () => $q.when(true),
           "_type": "Schema",


### PR DESCRIPTION
Currently, schemas have a very special role in each work package:

- It is turned into a HAL resource during initialization, but not loaded immediately if it exists. A newly created work package always has `schema.$loaded == false`, even though the schema MAY be loaded already

- Upon updating work packages through the cache service, it's `$loaded` state is checked and the schema is forcefully loaded to the work package via `$load`, which in turn accesses the schema state. **This will always call `$initialize` on the schema resource due to the way the HAL resource is loaded** [code reference](https://github.com/opf/openproject/blob/dev/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts#L127), and thus introduce some overhead to initialize the 'new' resource

- The schema **may** be overridden due to the form being loaded. This is required since changing, e.g., the type before saving results causes new fields to be visible and in turn, a new schema being required.

This PR suggests to address two of these points

1. Let the work package explicitly override the schema when the form is active, and reset that overridden value upon saving the WP. If no overridden schema is used, `get schema()` returns the state value and assumes it exists.

2. Introduce a `schemaCacheService` to alleviate loading a schema resource and making sure the work package has a schema (either a value in the state, or an overridden schema).

I did not address the problem of ensuring that values in `states.workPackages` always have a loaded schema, but I believe this can be solved through a dependent state in a separate PR.