### PR TITLE
[25127] Don't reload list if query was initialized before

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -340,8 +340,9 @@ function initializeResource(halResource:HalResource) {
   function setter(val:HalResource, linkName:string) {
     if (!val) {
       halResource.$source._links[linkName] = {href: null};
-    }
-    else if (val.$link) {
+    } else if (_.isArray(val)) {
+      halResource.$source._links[linkName] = val.map((el:any) => { return {href: el.href} });
+    } else if (val.$link) {
       const link = val.$link;
 
       if (link.href) {

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -72,7 +72,9 @@ function WorkPackagesListController($scope:any,
   function initialSetup() {
     setupObservers();
 
-    loadQuery();
+    if (wpListChecksumService.isUninitialized()) {
+      loadQuery();
+    }
   }
 
   function setupObservers() {

--- a/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
@@ -50,8 +50,6 @@ export abstract class WorkPackageTableBaseService {
     return this.states.table[this.stateName];
   };
 
-
-
   public observeOnScope(scope:ng.IScope) {
     return scopedObservable(scope, this.state.values$());
   }

--- a/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
@@ -28,7 +28,7 @@
 
 import {InputState} from "reactivestates";
 import {States} from "../../states.service";
-import {WorkPackageTableBaseInterface} from "../wp-table-base";
+import {WorkPackageTableBaseState} from "../wp-table-base";
 import {scopedObservable} from "../../../helpers/angular-rx-utils";
 import {Observable} from 'rxjs';
 
@@ -46,9 +46,11 @@ export abstract class WorkPackageTableBaseService {
   constructor(protected states: States) {
   }
 
-  protected get state(): InputState<WorkPackageTableBaseInterface> {
+  protected get state(): InputState<any> {
     return this.states.table[this.stateName];
   };
+
+
 
   public observeOnScope(scope:ng.IScope) {
     return scopedObservable(scope, this.state.values$());

--- a/frontend/app/components/wp-fast-table/state/wp-table-columns.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-columns.service.ts
@@ -38,7 +38,7 @@ import {WPTableRowSelectionState} from '../wp-table.interfaces';
 import {QueryColumn} from '../../api/api-v3/hal-resources/query-resource.service'
 import {Observable} from 'rxjs/Observable';
 import {WorkPackageTableColumns} from '../wp-table-columns'
-import {WorkPackageTableBaseInterface} from '../wp-table-base';
+import {WorkPackageTableBaseState} from '../wp-table-base';
 import {QueryResource} from '../../api/api-v3/hal-resources/query-resource.service';
 import {QuerySchemaResourceInterface} from '../../api/api-v3/hal-resources/query-schema-resource.service';
 

--- a/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -40,6 +40,8 @@ import {CollectionResource} from '../../api/api-v3/hal-resources/collection-reso
 import {opServicesModule} from '../../../angular-modules';
 import {States} from '../../states.service';
 import {WorkPackageTableFilters} from '../wp-table-filters';
+import {WorkPackageTableBaseState} from "../wp-table-base";
+import {HalResource} from "../../api/api-v3/hal-resources/hal-resource.service";
 
 export class WorkPackageTableFiltersService extends WorkPackageTableBaseService {
   protected stateName = 'filters' as TableStateStates;

--- a/frontend/app/components/wp-fast-table/state/wp-table-pagination.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-pagination.service.ts
@@ -38,7 +38,7 @@ import {
 } from '../../api/api-v3/hal-resources/query-resource.service';
 import {WorkPackageTablePagination} from '../wp-table-pagination';
 import {
-  WorkPackageTableBaseInterface,
+  WorkPackageTableBaseState,
 } from '../wp-table-base';
 
 interface PaginationUpdateObject {

--- a/frontend/app/components/wp-fast-table/wp-table-base.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-base.ts
@@ -26,6 +26,22 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-export interface WorkPackageTableBaseInterface {
-  current:any
+export class WorkPackageTableBaseState<T> {
+
+  /**
+   * Extract the current value from this state and pass it through the comparer function.
+   */
+  public get extractedCompareValue():any {
+    return this.current && this.comparerFunction()(this.current);
+  }
+
+  /**
+   * Returns a comparer function for this state's value used to compare state values,
+   * e.g., as a distinctUntilChanged() key function.
+   */
+  public comparerFunction():(current:T) => any {
+    return (current: T) => current;
+  }
+
+  public current:T;
 }

--- a/frontend/app/components/wp-fast-table/wp-table-columns.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-columns.ts
@@ -30,8 +30,9 @@ import {QueryColumn} from '../api/api-v3/hal-resources/query-resource.service'
 import {QueryResource} from '../api/api-v3/hal-resources/query-resource.service'
 import {QuerySchemaResourceInterface} from '../api/api-v3/hal-resources/query-schema-resource.service'
 import {Observable} from 'rxjs/Observable';
+import {WorkPackageTableBaseState} from "./wp-table-base";
 
-export class WorkPackageTableColumns {
+export class WorkPackageTableColumns extends WorkPackageTableBaseState<QueryColumn[]> {
 
   // Available columns
   public available:QueryColumn[]|undefined;
@@ -40,6 +41,7 @@ export class WorkPackageTableColumns {
   public current:QueryColumn[];
 
   constructor(query:QueryResource, schema?:QuerySchemaResourceInterface) {
+    super();
     this.update(query, schema);
   }
 

--- a/frontend/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-filters.ts
@@ -35,6 +35,7 @@ import {
 import {QueryResource} from '../api/api-v3/hal-resources/query-resource.service';
 import {QuerySchemaResourceInterface} from '../api/api-v3/hal-resources/query-schema-resource.service';
 import {QueryFilterInstanceSchemaResource} from '../api/api-v3/hal-resources/query-filter-instance-schema-resource.service';
+import {HalResource} from "../api/api-v3/hal-resources/hal-resource.service";
 
 export class WorkPackageTableFilters {
   public availableSchemas:QueryFilterInstanceSchemaResource[] = [];

--- a/frontend/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-filters.ts
@@ -36,12 +36,18 @@ import {QueryResource} from '../api/api-v3/hal-resources/query-resource.service'
 import {QuerySchemaResourceInterface} from '../api/api-v3/hal-resources/query-schema-resource.service';
 import {QueryFilterInstanceSchemaResource} from '../api/api-v3/hal-resources/query-filter-instance-schema-resource.service';
 import {HalResource} from "../api/api-v3/hal-resources/hal-resource.service";
+import {WorkPackageTableBaseState} from "./wp-table-base";
 
-export class WorkPackageTableFilters {
+export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilterInstanceResource[]> {
   public availableSchemas:QueryFilterInstanceSchemaResource[] = [];
   public current:QueryFilterInstanceResource[] = [];
 
+  public comparerFunction():(current:QueryFilterInstanceResource[]) => any {
+    return (current:QueryFilterInstanceResource[]) => current.map((el:HalResource) => el.$plain());
+  }
+
   constructor(filters:QueryFilterInstanceResource[], schema:QuerySchemaResourceInterface) {
+    super();
     this.current = filters;
     this.availableSchemas = schema
                             .filtersSchemas

--- a/frontend/app/components/wp-fast-table/wp-table-group-by.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-group-by.ts
@@ -32,12 +32,18 @@ import {
   QueryColumn
 } from '../api/api-v3/hal-resources/query-resource.service';
 import {QuerySchemaResourceInterface} from '../api/api-v3/hal-resources/query-schema-resource.service';
+import {WorkPackageTableBaseState} from "./wp-table-base";
 
-export class WorkPackageTableGroupBy {
+export class WorkPackageTableGroupBy extends WorkPackageTableBaseState<QueryGroupByResource | undefined> {
   public available:QueryGroupByResource[] = [];
   public current:QueryGroupByResource | undefined;
 
+  public comparerFunction():(current:QueryGroupByResource|undefined) => any {
+    return (current:QueryGroupByResource) => current && current.href;
+  }
+
   constructor(query:QueryResource, schema?:QuerySchemaResourceInterface) {
+    super();
     this.current = angular.copy(query.groupBy);
 
     if (schema) {

--- a/frontend/app/components/wp-fast-table/wp-table-hierarchies.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-hierarchies.ts
@@ -26,11 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-export class WorkPackageTableHierarchies {
+import {WorkPackageTableBaseState} from "./wp-table-base";
+export class WorkPackageTableHierarchies extends WorkPackageTableBaseState<boolean> {
   public current:boolean;
   public collapsed:{[workPackageId:string]:boolean};
 
   constructor(isVisible:boolean) {
+    super();
     this.current = isVisible;
     this.collapsed = {};
   }

--- a/frontend/app/components/wp-fast-table/wp-table-pagination.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-pagination.ts
@@ -27,12 +27,14 @@
 // ++
 
 import {WorkPackageCollectionResource} from '../api/api-v3/hal-resources/wp-collection-resource.service'
+import {WorkPackageTableBaseState} from "./wp-table-base";
 
-export class WorkPackageTablePaginationObject {
+export class WorkPackageTablePaginationObject extends WorkPackageTableBaseState<WorkPackageTablePagination> {
   constructor(public page:number,
               public perPage:number,
               public total:number,
               public count:number) {
+    super();
   }
 }
 

--- a/frontend/app/components/wp-fast-table/wp-table-sort-by.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-sort-by.ts
@@ -36,14 +36,21 @@ import {
   QueryColumn
 } from '../api/api-v3/hal-resources/query-resource.service';
 import {QuerySchemaResourceInterface} from '../api/api-v3/hal-resources/query-schema-resource.service';
+import {WorkPackageTableBaseState} from "./wp-table-base";
+import {HalResource} from "../api/api-v3/hal-resources/hal-resource.service";
 
-export class WorkPackageTableSortBy {
+export class WorkPackageTableSortBy extends WorkPackageTableBaseState<QuerySortByResource[]> {
   public available: QuerySortByResource[] = [];
   public current:QuerySortByResource[] = [];
 
   constructor(query:QueryResource, schema:QuerySchemaResourceInterface) {
+    super();
     this.current = angular.copy(query.sortBy);
     this.available = angular.copy(schema.sortBy.allowedValues as QuerySortByResource[]);
+  }
+
+  public comparerFunction():(current:QuerySortByResource[]) => any {
+    return (current:QuerySortByResource[]) => current.map((el:HalResource) => el.href);
   }
 
   public addCurrent(sortBy:QuerySortByResource) {

--- a/frontend/app/components/wp-fast-table/wp-table-sum.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-sum.ts
@@ -26,10 +26,12 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-export class WorkPackageTableSum {
+import {WorkPackageTableBaseState} from "./wp-table-base";
+export class WorkPackageTableSum extends WorkPackageTableBaseState<boolean> {
   public current:boolean;
 
   constructor(isSum:boolean) {
+    super();
     this.current = isSum;
   }
 

--- a/frontend/app/components/wp-fast-table/wp-table-timeline-visible.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-timeline-visible.ts
@@ -26,10 +26,12 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-export class WorkPackageTableTimelineVisible {
+import {WorkPackageTableBaseState} from "./wp-table-base";
+export class WorkPackageTableTimelineVisible extends WorkPackageTableBaseState<boolean> {
   public current:boolean;
 
   constructor(isVisible:boolean) {
+    super();
     this.current = isVisible;
   }
 

--- a/frontend/app/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/app/components/wp-list/wp-list-checksum.service.ts
@@ -93,7 +93,7 @@ export class WorkPackagesListChecksumService {
     this.visibleChecksum = null;
   }
 
-  private isUninitialized() {
+  public isUninitialized() {
     return !this.id && !this.checksum;
   }
 


### PR DESCRIPTION
When moving from show to list, the list controller is reinitialized
and the list is reloaded through `loadQuery()`.

We can bypass this by simply checking whether the query has ever been
checked by the checksum service. Since the query observers are still
registered, changes to the query are still caught.

https://community.openproject.com/work_packages/25127/activity