### PR TITLE
Fix/prevent empty string column names

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -348,16 +348,17 @@ class Query < ActiveRecord::Base
   end
 
   def column_names=(names)
-    if names.present?
-      names = names.inject([]) { |out, e| out += e.to_s.split(',') }
-      names = names.select { |n| n.is_a?(Symbol) || !n.blank? }
-      names = names.map { |n| n.is_a?(Symbol) ? n : n.to_sym }
-      # Set column_names to nil if default columns
-      if names.map(&:to_s) == Setting.work_package_list_default_columns
-        names = nil
-      end
+    col_names = Array(names)
+                .reject(&:blank?)
+                .map(&:to_sym)
+
+    # Set column_names to blank/nil if default columns
+    if (col_names.map(&:to_s) - Setting.work_package_list_default_columns).empty? &&
+       (Setting.work_package_list_default_columns - col_names.map(&:to_s)).empty?
+      col_names.clear
     end
-    write_attribute(:column_names, names)
+
+    write_attribute(:column_names, col_names)
   end
 
   def has_column?(column)

--- a/db/migrate/20170421071136_set_empty_columns_to_null.rb
+++ b/db/migrate/20170421071136_set_empty_columns_to_null.rb
@@ -1,0 +1,5 @@
+class SetEmptyColumnsToNull < ActiveRecord::Migration[5.0]
+  def up
+    Query.where("column_names = ''").update_all(column_names: nil)
+  end
+end


### PR DESCRIPTION
Apparently because of the 
```
if names.present?
 < do some useful stuff >
end

write_attribute(:column_names, names)
```

a lot of queries end up having `''` as their value for the column_names attribute.

Those queries throw a ruby error on validation.