### PR TITLE
Feature #25066 Add link to work package list

### DIFF
--- a/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
@@ -105,8 +105,8 @@ function SettingsDropdownMenuController($scope:IMyScope,
   let form = states.table.form.value!;
   let query = states.table.query.value!;
 
-  if (query.customFields) {
-    $scope.queryCustomFields = query.customFields;
+  if (query.results && query.results.customFields) {
+    $scope.queryCustomFields = query.results.customFields;
   }
 
   $scope.saveQuery = function (event:JQueryEventObject) {

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
@@ -105,6 +105,10 @@ function SettingsDropdownMenuController($scope:IMyScope,
   let form = states.table.form.value!;
   let query = states.table.query.value!;
 
+  if (query.customFields) {
+    $scope.queryCustomFields = query.customFields;
+  }
+
   $scope.saveQuery = function (event:JQueryEventObject) {
     event.stopPropagation();
     if (!query.id && allowQueryAction(event, 'updateImmediately')) {

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
@@ -72,5 +72,9 @@
            ng-class="{'inactive': showSettingsModalInvalid()}">
       <i class="icon-action-menu icon-settings"></i>{{ I18n.t('js.toolbar.settings.page_settings') }}</a>
     </li>
+    <li class="dropdown-divider" ng-if="queryCustomFields"></li>
+    <li><a class="menu-item" href="{{queryCustomFields.href}}" ng-if="queryCustomFields">
+      <i class="icon-action-menu icon-custom-fields"></i>{{ queryCustomFields.name }}</a>
+    </li>
   </ul>
 </div>

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -164,6 +164,14 @@ module API
           }
         end
 
+        link :customFields do
+          {
+            href: settings_project_path(represented.project.identifier, tab: 'custom_fields'),
+            type: 'text/html',
+            title: I18n.t('label_custom_field_plural')
+          } if current_user_allowed_to(:edit_project, context: represented.project)
+        end
+
         linked_property :user
         linked_property :project
 

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -164,14 +164,6 @@ module API
           }
         end
 
-        link :customFields do
-          {
-            href: settings_project_path(represented.project.identifier, tab: 'custom_fields'),
-            type: 'text/html',
-            title: I18n.t('label_custom_field_plural')
-          } if current_user_allowed_to(:edit_project, context: represented.project)
-        end
-
         linked_property :user
         linked_property :project
 

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -102,6 +102,14 @@ module API
           } if represented.any?
         end
 
+        link :customFields do
+          {
+            href: settings_project_path(project.identifier, tab: 'custom_fields'),
+            type: 'text/html',
+            title: I18n.t('label_custom_field_plural')
+          } if current_user.try(:admin?) || (project.present? && current_user_allowed_to(:edit_project, context: project))
+        end
+
         links :representations do
           representation_formats if current_user.allowed_to?(:export_work_packages, project, global: project.nil?)
         end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -103,11 +103,14 @@ module API
         end
 
         link :customFields do
-          {
-            href: settings_project_path(project.identifier, tab: 'custom_fields'),
-            type: 'text/html',
-            title: I18n.t('label_custom_field_plural')
-          } if current_user.try(:admin?) || (project.present? && current_user_allowed_to(:edit_project, context: project))
+          if project.present? &&
+              (current_user.try(:admin?) || current_user_allowed_to(:edit_project, context: project))
+            {
+              href: settings_project_path(project.identifier, tab: 'custom_fields'),
+              type: 'text/html',
+              title: I18n.t('label_custom_field_plural')
+            }
+          end
         end
 
         links :representations do

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -381,5 +381,58 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
           .at_path('_embedded/schemas/_embedded/elements/0/_links/self/href')
       end
     end
+
+    context 'with project admin priviliges' do
+      # In this spec a user responds to `allowed_to` with true per default.
+      let(:project) { FactoryGirl.build_stubbed(:project) }
+
+      it 'has a link to set the custom fields for that project' do
+        expected = {
+          href: "/projects/#{project.identifier}/settings/custom_fields",
+          type: "text/html",
+          title: "Custom fields"
+        }
+
+        is_expected
+          .to be_json_eql(expected.to_json)
+          .at_path('_links/customFields')
+      end
+    end
+
+    context 'without project admin priviliges' do
+      # In this spec a user responds to `allowed_to` with true per default.
+      let(:project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        allow(user).to receive(:allowed_to?).with(:edit_project, project).and_return(false)
+      end
+
+      it 'has no link to set the custom fields for that project' do
+        is_expected.to_not have_json_path('_links/customFields')
+      end
+    end
+
+    context 'with project admin priviliges' do
+      # In this spec a user responds to `allowed_to` with true per default.
+      let(:project) { FactoryGirl.build_stubbed(:project) }
+      let(:user) { FactoryGirl.build_stubbed(:admin) }
+
+      before do
+        allow(user).to receive(:allowed_to?).with(:edit_project, project).and_return(false)
+      end
+
+      it 'has a link to set the custom fields for that project' do
+        expected = {
+          href: "/projects/#{project.identifier}/settings/custom_fields",
+          type: "text/html",
+          title: "Custom fields"
+        }
+
+        is_expected
+          .to be_json_eql(expected.to_json)
+          .at_path('_links/customFields')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I added a „Custom fields“ link to the menu settings as described here:

https://community.openproject.com/projects/openproject/work_packages/25066

Unfortunately I did not find the place where to add some specs for it. Am I right that there is not a place yet? Where should I put it?