### PR TITLE
splash groups on assignee filter

### DIFF
--- a/app/models/queries/work_packages/filter/assigned_to_filter.rb
+++ b/app/models/queries/work_packages/filter/assigned_to_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -59,18 +60,25 @@ class Queries::WorkPackages::Filter::AssignedToFilter <
 
   private
 
-  def values_me_replaced
-    vals = values.clone
+  def values_replaced
+    vals = super
+    vals += group_members_added(vals)
+    vals + user_groups_added(vals)
+  end
 
-    if vals.delete('me')
-      if User.current.logged?
-        vals.push(User.current.id.to_s)
-        vals += User.current.group_ids.map(&:to_s)
-      else
-        vals.push('0')
-      end
-    end
+  def group_members_added(vals)
+    User
+      .joins(:groups)
+      .where(groups_users: { id: vals })
+      .pluck(:id)
+      .map(&:to_s)
+  end
 
-    vals
+  def user_groups_added(vals)
+    Group
+      .joins(:users)
+      .where(users_users: { id: vals })
+      .pluck(:id)
+      .map(&:to_s)
   end
 end

--- a/app/models/queries/work_packages/filter/principal_base_filter.rb
+++ b/app/models/queries/work_packages/filter/principal_base_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -44,7 +45,7 @@ class Queries::WorkPackages::Filter::PrincipalBaseFilter <
   end
 
   def where
-    operator_strategy.sql_for_field(values_me_replaced, self.class.model.table_name, self.class.key)
+    operator_strategy.sql_for_field(values_replaced, self.class.model.table_name, self.class.key)
   end
 
   private
@@ -59,7 +60,7 @@ class Queries::WorkPackages::Filter::PrincipalBaseFilter <
     @principal_loader ||= ::Queries::WorkPackages::Filter::PrincipalLoader.new(project)
   end
 
-  def values_me_replaced
+  def values_replaced
     vals = values.clone
 
     if vals.delete('me')

--- a/app/models/queries/work_packages/filter/watcher_filter.rb
+++ b/app/models/queries/work_packages/filter/watcher_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -77,14 +78,14 @@ class Queries::WorkPackages::Filter::WatcherFilter <
         (SELECT #{db_table}.watchable_id
          FROM #{db_table}
          WHERE #{db_table}.watchable_type='WorkPackage'
-           AND #{::Queries::Operators::Equals.sql_for_field values_me_replaced, db_table, db_field})
+           AND #{::Queries::Operators::Equals.sql_for_field values_replaced, db_table, db_field})
     SQL
   end
 
   def where_allowed_watchers
     sql_parts = []
 
-    if User.current.logged? && user_id = values_me_replaced.delete(User.current.id.to_s)
+    if User.current.logged? && user_id = values_replaced.delete(User.current.id.to_s)
       # a user can always see his own watched issues
       sql_parts << where_self_watcher(user_id)
     end
@@ -110,7 +111,7 @@ class Queries::WorkPackages::Filter::WatcherFilter <
         (SELECT #{db_table}.watchable_id
          FROM #{db_table}
          WHERE #{db_table}.watchable_type='WorkPackage'
-           AND #{::Queries::Operators::Equals.sql_for_field values_me_replaced, db_table, db_field})
+           AND #{::Queries::Operators::Equals.sql_for_field values_replaced, db_table, db_field})
            AND #{Project.table_name}.id IN
              (#{view_watcher_allowed_scoped.to_sql})
     SQL

--- a/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
@@ -1,0 +1,155 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
+  let(:instance) do
+    filter = described_class.new
+    filter.values = values
+    filter.operator = operator
+    filter
+  end
+
+  let(:operator) { '=' }
+  let(:values) { [] }
+
+  describe 'where filter results' do
+    let(:work_package) { FactoryGirl.create(:work_package, assigned_to: assignee) }
+    let(:assignee) { FactoryGirl.create(:user) }
+    let(:group) { FactoryGirl.create(:group) }
+
+    subject { WorkPackage.where(instance.where) }
+
+    context 'for the user value' do
+      let(:values) { [assignee.id.to_s] }
+
+      it 'returns the work package' do
+        is_expected
+          .to match_array [work_package]
+      end
+    end
+
+    context 'for the me value with the user being logged in' do
+      let(:values) { ['me'] }
+
+      before do
+        allow(User)
+          .to receive(:current)
+          .and_return(assignee)
+      end
+
+      it 'returns the work package' do
+        is_expected
+          .to match_array [work_package]
+      end
+    end
+
+    context 'for the me value with another user being logged in' do
+      let(:values) { ['me'] }
+
+      before do
+        allow(User)
+          .to receive(:current)
+          .and_return(FactoryGirl.create(:user))
+      end
+
+      it 'does not return the work package' do
+        is_expected
+          .to be_empty
+      end
+    end
+
+    context 'for a group value with the group being assignee' do
+      let(:assignee) { group }
+      let(:values) { [group.id.to_s] }
+
+      it 'returns the work package' do
+        is_expected
+          .to match_array [work_package]
+      end
+    end
+
+    context 'for a group value with a group member being assignee' do
+      let(:values) { [group.id.to_s] }
+
+      before do
+        group.users << assignee
+      end
+
+      it 'returns the work package' do
+        is_expected
+          .to match_array [work_package]
+      end
+    end
+
+    context 'for a group value with no group member being assignee' do
+      let(:values) { [group.id.to_s] }
+
+      it 'does not return the work package' do
+        is_expected
+          .to be_empty
+      end
+    end
+
+    context "for a user value with the user's group being assignee" do
+      let(:values) { [user.id.to_s] }
+      let(:assignee) { group }
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        group.users << user
+      end
+
+      it 'returns the work package' do
+        is_expected
+          .to match_array [work_package]
+      end
+    end
+
+    context "for a user value with the user not being member of the assigned group" do
+      let(:values) { [user.id.to_s] }
+      let(:assignee) { group }
+      let(:user) { FactoryGirl.create(:user) }
+
+      it 'does not return the work package' do
+        is_expected
+          .to be_empty
+      end
+    end
+
+    context 'for an unmatched value' do
+      let(:values) { ['0'] }
+
+      it 'does not return the work package' do
+        is_expected
+          .to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Inflates the values of an assigned_to filter to include:
* The groups any of the users listed as a value is a member of
* The users of groups listed as values

This extends what had been implemented for the "me" value which used to include all groups the current user is a member of.

https://community.openproject.com/projects/openproject/work_packages/25108 