### PR TITLE
on travis, only compile assets when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,12 +83,6 @@ before_install:
   # Install Node LTS Boron (6.9.1)
   - "nvm install 6.9.1"
 
-  # We need phantomjs 2.0 to get tests passing
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
-
 bundler_args: --binstubs --without development production docker
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,9 @@ before_install:
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
   - "echo `xdpyinfo -display :99 | grep 'dimensions' | awk '{ print $2 }'`"
+
   # Install Node LTS Boron (6.9.1)
-  - nvm install 6.9.1
-  # We need npm 4.0 for a bugfix in cross-platform shrinkwrap
-  # https://github.com/npm/npm/issues/14042
-  - npm install npm@4.0
+  - "nvm install 6.9.1"
 
   # We need phantomjs 2.0 to get tests passing
   - mkdir travis-phantomjs
@@ -96,10 +94,9 @@ before_install:
 
 install:
   - bundle install --without development production docker
-  - travis_retry npm install
 
 before_script:
-  - sh script/ci_setup.sh $DB
+  - sh script/ci_setup.sh $TEST_SUITE $DB
 
 script:
   - sh script/ci_runner.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,6 @@ env:
     - "TEST_SUITE=features          DB=postgres  GROUP_SIZE=4  GROUP=4"
 
 before_install:
-  - "rvm @default,@global do gem uninstall bundler -a -x"
-  - gem install bundler -v 1.12.5
-  - echo `bundle -v`
   - "echo `firefox -v`"
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
@@ -92,8 +89,7 @@ before_install:
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs:$PATH
 
-install:
-  - bundle install --without development production docker
+bundler_args: --binstubs --without development production docker
 
 before_script:
   - sh script/ci_setup.sh $TEST_SUITE $DB

--- a/script/ci_runner.sh
+++ b/script/ci_runner.sh
@@ -45,10 +45,10 @@ case "$TEST_SUITE" in
             exec bundle exec rspec -I spec_legacy -o "--seed $CI_SEED" spec_legacy
             ;;
         specs)
-            exec bundle exec parallel_test --type rspec -o "--seed $CI_SEED" -n $GROUP_SIZE --only-group $GROUP --pattern '^spec/(?!features\/)' spec
+            bin/parallel_test --type rspec -o "--seed $CI_SEED" -n $GROUP_SIZE --only-group $GROUP --pattern '^spec/(?!features\/)' spec
             ;;
         features)
-            exec bundle exec parallel_test --type rspec -o "--seed $CI_SEED" -n $GROUP_SIZE --only-group $GROUP --pattern '^spec\/features\/' spec
+            bin/parallel_test --type rspec -o "--seed $CI_SEED" -n $GROUP_SIZE --only-group $GROUP --pattern '^spec\/features\/' spec
             ;;
         *)
             bundle exec rake parallel:$TEST_SUITE

--- a/script/ci_setup.sh
+++ b/script/ci_setup.sh
@@ -72,3 +72,11 @@ else
   run "mkdir -p app/assets/stylesheets/bundles"
   run "touch app/assets/javascripts/bundles/openproject-core-app.css"
 fi
+
+if [ $1 = 'npm' ]; then
+  # We need phantomjs 2.0 to get tests passing
+  run "mkdir travis-phantomjs"
+  run "wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
+  run "tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs"
+  run "export PATH=$PWD/travis-phantomjs:$PATH"
+fi


### PR DESCRIPTION
Try to avoid unnecessary steps in the travis setup e.g.
* [x] don't precompile assets for specs/legacy_spec
* [x] don't install phantomjs for specs/legacy_spec
* [x] don't `npm install`, `nvm install` for specs/legacy_spec

Additionally 
* [x] fix bundler cache

Out of scope:
* introduce commit message parsing to e.g. avoid running ruby unit tests