### PR TITLE
Fix/circumvent lock version

### DIFF
--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -39,6 +39,11 @@ module WorkPackage::SchedulingRules
     return if delta.zero?
 
     if leaf?
+      # HACK: On some more deeply nested settings (not sure what causes it)
+      # the work package can already have been updated by one of the other after_save hooks.
+      # To prevent a stale object error, we reload the lock preemptively.
+      reload_lock_and_timestamps
+
       current_buffer = soonest_start - start_date
 
       max_allowed_delta = if current_buffer < delta
@@ -49,7 +54,8 @@ module WorkPackage::SchedulingRules
 
       self.start_date += max_allowed_delta
       self.due_date += max_allowed_delta
-      save
+
+      save(validate: false)
     else
       leaves.each do |leaf|
         # this depends on the "update_parent_attributes" after save hook
@@ -67,7 +73,7 @@ module WorkPackage::SchedulingRules
         self.due_date = date + duration - 1
         self.start_date = date
 
-        save
+        save(validate: false)
       end
     else
       leaves.each do |leaf|

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -35,7 +36,7 @@ module WorkPackage::SchedulingRules
   end
 
   def reschedule_by(delta)
-    return if delta == 0
+    return if delta.zero?
 
     if leaf?
       current_buffer = soonest_start - start_date
@@ -62,7 +63,10 @@ module WorkPackage::SchedulingRules
     return if date.nil?
     if leaf?
       if start_date.nil? || start_date < date
-        self.start_date, self.due_date = date, date + duration - 1
+        # order is important here as the calculation for duration factors in start and due date
+        self.due_date = date + duration - 1
+        self.start_date = date
+
         save
       end
     else


### PR DESCRIPTION
Circumvent lock_version on after_save hooks to ensure that work packages who get saved as a side effect of saving another work package are saved successfully. Given the current after_save heavy architecture, this is the best we can do for now.

![image](https://cloud.githubusercontent.com/assets/617519/25391620/efa6284e-29d6-11e7-9f9d-754eb5310592.png)

https://community.openproject.com/projects/openproject/work_packages/details/25055
