### PR TITLE
[25039] Set focus to new split screen only when actively requested

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -193,6 +193,12 @@ openprojectModule
         controller: 'WorkPackageDetailsController',
         controllerAs: '$ctrl',
         reloadOnSearch: false,
+        params: {
+          focus: {
+            dynamic: true,
+            value: true
+          }
+        },
         onEnter: () => angular.element('body').addClass('action-details'),
         onExit: () => angular.element('body').removeClass('action-details')
       })

--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -57,13 +57,13 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
     scopedObservable(
       $scope,
       this.states.focusedWorkPackage.values$())
-      .map(wpId => parseInt(wpId))
+      .map(wpId => wpId.toString())
       .distinctUntilChanged()
-      .subscribe((wpId) => {
-        if ($state.includes('work-packages.list.details')) {
+      .subscribe((newId) => {
+        if (wpId !== newId && $state.includes('work-packages.list.details')) {
           $state.go(
             ($state.current.name as string),
-            {workPackageId: wpId}
+            {workPackageId: newId, focus: false }
           );
         }
       });
@@ -79,6 +79,10 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
 
   public onWorkPackageSave() {
     this.$rootScope.$emit('workPackagesRefreshInBackground');
+  }
+
+  public get shouldFocus() {
+    return this.$state.params.focus === true;
   }
 
   protected initializeTexts() {

--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -39,7 +39,7 @@
       </ul>
     </div>
     <div class="work-packages--details-content">
-    <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="$ctrl.focusAnchorLabel">
+    <span class="hidden-for-sighted" tabindex="-1" focus="$ctrl.shouldFocus" ng-bind="$ctrl.focusAnchorLabel">
     </span>
 
       <wp-subject></wp-subject>

--- a/frontend/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -37,7 +37,7 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
 
     this.$state.go(
       (this.keepTab as any)[state],
-      { workPackageId: workPackageId }
+      { workPackageId: workPackageId, focus: true }
     );
 
     evt.preventDefault();


### PR DESCRIPTION
This allows switching the details pane due to other actions (e.g.,
selection, inline-create) without setting its focus.

https://community.openproject.com/projects/openproject/work_packages/25039