### PR TITLE
[25131] Disable dragging form attribute group when editing it

### DIFF
--- a/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
+++ b/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
@@ -54,7 +54,8 @@ function typesFormConfigurationCtrl(
 
   dragulaService.options($scope, 'groups', {
     moves: function (el:any, container:any, handle:any) {
-      return handle.classList.contains('group-handle');
+      const editing = angular.element(el).find('.group-edit-in-place--input').length > 0;
+      return !editing && handle.classList.contains('group-handle');
     }
   });
 


### PR DESCRIPTION
It appears that dragula clones the element before inserting it again,
causing issues when dragging a group element that is being edited.