### PR TITLE
[25073] Force table refresh when updating hierarchies

### DIFF
--- a/frontend/app/components/routing/wp-show/wp-show.controller.ts
+++ b/frontend/app/components/routing/wp-show/wp-show.controller.ts
@@ -31,6 +31,7 @@ import {HalResource} from "../../api/api-v3/hal-resources/hal-resource.service";
 import {UserResource} from "../../api/api-v3/hal-resources/user-resource.service";
 import {WorkPackageResourceInterface} from "../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageViewController} from "../wp-view-base/wp-view-base.controller";
+import {WorkPackagesListChecksumService} from "../../wp-list/wp-list-checksum.service";
 
 export class WorkPackageShowController extends WorkPackageViewController {
 
@@ -51,10 +52,11 @@ export class WorkPackageShowController extends WorkPackageViewController {
   public attachments:any;
 
   constructor(public $injector:ng.auto.IInjectorService,
-              public $scope:any,
+              public $scope:ng.IScope,
               public $state:ng.ui.IStateService,
               public $window:ng.IWindowService,
               public $location:ng.ILocationService,
+              public wpListChecksumService:WorkPackagesListChecksumService,
               public HookService:any,
               public AuthorisationService:any,
               public WorkPackageAuthorization:any,
@@ -69,6 +71,11 @@ export class WorkPackageShowController extends WorkPackageViewController {
     // initialization
     this.initializeAllowedActions();
     this.setWorkPackageScopeProperties(this.workPackage);
+
+    // Clear the list checksum if we're doing something that requires reloading the list
+    this.$scope.$root.$on('workPackagesRefreshRequired', () => {
+      this.wpListChecksumService.clear();
+    })
   }
 
   public goToList() {

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -34,6 +34,7 @@ import {WorkPackageNotificationService} from 'core-components/wp-edit/wp-notific
 export class WorkPackageRelationsHierarchyService {
   constructor(protected $state: ng.ui.IStateService,
               protected $q: ng.IQService,
+              protected $rootScope: ng.IRootScopeService,
               protected wpNotificationsService: WorkPackageNotificationService,
               protected wpCacheService: WorkPackageCacheService) {
 
@@ -48,6 +49,7 @@ export class WorkPackageRelationsHierarchyService {
       .then((wp: WorkPackageResourceInterface) => {
         this.wpCacheService.updateWorkPackage(wp);
         this.wpNotificationsService.showSave(wp);
+        this.$rootScope.$emit('workPackagesRefreshRequired');
         return wp;
       })
       .catch((err) => {
@@ -64,6 +66,7 @@ export class WorkPackageRelationsHierarchyService {
     const state = this.wpCacheService.loadWorkPackage(childWpId);
 
     state.valuesPromise().then((wpToBecomeChild: WorkPackageResourceInterface) => {
+      this.$rootScope.$emit('workPackagesRefreshRequired');
       deferred.resolve(this.changeParent(wpToBecomeChild, workPackage.id));
     });
 


### PR DESCRIPTION
Currently, altering the hierarchy of a work package does not properly update the table. For example, removing a parent of w1 that isnt visible in the table causes w1 to refresh in the table (due to cache service), but the entire table isn't refreshed.

We cannot refresh the entire table for cache service changes, since that happens quite often in the timeline mode and would cause a performance impact.

On the other hand, we don't have the information on _what_ changed in w1 when we subscribe to the cache service.

I reckon that two solutions exist:

1. Whenever the hierachy changes through user interaction, forcefully refresh the entire table. This is consistent to the current way of reloading the table in many situations and will get us the newest data.

2. Maintain a frontend representation of the hierarchy of work packages and update that according to the user's inputs. This puts a lot more effort into the frontend at the benefit of immediate updates.

The issue I currently see with solution (2) are that we use the `ancestors` information of a work package to display the hierarchy, while we modify `parent` and `children` in each work package.
We would need a tree representation of `ancestors` as well as parent and children maps for fast lookup.

Thus, this PR takes the quick route to fix the issue and forces the page reload. Since moving from show->list will no longer spawn a refresh after #5397 is done, we can simply clear the checksum by listening to the same events.

https://community.openproject.com/projects/openproject/work_packages/25073/activity?query_id=896