### PR TITLE
[25089] Subject cut off in hierarchy mode (Firefox)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -91,7 +91,7 @@
       padding-right: 0
 
 // Full width container
-.wp-table--cell-container
+.wp-table--cell-container .wp-edit-field:not(.wp-table--cell-span )
   display: inline-block
 
 // Editable fields cursor


### PR DESCRIPTION
This avoids a content cut off in Firefox. Therefore the `display: inline-block` is only applied when the edit mode is activated.

https://community.openproject.com/projects/openproject/work_packages/25089/activity