### PR TITLE
fix duplicate id columns when sorting by user cf

### DIFF
--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -102,7 +102,7 @@ module CustomField::OrderStatements
 
   def order_by_user_sql(column)
     <<-SQL
-    (SELECT #{column} FROM #{User.table_name} cv_user
+    (SELECT #{column} user_cv_#{column} FROM #{User.table_name} cv_user
      WHERE cv_user.id = #{select_custom_value_as_decimal}
      LIMIT 1)
     SQL


### PR DESCRIPTION
The active record statement for paged work packages issued by https://github.com/opf/openproject/blob/dev/lib/api/v3/work_packages/work_package_collection_representer.rb#L184
is actually executed in two phases (first only to get the id). The result table for that first statement looks something like this:
![image](https://cloud.githubusercontent.com/assets/617519/25529259/a64c2a02-2c21-11e7-991b-e9def0177c47.png)
It thus has two `id` columns. For the second statement, only the results of the id column are used to fetch the full work packages (the other columns are only projected to to satisfy postgres restirctions). Unfortunately, the wrong column is chosen (the one added to sort by the user cf). By renaming this column, such a collision no longer occurs.

https://community.openproject.com/projects/openproject/work_packages/25164