### PR TITLE
[25092] More robust refreshing of table upon changes

### DIFF
--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -32,15 +32,16 @@ import {States} from "../../states.service";
 import {WorkPackageTableSelection} from "../../wp-fast-table/state/wp-table-selection.service";
 import {KeepTabService} from "../../wp-panels/keep-tab/keep-tab.service";
 import {WorkPackageViewController} from "../wp-view-base/wp-view-base.controller";
+import {WorkPackageTableRefreshService} from "../../wp-table/wp-table-refresh-request.service";
 
 export class WorkPackageDetailsController extends WorkPackageViewController {
 
   constructor(public $injector:ng.auto.IInjectorService,
               public $scope:ng.IScope,
-              public $rootScope:ng.IRootScopeService,
               public states:States,
               public keepTab:KeepTabService,
               public wpTableSelection:WorkPackageTableSelection,
+              public wpTableRefresh: WorkPackageTableRefreshService,
               public $state:ng.ui.IStateService) {
     super($injector, $scope, $state.params['workPackageId']);
     this.observeWorkPackage();
@@ -78,7 +79,7 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
   }
 
   public onWorkPackageSave() {
-    this.$rootScope.$emit('workPackagesRefreshInBackground');
+    this.wpTableRefresh.request(false, `Work package ${this.workPackage.id} saved in details view.`);
   }
 
   public get shouldFocus() {

--- a/frontend/app/components/routing/wp-show/wp-show.controller.ts
+++ b/frontend/app/components/routing/wp-show/wp-show.controller.ts
@@ -31,6 +31,8 @@ import {HalResource} from "../../api/api-v3/hal-resources/hal-resource.service";
 import {UserResource} from "../../api/api-v3/hal-resources/user-resource.service";
 import {WorkPackageResourceInterface} from "../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageViewController} from "../wp-view-base/wp-view-base.controller";
+import {WorkPackagesListChecksumService} from "../../wp-list/wp-list-checksum.service";
+import {WorkPackageTableRefreshService} from "../../wp-table/wp-table-refresh-request.service";
 
 export class WorkPackageShowController extends WorkPackageViewController {
 
@@ -51,10 +53,11 @@ export class WorkPackageShowController extends WorkPackageViewController {
   public attachments:any;
 
   constructor(public $injector:ng.auto.IInjectorService,
-              public $scope:any,
+              public $scope:ng.IScope,
               public $state:ng.ui.IStateService,
               public $window:ng.IWindowService,
               public $location:ng.ILocationService,
+              public wpListChecksumService:WorkPackagesListChecksumService,
               public HookService:any,
               public AuthorisationService:any,
               public WorkPackageAuthorization:any,

--- a/frontend/app/components/states.service.ts
+++ b/frontend/app/components/states.service.ts
@@ -81,6 +81,8 @@ export class TableState {
   timelineVisible = input<WorkPackageTableTimelineVisible>();
   // Subject used to unregister all listeners of states above.
   stopAllSubscriptions = new Subject();
+  // Fire when table refresh is required
+  refreshRequired = input<boolean>();
 }
 
 

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -37,6 +37,7 @@ import {
 import {ApiWorkPackagesService} from "../api/api-work-packages/api-work-packages.service";
 import {States} from "../states.service";
 import {WorkPackageNotificationService} from "./../wp-edit/wp-notification.service";
+import {WorkPackageTableRefreshService} from "../wp-table/wp-table-refresh-request.service";
 import IScope = angular.IScope;
 import IPromise = angular.IPromise;
 
@@ -51,7 +52,6 @@ export class WorkPackageCacheService {
 
   /*@ngInject*/
   constructor(private states: States,
-              private $rootScope: ng.IRootScopeService,
               private $q: ng.IQService,
               private wpNotificationsService: WorkPackageNotificationService,
               private schemaCacheService: SchemaCacheService,
@@ -92,7 +92,6 @@ export class WorkPackageCacheService {
     workPackage.save()
       .then(() => {
         this.wpNotificationsService.showSave(workPackage);
-        this.$rootScope.$emit('workPackagesRefreshInBackground');
         deferred.resolve(workPackage);
       })
       .catch((error) => {

--- a/frontend/app/components/work-packages/work-package.service.ts
+++ b/frontend/app/components/work-packages/work-package.service.ts
@@ -26,25 +26,26 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {States} from "../states.service";
 angular
     .module('openproject.services')
     .factory('WorkPackageService', WorkPackageService);
 
-function WorkPackageService($http,
-                            $rootScope,
-                            $window,
-                            $q,
-                            $cacheFactory,
-                            $state,
-                            PathHelper,
-                            UrlParamsHelper,
-                            NotificationsService) {
+function WorkPackageService($http:ng.IHttpService,
+                            $window:ng.IWindowService,
+                            $cacheFactory:any,
+                            $state:ng.ui.IStateService,
+                            states:States,
+                            I18n:op.I18n,
+                            PathHelper:any,
+                            UrlParamsHelper:any,
+                            NotificationsService:any) {
 
   var workPackageCache = $cacheFactory('workPackageCache');
 
   var WorkPackageService = {
 
-    doQuery: function (url, params) {
+    doQuery: function (url:string, params:any) {
       return $http({
         method: 'GET',
         url: url,
@@ -70,7 +71,7 @@ function WorkPackageService($http,
       );
     },
 
-    performBulkDelete: function (ids, defaultHandling) {
+    performBulkDelete: function (ids:any, defaultHandling:any) {
       if (defaultHandling && !$window.confirm(I18n.t('js.text_work_packages_destroy_confirmation'))) {
         return;
       }
@@ -87,7 +88,7 @@ function WorkPackageService($http,
               NotificationsService.addSuccess(
                   I18n.t('js.work_packages.message_successful_bulk_delete')
               );
-              $rootScope.$emit('workPackagesRefreshRequired');
+              states.table.refreshRequired.putValue(true);
 
               if ($state.includes('**.list.details.**')
                   && ids.indexOf(+$state.params.workPackageId) > -1) {
@@ -98,7 +99,7 @@ function WorkPackageService($http,
               // FIXME catch this kind of failover in angular instead of redirecting
               // to a rails-based legacy view
               params = UrlParamsHelper.buildQueryString(params);
-              window.location = PathHelper.workPackagesBulkDeletePath() + '?' + params;
+              window.location.href = PathHelper.workPackagesBulkDeletePath() + '?' + params;
             });
       }
 

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -41,6 +41,7 @@ import {WorkPackageTableSelection} from "../wp-fast-table/state/wp-table-selecti
 import {WorkPackageCreateService} from "./wp-create.service";
 import IRootScopeService = angular.IRootScopeService;
 import {scopedObservable} from "../../helpers/angular-rx-utils";
+import {WorkPackageTableRefreshService} from "../wp-table/wp-table-refresh-request.service";
 
 export class WorkPackageCreateController {
   public newWorkPackage:WorkPackageResource|any;
@@ -75,7 +76,6 @@ export class WorkPackageCreateController {
 
   constructor(protected $state: ng.ui.IStateService,
               protected $scope: ng.IScope,
-              protected $rootScope: IRootScopeService,
               protected $q: ng.IQService,
               protected I18n: op.I18n,
               protected wpNotificationsService: WorkPackageNotificationService,
@@ -85,6 +85,7 @@ export class WorkPackageCreateController {
               protected wpEditModeState: WorkPackageEditModeStateService,
               protected wpTableSelection: WorkPackageTableSelection,
               protected wpCacheService:WorkPackageCacheService,
+              protected wpTableRefresh:WorkPackageTableRefreshService,
               protected $location:ng.ILocationService,
               protected RootDm:RootDmService,
               protected v3Path:any) {
@@ -143,7 +144,7 @@ export class WorkPackageCreateController {
     this.wpTableSelection.focusOn(wp.id);
     this.loadingIndicator.mainPage = this.$state.go(successState, {workPackageId: wp.id})
       .then(() => {
-        this.$rootScope.$emit('workPackagesRefreshInBackground');
+        this.wpTableRefresh.request(false, `Saved work package ${wp.id}`);
         this.wpNotificationsService.showSave(wp, true);
       });
   }

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -36,14 +36,15 @@ import {WorkPackageTableColumnsService} from '../wp-fast-table/state/wp-table-co
 import {rowId} from '../wp-fast-table/helpers/wp-table-row-helpers';
 import {States} from '../states.service';
 import {WorkPackageTable} from "../wp-fast-table/wp-fast-table";
+import {WorkPackageTableRefreshService} from "../wp-table/wp-table-refresh-request.service";
 
 export class TableRowEditContext implements WorkPackageEditContext {
 
   // Injections
   public wpCacheService:WorkPackageCacheService;
+  public wpTableRefresh:WorkPackageTableRefreshService;
   public wpTableColumns:WorkPackageTableColumnsService;
   public states:States;
-  public $rootScope:ng.IRootScopeService;
   public FocusHelper:any;
 
   // Use cell builder to reset edit fields
@@ -79,10 +80,10 @@ export class TableRowEditContext implements WorkPackageEditContext {
   }
 
   public onSaved(workPackage:WorkPackageResource) {
-    this.$rootScope.$emit('workPackagesRefreshInBackground');
+    this.wpTableRefresh.request(false, `Saved work package ${workPackage.id}`);
   }
 }
 
 TableRowEditContext.$inject = [
-  'wpCacheService', 'states', 'wpTableColumns', '$rootScope', 'FocusHelper'
+  'wpCacheService', 'states', 'wpTableColumns', 'wpTableRefresh', 'FocusHelper'
 ];

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -30,10 +30,15 @@ import {wpDirectivesModule} from '../../../angular-modules';
 import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
 import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 import {WorkPackageNotificationService} from 'core-components/wp-edit/wp-notification.service';
+import {States} from "../../states.service";
+import {WorkPackageTableRefreshService} from "../../wp-table/wp-table-refresh-request.service";
 
 export class WorkPackageRelationsHierarchyService {
   constructor(protected $state: ng.ui.IStateService,
               protected $q: ng.IQService,
+              protected states: States,
+              protected wpTableRefresh: WorkPackageTableRefreshService,
+              protected $rootScope: ng.IRootScopeService,
               protected wpNotificationsService: WorkPackageNotificationService,
               protected wpCacheService: WorkPackageCacheService) {
 
@@ -48,6 +53,7 @@ export class WorkPackageRelationsHierarchyService {
       .then((wp: WorkPackageResourceInterface) => {
         this.wpCacheService.updateWorkPackage(wp);
         this.wpNotificationsService.showSave(wp);
+        this.wpTableRefresh.request(true, `Changed parent of ${workPackage.id} to ${parentId}`);
         return wp;
       })
       .catch((err) => {
@@ -64,6 +70,7 @@ export class WorkPackageRelationsHierarchyService {
     const state = this.wpCacheService.loadWorkPackage(childWpId);
 
     state.valuesPromise().then((wpToBecomeChild: WorkPackageResourceInterface) => {
+      this.wpTableRefresh.request(true, `Added new child to ${workPackage.id}`);
       deferred.resolve(this.changeParent(wpToBecomeChild, workPackage.id));
     });
 

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell-mouse-handler.ts
@@ -34,6 +34,7 @@ import {keyCodes} from "../../common/keyCodes.enum";
 import IScope = angular.IScope;
 import * as moment from 'moment';
 import Moment = moment.Moment;
+import {WorkPackageTableRefreshService} from "../wp-table-refresh-request.service";
 
 const classNameBar = "bar";
 export const classNameLeftHandle = "leftHandle";
@@ -52,6 +53,7 @@ export function registerWorkPackageMouseHandler(this: void,
                                                 getRenderInfo: () => RenderInfo,
                                                 workPackageTimeline: WorkPackageTimelineTableController,
                                                 wpCacheService: WorkPackageCacheService,
+                                                wpTableRefresh: WorkPackageTableRefreshService,
                                                 cell: HTMLElement,
                                                 bar: HTMLDivElement,
                                                 renderer: TimelineCellRenderer,
@@ -211,6 +213,9 @@ export function registerWorkPackageMouseHandler(this: void,
 
   function saveWorkPackage(workPackage: WorkPackageResourceInterface) {
     wpCacheService.saveIfChanged(workPackage)
+      .then(() => {
+        wpTableRefresh.request(true, `Moved work package ${workPackage.id} through timeline`);
+      })
       .catch(() => {
         if (!workPackage.isNew) {
           // Reset the changes on error

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
@@ -39,6 +39,7 @@ import * as moment from "moment";
 import { injectorBridge } from "../../angular/angular-injector-bridge.functions";
 import IScope = angular.IScope;
 import Moment = moment.Moment;
+import {WorkPackageTableRefreshService} from "../wp-table-refresh-request.service";
 
 const renderers = {
   milestone: new TimelineMilestoneCellRenderer(),
@@ -47,6 +48,7 @@ const renderers = {
 
 export class WorkPackageTimelineCell {
   public wpCacheService: WorkPackageCacheService;
+  public wpTableRefresh: WorkPackageTableRefreshService;
   public states: States;
 
   private subscription: Subscription;
@@ -134,6 +136,7 @@ export class WorkPackageTimelineCell {
         () => this.latestRenderInfo,
         this.workPackageTimeline,
         this.wpCacheService,
+        this.wpTableRefresh,
         this.timelineCell,
         this.wpElement,
         renderer,

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
@@ -189,4 +189,4 @@ export class WorkPackageTimelineCell {
 
 }
 
-WorkPackageTimelineCell.$inject = ['wpCacheService', 'states', 'TimezoneService'];
+WorkPackageTimelineCell.$inject = ['wpCacheService', 'wpTableRefresh', 'states', 'TimezoneService'];

--- a/frontend/app/components/wp-table/wp-table-refresh-request.service.ts
+++ b/frontend/app/components/wp-table/wp-table-refresh-request.service.ts
@@ -1,0 +1,30 @@
+import {InputState} from "reactivestates";
+import {States} from "../states.service";
+import {opServicesModule} from "../../angular-modules";
+
+export class WorkPackageTableRefreshService {
+  constructor(public states:States) {
+  }
+
+  /**
+   * Request a refresh to the work package table.
+   * @param visible Whether a loading indicator should be shown while changing
+   * @param reason a reason for logging purposes.
+   */
+  public request(visible:boolean = false, reason:string) {
+    this.state.putValue(visible, reason);
+  }
+
+  /**
+   * Undo any potential pending refresh request
+   */
+  public clear(reason:string) {
+    this.state.clear(reason)
+  }
+
+  public get state():InputState<boolean> {
+    return this.states.table.refreshRequired;
+  }
+}
+
+opServicesModule.service('wpTableRefresh', WorkPackageTableRefreshService);


### PR DESCRIPTION
Currently, altering the hierarchy of a work package does not properly
update the table. For example, removing a parent of w1 that isnt visible in
the table causes w1 to refresh in the table (due to cache service), but
the entire table isn't refreshed.

We cannot refresh the entire table for cache service changes, since that
happens quite often in the timeline mode and would cause a peformance
impact.

On the other hand, we don't have the information on _what_ changed in w1
when we subscribe to the cache service.

This PR rather improves on the task of reloading the table after changes
to work packages by making two things explicit:

1. A separate state controlling requests to table refreshing instead of
a rootScope event

2. A service that orchestrates the state to allow moving to/from full
screen to reload the table whenever moving back and requests were made in the full
screen.

https://community.openproject.com/wp/25092