### PR TITLE
Fix/custom field filter saving

### DIFF
--- a/lib/api/v3/queries/query_serialization.rb
+++ b/lib/api/v3/queries/query_serialization.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -110,10 +111,10 @@ module API
         end
 
         def initialize_links!(attributes)
-          represented.project_id = get_project_id(attributes) || represented.project_id
-          represented.group_by = get_group_by(attributes) || represented.group_by
-          represented.column_names = get_columns(attributes) || represented.column_names
-          represented.sort_criteria = get_sort_criteria(attributes) || represented.sort_criteria
+          set_project_id(attributes)
+          set_group_by(attributes)
+          set_columns(attributes)
+          set_sort_criteria(attributes)
         end
 
         def get_user_id(query_attributes)
@@ -122,49 +123,46 @@ module API
           id_from_href "users", href
         end
 
-        def get_project_id(query_attributes)
+        def set_project_id(query_attributes)
           href = query_attributes.dig("_links", "project", "href")
           id = id_from_href "projects", href
 
-          if id.to_i.nonzero?
-            id # return numerical ID
-          else
-            Project.where(identifier: id).pluck(:id).first # lookup Project by identifier
-          end
+          id = if id.to_i.nonzero?
+                 id # return numerical ID
+               else
+                 Project.where(identifier: id).pluck(:id).first # lookup Project by identifier
+               end
+
+          represented.project_id = id if id
         end
 
-        def get_sort_criteria(query_attributes)
-          criteria = Array(query_attributes.dig("_links", "sortBy")).map do |sort_by|
-            if id = id_from_href("queries/sort_bys", sort_by['href'])
-              column, direction = id.split("-") # e.g. ["start_date", "desc"]
+        def set_sort_criteria(query_attributes)
+          raw_criteria = query_attributes.dig("_links", "sortBy")
 
-              if column && direction
-                column = ::API::Utilities::PropertyNameConverter.to_ar_name(column, context: WorkPackage.new)
-                direction = nil unless ["asc", "desc"].include? direction
-
-                [column, direction]
-              end
-            end
+          criteria = Array(raw_criteria).map do |sort_by|
+            column_direction_from_href(sort_by)
           end
 
-          criteria.compact.presence
+          represented.sort_criteria = criteria.compact if raw_criteria
         end
 
-        def get_group_by(query_attributes)
+        def set_group_by(query_attributes)
           href = query_attributes.dig "_links", "groupBy", "href"
           attr = id_from_href "queries/group_bys", href
 
-          ::API::Utilities::PropertyNameConverter.to_ar_name(attr, context: WorkPackage.new) if attr
+          represented.group_by = ::API::Utilities::PropertyNameConverter.to_ar_name(attr, context: WorkPackage.new) if attr
         end
 
-        def get_columns(query_attributes)
-          columns = Array(query_attributes.dig("_links", "columns")).map do |column|
+        def set_columns(query_attributes)
+          raw_columns = query_attributes.dig("_links", "columns")
+
+          columns = Array(raw_columns).map do |column|
             name = id_from_href "queries/columns", column['href']
 
             ::API::Utilities::PropertyNameConverter.to_ar_name(name, context: WorkPackage.new) if name
           end
 
-          columns.map(&:to_sym).compact.presence
+          represented.column_names = columns.map(&:to_sym).compact if raw_columns
         end
 
         def id_from_href(expected_namespace, href)
@@ -176,6 +174,19 @@ module API
             expected_version: "3",
             expected_namespace: expected_namespace
           )
+        end
+
+        def column_direction_from_href(sort_by)
+          if id = id_from_href("queries/sort_bys", sort_by['href'])
+            column, direction = id.split("-") # e.g. ["start_date", "desc"]
+
+            if column && direction
+              column = ::API::Utilities::PropertyNameConverter.to_ar_name(column, context: WorkPackage.new)
+              direction = nil unless ["asc", "desc"].include? direction
+
+              [column, direction]
+            end
+          end
         end
 
         def map_with_sort_by_as_decorated(sort_criteria)

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -154,4 +154,77 @@ describe 'filter work packages', js: true do
                                'dueDate')
     end
   end
+
+  context 'by list cf inside a project' do
+    let(:type) do
+      type = FactoryGirl.create(:type)
+
+      project.types << type
+
+      type
+    end
+
+    let(:work_package_with_list_value) do
+      wp = FactoryGirl.create :work_package, project: project, type: type
+      wp.send("#{list_cf.accessor_name}=", list_cf.custom_options.first.id)
+      wp.save!
+      wp
+    end
+
+    let(:work_package_with_anti_list_value) do
+      wp = FactoryGirl.create :work_package, project: project, type: type
+      wp.send("#{list_cf.accessor_name}=", list_cf.custom_options.last.id)
+      wp.save!
+      wp
+    end
+
+    let(:list_cf) do
+      cf = FactoryGirl.create :list_wp_custom_field
+
+      project.work_package_custom_fields << cf
+      type.custom_fields << cf
+
+      cf
+    end
+
+    before do
+      list_cf
+      work_package_with_list_value
+      work_package_with_anti_list_value
+
+      wp_table.visit!
+    end
+
+    it 'allows filtering, saving and retrieving the saved filter' do
+      filters.open
+
+      filters.add_filter_by(list_cf.name,
+                            'is not',
+                            list_cf.custom_options.last.value,
+                            "customField#{list_cf.id}")
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_list_value]
+      expect(wp_table).not_to have_work_packages_listed [work_package_with_anti_list_value]
+
+      wp_table.save_as('Some query name')
+
+      filters.remove_filter "customField#{list_cf.id}"
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_list_value, work_package_with_anti_list_value]
+
+      last_query = Query.last
+
+      wp_table.visit_query(last_query)
+
+      expect(wp_table).to have_work_packages_listed [work_package_with_list_value]
+      expect(wp_table).not_to have_work_packages_listed [work_package_with_anti_list_value]
+
+      filters.open
+
+      filters.expect_filter_by(list_cf.name,
+                               'is not',
+                               list_cf.custom_options.last.value,
+                               "customField#{list_cf.id}")
+    end
+  end
 end


### PR DESCRIPTION
Only when the project is set first can filters of custom fields be set correctly. We should get rid of this dependency but I chose the quick fix here.

Initialized by https://community.openproject.com/projects/openproject/work_packages/25178 but will probably not fix the whole of it.