### PR TITLE
Fix switching to types with new _links added

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -288,7 +288,6 @@ function initializeResource(halResource:HalResource) {
 
           return null;
         },
-
         (val:any) => setter(val, linkName)
       );
     });
@@ -337,17 +336,24 @@ function initializeResource(halResource:HalResource) {
     });
   }
 
-  function setter(val:HalResource, linkName:string) {
+  function setter(val:HalResource|{ href?: string }, linkName:string) {
     if (!val) {
       halResource.$source._links[linkName] = {href: null};
     } else if (_.isArray(val)) {
       halResource.$source._links[linkName] = val.map((el:any) => { return {href: el.href} });
-    } else if (val.$link) {
-      const link = val.$link;
+    } else if (val.hasOwnProperty('$link')) {
+      const link = (val as HalResource).$link;
 
       if (link.href) {
         halResource.$source._links[linkName] = link;
       }
+    } else if ('href' in val) {
+      halResource.$source._links[linkName] = {href: val.href};
+    }
+
+    if (halResource.$embedded && halResource.$embedded[linkName]) {
+      halResource.$embedded[linkName] = val;
+      halResource.$source._embedded[linkName] = (val as HalResource).$source || val;
     }
 
     return val;

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -370,7 +370,8 @@ export class WorkPackageResource extends HalResource {
 
         // Take over new values from the form
         // this resource doesn't know yet.
-        this.assignNewValues(form.$embedded.payload);
+        _.defaultsDeep(this.$source, form.$source._embedded.payload);
+        this.$initialize(this.$source);
 
         deferred.resolve(form);
       })
@@ -517,14 +518,6 @@ export class WorkPackageResource extends HalResource {
     });
 
     return plainPayload;
-  }
-
-  private assignNewValues(formPayload:{[attr:string]: any, $source:any}) {
-    Object.keys(formPayload.$source).forEach(key => {
-      if (angular.isUndefined(this[key])) {
-        this[key] = formPayload[key];
-      }
-    });
   }
 
   /**

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -50,7 +50,7 @@
     </option>
   </select>
 
-  <a href class="form-label no-decoration-on-hover -transparent" ng-click="vm.field.toggleMultiselect()">
+  <a href class="wp-inline-edit--toggle-multiselect form-label no-decoration-on-hover -transparent" ng-click="vm.field.toggleMultiselect()">
     <icon-wrapper icon-name="minus2"
                   icon-title="{{I18n.t('js.work_packages.label_switch_to_single_select')}}"
                   ng-if="vm.field.isMultiselect"

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -2,126 +2,214 @@ require 'spec_helper'
 
 describe 'Switching types in work package table', js: true do
   let(:user) { FactoryGirl.create :admin }
-  let(:cf_req_text) {
-    FactoryGirl.create(
-      :work_package_custom_field,
-      field_format: 'string',
-      is_required:  true,
-      is_for_all:   false
-    )
-  }
-  let(:cf_text) {
-    FactoryGirl.create(
-      :work_package_custom_field,
-      field_format: 'string',
-      is_required:  false,
-      is_for_all:   false
-    )
-  }
 
-  let(:type_task) { FactoryGirl.create(:type_task, custom_fields: [cf_text]) }
-  let(:type_bug) { FactoryGirl.create(:type_bug, custom_fields: [cf_req_text]) }
+  describe 'switching to required CF' do
+    let(:cf_req_text) {
+      FactoryGirl.create(
+        :work_package_custom_field,
+        field_format: 'string',
+        is_required:  true,
+        is_for_all:   false
+      )
+    }
+    let(:cf_text) {
+      FactoryGirl.create(
+        :work_package_custom_field,
+        field_format: 'string',
+        is_required:  false,
+        is_for_all:   false
+      )
+    }
 
-  let(:project) {
-    FactoryGirl.create(
-      :project,
-      types: [type_task, type_bug],
-      work_package_custom_fields: [cf_text, cf_req_text]
-    )
-  }
-  let(:work_package) {
-    FactoryGirl.create(:work_package,
-                       subject: 'Foobar',
-                       type:    type_task,
-                       project: project)
-  }
-  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+    let(:type_task) { FactoryGirl.create(:type_task, custom_fields: [cf_text]) }
+    let(:type_bug) { FactoryGirl.create(:type_bug, custom_fields: [cf_req_text]) }
 
-  let(:query) do
-    query              = FactoryGirl.build(:query, user: user, project: project)
-    query.column_names = ['subject', 'type', "cf_#{cf_text.id}"]
+    let(:project) {
+      FactoryGirl.create(
+        :project,
+        types: [type_task, type_bug],
+        work_package_custom_fields: [cf_text, cf_req_text]
+      )
+    }
+    let(:work_package) do
+      FactoryGirl.create(:work_package,
+                         subject: 'Foobar',
+                         type:    type_task,
+                         project: project)
+    end
+    let(:wp_table) { Pages::WorkPackagesTable.new(project) }
 
-    query.save!
-    query
+    let(:query) do
+      query              = FactoryGirl.build(:query, user: user, project: project)
+      query.column_names = ['subject', 'type', "cf_#{cf_text.id}"]
+
+      query.save!
+      query
+    end
+
+    let(:type_field) { wp_table.edit_field(work_package, :type) }
+    let(:text_field) { wp_table.edit_field(work_package, :customField1) }
+    let(:req_text_field) { wp_table.edit_field(work_package, :customField2) }
+
+    before do
+      login_as(user)
+      query
+      project
+      work_package
+
+      wp_table.visit_query(query)
+      wp_table.expect_work_package_listed(work_package)
+    end
+
+    it 'switches the types correctly' do
+      expect(text_field).to be_editable
+
+      # Set non-required CF
+      text_field.activate!
+      text_field.set_value 'Foobar'
+      text_field.save!
+
+      wp_table.expect_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+      # safegurards
+      wp_table.dismiss_notification!
+      wp_table.expect_no_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+
+      # Switch type
+      type_field.activate!
+      type_field.set_value type_bug.name
+
+      wp_table.expect_notification(
+        type:    :error,
+        message: "#{cf_req_text.name} can't be blank."
+      )
+      # safegurards
+      wp_table.dismiss_notification!
+      wp_table.expect_no_notification(
+        type:    :error,
+        message: "#{cf_req_text.name} can't be blank."
+      )
+
+      # Old text field should disappear
+      text_field.expect_state_text ''
+
+      # Required CF requires activation
+      req_text_field.activate!
+      req_text_field.set_value 'Required'
+      req_text_field.save!
+
+      wp_table.expect_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+      # safegurards
+      wp_table.dismiss_notification!
+      wp_table.expect_no_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+
+      expect(text_field).not_to be_editable
+
+      type_field.activate!
+      type_field.set_value type_task.name
+
+      wp_table.expect_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+      # safegurards
+      wp_table.dismiss_notification!
+      wp_table.expect_no_notification(
+        message: 'Successful update. Click here to open this work package in fullscreen view.'
+      )
+
+      req_text_field.expect_state_text ''
+    end
   end
 
-  let(:type_field) { wp_table.edit_field(work_package, :type) }
-  let(:text_field) { wp_table.edit_field(work_package, :customField1) }
-  let(:req_text_field) { wp_table.edit_field(work_package, :customField2) }
+  describe 'switching to list CF' do
+    let!(:wp_page) { Pages::FullWorkPackageCreate.new }
+    let!(:type_with_cf) { FactoryGirl.create(:type_task, custom_fields: [custom_field]) }
+    let!(:type) { FactoryGirl.create(:type_bug) }
+    let(:permissions) { %i(view_work_packages add_work_packages) }
+    let(:role) { FactoryGirl.create :role, permissions: permissions }
+    let(:user) do
+      FactoryGirl.create :user,
+                         member_in_project: project,
+                         member_through_role: role
+    end
 
-  before do
-    login_as(user)
-    query
-    project
-    work_package
+    before do
+      workflow
+      login_as user
+    end
 
-    wp_table.visit_query(query)
-    wp_table.expect_work_package_listed(work_package)
-  end
+    let(:custom_field) do
+      FactoryGirl.create(
+        :list_wp_custom_field,
+        name: "Ingredients",
+        multi_value: true,
+        possible_values: ["ham", "onions", "pineapple", "mushrooms"]
+      )
+    end
 
-  it 'switches the types correctly' do
-    expect(text_field).to be_editable
+    let!(:project) do
+      FactoryGirl.create(
+        :project,
+        types: [type, type_with_cf],
+        work_package_custom_fields: [custom_field]
+      )
+    end
+    let!(:status) { FactoryGirl.create(:default_status) }
+    let!(:workflow) do
+      FactoryGirl.create :workflow,
+                         type_id: type.id,
+                         old_status: status,
+                         new_status: FactoryGirl.create(:status),
+                         role: role
+    end
 
-    # Set non-required CF
-    text_field.activate!
-    text_field.set_value 'Foobar'
-    text_field.save!
+    let!(:priority) { FactoryGirl.create :priority, is_default: true }
 
-    wp_table.expect_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
-    # safegurards
-    wp_table.dismiss_notification!
-    wp_table.expect_no_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
+    let(:cf_edit_field) do
+      field = wp_page.edit_field "customField#{custom_field.id}"
+      field.field_type = 'select'
+      field
+    end
 
-    # Switch type
-    type_field.activate!
-    type_field.set_value type_bug.name
+    before do
+      login_as(user)
 
-    wp_table.expect_notification(
-      type:    :error,
-      message: "#{cf_req_text.name} can't be blank."
-    )
-    # safegurards
-    wp_table.dismiss_notification!
-    wp_table.expect_no_notification(
-      type:    :error,
-      message: "#{cf_req_text.name} can't be blank."
-    )
+      visit new_project_work_packages_path(project.identifier, type: type.id)
+    end
 
-    # Old text field should disappear
-    text_field.expect_state_text ''
+    it 'can switch to the type with CF list' do
+      # Set subject
+      subject = wp_page.edit_field :subject
+      subject.set_value 'My subject'
 
-    # Required CF requires activation
-    req_text_field.activate!
-    req_text_field.set_value 'Required'
-    req_text_field.save!
+      # Switch type
+      type_field = wp_page.edit_field :type
+      type_field.set_value type_with_cf.name
 
-    wp_table.expect_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
-    # safegurards
-    wp_table.dismiss_notification!
-    wp_table.expect_no_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
+      wp_page.view_all_attributes
 
-    expect(text_field).not_to be_editable
+      cf_edit_field.element.find('.wp-inline-edit--toggle-multiselect').click
+      sel = cf_edit_field.input_element
+      sel.select "pineapple"
+      sel.select "mushrooms"
 
-    type_field.activate!
-    type_field.set_value type_task.name
+      wp_page.save!
 
-    wp_table.expect_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
-    # safegurards
-    wp_table.dismiss_notification!
-    wp_table.expect_no_notification(
-      message: 'Successful update. Click here to open this work package in fullscreen view.'
-    )
+      wp_page.expect_notification(
+        message: 'Successful creation.'
+      )
 
-    req_text_field.expect_state_text ''
+      new_wp = WorkPackage.last
+      expect(new_wp.subject).to eq('My subject')
+      expect(new_wp.type_id).to eq(type_with_cf.id)
+      expect(new_wp.custom_value_for(custom_field.id).map(&:typed_value)).to match_array(%w(pineapple mushrooms))
+    end
   end
 end

--- a/spec/support/pages/full_work_package_create.rb
+++ b/spec/support/pages/full_work_package_create.rb
@@ -31,6 +31,10 @@ require 'support/pages/abstract_work_package_create'
 
 module Pages
   class FullWorkPackageCreate < AbstractWorkPackageCreate
+    def edit_field(attribute)
+      super(attribute, container)
+    end
+
     private
 
     def container


### PR DESCRIPTION
When switching to a type that has a multi-select CF, its values are sent
through `payload._links` of the form, however only embedded properites
of the form are taken over.

We can re-use `$initialize` of the HalResource if we merge both sources,
which is what this PR proposes. It also adds a spec to test moving to a
multi-select CF.