### PR TITLE
Fix/filter copy

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -169,7 +169,8 @@ export class HalResource {
   }
 
   public $copy() {
-    return this.constructor(this.$source);
+    let clone:any = this.constructor
+    return new clone(_.cloneDeep(this.$source), this.$loaded);;
   }
 
   protected $initialize(source:any) {

--- a/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-resource.service.ts
@@ -106,10 +106,6 @@ export class QueryFilterInstanceResource extends HalResource {
     return this.values.length || (this.currentSchema && !this.currentSchema.isValueRequired());
   }
 
-  public $copy() {
-    return this.constructor(this.$source);
-  }
-
   private static definesAllowedValues(schema:QueryFilterInstanceSchemaResource) {
     return _.some(schema._dependencies[0].dependencies,
                   (dependency:any) => dependency.values && dependency.values._links && dependency.values._links.allowedValues );

--- a/frontend/app/components/filters/query-filters/query-filters.directive.ts
+++ b/frontend/app/components/filters/query-filters/query-filters.directive.ts
@@ -83,13 +83,7 @@ function queryFiltersDirective($timeout:ng.ITimeoutService,
           };
 
           function initialize() {
-            let newState = wpTableFilters.currentState;
-            // prevent circular updates
-            if (scope.filters === newState) {
-              return;
-            }
-
-            scope.filters = _.cloneDeep(wpTableFilters.currentState);
+            scope.filters = wpTableFilters.currentState;
 
             updateRemainingFilters();
           }

--- a/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -67,7 +67,7 @@ export class WorkPackageTableFiltersService extends WorkPackageTableBaseService 
 
   public get current():QueryFilterInstanceResource[]{
     if (this.currentState) {
-      return this.currentState.current;
+      return _.map(this.currentState.current, filter => filter.$copy());
     } else {
       return [];
     }

--- a/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -99,12 +99,12 @@ export class WorkPackageTableFiltersService extends WorkPackageTableBaseService 
 
     filter.schema.$load().then(() => {
       if (_.has(filter, ['values.length', 'currentSchema.values.allowedValues.$load'])) {
-          (filter.currentSchema!.values!.allowedValues as CollectionResource).$load()
-            .then((options:CollectionResource) => {
-              this.setLoadedValues(filter, options);
+        (filter.currentSchema!.values!.allowedValues as CollectionResource).$load()
+          .then((options:CollectionResource) => {
+            this.setLoadedValues(filter, options);
 
-              deferred.resolve();
-            });
+            deferred.resolve();
+          });
       } else {
         deferred.resolve();
       }

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -83,7 +83,7 @@ describe 'filter work packages', js: true do
       wp_table.visit!
     end
 
-    it 'allows filtering, saving and retrieving the saved filter' do
+    it 'allows filtering, saving, retrieving and altering the saved filter' do
       filters.open
 
       filters.add_filter_by('Version', 'is', version.name)
@@ -107,6 +107,11 @@ describe 'filter work packages', js: true do
       filters.open
 
       filters.expect_filter_by('Version', 'is', version.name)
+
+      filters.set_operator 'Version', 'is not'
+
+      expect(wp_table).to have_work_packages_listed [work_package_without_version]
+      expect(wp_table).not_to have_work_packages_listed [work_package_with_version]
     end
   end
 
@@ -122,7 +127,7 @@ describe 'filter work packages', js: true do
       wp_table.visit!
     end
 
-    it 'allows filtering, saving and retrieving the saved filter' do
+    it 'allows filtering, saving and retrieving and altering the saved filter' do
       filters.open
 
       filters.add_filter_by('Due date',
@@ -152,6 +157,11 @@ describe 'filter work packages', js: true do
                                'between',
                                [(Date.today - 1.day).strftime('%Y-%m-%d'), Date.today.strftime('%Y-%m-%d')],
                                'dueDate')
+
+      filters.set_filter 'Due date', 'in more than', '1', 'dueDate'
+
+      expect(wp_table).to have_work_packages_listed [work_package_without_due_date]
+      expect(wp_table).not_to have_work_packages_listed [work_package_with_due_date]
     end
   end
 end

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -63,7 +63,7 @@ describe 'filter work packages', js: true do
       filters.open
       loading_indicator_saveguard
 
-      filters.filter_by_watcher watcher.name
+      filters.add_filter_by 'Watcher', 'is', watcher.name
       loading_indicator_saveguard
 
       expect(wp_table).to have_work_packages_listed [work_package_with_watcher]

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -55,10 +55,21 @@ module Components
       end
 
       def add_filter_by(name, operator, value, selector = nil)
+        select name, from: "add_filter_select"
+
+        set_filter(name, operator, value, selector)
+      end
+
+      def set_operator(name, operator, selector = nil)
         id = selector || name.downcase
 
-        select name, from: "add_filter_select"
         select operator, from: "operators-#{id}"
+      end
+
+      def set_filter(name, operator, value, selector = nil)
+        id = selector || name.downcase
+
+        set_operator(name, operator, selector)
 
         set_value(id, value)
       end

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -49,11 +49,6 @@ module Components
         expect(page).to have_selector(filters_selector, visible: :hidden)
       end
 
-      def filter_by_watcher(name)
-        select "Watcher", from: "add_filter_select"
-        select name, from: "values-watcher"
-      end
-
       def add_filter_by(name, operator, value, selector = nil)
         select name, from: "add_filter_select"
 


### PR DESCRIPTION
Fix copying filters which is required to successfully update existing filters.

Without copying the filters, and by that have separate instances of the filter, updating a filter value or operator of a filter already existing on page load will fail the safeguard we have implemented to ensure that only an update to the query will trigger a backend request. This is because with shared instances, the filter instances of the table will have changed together with the filter instances in the filter directive as they are the same.