### PR TITLE
Revert using $location on wp settings menu links

### DIFF
--- a/frontend/app/components/routing/wp-show/wp-show.controller.ts
+++ b/frontend/app/components/routing/wp-show/wp-show.controller.ts
@@ -92,7 +92,7 @@ export class WorkPackageShowController extends WorkPackageViewController {
         this.deleteSelectedWorkPackage();
         break;
       default:
-        this.$location.path(link);
+        window.location.href = link;
         break;
     }
   };

--- a/frontend/app/components/wp-details/wp-details-toolbar.directive.ts
+++ b/frontend/app/components/wp-details/wp-details-toolbar.directive.ts
@@ -103,7 +103,7 @@ function wpDetailsToolbar(
               deleteSelectedWorkPackage();
               break;
             default:
-              $location.path(link);
+              window.location.href = link;
               break;
           }
         };


### PR DESCRIPTION
This will cause ui-router to catch the location and try to match it
causing us to use `.otherwise`. However, since the application is
bootstrapped _everywhere_, this will match all other routes inside
OpenProject.

https://community.openproject.com/projects/openproject/work_packages/24911