### PR TITLE
Fix/cf list multi group by

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
@@ -153,7 +153,13 @@ export class GroupedRowsBuilder extends RowsBuilder {
       return false;
     }
 
-    return _.isEqualWith(property, group._links.valueLink, (a:any, b:any) => a.href === b.href);
+    let joinedOrderedHrefs = (objects:any[]) => {
+      return _.map(objects, object => object.href).sort().join(', ')
+    }
+
+    return _.isEqualWith(property,
+                         group.href,
+                         (a, b) => joinedOrderedHrefs(a) === joinedOrderedHrefs(b));
   }
 
   /**

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -159,7 +159,7 @@ module Redmine
           values = custom_values.select { |v| v.custom_field_id == field_id }
 
           if values.size > 1
-            values.sort_by(&:id)
+            values.sort_by { |v| v.id.to_i } # need to cope with nil
           else
             values.first
           end


### PR DESCRIPTION
Fixes:
* grouping by multi cf (e.g. list) that got broken by calling href on the array instead of each individual object https://community.openproject.com/projects/openproject/work_packages/25178
* altering the selected values for a multi cf as comparing an int with nil (which an unpersisted custom value will have) leads to an runtime error