### PR TITLE
Revert "quick fix existing filter updates"

### DIFF
--- a/frontend/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-filters.ts
@@ -43,15 +43,7 @@ export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilt
   public current:QueryFilterInstanceResource[] = [];
 
   public comparerFunction():(current:QueryFilterInstanceResource[]) => any {
-    // TODO: this should be
-    //
-    // return (current:QueryFilterInstanceResource[]) => current.map((el:HalResource) => el.$plain());
-    //
-    // instead. But for some reasons deeply burried probably within the
-    // HalResource, filters received from the server will not set the
-    // HalResource's source correctly when updating the values, operators ...
-    // Filters created in the frontend itself behave as expected.
-    return (current:QueryFilterInstanceResource[]) => current.map((el:HalResource) => _.cloneDeep(el));
+    return (current:QueryFilterInstanceResource[]) => current.map((el:HalResource) => el.$plain());
   }
 
   constructor(filters:QueryFilterInstanceResource[], schema:QuerySchemaResourceInterface) {


### PR DESCRIPTION
This reverts commit 2653fe54fc8ba88465d7211e7eb3f8b43144e585.

No longer necessary because of #5441

Because copying now works correctly, we also have to load the filters' schemas again (from cache) for extracting the payload. This used to be done magically.