### PR TITLE
allow skipping ruby unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ env:
     - "TEST_SUITE=features          DB=postgres  GROUP_SIZE=4  GROUP=4"
 
 before_install:
+  - sh script/travis_abort_conditions.sh
+
   - "echo `firefox -v`"
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start -v --pidfile ./tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"
@@ -86,10 +88,18 @@ before_install:
 bundler_args: --binstubs --without development production docker
 
 before_script:
-  - sh script/ci_setup.sh $TEST_SUITE $DB
+  - "if [ $SKIP_BUILD ]; then
+      true;
+     else
+      sh script/ci_setup.sh $TEST_SUITE $DB;
+     fi"
 
 script:
-  - sh script/ci_runner.sh
+  - "if [ $SKIP_BUILD ]; then
+      true;
+     else
+      sh script/ci_runner.sh
+     fi"
 
 notifications:
   email: false

--- a/script/travis_abort_conditions.sh
+++ b/script/travis_abort_conditions.sh
@@ -1,0 +1,45 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# script/travis_abort_conditions.sh
+#!/bin/sh
+
+echo `git log --pretty=%B -n 1 $TRAVIS_PULL_REQUEST_SHA`
+
+set -ev
+
+# abort if the commit message of the last commit
+# contains [ci-skip-ruby-unit]
+case ":`git log --pretty=%B -n 1 $TRAVIS_PULL_REQUEST_SHA`:" in
+  *\[ci-skip-ruby-unit\]*)
+    export SKIP_BUILD
+    ;;
+  *)
+    echo No abort commit message found;;
+esac


### PR DESCRIPTION
When '[ci-skip-ruby-unit]' is included in the commit message, the
CI will not execute the ruby unit specs.