### PR TITLE
Bump nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,7 @@ gem 'cocaine', '~> 0.5.8'
 # also, better than thin since we can control worker concurrency.
 gem 'unicorn'
 
-gem 'nokogiri', '~> 1.7.1'
+gem 'nokogiri', '~> 1.7.2'
 
 # carrierwave 0.11.3 should allow to use fog-aws without the rest of the
 # fog dependency chain. We only need aws here, so we can avoid it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (4.1.0.333)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     oj (3.0.5)
     openproject-token (1.0.0)


### PR DESCRIPTION
https://github.com/sparklemotion/nokogiri/issues/1634

It's marked a security patch, but I don't think its relevant for backporting.