### PR TITLE
Check contain:strict for extremely long timelines

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_table.sass
+++ b/app/assets/stylesheets/layout/_work_package_table.sass
@@ -110,7 +110,7 @@
   // Hint browser that this will inner-scroll
   will-change: transform
   // Hinter browser that the content of the flex is contained
-  contain: content
+  contain: strict
 
 // TIMELINE half of the tabletimeline flexbox
 .work-packages-tabletimeline--timeline-side
@@ -122,7 +122,7 @@
   // Hint browser that this will inner-scroll
   will-change: transform
   // Hinter browser that the content of the flex is contained
-  contain: content
+  contain: strict
 
 .work-packages--edit-actions
   .work-packages--left-panel &


### PR DESCRIPTION
For timelines with more than 10years, behavior will get sluggish due to the number of elements visible.

Locally, applying contain: strict will improve that further than contain: content