### PR TITLE
Avoid tabbing over the hierarchy indicator in the column headers

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -75,13 +75,11 @@
     padding-left: 0
 
 .hierarchy-header--icon
+  cursor: pointer
   display: inline-block
   width: 20px
 
-  span
-
-
-  span:before
+  i:before
     padding: 10px 0 0 0
     // Align the botched verticality of the hierarchy icons.
     vertical-align: text-top

--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.html
@@ -1,13 +1,14 @@
 <div class="generic-table--sort-header-outer">
   <span class="hierarchy-header--outer-span" ng-if="isHierarchyColumn">
-    <accessible-by-keyboard execute="toggleHierarchy($event)"
-                            ng-if="!isHierarchyDisabled"
-                            link-title="{{ text.toggleHierarchy }}"
-                            link-aria-label="{{ text.toggleHierarchy }}"
-                            link-class="hierarchy-header--icon"
-                            span-class="icon {{ hierarchyIcon }}"
-                            aria-hidden="true">
-    </accessible-by-keyboard>
+    <span
+       class="hierarchy-header--icon"
+       ng-click="toggleHierarchy($event)"
+       ng-if="!isHierarchyDisabled"
+       ng-attr-title="{{ text.toggleHierarchy }}"
+       tabindex="-1"
+       aria-hidden="true">
+      <op-icon icon-classes="icon {{ hierarchyIcon }}"></op-icon>
+    </span>
     <a href="javascript://"
        class="hierarchy-header--sort-title"
        ng-if="sortable"


### PR DESCRIPTION
This suggests to hide the icon from keyboard tab since this will always cause Jaws to either read `group (2 objects)`  due to the two links or to read the hierarchy button in each subject cell due to it being in the th.

This will cause the hierarchy button to be inaccessible _deliberately_, since the hierarchy mode can be enabled/disabled through the settings menu.

https://community.openproject.com/projects/openproject/work_packages/25225