### PR TITLE
Replace deprecated bourbon mixins with regular CSS attributes

### DIFF
--- a/app/assets/stylesheets/content/_datepicker.sass
+++ b/app/assets/stylesheets/content/_datepicker.sass
@@ -90,11 +90,11 @@ $dp-shadow-box-opacity: 1
 
     .ui-icon.ui-icon-circle-triangle-w
       background-position: -96px -16px
-      @include user-select(none)
+      user-select: none
 
     .ui-icon.ui-icon-circle-triangle-e
       background-position: -32px -16px
-      @include user-select(none)
+      user-select: none
 
     .ui-state-hover
       border-width: 0 !important

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -225,7 +225,7 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
     border: 3px solid #666666
     border-top: none
     border-right: none
-    @include transform(rotate(-50deg))
+    transform: rotate(-50deg)
 
 
 %form--fieldset-or-section

--- a/app/assets/stylesheets/content/_grid_table.sass
+++ b/app/assets/stylesheets/content/_grid_table.sass
@@ -41,7 +41,7 @@
   position: relative
 
   .grid-item
-    +transition(all 0.2s ease-in-out)
+    transition: all 0.2s ease-in-out
     height: $grid-item-height
     background: $grid-item-background
     width: 100%

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -49,7 +49,7 @@ $ng-modal-image-width:   $ng-modal-image-height
     cursor: pointer
 
   &.ng-enter
-    +transition(opacity 0.25s ease)
+    transition: opacity 0.25s ease
     opacity: 0
     visibility: hidden
 
@@ -65,7 +65,7 @@ $ng-modal-image-width:   $ng-modal-image-height
       overflow: visible
 
 .ng-modal-inner
-  +transition(opacity 0.25s ease)
+  transition: opacity 0.25s ease
   background: $ng-modal-background
   margin: auto
   max-height: 95%

--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -199,12 +199,12 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
 // awesome animations
 .notification-box
   &.ng-enter
-    +transition(opacity 0.5s ease)
+    transition: opacity 0.5s ease
     opacity: 0
   &.ng-enter.ng-enter-active
     opacity: 1
   &.ng-leave
-    +transition(opacity 2s ease)
+    transition: opacity 2s ease
     opacity: 1
   &.ng-leave.ng-leave-active
     opacity: 0

--- a/app/assets/stylesheets/content/_pagination.sass
+++ b/app/assets/stylesheets/content/_pagination.sass
@@ -29,32 +29,32 @@
 $pagination--font-size: 0.8125rem
 
 .pagination
-  +display(flex)
-  +justify-content(space-between)
+  display: flex
+  justify-content: space-between
   width: 100%
 
 .pagination--pages
-  +flex-grow(2)
-  +flex-shrink(2)
+  flex-grow: 2
+  flex-shrink: 2
   margin: 10px 5px 10px 0
 
 .pagination--options
-  +flex-grow(1)
-  +flex-shrink(1)
+  flex-grow: 1
+  flex-shrink: 1
   margin: 10px 0 0 5px
 
 .pagination--items
   list-style-type: none
-  +display(flex)
+  display: flex
   margin: 0
   padding: 0
   font-size: $pagination--font-size
 
   .pagination--pages &
-    +justify-content(flex-start)
+    justify-content: flex-start
 
   .pagination--options &
-    +justify-content(flex-end)
+    justify-content: flex-end
 
 .pagination--item
   min-width: 25px
@@ -96,7 +96,7 @@ $pagination--font-size: 0.8125rem
   margin: 0 5px 0 0
 
 .pagination--label
-  +flex(1)
+  flex: 1
   padding: 3px 0
   margin-right: 5px
   white-space: nowrap
@@ -105,7 +105,7 @@ $pagination--font-size: 0.8125rem
   text-overflow: ellipsis
 
 .pagination--range
-  +flex(1)
+  flex: 1
   margin: 0 0 0 5px
   padding: 3px 0
   display: block

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-@include keyframes(fade-out)
+@keyframes fade-out
   from
     opacity: 1
   to
@@ -57,7 +57,7 @@ $input-elements: input, 'input.form--text-field', select, 'select.form--select',
 #generic-table
   tr.issue
     &.ng-enter, &.ng-move
-      @include transition(0.5s linear all)
+      transition: 0.5s linear all
       opacity: 0
     &.ng-enter.ng-enter-active, &.ng-move.ng-move-active
       opacity: 1

--- a/app/assets/stylesheets/content/_user.sass
+++ b/app/assets/stylesheets/content/_user.sass
@@ -41,8 +41,8 @@ h1, h2, h3, h4, tr
 
 
 .user-avatar--container
-  +display(flex)
-  +align-items(flex-start)
+  display: flex
+  align-items: flex-start
   width: 100%
 
 .user-avatar--avatar
@@ -50,7 +50,7 @@ h1, h2, h3, h4, tr
   margin-right: 0.5em
 
 .user-avatar--user-with-role
-  +flex(1)
+  flex: 1
 
 .user-avatar--user
   display:        block

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -39,8 +39,7 @@ body
 
 #wrapper
   @include default-transition
-  +background-image(linear-gradient(to bottom, $main-menu-bg-color 0%, $main-menu-bg-color 100%))
-  background-repeat: no-repeat
+  background: linear-gradient(to bottom, $main-menu-bg-color 0%, $main-menu-bg-color 100%) no-repeat
   background-size: $main-menu-width 100%
   min-height: 100%
   height: auto


### PR DESCRIPTION
Removes sass compilation deprecation warnings of the form:

````
WARNING: [Bourbon] [Deprecation] `user-select` is deprecated and will be removed in 5.0.0. We suggest using an automated prefixing tool, like Autoprefixer.
         on line 10 of /Users/oliver/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/bourbon-4.3.4/app/assets/stylesheets/_bourbon-deprecate.scss, in `_bourbon-deprecate'
         from line 17 of /Users/oliver/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/bourbon-4.3.4/app/assets/stylesheets/_bourbon-deprecate.scss, in `_bourbon-deprecate-for-prefixing'
         from line 2 of /Users/oliver/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/bourbon-4.3.4/app/assets/stylesheets/css3/_user-select.scss, in `user-select'
         from line 97 of /Users/oliver/finn/openproject/dev/app/assets/stylesheets/content/_datepicker.sass
         from line 60 of /Users/oliver/finn/openproject/dev/app/assets/stylesheets/content/_index.sass
         from line 50 of /Users/oliver/finn/openproject/dev/app/assets/stylesheets/openproject.sass
```


They are covered by the `rails-autoprefixer`