### PR TITLE
only permit ids as relations api call filter params

### DIFF
--- a/frontend/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations.service.ts
@@ -202,10 +202,12 @@ export class WorkPackageRelationsService {
 
 
   private relationsRequest(workPackageIds:string[]):ng.IPromise<RelationResource[]> {
+    let validIds = _.filter(workPackageIds, id => /\d+/.test(id));
+
     return this.halRequest.get(
       '/api/v3/relations',
       {
-        filters: JSON.stringify([{ involved: {operator: '=', values: workPackageIds } }])
+        filters: JSON.stringify([{ involved: {operator: '=', values: validIds }}])
       },
       {
         caching: { enabled: false }


### PR DESCRIPTION
In case a new work package is inline created, its id, which is `new` at that point, is deduced from a data attribute of the table row the work package is create in. Only number are allowed.

As new work packages will not have relations, this is ok for now.

https://community.openproject.com/projects/openproject/work_packages/25229