### PR TITLE
Fix renaming/saving a query item in the frontend missing the icon

### DIFF
--- a/frontend/app/layout/query-menu-item-factory.js
+++ b/frontend/app/layout/query-menu-item-factory.js
@@ -72,7 +72,7 @@ module.exports = function(menuItemFactory, $state, $stateParams, $animate, $time
 
       scope.$on('openproject.layout.renameMenuItem', function(event, itemData) {
         if (itemData.itemType === QUERY_MENU_ITEM_TYPE && itemData.objectId == scope.queryId) {
-          element.html(itemData.objectName);
+          element.find('.menu-item--title').html(itemData.objectName);
         }
       });
     }

--- a/frontend/app/templates/layout/menu_item.html
+++ b/frontend/app/templates/layout/menu_item.html
@@ -6,5 +6,5 @@
      lang="{{lang || 'en'}}"
      title="{{title}}">
     <op-icon icon-classes="icon2 icon-pin ellipsis"></op-icon>
-    {{ title }}
+    <span class="menu-item--title" ng-bind="title"></span>
 </li>

--- a/frontend/tests/unit/tests/layout/query-menu-item-directive-test.js
+++ b/frontend/tests/unit/tests/layout/query-menu-item-directive-test.js
@@ -57,7 +57,7 @@ describe('queryMenuItem Directive', function() {
     }));
 
     beforeEach(inject(function($rootScope, $compile) {
-      html = '<div query-menu-item object-id=' + queryId + '></div>';
+      html = '<div query-menu-item object-id=' + queryId + '><span class="menu-item--title">title</span></div>';
 
       compile = function() {
         element = angular.element(html);

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -191,7 +191,7 @@ module Redmine::MenuManager::MenuHelper
     link_text = ''.html_safe
     link_text << op_icon(item.icon) if item.icon.present?
     link_text << you_are_here_info(selected)
-    link_text << content_tag(:span, caption, lang: menu_item_locale(item))
+    link_text << content_tag(:span, caption, class: 'menu-item--title', lang: menu_item_locale(item))
     html_options = item.html_options(selected: selected)
     html_options[:title] ||= selected ? t(:description_current_position) + caption : caption
 


### PR DESCRIPTION
The content of the node is replaced, even though now it contains an icon
tag for accessibility reasons.