### PR TITLE
[25251] Design bugs on WP page

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -84,6 +84,6 @@
   span:before
     padding: 10px 0 0 0
     // Align the botched verticality of the hierarchy icons.
-    vertical-align: text-top
-    font-size: 1.1rem
+    vertical-align: middle
+    font-size: 20px
     @include varprop(color, body-font-color)

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_legacy_inplace_styles.sass
@@ -81,7 +81,7 @@ a.inplace-editing--trigger-link,
   color: $body-font-color
   visibility: hidden
 
-  .icon-context
+  i
     position: relative
     // Position the icon in the middle
     top: calc(50% - 0.5rem)

--- a/app/assets/stylesheets/layout/_work_package_table.sass
+++ b/app/assets/stylesheets/layout/_work_package_table.sass
@@ -51,15 +51,16 @@
 
 .work-packages-list-view--container
   // Set minor padding on left side
-  padding-left: 5px
+  padding-left: 15px
   // Flexbox for the toolbar, filters and work package split view
   display: flex
   flex-direction: column
   height: 100%
 
   > .toolbar-container
+    margin-top: 0.5rem
     // not flex-item
-    padding-right: 5px
+    padding-right: 15px
 
   .work-packages--filters-optional-container
     // not flex-item
@@ -98,6 +99,8 @@
 // Footer of the left side
 .work-packages-split-view--tabletimeline-footer
   flex: 0 0 $footer-height
+  .pagination--options
+    margin-right: 10px
 
 // TABLE half of the tabletimeline flexbox
 .work-packages-tabletimeline--table-side

--- a/app/assets/stylesheets/layout/_work_packages_details_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_details_view.sass
@@ -35,9 +35,9 @@ body.action-create
     overflow-x: hidden
     overflow-y: auto
     position: relative
-    border-left: 4px solid #eee
-    border-top: 4px solid #eee
-    padding: 0 10px
+    border-left: 2px solid #eee
+    border-top: 2px solid #eee
+    padding: 0
 
 .work-packages--details
   height: 100%
@@ -75,11 +75,11 @@ body.action-create
 
 .work-packages--details-content
   position:   absolute
-  top:        80px
+  top:        50px
   bottom:     55px
   width:      100%
   +allow-vertical-scrolling
-  padding:    0
+  padding:    0 15px
   &.-create-mode
     top: 0
     h2

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -136,7 +136,7 @@ body.controller-work_packages.full-create
   width: 40%
 
   .work-packages--panel-inner
-    padding: 20px 0px 0px 15px
+    padding: 15px 15px 0px 15px
 
   .work-package-details-activities-activity-contents ul
     padding-left: 2em
@@ -177,7 +177,7 @@ body.controller-work_packages.full-create
     display: none
 
 .work-packages--show-view
-  padding: 0 10px
+  padding: 0 0 0 15px
 
   .subject-header
     margin: 0
@@ -209,6 +209,10 @@ body.controller-work_packages.full-create
     .work-packages--subject-element .wp-inline-edit--field
       height: 1.75rem
       margin-top: 11px
+
+  > .toolbar-container
+    margin: 10px 0 5px 0
+    padding-right: 15px
 
 .work-packages--subject-type-row
   display: flex

--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.ts
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.ts
@@ -83,11 +83,11 @@ function sortHeader(wpTableHierarchies: WorkPackageTableHierarchiesService,
       function setHierarchyIcon() {
         if (wpTableHierarchies.isEnabled) {
           scope.text.toggleHierarchy = I18n.t('js.work_packages.hierarchy.hide');
-          scope.hierarchyIcon = 'icon-no-hierarchy';
+          scope.hierarchyIcon = 'icon-hierarchy';
         }
         else {
           scope.text.toggleHierarchy = I18n.t('js.work_packages.hierarchy.show');
-          scope.hierarchyIcon = 'icon-hierarchy';
+          scope.hierarchyIcon = 'icon-no-hierarchy';
         }
       }
 

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -209,7 +209,7 @@ module OpenProject
       'generic-table--header-height'                         => '45px',
       'generic-table--footer-height'                         => '34px',
       'timeline--grid-color'                                 => '#dddddd',
-      'timeline--separator'                                  => '5px solid #E7E7E7'
+      'timeline--separator'                                  => '3px solid #E7E7E7'
     }.freeze
 
     ##


### PR DESCRIPTION
This fixes multiple design bugs on the WP page.
* The distance to the left and the top (List view)
* The distance below the tabs (details view)

Next to the issues mentioned in the ticket, the following bugs has been fixed.
* The inner padding of the details content (details, full screen view)
* The alignment of the icons within comments/watchers inlace edit 
* Switch and align hierarchy icons

https://community.openproject.com/projects/openproject/work_packages/25251/activity
https://community.openproject.com/projects/openproject/work_packages/25009/activity