### PR TITLE
[25247][25233] Disable flex behavior on children of timeline cells

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
@@ -54,6 +54,10 @@
   display: flex
   align-items: center
 
+  // Need to disable flex behavior on children
+  > div
+    flex: 0 0 auto
+
   // Relative position for positioning of elements within
   position: relative
 


### PR DESCRIPTION
The `display: flex` used solely for centering the cells vertically caused children to be grow/shrink depending on the total width.

https://community.openproject.com/projects/openproject/work_packages/25247/
https://community.openproject.com/projects/openproject/work_packages/25233/