### PR TITLE
Fix/inline create on open details pane

### DIFF
--- a/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
@@ -227,7 +227,7 @@ function SettingsDropdownMenuController($scope:IMyScope,
   };
 
   $scope.showExportModalInvalid = function () {
-    return AuthorisationService.cannot('work_package', 'representations');
+    return AuthorisationService.cannot('work_packages', 'representations');
   };
 
   $scope.deleteQueryInvalid = function () {
@@ -257,7 +257,7 @@ function SettingsDropdownMenuController($scope:IMyScope,
   }
 
   function allowWorkPackageAction(event:JQueryEventObject, action:any) {
-    return allowAction(event, 'work_package', action);
+    return allowAction(event, 'work_packages', action);
   }
 
   function allowFormAction(event:JQueryEventObject, action:string) {

--- a/frontend/app/components/routing/wp-list/wp.list.html
+++ b/frontend/app/components/routing/wp-list/wp.list.html
@@ -9,7 +9,7 @@
       <ul class="toolbar-items hide-when-print" ng-if="tableInformationLoaded">
         <li class="toolbar-item">
           <wp-create-button
-              allowed="allowed('work_package', 'createWorkPackage')"
+              allowed="allowed('work_packages', 'createWorkPackage')"
               project-identifier="projectIdentifier"
               state-name="work-packages.list.new">
           </wp-create-button>

--- a/frontend/app/components/work-packages/work-package-more-menu.service.ts
+++ b/frontend/app/components/work-packages/work-package-more-menu.service.ts
@@ -67,7 +67,7 @@ export class WorkPackageMoreMenuService {
         }
         break;
     }
-  };
+  }
 
   /**
    * Load allowed links on this work package.
@@ -75,7 +75,7 @@ export class WorkPackageMoreMenuService {
    */
   public initialize() {
     return this.workPackage.project.$load().then(() => {
-      AuthorisationService.initModelAuth('work_package', this.workPackage);
+      AuthorisationService.initModelAuth('work_package', this.workPackage.$links);
 
       var authorization = new WorkPackageAuthorization(this.workPackage);
       this.permittedActions = angular.extend(this.getPermittedActions(authorization, PERMITTED_MORE_MENU_ACTIONS),
@@ -113,7 +113,7 @@ export class WorkPackageMoreMenuService {
       var css:string[] = [].concat(action.css);
 
       if (css.length === 0) {
-        css = ["icon-" + action.key];
+        css = ['icon-' + action.key];
       }
 
       this[action.key] = { link: action.link, css: css };
@@ -125,7 +125,7 @@ export class WorkPackageMoreMenuService {
   private isLinkToAnguluar(link:string) {
     var stateForLink = $state.get().filter(state => (state as any).$$state().url.exec(link));
 
-    return stateForLink.length > 0
+    return stateForLink.length > 0;
   }
 }
 

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -218,7 +218,7 @@ export class WorkPackageInlineCreateController {
   }
 
   public get isAllowed():boolean {
-    return this.AuthorisationService.can('work_package', 'createWorkPackage');
+    return this.AuthorisationService.can('work_packages', 'createWorkPackage');
   }
 }
 

--- a/frontend/app/components/wp-list/wp-list.service.ts
+++ b/frontend/app/components/wp-list/wp-list.service.ts
@@ -50,7 +50,7 @@ import {WorkPackageTablePaginationService} from '../wp-fast-table/state/wp-table
 import {WorkPackagesListInvalidQueryService} from './wp-list-invalid-query.service';
 import {WorkPackageTableTimelineService} from './../wp-fast-table/state/wp-table-timeline.service';
 import {WorkPackageTableHierarchiesService} from './../wp-fast-table/state/wp-table-hierarchy.service';
-import {SchemaCacheService} from "../schemas/schema-cache.service";
+import {SchemaCacheService} from '../schemas/schema-cache.service';
 import {Observable} from 'rxjs';
 
 export class WorkPackagesListService {
@@ -121,7 +121,7 @@ export class WorkPackagesListService {
 
     promise
       .catch(error => {
-        let projectIdentifier = query.project && query.project.id
+        let projectIdentifier = query.project && query.project.id;
 
         return this.handleQueryLoadingError(error, {}, query.id, projectIdentifier);
       });
@@ -146,7 +146,7 @@ export class WorkPackagesListService {
     let pagination = this.getPaginationInfo();
     let query = this.currentQuery;
 
-    return this.loadResultsList(query, pagination)
+    return this.loadResultsList(query, pagination);
   }
 
   /**
@@ -157,10 +157,10 @@ export class WorkPackagesListService {
     pagination.offset = 1;
     let query = this.currentQuery;
 
-    return this.loadResultsList(query, pagination)
+    return this.loadResultsList(query, pagination);
   }
 
-  public loadForm(query:QueryResource):ng.IPromise<QueryFormResource>{
+  public loadForm(query:QueryResource):ng.IPromise<QueryFormResource> {
     return this.QueryFormDm.load(query).then((form:QueryFormResource) => {
       this.updateStatesFromForm(query, form);
 
@@ -296,7 +296,7 @@ export class WorkPackagesListService {
   }
 
   private updateStatesFromWPListOnPromise(promise:ng.IPromise<WorkPackageCollectionResource>):ng.IPromise<WorkPackageCollectionResource> {
-    return promise.then(this.updateStatesFromWPCollection.bind(this))
+    return promise.then(this.updateStatesFromWPCollection.bind(this));
   }
 
   private updateStatesFromQuery(query:QueryResource) {
@@ -335,7 +335,7 @@ export class WorkPackagesListService {
 
     this.wpTablePagination.initialize(results);
 
-    this.AuthorisationService.initModelAuth('work_package', results.$links);
+    this.AuthorisationService.initModelAuth('work_packages', results.$links);
   }
 
   private updateStatesFromForm(query:QueryResource, form:QueryFormResource) {
@@ -369,7 +369,7 @@ export class WorkPackagesListService {
   private updateQueryMenu() {
     let query = this.currentQuery;
 
-    if(query.starred) {
+    if (query.starred) {
       this.createMenuItem(query);
     } else {
       this.removeMenuItem(query);

--- a/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
@@ -368,7 +368,7 @@ describe('optionsDropdown Directive', function() {
       });
 
       it('activates the export modal on click', function() {
-        authorisation.withArgs('work_package', 'representations').returns(true);
+        authorisation.withArgs('work_packages', 'representations').returns(true);
 
         compile();
 


### PR DESCRIPTION
Avoid mixing permissions (read links) on work_package resource with those on the work_package**S** resource. The work_package permissions used to override the work_packages permission and by that, it was impossible to create a new work package inline once the timeline was opened.

https://community.openproject.com/projects/openproject/work_packages/25256
https://community.openproject.com/projects/openproject/work_packages/25239