### PR TITLE
[25253] Correct wp footer padding to match previous distance

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_table.sass
+++ b/app/assets/stylesheets/layout/_work_package_table.sass
@@ -99,8 +99,16 @@
 // Footer of the left side
 .work-packages-split-view--tabletimeline-footer
   flex: 0 0 $footer-height
+
+  // Only add padding to lower/right corner
+  // to override default margins
+  .pagination
+    margin: 0
+    padding: 15px 10px 5px 0
+
+  .pagination--pages,
   .pagination--options
-    margin-right: 10px
+    margin: 0
 
 // TABLE half of the tabletimeline flexbox
 .work-packages-tabletimeline--table-side


### PR DESCRIPTION
While still being 55px high as before, this corrects the padding to the
bottom to match the details pane.

https://community.openproject.com/projects/openproject/work_packages/25253/