### PR TITLE
[251939 Render clamp-style parent in timeline only when children visible

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -6,7 +6,10 @@ import {$injectFields} from "../../../../angular/angular-injector-bridge.functio
 import {Observable} from 'rxjs';
 import {RowRefreshBuilder} from "../../rows/row-refresh-builder";
 import {WorkPackageEditForm} from "../../../../wp-edit-form/work-package-edit-form";
-import {collapsedGroupClass, hierarchyRootClass} from "../../../helpers/wp-table-hierarchy-helpers";
+import {
+  collapsedGroupClass, hasChildrenInTable,
+  hierarchyRootClass
+} from "../../../helpers/wp-table-hierarchy-helpers";
 import {QueryColumn} from "../../../../api/api-v3/hal-resources/query-resource.service";
 import {UiStateLinkBuilder} from "../../ui-state-link-builder";
 
@@ -149,7 +152,7 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
     hierarchyIndicator.classList.add(hierarchyCellClassName);
     hierarchyIndicator.style.width = 25 + (20 * level) + 'px';
 
-    if (workPackage.$loaded && !this.hasChildrenInTable(workPackage)) {
+    if (workPackage.$loaded && !hasChildrenInTable(workPackage, this.workPackageTable)) {
       hierarchyIndicator.innerHTML = `
             <span tabindex="0" class="wp-table--leaf-indicator">
               <span class="hidden-for-sighted">${this.text.leaf(level)}</span>
@@ -168,21 +171,7 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
     return hierarchyIndicator;
   }
 
-  /**
-   * Returns whether any of the children of this work package
-   * are visible in the table results.
-   */
-  private hasChildrenInTable(workPackage:WorkPackageResourceInterface) {
-    if (workPackage.isLeaf) {
-      return false; // Work Package has no children at all
-    }
 
-    // If any visible children in the table
-    return !!_.find(workPackage.children, (child:WorkPackageResourceInterface) => {
-      const childId = child.idFromLink!;
-      return this.workPackageTable.rowIndex[childId] !== undefined;
-    });
-  }
 }
 
 SingleHierarchyRowBuilder.$inject = ['states', 'I18n'];

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
@@ -1,3 +1,5 @@
+import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
+import {WorkPackageTable} from '../wp-fast-table';
 /**
  * Returns the collapsed group class for the given ancestor id
  */
@@ -11,4 +13,20 @@ export function hierarchyGroupClass(ancestorId:string):string {
 
 export function hierarchyRootClass(ancestorId:string):string {
   return `__hierarchy-root-${ancestorId}`;
+}
+
+/**
+ * Returns whether any of the children of this work package
+ * are visible in the table results.
+ */
+export function hasChildrenInTable(workPackage:WorkPackageResourceInterface, table:WorkPackageTable) {
+  if (workPackage.isLeaf) {
+    return false; // Work Package has no children at all
+  }
+
+  // If any visible children in the table
+  return !!_.find(workPackage.children, (child:WorkPackageResourceInterface) => {
+    const childId = child.idFromLink!;
+    return table.rowIndex[childId] !== undefined;
+  });
 }

--- a/frontend/app/components/wp-table/timeline/cell-renderer/timeline-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cell-renderer/timeline-cell-renderer.ts
@@ -10,6 +10,8 @@ import {
 } from "../wp-timeline";
 import {classNameLeftHandle, classNameRightHandle} from "../wp-timeline-cell-mouse-handler";
 import Moment = moment.Moment;
+import {WorkPackageTimelineTableController} from '../container/wp-timeline-container.directive';
+import {hasChildrenInTable} from '../../../wp-fast-table/helpers/wp-table-hierarchy-helpers';
 
 interface CellDateMovement {
   // Target values to move work package to
@@ -22,6 +24,9 @@ export class TimelineCellRenderer {
   protected TimezoneService:any;
 
   protected dateDisplaysOnMouseMove: {left?: HTMLElement; right?: HTMLElement} = {};
+
+  constructor(public workPackageTimeline:WorkPackageTimelineTableController) {
+  }
 
   public get type(): string {
     return "bar";
@@ -328,8 +333,14 @@ export class TimelineCellRenderer {
    */
   checkForSpecialDisplaySituations(renderInfo: RenderInfo, bar: HTMLElement) {
     const wp = renderInfo.workPackage;
+
+    // Cannot eddit the work package if it has children
     if (!wp.isLeaf) {
       bar.classList.add("-readonly");
+    }
+
+    // Display the parent as clamp-style when it has children in the table
+    if (hasChildrenInTable(wp, this.workPackageTimeline.workPackageTable)) {
       bar.style.borderLeft = "2px solid black";
       bar.style.borderRight = "2px solid black";
       bar.style.borderTop = "2px solid black";

--- a/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -41,10 +41,13 @@ import {RenderInfo, timelineMarkerSelectionStartClass, TimelineViewParameters} f
 import {WorkPackageTimelineCell} from "../wp-timeline-cell";
 import IDirective = angular.IDirective;
 import IScope = angular.IScope;
+import {WorkPackageTable} from '../../../wp-fast-table/wp-fast-table';
 
 export class WorkPackageTimelineTableController {
 
-  public wpTable: WorkPackagesTableController;
+  public wpTableDirective: WorkPackagesTableController;
+
+  public workPackageTable: WorkPackageTable;
 
   private _viewParameters: TimelineViewParameters = new TimelineViewParameters();
 
@@ -60,7 +63,6 @@ export class WorkPackageTimelineTableController {
 
   constructor(private $scope:IScope,
               private $element:ng.IAugmentedJQuery,
-              private TypeResource:any,
               private states:States,
               private wpTableTimeline:WorkPackageTableTimelineService,
               private wpNotificationsService:WorkPackageNotificationService,
@@ -71,7 +73,7 @@ export class WorkPackageTimelineTableController {
 
   $onInit() {
     // Register this instance to the table
-    this.wpTable.registerTimeline(this, this.timelineBody[0]);
+    this.wpTableDirective.registerTimeline(this, this.timelineBody[0]);
 
     // Refresh timeline view after table rendered
     this.states.table.rendered.values$()
@@ -277,6 +279,6 @@ openprojectModule.component("wpTimelineContainer", {
   controller: WorkPackageTimelineTableController,
   templateUrl:  '/components/wp-table/timeline/container/wp-timeline-container.html',
   require: {
-    wpTable: '^wpTable'
+    wpTableDirective: '^wpTable'
   }
 });

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
@@ -40,11 +40,6 @@ import IScope = angular.IScope;
 import Moment = moment.Moment;
 import {WorkPackageTableRefreshService} from "../wp-table-refresh-request.service";
 
-const renderers = {
-  milestone: new TimelineMilestoneCellRenderer(),
-  generic: new TimelineCellRenderer()
-};
-
 export class WorkPackageTimelineCell {
   public wpCacheService: WorkPackageCacheService;
   public wpTableRefresh: WorkPackageTableRefreshService;
@@ -58,10 +53,17 @@ export class WorkPackageTimelineCell {
 
   private elementShape: string;
 
+  private renderers:{ milestone: TimelineMilestoneCellRenderer, generic: TimelineCellRenderer };
+
   constructor(private workPackageTimeline: WorkPackageTimelineTableController,
               private workPackageId: string,
               public timelineCell: HTMLElement) {
     injectorBridge(this);
+
+    this.renderers = {
+      milestone: new TimelineMilestoneCellRenderer(this.workPackageTimeline),
+      generic: new TimelineCellRenderer(this.workPackageTimeline)
+    };
   }
 
   activate() {
@@ -145,10 +147,10 @@ export class WorkPackageTimelineCell {
 
   private cellRenderer(workPackage: WorkPackageResourceInterface): TimelineCellRenderer {
     if (workPackage.isMilestone) {
-      return renderers.milestone;
+      return this.renderers.milestone;
     }
 
-    return renderers.generic;
+    return this.renderers.generic;
   }
 
   private updateView(renderInfo: RenderInfo) {

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -59,7 +59,7 @@ function wpTable(
 
     controller: WorkPackagesTableController,
 
-    link: function(scope:any,
+    link: function(scope:ng.IScope,
                    element:ng.IAugmentedJQuery,
                    attributes:ng.IAttributes) {
 
@@ -175,6 +175,7 @@ export class WorkPackagesTableController {
     const tbody = this.$element.find('.work-package--results-tbody');
     this.$scope.table = new WorkPackageTable(this.$element[0], tbody[0], body, controller);
     this.$scope.tbody = tbody;
+    controller.workPackageTable = this.$scope.table;
 
 
     var t1 = performance.now();


### PR DESCRIPTION
When no children is visible in the timeline, don't use the `clamp-style` to render the parent.

https://community.openproject.com/projects/openproject/work_packages/25193/