### PR TITLE
fix project dropdown highlight

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -119,11 +119,13 @@
         @extend .icon-pulldown:before
     &:hover
       @include varprop(background-color, header-item-bg-hover-color)
-    &.open .button--dropdown-indicator
+    &.open
       @include varprop(background-color, header-item-bg-hover-color)
       color: $header-item-font-hover-color
-      &:before
-        @extend .icon-pulldown-up:before
+
+      .button--dropdown-indicator
+        &:before
+          @extend .icon-pulldown-up:before
 
     li
       > a


### PR DESCRIPTION
Highlight whole li instead of only highlighting the expand icon

[ci skip]

https://community.openproject.com/projects/openproject/work_packages/25258