### PR TITLE
[25245] Show loading indicator for single WP save in timeline

### DIFF
--- a/frontend/app/components/common/loading-indicator/loading-indicator.service.ts
+++ b/frontend/app/components/common/loading-indicator/loading-indicator.service.ts
@@ -29,6 +29,7 @@
 export const indicatorLocationSelector = '.loading-indicator--location';
 export const indicatorBackgroundSelector = '.loading-indicator--background';
 
+
 export class LoadingIndicator {
 
   constructor(public indicator:JQuery, public element:JQuery) {}
@@ -36,7 +37,8 @@ export class LoadingIndicator {
   public set promise(promise:ng.IPromise<any>) {
     this.start();
     promise.finally(() => {
-      this.stop();
+      // Delay hiding the indicator a little bit.
+      setTimeout(() => this.stop(), 25);
     });
   }
 
@@ -46,6 +48,7 @@ export class LoadingIndicator {
 
   public stop() {
     this.element.remove();
+
   }
 }
 

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell-mouse-handler.ts
@@ -35,6 +35,7 @@ import IScope = angular.IScope;
 import * as moment from 'moment';
 import Moment = moment.Moment;
 import {WorkPackageTableRefreshService} from "../wp-table-refresh-request.service";
+import {LoadingIndicatorService} from '../../common/loading-indicator/loading-indicator.service';
 
 const classNameBar = "bar";
 export const classNameLeftHandle = "leftHandle";
@@ -45,6 +46,7 @@ export function registerWorkPackageMouseHandler(this: void,
                                                 workPackageTimeline: WorkPackageTimelineTableController,
                                                 wpCacheService: WorkPackageCacheService,
                                                 wpTableRefresh: WorkPackageTableRefreshService,
+                                                loadingIndicator: LoadingIndicatorService,
                                                 cell: HTMLElement,
                                                 bar: HTMLDivElement,
                                                 renderer: TimelineCellRenderer,
@@ -222,7 +224,7 @@ export function registerWorkPackageMouseHandler(this: void,
       return;
     }
 
-    wpCacheService.saveWorkPackage(workPackage)
+    loadingIndicator.table.promise = wpCacheService.saveWorkPackage(workPackage)
       .then(() => {
         wpTableRefresh.request(true, `Moved work package ${workPackage.id} through timeline`);
       })

--- a/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline-cell.ts
@@ -39,11 +39,13 @@ import { injectorBridge } from "../../angular/angular-injector-bridge.functions"
 import IScope = angular.IScope;
 import Moment = moment.Moment;
 import {WorkPackageTableRefreshService} from "../wp-table-refresh-request.service";
+import {LoadingIndicatorService} from '../../common/loading-indicator/loading-indicator.service';
 
 export class WorkPackageTimelineCell {
   public wpCacheService: WorkPackageCacheService;
   public wpTableRefresh: WorkPackageTableRefreshService;
   public states: States;
+  public loadingIndicator: LoadingIndicatorService;
 
   private subscription: Subscription;
 
@@ -138,6 +140,7 @@ export class WorkPackageTimelineCell {
         this.workPackageTimeline,
         this.wpCacheService,
         this.wpTableRefresh,
+        this.loadingIndicator,
         this.timelineCell,
         this.wpElement,
         renderer,
@@ -169,4 +172,4 @@ export class WorkPackageTimelineCell {
 
 }
 
-WorkPackageTimelineCell.$inject = ['wpCacheService', 'wpTableRefresh', 'states', 'TimezoneService'];
+WorkPackageTimelineCell.$inject = ['loadingIndicator', 'wpCacheService', 'wpTableRefresh', 'states', 'TimezoneService'];


### PR DESCRIPTION
After moving a single element in the timeline, the table has to be
reloaded for potential subsequent changes (e.g., movement in relations,
parents, children, etc).

By showing a loading indicator for the single WP save action, we avoid
having a gap between the action and the loading indicator for the table.

On the other hand, this is not shown for inline-editing (unchanged, the
work packages are loaded in the background after saving the line).

Quick fix for:
https://community.openproject.com/projects/openproject/work_packages/25245