### PR TITLE
truncate wp subject on split and full view

### DIFF
--- a/app/assets/stylesheets/layout/_work_packages_details_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_details_view.sass
@@ -98,12 +98,15 @@ body.action-create
 
   .work-packages--subject-element
     line-height: 24px
+    overflow: hidden
 
     .wp-inline-edit--field
       height: 38px
       line-height: 36px
       padding: 0 0.375rem
 
+.work-packages--type-selector
+  flex-shrink: 0
 
 .work-packages--details
   .work-packages--attachments

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -200,6 +200,9 @@ body.controller-work_packages.full-create
       padding-top: 0
       padding-bottom: 0
 
+    .work-packages--subject-element
+      overflow: hidden
+
     .work-packages--subject-element,
     .work-packages--details--subject .wp-inline-edit--field
       font-size: 20px


### PR DESCRIPTION
I don't consider this to be a permanent fix at least for the full view. The subject currently wraps together with the back button which I don't think to be desirable. It would IMO be better to leave them all in one row and let the subject wrap to the bottom as it becomes longer.

[ci skip]

https://community.openproject.com/projects/openproject/work_packages/25244