### PR TITLE
Remember which rows were rendered

### DIFF
--- a/frontend/app/components/states.service.ts
+++ b/frontend/app/components/states.service.ts
@@ -19,6 +19,7 @@ import {WPTableRowSelectionState} from "./wp-fast-table/wp-table.interfaces";
 import {whenDebugging} from "../helpers/debug_output";
 import {WorkPackageTableHierarchies} from "./wp-fast-table/wp-table-hierarchies";
 import {WorkPackageTableTimelineState} from "./wp-fast-table/wp-table-timeline";
+import {TableRenderResult} from './wp-fast-table/builders/modes/table-render-pass';
 
 export class States extends Component {
 
@@ -76,7 +77,7 @@ export class TableState {
   // Hierarchies of table
   hierarchies = input<WorkPackageTableHierarchies>();
   // State to be updated when the table is up to date
-  rendered = input<WorkPackageTable>();
+  rendered = input<TableRenderResult>();
   // State to determine timeline visibility
   timelineVisible = input<WorkPackageTableTimelineState>();
   // Subject used to unregister all listeners of states above.

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
@@ -1,0 +1,51 @@
+import {$injectFields} from '../../../../angular/angular-injector-bridge.functions';
+import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
+import {groupName} from './grouped-rows-helpers';
+export const rowGroupClassName = 'wp-table--group-header';
+
+export class GroupHeaderBuilder {
+  public I18n:op.I18n;
+  public text:{ collapse:string, expand:string };
+
+  constructor() {
+    $injectFields(this, 'I18n');
+
+    this.text = {
+      collapse: this.I18n.t('js.label_collapse'),
+      expand: this.I18n.t('js.label_expand'),
+    };
+  }
+
+  public buildGroupRow(group:GroupObject, colspan:number) {
+    let row = document.createElement('tr');
+    let togglerIconClass, text;
+
+    if (group.collapsed) {
+      text = this.text.expand;
+      togglerIconClass = 'icon-plus';
+    } else {
+      text = this.text.collapse;
+      togglerIconClass = 'icon-minus2';
+    }
+
+    row.classList.add(rowGroupClassName);
+    row.id = `wp-table-rowgroup-${group.index}`;
+    row.dataset['groupIndex'] = (group.index as number).toString();
+    row.dataset['groupIdentifier'] = group.identifier as string;
+    row.innerHTML = `
+      <td colspan="${colspan}" class="-no-highlighting">
+        <div class="expander icon-context ${togglerIconClass}">
+          <span class="hidden-for-sighted">${_.escape(text)}</span>
+        </div>
+        <div class="group--value">
+          ${_.escape(groupName(group))}
+          <span class="count">
+            (${group.count})
+          </span>
+        </div>
+      </td>
+    `;
+
+    return row;
+  }
+}

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -1,0 +1,110 @@
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {WorkPackageResourceInterface} from '../../../../api/api-v3/hal-resources/work-package-resource.service';
+import {WorkPackageTableRow} from '../../../wp-table.interfaces';
+import {SingleRowBuilder} from '../../rows/single-row-builder';
+import {collapsedRowClass, rowGroupClassName} from './grouped-rows-builder';
+import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
+import {HalResource} from '../../../../api/api-v3/hal-resources/hal-resource.service';
+import {GroupHeaderBuilder} from './group-header-builder';
+import {groupByProperty, groupedRowClassName} from './grouped-rows-helpers';
+import {Subject} from 'rxjs';
+import {PlainRenderPass} from '../plain/plain-render-pass';
+
+export class GroupedRenderPass extends PlainRenderPass {
+  constructor(public workPackageTable:WorkPackageTable,
+              public stopExisting$:Subject<undefined>,
+              public groups:GroupObject[],
+              public headerBuilder:GroupHeaderBuilder,
+              public colspan:number) {
+    super(workPackageTable, stopExisting$, new SingleRowBuilder(workPackageTable));
+  }
+
+  /**
+   * Rebuild the entire grouped tbody from the given table
+   */
+  protected doRender() {
+    let currentGroup:GroupObject | null = null;
+    this.workPackageTable.rows.forEach((wpId:string) => {
+      let row = this.workPackageTable.rowIndex[wpId];
+      let nextGroup = this.matchingGroup(row.object);
+
+      if (nextGroup && currentGroup !== nextGroup) {
+        let rowElement = this.headerBuilder.buildGroupRow(nextGroup, this.colspan);
+        this.appendRow(null, rowElement);
+        currentGroup = nextGroup;
+      }
+
+      row.group = currentGroup;
+      let tr = this.buildSingleRow(row);
+      this.appendRow(row.object, tr, [groupedRowClassName(currentGroup!.index as number)]);
+    });
+  }
+
+  /**
+   * Find a matching group for the given work package.
+   * The API sadly doesn't provide us with the information which group a WP belongs to.
+   */
+  private matchingGroup(workPackage:WorkPackageResourceInterface) {
+    return _.find(this.groups, (group:GroupObject) => {
+      let property = workPackage[groupByProperty(group)];
+      // explicitly check for undefined as `false` (bool) is a valid value.
+      if (property === undefined) {
+        property = null;
+      }
+
+      // If the property is a multi-value
+      // Compare the href's of all resources with the ones in valueLink
+      if (_.isArray(property)) {
+        return this.matchesMultiValue(property as HalResource[], group);
+      }
+
+      //// If its a linked resource, compare the href,
+      //// which is an array of links the resource offers
+      if (property && property.$href) {
+        return !!_.find(group._links.valueLink, (l:any):any => property.$href === l.href);
+      }
+
+      // Otherwise, fall back to simple value comparison.
+      let value = group.value === '' ? null : group.value;
+      return value === property;
+    }) as GroupObject;
+  }
+
+  private matchesMultiValue(property:HalResource[], group:GroupObject) {
+    if (property.length !== group.href.length) {
+      return false;
+    }
+
+    let joinedOrderedHrefs = (objects:any[]) => {
+      return _.map(objects, object => object.href).sort().join(', ');
+    };
+
+    return _.isEqualWith(
+      property,
+      group.href,
+      (a, b) => joinedOrderedHrefs(a) === joinedOrderedHrefs(b)
+    );
+  }
+
+  /**
+   * Enhance a row from the rowBuilder with group information.
+   */
+  private buildSingleRow(row:WorkPackageTableRow):HTMLElement {
+    // Do not re-render rows before their grouping data
+    // is completed after the first try
+    if (!row.group) {
+      return row.element as HTMLElement;
+    }
+
+    const group = row.group as GroupObject;
+    let tr = this.rowBuilder.buildEmpty(row.object);
+    tr.classList.add(groupedRowClassName(group.index as number));
+
+    if (row.group.collapsed) {
+      tr.classList.add(collapsedRowClass);
+    }
+
+    row.element = tr;
+    return tr;
+  }
+}

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
@@ -1,13 +1,12 @@
-import {RowsBuilder} from "../rows-builder";
-import {States} from "../../../../states.service";
-import {WorkPackageTableColumnsService} from "../../../state/wp-table-columns.service";
-import {WorkPackageTable} from "../../../wp-fast-table";
-import {injectorBridge} from "../../../../angular/angular-injector-bridge.functions";
-import {GroupObject} from "../../../../api/api-v3/hal-resources/wp-collection-resource.service";
-import {WorkPackageResource} from "../../../../api/api-v3/hal-resources/work-package-resource.service";
-import {HalResource} from "../../../../api/api-v3/hal-resources/hal-resource.service";
-import {groupedRowClassName} from "../../../helpers/wp-table-row-helpers";
-import {WorkPackageTableRow} from "../../../wp-table.interfaces";
+import {RowsBuilder} from '../rows-builder';
+import {States} from '../../../../states.service';
+import {WorkPackageTableColumnsService} from '../../../state/wp-table-columns.service';
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {injectorBridge} from '../../../../angular/angular-injector-bridge.functions';
+import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
+import {GroupedRenderPass} from './grouped-render-pass';
+import {groupedRowClassName, groupIdentifier} from './grouped-rows-helpers';
+import {GroupHeaderBuilder} from './group-header-builder';
 
 export const rowGroupClassName = 'wp-table--group-header';
 export const collapsedRowClass = '-collapsed';
@@ -18,16 +17,13 @@ export class GroupedRowsBuilder extends RowsBuilder {
   public wpTableColumns:WorkPackageTableColumnsService;
   public I18n:op.I18n;
 
-  private text:any;
+  private headerBuilder:GroupHeaderBuilder;
 
-  constructor(workPackageTable: WorkPackageTable) {
+  constructor(workPackageTable:WorkPackageTable) {
     super(workPackageTable);
     injectorBridge(this);
 
-    this.text = {
-      collapse: this.I18n.t('js.label_collapse'),
-      expand: this.I18n.t('js.label_expand'),
-    };
+    this.headerBuilder = new GroupHeaderBuilder();
   }
 
   /**
@@ -51,67 +47,18 @@ export class GroupedRowsBuilder extends RowsBuilder {
     return this.states.table.collapsedGroups.value || {};
   }
 
-  /**
-   * Rebuild the entire grouped tbody from the given table
-   * @param table
-   */
-  public internalBuildRows(table:WorkPackageTable):[DocumentFragment, DocumentFragment] {
-    const groups = this.getGroupData();
-
-    // Remember the colspan for the group rows from the current column count
-    // and add one for the details link.
-    let colspan = this.wpTableColumns.columnCount + 1;
-
-    let tableBody = document.createDocumentFragment();
-    let timelineBody = document.createDocumentFragment();
-
-    let currentGroup:GroupObject|null = null;
-    table.rows.forEach((wpId:string) => {
-      let row = table.rowIndex[wpId];
-      let nextGroup = this.matchingGroup(row.object, groups);
-
-      if (nextGroup && currentGroup !== nextGroup) {
-        let rowElement = this.buildGroupRow(nextGroup, colspan);
-        this.appendRow(null, rowElement, tableBody, timelineBody, [rowGroupClassName]);
-        currentGroup = nextGroup;
-      }
-
-      row.group = currentGroup;
-      let tr = this.buildSingleRow(row);
-      this.appendRow(row.object, tr, tableBody, timelineBody, [this.groupClassName(currentGroup!)]);
-    });
-
-    return [tableBody, timelineBody];
+  public get colspan() {
+    return this.wpTableColumns.columnCount + 1;
   }
 
-  /**
-   * Find a matching group for the given work package.
-   * The API sadly doesn't provide us with the information which group a WP belongs to.
-   */
-  private matchingGroup(workPackage:WorkPackageResource, groups:GroupObject[]) {
-    return _.find(groups, (group:GroupObject) => {
-      let property = workPackage[this.groupByProperty(group)]
-      // explicitly check for undefined as `false` (bool) is a valid value.
-      if (property === undefined) {
-        property = null;
-      }
-
-      // If the property is a multi-value
-      // Compare the href's of all resources with the ones in valueLink
-      if (_.isArray(property)) {
-        return this.matchesMultiValue(property as HalResource[], group);
-      }
-
-      //// If its a linked resource, compare the href,
-      //// which is an array of links the resource offers
-      if (property && property.$href) {
-        return !!_.find(group._links.valueLink, (l:any):any => property.$href === l.href);
-      }
-
-      // Otherwise, fall back to simple value comparison.
-      let value = group.value === '' ? null : group.value;
-      return value === property;
-    }) as GroupObject;
+  public buildRows() {
+    return new GroupedRenderPass(
+      this.workPackageTable,
+      this.stopExisting$,
+      this.getGroupData(),
+      this.headerBuilder,
+      this.colspan
+    ).render();
   }
 
   /**
@@ -129,7 +76,7 @@ export class GroupedRowsBuilder extends RowsBuilder {
       jQuery(`.${groupedRowClassName(groupIndex)}`).toggleClass(collapsedRowClass, group.collapsed);
 
       // Refresh the group header
-      let newRow = this.buildGroupRow(group, colspan);
+      let newRow = this.headerBuilder.buildGroupRow(group, colspan);
 
       if (oldRow.parentNode) {
         oldRow.parentNode.replaceChild(newRow, oldRow);
@@ -146,110 +93,10 @@ export class GroupedRowsBuilder extends RowsBuilder {
       if (group._links && group._links.valueLink) {
         group.href = group._links.valueLink;
       }
-      group.identifier = this.groupIdentifier(group);
+      group.identifier = groupIdentifier(group);
       group.collapsed = this.collapsedGroups[group.identifier] === true;
       return group;
     });
-  }
-
-  private matchesMultiValue(property:HalResource[], group:GroupObject) {
-    if (property.length !== group.href.length) {
-      return false;
-    }
-
-    let joinedOrderedHrefs = (objects:any[]) => {
-      return _.map(objects, object => object.href).sort().join(', ')
-    }
-
-    return _.isEqualWith(property,
-                         group.href,
-                         (a, b) => joinedOrderedHrefs(a) === joinedOrderedHrefs(b));
-  }
-
-  /**
-   * Redraw a single row, while maintain its group state.
-   */
-  public buildEmptyRow(row:WorkPackageTableRow, table:WorkPackageTable):HTMLElement {
-    return this.buildSingleRow(row);
-  }
-
-  public groupIdentifier(group:GroupObject) {
-    return `${this.groupByProperty(group)}-${group.value || 'nullValue'}`;
-  }
-
-  /**
-   * Enhance a row from the rowBuilder with group information.
-   */
-  private buildSingleRow(row:WorkPackageTableRow):HTMLElement {
-    // Do not re-render rows before their grouping data
-    // is completed after the first try
-    if (!row.group) {
-      return row.element as HTMLElement;
-    }
-
-    const group = row.group as GroupObject;
-    let tr = this.rowBuilder.buildEmpty(row.object);
-    tr.classList.add(this.groupClassName(group));
-
-    if (row.group.collapsed) {
-      tr.classList.add(collapsedRowClass);
-    }
-
-    row.element = tr;
-    return tr;
-  }
-
-  private groupClassName(group: GroupObject) {
-    return groupedRowClassName(group.index as number);
-  }
-
-  /**
-   * Build group header row
-   */
-  private buildGroupRow(group:GroupObject, colspan:number) {
-    let row = document.createElement('tr');
-    let togglerIconClass, text;
-
-    if (group.collapsed) {
-      text = this.text.expand;
-      togglerIconClass = 'icon-plus';
-    } else {
-      text = this.text.collapse;
-      togglerIconClass = 'icon-minus2';
-    }
-
-    row.classList.add(rowGroupClassName);
-    row.id = `wp-table-rowgroup-${group.index}`;
-    row.dataset['groupIndex'] = (group.index as number).toString();
-    row.dataset['groupIdentifier'] = group.identifier as string;
-    row.innerHTML = `
-      <td colspan="${colspan}" class="-no-highlighting">
-        <div class="expander icon-context ${togglerIconClass}">
-          <span class="hidden-for-sighted">${_.escape(text)}</span>
-        </div>
-        <div class="group--value">
-          ${_.escape(this.groupName(group))}
-          <span class="count">
-            (${group.count})
-          </span>
-        </div>
-      </td>
-    `;
-
-    return row;
-  }
-
-  private groupName(group:GroupObject) {
-    let value = group.value;
-    if (value === null) {
-      return '-';
-    } else {
-      return value;
-    }
-  }
-
-  private groupByProperty(group:GroupObject):string {
-    return group._links!.groupBy.href.split('/').pop()!;
   }
 }
 

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-helpers.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-helpers.ts
@@ -1,0 +1,25 @@
+import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
+
+export function groupIdentifier(group:GroupObject) {
+  return `${groupByProperty(group)}-${group.value || 'nullValue'}`;
+}
+
+export function groupName(group:GroupObject) {
+  let value = group.value;
+  if (value === null) {
+    return '-';
+  } else {
+    return value;
+  }
+}
+
+export function groupByProperty(group:GroupObject):string {
+  return group._links!.groupBy.href.split('/').pop()!;
+}
+
+/**
+ * Get the row group class name for the given group id.
+ */
+export function groupedRowClassName(groupIndex:number) {
+  return `__row-group-${groupIndex}`;
+}

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -1,16 +1,14 @@
-import {WorkPackageTable} from "../../../wp-fast-table";
-import {WorkPackageResourceInterface} from "../../../../api/api-v3/hal-resources/work-package-resource.service";
-import {hierarchyCellClassName, SingleHierarchyRowBuilder} from "./single-hierarchy-row-builder";
-import {WorkPackageTableRow} from "../../../wp-table.interfaces";
-import {hierarchyGroupClass, hierarchyRootClass} from "../../../helpers/wp-table-hierarchy-helpers";
-import {TimelineRowBuilder} from "../../timeline/timeline-row-builder";
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {WorkPackageResourceInterface} from '../../../../api/api-v3/hal-resources/work-package-resource.service';
+import {SingleHierarchyRowBuilder} from './single-hierarchy-row-builder';
+import {WorkPackageTableRow} from '../../../wp-table.interfaces';
+import {hierarchyGroupClass, hierarchyRootClass} from '../../../helpers/wp-table-hierarchy-helpers';
+import {TableRenderPass} from '../table-render-pass';
+import {Subject} from 'rxjs';
 
-export class HierarchyRenderPass {
+export class HierarchyRenderPass extends TableRenderPass {
   // Remember which rows were already rendered
   public rendered:{[workPackageId:string]: boolean};
-
-  // Remember the actual order of rendering
-  public renderedOrder:string[];
 
   // Remember additional parents inserted that are not part of the results table
   public additionalParents:{[workPackageId:string]: WorkPackageResourceInterface};
@@ -18,27 +16,24 @@ export class HierarchyRenderPass {
   // Defer children to be rendered when their parent occurs later in the table
   public deferred:{[parentId:string]: WorkPackageResourceInterface[]};
 
-  // The resulting rows fragments
-  public tableBody:DocumentFragment;
-  public timelineBody:DocumentFragment;
-
   constructor(public workPackageTable:WorkPackageTable,
-              public rowBuilder:SingleHierarchyRowBuilder,
-              public timelineBuilder:TimelineRowBuilder) {
+              public stopExisting$:Subject<undefined>,
+              public rowBuilder:SingleHierarchyRowBuilder) {
+    super(stopExisting$, workPackageTable);
+  }
+
+  protected prepare() {
+    super.prepare();
+
     this.rendered = {};
-    this.renderedOrder = [];
     this.additionalParents = {};
     this.deferred = {};
-    this.tableBody = document.createDocumentFragment();
-    this.timelineBody = document.createDocumentFragment();
-
-    this.render();
   }
 
   /**
    * Render the hierarchy table into the document fragment
    */
-  private render() {
+  protected doRender() {
     this.workPackageTable.rows.forEach((wpId:string) => {
       const row:WorkPackageTableRow = this.workPackageTable.rowIndex[wpId];
       const workPackage:WorkPackageResourceInterface = row.object;
@@ -96,7 +91,6 @@ export class HierarchyRenderPass {
    * Render any deferred children of the given work package. If recursive children were
    * deferred, each of them will be passed through renderCallback.
    * @param workPackage
-   * @param renderCallback
    */
   private renderAllDeferredChildren(workPackage:WorkPackageResourceInterface) {
     const wpId = workPackage.id.toString();

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -163,7 +163,7 @@ export class HierarchyRenderPass extends TableRenderPass {
    */
   private markRendered(workPackage:WorkPackageResourceInterface) {
     this.rendered[workPackage.id] = true;
-    this.renderedOrder.push(workPackage.id);
+    this.renderedOrder.push(workPackage.id.toString());
   }
 
 

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-rows-builder.ts
@@ -1,29 +1,27 @@
-import {PlainRowsBuilder} from "../plain/plain-rows-builder";
-import {WorkPackageTableColumnsService} from "../../../state/wp-table-columns.service";
-import {States} from "../../../../states.service";
-import {WorkPackageTableHierarchiesService} from "../../../state/wp-table-hierarchy.service";
-import {WorkPackageTable} from "../../../wp-fast-table";
-import {injectorBridge} from "../../../../angular/angular-injector-bridge.functions";
-import {SingleHierarchyRowBuilder} from "./single-hierarchy-row-builder";
-import {HierarchyRenderPass} from "./hierarchy-render-pass";
-import {TimelineRowBuilder} from "../../timeline/timeline-row-builder";
+import {WorkPackageTableColumnsService} from '../../../state/wp-table-columns.service';
+import {States} from '../../../../states.service';
+import {WorkPackageTableHierarchiesService} from '../../../state/wp-table-hierarchy.service';
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {injectorBridge} from '../../../../angular/angular-injector-bridge.functions';
+import {SingleHierarchyRowBuilder} from './single-hierarchy-row-builder';
+import {HierarchyRenderPass} from './hierarchy-render-pass';
+import {RowsBuilder} from '../rows-builder';
 
-
-export class HierarchyRowsBuilder extends PlainRowsBuilder {
+export class HierarchyRowsBuilder extends RowsBuilder {
   // Injections
   public states:States;
   public wpTableColumns:WorkPackageTableColumnsService;
   public wpTableHierarchies:WorkPackageTableHierarchiesService;
   public I18n:op.I18n;
 
-  // Row builders
   protected rowBuilder:SingleHierarchyRowBuilder;
-  protected refreshBuilder:SingleHierarchyRowBuilder;
 
   // The group expansion state
-  constructor(public workPackageTable: WorkPackageTable) {
+  constructor(public workPackageTable:WorkPackageTable) {
     super(workPackageTable);
     injectorBridge(this);
+    this.rowBuilder = new SingleHierarchyRowBuilder(this.workPackageTable);
+    this.refreshBuilder = this.rowBuilder;
   }
 
   /**
@@ -35,19 +33,10 @@ export class HierarchyRowsBuilder extends PlainRowsBuilder {
 
   /**
    * Rebuild the entire grouped tbody from the given table
-   * @param table
    */
-  public internalBuildRows(table:WorkPackageTable):[DocumentFragment, DocumentFragment] {
-    const instance = new HierarchyRenderPass(table, this.rowBuilder, this.timelineBuilder);
-    return [instance.tableBody, instance.timelineBody];
-  }
-
-  protected setupRowBuilders() {
-    this.rowBuilder = new SingleHierarchyRowBuilder(this.stopExisting$, this.workPackageTable);
-    this.timelineBuilder = new TimelineRowBuilder(this.stopExisting$, this.workPackageTable);
-    this.refreshBuilder = this.rowBuilder;
+  public buildRows():HierarchyRenderPass {
+    return new HierarchyRenderPass(this.workPackageTable, this.stopExisting$, this.rowBuilder).render();
   }
 }
-
 
 HierarchyRowsBuilder.$inject = ['wpTableColumns', 'wpTableHierarchies', 'states', 'I18n'];

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -3,7 +3,6 @@ import {WorkPackageTableRow} from "../../../wp-table.interfaces";
 import {WorkPackageResourceInterface} from "../../../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageTableHierarchiesService} from "../../../state/wp-table-hierarchy.service";
 import {$injectFields} from "../../../../angular/angular-injector-bridge.functions";
-import {Observable} from 'rxjs';
 import {RowRefreshBuilder} from "../../rows/row-refresh-builder";
 import {WorkPackageEditForm} from "../../../../wp-edit-form/work-package-edit-form";
 import {
@@ -27,8 +26,8 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
     collapsed:(level:number) => string;
   };
 
-  constructor(protected stopExisting$: Observable<any>, protected workPackageTable: WorkPackageTable) {
-    super(stopExisting$, workPackageTable);
+  constructor(protected workPackageTable: WorkPackageTable) {
+    super(workPackageTable);
     $injectFields(this, 'wpTableHierarchies');
 
     this.text = {

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
@@ -1,0 +1,26 @@
+import {TableRenderPass} from '../table-render-pass';
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {SingleRowBuilder} from '../../rows/single-row-builder';
+import {Subject} from 'rxjs';
+
+export class PlainRenderPass extends TableRenderPass {
+
+  constructor(public workPackageTable:WorkPackageTable,
+              public stopExisting$:Subject<undefined>,
+              public rowBuilder:SingleRowBuilder) {
+    super(stopExisting$, workPackageTable);
+  }
+
+  /**
+   * The actual render function of this renderer.
+   */
+  protected doRender():void {
+    this.workPackageTable.rows.forEach((wpId:string) => {
+      let row = this.workPackageTable.rowIndex[wpId];
+      let tr = this.rowBuilder.buildEmpty(row.object);
+      row.element = tr;
+      this.appendRow(row.object, tr);
+      this.tableBody.appendChild(tr);
+    });
+  }
+}

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-rows-builder.ts
@@ -1,39 +1,29 @@
-import {RowsBuilder} from "../rows-builder";
-import {WorkPackageTable} from "../../../wp-fast-table";
-import {injectorBridge} from "../../../../angular/angular-injector-bridge.functions";
-import {WorkPackageTableRow} from "../../../wp-table.interfaces";
+import {RowsBuilder} from '../rows-builder';
+import {WorkPackageTable} from '../../../wp-fast-table';
+import {injectorBridge} from '../../../../angular/angular-injector-bridge.functions';
+import {TableRenderPass} from '../table-render-pass';
+import {PlainRenderPass} from './plain-render-pass';
+import {SingleRowBuilder} from '../../rows/single-row-builder';
 
 export class PlainRowsBuilder extends RowsBuilder {
   // Injections
   public I18n:op.I18n;
 
+  protected rowBuilder:SingleRowBuilder;
+
   // The group expansion state
   constructor(workPackageTable: WorkPackageTable) {
     super(workPackageTable);
     injectorBridge(this);
+
+    this.rowBuilder = new SingleRowBuilder(this.workPackageTable);
   }
 
   /**
    * Rebuild the entire grouped tbody from the given table
-   * @param table
    */
-  public internalBuildRows(table:WorkPackageTable):[DocumentFragment,DocumentFragment] {
-    let tableBody = document.createDocumentFragment();
-    let timelineBody = document.createDocumentFragment();
-
-    table.rows.forEach((wpId:string) => {
-      let row = table.rowIndex[wpId];
-      let tr = this.buildEmptyRow(row);
-      row.element = tr;
-      this.appendRow(row.object, tr, tableBody, timelineBody);
-      tableBody.appendChild(tr);
-    });
-
-    return [tableBody, timelineBody];
-  }
-
-  public buildEmptyRow(row:WorkPackageTableRow, table?:WorkPackageTable) {
-    return this.rowBuilder.buildEmpty(row.object);
+  public buildRows():TableRenderPass {
+    return new PlainRenderPass(this.workPackageTable, this.stopExisting$, this.rowBuilder).render();
   }
 }
 

--- a/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
@@ -1,34 +1,24 @@
-import {Subject} from "rxjs";
-import {States} from "../../../states.service";
-import {WorkPackageTable} from "../../wp-fast-table";
-import {WorkPackageTableRow} from "../../wp-table.interfaces";
-import {SingleRowBuilder} from "../rows/single-row-builder";
-import {RowRefreshBuilder} from "../rows/row-refresh-builder";
-import {WorkPackageResourceInterface} from "../../../api/api-v3/hal-resources/work-package-resource.service";
-import {TimelineRowBuilder} from "../timeline/timeline-row-builder";
+import {States} from '../../../states.service';
+import {WorkPackageTable} from '../../wp-fast-table';
+import {WorkPackageTableRow} from '../../wp-table.interfaces';
+import {RowRefreshBuilder} from '../rows/row-refresh-builder';
+import {TableRenderPass} from './table-render-pass';
+import {Subject} from 'rxjs';
 
 export abstract class RowsBuilder {
   public states:States;
 
-  protected timelineBuilder:TimelineRowBuilder;
-  protected rowBuilder:SingleRowBuilder;
   protected refreshBuilder:RowRefreshBuilder;
+  protected stopExisting$ = new Subject<undefined>();
 
-  protected stopExisting$ = new Subject();
-
-  constructor(public workPackageTable: WorkPackageTable) {
-    this.setupRowBuilders();
+  constructor(public workPackageTable:WorkPackageTable) {
+    this.refreshBuilder = new RowRefreshBuilder(this.workPackageTable);
   }
 
   /**
    * Build all rows of the table.
    */
-  public buildRows(table: WorkPackageTable): [DocumentFragment,DocumentFragment] {
-    this.stopExisting$.next();
-    return this.internalBuildRows(table);
-  }
-
-  public abstract internalBuildRows(table: WorkPackageTable): [DocumentFragment,DocumentFragment];
+  public abstract buildRows():TableRenderPass;
 
   /**
    * Determine if this builder applies to the current view mode.
@@ -38,60 +28,13 @@ export abstract class RowsBuilder {
   }
 
   /**
-   * Called after a row is added through +appendRow+.
-   * Inserts a new cell to the synced timeline, if open.
-   * @param workPackage The work package that was added (if any)
-   * @param timelineBody The timeline body container
-   * @param rowClasses Additional classes to apply to the row for mirroring purposes
-   */
-  public addToTimeline(workPackage:WorkPackageResourceInterface|null,
-                       timelineBody:HTMLElement|DocumentFragment,
-                       rowClasses: string[] = []) {
-    // Append row into timeline
-    this.timelineBuilder.insert(workPackage, timelineBody);
-  }
-
-
-  /**
    * Refresh a single row after structural changes.
    * Will perform dirty checking for when a work package is currently being edited.
    */
-  public refreshRow(row:WorkPackageTableRow):HTMLElement|null {
+  public refreshRow(row:WorkPackageTableRow):HTMLElement | null {
     let editing = this.states.editing.get(row.workPackageId).value;
     return this.refreshBuilder.refreshRow(row, editing);
   }
-
-  /**
-   * Construct the single and refresh row builders for this instance
-   */
-  protected setupRowBuilders() {
-    this.rowBuilder = new SingleRowBuilder(this.stopExisting$, this.workPackageTable);
-    this.refreshBuilder = new RowRefreshBuilder(this.stopExisting$, this.workPackageTable);
-    this.timelineBuilder = new TimelineRowBuilder(this.stopExisting$, this.workPackageTable);
-  }
-
-  /**
-   * Append a new row a work package (or a virtual row) to both containers
-   * @param workPackage The work package, if the row belongs to one
-   * @param row HTMLElement to append
-   * @param tableBody DocumentFragement to replace the table body
-   * @param timelineBody DocumentFragment to replace the timeline
-   * @param rowClasses Additional classes to apply to the timeline row for mirroring purposes
-   */
-  protected appendRow(workPackage: WorkPackageResourceInterface|null,
-                      row:HTMLElement,
-                      tableBody:DocumentFragment,
-                      timelineBody:DocumentFragment,
-                      rowClasses:string[] = []) {
-
-    tableBody.appendChild(row);
-    this.addToTimeline(workPackage, timelineBody, rowClasses);
-  }
-
-  /**
-   * Build an empty row for the given work package.
-   */
-  protected abstract buildEmptyRow(row:WorkPackageTableRow, table:WorkPackageTable):HTMLElement;
 }
 
 RowsBuilder.$inject = ['states'];

--- a/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
@@ -5,6 +5,10 @@ import {TimelineRowBuilder} from '../timeline/timeline-row-builder';
 import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
 import {Subject} from 'rxjs';
 
+export interface TableRenderResult {
+  renderedOrder:(string|null)[];
+}
+
 export abstract class TableRenderPass {
   public states:States;
   public I18n:op.I18n;
@@ -35,6 +39,12 @@ export abstract class TableRenderPass {
     return this;
   }
 
+  public get result():TableRenderResult {
+    return {
+      renderedOrder: this.renderedOrder
+    };
+  }
+
   protected prepare() {
     this.tableBody = document.createDocumentFragment();
     this.timelineBody = document.createDocumentFragment();
@@ -61,5 +71,11 @@ export abstract class TableRenderPass {
 
     this.tableBody.appendChild(row);
     this.timelineBuilder.insert(workPackage, this.timelineBody, rowClasses);
+
+    if (workPackage) {
+      this.renderedOrder.push(workPackage.id.toString());
+    } else {
+      this.renderedOrder.push(null);
+    }
   }
 }

--- a/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
@@ -1,0 +1,65 @@
+import {States} from '../../../states.service';
+import {WorkPackageTable} from '../../wp-fast-table';
+import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
+import {TimelineRowBuilder} from '../timeline/timeline-row-builder';
+import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
+import {Subject} from 'rxjs';
+
+export abstract class TableRenderPass {
+  public states:States;
+  public I18n:op.I18n;
+
+  /** Row builders */
+  protected timelineBuilder:TimelineRowBuilder;
+
+  /** The rendered order of rows of work package IDs or <null>, if not a work package row */
+  public renderedOrder:(string|null)[];
+
+  /** Resulting table body */
+  public tableBody:DocumentFragment;
+
+  /** Resulting timeline body */
+  public timelineBody:DocumentFragment;
+
+  constructor(public stopExisting$:Subject<void>, public workPackageTable:WorkPackageTable) {
+    $injectFields(this, 'states', 'I18n');
+  }
+
+  public render():this {
+    // Prepare and reset the render pass
+    this.prepare();
+    // Render into the fragments
+    this.stopExisting$.next();
+    this.doRender();
+
+    return this;
+  }
+
+  protected prepare() {
+    this.tableBody = document.createDocumentFragment();
+    this.timelineBody = document.createDocumentFragment();
+    this.timelineBuilder = new TimelineRowBuilder(this.stopExisting$, this.workPackageTable);
+    this.renderedOrder = [];
+  }
+
+  /**
+   * The actual render function of this renderer.
+   */
+  protected abstract doRender():void;
+
+  /**
+   * Append a new row a work package (or a virtual row) to both containers
+   * @param workPackage The work package, if the row belongs to one
+   * @param row HTMLElement to append
+   * @param tableBody DocumentFragement to replace the table body
+   * @param timelineBody DocumentFragment to replace the timeline
+   * @param rowClasses Additional classes to apply to the timeline row for mirroring purposes
+   */
+  protected appendRow(workPackage:WorkPackageResourceInterface | null,
+                      row:HTMLElement,
+                      rowClasses:string[] = []) {
+
+    this.tableBody.appendChild(row);
+    this.timelineBuilder.insert(workPackage, this.timelineBody, rowClasses);
+  }
+}

--- a/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -30,7 +30,7 @@ export class SingleRowBuilder {
   // Details Link builder
   protected detailsLinkBuilder = new DetailsLinkBuilder();
 
-  constructor(protected stopExisting$:Observable<any>, protected workPackageTable:WorkPackageTable) {
+  constructor(protected workPackageTable:WorkPackageTable) {
     $injectFields(this, 'wpTableSelection', 'wpTableColumns', 'I18n');
   }
 

--- a/frontend/app/components/wp-fast-table/builders/timeline/timeline-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/timeline/timeline-row-builder.ts
@@ -1,12 +1,12 @@
+import {WorkPackageTable} from '../../wp-fast-table';
+import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
+import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
+import {States} from '../../../states.service';
+import {WorkPackageTableTimelineService} from '../../state/wp-table-timeline.service';
+import {WorkPackageCacheService} from '../../../work-packages/work-package-cache.service';
+import {WorkPackageTimelineCell} from '../../../wp-table/timeline/wp-timeline-cell';
+import {commonRowClassName} from '../rows/single-row-builder';
 import {Observable} from 'rxjs';
-import {WorkPackageTable} from "../../wp-fast-table";
-import {$injectFields} from "../../../angular/angular-injector-bridge.functions";
-import {WorkPackageResourceInterface} from "../../../api/api-v3/hal-resources/work-package-resource.service";
-import {States} from "../../../states.service";
-import {WorkPackageTableTimelineService} from "../../state/wp-table-timeline.service";
-import {WorkPackageCacheService} from "../../../work-packages/work-package-cache.service";
-import {WorkPackageTimelineCell} from "../../../wp-table/timeline/wp-timeline-cell";
-import {commonRowClassName} from "../rows/single-row-builder";
 
 export const timelineCellClassName = 'wp-timeline-cell';
 
@@ -15,7 +15,7 @@ export class TimelineRowBuilder {
   public wpTableTimeline:WorkPackageTableTimelineService;
   public wpCacheService:WorkPackageCacheService;
 
-  constructor(protected stopExisting$:Observable<any>, protected workPackageTable:WorkPackageTable) {
+  constructor(protected stopExisting$:Observable<void>, protected workPackageTable:WorkPackageTable) {
     $injectFields(this, 'states', 'wpTableTimeline', 'wpCacheService');
   }
 

--- a/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -1,7 +1,7 @@
-import {debugLog} from "../../../../helpers/debug_output";
-import {injectorBridge} from "../../../angular/angular-injector-bridge.functions";
-import {States} from "../../../states.service";
-import {WorkPackageTable} from "../../wp-fast-table";
+import {debugLog} from '../../../../helpers/debug_output';
+import {injectorBridge} from '../../../angular/angular-injector-bridge.functions';
+import {States} from '../../../states.service';
+import {WorkPackageTable} from '../../wp-fast-table';
 
 export class ColumnsTransformer {
   public states:States;
@@ -21,7 +21,6 @@ export class ColumnsTransformer {
           let row = table.rowIndex[wpId];
           table.refreshRow(row);
         });
-        table.postRender();
         var t1 = performance.now();
 
         debugLog("column redraw took " + (t1 - t0) + " milliseconds.");

--- a/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -19,7 +19,6 @@ export class HierarchyTransformer {
       .subscribe((state: WorkPackageTableHierarchies) => {
         if (enabled !== state.isEnabled) {
           table.refreshBody();
-          table.postRender();
         } else if (enabled) {
           // No change in hierarchy mode
           // Refresh groups

--- a/frontend/app/components/wp-fast-table/handlers/state/rows-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/rows-transformer.ts
@@ -19,7 +19,6 @@ export class RowsTransformer {
         var t0 = performance.now();
 
         table.initialSetup(rows);
-        table.postRender();
 
         var t1 = performance.now();
         debugLog("[RowTransformer] Reinitialized in " + (t1 - t0) + " milliseconds.");

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
@@ -12,9 +12,4 @@ export function locateRow(id:string):HTMLElement|null {
   return document.getElementById(rowId(id));
 }
 
-/**
- * Get the row group class name for the given group id.
- */
-export function groupedRowClassName(groupIndex:number) {
-  return `__row-group-${groupIndex}`
-}
+

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -29,8 +29,6 @@ export class WorkPackageTable {
     new PlainRowsBuilder(this)
   ];
 
-  // Timeline elements
-
   constructor(public container:HTMLElement,
               public tbody:HTMLElement,
               public timelineBody:HTMLElement,
@@ -41,13 +39,6 @@ export class WorkPackageTable {
 
   public rowObject(workPackageId:string):WorkPackageTableRow {
     return this.rowIndex[workPackageId];
-  }
-
-  /**
-   * Returns the reference to the last table.query state value
-   */
-  public get query() {
-    return this.states.table.query.value;
   }
 
   public get rowBuilder():RowsBuilder {
@@ -88,13 +79,13 @@ export class WorkPackageTable {
    * all elements.
    */
   public refreshBody() {
-    let [tableBody, timelineBody] = this.rowBuilder.buildRows(this);
+    let renderResult = this.rowBuilder.buildRows();
 
     this.tbody.innerHTML = '';
-    this.tbody.appendChild(tableBody);
+    this.tbody.appendChild(renderResult.tableBody);
 
     this.timelineBody.innerHTML = '';
-    this.timelineBody.appendChild(timelineBody);
+    this.timelineBody.appendChild(renderResult.timelineBody);
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -79,13 +79,15 @@ export class WorkPackageTable {
    * all elements.
    */
   public refreshBody() {
-    let renderResult = this.rowBuilder.buildRows();
+    let renderPass = this.rowBuilder.buildRows();
 
     this.tbody.innerHTML = '';
-    this.tbody.appendChild(renderResult.tableBody);
+    this.tbody.appendChild(renderPass.tableBody);
 
     this.timelineBody.innerHTML = '';
-    this.timelineBody.appendChild(renderResult.timelineBody);
+    this.timelineBody.appendChild(renderPass.timelineBody);
+
+    this.states.table.rendered.putValue(renderPass.result);
   }
 
   /**
@@ -101,13 +103,6 @@ export class WorkPackageTable {
       row.element = newRow;
       this.rowIndex[row.workPackageId] = row;
     }
-  }
-
-  /**
-   * Update the rendered state that the table is now refreshed.
-   */
-  public postRender() {
-    this.states.table.rendered.putValue(this);
   }
 }
 

--- a/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
+++ b/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
@@ -32,8 +32,8 @@ export class InlineCreateRowBuilder extends RowRefreshBuilder {
 
   protected text:{ cancelButton:string };
 
-  constructor(scope: IScope, workPackageTable: WorkPackageTable) {
-    super(scopeDestroyed$(scope), workPackageTable);
+  constructor(workPackageTable: WorkPackageTable) {
+    super(workPackageTable);
     injectorBridge(this);
 
     this.text = {

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -44,6 +44,7 @@ import {WorkPackageEditForm} from "../wp-edit-form/work-package-edit-form";
 import {WorkPackageTable} from "../wp-fast-table/wp-fast-table";
 import {WorkPackageTableRow} from "../wp-fast-table/wp-table.interfaces";
 import {WorkPackageTableTimelineService} from "../wp-fast-table/state/wp-table-timeline.service";
+import {TimelineRowBuilder} from '../wp-fast-table/builders/timeline/timeline-row-builder';
 
 export class WorkPackageInlineCreateController {
 
@@ -58,6 +59,7 @@ export class WorkPackageInlineCreateController {
   private currentWorkPackage:WorkPackageResourceInterface|null;
   private workPackageEditForm:WorkPackageEditForm|undefined;
   private rowBuilder:InlineCreateRowBuilder;
+  private timelineBuilder:TimelineRowBuilder;
 
   constructor(
     public $scope:ng.IScope,
@@ -73,7 +75,8 @@ export class WorkPackageInlineCreateController {
     private $q:ng.IQService,
     private I18n:op.I18n
   ) {
-    this.rowBuilder = new InlineCreateRowBuilder($scope, this.table);
+    this.rowBuilder = new InlineCreateRowBuilder(this.table);
+    this.timelineBuilder = new TimelineRowBuilder(scopeDestroyed$($scope).mapTo(undefined), this.table);
     this.text = {
       create: I18n.t('js.label_create_work_package')
     };
@@ -149,7 +152,7 @@ export class WorkPackageInlineCreateController {
 
         this.workPackageEditForm = new WorkPackageEditForm('new');
         const row = this.rowBuilder.buildNew(wp, this.workPackageEditForm);
-        this.table.rowBuilder.addToTimeline(wp, this.table.timelineBody);
+        this.timelineBuilder.insert(wp, this.table.timelineBody);
         this.$element.append(row);
 
         this.$timeout(() => {

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -53,6 +53,7 @@
       <tbody class="results-tbody work-package--results-tbody">
       </tbody>
       <tbody wp-inline-create
+             ng-if="!!table"
              project-identifier="projectIdentifier"
              table="table">
       </tbody>


### PR DESCRIPTION
Mere refactoring PR towards:

https://community.openproject.com/projects/openproject/work_packages/25264

- Refactors the row renders into render passes / services that return a result of the rendering process.
- Let all modes report which rows they actually rendered
- Pass that data to the `rendered` state
- Use that data in wp-relations state (in the context of this PR: only for determining the `workPackageIdOrder`)

Also fixes an error with the inline create row not opening on occasions due to a digest happening before the timeline loads (and in turn, `table` in inline-create directive being empty).