### PR TITLE
[25276][25264][25175][25232] Fix relations drawing after rendered state changes

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/_grid.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_grid.sass
@@ -1,10 +1,3 @@
-.wp-table-timeline--grid
-  position: absolute
-  width: 100%
-  // Position 45px below header
-  top: $generic-table--header-height
-  height: calc(100% - #{$generic-table--header-height})
-
 .wp-timeline--grid-element
   position: absolute
   top: 0

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
@@ -29,6 +29,14 @@
   position: relative
   width: 100%
 
+.wp-table-timeline--relations,
+.wp-table-timeline--grid
+  position: absolute
+  width: 100%
+  // Position 45px below header
+  top: $generic-table--header-height
+  height: calc(100% - #{$generic-table--header-height})
+
 // Left border for the timeline
 .work-packages-split-view--left-timeline
   border-left: 5px solid #888

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
@@ -1,7 +1,12 @@
 import {$injectFields} from '../../../../angular/angular-injector-bridge.functions';
 import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
 import {groupName} from './grouped-rows-helpers';
+
 export const rowGroupClassName = 'wp-table--group-header';
+
+export function groupClassNameFor(group:GroupObject) {
+  return `group-${group.identifier}`;
+}
 
 export class GroupHeaderBuilder {
   public I18n:op.I18n;
@@ -28,7 +33,7 @@ export class GroupHeaderBuilder {
       togglerIconClass = 'icon-minus2';
     }
 
-    row.classList.add(rowGroupClassName);
+    row.classList.add(rowGroupClassName, groupClassNameFor(group));
     row.id = `wp-table-rowgroup-${group.index}`;
     row.dataset['groupIndex'] = (group.index as number).toString();
     row.dataset['groupIdentifier'] = group.identifier as string;

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-helpers.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-helpers.ts
@@ -1,7 +1,9 @@
 import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-resource.service';
 
 export function groupIdentifier(group:GroupObject) {
-  return `${groupByProperty(group)}-${group.value || 'nullValue'}`;
+  let value = group.value || 'nullValue';
+  value = value.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return `${groupByProperty(group)}-${value}`;
 }
 
 export function groupName(group:GroupObject) {

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -2,11 +2,20 @@ import {WorkPackageTable} from '../../../wp-fast-table';
 import {WorkPackageResourceInterface} from '../../../../api/api-v3/hal-resources/work-package-resource.service';
 import {SingleHierarchyRowBuilder} from './single-hierarchy-row-builder';
 import {WorkPackageTableRow} from '../../../wp-table.interfaces';
-import {hierarchyGroupClass, hierarchyRootClass} from '../../../helpers/wp-table-hierarchy-helpers';
+import {
+  collapsedGroupClass, hierarchyGroupClass,
+  hierarchyRootClass
+} from '../../../helpers/wp-table-hierarchy-helpers';
 import {TableRenderPass} from '../table-render-pass';
 import {Subject} from 'rxjs';
+import {States} from '../../../../states.service';
+import {$injectFields} from '../../../../angular/angular-injector-bridge.functions';
+import {WorkPackageTableHierarchies} from '../../../wp-table-hierarchies';
+import {rowClass} from '../../../helpers/wp-table-row-helpers';
 
 export class HierarchyRenderPass extends TableRenderPass {
+  public states:States;
+
   // Remember which rows were already rendered
   public rendered:{[workPackageId:string]: boolean};
 
@@ -16,15 +25,21 @@ export class HierarchyRenderPass extends TableRenderPass {
   // Defer children to be rendered when their parent occurs later in the table
   public deferred:{[parentId:string]: WorkPackageResourceInterface[]};
 
+  // Collapsed state
+  private hierarchies:WorkPackageTableHierarchies;
+
   constructor(public workPackageTable:WorkPackageTable,
               public stopExisting$:Subject<undefined>,
               public rowBuilder:SingleHierarchyRowBuilder) {
     super(stopExisting$, workPackageTable);
+
+    $injectFields(this, 'states');
   }
 
   protected prepare() {
     super.prepare();
 
+    this.hierarchies = this.states.table.hierarchies.value!;
     this.rendered = {};
     this.additionalParents = {};
     this.deferred = {};
@@ -48,11 +63,11 @@ export class HierarchyRenderPass extends TableRenderPass {
         this.buildWithHierarchy(row);
       } else {
         // Render a work package root with no parents
-        let tr = this.rowBuilder.buildEmpty(workPackage);
+        let [tr, hidden] = this.rowBuilder.buildEmpty(workPackage);
         row.element = tr;
         this.tableBody.appendChild(tr);
         this.timelineBody.appendChild(this.buildTimelineRow(workPackage));
-        this.markRendered(workPackage);
+        this.markRendered(workPackage, hidden);
       }
 
       // Render all potentially deferred rows
@@ -119,7 +134,7 @@ export class HierarchyRenderPass extends TableRenderPass {
       // If we see the parent the first time,
       // build it as an additional row and insert it into the ancestry
       if (!this.rendered[ancestor.id]) {
-        let ancestorRow = this.rowBuilder.buildAncestorRow(ancestor, ancestorGroups, index);
+        let [ancestorRow, hidden] = this.rowBuilder.buildAncestorRow(ancestor, ancestorGroups, index);
         // Insert the ancestor row, either right here if it's a root node
         // Or below the appropriate parent
 
@@ -127,11 +142,11 @@ export class HierarchyRenderPass extends TableRenderPass {
           // Special case, first ancestor => root without parent
           this.tableBody.appendChild(ancestorRow);
           this.timelineBody.appendChild(this.buildTimelineRow(ancestor));
-          this.markRendered(ancestor);
+          this.markRendered(ancestor, hidden);
         } else {
           // This ancestor must be inserted in the last position of its root
           const parent = ancestors[index - 1];
-          this.insertAtExistingHierarchy(ancestor, ancestorRow, parent.id);
+          this.insertAtExistingHierarchy(ancestor, ancestorRow, parent.id, hidden);
         }
 
         // Remember we just added this extra ancestor row
@@ -152,18 +167,23 @@ export class HierarchyRenderPass extends TableRenderPass {
    * @param parentId
    */
   private insertUnderParent(row:WorkPackageTableRow, parentId:string) {
-    const tr = this.rowBuilder.buildEmpty(row.object);
+    const [tr, hidden] = this.rowBuilder.buildEmpty(row.object);
     row.element = tr;
-    this.insertAtExistingHierarchy(row.object, tr, parentId);
+    this.insertAtExistingHierarchy(row.object, tr, parentId, hidden);
   }
 
   /**
    * Mark the given work package as rendered
    * @param workPackage
+   * @param hidden
    */
-  private markRendered(workPackage:WorkPackageResourceInterface) {
+  private markRendered(workPackage:WorkPackageResourceInterface, hidden:boolean = false) {
     this.rendered[workPackage.id] = true;
-    this.renderedOrder.push(workPackage.id.toString());
+    this.renderedOrder.push({
+      workPackageId: workPackage.id.toString(),
+      classIdentifier: rowClass(workPackage.id),
+      hidden: hidden
+    });
   }
 
 
@@ -173,6 +193,11 @@ export class HierarchyRenderPass extends TableRenderPass {
     if (_.isArray(workPackage.ancestors)) {
       workPackage.ancestors.forEach((ancestor) => {
         rowClasses.push(hierarchyGroupClass(ancestor.id));
+
+        if (this.hierarchies.collapsed[ancestor.id]) {
+          rowClasses.push(collapsedGroupClass(ancestor.id));
+        }
+
       });
     }
 
@@ -182,7 +207,7 @@ export class HierarchyRenderPass extends TableRenderPass {
   /**
    * Append a row to the given parent hierarchy group.
    */
-  private insertAtExistingHierarchy(workPackage:WorkPackageResourceInterface, el:HTMLElement, parentId:string) {
+  private insertAtExistingHierarchy(workPackage:WorkPackageResourceInterface, el:HTMLElement, parentId:string, hidden:boolean) {
     // Either append to the hierarchy group root (= the parentID row itself)
     const hierarchyRoot = `.__hierarchy-root-${parentId}`;
     // Or, if it has descendants, append to the LATEST of that set
@@ -194,6 +219,6 @@ export class HierarchyRenderPass extends TableRenderPass {
     const timelineRow = this.buildTimelineRow(workPackage);
     jQuery(this.timelineBody).find(`${hierarchyRoot},${hierarchyGroup}`).last().after(timelineRow);
 
-    this.markRendered(workPackage);
+    this.markRendered(workPackage, hidden);
   }
 }

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -214,11 +214,19 @@ export class HierarchyRenderPass extends TableRenderPass {
     const hierarchyGroup = `.__hierarchy-group-${parentId}`;
 
     // Insert into table
-    jQuery(this.tableBody).find(`${hierarchyRoot},${hierarchyGroup}`).last().after(el);
+    const target = jQuery(this.tableBody).find(`${hierarchyRoot},${hierarchyGroup}`).last()
+    target.after(el);
+
+    // Mark as rendered at the given position
+    const index = target.index();
+    this.renderedOrder.splice(index + 1, 0, {
+      workPackageId: workPackage.id.toString(),
+      classIdentifier: rowClass(workPackage.id),
+      hidden: hidden
+    });
+
     // Insert into timeline
     const timelineRow = this.buildTimelineRow(workPackage);
     jQuery(this.timelineBody).find(`${hierarchyRoot},${hierarchyGroup}`).last().after(timelineRow);
-
-    this.markRendered(workPackage, hidden);
   }
 }

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -214,7 +214,7 @@ export class HierarchyRenderPass extends TableRenderPass {
     const hierarchyGroup = `.__hierarchy-group-${parentId}`;
 
     // Insert into table
-    const target = jQuery(this.tableBody).find(`${hierarchyRoot},${hierarchyGroup}`).last()
+    const target = jQuery(this.tableBody).find(`${hierarchyRoot},${hierarchyGroup}`).last();
     target.after(el);
 
     // Mark as rendered at the given position
@@ -224,6 +224,7 @@ export class HierarchyRenderPass extends TableRenderPass {
       classIdentifier: rowClass(workPackage.id),
       hidden: hidden
     });
+    this.rendered[workPackage.id] = true;
 
     // Insert into timeline
     const timelineRow = this.buildTimelineRow(workPackage);

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -41,16 +41,17 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
    * Refresh a single row after structural changes.
    * Remembers and re-adds the hierarchy indicator if neccessary.
    */
-  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean] {
+  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean]|null {
     // Remove any old hierarchy
-    const [newRow, hidden] = super.refreshRow(row, editForm);
+    const result = super.refreshRow(row, editForm);
 
-    if (newRow) {
+    if (result !== null) {
+      const [newRow, _hidden] = result;
       jQuery(newRow).find(`.wp-table--hierarchy-span`).remove();
       this.appendHierarchyIndicator(row.object, newRow);
     }
 
-    return [newRow, hidden];
+    return result;
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -41,36 +41,37 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
    * Refresh a single row after structural changes.
    * Remembers and re-adds the hierarchy indicator if neccessary.
    */
-  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined): HTMLElement | null {
+  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean] {
     // Remove any old hierarchy
-    const newRow = super.refreshRow(row, editForm);
+    const [newRow, hidden] = super.refreshRow(row, editForm);
 
     if (newRow) {
       jQuery(newRow).find(`.wp-table--hierarchy-span`).remove();
       this.appendHierarchyIndicator(row.object, newRow);
     }
 
-    return newRow;
+    return [newRow, hidden];
   }
 
   /**
    * Build the columns on the given empty row
    */
-  public buildEmpty(workPackage:WorkPackageResourceInterface) {
-    const element = super.buildEmpty(workPackage);
+  public buildEmpty(workPackage:WorkPackageResourceInterface):[HTMLElement, boolean] {
+    let [element, hidden] = super.buildEmpty(workPackage);
     const state = this.wpTableHierarchies.currentState;
 
     workPackage.ancestors.forEach((ancestor:WorkPackageResourceInterface) => {
       element.classList.add(`__hierarchy-group-${ancestor.id}`);
 
       if (state.collapsed[ancestor.id]) {
+        hidden = true;
         element.classList.add(collapsedGroupClass(ancestor.id));
       }
     });
 
     element.classList.add(`__hierarchy-root-${workPackage.id}`);
     this.appendHierarchyIndicator(workPackage, element);
-    return element;
+    return [element, hidden];
   }
 
   /**
@@ -79,14 +80,14 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
   public buildAncestorRow(
     ancestor:WorkPackageResourceInterface,
     ancestorGroups:string[],
-    index:number):HTMLElement {
+    index:number):[HTMLElement, boolean] {
 
     const loadedRow = this.workPackageTable.rowIndex[ancestor.id];
 
     if (loadedRow) {
-      const tr =  this.buildEmpty(loadedRow.object);
+      const [tr, hidden] = this.buildEmpty(loadedRow.object);
       tr.classList.add('wp-table--hierarchy-aditional-row');
-      return tr;
+      return [tr, hidden];
     }
 
     const tr = this.createEmptyRow(ancestor);
@@ -123,7 +124,7 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
     const td = document.createElement('td');
     tr.appendChild(td);
 
-    return tr;
+    return [tr, false];
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
@@ -17,7 +17,7 @@ export class PlainRenderPass extends TableRenderPass {
   protected doRender():void {
     this.workPackageTable.rows.forEach((wpId:string) => {
       let row = this.workPackageTable.rowIndex[wpId];
-      let tr = this.rowBuilder.buildEmpty(row.object);
+      let [tr, _hidden] = this.rowBuilder.buildEmpty(row.object);
       row.element = tr;
       this.appendRow(row.object, tr);
       this.tableBody.appendChild(tr);

--- a/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
@@ -31,7 +31,7 @@ export abstract class RowsBuilder {
    * Refresh a single row after structural changes.
    * Will perform dirty checking for when a work package is currently being edited.
    */
-  public refreshRow(row:WorkPackageTableRow):[HTMLElement, boolean] {
+  public refreshRow(row:WorkPackageTableRow):[HTMLElement, boolean]|null {
     let editing = this.states.editing.get(row.workPackageId).value;
     return this.refreshBuilder.refreshRow(row, editing);
   }

--- a/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
@@ -31,7 +31,7 @@ export abstract class RowsBuilder {
    * Refresh a single row after structural changes.
    * Will perform dirty checking for when a work package is currently being edited.
    */
-  public refreshRow(row:WorkPackageTableRow):HTMLElement | null {
+  public refreshRow(row:WorkPackageTableRow):[HTMLElement, boolean] {
     let editing = this.states.editing.get(row.workPackageId).value;
     return this.refreshBuilder.refreshRow(row, editing);
   }

--- a/frontend/app/components/wp-fast-table/builders/rows/row-refresh-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/row-refresh-builder.ts
@@ -10,11 +10,12 @@ export class RowRefreshBuilder extends SingleRowBuilder {
   /**
    * Refresh a row that is currently being edited, that is, some edit fields may be open
    */
-  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined): HTMLElement | null {
+  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean] {
     // Get the row for the WP if refreshing existing
     const rowElement = row.element || locateRow(row.workPackageId);
+
     if (!rowElement) {
-      return null;
+      throw new Error(`Trying to refresh row for ${row.workPackageId} that is not in the table`);
     }
 
     // Iterate all columns, reattaching or rendering new columns
@@ -41,7 +42,7 @@ export class RowRefreshBuilder extends SingleRowBuilder {
     });
 
     jRow.prepend(newCells);
-    return rowElement;
+    return [rowElement!, false];
   }
 
   private isColumnBeingEdited(editForm: WorkPackageEditForm | undefined, column: QueryColumn) {

--- a/frontend/app/components/wp-fast-table/builders/rows/row-refresh-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/row-refresh-builder.ts
@@ -4,18 +4,20 @@ import {locateRow} from "../../helpers/wp-table-row-helpers";
 import {WorkPackageTableRow} from "../../wp-table.interfaces";
 import {wpCellTdClassName} from "../cell-builder";
 import {SingleRowBuilder} from "./single-row-builder";
+import {debugLog} from '../../../../helpers/debug_output';
 
 export class RowRefreshBuilder extends SingleRowBuilder {
 
   /**
    * Refresh a row that is currently being edited, that is, some edit fields may be open
    */
-  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean] {
+  public refreshRow(row: WorkPackageTableRow, editForm: WorkPackageEditForm | undefined):[HTMLElement, boolean] | null {
     // Get the row for the WP if refreshing existing
     const rowElement = row.element || locateRow(row.workPackageId);
 
     if (!rowElement) {
-      throw new Error(`Trying to refresh row for ${row.workPackageId} that is not in the table`);
+      debugLog(`Trying to refresh row for ${row.workPackageId} that is not in the table`);
+      return null;
     }
 
     // Iterate all columns, reattaching or rendering new columns

--- a/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -61,7 +61,7 @@ export class SingleRowBuilder {
   /**
    * Build the columns on the given empty row
    */
-  public buildEmpty(workPackage:WorkPackageResource):HTMLElement {
+  public buildEmpty(workPackage:WorkPackageResource):[HTMLElement,boolean] {
     let row = this.createEmptyRow(workPackage);
     let cell = null;
 
@@ -75,7 +75,7 @@ export class SingleRowBuilder {
       row.classList.add(checkedClassName);
     }
 
-    return row;
+    return [row, false];
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
@@ -1,8 +1,13 @@
+import {commonRowClassName} from '../builders/rows/single-row-builder';
 /**
  * Return the row html id attribute for the given work package ID.
  */
 export function rowId(workPackageId:string):string {
   return `wp-row-${workPackageId}`;
+}
+
+export function rowClass(workPackageId:string):string {
+  return `${commonRowClassName}-${workPackageId}`;
 }
 
 /**

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -96,9 +96,10 @@ export class WorkPackageTable {
   public refreshRow(row:WorkPackageTableRow) {
     // Find the row we want to replace
     let oldRow = row.element || locateRow(row.workPackageId);
-    let [newRow, hidden] = this.rowBuilder.refreshRow(row);
+    let result = this.rowBuilder.refreshRow(row);
 
-    if (newRow && oldRow && oldRow.parentNode) {
+    if (result !== null && oldRow && oldRow.parentNode) {
+      let [newRow, _hidden] = result;
       oldRow.parentNode.replaceChild(newRow, oldRow);
       row.element = newRow;
       this.rowIndex[row.workPackageId] = row;

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -96,7 +96,7 @@ export class WorkPackageTable {
   public refreshRow(row:WorkPackageTableRow) {
     // Find the row we want to replace
     let oldRow = row.element || locateRow(row.workPackageId);
-    let newRow = this.rowBuilder.refreshRow(row);
+    let [newRow, hidden] = this.rowBuilder.refreshRow(row);
 
     if (newRow && oldRow && oldRow.parentNode) {
       oldRow.parentNode.replaceChild(newRow, oldRow);

--- a/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
+++ b/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
@@ -50,15 +50,15 @@ export class InlineCreateRowBuilder extends RowRefreshBuilder {
     }
   }
 
-  public buildNew(workPackage:WorkPackageResource, form:WorkPackageEditForm):HTMLElement {
+  public buildNew(workPackage:WorkPackageResource, form:WorkPackageEditForm):[HTMLElement, boolean] {
     // Get any existing edit state for this work package
-    const row = this.buildEmpty(workPackage);
+    const [row, hidden] = this.buildEmpty(workPackage);
 
     // Set editing context to table
     form.editContext = new TableRowEditContext(workPackage.id);
     this.states.editing.get(workPackage.id).putValue(form);
 
-    return row;
+    return [row, hidden];
   }
 
   /**

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -41,6 +41,7 @@ import {Observable} from 'rxjs';
 import * as moment from 'moment';
 import Moment = moment.Moment;
 import {RenderedRow} from '../../../wp-fast-table/builders/modes/table-render-pass';
+import {debugLog} from '../../../../helpers/debug_output';
 
 
 export const timelineGlobalElementCssClassname = 'relation-line';
@@ -75,6 +76,7 @@ export class WorkPackageTableTimelineRelations {
   private container:JQuery;
 
   private workPackageIdOrder:RenderedRow[] = [];
+  private relationsRequestedFor:string[] = [];
 
   private elements:TimelineRelationElement[] = [];
 
@@ -109,7 +111,6 @@ export class WorkPackageTableTimelineRelations {
       .takeUntil(scopeDestroyed$(this.$scope))
       .filter(([timelineState, result]) => timelineState.isVisible && result.renderedOrder.length > 0)
       .map(([timelineState, result]) => result.renderedOrder)
-      .distinctUntilChanged()
       .subscribe((orderedRows) => {
         this.workPackageIdOrder = orderedRows;
         this.getRequiredRelations();
@@ -125,6 +126,13 @@ export class WorkPackageTableTimelineRelations {
       }
     });
 
+    if (_.isEqual(requiredForRelations, this.relationsRequestedFor)) {
+      debugLog('WP order unchanged, not requesting new relations, only updating them.');
+      this.update(this.wpTimeline.viewParameters);
+      return;
+    }
+
+    this.relationsRequestedFor = requiredForRelations;
     this.wpRelations.requireInvolved(requiredForRelations);
   }
 

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -244,7 +244,7 @@ export class WorkPackageTableTimelineRelations {
     // Draw end corner to the target
     if (directionX === 1) {
       if (directionY === 1) {
-        this.container.append(newSegment(vp, e.classNames, idxTo, 0, lastX, 1, 19));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, targetX - lastX, 1));
       } else {
         this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, 1, 22));
         this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, targetX - lastX, 1));

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -46,7 +46,7 @@ export const timelineGlobalElementCssClassname = 'relation-line';
 
 function newSegment(vp:TimelineViewParameters,
                     classNames:string[],
-                    color:string,
+                    Yposition:number,
                     top:number,
                     left:number,
                     width:number,
@@ -60,7 +60,7 @@ function newSegment(vp:TimelineViewParameters,
   );
 
   // segment.style.backgroundColor = color;
-  segment.style.top = top + 'px';
+  segment.style.top = ((Yposition * 41) + top) + 'px';
   segment.style.left = left + 'px';
   segment.style.width = width + 'px';
   segment.style.height = height + 'px';
@@ -71,7 +71,7 @@ export class WorkPackageTableTimelineRelations {
 
   public wpTimeline:WorkPackageTimelineTableController;
 
-  private container:ng.IAugmentedJQuery;
+  private container:JQuery;
 
   private workPackageIdOrder:(string|null)[] = [];
 
@@ -143,7 +143,7 @@ export class WorkPackageTableTimelineRelations {
   private refreshRelations(workPackageId:string, relations:Object) {
     // Remove all previous relations for the work package
     const prefix = TimelineRelationElement.workPackagePrefix(workPackageId);
-    jQuery(`.${prefix}`).remove();
+    this.container.find(`.${prefix}`).remove();
     _.remove(this.elements, (element) => element.belongsToId === workPackageId);
 
     _.each(relations, (relation:RelationResource) => {
@@ -160,7 +160,7 @@ export class WorkPackageTableTimelineRelations {
   }
 
   private removeAllVisibleElements() {
-    jQuery('.' + timelineGlobalElementCssClassname).remove();
+    this.container.find('.' + timelineGlobalElementCssClassname).remove();
   }
 
   private renderElements(vp:TimelineViewParameters) {
@@ -177,10 +177,12 @@ export class WorkPackageTableTimelineRelations {
     const startCell = this.wpTimeline.cells[involved.from];
     const endCell = this.wpTimeline.cells[involved.to];
 
+    // If targets do not exist (or are hidden) anywhere in the table, skip
     if (idxFrom === -1 || idxTo === -1 || _.isNil(startCell) || _.isNil(endCell)) {
       return;
     }
 
+    // Skip if relations cannot be drawn between these cells
     if (!startCell.canConnectRelations() || !endCell.canConnectRelations()) {
       return;
     }
@@ -195,50 +197,40 @@ export class WorkPackageTableTimelineRelations {
       return;
     }
 
+    // Draw the first line next to the bar/milestone element
     const startLength = 13;
-    startCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 19, lastX, startLength, 1));
+    const height = Math.abs(idxTo - idxFrom);
+    this.container.append(newSegment(vp, e.classNames, idxFrom, 19, lastX, startLength, 1));
     lastX += startLength;
 
     if (directionY === 1) {
-      startCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'red', 19, lastX, 1, 22));
+      // Draw a line down from from idxFrom to idxTo
+      this.container.append(newSegment(vp, e.classNames, idxFrom, 19, lastX, 1, height * 41));
     } else {
-      startCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'red', -1, lastX, 1, 21));
+      // Draw a line from target row down to idxFrom
+      this.container.append(newSegment(vp, e.classNames, idxTo, 20, lastX, 1, height * 41));
     }
 
-    // vert segment
-    for (let index = idxFrom + directionY; index !== idxTo; index += directionY) {
-      const id = this.workPackageIdOrder[index];
-      if (!id) {
-        continue;
-      }
-
-      const cell = this.wpTimeline.cells[id];
-      if (_.isNil(cell)) {
-        continue;
-      }
-      cell.timelineCell.appendChild(newSegment(vp, e.classNames, 'blue', 0, lastX, 1, 42));
-    }
-
-    // end
+    // Draw end corner to the target
     if (directionX === 1) {
       if (directionY === 1) {
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 0, lastX, 1, 19));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'blue', 19, lastX, targetX - lastX, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 0, lastX, 1, 19));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, targetX - lastX, 1));
       } else {
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 19, lastX, 1, 22));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'blue', 19, lastX, targetX - lastX, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, 1, 22));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, lastX, targetX - lastX, 1));
       }
     } else {
       if (directionY === 1) {
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 0, lastX, 1, 8));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'blue', 8, targetX - 10, lastX - targetX + 11, 1));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 8, targetX - 10, 1, 11));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'red', 19, targetX - 10, 10, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 0, lastX, 1, 8));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 8, targetX - 10, lastX - targetX + 11, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 8, targetX - 10, 1, 11));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, targetX - 10, 10, 1));
       } else {
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 32, lastX, 1, 8));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'blue', 32, targetX - 10, lastX - targetX + 11, 1));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'green', 19, targetX - 10, 1, 13));
-        endCell.timelineCell.appendChild(newSegment(vp, e.classNames, 'red', 19, targetX - 10, 10, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 32, lastX, 1, 8));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 32, targetX - 10, lastX - targetX + 11, 1));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, targetX - 10, 1, 13));
+        this.container.append(newSegment(vp, e.classNames, idxTo, 19, targetX - 10, 10, 1));
       }
     }
   }

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -112,12 +112,14 @@ export class WorkPackageTableTimelineRelations {
       .filter(([timelineState, result]) => timelineState.isVisible && result.renderedOrder.length > 0)
       .map(([timelineState, result]) => result.renderedOrder)
       .subscribe((orderedRows) => {
+        // remove all elements. They are refreshed either after initial loading
+        this.removeAllVisibleElements();
         this.workPackageIdOrder = orderedRows;
-        this.getRequiredRelations();
+        this.refreshRelationsWhenNeeded();
       });
   }
 
-  private getRequiredRelations():void {
+  private refreshRelationsWhenNeeded():void {
     const requiredForRelations:string[] = [];
 
     _.each(this.workPackageIdOrder, (el:RenderedRow) => {
@@ -128,7 +130,7 @@ export class WorkPackageTableTimelineRelations {
 
     if (_.isEqual(requiredForRelations, this.relationsRequestedFor)) {
       debugLog('WP order unchanged, not requesting new relations, only updating them.');
-      this.update(this.wpTimeline.viewParameters);
+      this.renderElements(this.wpTimeline.viewParameters);
       return;
     }
 

--- a/frontend/app/helpers/debug_output.ts
+++ b/frontend/app/helpers/debug_output.ts
@@ -13,5 +13,5 @@ export function whenDebugging(cb:Function) {
  * through webpack.
  */
 export function debugLog(...args:any[]) {
-  whenDebugging(() => console.log('[DEBUG] ', args));
+  whenDebugging(() => console.log('[DEBUG] ', args.join('-- ')));
 }

--- a/spec/features/work_packages/details/details_relations_spec.rb
+++ b/spec/features/work_packages/details/details_relations_spec.rb
@@ -84,14 +84,14 @@ describe 'Work package relations tab', js: true, selenium: true do
   end
 
   describe 'as admin' do
-     let!(:parent) { FactoryGirl.create(:work_package, project: project) }
-     let!(:child) { FactoryGirl.create(:work_package, project: project) }
-     let!(:child2) { FactoryGirl.create(:work_package, project: project, subject: 'Something new') }
+    let!(:parent) { FactoryGirl.create(:work_package, project: project) }
+    let!(:child) { FactoryGirl.create(:work_package, project: project) }
+    let!(:child2) { FactoryGirl.create(:work_package, project: project, subject: 'Something new') }
 
     it 'allows to mange hierarchy' do
       # Shows link parent link
       expect(page).to have_selector('#hierarchy--add-parent')
-      find('.wp-inline-create--add-link',
+      find('.work-packages--details .wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_parent')).click
 
       # Add parent
@@ -99,14 +99,14 @@ describe 'Work package relations tab', js: true, selenium: true do
 
       ##
       # Add child #1
-      find('.wp-inline-create--add-link',
+      find('.work-packages--details .wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       add_hierarchy('.wp-relations--child-form', child.id, child.subject)
 
       ##
       # Add child #2
-      find('.wp-inline-create--add-link',
+      find('.work-packages--details .wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       add_hierarchy('.wp-relations--child-form', child2.subject, child2.subject)
@@ -208,7 +208,7 @@ describe 'Work package relations tab', js: true, selenium: true do
       it 'should be able to link parent and children' do
         # Shows link parent link
         expect(page).to have_selector('#hierarchy--add-parent')
-        find('.wp-inline-create--add-link',
+        find('.work-packages--details .wp-inline-create--add-link',
              text: I18n.t('js.relation_buttons.add_parent')).click
 
         # Add parent
@@ -216,7 +216,7 @@ describe 'Work package relations tab', js: true, selenium: true do
 
         ##
         # Add child
-        find('.wp-inline-create--add-link',
+        find('.work-packages--details .wp-inline-create--add-link',
              text: I18n.t('js.relation_buttons.add_existing_child')).click
 
         add_hierarchy('.wp-relations--child-form', child.id, child.subject)

--- a/spec/features/work_packages/timeline/timeline_hierarchy_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_hierarchy_spec.rb
@@ -1,0 +1,123 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+RSpec.feature 'Work package timeline hierarchies', js: true, selenium: true do
+  let(:user) { FactoryGirl.create :admin }
+  let(:project) { FactoryGirl.create(:project) }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:hierarchy) { ::Components::WorkPackages::Hierarchies.new }
+  let(:wp_timeline) { Pages::WorkPackagesTimeline.new(project) }
+  let(:settings_menu) { Components::WorkPackages::SettingsMenu.new }
+
+  before do
+    login_as(user)
+  end
+
+  let!(:wp_root) do
+    FactoryGirl.create :work_package,
+                       project: project
+  end
+
+  let!(:wp_leaf) do
+    FactoryGirl.create :work_package,
+                       project: project,
+                       parent: wp_root,
+                       start_date: Date.today,
+                       due_date: (Date.today + 5.days)
+  end
+
+  let!(:query) do
+    query              = FactoryGirl.build(:query, user: user, project: project)
+    query.column_names = ['subject']
+    query.filters.clear
+    query.show_hierarchies = true
+    query.timeline_visible = true
+
+    query.save!
+    query
+  end
+
+  it 'hides the row in both hierarchy and timeline' do
+    wp_timeline.visit_query query
+
+    # Expect root and leaf visible in table and timeline
+    wp_timeline.expect_work_package_listed(wp_root, wp_leaf)
+
+    # Hide the hierarchy root
+    hierarchy.expect_hierarchy_at(wp_root)
+    hierarchy.expect_leaf_at(wp_leaf)
+
+    # Toggling hierarchies hides the inner children
+    hierarchy.toggle_row(wp_root)
+
+    # Root, other showing
+    wp_timeline.expect_work_package_listed(wp_root)
+    # Inter, Leaf hidden
+    hierarchy.expect_hidden(wp_leaf)
+    wp_timeline.expect_hidden_row(wp_leaf)
+
+    # Should now have exactly two rows (one in each split view)
+    expect(page).to have_selector('.wp--row', count: 2)
+  end
+
+  context 'with a relation being rendered to a hidden row' do
+    let!(:wp_other) do
+      FactoryGirl.create :work_package,
+                         project: project,
+                         start_date: Date.today + 5.days,
+                         due_date: (Date.today + 10.days)
+    end
+    let!(:relation) do
+      FactoryGirl.create(:relation,
+                         from: wp_leaf,
+                         to: wp_other,
+                         relation_type: Relation::TYPE_FOLLOWS)
+    end
+
+    it 'does not render the relation when hierarchy is collapsed' do
+      wp_timeline.visit_query query
+
+      # Expect root and leaf visible in table and timeline
+      wp_timeline.expect_work_package_listed(wp_root, wp_leaf, wp_other)
+      wp_timeline.expect_timeline_relation(wp_leaf, wp_other)
+
+      # Toggling hierarchies hides the inner children
+      hierarchy.toggle_row(wp_root)
+
+      wp_timeline.expect_work_package_listed(wp_root, wp_other)
+      hierarchy.expect_hidden(wp_leaf)
+
+      # Relation should now not be rendered
+      wp_timeline.expect_no_timeline_relation(wp_leaf, wp_other)
+      wp_timeline.expect_no_relations
+    end
+  end
+end

--- a/spec/support/pages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages_timeline.rb
@@ -39,6 +39,30 @@ module Pages
       "#wp-timeline-row-#{wp_id}"
     end
 
+    def timeline_container
+      '.work-packages-tabletimeline--timeline-side'
+    end
+
+    def expect_work_package_listed(*work_packages)
+      super(*work_packages)
+
+      within(table_container) do
+        work_packages.each do |wp|
+          expect(page).to have_selector("#wp-timeline-row-#{wp.id}", visible: true)
+        end
+      end
+    end
+
+    def expect_work_package_not_listed(*work_packages)
+      super(*work_packages)
+
+      within(table_container) do
+        work_packages.each do |wp|
+          expect(page).to have_no_selector("#wp-timeline-row-#{wp.id}", visible: true)
+        end
+      end
+    end
+
     def expect_timeline!(open: true)
       if open
         expect(page).to have_selector('#work-packages-timeline-toggle-button.-active')
@@ -52,6 +76,24 @@ module Pages
     def expect_timeline_element(work_package)
       type = work_package.milestone? ? :milestone : :bar
       expect(page).to have_selector("#{timeline_row_selector(work_package.id)} .timeline-element.#{type}")
+    end
+
+    def expect_timeline_relation(from, to)
+      within(timeline_container) do
+        expect(page).to have_selector(".relation-line.__tl-relation-#{from.id}-#{to.id}", minimum: 1)
+      end
+    end
+
+    def expect_no_timeline_relation(from, to)
+      within(timeline_container) do
+        expect(page).to have_no_selector(".relation-line.__tl-relation-#{from.id}-#{to.id}")
+      end
+    end
+
+    def expect_no_relations
+      within(timeline_container) do
+        expect(page).to have_no_selector(".relation-line")
+      end
     end
 
     def expect_hidden_row(work_package)


### PR DESCRIPTION
Updates the `rendered` state appropriately in the hierarchy and grouped transformers to let the timeline properly handle structural changes

As we rely on the DOM to handle collapsing/expanding rows in the grouped and hierarchy mode due to its performance. We can thus derive the changes to `rendered` from each row that is changed in these transformers.

This PR provides:

1. Relation rendering that happens in the background instead of each cell. Fixes [#25175](https://community.openproject.com/projects/openproject/work_packages/25175) as it does no longer care for which cells are not actually there in the timeline.

2. Knowledge which rows are part of the table, but currently hidden. Fixes [#25264](https://community.openproject.com/projects/openproject/work_packages/25264)

3. Appears to fix this following bug probably due to changes in how the relation subscribes to changes: [#25276](https://community.openproject.com/projects/openproject/work_packages/25276)

4. I couldn't reproduce [#25232](https://community.openproject.com/projects/openproject/work_packages/25232/) anymore, probably due to all relations being removed on `rendered` updates.
