### PR TITLE
[25266] Let the timeline container keep the overflow width

### DIFF
--- a/frontend/app/components/wp-table/wp-table-scroll-sync.ts
+++ b/frontend/app/components/wp-table/wp-table-scroll-sync.ts
@@ -28,8 +28,8 @@
 
 import {IAugmentedJQuery} from "angular";
 
-const selectorTableSide = ".work-packages-tabletimeline--table-side";
-const selectorTimelineSide = ".work-packages-tabletimeline--timeline-side";
+export const selectorTableSide = ".work-packages-tabletimeline--table-side";
+export const selectorTimelineSide = ".work-packages-tabletimeline--timeline-side";
 const jQueryScrollSyncEventNamespace = ".scroll-sync";
 const scrollStep = 15;
 


### PR DESCRIPTION
Since all global elements are positioned absolute, we don't know the actual width from within the timeline container.

This causes all elements to be of 100% width, and beyond that not responding to events.

However, the browser gives us the total size of all overflowing elements in the container through `scrollWidth`, which we can simply set when drawing.

To use that, we only have to reset its width before rendering, only to get the new/correct scrollWidth afterwards.

https://community.openproject.com/projects/openproject/work_packages/25266/