### PR TITLE
Fix/memorize per page option

### DIFF
--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.html
@@ -1,4 +1,4 @@
-<div class="pagination" ng-if="pageNumbers.length">
+<div class="pagination" ng-if="totalEntries">
   <nav class="pagination--pages">
     <ul class="pagination--items">
 
@@ -70,11 +70,11 @@
     </ul>
   </nav>
 
-  <div class="pagination--options" ng-if="totalEntries > paginationOptions.perPageOptions[0]">
+  <div class="pagination--options" ng-if="totalEntries > perPageOptions[0]">
     <ul class="pagination--items">
       <li class="pagination--label" ng-bind="::text.per_page" title="{{ ::text.per_page }}"></li>
 
-      <li ng-repeat="perPageOption in paginationOptions.perPageOptions"
+      <li ng-repeat="perPageOption in perPageOptions"
           ng-class="{ '-current': perPageOption == paginationOptions.perPage }"
           class="pagination--item">
 

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
@@ -90,6 +90,7 @@ describe('tablePagination Directive', function () {
     subject = new BehaviorSubject(state);
 
     sinon.stub(PaginationService, 'loadPerPageOptions');
+    sinon.stub(PaginationService, 'getPerPageOptions', () => [10, 100, 500, 1000]);
 
     compile = function () {
       subject = new BehaviorSubject(state);

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.test.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {BehaviorSubject} from "rxjs";
+import {BehaviorSubject} from 'rxjs';
 
 describe('tablePagination Directive', function () {
   var compile:any, element:any, rootScope:any, scope:any, PaginationService:any, paginationOptions:any;
@@ -55,8 +55,8 @@ describe('tablePagination Directive', function () {
   let setTotalResults = (total:number) => {
     let current = subject.getValue();
 
-    pushState(total, current.current.perPage, current.current.page)
-  }
+    pushState(total, current.current.perPage, current.current.page);
+  };
 
   let pushState = (total:number, perPage:number, page:number) => {
     subject.next({
@@ -67,7 +67,7 @@ describe('tablePagination Directive', function () {
       }
     });
     scope.$apply();
-  }
+  };
 
   beforeEach(inject(function ($rootScope:any, $compile:any) {
     var html;

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.ts
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.ts
@@ -73,10 +73,10 @@ function tablePagination(PaginationService:any,
        * @description Defines a string containing page bound information inside the directive scope
        */
       function updateCurrentRangeLabel() {
-        if (scope.totalEntries){
-          scope.currentRange = "(" + PaginationService.getLowerPageBound() + " - " + PaginationService.getUpperPageBound(scope.totalEntries) + "/" + scope.totalEntries + ")";
+        if (scope.totalEntries) {
+          scope.currentRange = '(' + PaginationService.getLowerPageBound() + ' - ' + PaginationService.getUpperPageBound(scope.totalEntries) + '/' + scope.totalEntries + ')';
         } else {
-          scope.currentRange = "(0 - 0/0)";
+          scope.currentRange = '(0 - 0/0)';
         }
       }
 
@@ -110,11 +110,13 @@ function tablePagination(PaginationService:any,
         scope.pageNumbers = pageNumbers;
       }
 
-      function truncatePageNums(pageNumbers:any, perform:any, disectFrom:any, disectLength:any, truncateFrom:any){
-        if (perform){
+      function truncatePageNums(pageNumbers:any, perform:any, disectFrom:any, disectLength:any, truncateFrom:any) {
+        if (perform) {
           var truncationSize = PaginationService.getOptionsTruncationSize();
           var truncatedNums = pageNumbers.splice(disectFrom, disectLength);
-          if (truncatedNums.length >= truncationSize * 2) truncatedNums.splice(truncateFrom, truncatedNums.length - truncationSize);
+          if (truncatedNums.length >= truncationSize * 2) {
+            truncatedNums.splice(truncateFrom, truncatedNums.length - truncationSize);
+          }
           return truncatedNums;
         } else {
           return [];

--- a/frontend/app/components/wp-table/table-pagination/table-pagination.directive.ts
+++ b/frontend/app/components/wp-table/table-pagination/table-pagination.directive.ts
@@ -67,6 +67,10 @@ function tablePagination(PaginationService:any,
         wpTablePagination.updateFromObject({page: pageNumber});
       };
 
+      Object.defineProperty(scope, 'perPageOptions', {
+        get: () => PaginationService.getPerPageOptions()
+      });
+
       /**
        * @name updateCurrentRange
        *

--- a/frontend/app/helpers/index.js
+++ b/frontend/app/helpers/index.js
@@ -32,7 +32,7 @@ angular.module('openproject.helpers')
   .service('CustomFieldHelper', ['CUSTOM_FIELD_PREFIX', 'I18n', require(
     './custom-field-helper')])
   .factory('SvgHelper', require('./svg-helper'))
-  .service('UrlParamsHelper', ['I18n', 'PaginationService', 'PathHelper',
+  .service('UrlParamsHelper', ['PaginationService',
     require('./url-params-helper')])
   .service('WorkPackageLoadingHelper', ['$timeout', require(
     './work-package-loading-helper')]);

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -94,7 +94,9 @@ module.exports = function(PaginationService) {
     },
 
     buildV3GetQueryFromJsonParams: function(updateJson) {
-      var queryData = {};
+      var queryData = {
+        pageSize: PaginationService.getPerPage()
+      }
 
       if (!updateJson) {
         return queryData;

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function(I18n, PaginationService, PathHelper) {
+module.exports = function(PaginationService) {
   var UrlParamsHelper = {
     // copied more or less from angular buildUrl
     buildQueryString: function(params) {

--- a/frontend/app/services/index.js
+++ b/frontend/app/services/index.js
@@ -40,7 +40,7 @@ angular.module('openproject.services')
     '$timeout',
     'PathHelper',
     require('./keyboard-shortcut-service')])
-  .service('PaginationService', ['DEFAULT_PAGINATION_OPTIONS', 'ConfigurationDm', require(
+  .service('PaginationService', ['DEFAULT_PAGINATION_OPTIONS', 'ConfigurationDm', '$window', require(
     './pagination-service')])
   .service('SortService', require('./sort-service'))
   .service('StatusService', ['$http', 'PathHelper', require('./status-service')])

--- a/frontend/app/services/pagination-service.js
+++ b/frontend/app/services/pagination-service.js
@@ -26,11 +26,11 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-module.exports = function(DEFAULT_PAGINATION_OPTIONS, ConfigurationDm) {
+module.exports = function(DEFAULT_PAGINATION_OPTIONS, ConfigurationDm, $window) {
   var paginationOptions = {
     page: DEFAULT_PAGINATION_OPTIONS.page,
-    perPage: DEFAULT_PAGINATION_OPTIONS.perPage,
-    perPageOptions: DEFAULT_PAGINATION_OPTIONS.perPageOptions,
+    perPage: $window.localStorage.getItem('pagination.perPage'),
+    perPageOptions: [],
     maxVisiblePageOptions: DEFAULT_PAGINATION_OPTIONS.maxVisiblePageOptions,
     optionsTruncationSize: DEFAULT_PAGINATION_OPTIONS.optionsTruncationSize
   };
@@ -55,6 +55,7 @@ module.exports = function(DEFAULT_PAGINATION_OPTIONS, ConfigurationDm) {
       return paginationOptions.optionsTruncationSize;
     },
     setPerPage: function(perPage) {
+      $window.localStorage.setItem('pagination.perPage', perPage);
       paginationOptions.perPage = perPage;
     },
     getPerPageOptions: function() {

--- a/frontend/app/work_packages/config/index.js
+++ b/frontend/app/work_packages/config/index.js
@@ -34,8 +34,6 @@ angular.module('openproject.workPackages.config')
 
 .constant('DEFAULT_PAGINATION_OPTIONS', {
   page: 1,
-  perPage: 10,
-  perPageOptions: [10, 100, 500, 1000],
   maxVisiblePageOptions: 6,
   optionsTruncationSize: 1
 });

--- a/spec/support/local_storage_cleanup.rb
+++ b/spec/support/local_storage_cleanup.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+RSpec.configure do |config|
+  config.after(:each, js: true) do
+    Capybara.current_session.driver.execute_script('window.localStorage.clear()')
+  end
+end


### PR DESCRIPTION
Stores the selected perPage option in localStorage for it to be used later on when no perPage option is specified. In effect, this leads to the system memorizing the perPage upon:
* initial loading
* query changes
* ...

https://community.openproject.com/projects/openproject/work_packages/25273

