### PR TITLE
[25288] Re-add translations to default attribute groups

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -138,7 +138,7 @@ module Type::AttributeGroups
     active_form = get_active_groups(available, inactive)
     inactive_form = inactive
                     .map { |key, attribute| attr_form_map(key, attribute) }
-                    .sort_by { |_key, _attribute, translation| translation }
+                    .sort_by { |attr| attr[:translation] }
 
     {
       actives: active_form,

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -80,6 +80,17 @@ module Type::AttributeGroups
   end
 
   ##
+  # Translate the given attribute group if its internal
+  # (== if it's a symbol)
+  def translated_attribute_group(groupkey)
+    if groupkey.is_a? Symbol
+      I18n.t(default_groups[groupkey])
+    else
+      groupkey
+    end
+  end
+
+  ##
   # Read the serialized attribute groups, if customized.
   # Otherwise, return +default_attribute_groups+
   def attribute_groups
@@ -108,7 +119,7 @@ module Type::AttributeGroups
     ordered = []
     default_groups.map do |groupkey, label_key|
       members = values[groupkey]
-      ordered << [I18n.t(label_key, locale: Setting.default_language), members.sort] if members.present?
+      ordered << [groupkey, members.sort] if members.present?
     end
 
     ordered

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -45,7 +45,11 @@ class BaseTypeService
       type.attributes = permitted
 
       if unsafe_params[:attribute_groups].present?
-        type.attribute_groups = JSON.parse(unsafe_params[:attribute_groups])
+        type.attribute_groups =
+          JSON.parse(unsafe_params[:attribute_groups])
+              .map do |group|
+                [(group[2] ? group[0].to_sym : group[0]), group[1]]
+              end
       end
       if unsafe_params[:attribute_visibility].present?
         type.attribute_visibility = JSON.parse(unsafe_params[:attribute_visibility])

--- a/app/views/types/form/_form_configuration.html.erb
+++ b/app/views/types/form/_form_configuration.html.erb
@@ -28,10 +28,10 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% form_attributes = @type.form_configuration_groups %>
-
 <section class="form--section">
-      <%= f.hidden_field :attribute_groups, value: @type.attribute_groups.to_json %>
-      <%= f.hidden_field :attribute_visibility, value: @type.attribute_visibility.to_json %>
+  <%= f.hidden_field :attribute_groups, value: @type.attribute_groups.map { |group| [group[0], group[1], (group[0].is_a? Symbol)] }.to_json %>
+  <%= f.hidden_field :attribute_visibility,
+                      value: @type.attribute_visibility.to_json %>
   <div id="types-form-configuration" op-drag-scroll ng-controller="TypesFormConfigurationCtrl" ng-init="upsaleLink = <%= '"' + OpenProject::Static::Links.links[:upsale][:href] +  '?utm_source=ce-form-configuration' + '"' %>">
     <div class="grid-block wrap">
       <div class="grid-content small-12 large-10">
@@ -93,7 +93,7 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
     <div class="grid-block wrap">
       <div class="grid-content small-12 medium-6 large-5">
-        <div id="type-form-conf-group-template" class="type-form-conf-group" data-original-key="" data-key="">
+        <div id="type-form-conf-group-template" class="type-form-conf-group" data-original-key="" data-key="" data-key-is-symbol="false">
           <div class="group-head">
             <span class="group-handle icon-toggle"></span>
             <group-edit-in-place
@@ -111,16 +111,16 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
         <div id="draggable-groups" dragula='"groups"'>
           <% form_attributes[:actives].each do |group, attributes| %>
-            <div class="type-form-conf-group" data-original-key="<%= group %>" data-key="<%= group %>">
+            <div class="type-form-conf-group" data-original-key="<%= group.to_s %>" data-key="<%= group %>" data-key-is-symbol="<%= group.is_a? Symbol %>">
               <div class="group-head">
                 <span class="group-handle icon-toggle"></span>
                 <group-edit-in-place
-                  name="<%= group %>"
+                  name="<%= @type.translated_attribute_group(group) %>"
                   key="<%= group %>"
                   onvaluechange="groupNameChange"
                   onupsale="<%= EnterpriseToken.allows_to?(:edit_attribute_groups) ? '' : 'showEEOnlyHint' %>"
                   class="group-name">
-                  <%= group %>
+                  <%= @type.translated_attribute_group(group) %>
                 </group-edit-in-place>
                 <span class="visibility-check"><%= t('label_always_visible') %></span>
                 <span class="delete-group icon icon-close" ng-click="deleteGroup($event)"></span>

--- a/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
+++ b/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
@@ -124,7 +124,7 @@ function typesFormConfigurationCtrl(
   $scope.updateHiddenFields = ():void => {
     let groups:HTMLElement[] = angular.element('.type-form-conf-group').not('#type-form-conf-group-template').toArray();
     let seenGroupNames:{[name:string]:boolean} = {};
-    let newAttrGroups:Array<Array<(string | Array<string>)>> = [];
+    let newAttrGroups:Array<Array<(string | Array<string> | boolean)>> = [];
     let newAttrVisibility:any = {};
     let inputAttributeGroups:JQuery;
     let inputAttributeVisibility:JQuery;
@@ -136,6 +136,7 @@ function typesFormConfigurationCtrl(
     // with the active groups.
     groups.forEach((group:HTMLElement) => {
       let groupKey:string = angular.element(group).attr('data-key');
+      let keyIsSymbol:boolean = JSON.parse(angular.element(group).attr('data-key-is-symbol'));
       let attributes:HTMLElement[] = angular.element('.type-form-conf-attribute', group).toArray();
       let attrKeys:string[] = [];
 
@@ -167,7 +168,7 @@ function typesFormConfigurationCtrl(
         }
       });
 
-      newAttrGroups.push([groupKey, attrKeys]);
+      newAttrGroups.push([groupKey, attrKeys, keyIsSymbol]);
     });
 
 
@@ -187,7 +188,7 @@ function typesFormConfigurationCtrl(
   };
 
   $scope.groupNameChange = function(key:string, newValue:string):void {
-    angular.element(`.type-form-conf-group[data-original-key="${key}"]`).attr('data-key', newValue);
+    angular.element(`.type-form-conf-group[data-original-key="${key}"]`).attr('data-key', newValue).attr('data-key-is-symbol', "false");
     $scope.updateHiddenFields();
   };
 

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -119,6 +119,7 @@ module API
                 end
 
                 group[1].compact!
+                group[0] = type.translated_attribute_group(group[0])
                 group
               end
             end

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -93,7 +93,7 @@ describe 'form configuration', type: :feature, js: true do
     handle = find_attribute_handle(attribute)
     group = find(group_selector(group_label))
     drag_and_drop(handle, group)
-    expect_group(group_label, key: attribute)
+    expect_group(group_label, group_label, key: attribute)
   end
 
   def drag_and_drop(handle, group)
@@ -120,7 +120,7 @@ describe 'form configuration', type: :feature, js: true do
     input.set(name)
     input.send_keys(:return)
 
-    expect_group(name) if expect
+    expect_group(name, name) if expect
   end
 
   def rename_group(from, to)
@@ -134,8 +134,8 @@ describe 'form configuration', type: :feature, js: true do
     expect(page).to have_selector('.group-edit-handler', text: to.upcase)
   end
 
-  def expect_group(label, *attributes)
-    expect(page).to have_selector("#{group_selector(label)} .group-edit-handler", text: label.upcase)
+  def expect_group(label, translation, *attributes)
+    expect(page).to have_selector("#{group_selector(label)} .group-edit-handler", text: translation.upcase)
 
     within group_selector(label) do
       attributes.each do |attribute|
@@ -178,7 +178,7 @@ describe 'form configuration', type: :feature, js: true do
         dialog.confirm
 
         expect(page).to have_no_selector(group_selector('Whatever'))
-        expect_group('Details')
+        expect_group('details', 'Details')
         expect_attribute(key: :assignee, checked: false)
       end
 
@@ -193,20 +193,24 @@ describe 'form configuration', type: :feature, js: true do
         #
         # Test default set of groups
         #
-        expect_group 'People',
+        expect_group 'people',
+                     'People',
                      { key: :assignee, checked: false, translation: 'Assignee' },
                      { key: :responsible, checked: false, translation: 'Responsible' }
 
-        expect_group 'Estimates and time',
+        expect_group 'estimates_and_time',
+                     'Estimates and time',
                      { key: :estimated_time, checked: false, translation: 'Estimated time' },
                      { key: :spent_time, checked: false, translation: 'Spent time' }
 
-        expect_group 'Details',
+        expect_group 'details',
+                     'Details',
                      { key: :category, checked: false, translation: 'Category' },
                      { key: :date, checked: false, translation: 'Date' },
                      { key: :percentage_done, checked: false, translation: 'Progress (%)' },
                      { key: :priority, checked: false, translation: 'Priority' },
                      { key: :version, checked: false, translation: 'Version' }
+
 
 
         #
@@ -244,18 +248,23 @@ describe 'form configuration', type: :feature, js: true do
 
         # Expect configuration to be correct now
         expect_group 'Cool Stuff',
+                    'Cool Stuff',
                     { key: :assignee, checked: true, translation: 'Assignee' },
                     { key: :responsible, checked: false, translation: 'Responsible' }
 
-        expect_group 'Estimates and time',
+        expect_group 'estimates_and_time',
+                    'Estimates and time',
                     { key: :estimated_time, checked: false, translation: 'Estimated time' },
                     { key: :spent_time, checked: false, translation: 'Spent time' }
 
+
         expect_group 'Whatever',
+                    'Whatever',
                     { key: :date, checked: false, translation: 'Date' },
                     { key: :percentage_done, checked: false, translation: 'Progress (%)' }
 
         expect_group 'New Group',
+                    'New Group',
                     { key: :category, checked: false, translation: 'Category' }
 
         expect_inactive(:version)

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -269,6 +269,11 @@ describe 'form configuration', type: :feature, js: true do
 
         expect_inactive(:version)
 
+        # Test the actual type backend
+        type.reload
+        expect(type.attribute_groups.map { |el| el[0] })
+          .to match_array(['Cool Stuff', :estimates_and_time, 'Whatever', 'New Group'])
+
         # Visit work package with that type
         wp_page.visit!
         wp_page.ensure_page_loaded

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -67,11 +67,11 @@ describe ::Type, type: :model do
       expect(subject.detect { |g| g.class != Array }).to be_falsey
     end
 
-    it "each attribute group's 1st element is a String (the group name)" do
-      expect(subject.detect { |g| g.first.class != String }).to be_falsey
+    it "each attribute group's 1st element is a String (the group name) or symbol (for i18n)" do
+      expect(subject.detect { |g| g.first.class != String && g.first.class != Symbol }).to be_falsey
     end
 
-    it "each attribute group's 2nd element is a String (the group members)" do
+    it "each attribute group's 2nd element is an Array (the group members)" do
       expect(subject.detect { |g| g.second.class != Array }).to be_falsey
     end
 
@@ -135,7 +135,7 @@ describe ::Type, type: :model do
 
       it 'contains Hashes ordered by key :translation' do
         # The first left over attribute should currently be "date"
-        expect(subject.first[:key]).to eq "date"
+        expect(subject.first[:key]).to eq "category"
         expect(subject.first[:translation]).to be_present
         expect(subject.first[:translation] <= subject.second[:translation]).to be_truthy
       end


### PR DESCRIPTION
Uses symbols to mark internal attribute groups and translates them in
the schema representer to the user's locale.