### PR TITLE
[25299] Fix copying WP with multiple custom_values

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -283,7 +283,7 @@ class WorkPackage < ActiveRecord::Base
     self.parent_id = work_package.parent_id if work_package.parent_id
     self.custom_field_values =
       work_package.custom_field_values.inject({}) do |h, v|
-        h[v.custom_field_id] = v.value
+        h[v.custom_field_id] = work_package.custom_value_for(v.custom_field_id)
         h
       end
     self.status = work_package.status


### PR DESCRIPTION
Use `custom_value_for(id)` instead of manually injecting the values, as it correctly handles multi values already.

https://community.openproject.com/projects/openproject/work_packages/25299