### PR TITLE
revert whole of syck Object patch within migration

### DIFF
--- a/db/migrate/migration_utils/legacy_yamler.rb
+++ b/db/migrate/migration_utils/legacy_yamler.rb
@@ -76,6 +76,9 @@ module Migration
       Object.class_eval <<-EORB, __FILE__, __LINE__ + 1
         remove_const 'YAML' if defined? YAML
         YAML = ::Psych
+
+        remove_method :to_yaml
+        alias :to_yaml :psych_to_yaml
       EORB
 
       ::Syck


### PR DESCRIPTION
to_yaml used to be kept linked to syck which resulted in invalid (`--!seq{}`) being written by later migration instead of an array

![image](https://cloud.githubusercontent.com/assets/617519/26156340/4eb357d0-3b16-11e7-9a1c-19c99ab29f02.png)

With the patch, the desired arrays are produced:

![image](https://cloud.githubusercontent.com/assets/617519/26156384/705f72b0-3b16-11e7-94be-993e795ac629.png)
