### PR TITLE
update timeline removal warning

### DIFF
--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -71,7 +71,15 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="notification-box -warning">
   <a title="close" class="notification-box--close icon-context icon-close"></a>
   <div class="notification-box--content">
-    <p><%=raw t('deprecations.old_timeline') %></p>
+    <p><%= t('deprecations.old_timeline.replacement')%></p>
+    <p><%= t('deprecations.old_timeline.removal')%></p>
+    <p>
+      <%= t('deprecations.old_timeline.further_information_before')%>
+      <a href="https://www.openproject.org/old-timeline-view-discontinued-please-migrate-timeline-openproject-7-0">
+        <%= t('deprecations.old_timeline.link_name')%>
+      </a>
+      <%= t('deprecations.old_timeline.further_information_after')%>
+    </p>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,12 +81,12 @@ en:
       no_results_content_text: Create a new custom field
 
   deprecations:
-    old_timeline: |-
-      This timelines module will be replaced by an interactive timelines view embedded into
-      the work packages module. This module is being removed from OpenProject 7.0.
-      <br/>
-      Please note that all data within this module will NOT be migrated to the new view,
-      please make all necessary preparations to recreate the information in the new view.
+    old_timeline:
+      replacement: "This timelines module is being replaced by the interactive timeline embedded into the work packages module."
+      removal: "This module is going to be removed with OpenProject 8.0. The configuration for this view will NOT be migrated to the work package view."
+      further_information_before: "Please take a look at"
+      link_name: "how to migrate to the new timeline."
+      further_information_after: ""
 
   groups:
     index:


### PR DESCRIPTION
As everybody can provide localizations, the raw whiteflag for the string was replaced by a set of i18n keys

Looks like this now:
![image](https://cloud.githubusercontent.com/assets/617519/26194522/f0214f1c-3bb8-11e7-8216-44255b9ed45f.png)

https://community.openproject.com/projects/openproject/work_packages/25027