### PR TITLE
[25237] Open select2 after a small timeout

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -396,10 +396,9 @@ jQuery(document).ready(function($) {
     });
 
     menu.bind("opened", function () {
-      // Open select2 element, when menu is opened
-      select2.open();
-
       setTimeout(function () {
+        // Open select2 element, when menu is opened
+        select2.open();
         jQuery("#select2-drop-mask").hide();
       }, 50);
 


### PR DESCRIPTION
This avoids the internal mousedown handler of select2 firing before
the menu is fully opened.

https://community.openproject.com/projects/openproject/work_packages/25237/