### PR TITLE
[25312] Refresh the complete table side on column changes

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -7,16 +7,14 @@ import {GroupObject} from '../../../../api/api-v3/hal-resources/wp-collection-re
 import {HalResource} from '../../../../api/api-v3/hal-resources/hal-resource.service';
 import {groupClassNameFor, GroupHeaderBuilder} from './group-header-builder';
 import {groupByProperty, groupedRowClassName} from './grouped-rows-helpers';
-import {Subject} from 'rxjs';
 import {PlainRenderPass} from '../plain/plain-render-pass';
 
 export class GroupedRenderPass extends PlainRenderPass {
   constructor(public workPackageTable:WorkPackageTable,
-              public stopExisting$:Subject<undefined>,
               public groups:GroupObject[],
               public headerBuilder:GroupHeaderBuilder,
               public colspan:number) {
-    super(workPackageTable, stopExisting$, new SingleRowBuilder(workPackageTable));
+    super(workPackageTable, new SingleRowBuilder(workPackageTable));
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
@@ -55,7 +55,6 @@ export class GroupedRowsBuilder extends RowsBuilder {
   public buildRows() {
     return new GroupedRenderPass(
       this.workPackageTable,
-      this.stopExisting$,
       this.getGroupData(),
       this.headerBuilder,
       this.colspan

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -29,9 +29,8 @@ export class HierarchyRenderPass extends TableRenderPass {
   private hierarchies:WorkPackageTableHierarchies;
 
   constructor(public workPackageTable:WorkPackageTable,
-              public stopExisting$:Subject<undefined>,
               public rowBuilder:SingleHierarchyRowBuilder) {
-    super(stopExisting$, workPackageTable);
+    super(workPackageTable);
 
     $injectFields(this, 'states');
   }

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-rows-builder.ts
@@ -35,7 +35,7 @@ export class HierarchyRowsBuilder extends RowsBuilder {
    * Rebuild the entire grouped tbody from the given table
    */
   public buildRows():HierarchyRenderPass {
-    return new HierarchyRenderPass(this.workPackageTable, this.stopExisting$, this.rowBuilder).render();
+    return new HierarchyRenderPass(this.workPackageTable, this.rowBuilder).render();
   }
 }
 

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
@@ -1,14 +1,12 @@
 import {TableRenderPass} from '../table-render-pass';
 import {WorkPackageTable} from '../../../wp-fast-table';
 import {SingleRowBuilder} from '../../rows/single-row-builder';
-import {Subject} from 'rxjs';
 
 export class PlainRenderPass extends TableRenderPass {
 
   constructor(public workPackageTable:WorkPackageTable,
-              public stopExisting$:Subject<undefined>,
               public rowBuilder:SingleRowBuilder) {
-    super(stopExisting$, workPackageTable);
+    super(workPackageTable);
   }
 
   /**

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-rows-builder.ts
@@ -23,7 +23,7 @@ export class PlainRowsBuilder extends RowsBuilder {
    * Rebuild the entire grouped tbody from the given table
    */
   public buildRows():TableRenderPass {
-    return new PlainRenderPass(this.workPackageTable, this.stopExisting$, this.rowBuilder).render();
+    return new PlainRenderPass(this.workPackageTable, this.rowBuilder).render();
   }
 }
 

--- a/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/rows-builder.ts
@@ -9,7 +9,6 @@ export abstract class RowsBuilder {
   public states:States;
 
   protected refreshBuilder:RowRefreshBuilder;
-  protected stopExisting$ = new Subject<undefined>();
 
   constructor(public workPackageTable:WorkPackageTable) {
     this.refreshBuilder = new RowRefreshBuilder(this.workPackageTable);

--- a/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
@@ -32,7 +32,7 @@ export abstract class TableRenderPass {
   /** Resulting timeline body */
   public timelineBody:DocumentFragment;
 
-  constructor(public stopExisting$:Subject<void>, public workPackageTable:WorkPackageTable) {
+  constructor(public workPackageTable:WorkPackageTable) {
     $injectFields(this, 'states', 'I18n');
   }
 
@@ -40,7 +40,6 @@ export abstract class TableRenderPass {
     // Prepare and reset the render pass
     this.prepare();
     // Render into the fragments
-    this.stopExisting$.next();
     this.doRender();
 
     return this;
@@ -55,7 +54,7 @@ export abstract class TableRenderPass {
   protected prepare() {
     this.tableBody = document.createDocumentFragment();
     this.timelineBody = document.createDocumentFragment();
-    this.timelineBuilder = new TimelineRowBuilder(this.stopExisting$, this.workPackageTable);
+    this.timelineBuilder = new TimelineRowBuilder(this.workPackageTable);
     this.renderedOrder = [];
   }
 

--- a/frontend/app/components/wp-fast-table/builders/timeline/timeline-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/timeline/timeline-row-builder.ts
@@ -15,7 +15,7 @@ export class TimelineRowBuilder {
   public wpTableTimeline:WorkPackageTableTimelineService;
   public wpCacheService:WorkPackageCacheService;
 
-  constructor(protected stopExisting$:Observable<void>, protected workPackageTable:WorkPackageTable) {
+  constructor(protected workPackageTable:WorkPackageTable) {
     $injectFields(this, 'states', 'wpTableTimeline', 'wpCacheService');
   }
 
@@ -60,7 +60,7 @@ export class TimelineRowBuilder {
 
     // show timeline cell
     timelineCell.activate();
-    this.stopExisting$.take(1)
+    this.workPackageTable.unsubscribeTimelineCells$.take(1)
       .subscribe(() => {
         timelineCell.deactivate();
       });

--- a/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -16,11 +16,8 @@ export class ColumnsTransformer {
       if (table.rows.length > 0) {
 
         var t0 = performance.now();
-        // Redraw all visible rows without reloading the table
-        table.rows.forEach((wpId) => {
-          let row = table.rowIndex[wpId];
-          table.refreshRow(row);
-        });
+        // Redraw the table section, ignore timeline
+        table.redrawTable();
         var t1 = performance.now();
 
         debugLog("column redraw took " + (t1 - t0) + " milliseconds.");

--- a/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -20,7 +20,7 @@ export class HierarchyTransformer {
       .observeUntil(this.states.table.stopAllSubscriptions)
       .subscribe((state: WorkPackageTableHierarchies) => {
         if (enabled !== state.isEnabled) {
-          table.refreshBody();
+          table.redrawTableAndTimeline();
         } else if (enabled) {
           // No change in hierarchy mode
           // Refresh groups

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -13,6 +13,7 @@ import {HierarchyRowsBuilder} from "./builders/modes/hierarchy/hierarchy-rows-bu
 import {RowsBuilder} from "./builders/modes/rows-builder";
 import {WorkPackageTimelineTableController} from "../wp-table/timeline/container/wp-timeline-container.directive";
 import {TableRenderPass} from './builders/modes/table-render-pass';
+import {Subject} from 'rxjs';
 
 export class WorkPackageTable {
   public wpCacheService:WorkPackageCacheService;
@@ -30,11 +31,15 @@ export class WorkPackageTable {
     new PlainRowsBuilder(this)
   ];
 
+  // Subject fired whenever timeline cells are about to be refreshed
+  public unsubscribeTimelineCells$:Subject<undefined>;
+
   constructor(public container:HTMLElement,
               public tbody:HTMLElement,
               public timelineBody:HTMLElement,
               public timelineController:WorkPackageTimelineTableController) {
     injectorBridge(this);
+    this.unsubscribeTimelineCells$ = new Subject<undefined>();
     TableHandlerRegistry.attachTo(this);
   }
 
@@ -80,6 +85,7 @@ export class WorkPackageTable {
    * all elements.
    */
   public redrawTableAndTimeline() {
+    this.unsubscribeTimelineCells$.next();
     const renderPass = this.redrawTable();
 
     this.timelineBody.innerHTML = '';

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -12,6 +12,7 @@ import {GroupedRowsBuilder} from "./builders/modes/grouped/grouped-rows-builder"
 import {HierarchyRowsBuilder} from "./builders/modes/hierarchy/hierarchy-rows-builder";
 import {RowsBuilder} from "./builders/modes/rows-builder";
 import {WorkPackageTimelineTableController} from "../wp-table/timeline/container/wp-timeline-container.directive";
+import {TableRenderPass} from './builders/modes/table-render-pass';
 
 export class WorkPackageTable {
   public wpCacheService:WorkPackageCacheService;
@@ -66,7 +67,7 @@ export class WorkPackageTable {
     this.buildIndex(rows);
 
     // Draw work packages
-    this.refreshBody();
+    this.redrawTableAndTimeline();
 
     // Preselect first work package as focused
     if (this.rows.length && this.states.focusedWorkPackage.isPristine()) {
@@ -78,16 +79,25 @@ export class WorkPackageTable {
    * Removes the contents of this table's tbody and redraws
    * all elements.
    */
-  public refreshBody() {
-    let renderPass = this.rowBuilder.buildRows();
-
-    this.tbody.innerHTML = '';
-    this.tbody.appendChild(renderPass.tableBody);
+  public redrawTableAndTimeline() {
+    const renderPass = this.redrawTable();
 
     this.timelineBody.innerHTML = '';
     this.timelineBody.appendChild(renderPass.timelineBody);
 
     this.states.table.rendered.putValue(renderPass.result);
+  }
+
+  /**
+   * Redraw all elements in the table section only
+   */
+  public redrawTable():TableRenderPass {
+    const renderPass = this.rowBuilder.buildRows();
+
+    this.tbody.innerHTML = '';
+    this.tbody.appendChild(renderPass.tableBody);
+
+    return renderPass;
   }
 
   /**

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -76,7 +76,7 @@ export class WorkPackageInlineCreateController {
     private I18n:op.I18n
   ) {
     this.rowBuilder = new InlineCreateRowBuilder(this.table);
-    this.timelineBuilder = new TimelineRowBuilder(scopeDestroyed$($scope).mapTo(undefined), this.table);
+    this.timelineBuilder = new TimelineRowBuilder(this.table);
     this.text = {
       create: I18n.t('js.label_create_work_package')
     };


### PR DESCRIPTION
After the integration of the timeline into the table, it was too costly to refresh the table (and re-initialize the timeline) for everytime the column were changed, so only each row was refreshed.

Since the timeline is now separate, we can refresh them invidividually when being careful that this results in now row changes (such as changes to the columns)

https://community.openproject.com/projects/openproject/work_packages/25312/