### PR TITLE
[25265] Column highlight on work package page wrong

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -41,8 +41,10 @@
 
 // Highlight the additional hierarchy
 // so it becomes clear they're not part of the sort
-.wp-table--hierarchy-aditional-row
-  @include varprop(background, gray-light)
+body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
+  @include varprop(color, gray-dark)
+  .wp-table--hierarchy-indicator
+    @include varprop(color, gray-dark)
 
   // Fix padding on additional row/id field
   // since we don't have the edit-span's padding here


### PR DESCRIPTION
This changes the highlighting of columns which are filtered out but shown because of the hierarchy. Thus the highlighting does not conflict any more with the hover effects of the table columns.

https://community.openproject.com/projects/openproject/work_packages/25265/activity