### PR TITLE
configure multiline method call indentation in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -210,6 +210,9 @@ SpecialGlobalVars:
 StringLiterals:
   Enabled: false
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+
 VariableInterpolation:
   Enabled: false
 


### PR DESCRIPTION
Allows code like the following:

```
some_instance.member.attributes = SomeService
  .new(@class_member)
  .permit_method_call(params[:some_key])
```