### PR TITLE
[25326] Modules menu is shown when there are no entries

### DIFF
--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -107,12 +107,14 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_module_top_menu_node(items = more_top_menu_items)
-    render_menu_dropdown_with_items(
-      label: '',
-      label_options: { icon: 'icon-menu', title: I18n.t('label_modules') },
-      items: items,
-      options: { drop_down_id: 'more-menu', drop_down_class: 'drop-down--modules ' }
-    )
+    unless items.empty?
+      render_menu_dropdown_with_items(
+        label: '',
+        label_options: { icon: 'icon-menu', title: I18n.t('label_modules') },
+        items: items,
+        options: { drop_down_id: 'more-menu', drop_down_class: 'drop-down--modules ' }
+      )
+    end
   end
 
   def render_main_top_menu_nodes(items = main_top_menu_items)

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -68,7 +68,7 @@ feature 'Top menu items', js: true, selenium: true do
   end
 
   describe 'Modules' do
-    let(:top_menu) { find(:css, "[title=#{I18n.t('label_modules')}]") }
+    !let(:top_menu) { find(:css, "[title=#{I18n.t('label_modules')}]") }
 
     let(:news_item) { I18n.t('label_news_plural') }
     let(:time_entries_item) { I18n.t('label_time_sheet_menu') }
@@ -101,6 +101,14 @@ feature 'Top menu items', js: true, selenium: true do
     context 'as a user with permissions', allowed_to: true do
       it 'displays all options' do
         has_menu_items?(time_entries_item, news_item)
+      end
+    end
+
+    context 'as a user without permissions', allowed_to: false do
+      let(:open_menu) { false }
+      it 'displays no options and hides the module menu' do
+        has_menu_items?
+        expect(page).not_to have_link('Modules')
       end
     end
 


### PR DESCRIPTION
When the modules menu is empty it should not be rendered at all. Thus an empty drop down is avoided.

https://community.openproject.com/projects/openproject/work_packages/25326/activity