### PR TITLE
Experiment: bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -229,6 +229,7 @@ group :development, :test do
   gem 'pry-rescue', '~> 1.4.5'
   gem 'pry-byebug', '~> 3.4.2', platforms: [:mri]
   gem 'pry-doc', '~> 0.10'
+  gem 'bootsnap', '~> 1.1.2', require: false
 end
 
 # API gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.1.2)
+      msgpack (~> 1.0)
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -350,6 +352,7 @@ GEM
     minisyntax (0.2.5)
     minitest (5.10.2)
     mixlib-shellout (2.1.0)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_test (0.1.2)
     mustermann (1.0.0)
@@ -618,6 +621,7 @@ DEPENDENCIES
   awesome_nested_set (~> 3.1.3)
   aws-sdk (~> 2.10.1)
   bcrypt (~> 3.1.6)
+  bootsnap (~> 1.1.2)
   bourbon (~> 4.3.4)
   capybara (~> 2.14.0)
   capybara-ng (~> 0.2.7)
@@ -729,4 +733,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -37,3 +37,21 @@ end
 
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+# Rails is not yet loaded here
+if ENV['RAILS_ENV'] == 'development'
+  $stderr.puts "Starting with bootstnap."
+
+  require 'bootsnap'
+
+  is_mac = RUBY_PLATFORM.include? 'darwin'
+  Bootsnap.setup(
+    cache_dir:            'tmp/cache', # Path to your cache
+    development_mode:     true,
+    load_path_cache:      true,        # Should we optimize the LOAD_PATH with a cache?
+    autoload_paths_cache: true,        # Should we optimize ActiveSupport autoloads with cache?
+    disable_trace:        false,       # Sets `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+    compile_cache_iseq:   is_mac,      # Should compile Ruby code into ISeq cache?
+    compile_cache_yaml:   is_mac       # Should compile YAML into a cache?
+  )
+end


### PR DESCRIPTION
Tests whether we can make use of https://engineering.shopify.com/235340559-bootsnap-optimizing-ruby-app-boot-time in dev mode.

It appears to raise errors stemming from cucumber in `RAILS_ENV=test`, but it appears quite a bit faster in dev mode.