### PR TITLE
prepare the query before reading results

### DIFF
--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -35,7 +36,7 @@ class Queries::Filters::Base
   class_attribute :model,
                   :filter_params
 
-  self.filter_params = [:operator, :values]
+  self.filter_params = %i(operator values)
 
   attr_accessor :context,
                 *filter_params
@@ -71,6 +72,10 @@ class Queries::Filters::Base
 
   def allowed_values
     nil
+  end
+
+  def valid_values!
+    type_strategy.valid_values!
   end
 
   def available?

--- a/app/models/queries/filters/strategies/base_strategy.rb
+++ b/app/models/queries/filters/strategies/base_strategy.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -51,6 +52,8 @@ module Queries::Filters::Strategies
       operator_map
         .slice(*self.class.supported_operators)[filter.operator]
     end
+
+    def valid_values!; end
 
     def supported_operator_classes
       operator_map

--- a/app/models/queries/filters/strategies/list.rb
+++ b/app/models/queries/filters/strategies/list.rb
@@ -43,5 +43,9 @@ module Queries::Filters::Strategies
         errors.add(:values, :inclusion)
       end
     end
+
+    def valid_values!
+      filter.values &= (allowed_values.map(&:last) + ['-1'])
+    end
   end
 end

--- a/app/models/queries/filters/strategies/list_optional.rb
+++ b/app/models/queries/filters/strategies/list_optional.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/author_filter.rb
+++ b/app/models/queries/work_packages/filter/author_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/category_filter.rb
+++ b/app/models/queries/work_packages/filter/category_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -29,7 +30,6 @@
 
 class Queries::WorkPackages::Filter::CategoryFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
-
   def allowed_values
     all_project_categories.map { |s| [s.name, s.id.to_s] }
   end

--- a/app/models/queries/work_packages/filter/custom_field_filter.rb
+++ b/app/models/queries/work_packages/filter/custom_field_filter.rb
@@ -37,7 +37,7 @@ class Queries::WorkPackages::Filter::CustomFieldFilter <
   def allowed_values
     case custom_field.field_format
     when 'list'
-      custom_field.custom_options.map { |co| [co.value, co.id] }
+      custom_field.custom_options.map { |co| [co.value, co.id.to_s] }
     when 'bool'
       [[I18n.t(:general_text_yes), CustomValue::BoolStrategy::DB_VALUE_TRUE],
        [I18n.t(:general_text_no), CustomValue::BoolStrategy::DB_VALUE_FALSE]]

--- a/app/models/queries/work_packages/filter/status_filter.rb
+++ b/app/models/queries/work_packages/filter/status_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -231,6 +231,26 @@ class Query < ActiveRecord::Base
     end
   end
 
+  # Try to fix an invalid query
+  #
+  # Fixes:
+  # * filters:
+  #     Reduces the filter's values to those that are valid.
+  #     If the filter remains invalid, it is removed.
+  #
+  # If the query has been valid or if the error
+  # is not one of the addressed, the query is unchanged.
+
+  def valid_subset!
+    filters.each do |filter|
+      filter.valid_values!
+
+      if filter.invalid?
+        self.filters -= [filter]
+      end
+    end
+  end
+
   def add_filter(field, operator, values)
     filter = filter_for(field)
 

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -115,6 +115,15 @@ module API
             end
 
             get do
+              # We try to ignore invalid aspects of the query as the user
+              # might not even be able to fix them (public  query)
+              # and because they might only be invalid in his context
+              # but not for somebody having more permissions, e.g. subproject
+              # filter for admin vs for anonymous.
+              # Permissions are enforced nevertheless.
+              @query.valid_subset!
+
+              # We do not ignore invalid params provided by the client.
               query_representer_response(@query, params)
             end
 

--- a/lib/api/v3/queries/query_helper.rb
+++ b/lib/api/v3/queries/query_helper.rb
@@ -38,9 +38,15 @@ module API
         # @param query [Query]
         # @param contract [Class]
         # @param form_representer [Class]
+        #
+        # Additionally, two parameters are accepted under the hood.
+        #
+        # # request_body
+        # # params
+        #
+        # Both are applied to the query in order to adapt it.
         def create_or_update_query_form(query, contract, form_representer)
-          representer = ::API::V3::Queries::QueryRepresenter.create query, current_user: current_user
-          query = representer.from_hash Hash(request_body)
+          query = update_query_from_body_and_params(query, request_body, params)
           contract = contract.new query, current_user
           contract.validate
 
@@ -96,6 +102,15 @@ module API
           UpdateQueryFromV3ParamsService.new(query, current_user).call(params)
           # the service mutates the given query in place so we just return it
           query
+        end
+
+        def update_query_from_body_and_params(query, body, params)
+          representer = ::API::V3::Queries::QueryRepresenter.create query, current_user: current_user
+          # Note that we do not deal with failures here. The query
+          # needs to be validated later.
+          UpdateQueryFromV3ParamsService.new(query, current_user).call(params)
+
+          representer.from_hash Hash(body)
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
@@ -152,4 +152,40 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
       end
     end
   end
+
+  it_behaves_like 'basic query filter' do
+    let(:order) { 4 }
+    let(:type) { :list_optional }
+    let(:class_key) { :assigned_to_id }
+
+    describe '#valid_values!' do
+      let(:user) { FactoryGirl.build_stubbed(:user) }
+      let(:loader) do
+        loader = double('loader')
+
+        allow(loader)
+          .to receive(:user_values)
+          .and_return([[user.name, user.id.to_s]])
+        allow(loader)
+          .to receive(:group_values)
+          .and_return([])
+
+        loader
+      end
+
+      before do
+        allow(::Queries::WorkPackages::Filter::PrincipalLoader)
+          .to receive(:new)
+          .and_return(loader)
+
+        instance.values = [user.id.to_s, '99999']
+      end
+
+      it 'remove the invalid value' do
+        instance.valid_values!
+
+        expect(instance.values).to match_array [user.id.to_s]
+      end
+    end
+  end
 end

--- a/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
@@ -295,7 +295,7 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter, type: :model do
     it 'is list_optional for a list' do
       instance.name = "cf_#{list_wp_custom_field.id}"
       expect(instance.allowed_values)
-        .to match_array(list_wp_custom_field.custom_options.map { |co| [co.value, co.id] })
+        .to match_array(list_wp_custom_field.custom_options.map { |co| [co.value, co.id.to_s] })
     end
 
     it 'is list_optional for a user' do

--- a/spec/models/queries/work_packages/filter/status_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/status_filter_spec.rb
@@ -68,6 +68,22 @@ describe Queries::WorkPackages::Filter::StatusFilter, type: :model do
       end
     end
 
+    describe '#valid_values!' do
+      before do
+        allow(Status)
+          .to receive(:all)
+          .and_return [status]
+
+        instance.values = [status.id.to_s, '99999']
+      end
+
+      it 'remove the invalid value' do
+        instance.valid_values!
+
+        expect(instance.values).to match_array [status.id.to_s]
+      end
+    end
+
     describe '#value_objects' do
       before do
         allow(Status)

--- a/spec/models/queries/work_packages/filter/subject_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subject_filter_spec.rb
@@ -46,6 +46,17 @@ describe Queries::WorkPackages::Filter::SubjectFilter, type: :model do
       end
     end
 
+    describe '#valid_values!' do
+      it 'is a noop' do
+        instance.values = ['none', 'is', 'changed']
+
+        instance.valid_values!
+
+        expect(instance.values)
+          .to match_array ['none', 'is', 'changed']
+      end
+    end
+
     it_behaves_like 'non ar filter'
   end
 end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -190,6 +190,42 @@ describe Query, type: :model do
     end
   end
 
+  describe '#valid_subset!' do
+    let(:valid_status) { FactoryGirl.build_stubbed(:status) }
+
+    before do
+      allow(Status)
+        .to receive(:all)
+        .and_return([valid_status])
+
+      query.filters.clear
+      query.add_filter('status_id', '=', values)
+
+      query.valid_subset!
+    end
+
+    context 'for a status filter having valid and invalid values' do
+      let(:values) { [valid_status.id.to_s, '99999'] }
+
+      it 'leaves the filter' do
+        expect(query.filters.length).to eq 1
+      end
+
+      it 'leaves only the invalid value' do
+        expect(query.filters[0].values)
+          .to match_array [valid_status.id.to_s]
+      end
+    end
+
+    context 'for a status filter having only invalid values' do
+      let(:values) { ['99999'] }
+
+      it 'removes the filter' do
+        expect(query.filters.length).to eq 0
+      end
+    end
+  end
+
   describe '#filter_for' do
     context 'for a status_id filter' do
       before do

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -74,7 +74,18 @@ module Components
 
         expect(page).to have_select("operators-#{id}", selected: operator)
 
-        expect_value(id, value)
+        if value
+          expect_value(id, value)
+        else
+          expect(page).to have_no_select("values-#{id}")
+        end
+      end
+
+      def expect_no_filter_by(name, selector = nil)
+        id = selector || name.downcase
+
+        expect(page).to have_no_select("operators-#{id}")
+        expect(page).to have_no_select("values-#{id}")
       end
 
       def remove_filter(field)

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -40,6 +40,10 @@ module Pages
       visit "#{path}?query_id=#{query.id}"
     end
 
+    def visit_with_params(params)
+      visit "#{path}?#{params}"
+    end
+
     def expect_work_package_listed(*work_packages)
       within(table_container) do
         work_packages.each do |wp|
@@ -163,6 +167,10 @@ module Pages
 
       expect_notification message: 'Successful creation.'
       expect_title name
+    end
+
+    def save
+      click_setting_item /Save$/
     end
 
     def open_filter_section

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -173,6 +173,14 @@ module Pages
       click_setting_item /Save$/
     end
 
+    def group_by(name)
+      click_setting_item 'Group by ...'
+
+      select name, from: 'Group by'
+
+      click_button 'Apply'
+    end
+
     def open_filter_section
       unless page.has_selector?('#work-packages-filter-toggle-button.-active')
         click_button('work-packages-filter-toggle-button')


### PR DESCRIPTION
Changes the paradigm of how the application deals with invalid queries.

* Queries which are persisted in an invalid state are presented as a valid query to a user fetching the query (read). This is done by reducing the query to a valid state. The reason for this is that a query might be valid for one user (e.g. an admin) while being invalid for the next (e.g. anonymous). Additionally, a user might not have the permission to turn an invalid query into a valid one. The is the case when a public query is invalid while the user reading the query lacks the manage_public_queries permission.  
* Changes to a query (update/create) even if they are not persisted (read) that are invalid will result in a user visible error message.

https://community.openproject.com/projects/openproject/work_packages/25334