### PR TITLE
[25338] Append autocompleter to within relations tab

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -91,6 +91,11 @@ div[class*='work-packages--details--']
   margin: 0
   line-height: 18px
 
+// Let the absolute autocomplete modify the height
+// of the relation tab so we can scroll to the results
+.detail-panel--autocomplete-target
+  position: relative
+
 i
   &.icon-left
     padding: 0 5px 0 0

--- a/frontend/app/components/wp-panels/relations-panel/relations-panel.directive.html
+++ b/frontend/app/components/wp-panels/relations-panel/relations-panel.directive.html
@@ -1,4 +1,4 @@
-<div class="detail-panel-description" ng-if="$ctrl.workPackage">
+<div class="detail-panel-description detail-panel--autocomplete-target" ng-if="$ctrl.workPackage">
   <div class="detail-panel-description-content">
     <wp-relations work-package="$ctrl.workPackage"
     ></wp-relations>

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
@@ -63,6 +63,7 @@ function wpRelationsAutocompleteDirective(
       input.autocomplete({
         delay: 250,
         autoFocus: false, // Accessibility!
+        appendTo: '.detail-panel--autocomplete-target',
         source: (request:{ term:string }, response:Function) => {
           autocompleteWorkPackages(request.term).then((values) => {
             selected = false;


### PR DESCRIPTION
This allows the result list to scroll the relations tab instead of
appending to a fixed height body.

https://community.openproject.com/projects/openproject/work_packages/25338