### PR TITLE
[25345] Remove [data-ui-route], instead use ui-router ui-sref

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -238,7 +238,7 @@ Redmine::MenuManager.map :project_menu do |menu|
             icon: 'icon2 icon-work-packages',
             html: {
               id: 'main-menu-work-packages',
-              'data-ui-route' => '',
+              'ui-sref' => 'work-packages.list()',
               query_menu_item: 'query_menu_item'
             }
 

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -212,31 +212,11 @@ openprojectModule
   .run(($location:ng.ILocationService,
         $rootElement:ng.IRootElementService,
         $rootScope:ng.IRootScopeService,
-        $state:ng.ui.IStateService,
-        $window:ng.IWindowService) => {
+        $state:ng.ui.IStateService) => {
     // Our application is still a hybrid one, meaning most routes are still
     // handled by Rails. As such, we disable the default link-hijacking that
     // Angular's HTML5-mode turns on.
     $rootElement.off('click');
-    $rootElement.on('click', 'a[data-ui-route]', (event) => {
-      if (!jQuery('body').has('div[ui-view]').length || event.ctrlKey || event.metaKey
-        || event.which === 2) {
-
-        return;
-
-      }
-
-      // NOTE: making use of event delegation, thus jQuery-only.
-      var elm = jQuery(event.target);
-      var absHref = elm.prop('href');
-
-      if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
-        event.preventDefault();
-        var targetUrl = URI(absHref);
-        $location.url(targetUrl.path() + targetUrl.search());
-        $rootScope.$apply();
-      }
-    });
 
     $rootScope.$on('$stateChangeStart', (event, toState, toParams) => {
       const projectIdentifier = toParams.projectPath || $rootScope['projectIdentifier'];

--- a/frontend/app/layout/query-menu-item-factory.js
+++ b/frontend/app/layout/query-menu-item-factory.js
@@ -40,6 +40,7 @@ module.exports = function(menuItemFactory, $state, $stateParams, $animate, $time
     container: '#main-menu-work-packages-wrapper ~ .menu-children',
     linkFn: function(scope, element, attrs) {
       scope.queryId = scope.objectId || attrs.objectId;
+      scope.uiStateName = "work-packages.list({ query_id: " + scope.queryId + " })";
 
       function setActiveState() {
         // Apparently the queryId sometimes is a number, sometimes a string, sometimes

--- a/frontend/app/templates/layout/menu_item.html
+++ b/frontend/app/templates/layout/menu_item.html
@@ -2,7 +2,7 @@
   <a ng-href="{{path}}"
      object-id="objectId"
      ng-class="[type, normalizedTitle]"
-     data-ui-route=""
+     ui-sref="{{ uiStateName }}"
      lang="{{lang || 'en'}}"
      title="{{title}}">
     <op-icon icon-classes="icon2 icon-pin ellipsis"></op-icon>

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -64,7 +64,7 @@ module Redmine::MenuManager::MenuHelper
                   icon: 'icon2 icon-pin',
                   html:    {
                     class: 'query-menu-item',
-                    'data-ui-route' => '',
+                    'ui-sref' => "work-packages.list({ query_id: #{query_menu_item.navigatable_id} })",
                     'query-menu-item' => 'query-menu-item',
                     'object-id' => query_menu_item.navigatable_id
                   }


### PR DESCRIPTION
The query menu items are rendered by rails but should be processed by angular, so the solution was to find clicks on special links marked with a [data-ui-route] attribute and pass the link to $location.

1. This fails on installations with relative URL, since a base tag is set and everything passed to $location will be ASSUMED relative to that base. Passing `/myrelative/work_packages` will result in
`/myrelative/myrelative/work_packages` if the base is `/myrelative`.

2. ui-router already provides a way to build links from state names with parameters: `ui-sref`. We can simply use that from rails to render the link.

https://community.openproject.com/projects/openproject/work_packages/25345