### PR TITLE
[25333] Workaround for height flexbug in Safari 9

### DIFF
--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -40,7 +40,11 @@
 @import work_packages/single_view/single_view
 @import work_packages/single_view/attachments
 @import work_packages/single_view/inplace_esque_fields
+
+
+// WP details specific styles
 @import work_packages/details/fullscreen_toggle
+@import work_packages/details/safari_flexbug_workaround
 
 // WP fullscreen specific styles
 @import work_packages/fullscreen/fullscreen

--- a/app/assets/stylesheets/content/work_packages/details/_safari_flexbug_workaround.sass
+++ b/app/assets/stylesheets/content/work_packages/details/_safari_flexbug_workaround.sass
@@ -1,0 +1,16 @@
+html.-browser-safari
+  // The details view doesn't receive the correct height due to Safari's flexbugs
+  .work-packages-split-view--details-side
+    flex: 0 0 auto
+
+  .action-details .work-packages-split-view--details-side,
+  .action-create .work-packages-split-view--details-side
+    @media only screen and (max-width: 1280px)
+      flex-basis: 480px
+    @media only screen and (min-width: 1440px)
+      flex-basis: 580px
+
+  .work-packages--details
+    position: absolute
+    top: 0
+

--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -1,6 +1,7 @@
 <div class="work-packages--details loading-indicator--location"
       data-indicator-name="wpDetails">
   <div wp-edit-form="$ctrl.workPackage"
+       class="work-packages--details-edit-form"
        wp-edit-form-on-save="$ctrl.onWorkPackageSave()"
        has-edit-mode="true"
        ng-if="$ctrl.workPackage">

--- a/frontend/app/globals/browser-specific-flags.ts
+++ b/frontend/app/globals/browser-specific-flags.ts
@@ -28,7 +28,11 @@
 
 jQuery(function() {
   if (bowser.chrome && bowser.version >= '58') {
-    document.documentElement.classList.add('-supports-sticky-headers');
+    document.documentElement.classList.add('-browser-chrome', '-supports-sticky-headers');
+  }
+
+  if (bowser.safari) {
+    document.documentElement.classList.add('-browser-safari');
   }
 });
 


### PR DESCRIPTION
Safari doesn't properly set the height of a flex container, so we need
to enforce the height in  its child through position absolute.

That however requires us to set an explicit width to the non-growing
details-view split pane, so there is some selector duplication.