### PR TITLE
add showHierarchies to query payload representer

### DIFF
--- a/lib/api/v3/queries/query_payload_representer.rb
+++ b/lib/api/v3/queries/query_payload_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -72,6 +73,8 @@ module API
 
         # Timeline properties
         property :timeline_visible
+
+        property :show_hierarchies
 
         private
 

--- a/spec/lib/api/v3/queries/query_payload_representer_spec.rb
+++ b/spec/lib/api/v3/queries/query_payload_representer_spec.rb
@@ -1,0 +1,60 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Queries::QueryPayloadRepresenter do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:user) { double('current_user') }
+  let(:representer) do
+    described_class.new(query, current_user: user)
+  end
+
+  subject { representer.to_json }
+
+  describe 'generation' do
+    context 'properties' do
+      context 'showHierarchies' do
+        it 'is true if query.show_hierarchies is true' do
+          query.show_hierarchies = true
+
+          is_expected.to be_json_eql(true.to_json).at_path('showHierarchies')
+        end
+
+        it 'is false if query.show_hierarchies is false' do
+          query.show_hierarchies = false
+
+          is_expected.to be_json_eql(false.to_json).at_path('showHierarchies')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without the showHierarchies mode communicated correctly, the frontend will always set the hierarchy mode to true.

This is bad in a scenario where the query is invalid. Then we fall back on the payload to recreate as much of the query as possible. When the invalid query is grouped, it is not allowed to have showHierarchy set to true. But because the value is not communicated, it is assumed to be true.  