### PR TITLE
[25345] Pass ui-router state in [data-ui-route]

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -238,7 +238,6 @@ Redmine::MenuManager.map :project_menu do |menu|
             icon: 'icon2 icon-work-packages',
             html: {
               id: 'main-menu-work-packages',
-              'data-ui-route' => '',
               query_menu_item: 'query_menu_item'
             }
 

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -28,6 +28,7 @@
 
 import {WorkPackageEditModeStateService} from '../wp-edit/wp-edit-mode-state.service';
 import {openprojectModule} from '../../angular-modules';
+import {debugLog} from "../../helpers/debug_output";
 
 const panels = {
   get overview() {
@@ -219,22 +220,24 @@ openprojectModule
     // Angular's HTML5-mode turns on.
     $rootElement.off('click');
     $rootElement.on('click', 'a[data-ui-route]', (event) => {
-      if (!jQuery('body').has('div[ui-view]').length || event.ctrlKey || event.metaKey
+      if (jQuery('div[ui-view]').length === 0
+        || event.shiftKey || event.ctrlKey || event.metaKey
         || event.which === 2) {
-
-        return;
-
+        return true;
       }
 
-      // NOTE: making use of event delegation, thus jQuery-only.
-      var elm = jQuery(event.target);
-      var absHref = elm.prop('href');
+      const el = jQuery(event.target);
 
-      if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
+      try {
+        const stateName = el.data('uiRoute');
+        const params = $rootScope.$eval(el.data('uiRouteParams')) || {};
+
+        $state.go(stateName, params);
         event.preventDefault();
-        var targetUrl = URI(absHref);
-        $location.url(targetUrl.path() + targetUrl.search());
-        $rootScope.$apply();
+        return false;
+      } catch(e) {
+        console.error("Tried to parse ui-route link but failed with: " + e);
+        return true;
       }
     });
 

--- a/frontend/app/layout/query-menu-item-factory.js
+++ b/frontend/app/layout/query-menu-item-factory.js
@@ -40,6 +40,8 @@ module.exports = function(menuItemFactory, $state, $stateParams, $animate, $time
     container: '#main-menu-work-packages-wrapper ~ .menu-children',
     linkFn: function(scope, element, attrs) {
       scope.queryId = scope.objectId || attrs.objectId;
+      scope.uiRouteStateName = 'work-packages.list';
+      scope.uiRouteParams = '{ query_id: ' + scope.queryId + ' }';
 
       function setActiveState() {
         // Apparently the queryId sometimes is a number, sometimes a string, sometimes

--- a/frontend/app/templates/layout/menu_item.html
+++ b/frontend/app/templates/layout/menu_item.html
@@ -2,6 +2,8 @@
   <a ng-href="{{path}}"
      object-id="objectId"
      ng-class="[type, normalizedTitle]"
+     data-ui-route="{{ uiRouteStateName }}"
+     data-ui-route-params="{{ uiRouteParams }}"
      data-ui-route=""
      lang="{{lang || 'en'}}"
      title="{{title}}">

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -64,7 +64,8 @@ module Redmine::MenuManager::MenuHelper
                   icon: 'icon2 icon-pin',
                   html:    {
                     class: 'query-menu-item',
-                    'data-ui-route' => '',
+                    'data-ui-route' => 'work-packages.list',
+                    'data-ui-route-params' => "{ query_id: #{query_menu_item.navigatable_id} }",
                     'query-menu-item' => 'query-menu-item',
                     'object-id' => query_menu_item.navigatable_id
                   }


### PR DESCRIPTION
The query menu items are rendered by rails but should be processed by angular, so the solution was to find clicks on special links marked with
a [data-ui-route] attribute and pass the link to $location.

1. This fails on installations with relative URL, since a base tag is set and everything passed to $location will be ASSUMED relative to that
base. Passing `/myrelative/work_packages` will result in `/myrelative/myrelative/work_packages` if the base is `/myrelative`.

2. The process of parsing the URL is buggy and may not lead to the correct state.

Instead, I suggest to be explicit in what state this element should route to. I also removed the ui-route from the work packages module itself to allow reloading the list through that link everytime.

https://community.openproject.com/projects/openproject/work_packages/25345