### PR TITLE
Fix/project dropdown position

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -290,8 +290,7 @@ jQuery(document).ready(function($) {
 
     select = $(select);
     var select2,
-        menu = select.parents('li.drop-down'),
-        that = this;
+        menu = select.parents('li.drop-down');
 
     select.select2({
         formatResult : OpenProject.Helpers.Search.formatter,
@@ -300,7 +299,7 @@ jQuery(document).ready(function($) {
                                     jQuery.proxy(openProject, 'fetchProjects'),
                                     PROJECT_JUMP_BOX_PAGE_SIZE),
         dropdownCssClass : "project-search-results",
-        containerCssClass : "select2-select",
+        containerCssClass : "select2-select"
       }).
       on('change', function (e) {
         // this handles expected 'new-tab behaviour'

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -354,11 +354,9 @@ jQuery(document).ready(function($) {
     });
 
     menu.bind("opened", function () {
-      setTimeout(function () {
-        // Open select2 element, when menu is opened
-        select2.open();
-        jQuery("#select2-drop-mask").hide();
-      }, 50);
+      // Open select2 element, when menu is opened
+      select2.open();
+      jQuery("#select2-drop-mask").hide();
 
       // Include input in tab cycle by attaching keydown handlers to previous
       // and next interactive DOM element.

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -197,45 +197,6 @@ function observeProjectIdentifier() {
   });
 }
 
-var WarnLeavingUnsaved = function(message) {
-  this.message = message;
-  var changedForms = false;
-  var isEmbed = window != window.parent;
-  var obj = this;
-
-  this.unload = function() {
-    if(changedForms && !isEmbed) {
-      return message;
-    }
-  };
-
-  this.getChanged = function() {
-    return changedForms;
-  };
-
-  this.setChanged = function() {
-    changedForms = true;
-  };
-
-  this.setUnchanged = function() {
-    changedForms = false;
-  };
-
-  this.init = function() {
-    jQuery(document).on('change', 'textarea', function() {
-      obj.setChanged();
-    });
-
-    jQuery(document).on('submit', 'form', function() {
-      obj.setUnchanged();
-    });
-
-    jQuery(window).bind('beforeunload', this.unload);
-  };
-
-  this.init();
-};
-
 function hideOnLoad() {
   jQuery('.hol').hide();
 }

--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -153,8 +153,9 @@
     open: function (dropdown) {
       this.dontCloseWhenUsing(dropdown);
       this.closeOtherItems(dropdown);
-      this.slideAndFocus(dropdown);
-      dropdown.trigger("opened", dropdown);
+      this.slideAndFocus(dropdown, function() {
+        dropdown.trigger("opened", dropdown);
+      });
     },
 
     close: function (dropdown, immediate) {
@@ -180,15 +181,15 @@
       });
     },
 
-    slideAndFocus: function (dropdown) {
-      this.slideDown(dropdown);
+    slideAndFocus: function (dropdown, callback) {
+      this.slideDown(dropdown, callback);
       this.focusFirstInputOrLink(dropdown);
     },
 
-    slideDown: function (dropdown) {
+    slideDown: function (dropdown, callback) {
       var toDrop = dropdown.find("> ul");
       dropdown.addClass("open");
-      toDrop.slideDown(animationRate).attr("aria-expanded","true");
+      toDrop.slideDown(animationRate, callback).attr("aria-expanded","true");
     },
 
     slideUp: function (dropdown, immediate) {


### PR DESCRIPTION
Ensure that the opened event is thrown after the dropdown has slid down instead of throwing it while it is sliding down. Doing that, we can remove the timeout hack which might work, but could also result in the select2 input replacement being rendered somewhere on the way down which would hide previous menu items.

https://community.openproject.com/projects/openproject/work_packages/25360