### PR TITLE
[25269] Add typed_custom_value_for to retrieve CF value names

### DIFF
--- a/app/models/query_custom_field_column.rb
+++ b/app/models/query_custom_field_column.rb
@@ -74,8 +74,7 @@ class QueryCustomFieldColumn < QueryColumn
   end
 
   def value(work_package)
-    cv = work_package.custom_values.detect { |value| value.custom_field_id == @cf.id }
-    cv && cv.typed_value
+    work_package.typed_custom_value_for(@cf.id)
   end
 
   def sum_of(work_packages)

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -165,6 +165,18 @@ module Redmine
           end
         end
 
+        def typed_custom_value_for(c)
+          cvs = custom_value_for(c)
+
+          if cvs.is_a? Array
+            cvs.map(&:typed_value)
+          elsif cvs.is_a? CustomValue
+            cvs.typed_value
+          else
+            cvs
+          end
+        end
+
         def save_custom_field_values
           self.custom_values = custom_field_values
           custom_field_values.each(&:save)

--- a/spec/models/query_custom_field_column_spec.rb
+++ b/spec/models/query_custom_field_column_spec.rb
@@ -50,4 +50,13 @@ describe ::QueryCustomFieldColumn, type: :model do
       end
     end
   end
+
+  describe '#value' do
+    let(:mock) { double(WorkPackage) }
+
+    it 'delegates to typed_custom_value_for' do
+      expect(mock).to receive(:typed_custom_value_for).with(custom_field.id)
+      instance.value(mock)
+    end
+  end
 end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -162,8 +162,7 @@ describe WorkPackage, type: :model do
             work_package.reload
           end
 
-          subject { work_package.custom_value_for(custom_field.id).typed_value }
-
+          subject { work_package.typed_custom_value_for(custom_field.id) }
           it { is_expected.to eq('PostgreSQL') }
         end
 
@@ -210,8 +209,7 @@ describe WorkPackage, type: :model do
             work_package.type = type_feature
           end
 
-          subject { WorkPackage.find(work_package.id).custom_value_for(custom_field).typed_value }
-
+          subject { WorkPackage.find(work_package.id).typed_custom_value_for(custom_field) }
           it { is_expected.to eq('PostgreSQL') }
         end
       end

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -1,0 +1,77 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe WorkPackage, type: :model do
+  let(:type) { FactoryGirl.create :type }
+  let(:project) { FactoryGirl.create :project, types: [type] }
+
+  let(:custom_field) do
+    FactoryGirl.create(
+      :list_wp_custom_field,
+      name: "Ingredients",
+      multi_value: true,
+      types: [type],
+      projects: [project],
+      possible_values: ["ham", "onions", "pineapple", "mushrooms"]
+    )
+  end
+
+  let(:custom_values) do
+    ["ham", "onions", "pineapple"].map do |str|
+      custom_field.custom_options.find { |co| co.value == str }.try(:id)
+    end
+  end
+
+  let(:work_package) do
+    wp = FactoryGirl.create :work_package, project: project, type: type
+    wp.custom_field_values = {
+      custom_field.id => custom_values
+    }
+    wp.save
+    wp
+  end
+
+  let(:values) { work_package.custom_value_for(custom_field) }
+  let(:typed_values) { work_package.typed_custom_value_for(custom_field.id) }
+
+  it 'returns the properly typed values' do
+    expect(values.map { |cv| cv.value.to_i } ).to eq(custom_values)
+    expect(typed_values).to eq(%w(ham onions pineapple))
+  end
+
+  context 'when value not present' do
+    let(:work_package) { FactoryGirl.create :work_package, project: project, type: type }
+
+    it 'returns nil properly' do
+      expect(values).to eq(nil)
+      expect(typed_values).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
To provide a common interface to get _ALL_ values for the given custom
field id (either multi or single value), this PR adds
`typed_custom_value_for` which maps all custom_values (if any) to their
`typed_value`s.

This is a requirement to output all values in `QueryCustomFieldColumn`.

Fixes https://community.openproject.com/projects/openproject/work_packages/25269 together with this PR: https://github.com/finnlabs/openproject-xls_export/pull/41