### PR TITLE
Fix ArgumentError in QueryRepresenter

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -428,14 +428,22 @@ class Query < ActiveRecord::Base
   end
 
   def sort_criteria_columns
-    sort_criteria.map do |attribute, direction|
-      attribute = attribute.to_sym
+    sort_criteria
+      .map do |attribute, direction|
+        attribute = attribute.to_sym
 
-      column = sortable_columns
-               .detect { |candidate| candidate.name == attribute }
+        column = sortable_columns
+                 .detect { |candidate| candidate.name == attribute }
 
-      [column, direction]
-    end
+        # FIXME why can this be nil here?
+        # It appears to be nil for the backlogs :position
+        if column.nil?
+          nil
+        else
+          [column, direction]
+        end
+      end
+      .compact
   end
 
   def sorted?


### PR DESCRIPTION
quick fixes

```
ArgumentError: Column needs to be set
        from /usr/src/app/lib/api/v3/queries/sort_bys/sort_by_decorator.rb:41:in `initialize'
        from /usr/src/app/lib/api/v3/queries/query_serialization.rb:194:in `new'
        from /usr/src/app/lib/api/v3/queries/query_serialization.rb:194:in `block in map_with_sort_by_as_decorated'
        from /usr/src/app/lib/api/v3/queries/query_serialization.rb:193:in `map'
```