### PR TITLE
Add switch state in query state handling to clarify access to states

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -128,8 +128,9 @@ function WorkPackagesListController($scope:any,
   function setupChangeObserver(service:WorkPackageTableBaseService, name:string, triggerUpdate:boolean = true) {
     const queryState = states.table.query;
 
-    service
-      .observeUntil(scopeDestroyed$($scope))
+    states.table.context.fireOnStateChange(service.state, 'Query loaded')
+      .values$()
+      .takeUntil(scopeDestroyed$($scope))
       .filter(() => !isAnyDependentStateClear()) // Avoid updating while not all states are initialized
       .filter(() => queryState.hasValue())
       .filter((stateValue:WorkPackageTableBaseState<any>) => {

--- a/frontend/app/components/states/switch-state.test.ts
+++ b/frontend/app/components/states/switch-state.test.ts
@@ -1,0 +1,49 @@
+import {input} from 'reactivestates';
+import {SwitchState} from "./switch-state";
+
+describe("SwitchState", function () {
+
+  it("switching", function () {
+    const automata = new SwitchState<"Init" | "Phase1">();
+
+    // switch and value to process differently based on the switch
+    const value = input("result");
+
+    // Output states of value when matching substate is active
+    const whenInit = automata.fireOnTransition(value, 'Init');
+    const whenPhase1 = automata.fireOnTransition(value, 'Phase1');
+
+    // Initialized with <no value>, so neither stream is active
+    expect(whenInit.hasValue()).to.be.false;
+    expect(whenPhase1.hasValue()).to.be.false;
+
+    // Test: switch to valid substate
+    automata.transition("Init");
+
+    // Invalid substate will yield TS error
+    // automata.switch("Unknown"); will result in TS error
+
+
+    // No subscribers -> no downstream values
+    expect(whenInit.hasValue()).to.be.false;
+    expect(whenPhase1.hasValue()).to.be.false;
+
+    whenInit.changes$().subscribe();
+    whenPhase1.changes$().subscribe();
+
+    expect(whenInit.hasValue()).to.be.true;
+    expect(whenPhase1.hasValue()).to.be.false;
+
+    // Test: switch to Phase1
+    automata.transition("Phase1");
+    expect(whenInit.hasValue()).to.be.false;
+    expect(whenPhase1.hasValue()).to.be.true;
+
+    // Reset substate
+    automata.reset();
+    expect(whenInit.hasValue()).to.be.false;
+    expect(whenPhase1.hasValue()).to.be.false;
+
+  });
+
+});

--- a/frontend/app/components/states/switch-state.ts
+++ b/frontend/app/components/states/switch-state.ts
@@ -1,0 +1,38 @@
+import {InputState, derive, input, State, IfThen} from 'reactivestates';
+import {debugLog} from "../../helpers/debug_output";
+
+export class SwitchState<StateName> {
+
+  private readonly contextSwitch$: InputState<StateName> = input<StateName>();
+
+  public transition(context: StateName) {
+    if (this.validTransition(context)) {
+      debugLog(`Switching table context to ${context}`);
+      this.contextSwitch$.putValue(context);
+    }
+  }
+
+  public validTransition(to: StateName) {
+    return (this.contextSwitch$.value !== to);
+  }
+
+  public reset(reason?: string) {
+    debugLog('Resetting table context.');
+    this.contextSwitch$.clear(reason);
+  }
+
+  public doAndTransition(context: StateName, callback:() => any) {
+    this.reset('Clearing before transitioning to ' + context);
+    callback();
+    this.transition(context);
+  }
+
+  public fireOnTransition<T>(cb: State<T>, ...context: StateName[]): State<T> {
+    return IfThen(this.contextSwitch$, s => context.indexOf(s) > -1, cb);
+  }
+
+  public fireOnStateChange<T>(state: State<T>, ...context: StateName[]): State<T> {
+    return derive(state, $ => $
+      .filter(() => this.contextSwitch$.hasValue() && context.indexOf(this.contextSwitch$.value!) > -1))
+  }
+}

--- a/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -9,19 +9,20 @@ export class ColumnsTransformer {
   constructor(public table: WorkPackageTable) {
     injectorBridge(this);
 
-    // observeOnScope
-    // observeUntil
-    this.states.table.columns.values$()
-      .takeUntil(this.states.table.stopAllSubscriptions).subscribe(() => {
-      if (table.rows.length > 0) {
+    this.states.updates.columnsUpdates
+      .values$('Refreshing columns on user request')
+      .takeUntil(this.states.table.stopAllSubscriptions)
+      .subscribe(() => {
+        if (table.rows.length > 0) {
 
-        var t0 = performance.now();
-        // Redraw the table section, ignore timeline
-        table.redrawTable();
-        var t1 = performance.now();
+          var t0 = performance.now();
+          // Redraw the table section, ignore timeline
+          table.redrawTable();
 
-        debugLog("column redraw took " + (t1 - t0) + " milliseconds.");
-      }
+          var t1 = performance.now();
+
+          debugLog("column redraw took " + (t1 - t0) + " milliseconds.");
+        }
     });
   }
 }

--- a/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -16,8 +16,9 @@ export class HierarchyTransformer {
     injectorBridge(this);
     let enabled = false;
 
-    this.wpTableHierarchies
-      .observeUntil(this.states.table.stopAllSubscriptions)
+
+    this.states.updates.hierarchyUpdates
+      .values$('Refreshing hierarchies on user request')
       .subscribe((state: WorkPackageTableHierarchies) => {
         if (enabled !== state.isEnabled) {
           table.redrawTableAndTimeline();

--- a/frontend/app/components/wp-fast-table/handlers/state/rows-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/rows-transformer.ts
@@ -13,7 +13,8 @@ export class RowsTransformer {
     injectorBridge(this);
 
     // Redraw table if the current row state changed
-    this.states.table.rows.values$()
+    this.states.table.context.fireOnTransition(this.states.table.rows, 'Query loaded')
+      .values$('Initializing table after query was initialized')
       .takeUntil(this.states.table.stopAllSubscriptions)
       .subscribe((rows: WorkPackageResourceInterface[]) => {
         var t0 = performance.now();

--- a/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
@@ -46,7 +46,7 @@ export abstract class WorkPackageTableBaseService {
   constructor(protected states: States) {
   }
 
-  protected get state(): InputState<any> {
+  public get state(): InputState<any> {
     return this.states.table[this.stateName];
   };
 

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -86,8 +86,14 @@ export class WorkPackageTable {
    */
   public redrawTableAndTimeline() {
     this.unsubscribeTimelineCells$.next();
-    const renderPass = this.redrawTable();
 
+    const renderPass = this.rowBuilder.buildRows();
+
+    // Insert table body
+    this.tbody.innerHTML = '';
+    this.tbody.appendChild(renderPass.tableBody);
+
+    // Insert timeline body
     this.timelineBody.innerHTML = '';
     this.timelineBody.appendChild(renderPass.timelineBody);
 
@@ -97,13 +103,13 @@ export class WorkPackageTable {
   /**
    * Redraw all elements in the table section only
    */
-  public redrawTable():TableRenderPass {
+  public redrawTable() {
     const renderPass = this.rowBuilder.buildRows();
 
     this.tbody.innerHTML = '';
     this.tbody.appendChild(renderPass.tableBody);
 
-    return renderPass;
+    this.states.table.rendered.putValue(renderPass.result);
   }
 
   /**


### PR DESCRIPTION
The `wpList` service pushes several times into the query states, which may result in transforming subscribers of the work package table to pick up these changes and try to modify the table, despite the query initialization step not being completed.

This PR introduces a switch state that lets downstream states fire only when it is in a given context.

Fixes https://community.openproject.com/projects/openproject/work_packages/25384/activity?query_id=896