### PR TITLE
Fix/group user mgmt

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -279,9 +279,12 @@ jQuery.viewportHeight = function() {
 * 2 - shows and hides ajax indicator
 */
 jQuery(document).ready(function($) {
-  document.ajaxActive = false;
   jQuery(document).ajaxSend(function (event, request) {
-    document.ajaxActive = true;
+    if ($(event.target.activeElement).closest('[ajax-indicated]').length &&
+        $('ajax-indicator')) {
+      $('#ajax-indicator').show();
+    }
+
     var csrf_meta_tag = $('meta[name=csrf-token]');
 
     if (csrf_meta_tag) {
@@ -293,11 +296,11 @@ jQuery(document).ready(function($) {
 
     request.setRequestHeader('X-Authentication-Scheme', "Session");
   });
+
   // ajaxStop gets called when ALL Requests finish, so we won't need a counter as in PT
   jQuery(document).ajaxStop(function () {
-    document.ajaxActive = false;
     if ($('#ajax-indicator')) {
-      jQuery('#ajax-indicator').hide();
+      $('#ajax-indicator').hide();
     }
     addClickEventToAllErrorMessages();
   });

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -42,8 +42,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="grid-content">
     <% users = User.active.not_in_group(@group).limit(100) %>
     <% if users.any? %>
-      <%= styled_form_tag(members_of_group_path(@group), method: :post, remote: true) do |f| %>
-        <remote-field-updater url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group) %>">
+      <%= styled_form_tag(members_of_group_path(@group),
+                          method: :post,
+                          remote: true,
+                          'ajax-indicated': '') do |f| %>
+        <remote-field-updater url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group)%>">
           <fieldset class="form--fieldset">
             <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
               <div class="form--field -vertical">
@@ -60,9 +63,12 @@ See doc/COPYRIGHT.rdoc for more details.
                   <%= principals_check_box_tags 'user_ids[]', users %>
                 </div>
               </div>
-            <div><%= styled_button_tag l(:button_add), class: '-highlight -with-icon icon-checkmark' %></div>
           </fieldset>
         </remote-field-updater>
+        <div>
+          <%= styled_button_tag l(:button_add),
+                                class: '-highlight -with-icon icon-checkmark' %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -40,7 +40,11 @@ See doc/COPYRIGHT.rdoc for more details.
     <% end %>
   </div>
   <div class="grid-content">
-    <% users = User.active.not_in_group(@group).limit(100) %>
+    <% users = User
+               .not_builtin
+               .active
+               .not_in_group(@group)
+               .limit(100) %>
     <% if users.any? %>
       <%= styled_form_tag(members_of_group_path(@group),
                           method: :post,

--- a/app/views/groups/_users_table.html.erb
+++ b/app/views/groups/_users_table.html.erb
@@ -53,6 +53,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <%= link_to l(:button_remove), member_of_group_path(@group, user),
                       method: :delete,
                       remote: :true,
+                      'ajax-indicated': '',
                       class: 'icon icon-remove' %>
         </td>
       </tr>

--- a/app/views/groups/change_members.js.erb
+++ b/app/views/groups/change_members.js.erb
@@ -27,4 +27,12 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-jQuery('#group_users_table').html("<%= escape_javascript render(partial: 'groups/users_table') %>")
+var tab = jQuery('#tab-content-users')
+<% content = escape_javascript render(partial: 'users') %>
+tab.html('<%= content %>');
+
+<% flash_message = escape_javascript render(partial: "members/common_notice",
+                                            locals: { message: l(:notice_successful_update) }) %>
+tab.prepend('<%= flash_message %>');
+
+autoHideFlashMessage();


### PR DESCRIPTION
* Updates the whole of the "Users" tab upon adding/removing a user from a group https://community.openproject.com/projects/openproject/work_packages/25367
* Reintroduces the loading indicator that was dormant after removal of prototype. It would have been better to write all of this as an angular directive but there currently seem to be problems with angular directives not executing when updating parts of the page. E.g. the autocompleter suffers from this problem. I needed a quick fix so I didn't look into the problem.
* Prevents the autocompleter from showing builtin users (e.g. anonymous, system) 