### PR TITLE
Fix/increase query api robustness

### DIFF
--- a/app/models/queries/work_packages/filter/custom_field_filter.rb
+++ b/app/models/queries/work_packages/filter/custom_field_filter.rb
@@ -116,6 +116,10 @@ class Queries::WorkPackages::Filter::CustomFieldFilter <
     %w{user version list}.include? custom_field.field_format
   end
 
+  def available?
+    custom_field.present?
+  end
+
   def value_objects
     case custom_field.field_format
     when 'user'

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -555,12 +555,8 @@ class Query < ActiveRecord::Base
   end
 
   def valid_filter_subset!
-    filters.each do |filter|
-      filter.valid_values!
-
-      if filter.invalid?
-        filters.delete(filter)
-      end
+    filters.each(&:valid_values!).select! do |filter|
+      filter.available? && filter.valid?
     end
   end
 
@@ -573,10 +569,8 @@ class Query < ActiveRecord::Base
   def valid_sort_criteria_subset!
     available_criteria = sortable_columns.map(&:name).map(&:to_s)
 
-    sort_criteria.each do |criteria|
-      unless available_criteria.include? criteria.first.to_s
-        sort_criteria.delete(criteria)
-      end
+    sort_criteria.select! do |criteria|
+      available_criteria.include? criteria.first.to_s
     end
   end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -200,12 +200,11 @@ class Query < ActiveRecord::Base
   end
 
   def validate_columns
-    available_names = available_columns.map(&:name).map(&:to_s)
+    available_names = available_columns.map(&:name).map(&:to_sym)
 
-    column_names.each do |name|
-      unless available_names.include? name.to_s
-        errors.add :column_names, I18n.t(:error_invalid_query_column, value: name)
-      end
+    (column_names - available_names).each do |name|
+      errors.add :column_names,
+                 I18n.t(:error_invalid_query_column, value: name)
     end
   end
 
@@ -241,6 +240,8 @@ class Query < ActiveRecord::Base
   #     Removes the group by if it is invalid
   # * sort_criteria
   #     Removes all invalid criteria
+  # * columns
+  #     Removes all invalid columns
   #
   # If the query has been valid or if the error
   # is not one of the addressed, the query is unchanged.
@@ -248,6 +249,7 @@ class Query < ActiveRecord::Base
     valid_filter_subset!
     valid_group_by_subset!
     valid_sort_criteria_subset!
+    valid_column_subset!
   end
 
   def add_filter(field, operator, values)
@@ -572,5 +574,11 @@ class Query < ActiveRecord::Base
     sort_criteria.select! do |criteria|
       available_criteria.include? criteria.first.to_s
     end
+  end
+
+  def valid_column_subset!
+    available_names = available_columns.map(&:name).map(&:to_sym)
+
+    self.column_names &= available_names
   end
 end

--- a/lib/api/v3/queries/query_collection_representer.rb
+++ b/lib/api/v3/queries/query_collection_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -38,6 +39,15 @@ module API
                 self_link,
                 current_user: current_user)
         end
+
+        collection :elements,
+                   getter: ->(*) {
+                     represented.each(&:valid_subset!).map do |model|
+                       element_decorator.create(model, current_user: current_user)
+                     end
+                   },
+                   exec_context: :decorator,
+                   embedded: true
       end
     end
   end

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/query_payload_representer.rb
+++ b/lib/api/v3/queries/query_payload_representer.rb
@@ -79,7 +79,7 @@ module API
         private
 
         ##
-        # Uses the a normal query's filter representation and removes the bits
+        # Uses the normal query's filter representation and removes the bits
         # we don't want for a payload.
         def trimmed_filters(filters)
           filters.map(&:to_hash).map { |v| trim_links v }

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/update_form_api.rb
+++ b/lib/api/v3/queries/update_form_api.rb
@@ -37,6 +37,14 @@ module API
           helpers ::API::V3::Queries::QueryHelper
 
           post do
+            # We try to ignore invalid aspects of the query as the user
+            # might not even be able to fix them (public  query)
+            # and because they might only be invalid in his context
+            # but not for somebody having more permissions, e.g. subproject
+            # filter for admin vs for anonymous.
+            # Permissions are enforced nevertheless.
+            @query.valid_subset!
+
             create_or_update_query_form @query, ::Queries::UpdateContract, UpdateFormRepresenter
           end
         end

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -36,12 +36,15 @@ feature 'Query menu items' do
   let(:project) { FactoryGirl.create :project }
   let(:work_packages_page) { WorkPackagesPage.new(project) }
   let(:notification) { PageObjects::Notifications.new(page) }
+  let(:status) { FactoryGirl.create :status }
 
   def visit_index_page(query)
     work_packages_page.select_query(query)
   end
 
   before do
+    status
+
     allow(User).to receive(:current).and_return user
   end
 

--- a/spec/features/work_packages/table/invalid_query_spec.rb
+++ b/spec/features/work_packages/table/invalid_query_spec.rb
@@ -4,7 +4,7 @@ describe 'Invalid query spec', js: true do
   let(:user) { FactoryGirl.create :admin }
   let(:project) { FactoryGirl.create :project }
 
-  let(:wp_table) { ::Pages::WorkPackagesTable.new }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }
 
   let(:member) do
@@ -54,8 +54,7 @@ describe 'Invalid query spec', js: true do
     work_package_assigned
   end
 
-  # Regression test for bug #24114 (broken watcher filter)
-  it 'should load a faulty query' do
+  it 'should load a faulty query and also the drop down' do
     wp_table.visit_query(invalid_query)
 
     filters.open
@@ -67,6 +66,8 @@ describe 'Invalid query spec', js: true do
                                     message: I18n.t('js.work_packages.faulty_query.description'))
 
     wp_table.expect_work_package_listed [work_package_assigned]
+
+    wp_table.expect_query_in_select_dropdown(invalid_query.name)
   end
 
   it 'should not load with faulty parameters but can be fixed' do

--- a/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_field_filter_spec.rb
@@ -344,6 +344,22 @@ describe Queries::WorkPackages::Filter::CustomFieldFilter, type: :model do
     end
   end
 
+  describe '#available?' do
+    context 'for an existing custom field' do
+      it 'is true' do
+        instance.custom_field = list_wp_custom_field
+        expect(instance).to be_available
+      end
+    end
+
+    context 'for a non existing custom field (deleted)' do
+      it 'is false' do
+        instance.custom_field = nil
+        expect(instance).not_to be_available
+      end
+    end
+  end
+
   describe '.all_for' do
     context 'within a project' do
       before do

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -306,6 +306,45 @@ describe Query, type: :model do
         end
       end
     end
+
+    context 'columns' do
+      before do
+        query.column_names = columns
+      end
+
+      context 'valid' do
+        let(:columns) { %i(status project) }
+
+        it 'leaves the values untouched' do
+          query.valid_subset!
+
+          expect(query.column_names)
+            .to match_array columns
+        end
+      end
+
+      context 'invalid' do
+        let(:columns) { %i(bogus cf_0815) }
+
+        it 'removes the values' do
+          query.valid_subset!
+
+          expect(query.column_names)
+            .to be_empty
+        end
+      end
+
+      context 'partially invalid' do
+        let(:columns) { %i(status cf_0815) }
+
+        it 'removes the offending values' do
+          query.valid_subset!
+
+          expect(query.column_names)
+            .to match_array [:status]
+        end
+      end
+    end
   end
 
   describe '#filter_for' do

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -199,6 +199,10 @@ describe Query, type: :model do
           .to receive(:all)
           .and_return([valid_status])
 
+        allow(Status)
+          .to receive(:exists?)
+          .and_return(true)
+
         query.filters.clear
         query.add_filter('status_id', '=', values)
 
@@ -212,7 +216,7 @@ describe Query, type: :model do
           expect(query.filters.length).to eq 1
         end
 
-        it 'leaves only the invalid value' do
+        it 'leaves only the valid value' do
           expect(query.filters[0].values)
             .to match_array [valid_status.id.to_s]
         end
@@ -223,6 +227,20 @@ describe Query, type: :model do
 
         it 'removes the filter' do
           expect(query.filters.length).to eq 0
+        end
+      end
+
+      context 'for an unavailable filter' do
+        let(:values) { [valid_status.id.to_s] }
+        before do
+          query.add_filter('cf_0815', '=', ['1'])
+
+          query.valid_subset!
+        end
+
+        it 'removes the invalid filter' do
+          expect(query.filters.length).to eq 1
+          expect(query.filters[0].name).to eq :status_id
         end
       end
     end

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -83,6 +83,14 @@ module Pages
                           text: name)
     end
 
+    def expect_query_in_select_dropdown(name)
+      page.find('.title-container').click
+
+      page.within('#querySelectDropdown') do
+        expect(page).to have_selector('.ui-menu-item', text: name)
+      end
+    end
+
     def click_inline_create
       find('.wp-inline-create--add-link').click
       expect(page).to have_selector('.wp-inline-create-row')


### PR DESCRIPTION
Applies cleaning up a query to the query form and collection endpoint. 

In addition to having their values checked, filters also need to be available to not be removed on cleanup. This is necessary e.g. in case a custom field is removed.

The cleanup is also applied to columns. 'Sort by' and 'Group by' where already covered.

https://community.openproject.com/projects/openproject/work_packages/25375/activity