### PR TITLE
[25400][25357][25399] Remove title from wp-display-formattable

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-formattable-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-formattable-field.module.ts
@@ -42,12 +42,6 @@ export class FormattableDisplayField extends DisplayField {
   }
 
   public render(element:HTMLElement, displayText:string):void {
-    // title stripped of html tags
-    if (this.value) {
-      let title = angular.element(this.value).text();
-      element.setAttribute('title', title);
-    }
-
     angular.element(element).addClass('-multiline');
     angular.element(element).addClass('read-value--html');
 


### PR DESCRIPTION
Removes the title from formattible attributes. Fixes

https://community.openproject.com/projects/openproject/work_packages/25399
https://community.openproject.com/projects/openproject/work_packages/25357
https://community.openproject.com/projects/openproject/work_packages/25400