### PR TITLE
Enforce type for activity id

### DIFF
--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -34,7 +34,7 @@ module API
       class ActivitiesAPI < ::API::OpenProjectAPI
         resources :activities do
           params do
-            requires :id, desc: 'Activity id'
+            requires :id, type: Integer, desc: 'Activity id'
           end
           route_param :id do
             before do


### PR DESCRIPTION
Otherwise, anything is passed to `AggregatedJournal.with_nodes_id`.