### PR TITLE
Fix/roadmaps wp list links

### DIFF
--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,7 +33,7 @@ module WorkPackagesFilterHelper
   def project_property_path(project, property, property_id, options = {})
     query = {
       f: [
-        filter_object(property, '=', property_id),
+        filter_object(property, '=', property_id)
       ],
       t: default_sort
     }
@@ -158,7 +159,7 @@ module WorkPackagesFilterHelper
       f: [
         filter_object('status_id', '*'),
         filter_object('subproject_id', '!*'),
-        filter_object(property_name, '=', property_id),
+        filter_object(property_name, '=', property_id)
       ],
       t: default_sort
     }
@@ -170,7 +171,7 @@ module WorkPackagesFilterHelper
       f: [
         filter_object('status_id', '=', status_id),
         filter_object('subproject_id', '!*'),
-        filter_object(property, '=', property_id),
+        filter_object(property, '=', property_id)
       ],
       t: default_sort
     }
@@ -182,7 +183,7 @@ module WorkPackagesFilterHelper
       f: [
         filter_object('status_id', 'o'),
         filter_object('subproject_id', '!*'),
-        filter_object(property, '=', property_id),
+        filter_object(property, '=', property_id)
       ],
       t: default_sort
     }
@@ -194,7 +195,7 @@ module WorkPackagesFilterHelper
       f: [
         filter_object('status_id', 'c'),
         filter_object('subproject_id', '!*'),
-        filter_object(property, '=', property_id),
+        filter_object(property, '=', property_id)
       ],
       t: default_sort
     }
@@ -206,7 +207,7 @@ module WorkPackagesFilterHelper
       f: [
         filter_object('status_id', '*'),
         filter_object('fixed_version_id', '=', version.id),
-        filter_object(property_name, '=', property_id),
+        filter_object(property_name, '=', property_id)
       ],
       t: default_sort
     }
@@ -228,11 +229,12 @@ module WorkPackagesFilterHelper
   end
 
   def filter_object(property, operator, values = nil)
-    f = {
-      n: property,
+    v3_property = API::Utilities::PropertyNameConverter.from_ar_name(property)
+
+    {
+      n: v3_property,
       o: operator,
-    }
-    f = f.reverse_merge(v: values) if values
-    f
+      v: values
+    }.compact
   end
 end

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -230,6 +230,7 @@ module WorkPackagesFilterHelper
 
   def filter_object(property, operator, values = nil)
     v3_property = API::Utilities::PropertyNameConverter.from_ar_name(property)
+    values = values.to_s if values
 
     {
       n: v3_property,

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -144,7 +144,9 @@ module.exports = function(PaginationService) {
       }
 
       // Sortation
-      queryData.sortBy = JSON.stringify(properties.t.split(',').map(function(sort) { return sort.split(':') }));
+      if(properties.t) {
+        queryData.sortBy = JSON.stringify(properties.t.split(',').map(function(sort) { return sort.split(':') }));
+      }
 
       // Pagination
       if(properties.pa) {


### PR DESCRIPTION
Increases the robustness of the frontend query params parser when no sort criteria is provided. In addition, it uses the v3 filter names for some urls generated by rails (e.g. on roadmap) although it is not strictly necessary as the v3 does also handle the AR property names. But it looks better for consistency sake.

https://community.openproject.com/projects/openproject/work_packages/25403