### PR TITLE
Fix/empty filters on export

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -288,10 +288,6 @@ class Query < ActiveRecord::Base
     filter
   end
 
-  def filtered?
-    filters.any?
-  end
-
   def normalized_name
     name.parameterize.underscore
   end

--- a/frontend/app/helpers/url-params-helper.js
+++ b/frontend/app/helpers/url-params-helper.js
@@ -86,7 +86,10 @@ module.exports = function(PaginationService) {
                            v: _.map(filter.values, UrlParamsHelper.queryFilterValueToParam)
                          };
                        });
+      } else {
+        paramsData.f = [];
       }
+
       paramsData.pa = additional.page;
       paramsData.pp = additional.perPage;
 

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -46,7 +47,10 @@ module API
           p[:showSums] = 'true' if query.display_sums?
           p[:groupBy] = query.group_by if query.group_by?
           p[:sortBy] = sort_criteria_to_v3 if query.sorted?
-          p[:filters] = filters_to_v3 if query.filtered?
+
+          # an empty filter param is also relevant as this would mean to not apply
+          # the default filter (status - open)
+          p[:filters] = filters_to_v3
 
           p
         end

--- a/spec/lib/api/v3/queries/query_representer_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_spec.rb
@@ -64,6 +64,16 @@ describe ::API::V3::Queries::QueryRepresenter do
     policy
   end
 
+  def non_empty_to_query(hash)
+    hash.map do |key, value|
+      if value.is_a?(Array) && value.empty?
+        "#{key}=%5B%5D"
+      else
+        value.to_query(key)
+      end
+    end.compact.sort! * '&'
+  end
+
   subject { representer.to_json }
 
   describe 'generation' do
@@ -91,9 +101,10 @@ describe ::API::V3::Queries::QueryRepresenter do
         let(:href) do
           params = {
             offset: 1,
-            pageSize: Setting.per_page_options_array.first
+            pageSize: Setting.per_page_options_array.first,
+            filters: []
           }
-          "#{api_v3_paths.work_packages_by_project(project.id)}?#{params.to_query}"
+          "#{api_v3_paths.work_packages_by_project(project.id)}?#{non_empty_to_query(params)}"
         end
       end
 
@@ -119,9 +130,10 @@ describe ::API::V3::Queries::QueryRepresenter do
           let(:href) do
             params = {
               offset: 1,
-              pageSize: Setting.per_page_options_array.first
+              pageSize: Setting.per_page_options_array.first,
+              filters: []
             }
-            "#{api_v3_paths.work_packages}?#{params.to_query}"
+            "#{api_v3_paths.work_packages}?#{non_empty_to_query(params)}"
           end
         end
       end
@@ -264,10 +276,11 @@ describe ::API::V3::Queries::QueryRepresenter do
         let(:expected_href) do
           params = {
             offset: 2,
-            pageSize: 25
+            pageSize: 25,
+            filters: []
           }
 
-          api_v3_paths.work_packages_by_project(project.id) + "?#{params.to_query}"
+          api_v3_paths.work_packages_by_project(project.id) + "?#{non_empty_to_query(params)}"
         end
 
         it_behaves_like 'has an untitled link' do

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -330,6 +330,13 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
             expect(subject.query[:filters])
               .to eq(expected_filters)
           end
+
+          it 'represents no filters' do
+            expected_filters = JSON::dump([])
+
+            expect(subject.query[:filters])
+              .to eq(expected_filters)
+          end
         end
       end
 


### PR DESCRIPTION
In order to have no filter active at all, the front end has to pass an empty `filters` parameter to the back end. Otherwise the default filter (status - open) is applied.

Therefore, an empty filter parameter is added in such cases for:
* The work package collection url and by that to its representation links (fixing https://community.openproject.com/projects/openproject/work_packages/25385)
* The url in the front end when removing the last filter. By that it becomes possible to reload such a url without having the default filter again.