### PR TITLE
fix sorting by parent

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -82,8 +82,8 @@ class Query < ActiveRecord::Base
                     sortable: "#{::Type.table_name}.position",
                     groupable: true),
     QueryColumn.new(:parent,
-                    sortable: ["#{WorkPackage.table_name}.root_id ASC",
-                               "#{WorkPackage.table_name}.lft ASC"],
+                    sortable: ["#{WorkPackage.table_name}.root_id",
+                               "#{WorkPackage.table_name}.lft"],
                     default_order: 'asc'),
     QueryColumn.new(:status,
                     sortable: "#{Status.table_name}.position",
@@ -178,7 +178,7 @@ class Query < ActiveRecord::Base
   def set_default_sort
     return if sort_criteria.any?
 
-    self.sort_criteria = [['parent', 'desc']]
+    self.sort_criteria = [['parent', 'asc']]
   end
 
   def context

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -36,7 +36,7 @@ describe Query, type: :model do
       query = Query.new_default
 
       expect(query.sort_criteria)
-        .to match_array([['parent', 'desc']])
+        .to match_array([['parent', 'asc']])
     end
 
     it 'does not use the default sortation if an order is provided' do


### PR DESCRIPTION
The default direction is still ASC. But when applying the ASC statement directly to the sortable string, it becomes impossible to filter DESC.