### PR TITLE
[25411] Never render extra parents in timeline

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -66,7 +66,7 @@ export class HierarchyRenderPass extends TableRenderPass {
         row.element = tr;
         this.tableBody.appendChild(tr);
         this.timelineBody.appendChild(this.buildTimelineRow(workPackage));
-        this.markRendered(workPackage, hidden);
+        this.markRendered(workPackage, hidden, false);
       }
 
       // Render all potentially deferred rows
@@ -141,11 +141,11 @@ export class HierarchyRenderPass extends TableRenderPass {
           // Special case, first ancestor => root without parent
           this.tableBody.appendChild(ancestorRow);
           this.timelineBody.appendChild(this.buildTimelineRow(ancestor));
-          this.markRendered(ancestor, hidden);
+          this.markRendered(ancestor, hidden, true);
         } else {
           // This ancestor must be inserted in the last position of its root
           const parent = ancestors[index - 1];
-          this.insertAtExistingHierarchy(ancestor, ancestorRow, parent.id, hidden);
+          this.insertAtExistingHierarchy(ancestor, ancestorRow, parent.id, hidden, true);
         }
 
         // Remember we just added this extra ancestor row
@@ -168,7 +168,7 @@ export class HierarchyRenderPass extends TableRenderPass {
   private insertUnderParent(row:WorkPackageTableRow, parentId:string) {
     const [tr, hidden] = this.rowBuilder.buildEmpty(row.object);
     row.element = tr;
-    this.insertAtExistingHierarchy(row.object, tr, parentId, hidden);
+    this.insertAtExistingHierarchy(row.object, tr, parentId, hidden, false);
   }
 
   /**
@@ -176,10 +176,10 @@ export class HierarchyRenderPass extends TableRenderPass {
    * @param workPackage
    * @param hidden
    */
-  private markRendered(workPackage:WorkPackageResourceInterface, hidden:boolean = false) {
+  private markRendered(workPackage:WorkPackageResourceInterface, hidden:boolean = false, isAncestor:boolean) {
     this.rendered[workPackage.id] = true;
     this.renderedOrder.push({
-      workPackageId: workPackage.id.toString(),
+      workPackageId: isAncestor ? null : workPackage.id.toString(),
       classIdentifier: rowClass(workPackage.id),
       hidden: hidden
     });
@@ -206,7 +206,7 @@ export class HierarchyRenderPass extends TableRenderPass {
   /**
    * Append a row to the given parent hierarchy group.
    */
-  private insertAtExistingHierarchy(workPackage:WorkPackageResourceInterface, el:HTMLElement, parentId:string, hidden:boolean) {
+  private insertAtExistingHierarchy(workPackage:WorkPackageResourceInterface, el:HTMLElement, parentId:string, hidden:boolean, isAncestor:boolean) {
     // Either append to the hierarchy group root (= the parentID row itself)
     const hierarchyRoot = `.__hierarchy-root-${parentId}`;
     // Or, if it has descendants, append to the LATEST of that set
@@ -219,9 +219,9 @@ export class HierarchyRenderPass extends TableRenderPass {
     // Mark as rendered at the given position
     const index = target.index();
     this.renderedOrder.splice(index + 1, 0, {
-      workPackageId: workPackage.id.toString(),
+      workPackageId: isAncestor ? null : workPackage.id.toString(),
       classIdentifier: rowClass(workPackage.id),
-      hidden: hidden
+      hidden: hidden,
     });
     this.rendered[workPackage.id] = true;
 

--- a/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/table-render-pass.ts
@@ -7,7 +7,7 @@ import {Subject} from 'rxjs';
 import {rowClass} from '../../helpers/wp-table-row-helpers';
 
 export interface RenderedRow {
-  workPackageId?:string;
+  workPackageId:string|null;
   classIdentifier:string;
   hidden:boolean;
 }
@@ -98,6 +98,7 @@ export abstract class TableRenderPass {
     this.timelineBuilder.insert(null, this.timelineBody, additionalClasses.concat([classIdentifer]));
 
     this.renderedOrder.push({
+      workPackageId: null,
       classIdentifier: classIdentifer,
       hidden: hidden
     });


### PR DESCRIPTION
Currently, hierarchy mode does NOT load extra parents that are not part
of the results table (marked grey).

As they are not loaded, the timeline doesn't have any information to
draw them with.

However, IF the workPackages state _had_ the value of the work package
(e.g., because it's open in split view or it is part of a relation), it would still be
rendered.

This PR avoids rendering these rows at all times.

https://community.openproject.com/projects/openproject/work_packages/25411/