### PR TITLE
[25415] Add ancestor groups always when inserting extra rows

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -150,9 +150,13 @@ export class HierarchyRenderPass extends TableRenderPass {
 
         // Remember we just added this extra ancestor row
         this.additionalParents[ancestor.id] = ancestor;
-        // Push the correct ancestor groups for identifiying a hierarchy group
-        ancestorGroups.push(hierarchyGroupClass(ancestor.id));
       }
+
+      // Push the correct ancestor groups for identifiying a hierarchy group
+      ancestorGroups.push(hierarchyGroupClass(ancestor.id));
+      ancestors.slice(0, index).forEach((previousAncestor) => {
+        ancestorGroups.push(hierarchyGroupClass(previousAncestor.id));
+      });
     });
 
     // Insert this row to parent


### PR DESCRIPTION
The hierarchy render pass uses ancestor groups to identify which rows belong to a certain hierarchy group for simple selector-based hiding/expanding of nested groups.

For extra added rows, these groups were only added when the ancestor was not yet added to the list, causing them to not respond to collapsing the ancestor group.

https://community.openproject.com/projects/openproject/work_packages/25415