### PR TITLE
[25416] Refresh query on removed query_props with ID set

### DIFF
--- a/frontend/app/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/app/components/wp-list/wp-list-checksum.service.ts
@@ -34,9 +34,9 @@ export class WorkPackagesListChecksumService {
               protected $state:ng.ui.IStateService) {
   }
 
-  public id:number|null;
-  public checksum:string|null;
-  public visibleChecksum:string|null;
+  public id:number | null;
+  public checksum:string | null;
+  public visibleChecksum:string | null;
 
   public updateIfDifferent(query:QueryResource,
                            pagination:WorkPackageTablePagination) {
@@ -82,7 +82,7 @@ export class WorkPackagesListChecksumService {
     }
   }
 
-  private set(id:number|null, checksum:string) {
+  private set(id:number | null, checksum:string) {
     this.id = id;
     this.checksum = checksum;
   }
@@ -97,7 +97,7 @@ export class WorkPackagesListChecksumService {
     return !this.id && !this.checksum;
   }
 
-  private isIdDifferent(otherId:number|null) {
+  private isIdDifferent(otherId:number | null) {
     return this.id !== otherId;
   }
 
@@ -105,21 +105,36 @@ export class WorkPackagesListChecksumService {
     return this.checksum && otherChecksum !== this.checksum;
   }
 
-  private isOutdated(otherId:number|null, otherChecksum:string|null) {
-    return ((this.id || this.checksum) &&
-      ((this.id !== otherId) ||
-      (this.id === otherId && (otherChecksum && (otherChecksum !== this.checksum))) ||
-       (!this.id && this.checksum && !otherChecksum && this.visibleChecksum)));
+  private isOutdated(otherId:number | null, otherChecksum:string | null) {
+    const hasCurrentQueryID = !!this.id;
+    const hasCurrentChecksum = !!this.checksum;
+    const idChanged = (this.id !== otherId);
+
+    const checksumChanged = (otherChecksum !== this.checksum);
+    const visibleChecksumChanged = (this.checksum && !otherChecksum && this.visibleChecksum);
+
+    return (
+      // Can only be outdated if either ID or props set
+      (hasCurrentQueryID || hasCurrentChecksum) &&
+      (
+        // Query ID changed
+        idChanged ||
+        // Query ID same + query props changed
+        (!idChanged && checksumChanged) ||
+        // No query ID set
+        (!hasCurrentQueryID && visibleChecksumChanged)
+      )
+    );
   }
 
   private getNewChecksum(query:QueryResource, pagination:WorkPackageTablePagination) {
     return this.UrlParamsHelper.encodeQueryJsonParams(query, _.pick(pagination, ['page', 'perPage']));
   }
 
-  private maintainUrlQueryState(id:string|number|null, checksum:string|null) {
+  private maintainUrlQueryState(id:string | number | null, checksum:string | null) {
     this.visibleChecksum = checksum;
 
-    this.$state.go('.', { query_props: checksum, query_id: id }, { notify: false });
+    this.$state.go('.', {query_props: checksum, query_id: id}, {notify: false});
   };
 }
 

--- a/spec/features/work_packages/table/query_menu_spec.rb
+++ b/spec/features/work_packages/table/query_menu_spec.rb
@@ -84,15 +84,26 @@ describe 'Query menu item', js: true do
 
       # Locate query
       query_item = page.find(".query-menu-item[object-id='#{last_query.id}']")
-
       query_item.click
 
       # Overrides the query_props
-      expect(page.current_path).not_to include('query_props')
+      expect(page.current_url).not_to include('query_props')
 
       expect(wp_table).to have_work_packages_listed [work_package_with_version]
       expect(wp_table).not_to have_work_packages_listed [work_package_without_version]
 
+      filters.expect_filter_count 2
+      filters.expect_filter_by('Version', 'is', version.name)
+
+      # Removing the filter and returning to query restores it
+      filters.remove_filter 'version'
+      filters.expect_filter_count 1
+      expect(page.current_url).to include('query_props')
+
+      query_item = page.find(".query-menu-item[object-id='#{last_query.id}']")
+      query_item.click
+
+      expect(page.current_url).not_to include('query_props')
       filters.expect_filter_count 2
       filters.expect_filter_by('Version', 'is', version.name)
     end


### PR DESCRIPTION
When you're navigating to a query and override a filter, then move back
to the query, the URL is changed, however the query is not being
refreshed.

This is due to the checksum being required to be non-null, even though
it can possibly become null in the above case.

https://community.openproject.com/projects/openproject/work_packages/25416/