### PR TITLE
have sums listen for changes

### DIFF
--- a/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
+++ b/frontend/app/components/work-packages/wp-display-attr/wp-display-attr.directive.ts
@@ -57,11 +57,6 @@ export class WorkPackageDisplayAttributeController {
               protected wpDisplayField: WorkPackageDisplayFieldService,
               protected wpCacheService: WorkPackageCacheService,
               protected $scope: ng.IScope) {
-
-    // Update the attribute initially
-    if (this.workPackage && this.customSchema && this.schema[this.attribute]) {
-      this.updateAttribute(this.workPackage);
-    }
   }
 
   public get placeholder() {
@@ -139,9 +134,15 @@ function wpDisplayAttrDirective(wpCacheService:WorkPackageCacheService) {
       scopedObservable(
         scope,
         wpCacheService.loadWorkPackage(scope.$ctrl.workPackage.id).values$())
-        .subscribe((wp: WorkPackageResource) => {
+        .subscribe((wp:WorkPackageResource) => {
           scope.$ctrl.updateAttribute(wp);
         });
+    } else {
+      scope.$watch('$ctrl.workPackage', (newValue:any) => {
+        if (newValue) {
+          scope.$ctrl.updateAttribute(scope.$ctrl.workPackage);
+        }
+      });
     }
   }
 

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -58,15 +58,16 @@
              table="table">
       </tbody>
       <tfoot>
-      <tr ng-if="sumsLoaded()"
-          class="sum group all issue work_package">
+      <tr ng-if="displaySums"
+        class="sum group all issue work_package">
         <td ng-repeat="column in columns track by column.href">
           <div class="generic-table--footer-outer">
             <span ng-if="$first">{{ text.sumFor }} {{ text.allWorkPackages }}</span>
             <wp-display-attr
               attribute="column.id"
               custom-schema="resource.sumsSchema"
-              work-package="resource.totalSums">
+              work-package="resource.totalSums"
+              ng-if="resource.sumsSchema && resource.sumsSchema[column.id]">
             </wp-display-attr>
           </div>
         </td>

--- a/frontend/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/app/components/wp-table/wp-table.directive.ts
@@ -70,13 +70,6 @@ function wpTable(
         event.pageY -= topMenuHeight;
       };
 
-      scope.sumsLoaded = function() {
-        return scope.displaySums &&
-          scope.resource.sumsSchema &&
-          scope.resource.sumsSchema.$loaded &&
-          scope.resource.totalSums;
-      };
-
       // Set and keep the current details tab state remembered
       // for the open-in-details button in each WP row.
       scope.desiredSplitViewState = keepTab.currentDetailsState;
@@ -154,8 +147,6 @@ export class WorkPackagesTableController {
       $scope.displaySums = sum.current;
       $scope.groupBy = groupBy.current;
       $scope.columns = columns.current;
-      // Total columns = all available columns + id + checkbox
-      $scope.numTableColumns = $scope.columns.length + 2;
 
       if ($scope.timelineVisible !== timelines.current) {
         this.scrollSyncUpdate(timelines.current);


### PR DESCRIPTION
Before, the sums where initialized once and did not listen for updates. They used to listen for updates before the display directive was rebuild to make use of the wp cache service. As the sums are not placed in the cache, although they could have their own state in the long run, we need to watch ourselves for changes in case of a custom schema.

https://community.openproject.com/projects/openproject/work_packages/25421