### PR TITLE
[25428] Left border is missing in WP overview

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -126,12 +126,13 @@ td.subject .wp-table--cell-container .wp-edit-field:not(.wp-table--cell-span)
 
 // Style no-label fields (long text, description, ..) with padding
 .wp-edit-field.-no-label:not(.-active)
-  margin-left: -0.375rem
-
   .wp-table--cell-span
     display: block
     padding: 5px
     padding-right: 0
+
+.wp-edit-field.description.-no-label
+  margin-left: -0.375rem
 
 // Do not hover trigger-link when element is read-only
 .-read-only


### PR DESCRIPTION
The left border of a WP subject and type was not shown because of an overlay.

https://community.openproject.com/projects/openproject/work_packages/25428/activity