### PR TITLE
[25420] Don't use the state's history for distinctUntilChanged

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -140,10 +140,6 @@ function WorkPackagesListController($scope:any,
         const queryValue = stateValue.comparerFunction()(queryState.value![name]);
         return _.isEqual(queryValue, stateValue.extractedCompareValue) === false;
       })
-      .distinctUntilChanged(
-        (a,b) => _.isEqual(a,b),
-        (stateValue:WorkPackageTableBaseState<any>) => stateValue.extractedCompareValue
-      )
       .subscribe((stateValue:WorkPackageTableBaseState<any>) => {
         const newQuery = queryState.value!;
         newQuery[name] = _.cloneDeep(stateValue.currentQueryValue);


### PR DESCRIPTION
When activating WP sums and moving to a different query, the sums can no longer be activated due to the `distinctUntilChanged` comparing the same value.

Even if we clear the sums state, the values compared there are the same.

https://community.openproject.com/projects/openproject/work_packages/25420/