### PR TITLE
refresh wp list after saving in full screen

### DIFF
--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -32,7 +32,6 @@ import {States} from "../../states.service";
 import {WorkPackageTableSelection} from "../../wp-fast-table/state/wp-table-selection.service";
 import {KeepTabService} from "../../wp-panels/keep-tab/keep-tab.service";
 import {WorkPackageViewController} from "../wp-view-base/wp-view-base.controller";
-import {WorkPackageTableRefreshService} from "../../wp-table/wp-table-refresh-request.service";
 
 export class WorkPackageDetailsController extends WorkPackageViewController {
 
@@ -41,7 +40,6 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
               public states:States,
               public keepTab:KeepTabService,
               public wpTableSelection:WorkPackageTableSelection,
-              public wpTableRefresh: WorkPackageTableRefreshService,
               public $state:ng.ui.IStateService) {
     super($injector, $scope, $state.params['workPackageId']);
     this.observeWorkPackage();
@@ -76,10 +74,6 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
 
   public switchToFullscreen() {
     this.$state.go(this.keepTab.currentShowState, this.$state.params);
-  }
-
-  public onWorkPackageSave() {
-    this.wpTableRefresh.request(false, `Work package ${this.workPackage.id} saved in details view.`);
   }
 
   public get shouldFocus() {

--- a/frontend/app/components/routing/wp-show/wp-show.controller.ts
+++ b/frontend/app/components/routing/wp-show/wp-show.controller.ts
@@ -32,7 +32,6 @@ import {UserResource} from "../../api/api-v3/hal-resources/user-resource.service
 import {WorkPackageResourceInterface} from "../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageViewController} from "../wp-view-base/wp-view-base.controller";
 import {WorkPackagesListChecksumService} from "../../wp-list/wp-list-checksum.service";
-import {WorkPackageTableRefreshService} from "../../wp-table/wp-table-refresh-request.service";
 import {WorkPackageMoreMenuService} from '../../work-packages/work-package-more-menu.service'
 
 export class WorkPackageShowController extends WorkPackageViewController {

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -1,6 +1,7 @@
 <div class="work-packages--show-view"
      ng-class="{'edit-all-mode': $ctrl.wpEditModeState.active}"
      wp-edit-form="$ctrl.workPackage"
+     wp-edit-form-on-save="$ctrl.onWorkPackageSave()"
      has-edit-mode="true"
      ng-if="$ctrl.workPackage">
   <div class="toolbar-container">

--- a/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
+++ b/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
@@ -33,6 +33,7 @@ import {States} from "../../states.service";
 import {WorkPackageCacheService} from "../../work-packages/work-package-cache.service";
 import {WorkPackageEditModeStateService} from "../../wp-edit/wp-edit-mode-state.service";
 import {KeepTabService} from "../../wp-panels/keep-tab/keep-tab.service";
+import {WorkPackageTableRefreshService} from '../../wp-table/wp-table-refresh-request.service';
 
 export class WorkPackageViewController {
 
@@ -46,6 +47,7 @@ export class WorkPackageViewController {
   protected WorkPackageService:any;
   protected PathHelper:op.PathHelper;
   protected I18n:op.I18n;
+  protected wpTableRefresh:WorkPackageTableRefreshService;
 
   // Helper promise to detect when the controller has been initialized
   // (when a WP has loaded).
@@ -66,7 +68,7 @@ export class WorkPackageViewController {
     public $scope:ng.IScope,
     protected workPackageId:string) {
     this.$inject('$q', '$state', 'keepTab', 'wpCacheService', 'WorkPackageService',
-                 'states', 'wpEditModeState', 'PathHelper', 'I18n');
+                 'states', 'wpEditModeState', 'PathHelper', 'I18n', 'wpTableRefresh');
 
     this.initialized = this.$q.defer();
     this.initializeTexts();
@@ -135,6 +137,10 @@ export class WorkPackageViewController {
 
   public canViewWorkPackageWatchers() {
     return !!(this.workPackage && this.workPackage.watchers);
+  }
+
+  public onWorkPackageSave() {
+    this.wpTableRefresh.request(false, `Work package ${this.workPackage.id} saved by user.`);
   }
 }
 


### PR DESCRIPTION
Generalize the behaviour defined for the split screen to also work for the full screen where going back to the list might require an update after saving a work package.

https://community.openproject.com/projects/openproject/work_packages/25429