### PR TITLE
Add missing toolbar class

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -28,13 +28,15 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 <% html_title l(:label_administration), l(:label_user_plural) -%>
 <%= toolbar title: l(:label_user_plural) do %>
-  <%= link_to new_user_path,
-      { class: 'button -alt-highlight',
-        aria: {label: t(:label_user_new)},
-        title: t(:label_user_new)} do %>
-    <%= op_icon('button--icon icon-add') %>
-    <span class="button--text"><%= t('activerecord.models.user') %></span>
-  <% end %>
+  <li class="toolbar-item">
+    <%= link_to new_user_path,
+        { class: 'button -alt-highlight',
+          aria: {label: t(:label_user_new)},
+          title: t(:label_user_new)} do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('activerecord.models.user') %></span>
+    <% end %>
+  </li>
   <%= call_hook(:user_admin_action_menu) %>
 <% end %>
 


### PR DESCRIPTION
This adds a missing class for the toolbar element in Admin/Users. The missing class caused a styling break.