### PR TITLE
[25431] Top menu toggles on mobile screens

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -139,6 +139,12 @@
             self.open($(this));
           }
         });
+        $(it).on('touchstart', function(e) {
+          // This shall avoid the hover event is fired,
+          // which would otherwise lead to menu being closed directly after its opened.
+          e.preventDefault();
+          $(this).click();
+        });
       });
     },
 


### PR DESCRIPTION
On mobile devices the top menu closes directly after its opened when another menu was open before (see ticket). This is caused because the `touchstart` event fires `click` as well as `hover`. 
This PR prevents all other events and fires the click manually afterwards. This the flickering shall be avoided.

https://community.openproject.com/projects/openproject/work_packages/25431/activity