### PR TITLE
[25432] Correctly transmit hasDefault to frontend

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -96,6 +96,7 @@ module Type::Attributes
       key: key,
       is_cf: custom_field?(key),
       always_visible: attr_visibility(key) == 'visible',
+      is_required: represented[:required] && !represented[:has_default],
       translation: translated_attribute_name(key, represented)
     }
   end

--- a/app/views/types/form/_form_configuration.html.erb
+++ b/app/views/types/form/_form_configuration.html.erb
@@ -142,11 +142,15 @@ See doc/COPYRIGHT.rdoc for more details.
                       <% end %>
                     </span>
                     <div class="visibility-check">
-                      <%= check_box_tag "",
-                        'visible',
-                        attribute[:always_visible],
-                        title: t('tooltip.attribute_visibility.visible'),
-                        'ng-click': "updateHiddenFields()" %>
+                      <% if attribute[:is_required] %>
+                        <%= content_tag(:span, t(:label_always_visible), title: t(:text_form_configuration_required_attribute)) %>
+                      <% else %>
+                        <%= check_box_tag "",
+                          'visible',
+                          attribute[:always_visible],
+                          title: t('tooltip.attribute_visibility.visible'),
+                          'ng-click': "updateHiddenFields()" %>
+                      <% end %>
                     </div>
                     <span class="delete-attribute icon icon-small icon-close" ng-click="deactivateAttribute($event)"></span>
                   </div>
@@ -174,11 +178,15 @@ See doc/COPYRIGHT.rdoc for more details.
                 </span>
 
                 <div class="visibility-check">
+                  <% if inactive_attribute[:is_required] %>
+                      <%= content_tag(:span, t(:label_always_visible), title: t(:text_form_configuration_required_attribute)) %>
+                  <% else %>
                   <%= check_box_tag "",
                                     'hidden',
                                     false,
                                     title: t('tooltip.attribute_visibility.visible'),
                                     'ng-click': "updateHiddenFields()" %>
+                  <% end %>
                 </div>
                 <span class="delete-group icon icon-close" ng-click="deactivateAttribute($event)"></span>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1967,6 +1967,7 @@ en:
     Fields that are 'Always displayed' will be visibile even
     if they don't have a value.
   text_form_configuration_drag_to_activate: "Drag fields from here to activate them"
+  text_form_configuration_required_attribute: "Attribute is marked required and thus always shown"
   text_caracters_maximum: "%{count} characters maximum."
   text_caracters_minimum: "Must be at least %{count} characters long."
   text_comma_separated: "Multiple values allowed (comma separated)."

--- a/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
+++ b/frontend/app/components/types/form-configuration/types-form-configuration.controller.ts
@@ -164,7 +164,7 @@ function typesFormConfigurationCtrl(
         newAttrVisibility[key] = 'default';
         if (angular.element('input[type=checkbox]', attr)) {
           let checkbox:HTMLInputElement = angular.element('input[type=checkbox]', attr)[0] as HTMLInputElement;
-          if (checkbox.checked) {
+          if (checkbox && checkbox.checked) {
             newAttrVisibility[key] = 'visible';
           }
         }

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -241,7 +241,7 @@ module API
                         type: TYPE_MAP[custom_field.field_format],
                         name_source: ->(*) { custom_field.name },
                         required: custom_field.is_required,
-                        has_default: (not custom_field.default_value.nil?),
+                        has_default: custom_field.default_value.present?,
                         writable: true,
                         min_length: (custom_field.min_length if custom_field.min_length > 0),
                         max_length: (custom_field.max_length if custom_field.max_length > 0),

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -68,7 +68,25 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:name) { custom_field.name }
         let(:required) { true }
         let(:writable) { true }
-        let(:has_default) { true }
+        let(:has_default) { false }
+      end
+
+      context 'with default set' do
+        let(:custom_field) do
+          FactoryGirl.build(:custom_field,
+                            id: 1,
+                            field_format: 'string',
+                            default_value: 'foo',
+                            is_required: true)
+        end
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'String' }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { true }
+          let(:has_default) { true }
+        end
       end
 
       it 'indicates no regular expression' do


### PR DESCRIPTION
The default value for CFs is '', which is obviously not nil despite not being a default, however the frontend only _always_ shows the attribute when it is required and has no default.

This PR also adds a 'always visible' flag to the form configuration when the CF is set required.

https://community.openproject.com/projects/openproject/work_packages/25432/