### PR TITLE
[25430] inline edit text inputs not 100% available width

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_edit_fields.sass
@@ -91,8 +91,13 @@
       padding-right: 0
 
 // Full width container
-td.subject .wp-table--cell-container .wp-edit-field:not(.wp-table--cell-span)
-  display: inline-block
+td.subject .wp-table--cell-container
+  max-width: inherit
+
+  .wp-edit-field:not(.wp-table--cell-span)
+    display: inline-block
+    width: 100%
+    max-width: inherit
 
 // Editable fields cursor
 .-editable .wp-table--cell-span,


### PR DESCRIPTION
This increase the width of the subject edit field. The maximum is however inherited from the table cell. Because of the width calculation with the hierarchy the only way to let the input span the whole width would be with further calculation. Since this implementation here is sufficient for most cases and more elegant I refrained from the calculation.

https://community.openproject.com/projects/openproject/work_packages/25430/activity