### PR TITLE
add relations columns to query

### DIFF
--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -52,7 +52,7 @@ module QueriesHelper
   end
 
   def column_locale(column)
-    column.is_a?(QueryCustomFieldColumn) ? column.custom_field.name_locale : nil
+    column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) ? column.custom_field.name_locale : nil
   end
 
   def add_filter_from_params(query, filters: params)

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,25 +29,34 @@
 #++
 
 module Queries::WorkPackages
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::AssignedToFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::AuthorFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CategoryFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CreatedAtFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::CustomFieldFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::DoneRatioFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::DueDateFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::EstimatedHoursFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::GroupFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::PriorityFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::ProjectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::ResponsibleFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::RoleFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::StartDateFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::StatusFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::SubjectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::SubprojectFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::TypeFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::UpdatedAtFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::VersionFilter
-  Queries::Register.filter Query, Queries::WorkPackages::Filter::WatcherFilter
+  filters_module = Queries::WorkPackages::Filter
+  register = Queries::Register
+
+  register.filter Query, filters_module::AssignedToFilter
+  register.filter Query, filters_module::AuthorFilter
+  register.filter Query, filters_module::CategoryFilter
+  register.filter Query, filters_module::CreatedAtFilter
+  register.filter Query, filters_module::CustomFieldFilter
+  register.filter Query, filters_module::DoneRatioFilter
+  register.filter Query, filters_module::DueDateFilter
+  register.filter Query, filters_module::EstimatedHoursFilter
+  register.filter Query, filters_module::GroupFilter
+  register.filter Query, filters_module::PriorityFilter
+  register.filter Query, filters_module::ProjectFilter
+  register.filter Query, filters_module::ResponsibleFilter
+  register.filter Query, filters_module::RoleFilter
+  register.filter Query, filters_module::StartDateFilter
+  register.filter Query, filters_module::StatusFilter
+  register.filter Query, filters_module::SubjectFilter
+  register.filter Query, filters_module::SubprojectFilter
+  register.filter Query, filters_module::TypeFilter
+  register.filter Query, filters_module::UpdatedAtFilter
+  register.filter Query, filters_module::VersionFilter
+  register.filter Query, filters_module::WatcherFilter
+
+  columns_module = Queries::WorkPackages::Columns
+
+  register.column Query, columns_module::PropertyColumn
+  register.column Query, columns_module::CustomFieldColumn
+  register.column Query, columns_module::RelationColumn
 end

--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,7 +28,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class QueryCustomFieldColumn < QueryColumn
+class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages::Columns::WorkPackageColumn
   def initialize(custom_field)
     super
 
@@ -35,7 +36,6 @@ class QueryCustomFieldColumn < QueryColumn
     set_sortable! custom_field
     set_groupable! custom_field
     set_summable! custom_field
-    set_available! custom_field
 
     @cf = custom_field
   end
@@ -55,10 +55,6 @@ class QueryCustomFieldColumn < QueryColumn
 
   def set_summable!(custom_field)
     self.summable = %w(float int).include?(custom_field.field_format)
-  end
-
-  def set_available!(custom_field)
-    self.available = custom_field.field_format != 'text'
   end
 
   def groupable_custom_field?(custom_field)
@@ -89,5 +85,15 @@ class QueryCustomFieldColumn < QueryColumn
 
     # TODO: eliminate calls of this method with an Array and drop the :compact call below
     work_packages.map { |wp| value(wp) }.compact.reduce(:+)
+  end
+
+  def self.instances(context = nil)
+    if context
+      context.all_work_package_custom_fields
+    else
+      WorkPackageCustomField.all
+    end
+      .reject { |cf| cf.field_format == 'text' }
+      .map { |cf| new(cf) }
   end
 end

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -1,0 +1,142 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Columns::WorkPackageColumn
+  def caption
+    WorkPackage.human_attribute_name(name)
+  end
+
+  class_attribute :property_columns
+
+  self.property_columns = {
+    id: {
+      sortable: "#{WorkPackage.table_name}.id",
+      groupable: false
+    },
+    project: {
+      sortable: "#{Project.table_name}.name",
+      groupable: true
+    },
+    subject: {
+      sortable: "#{WorkPackage.table_name}.subject"
+    },
+    type: {
+      sortable: "#{::Type.table_name}.position",
+      groupable: true
+    },
+    parent: {
+      sortable: ["#{WorkPackage.table_name}.root_id",
+                 "#{WorkPackage.table_name}.lft"],
+      default_order: 'asc'
+    },
+    status: {
+      sortable: "#{Status.table_name}.position",
+      groupable: true
+    },
+    priority: {
+      sortable: "#{IssuePriority.table_name}.position",
+      default_order: 'desc',
+      groupable: true
+    },
+    author: {
+      sortable: ["#{User.table_name}.lastname",
+                 "#{User.table_name}.firstname",
+                 "#{WorkPackage.table_name}.author_id"],
+      groupable: true
+    },
+    assigned_to: {
+      sortable: ["#{User.table_name}.lastname",
+                 "#{User.table_name}.firstname",
+                 "#{WorkPackage.table_name}.assigned_to_id"],
+      groupable: true
+    },
+    responsible: {
+      sortable: ["#{User.table_name}.lastname",
+                 "#{User.table_name}.firstname",
+                 "#{WorkPackage.table_name}.responsible_id"],
+      groupable: true,
+      join: 'LEFT OUTER JOIN users as responsible ON ' +
+            "(#{WorkPackage.table_name}.responsible_id = responsible.id)"
+    },
+    updated_at: {
+      sortable: "#{WorkPackage.table_name}.updated_at",
+      default_order: 'desc'
+    },
+    category: {
+      sortable: "#{Category.table_name}.name",
+      groupable: true
+    },
+    fixed_version: {
+      sortable: ["#{Version.table_name}.effective_date",
+                 "#{Version.table_name}.name"],
+      default_order: 'desc',
+      groupable: true
+    },
+    start_date: {
+      # Put empty start_dates in the far future rather than in the far past
+      sortable: ["CASE WHEN #{WorkPackage.table_name}.start_date IS NULL
+                  THEN 1
+                  ELSE 0 END",
+                 "#{WorkPackage.table_name}.start_date"]
+    },
+    due_date: {
+      # Put empty due_dates in the far future rather than in the far past
+      sortable: ["CASE WHEN #{WorkPackage.table_name}.due_date IS NULL
+                  THEN 1
+                  ELSE 0 END",
+                 "#{WorkPackage.table_name}.due_date"]
+    },
+    estimated_hours: {
+      sortable: "#{WorkPackage.table_name}.estimated_hours",
+      summable: true
+    },
+    spent_hours: {
+      sortable: false,
+      summable: false
+    },
+    done_ratio: {
+      sortable: "#{WorkPackage.table_name}.done_ratio",
+      groupable: true,
+      if: ->(*) { !WorkPackage.done_ratio_disabled? }
+    },
+    created_at: {
+      sortable: "#{WorkPackage.table_name}.created_at",
+      default_order: 'desc'
+    }
+  }
+
+  def self.instances(_context = nil)
+    property_columns.map do |name, options|
+      next unless !options[:if] || options[:if].call
+
+      new(name, options.except(:if))
+    end.compact
+  end
+end

--- a/app/models/queries/work_packages/columns/relation_column.rb
+++ b/app/models/queries/work_packages/columns/relation_column.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,37 +28,30 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-require_relative 'shared_query_column_specs'
+class Queries::WorkPackages::Columns::RelationColumn < Queries::WorkPackages::Columns::WorkPackageColumn
+  attr_accessor :type
 
-describe ::QueryCustomFieldColumn, type: :model do
-  let(:custom_field) {
-    mock_model(CustomField, field_format: 'string',
-                            order_statements: nil)
-  }
-  let(:instance) { described_class.new(custom_field) }
+  def initialize(type)
+    super
 
-  it_behaves_like 'query column'
-
-  describe '#available?' do
-    context 'for text custom fields' do
-      let(:custom_field) {
-        mock_model(CustomField, field_format: 'text',
-                                order_statements: nil)
-      }
-
-      it 'is false for long text custom fields' do
-        expect(instance.available?).to be_falsey
-      end
-    end
+    set_name! type
+    self.type = type
   end
 
-  describe '#value' do
-    let(:mock) { double(WorkPackage) }
+  def set_name!(type)
+    self.name = "relations_to_type_#{type.id}".to_sym
+  end
 
-    it 'delegates to typed_custom_value_for' do
-      expect(mock).to receive(:typed_custom_value_for).with(custom_field.id)
-      instance.value(mock)
-    end
+  def caption
+    I18n.t(:'activerecord.attributes.query.relations_to_type_column',
+           type: type.name)
+  end
+
+  def self.instances(context = nil)
+    if context
+      context.types
+    else
+      Type.all
+    end.map { |type| new(type) }
   end
 end

--- a/app/models/queries/work_packages/columns/work_package_column.rb
+++ b/app/models/queries/work_packages/columns/work_package_column.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,25 +28,18 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-require_relative 'shared_query_column_specs'
+class Queries::WorkPackages::Columns::WorkPackageColumn < Queries::Columns::Base
+  def caption
+    WorkPackage.human_attribute_name(name)
+  end
 
-describe ::QueryColumn, type: :model do
-  let(:instance) { QueryColumn.new(:query_column) }
-
-  it_behaves_like 'query column'
-
-  describe '#available?' do
-    context ':done_ratio column' do
-      let(:instance) { QueryColumn.new(:done_ratio) }
-
-      it 'is not available if the setting disables it' do
-        allow(WorkPackage)
-          .to receive(:done_ratio_disabled?)
-          .and_return(true)
-
-        expect(instance).to_not be_available
-      end
+  def sum_of(work_packages)
+    if work_packages.is_a?(Array)
+      # TODO: Sums::grouped_sums might call through here without an AR::Relation
+      # Ensure that this also calls using a Relation and drop this (slow!) implementation
+      work_packages.map { |wp| value(wp) }.compact.reduce(:+)
+    else
+      work_packages.sum(name)
     end
   end
 end

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -172,9 +172,9 @@ class ::Query::Results
   def transform_group_keys(groups)
     column = query.group_by_column
 
-    if column.is_a?(QueryCustomFieldColumn) && column.custom_field.list?
+    if column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) && column.custom_field.list?
       transform_list_group_by_keys(column.custom_field, groups)
-    elsif column.is_a?(QueryCustomFieldColumn)
+    elsif column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn)
       transform_custom_field_keys(column.custom_field, groups)
     else
       groups

--- a/app/models/query_relation_column.rb
+++ b/app/models/query_relation_column.rb
@@ -28,40 +28,22 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Queries
-      module Columns
-        class QueryColumnRepresenter < ::API::Decorators::Single
-          self_link path: 'query_column',
-                    id_attribute: ->(*) { converted_name },
-                    title_getter: ->(*) { represented.caption }
+class QueryRelationColumn < QueryColumn
+  attr_accessor :type
 
-          def initialize(model, *_)
-            super(model, current_user: nil, embed_links: true)
-          end
+  def initialize(type)
+    super
 
-          property :id,
-                   exec_context: :decorator
+    set_name! type
+    self.type = type
+  end
 
-          property :caption,
-                   as: :name
+  def set_name!(type)
+    self.name = "relations_to_type_#{type.id}".to_sym
+  end
 
-          def converted_name
-            convert_attribute(represented.name)
-          end
-
-          alias :id :converted_name
-
-          def _type
-            'QueryColumn'
-          end
-
-          def convert_attribute(attribute)
-            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
-          end
-        end
-      end
-    end
+  def caption
+    I18n.t(:'activerecord.attributes.query.relations_to_type_column',
+           type: type.name)
   end
 end

--- a/app/models/work_package/csv_exporter.rb
+++ b/app/models/work_package/csv_exporter.rb
@@ -88,7 +88,7 @@ module WorkPackage::CsvExporter
   end
 
   def csv_format_value(work_package, column)
-    if column.is_a?(QueryCustomFieldColumn)
+    if column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn)
       csv_format_custom_value(work_package, column)
     else
       value = work_package.send(column.name)

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -111,7 +111,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
   end
 
   def text_column?(column)
-    column.is_a?(QueryCustomFieldColumn) &&
+    column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) &&
       ['string', 'text'].include?(column.custom_field.field_format)
   end
 
@@ -157,7 +157,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
   end
 
   def make_column_value(work_package, column)
-    if column.is_a?(QueryCustomFieldColumn)
+    if column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn)
       make_custom_field_value work_package, column
     else
       make_field_value work_package, column.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,7 @@ en:
         work_packages: "Work Packages"
       query:
         column_names: "Columns"
+        relations_to_type_column: "Relations to %{type}"
         group_by: "Group results by"
         filters: "Filters"
       repository:

--- a/docs/api/apiv3/endpoints/queries.apib
+++ b/docs/api/apiv3/endpoints/queries.apib
@@ -2030,7 +2030,7 @@ Gets a list of projects that are available as projects a query can be assigned t
 
 # Group Query Columns
 
-A QueryColumn can be referenced by a Query to denote the work package properties the client should display for the work packages returned as query results. The columns maps to the WorkPackage by the id property.
+A QueryColumn can be referenced by a Query to denote the work package properties the client should display for the work packages returned as query results. The columns maps to the WorkPackage by the id property. QueryColumns exist in two types: QueryColumn::Property and QueryColumn::Relation
 
 ## Actions
 
@@ -2041,9 +2041,10 @@ As of now, no actions are defined.
 
 ## Linked Properties
 
-| Property         | Description                                            | Type        | Constraints                      | Supported operations |
-| :--------------: | ------------------------------------------------------ | ----------- | -------------------------------- | -------------------- |
-| self             | This query column                                      | QueryColumn | not null                         | READ                 |
+| Property         | Description                                            | Type                                           | Constraints                                    | Supported operations |
+| :--------------: | ------------------------------------------------------ | -----------                                    | --------------------------------               | -------------------- |
+| self             | This query column                                      | QueryColumn::Property or QueryColumn::Relation | not null                                       | READ                 |
+|  type            | The type relations point to                            | Type                                           | not null, exists only on QueryColumn::Relation | READ                 |
 
 ## Local Properties
 
@@ -2058,7 +2059,7 @@ As of now, no actions are defined.
     + Body
 
             {
-              "_type": "QueryColumn",
+              "_type": "QueryColumn::Property",
               "id": "priority",
               "name": "Priority",
               "_links": {

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -60,18 +61,28 @@ module API
       end
 
       links :allowedValues do
+        next unless allowed_values
+
         allowed_values.map do |value|
           link_factory.call(value)
-        end if allowed_values
+        end
       end
 
       collection :allowed_values,
                  exec_context: :decorator,
                  embedded: true,
-                 getter: -> (*) {
+                 getter: ->(*) {
+                   next unless allowed_values
+
                    allowed_values.map do |value|
-                     value_representer.new(value, current_user: current_user)
-                   end if allowed_values
+                     representer = if value_representer.respond_to?(:call)
+                                     value_representer.(value)
+                                   else
+                                     value_representer
+                                   end
+
+                     representer.new(value, current_user: current_user)
+                   end
                  }
     end
   end

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -63,7 +64,7 @@ module API
                exec_context: :decorator,
                render_nil: false
 
-      def self.self_link(path: nil, id_attribute: :id, title_getter: -> (*) { represented.name })
+      def self.self_link(path: nil, id_attribute: :id, title_getter: ->(*) { represented.name })
         link :self do
           self_path = self_v3_path(path, id_attribute)
 
@@ -78,8 +79,8 @@ module API
       def self.linked_property(property,
                                path: property,
                                getter: property,
-                               title_getter: -> (*) { call_or_send_to_represented(getter).name },
-                               show_if: -> (*) { true },
+                               title_getter: ->(*) { call_or_send_to_represented(getter).name },
+                               show_if: ->(*) { true },
                                embed_as: nil)
         link ::API::Utilities::PropertyNameConverter.from_ar_name(property) do
           next unless instance_eval(&show_if)
@@ -105,9 +106,9 @@ module API
         property_name = ::API::Utilities::PropertyNameConverter.from_ar_name(property)
         property property_name,
                  exec_context: :decorator,
-                 getter: -> (*) { call_or_send_to_represented(getter) },
+                 getter: ->(*) { call_or_send_to_represented(getter) },
                  embedded: true,
-                 decorator: -> (*) {
+                 decorator: ->(*) {
                    ::API::Utilities::DecoratorFactory.new(decorator: decorator,
                                                           current_user: current_user)
                  },

--- a/lib/api/v3/queries/columns/query_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_column_representer.rb
@@ -53,10 +53,6 @@ module API
 
           alias :id :converted_name
 
-          def _type
-            'QueryColumn'
-          end
-
           def convert_attribute(attribute)
             ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
           end

--- a/lib/api/v3/queries/columns/query_columns_api.rb
+++ b/lib/api/v3/queries/columns/query_columns_api.rb
@@ -36,15 +36,6 @@ module API
               def convert_to_ar(attribute)
                 ::API::Utilities::WpPropertyNameConverter.to_ar_name(attribute)
               end
-
-              def representer_class(column)
-                case column
-                when QueryRelationColumn
-                  ::API::V3::Queries::Columns::QueryRelationColumnRepresenter
-                else
-                  ::API::V3::Queries::Columns::QueryColumnRepresenter
-                end
-              end
             end
 
             params do
@@ -58,10 +49,10 @@ module API
             route_param :id do
               get do
                 ar_id = convert_to_ar(params[:id]).to_sym
-                column = Query.all_columns.detect { |candidate| candidate.name == ar_id }
+                column = Query.available_columns.detect { |candidate| candidate.name == ar_id }
 
                 if column
-                  representer_class(column).new(column)
+                  QueryColumnsFactory.create(column)
                 else
                   raise API::Errors::NotFound
                 end

--- a/lib/api/v3/queries/columns/query_columns_api.rb
+++ b/lib/api/v3/queries/columns/query_columns_api.rb
@@ -36,6 +36,15 @@ module API
               def convert_to_ar(attribute)
                 ::API::Utilities::WpPropertyNameConverter.to_ar_name(attribute)
               end
+
+              def representer_class(column)
+                case column
+                when QueryRelationColumn
+                  ::API::V3::Queries::Columns::QueryRelationColumnRepresenter
+                else
+                  ::API::V3::Queries::Columns::QueryColumnRepresenter
+                end
+              end
             end
 
             params do
@@ -52,7 +61,7 @@ module API
                 column = Query.all_columns.detect { |candidate| candidate.name == ar_id }
 
                 if column
-                  ::API::V3::Queries::Columns::QueryColumnRepresenter.new(column)
+                  representer_class(column).new(column)
                 else
                   raise API::Errors::NotFound
                 end

--- a/lib/api/v3/queries/columns/query_columns_factory.rb
+++ b/lib/api/v3/queries/columns/query_columns_factory.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,34 +26,25 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Register
-  class << self
-    def filter(query, filter)
-      @filters ||= Hash.new do |hash, filter_key|
-        hash[filter_key] = []
+module API
+  module V3
+    module Queries
+      module Columns
+        module QueryColumnsFactory
+          def self.representer(column)
+            case column
+            when ::Queries::WorkPackages::Columns::RelationColumn
+              ::API::V3::Queries::Columns::QueryRelationColumnRepresenter
+            else
+              ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter
+            end
+          end
+
+          def self.create(column)
+            representer(column).new(column)
+          end
+        end
       end
-
-      @filters[query] << filter
     end
-
-    def order(query, order)
-      @orders ||= Hash.new do |hash, order_key|
-        hash[order_key] = []
-      end
-
-      @orders[query] << order
-    end
-
-    def column(query, column)
-      @columns ||= Hash.new do |hash, column_key|
-        hash[column_key] = []
-      end
-
-      @columns[query] << column
-    end
-
-    attr_accessor :filters,
-                  :orders,
-                  :columns
   end
 end

--- a/lib/api/v3/queries/columns/query_property_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_property_column_representer.rb
@@ -34,7 +34,7 @@ module API
       module Columns
         class QueryPropertyColumnRepresenter < QueryColumnRepresenter
           def _type
-            'QueryColumn'
+            'QueryColumn::Property'
           end
         end
       end

--- a/lib/api/v3/queries/columns/query_property_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_property_column_representer.rb
@@ -28,22 +28,16 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class QueryRelationColumn < QueryColumn
-  attr_accessor :type
-
-  def initialize(type)
-    super
-
-    set_name! type
-    self.type = type
-  end
-
-  def set_name!(type)
-    self.name = "relations_to_type_#{type.id}".to_sym
-  end
-
-  def caption
-    I18n.t(:'activerecord.attributes.query.relations_to_type_column',
-           type: type.name)
+module API
+  module V3
+    module Queries
+      module Columns
+        class QueryPropertyColumnRepresenter < QueryColumnRepresenter
+          def _type
+            'QueryColumn'
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/api/v3/queries/columns/query_relation_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_relation_column_representer.rb
@@ -32,33 +32,16 @@ module API
   module V3
     module Queries
       module Columns
-        class QueryColumnRepresenter < ::API::Decorators::Single
-          self_link path: 'query_column',
-                    id_attribute: ->(*) { converted_name },
-                    title_getter: ->(*) { represented.caption }
-
-          def initialize(model, *_)
-            super(model, current_user: nil, embed_links: true)
+        class QueryRelationColumnRepresenter < QueryColumnRepresenter
+          link :type do
+            {
+              href: api_v3_paths.type(represented.type.id),
+              title: represented.type.name
+            }
           end
-
-          property :id,
-                   exec_context: :decorator
-
-          property :caption,
-                   as: :name
-
-          def converted_name
-            convert_attribute(represented.name)
-          end
-
-          alias :id :converted_name
 
           def _type
-            'QueryColumn'
-          end
-
-          def convert_attribute(attribute)
-            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
+            'QueryColumn::Relation'
           end
         end
       end

--- a/lib/api/v3/queries/query_serialization.rb
+++ b/lib/api/v3/queries/query_serialization.rb
@@ -43,7 +43,7 @@ module API
 
         def columns
           represented.columns.map do |column|
-            ::API::V3::Queries::Columns::QueryColumnRepresenter.new(column)
+            ::API::V3::Queries::Columns::QueryColumnsFactory.create(column)
           end
         end
 

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -127,11 +127,7 @@ module API
                                          visibility: false,
                                          values_callback: -> { represented.available_columns },
                                          value_representer: ->(column) {
-                                           if column.is_a?(QueryRelationColumn)
-                                             Columns::QueryRelationColumnRepresenter
-                                           else
-                                             Columns::QueryColumnRepresenter
-                                           end
+                                           Columns::QueryColumnsFactory.representer(column)
                                          },
                                          link_factory: ->(column) {
                                            converted_name = convert_attribute(column.name)

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -126,7 +126,13 @@ module API
                                          has_default: true,
                                          visibility: false,
                                          values_callback: -> { represented.available_columns },
-                                         value_representer: Columns::QueryColumnRepresenter,
+                                         value_representer: ->(column) {
+                                           if column.is_a?(QueryRelationColumn)
+                                             Columns::QueryRelationColumnRepresenter
+                                           else
+                                             Columns::QueryColumnRepresenter
+                                           end
+                                         },
                                          link_factory: ->(column) {
                                            converted_name = convert_attribute(column.name)
 

--- a/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
@@ -45,9 +45,9 @@ describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter do
       end
     end
 
-    it 'has _type QueryColumn' do
+    it 'has _type QueryColumn::Property' do
       is_expected
-        .to be_json_eql('QueryColumn'.to_json)
+        .to be_json_eql('QueryColumn::Property'.to_json)
         .at_path('_type')
     end
 

--- a/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryColumnRepresenter do
+describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:column) { Query.available_columns.detect { |column| column.name == :status } }

--- a/spec/lib/api/v3/queries/columns/query_relation_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_column_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,40 +26,48 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Queries
-      module Columns
-        class QueryColumnRepresenter < ::API::Decorators::Single
-          self_link path: 'query_column',
-                    id_attribute: ->(*) { converted_name },
-                    title_getter: ->(*) { represented.caption }
+require 'spec_helper'
 
-          def initialize(model, *_)
-            super(model, current_user: nil, embed_links: true)
-          end
+describe ::API::V3::Queries::Columns::QueryRelationColumnRepresenter do
+  include ::API::V3::Utilities::PathHelper
 
-          property :id,
-                   exec_context: :decorator
+  let(:type) { FactoryGirl.build_stubbed(:type) }
+  let(:column) { QueryRelationColumn.new(type) }
+  let(:representer) { described_class.new(column) }
 
-          property :caption,
-                   as: :name
+  subject { representer.to_json }
 
-          def converted_name
-            convert_attribute(represented.name)
-          end
-
-          alias :id :converted_name
-
-          def _type
-            'QueryColumn'
-          end
-
-          def convert_attribute(attribute)
-            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
-          end
-        end
+  describe 'generation' do
+    describe '_links' do
+      it_behaves_like 'has a titled link' do
+        let(:link) { 'self' }
+        let(:href) { api_v3_paths.query_column "relationsToType#{type.id}" }
+        let(:title) { "Relations to #{type.name}" }
       end
+
+      it_behaves_like 'has a titled link' do
+        let(:link) { 'type' }
+        let(:href) { api_v3_paths.type type.id }
+        let(:title) { type.name }
+      end
+    end
+
+    it 'has _type QueryColumn::Relation' do
+      is_expected
+        .to be_json_eql('QueryColumn::Relation'.to_json)
+        .at_path('_type')
+    end
+
+    it 'has id attribute' do
+      is_expected
+        .to be_json_eql("relationsToType#{type.id}".to_json)
+        .at_path('id')
+    end
+
+    it 'has name attribute' do
+      is_expected
+        .to be_json_eql("Relations to #{type.name}".to_json)
+        .at_path('name')
     end
   end
 end

--- a/spec/lib/api/v3/queries/columns/query_relation_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_column_representer_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::Queries::Columns::QueryRelationColumnRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:type) { FactoryGirl.build_stubbed(:type) }
-  let(:column) { QueryRelationColumn.new(type) }
+  let(:column) { Queries::WorkPackages::Columns::RelationColumn.new(type) }
   let(:representer) { described_class.new(column) }
 
   subject { representer.to_json }

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -253,10 +253,10 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:form_embedded) { true }
           let(:type) { FactoryGirl.build_stubbed(:type) }
           let(:available_values) do
-            [QueryColumn.new(:bogus1),
-             QueryColumn.new(:bogus2),
-             QueryColumn.new(:bogus3),
-             QueryRelationColumn.new(type)]
+            [Queries::WorkPackages::Columns::PropertyColumn.new(:bogus1),
+             Queries::WorkPackages::Columns::PropertyColumn.new(:bogus2),
+             Queries::WorkPackages::Columns::PropertyColumn.new(:bogus3),
+             Queries::WorkPackages::Columns::RelationColumn.new(type)]
           end
           let(:available_values_method) { :available_columns }
 
@@ -337,9 +337,9 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
 
           it_behaves_like 'has a collection of allowed values' do
             let(:available_values) do
-              [QueryColumn.new(:bogus1),
-               QueryColumn.new(:bogus2),
-               QueryColumn.new(:bogus3)]
+              [Queries::WorkPackages::Columns::PropertyColumn.new(:bogus1),
+               Queries::WorkPackages::Columns::PropertyColumn.new(:bogus2),
+               Queries::WorkPackages::Columns::PropertyColumn.new(:bogus3)]
             end
             let(:available_values_method) { :groupable_columns }
             let(:expected_hrefs) do
@@ -377,9 +377,9 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
             end
 
             let(:available_values) do
-              [QueryColumn.new(:bogus1),
-               QueryColumn.new(:bogus2),
-               QueryColumn.new(:bogus3)]
+              [Queries::WorkPackages::Columns::PropertyColumn.new(:bogus1),
+               Queries::WorkPackages::Columns::PropertyColumn.new(:bogus2),
+               Queries::WorkPackages::Columns::PropertyColumn.new(:bogus3)]
             end
             let(:available_values_method) { :sortable_columns }
 

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -251,18 +251,31 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
 
         context 'when embedding' do
           let(:form_embedded) { true }
+          let(:type) { FactoryGirl.build_stubbed(:type) }
+          let(:available_values) do
+            [QueryColumn.new(:bogus1),
+             QueryColumn.new(:bogus2),
+             QueryColumn.new(:bogus3),
+             QueryRelationColumn.new(type)]
+          end
+          let(:available_values_method) { :available_columns }
 
           it_behaves_like 'has a collection of allowed values' do
-            let(:available_values) do
-              [QueryColumn.new(:bogus1),
-               QueryColumn.new(:bogus2),
-               QueryColumn.new(:bogus3)]
-            end
-            let(:available_values_method) { :available_columns }
             let(:expected_hrefs) do
               available_values.map do |value|
-                api_v3_paths.query_column(value.name)
+                api_v3_paths.query_column(value.name.to_s.camelcase(:lower))
               end
+            end
+
+            it 'has available columns of both types' do
+              types = JSON.parse(generated)
+                          .dig('columns',
+                               '_embedded',
+                               'allowedValues')
+                          .map { |v| v['_type'] }
+                          .uniq
+
+              expect(types).to match_array(%w(QueryColumn QueryColumn::Relation))
             end
           end
         end

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -275,7 +275,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
                           .map { |v| v['_type'] }
                           .uniq
 
-              expect(types).to match_array(%w(QueryColumn QueryColumn::Relation))
+              expect(types).to match_array(%w(QueryColumn::Property QueryColumn::Relation))
             end
           end
         end

--- a/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::Queries::SortBys::QuerySortByRepresenter do
 
   let(:column_name) { 'status' }
   let(:direction) { 'desc' }
-  let(:column) { QueryColumn.new(column_name) }
+  let(:column) { Queries::WorkPackages::Columns::PropertyColumn.new(column_name) }
   let(:representer) do
     described_class
       .new(::API::V3::Queries::SortBys::SortByDecorator.new(column, direction))

--- a/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
@@ -1,0 +1,94 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require_relative 'shared_query_column_specs'
+
+describe Queries::WorkPackages::Columns::CustomFieldColumn, type: :model do
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:custom_field) do
+    mock_model(CustomField, field_format: 'string',
+                            order_statements: nil)
+  end
+  let(:instance) { described_class.new(custom_field) }
+
+  it_behaves_like 'query column'
+
+  describe 'instances' do
+    let(:text_custom_field) do
+      FactoryGirl.create(:text_wp_custom_field)
+    end
+
+    let(:list_custom_field) do
+      FactoryGirl.create(:list_wp_custom_field)
+    end
+
+    context 'within project' do
+      before do
+        allow(project)
+          .to receive(:all_work_package_custom_fields)
+          .and_return([text_custom_field,
+                       list_custom_field])
+      end
+
+      it 'contains only non text cf columns' do
+        expect(described_class.instances(project).length)
+          .to eq 1
+
+        expect(described_class.instances(project)[0].custom_field)
+          .to eq list_custom_field
+      end
+    end
+
+    context 'global' do
+      before do
+        allow(WorkPackageCustomField)
+          .to receive(:all)
+          .and_return([text_custom_field,
+                       list_custom_field])
+      end
+
+      it 'contains only non text cf columns' do
+        expect(described_class.instances.length)
+          .to eq 1
+
+        expect(described_class.instances[0].custom_field)
+          .to eq list_custom_field
+      end
+    end
+  end
+
+  describe '#value' do
+    let(:mock) { double(WorkPackage) }
+
+    it 'delegates to typed_custom_value_for' do
+      expect(mock).to receive(:typed_custom_value_for).with(custom_field.id)
+      instance.value(mock)
+    end
+  end
+end

--- a/spec/models/queries/work_packages/columns/property_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/property_column_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,34 +26,33 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Register
-  class << self
-    def filter(query, filter)
-      @filters ||= Hash.new do |hash, filter_key|
-        hash[filter_key] = []
-      end
+require 'spec_helper'
+require_relative 'shared_query_column_specs'
 
-      @filters[query] << filter
+describe Queries::WorkPackages::Columns::PropertyColumn, type: :model do
+  let(:instance) { described_class.new(:query_column) }
+
+  it_behaves_like 'query column'
+
+  describe 'instances' do
+    context 'done_ratio disabled' do
+      it 'the done ratio column does not exist' do
+        allow(WorkPackage)
+          .to receive(:done_ratio_disabled?)
+          .and_return(true)
+
+        expect(described_class.instances.map(&:name)).not_to include :done_ratio
+      end
     end
 
-    def order(query, order)
-      @orders ||= Hash.new do |hash, order_key|
-        hash[order_key] = []
+    context 'done_ratio enabled' do
+      it 'the done ratio column exists' do
+        allow(WorkPackage)
+          .to receive(:done_ratio_disabled?)
+          .and_return(false)
+
+        expect(described_class.instances.map(&:name)).to include :done_ratio
       end
-
-      @orders[query] << order
     end
-
-    def column(query, column)
-      @columns ||= Hash.new do |hash, column_key|
-        hash[column_key] = []
-      end
-
-      @columns[query] << column
-    end
-
-    attr_accessor :filters,
-                  :orders,
-                  :columns
   end
 end

--- a/spec/models/queries/work_packages/columns/relation_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/relation_column_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,34 +26,47 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Register
-  class << self
-    def filter(query, filter)
-      @filters ||= Hash.new do |hash, filter_key|
-        hash[filter_key] = []
+require 'spec_helper'
+require_relative 'shared_query_column_specs'
+
+describe Queries::WorkPackages::Columns::RelationColumn, type: :model do
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:type) { FactoryGirl.build_stubbed(:type) }
+  let(:instance) { described_class.new(type) }
+
+  it_behaves_like 'query column'
+
+  describe 'instances' do
+    context 'within project' do
+      before do
+        allow(project)
+          .to receive(:types)
+          .and_return([type])
       end
 
-      @filters[query] << filter
+      it 'contains the type columns' do
+        expect(described_class.instances(project).length)
+          .to eq 1
+
+        expect(described_class.instances(project)[0].type)
+          .to eq type
+      end
     end
 
-    def order(query, order)
-      @orders ||= Hash.new do |hash, order_key|
-        hash[order_key] = []
+    context 'global' do
+      before do
+        allow(Type)
+          .to receive(:all)
+          .and_return([type])
       end
 
-      @orders[query] << order
-    end
+      it 'contains the type columns' do
+        expect(described_class.instances.length)
+          .to eq 1
 
-    def column(query, column)
-      @columns ||= Hash.new do |hash, column_key|
-        hash[column_key] = []
+        expect(described_class.instances[0].type)
+          .to eq type
       end
-
-      @columns[query] << column
     end
-
-    attr_accessor :filters,
-                  :orders,
-                  :columns
   end
 end

--- a/spec/models/queries/work_packages/columns/shared_query_column_specs.rb
+++ b/spec/models/queries/work_packages/columns/shared_query_column_specs.rb
@@ -114,20 +114,4 @@ shared_examples_for 'query column' do
       expect(instance.sortable?).to be_truthy
     end
   end
-
-  describe '#available?' do
-    it 'is true by default' do
-      expect(instance.available?).to be_truthy
-    end
-
-    it 'is whatever one tells it to be' do
-      instance.available = false
-
-      expect(instance.available?).to be_falsey
-
-      instance.available = true
-
-      expect(instance.available?).to be_truthy
-    end
-  end
 end

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -130,7 +130,7 @@ describe "POST /api/v3/queries/form", type: :request do
                                spentTime startDate status subject type
                                updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
           {
-            '_type': 'QueryColumn',
+            '_type': 'QueryColumn::Property',
             'id': id
           }
         end
@@ -197,7 +197,7 @@ describe "POST /api/v3/queries/form", type: :request do
                                spentTime startDate status subject type
                                updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
           {
-            '_type': 'QueryColumn',
+            '_type': 'QueryColumn::Property',
             'id': id
           }
         end

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -40,8 +40,12 @@ describe "POST /api/v3/queries/form", type: :request do
   let(:override_params) { {} }
   let(:form) { JSON.parse response.body }
 
+  let(:additional_setup) {}
+
   before do
     login_as(user)
+
+    additional_setup
 
     post path,
          params: parameters.merge(override_params).to_json,
@@ -97,6 +101,133 @@ describe "POST /api/v3/queries/form", type: :request do
 
       it "has the correct method" do
         expect(form.dig("_links", "commit", "method")).to eq "post"
+      end
+    end
+
+    describe 'columns' do
+      let(:custom_field) do
+        cf = FactoryGirl.create(:list_wp_custom_field)
+        project.work_package_custom_fields << cf
+        cf.types << project.types.first
+
+        cf
+      end
+
+      let(:non_project_type) do
+        FactoryGirl.create(:type)
+      end
+
+      let(:additional_setup) do
+        custom_field
+
+        non_project_type
+      end
+
+      it 'has the static, custom field and relation columns' do
+        expected_columns = (%w(id project assignee author
+                               category createdAt dueDate estimatedTime
+                               parent percentageDone priority responsible
+                               spentTime startDate status subject type
+                               updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
+          {
+            '_type': 'QueryColumn',
+            'id': id
+          }
+        end
+
+        expected_columns += Type.all.map do |type|
+          {
+            '_type': 'QueryColumn::Relation',
+            'id': "relationsToType#{type.id}"
+          }
+        end
+
+        actual_columns = form.dig('_embedded',
+                                  'schema',
+                                  'columns',
+                                  '_embedded',
+                                  'allowedValues')
+                             .map do |column|
+                               {
+                                 '_type': column['_type'],
+                                 'id': column['id']
+                               }
+                             end
+
+        expect(actual_columns).to include *expected_columns
+      end
+    end
+  end
+
+  describe 'with minimum parameters for a project' do
+    let(:parameters) do
+      {
+        name: 'Some Query',
+        _links: {
+          project: {
+            href: "/api/v3/projects/#{project.id}"
+          }
+        }
+      }
+    end
+
+    describe 'columns' do
+      let(:custom_field) do
+        cf = FactoryGirl.create(:list_wp_custom_field)
+        project.work_package_custom_fields << cf
+        cf.types << project.types.first
+
+        cf
+      end
+
+      let(:non_project_type) do
+        FactoryGirl.create(:type)
+      end
+
+      let(:additional_setup) do
+        custom_field
+
+        non_project_type
+      end
+
+      it 'has the static, custom field and relation columns' do
+        expected_columns = (%w(id project assignee author
+                               category createdAt dueDate estimatedTime
+                               parent percentageDone priority responsible
+                               spentTime startDate status subject type
+                               updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
+          {
+            '_type': 'QueryColumn',
+            'id': id
+          }
+        end
+
+        expected_columns += project.types.map do |type|
+          {
+            '_type': 'QueryColumn::Relation',
+            'id': "relationsToType#{type.id}"
+          }
+        end
+
+        actual_columns = form.dig('_embedded',
+                                  'schema',
+                                  'columns',
+                                  '_embedded',
+                                  'allowedValues')
+                             .map do |column|
+                               {
+                                 '_type': column['_type'],
+                                 'id': column['id']
+                               }
+                             end
+
+        non_project_type_hash = {
+          '_type': 'QueryColumn::Relation',
+          'id': "relationsToType#{non_project_type.id}"
+        }
+
+        expect(actual_columns).to include *expected_columns
+        expect(actual_columns).not_to include(non_project_type_hash)
       end
     end
   end

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -138,7 +138,7 @@ describe "POST /api/v3/queries/form", type: :request do
                                  spentTime startDate status subject type
                                  updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
             {
-              '_type': 'QueryColumn',
+              '_type': 'QueryColumn::Property',
               'id': id
             }
           end
@@ -188,7 +188,7 @@ describe "POST /api/v3/queries/form", type: :request do
                                  spentTime startDate status subject type
                                  updatedAt version) + ["customField#{custom_field.id}"]).map do |id|
             {
-              '_type': 'QueryColumn',
+              '_type': 'QueryColumn::Property',
               'id': id
             }
           end

--- a/spec_legacy/unit/query_spec.rb
+++ b/spec_legacy/unit/query_spec.rb
@@ -260,7 +260,7 @@ describe Query, type: :model do
 
   it 'should groupable columns should include custom fields' do
     q = Query.new name: '_'
-    assert q.groupable_columns.detect { |c| c.is_a? QueryCustomFieldColumn }
+    assert q.groupable_columns.detect { |c| c.is_a? Queries::WorkPackages::Columns::CustomFieldColumn }
   end
 
   it 'should grouped with valid column' do
@@ -306,7 +306,7 @@ describe Query, type: :model do
 
   it 'should sort by string custom field asc' do
     q = Query.new name: '_'
-    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
+    c = q.available_columns.find { |col| col.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
     issues = WorkPackage.includes(:assigned_to, :status, :type, :project, :priority)
@@ -320,7 +320,7 @@ describe Query, type: :model do
 
   it 'should sort by string custom field desc' do
     q = Query.new name: '_'
-    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'string' }
+    c = q.available_columns.find { |col| col.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) && col.custom_field.field_format == 'string' }
     assert c
     assert c.sortable
     issues = WorkPackage.includes(:assigned_to, :status, :type, :project, :priority)
@@ -334,7 +334,7 @@ describe Query, type: :model do
 
   it 'should sort by float custom field asc' do
     q = Query.new name: '_'
-    c = q.available_columns.find { |col| col.is_a?(QueryCustomFieldColumn) && col.custom_field.field_format == 'float' }
+    c = q.available_columns.find { |col| col.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) && col.custom_field.field_format == 'float' }
     assert c
     assert c.sortable
     issues = WorkPackage


### PR DESCRIPTION
Adds relation columns to the query.

https://community.openproject.com/projects/openproject/work_packages/25423

### TODO
- [x] Change `_type` of Column to reflect Relation column, have link to type `QueryColumn::Relation`
- [x] Consider renaming non relation columns `_type` to `QueryColumn::Property`
- [x] Add unit tests
  - [x] RelationQueryColumn
  - [x] Query: get available columns, store with columns
- [x] Add integration tests to update form api
- [x] Check calendar and other placed for unwanted effects of the columns 
- [x] Restructure columns in backend
  - [x] Nest the columns inside app/models/queries
  - [x] Extract available columns from query model and implement a register similar to filters
  - [x] Adapt plugins to interface changes 
    - [x] costs
    - [x] backlogs
    - [x] xls export