### PR TITLE
[25438] Fix only saving changed column positions

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -369,9 +369,8 @@ class Query < ActiveRecord::Base
                 .reject(&:blank?)
                 .map(&:to_sym)
 
-    # Set column_names to blank/nil if default columns
-    if (col_names.map(&:to_s) - Setting.work_package_list_default_columns).empty? &&
-       (Setting.work_package_list_default_columns - col_names.map(&:to_s)).empty?
+    # Set column_names to blank/nil if it is equal to the default columns
+    if col_names.map(&:to_s) == Setting.work_package_list_default_columns
       col_names.clear
     end
 

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -140,10 +140,6 @@ function WorkPackagesListController($scope:any,
         const queryValue = stateValue.comparerFunction()(queryState.value![name]);
         return _.isEqual(queryValue, stateValue.extractedCompareValue) === false;
       })
-      .distinctUntilChanged(
-        (a,b) => _.isEqual(a,b),
-        (stateValue:WorkPackageTableBaseState<any>) => stateValue.extractedCompareValue
-      )
       .subscribe((stateValue:WorkPackageTableBaseState<any>) => {
         const newQuery = queryState.value!;
         newQuery[name] = _.cloneDeep(stateValue.currentQueryValue);


### PR DESCRIPTION
When changing only the positions of the default query columns, the query incorrectly checked only for the permutation of the default columns, not the actual order.

Thus the columns were not actually saved in the query.

Additionally, the `observeUntilChanged` incorrectly reflects previous values which causes the movement of a column twice to only result in a move by one position.

As this was already suggested to remove in https://github.com/opf/openproject/pull/5597, let's resolve this together in this PR.

https://community.openproject.com/projects/openproject/work_packages/25438/