### PR TITLE
fix user/version cf rendering in forms

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -110,19 +110,10 @@ class CustomField < ActiveRecord::Base
       else
         []
       end
+    when 'list'
+      possible_values.map { |option| [option.value, option.id.to_s] }
     else
       possible_values
-    end
-  end
-
-  def possible_values_options_in_project(project)
-    case field_format
-    when 'user'
-      project.users.sort.map { |u| [u.to_s, u.id.to_s] }
-    when 'version'
-      project.versions.sort.map { |u| [u.to_s, u.id.to_s] }
-    else
-      []
     end
   end
 
@@ -235,6 +226,17 @@ class CustomField < ActiveRecord::Base
   end
 
   private
+
+  def possible_values_options_in_project(project)
+    case field_format
+    when 'user'
+      project.users
+    when 'version'
+      project.versions
+    else
+      []
+    end.sort.map { |u| [u.to_s, u.id.to_s] }
+  end
 
   def possible_values_from_arg(arg)
     if arg.is_a?(Array)

--- a/app/models/queries/work_packages/filter/custom_field_filter.rb
+++ b/app/models/queries/work_packages/filter/custom_field_filter.rb
@@ -36,12 +36,10 @@ class Queries::WorkPackages::Filter::CustomFieldFilter <
 
   def allowed_values
     case custom_field.field_format
-    when 'list'
-      custom_field.custom_options.map { |co| [co.value, co.id.to_s] }
     when 'bool'
       [[I18n.t(:general_text_yes), CustomValue::BoolStrategy::DB_VALUE_TRUE],
        [I18n.t(:general_text_no), CustomValue::BoolStrategy::DB_VALUE_FALSE]]
-    when 'user', 'version'
+    when 'user', 'version', 'list'
       custom_field.possible_values_options(project)
     end
   end

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -47,6 +47,12 @@ class CustomFieldFormBuilder < TabularFormBuilder
 
   private
 
+  def possible_options_for_object
+    object
+      .custom_field
+      .possible_values_options(object.customized)
+  end
+
   def custom_field_input(options = {})
     field = :value
 
@@ -77,13 +83,6 @@ class CustomFieldFormBuilder < TabularFormBuilder
     selectable_options = template.options_for_select(possible_options, object.value)
 
     select(field, selectable_options, select_options, input_options).html_safe
-  end
-
-  def possible_options_for_object
-    object
-      .custom_field
-      .possible_values_options(object.customized)
-      .map { |option| [option.value, option.id] }
   end
 
   def custom_field_select_options_for_object

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -32,27 +32,19 @@ require 'ostruct'
 describe CustomFieldFormBuilder do
   include Capybara::RSpecMatchers
 
-  let(:helper)   { ActionView::Base.new }
-  let(:resource) {
-    FactoryGirl.build(:user,
-                      firstname:  'JJ',
-                      lastname:   'Abrams',
-                      login:      'lost',
-                      mail:       'jj@lost-mail.com',
-                      failed_login_count: 45)
-  }
-  let(:builder)  { described_class.new(:user, resource, helper, {}) }
+  let(:helper) { ActionView::Base.new }
+  let(:builder) { described_class.new(:user, resource, helper, {}) }
 
   describe '#custom_field' do
     let(:options) { { class: 'custom-class' } }
 
-    let(:resource) {
+    let(:resource) do
       FactoryGirl.build_stubbed(:custom_value)
-    }
+    end
 
-    subject(:output) {
+    subject(:output) do
       builder.custom_field options
-    }
+    end
 
     it_behaves_like 'labelled by default'
     it_behaves_like 'wrapped in field-container by default' do
@@ -240,8 +232,16 @@ describe CustomFieldFormBuilder do
     end
 
     context 'for a user custom field' do
+      let(:project) { FactoryGirl.build_stubbed(:project) }
+      let(:user1) { FactoryGirl.build_stubbed(:user) }
+      let(:user2) { FactoryGirl.build_stubbed(:user) }
+
       before do
         resource.custom_field.field_format = 'user'
+        resource.customized = project
+        allow(project)
+          .to receive(:users)
+          .and_return([user1, user2])
       end
 
       it_behaves_like 'wrapped in container', 'select-container'
@@ -251,7 +251,10 @@ describe CustomFieldFormBuilder do
           <select class="custom-class form--select"
                   id="user#{resource.custom_field_id}"
                   name="user[#{resource.custom_field_id}]"
-                  no_label="true"><option value=\"\"></option>
+                  no_label="true">
+            <option value=\"\"></option>
+            <option value="#{user1.id}">#{user1.name}</option>
+            <option value="#{user2.id}">#{user2.name}</option>
           </select>
         }).at_path('select')
       end
@@ -266,8 +269,10 @@ describe CustomFieldFormBuilder do
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     name="user[#{resource.custom_field_id}]"
-                    no_label="true"><option value=\"\">---
-                    Please select ---</option>
+                    no_label="true">
+              <option value=\"\">--- Please select ---</option>
+              <option value="#{user1.id}">#{user1.name}</option>
+              <option value="#{user2.id}">#{user2.name}</option>
             </select>
           }).at_path('select')
         end
@@ -275,8 +280,16 @@ describe CustomFieldFormBuilder do
     end
 
     context 'for a version custom field' do
+      let(:project) { FactoryGirl.build_stubbed(:project) }
+      let(:version1) { FactoryGirl.build_stubbed(:version) }
+      let(:version2) { FactoryGirl.build_stubbed(:version) }
+
       before do
         resource.custom_field.field_format = 'version'
+        resource.customized = project
+        allow(project)
+          .to receive(:versions)
+          .and_return([version1, version2])
       end
 
       it_behaves_like 'wrapped in container', 'select-container'
@@ -286,7 +299,10 @@ describe CustomFieldFormBuilder do
           <select class="custom-class form--select"
                   id="user#{resource.custom_field_id}"
                   name="user[#{resource.custom_field_id}]"
-                  no_label="true"><option value=\"\"></option>
+                  no_label="true">
+            <option value=\"\"></option>
+            <option value="#{version1.id}">#{version1.name}</option>
+            <option value="#{version2.id}">#{version2.name}</option>
           </select>
         }).at_path('select')
       end
@@ -301,8 +317,10 @@ describe CustomFieldFormBuilder do
             <select class="custom-class form--select"
                     id="user#{resource.custom_field_id}"
                     name="user[#{resource.custom_field_id}]"
-                    no_label="true"><option value=\"\">---
-                    Please select ---</option>
+                    no_label="true">
+              <option value=\"\">--- Please select ---</option>
+              <option value="#{version1.id}">#{version1.name}</option>
+              <option value="#{version2.id}">#{version2.name}</option>
             </select>
           }).at_path('select')
         end


### PR DESCRIPTION
https://github.com/opf/openproject/compare/release/7.0...fix/user_cf_form_rendering?expand=1#diff-cde3106e6f2ae178ad8d77717ab5b37aL86

assumed to always get a list of custom options returned. For user/version cfs, a list of arrays [name, id] is returned instead. With the fix, the transformation of the values is handled within custom_field itself where the code can differentiate better.

https://community.openproject.com/projects/openproject/work_packages/25442