### PR TITLE
handle non existing properties on inline create default values

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -304,18 +304,22 @@ export class WorkPackageResource extends HalResource {
       });
   }
 
-  public allowedValuesFor(field:string): ng.IPromise<HalResource[]> {
+  public allowedValuesFor(field:string):ng.IPromise<HalResource[]> {
     var deferred = $q.defer();
 
     this.getForm().then((form:any) => {
-      const allowedValues = form.$embedded.schema[field].allowedValues;
+      const fieldSchema = form.$embedded.schema[field];
 
-      if (allowedValues && allowedValues['$load']) {
+      if (!fieldSchema) {
+        deferred.resolve([]);
+      } else if (fieldSchema.allowedValues && fieldSchema.allowedValues['$load']) {
+        let allowedValues = fieldSchema.allowedValues;
+
         return allowedValues.$load().then((loadedValues:CollectionResource) => {
           deferred.resolve(loadedValues.elements);
         });
       } else {
-        deferred.resolve(allowedValues);
+        deferred.resolve(fieldSchema.allowedValues);
       }
     });
 


### PR DESCRIPTION
OP has filters defined for non work package properties. E.g. there is no subprojectId property on the work package resource. We need to ignore those filters when determining the default value on inline created work packages

https://community.openproject.com/projects/openproject/work_packages/25455