### PR TITLE
Fix/loading indicator on query change

### DIFF
--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -90,7 +90,7 @@ function WorkPackagesListController($scope:any,
 
   // Teardown
   $scope.$on('$destroy', () => {
-    wpTableRefresh.clear("Table controller scope destroyed.");
+    wpTableRefresh.clear('Table controller scope destroyed.');
   });
 
   function setupQueryObservers() {
@@ -185,10 +185,10 @@ function WorkPackagesListController($scope:any,
    if (visibleLink.length) {
      visibleLink.focus();
    }
-  }
+  };
 
   function updateResults() {
-    return wpListService.reloadCurrentResultsList()
+    return wpListService.reloadCurrentResultsList();
   }
 
   function updateToFirstResultsPage() {

--- a/frontend/app/components/wp-query-select/wp-query-select.controller.ts
+++ b/frontend/app/components/wp-query-select/wp-query-select.controller.ts
@@ -62,7 +62,8 @@ export class WorkPackageQuerySelectController {
               private states:States,
               private wpListService:WorkPackagesListService,
               private contextMenu:ContextMenuService,
-              private I18n:op.I18n) {
+              private I18n:op.I18n,
+              private loadingIndicator:LoadingIndicatorService) {
 
     this.$scope.loaded = false;
     this.$scope.i18n = {
@@ -148,7 +149,7 @@ export class WorkPackageQuerySelectController {
   }
 
   private loadQuery(query:QueryResource) {
-    this.wpListService.reloadQuery(query);
+    this.loadingIndicator.table.promise = this.wpListService.reloadQuery(query);
     this.contextMenu.close();
   }
 

--- a/frontend/app/components/wp-query-select/wp-query-select.controller.ts
+++ b/frontend/app/components/wp-query-select/wp-query-select.controller.ts
@@ -32,6 +32,7 @@ import {States} from '../states.service';
 import {WorkPackagesListService} from '../wp-list/wp-list.service';
 import {ContextMenuService} from '../context-menus/context-menu.service';
 import {LoadingIndicatorService} from '../common/loading-indicator/loading-indicator.service';
+import {WorkPackagesListChecksumService} from '../wp-list/wp-list-checksum.service';
 
 interface IAutocompleteItem {
   label:string;
@@ -63,6 +64,7 @@ export class WorkPackageQuerySelectController {
               private wpListService:WorkPackagesListService,
               private contextMenu:ContextMenuService,
               private I18n:op.I18n,
+              private wpListChecksumService:WorkPackagesListChecksumService,
               private loadingIndicator:LoadingIndicatorService) {
 
     this.$scope.loaded = false;
@@ -149,6 +151,7 @@ export class WorkPackageQuerySelectController {
   }
 
   private loadQuery(query:QueryResource) {
+    this.wpListChecksumService.clear();
     this.loadingIndicator.table.promise = this.wpListService.reloadQuery(query);
     this.contextMenu.close();
   }


### PR DESCRIPTION
It:
* displays the loading indicator on query selection https://community.openproject.com/projects/openproject/work_packages/25454
* prevents loading the query (and it's form) twice by clearing the checksum service before the reload.