### PR TITLE
[25460] Only fire click when on dropdown handler

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -142,8 +142,13 @@
         $(it).on('touchstart', function(e) {
           // This shall avoid the hover event is fired,
           // which would otherwise lead to menu being closed directly after its opened.
+          // Ignore clicks from within the dropdown
+          if ($(e.target).closest('.menu-drop-down-container').length) {
+            return true;
+          }
           e.preventDefault();
           $(this).click();
+          return false;
         });
       });
     },

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -115,7 +115,7 @@ module Redmine::MenuManager::MenuHelper
       concat(content_tag(:ul,
                          style: 'display:none',
                          id: options[:drop_down_id],
-                         class: options[:drop_down_class],
+                         class: 'menu-drop-down-container ' + options.fetch(:drop_down_class, ''),
                          &block))
     end
   end


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/opf/openproject/pull/5602 while retaining the fix made there. Switching menus should still work.

https://community.openproject.com/projects/openproject/work_packages/25460