### PR TITLE
memoize custom_field evaluation for default_attribute_group

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -185,7 +185,9 @@ module Type::Attributes
   # Returns whether this type has the custom field currently
   # (e.g. because it was checked in the removed CF view).
   def has_custom_field?(attribute)
-    custom_field_ids.map { |id| "custom_field_#{id}" }.include? attribute
+    @has_custom_field_custom_field_ids ||= custom_field_ids.map { |id| "custom_field_#{id}" }
+
+    @has_custom_field_custom_field_ids.include? attribute
   end
 
   ##


### PR DESCRIPTION
This can become quite costly when the same calculation is done 200 times (for each custom field that could be active on the type)

In my test data it saves about 5% of the call to `/api/v3/work_packages`

Before:
![image](https://user-images.githubusercontent.com/617519/26933110-dd9d14b2-4c65-11e7-9bb3-d5d62963c963.png)

After:
![image](https://user-images.githubusercontent.com/617519/26933171-0daaca50-4c66-11e7-8cc4-aef310a4d5fc.png)
