### PR TITLE
Fix/sort version filter options

### DIFF
--- a/app/models/queries/versions.rb
+++ b/app/models/queries/versions.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -30,7 +31,10 @@
 module Queries::Versions
   register = ::Queries::Register
   filters = ::Queries::Versions::Filters
+  orders = ::Queries::Versions::Orders
   query = ::Queries::Versions::VersionQuery
 
   register.filter query, filters::SharingFilter
+
+  register.order query, orders::NameOrder
 end

--- a/app/models/queries/versions/orders/name_order.rb
+++ b/app/models/queries/versions/orders/name_order.rb
@@ -28,36 +28,22 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Queries
-      module Schemas
-        class VersionFilterDependencyRepresenter <
-          FilterDependencyRepresenter
+class Queries::Versions::Orders::NameOrder < Queries::BaseOrder
+  self.model = Version
 
-          def href_callback
-            order = "sortBy=#{to_query [%i(name asc)]}"
+  def self.key
+    :name
+  end
 
-            if filter.project.nil?
-              filter_params = [{ sharing: { operator: '=', values: ['system'] } }]
+  private
 
-              "#{api_v3_paths.versions}?filters=#{to_query filter_params}&#{order}"
-            else
-              "#{api_v3_paths.versions_by_project(filter.project.id)}?#{order}"
-            end
-          end
+  def order
+    ordered = Version.order_by_name
 
-          def type
-            "[]Version"
-          end
-
-          private
-
-          def to_query(param)
-            CGI.escape(::JSON.dump(param))
-          end
-        end
-      end
+    if direction == :desc
+      ordered = ordered.reverse_order
     end
+
+    ordered
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -35,6 +36,7 @@ class Version < ActiveRecord::Base
   after_update :update_issues_from_sharing_change
   belongs_to :project
   has_many :fixed_issues, class_name: 'WorkPackage', foreign_key: 'fixed_version_id', dependent: :nullify
+  has_many :work_packages, foreign_key: :fixed_version_id
   acts_as_customizable
 
   VERSION_STATUSES = %w(open locked closed)
@@ -56,6 +58,8 @@ class Version < ActiveRecord::Base
   }
 
   scope :systemwide, -> { where(sharing: 'system') }
+
+  scope :order_by_name, -> { order("LOWER(#{Version.table_name}.name)") }
 
   # Returns true if +user+ or current user is allowed to view the version
   def visible?(user = User.current)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -39,8 +39,8 @@ class Version < ActiveRecord::Base
   has_many :work_packages, foreign_key: :fixed_version_id
   acts_as_customizable
 
-  VERSION_STATUSES = %w(open locked closed)
-  VERSION_SHARINGS = %w(none descendants hierarchy tree system)
+  VERSION_STATUSES = %w(open locked closed).freeze
+  VERSION_SHARINGS = %w(none descendants hierarchy tree system).freeze
 
   validates_presence_of :name
   validates_uniqueness_of :name, scope: [:project_id]
@@ -89,10 +89,11 @@ class Version < ActiveRecord::Base
 
   # Returns the total reported time for this version
   def spent_hours
-    @spent_hours ||= TimeEntry.includes(:work_package)
-                     .where(["#{WorkPackage.table_name}.fixed_version_id = ?", id])
-                     .references(:work_packages)
-                     .sum(:hours).to_f
+    @spent_hours ||= TimeEntry
+                     .includes(:work_package)
+                     .where(work_packages: { fixed_version_id: id })
+                     .sum(:hours)
+                     .to_f
   end
 
   def closed?
@@ -105,15 +106,15 @@ class Version < ActiveRecord::Base
 
   # Returns true if the version is completed: due date reached and no open issues
   def completed?
-    effective_date && (effective_date <= Date.today) && (open_issues_count == 0)
+    effective_date && (effective_date <= Date.today) && open_issues_count.zero?
   end
 
   def behind_schedule?
     if completed_percent == 100
-      return false
+      false
     elsif due_date && start_date
       done_date = start_date + ((due_date - start_date + 1) * completed_percent / 100).floor
-      return done_date <= Date.today
+      done_date <= Date.today
     else
       false # No issues so it's not late
     end
@@ -122,9 +123,9 @@ class Version < ActiveRecord::Base
   # Returns the completion percentage of this version based on the amount of open/closed issues
   # and the time spent on the open issues.
   def completed_percent
-    if issues_count == 0
+    if issues_count.zero?
       0
-    elsif open_issues_count == 0
+    elsif open_issues_count.zero?
       100
     else
       issues_progress(false) + issues_progress(true)
@@ -134,7 +135,7 @@ class Version < ActiveRecord::Base
 
   # Returns the percentage of issues that have been marked as 'closed'.
   def closed_percent
-    if issues_count == 0
+    if issues_count.zero?
       0
     else
       issues_progress(false)
@@ -154,18 +155,12 @@ class Version < ActiveRecord::Base
 
   # Returns the total amount of open issues for this version.
   def open_issues_count
-    @open_issues_count ||= WorkPackage.where(["#{WorkPackage.table_name}.fixed_version_id = ? AND #{Status.table_name}.is_closed = ?", id, false])
-                           .includes(:status)
-                           .references(:statuses)
-                           .size
+    @open_issues_count ||= work_packages.merge(WorkPackage.open).size
   end
 
   # Returns the total amount of closed issues for this version.
   def closed_issues_count
-    @closed_issues_count ||= WorkPackage.where(["#{WorkPackage.table_name}.fixed_version_id = ? AND #{Status.table_name}.is_closed = ?", id, true])
-                             .includes(:status)
-                             .references(:statuses)
-                             .size
+    @closed_issues_count ||= work_packages.merge(WorkPackage.closed).size
   end
 
   def wiki_page
@@ -245,7 +240,7 @@ class Version < ActiveRecord::Base
   def estimated_average
     if @estimated_average.nil?
       average = fixed_issues.average(:estimated_hours).to_f
-      if average == 0
+      if average.zero?
         average = 1
       end
       @estimated_average = average
@@ -266,9 +261,9 @@ class Version < ActiveRecord::Base
       if issues_count > 0
         ratio = open ? 'done_ratio' : 100
 
-        done = fixed_issues.where(["#{Status.table_name}.is_closed = ?", !open])
+        done = fixed_issues
+               .where(statuses: { is_closed: !open })
                .includes(:status)
-               .references(:statuses)
                .sum("COALESCE(#{WorkPackage.table_name}.estimated_hours, #{estimated_average}) * #{ratio}")
         progress = done.to_f / (estimated_average * issues_count)
       end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -90,7 +90,12 @@ class WorkPackage < ActiveRecord::Base
   # >>> issues.rb >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   scope :open, ->() {
     includes(:status)
-      .where(statuses: { is_closed: false  })
+      .where(statuses: { is_closed: false })
+  }
+
+  scope :closed, ->() {
+    includes(:status)
+      .where(statuses: { is_closed: true })
   }
 
   scope :with_limit, ->(limit) {

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -33,7 +34,10 @@ module API
       class VersionsAPI < ::API::OpenProjectAPI
         resources :versions do
           get do
-            ::API::V3::Utilities::ParamsToQuery.collection_response(Version.visible(current_user),
+            # the distinct(false) is added in order to allow ORDER BY LOWER(name)
+            # which would otherwise be invalid in postgresql
+            # SELECT DISTINCT, ORDER BY expressions must appear in select list
+            ::API::V3::Utilities::ParamsToQuery.collection_response(Version.visible(current_user).distinct(false),
                                                                     current_user,
                                                                     params)
           end
@@ -49,7 +53,7 @@ module API
               def authorized_for_version?(version)
                 projects = version.projects
 
-                permissions = [:view_work_packages, :manage_versions]
+                permissions = %i(view_work_packages manage_versions)
 
                 authorize_any(permissions, projects: projects, user: current_user)
               end

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -42,9 +42,10 @@ module API
           end
 
           get do
-            VersionCollectionRepresenter.new(@versions,
-                                             api_v3_paths.versions_by_project(@project.id),
-                                             current_user: current_user)
+            ::API::V3::Utilities::ParamsToQuery.collection_response(@versions,
+                                                                    current_user,
+                                                                    params.except('id'),
+                                                                    self_link: api_v3_paths.versions_by_project(@project.id))
           end
         end
       end

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -49,6 +49,7 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
       describe 'values' do
         let(:path) { 'values' }
         let(:type) { '[]Version' }
+        let(:order) { "sortBy=#{CGI.escape(JSON.dump([%i(name asc)]))}" }
 
         context "for operator 'Queries::Operators::All'" do
           let(:operator) { Queries::Operators::All }
@@ -64,7 +65,7 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
 
         context 'within project' do
           let(:href) do
-            api_v3_paths.versions_by_project(project.id)
+            "#{api_v3_paths.versions_by_project(project.id)}?#{order}"
           end
 
           context "for operator 'Queries::Operators::Equals'" do
@@ -86,7 +87,7 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
             [{ sharing: { operator: '=', values: ['system'] } }]
           end
           let(:href) do
-            "#{api_v3_paths.types}?filters=#{CGI.escape(::JSON.dump(filter_params))}"
+            "#{api_v3_paths.versions}?filters=#{CGI.escape(::JSON.dump(filter_params))}&#{order}"
           end
 
           context "for operator 'Queries::Operators::Equals'" do

--- a/spec_legacy/unit/version_spec.rb
+++ b/spec_legacy/unit/version_spec.rb
@@ -26,7 +26,7 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Version, type: :model do
   fixtures :all


### PR DESCRIPTION
Adds the `name` order to the version query and employs it to order the version filter options alphabetically: https://community.openproject.com/projects/openproject/work_packages/25465

Additionally, it fixes the version filter options for global queries which used to return types instead of versions.