### PR TITLE
add fs relation to seed

### DIFF
--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -103,7 +103,8 @@ module DemoData
                             show_hierarchies: true,
                             timeline_visible: true,
                             column_names: [:subject, :type, :status],
-                            sort_criteria: [['id', 'asc']]
+                            sort_criteria: [['id', 'asc']],
+                            timeline_zoom_level: 'weeks'
 
       MenuItems::QueryMenuItem.create! navigatable_id: query.id,
                                        name: SecureRandom.uuid,

--- a/config/locales/en.seeders.yml
+++ b/config/locales/en.seeders.yml
@@ -75,14 +75,14 @@ en:
           status_name: :default_status_in_progress
           type_name: :default_type_phase
           start: 1
-          duration: 14
+          duration: 9
           relations: []
           children: []
 
         - subject: Development
           status_name: :default_status_scheduled
           type_name: :default_type_phase
-          start: 14
+          start: 10
           duration: 26
           relations:
             - to: 'Project planning'
@@ -91,7 +91,7 @@ en:
           - subject: Great feature
             status_name: :default_status_developed
             type_name: :default_type_feature
-            start: 14
+            start: 10
             duration: 11
             version: Sprint 1
             relations: []
@@ -99,8 +99,8 @@ en:
           - subject: Best feature
             status_name: :default_status_specified
             type_name: :default_type_feature
-            start: 25
-            duration: 8
+            start: 21
+            duration: 5
             version: Sprint 2
             relations:
               - to: 'Great feature'
@@ -109,15 +109,17 @@ en:
           - subject: Terrible bug
             status_name: :default_status_confirmed
             type_name: :default_type_bug
-            start: 30
-            duration: 3
+            start: 26
+            duration: 2
             version: Sprint 1
-            relations: []
+            relations:
+              - to: 'Best feature'
+                type: 'follows'
 
         - subject: Go-Live
           status_name: :default_status_scheduled
           type_name: :default_type_milestone
-          start: 37
+          start: 32
           duration: 1
           relations:
             - to: 'Development'


### PR DESCRIPTION
On top of what the wp specified, I reduced the length of the phases (had to adapt them anyway) in order to have more of the timeline displayed on the screen. 
https://community.openproject.com/projects/openproject/work_packages/25488

The zoom level is also adapted in accordance with
https://community.openproject.com/projects/openproject/work_packages/25489

Formerly:

![image](https://user-images.githubusercontent.com/617519/27024002-45a9e764-4f55-11e7-9f4e-ca02e969d754.png)

Now:

![image](https://user-images.githubusercontent.com/617519/27024853-9aee068a-4f58-11e7-99dd-61d78252effd.png)

