### PR TITLE
fix wp subject display in ff

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -87,6 +87,13 @@ table.generic-table tbody tr.issue .checkbox
 .wp-table--cell .ui-datepicker
   margin-left: -38%
 
+.wp-table--cell-container
+  @extend .ellipsis
+  display: block
+  pointer-events: none
+
+  .inplace-edit
+    pointer-events: all
 
 .inplace-editing--container
   display: inline-block

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -90,6 +90,11 @@ table.generic-table tbody tr.issue .checkbox
 .wp-table--cell-container
   @extend .ellipsis
   display: block
+  // Because of the display: block the elements now
+  // take up the whole of the cell. This would block
+  // the user from using click (to select) or double-click (to open full screen)
+  // on the cell. Hence we disable events on this element but have to reenable them
+  // for the inplace-edit fields.
   pointer-events: none
 
   .inplace-edit

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -4,6 +4,7 @@
 // collapsed: left arrow
 .wp-table--hierarchy-indicator
   @include varprop(color, body-font-color)
+  pointer-events: all
 
   &:hover
     text-decoration: none
@@ -25,6 +26,7 @@
   float: left
   margin-left: 5px
   padding-right: 8px
+  pointer-events: none
   height: 1rem
   // width calculation done in js code
 

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -21,9 +21,12 @@
 
 .wp-table--hierarchy-span
   text-align: end
-  display: inline-block
+  display: block
+  float: left
   margin-left: 5px
   padding-right: 8px
+  height: 1rem
+  // width calculation done in js code
 
 .wp-table--hierarchy-indicator-icon
   @include icon-common

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -26,6 +26,8 @@
   float: left
   margin-left: 5px
   padding-right: 8px
+  // Avoid catching double click/click events
+  // meant to open the full screen view
   pointer-events: none
   height: 1rem
   // width calculation done in js code

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -154,14 +154,6 @@ export class SingleHierarchyRowBuilder extends RowRefreshBuilder {
     hierarchyIndicator.classList.add(hierarchyCellClassName);
     hierarchyIndicator.style.width = indicatorWidth;
 
-    // Set the width of the container
-    if (jRow != null) {
-      jRow
-        .find('td.subject .wp-table--cell-container')
-        .css('width', `calc(100% - ${indicatorWidth})`)
-        .css('display', 'inline-block');
-    }
-
     if (workPackage.$loaded && !hasChildrenInTable(workPackage, this.workPackageTable)) {
       hierarchyIndicator.innerHTML = `
             <span tabindex="0" class="wp-table--leaf-indicator">


### PR DESCRIPTION
The subject used to be hidden because the width calculation was off. Instead of tempering with the width calculcation, I decided to use float instead so that we end up with fewer objects having their width calculated in js

https://community.openproject.com/projects/openproject/work_packages/25520

also fixes:

https://community.openproject.com/projects/openproject/work_packages/25493

by controlling the `pointer-events`