### PR TITLE
Improve timeline update performance

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resource-dms/query-dm.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-dms/query-dm.service.ts
@@ -86,6 +86,27 @@ export class QueryDmService {
     return this.halRequest.get(url, queryData, {caching: {enabled: false} });
   }
 
+  public loadIdsUpdatedSince(ids:any, timestamp:any):ng.IPromise<WorkPackageCollectionResource> {
+    const filters = [
+      {
+        id: {
+          operator: '=',
+          values: ids.filter((n:String|null) => n) // no null values
+        },
+      },
+      {
+        updatedAt: {
+          operator: '<>d',
+          values: [timestamp, '']
+        }
+      }
+    ];
+
+    return this.halRequest.get(this.v3Path.wps(),
+                               {filters: JSON.stringify(filters)},
+                               {caching: {enabled: false} });
+  }
+
   public save(query:QueryResource, form:FormResource) {
     return this.extractPayload(query, form).then(payload => {
       return query.updateImmediately(payload);


### PR DESCRIPTION
Instead of visually (via spinner) waiting for the update of all the work packages after moving a wp in timeline, we can split the process up into two steps:

1) Visually wait for a request getting all currently visible work packages updated since the work package has been moved. This will get all the dates possibly updated by moving a work package with relations/parents/children the user is waiting for.
2) Refresh the query results (invisibly) to get all work packages not currently displayed that might have been updated by moving the work packages. 

This means that we will only show the spinner until the first step completes.

Of course, this adds another request to the update process resulting in a higher server load. But the user's subjective perception of the update will improve as the spinner is displayed less long, even though a request is still running. How much time is saved depends on the number of work packages that have been updated by moving work packages and that thus have been updated since. As a worst case scenario, the update spinner will hence be shown just as long as without the change. But if the work packages are not all interconnected, the first request will take less time than. If only one relationship exists, the change reduces the perceived time necessary for the update by 600ms on my machine when displaying 100 work packages. 

![image](https://user-images.githubusercontent.com/617519/27072107-9e9785fa-501f-11e7-9ff2-e507037c7c5a.png)

In the scenario described above, the change reduces the time a user has to wait after an update by almost 40%.


https://community.openproject.com/projects/openproject/work_packages/26109/activity