### PR TITLE
bump mail to get rid of gemnasium security warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem 'activerecord-session_store', '~> 1.0.0'
 gem 'rails', '~> 5.0.3'
 gem 'responders', '~> 2.4'
 
+# TODO: remove once 2.6.6 has been released
+gem 'mail', '~> 2.6.6.rc1'
+
 gem 'coderay', '~> 1.1.0'
 gem 'rubytree', git: 'https://github.com/dr0verride/RubyTree.git', ref: '06f53ee'
 gem 'rdoc', '>= 2.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
       tilt
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.5)
+    mail (2.6.6)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.3)
@@ -666,6 +666,7 @@ DEPENDENCIES
   launchy (~> 2.4.3)
   letter_opener
   livingstyleguide (~> 2.0.1)
+  mail (~> 2.6.6.rc1)
   multi_json (~> 1.12.1)
   mysql2 (~> 0.4.4)
   net-ldap (~> 0.16.0)


### PR DESCRIPTION
OP is not affected by the vulnerability as:
* We limit the length of mail fields
* 2.6.x is not vulnerable at all (https://github.com/mikel/mail/pull/1097#issuecomment-301380415)

But gemnasium complains and this produces a red badge which looks bad.

![image](https://user-images.githubusercontent.com/617519/27075226-ceff0f10-5029-11e7-8614-5b80e846f8bf.png)

The rc has been around for some time now, so it should be stable enough.

I expect to bump the version once the official 2.6.6 has been released.