### PR TITLE
Bump omniauth to silence hashie warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'rubytree', git: 'https://github.com/dr0verride/RubyTree.git', ref: '06f53ee
 gem 'rdoc', '>= 2.4.2'
 
 gem 'globalize', git: 'https://github.com/globalize/globalize', ref: '38443bcd', require: false
-gem 'omniauth', git: 'https://github.com/oliverguenther/omniauth', ref: '8385bc0'
+gem 'omniauth', git: 'https://github.com/oliverguenther/omniauth', ref: '40c6f5f751d2da7cce5444bbd96c390c450440a9'
 gem 'request_store', '~> 1.3.1'
 gem 'gravatar_image_tag', '~> 1.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,12 +51,12 @@ GIT
 
 GIT
   remote: https://github.com/oliverguenther/omniauth
-  revision: 8385bc0da47e4fc4f4a256c97725bcf8215d13c2
-  ref: 8385bc0
+  revision: 40c6f5f751d2da7cce5444bbd96c390c450440a9
+  ref: 40c6f5f751d2da7cce5444bbd96c390c450440a9
   specs:
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
 
 GIT
   remote: https://github.com/opf/openproject-translations.git


### PR DESCRIPTION
Fixes hashie warnings of the kind

```
You are setting a key that conflicts with a built-in method Foo#bar.
```

Warnings have been silenced in: https://github.com/omniauth/omniauth/pull/874

Since our PR (https://github.com/omniauth/omniauth/pull/837) has not been answered, we maintain our own fork, which I've just updated to the last released version.