### PR TITLE
[25534] Fix needless escaping with jquery-ui

### DIFF
--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.directive.ts
@@ -83,7 +83,7 @@ function wpRelationsAutocompleteDirective(
 
       function getIdentifier(workPackage:WorkPackageResourceInterface):string {
         if (workPackage) {
-          return _.escape(`#${workPackage.id} - ${workPackage.subject}`);
+          return `#${workPackage.id} - ${workPackage.subject}`;
         } else {
           return '';
         }


### PR DESCRIPTION
The `_.escape` was used for the typehead that was since replaced by ui-autocompleter,
which uses a text node to insert the label:

https://github.com/jquery/jquery-ui/blob/master/ui/widgets/autocomplete.js#L568

Thus the escape is no longer necessary.

https://community.openproject.com/projects/openproject/work_packages/25534/activity?query_id=930