### PR TITLE
[25464] Optional additional_boot instructions to evaluate early

### DIFF
--- a/config/additional_boot.rb.example
+++ b/config/additional_boot.rb.example
@@ -1,0 +1,8 @@
+# Copy this file to additional_boot.rb and add any statements
+# that should run prior to Rails booting.
+#
+# Example:
+#
+# Silence Hashie warnings in OpenProject 7.0.x
+# require 'hashie'
+# Hashie.logger = Logger.new(nil)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -29,4 +29,11 @@
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
+# Load any local boot extras that is kept out of source control
+# (e.g., silencing of deprecations)
+if File.exists?(File.join(File.dirname(__FILE__), 'additional_boot.rb'))
+  instance_eval File.read(File.join(File.dirname(__FILE__), 'additional_boot.rb'))
+end
+
+
 require 'bundler/setup' # Set up gems listed in the Gemfile.


### PR DESCRIPTION
The hashie warnings from 25464 are evalauted early on while bundler requires all necessary gems,
so silencing them is not possible without modifications to the code, subject to be overridden on each release.

Since there may be other instructions before Rails boots, let's add a simple `additional_boot.rb` functionality
similary to the `additional_environment.rb`, that a user MAY use to provide these statements.

https://community.openproject.com/projects/openproject/work_packages/25464/activity