### PR TITLE
Fix/remove relation columns from export

### DIFF
--- a/app/helpers/timelog_helper.rb
+++ b/app/helpers/timelog_helper.rb
@@ -29,7 +29,6 @@
 
 module TimelogHelper
   include ApplicationHelper
-  include WorkPackage::CsvExporter
 
   def render_timelog_breadcrumb
     links = []
@@ -114,7 +113,7 @@ module TimelogHelper
       # Export custom fields
       headers += custom_fields.map(&:name)
 
-      csv << encode_csv_columns(headers)
+      csv << WorkPackage::Exporter::CSV.encode_csv_columns(headers)
       # csv lines
       entries.each do |entry|
         fields = [format_date(entry.spent_on),
@@ -129,7 +128,7 @@ module TimelogHelper
                  ]
         fields += custom_fields.map { |f| show_value(entry.custom_value_for(f)) }
 
-        csv << encode_csv_columns(fields)
+        csv << WorkPackage::Exporter::CSV.encode_csv_columns(fields)
       end
     }
     export

--- a/app/models/work_package/exporter/error.rb
+++ b/app/models/work_package/exporter/error.rb
@@ -28,37 +28,14 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module WorkPackage::Exporter
-  def self.for_list(type)
-    @for_list[type]
+class WorkPackage::Exporter::Error < WorkPackage::Exporter::Result
+  attr_accessor :message
+
+  def initialize(message)
+    self.message = message
   end
 
-  def self.register_for_list(type, exporter)
-    @for_list ||= {}
-
-    @for_list[type] = exporter
+  def error?
+    true
   end
-
-  def self.list_formats
-    @for_list.keys
-  end
-
-  def self.for_single(type)
-    @for_single[type]
-  end
-
-  def self.register_for_single(type, exporter)
-    @for_single ||= {}
-
-    @for_single[type] = exporter
-  end
-
-  def self.single_formats
-    @for_single.keys
-  end
-
-  register_for_list(:csv, WorkPackage::Exporter::CSV)
-  register_for_list(:pdf, WorkPackage::Exporter::PDF)
-
-  register_for_single(:pdf, WorkPackage::Exporter::PDF)
 end

--- a/app/models/work_package/exporter/pdf.rb
+++ b/app/models/work_package/exporter/pdf.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,26 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-
-describe WorkPackagesController, type: :controller do
-  let(:user) { FactoryGirl.create :admin }
-  let(:project) { FactoryGirl.create :project, identifier: "exp" }
-
-  before do
-    allow(User).to receive(:current).and_return user
+class WorkPackage::Exporter::PDF < WorkPackage::Exporter::Base
+  # Returns a PDF string of a list of work_packages
+  def list
+    ::WorkPackage::PdfExport::WorkPackageListToPdf
+      .new(query,
+           options)
+      .render!
   end
 
-  describe "#index .pdf" do
-    before do
-      expect(WorkPackage::Exporter)
-        .to receive(:pdf).and_raise(Prawn::Errors::CannotFit)
-
-      get :index, format: "pdf"
-    end
-
-    it "should redirect to the html index and show an error message" do
-      expect(flash[:error].downcase).to include("too many columns")
-    end
+  # Returns a PDF string of a single work_package
+  def single
+    ::WorkPackage::PdfExport::WorkPackageToPdf
+      .new(work_package)
+      .render!
   end
 end

--- a/app/models/work_package/exporter/result.rb
+++ b/app/models/work_package/exporter/result.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,22 +28,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module WorkPackage::PdfExporter
-  # Returns a PDF string of a list of work_packages
-  def pdf(work_packages, project, query, results, options = {})
-    ::WorkPackage::PdfExport::WorkPackageListToPdf
-      .new(work_packages,
-           project,
-           query,
-           results,
-           options)
-      .render!
-  end
-
-  # Returns a PDF string of a single work_package
-  def work_package_to_pdf(work_package)
-    ::WorkPackage::PdfExport::WorkPackageToPdf
-      .new(work_package)
-      .render!
+class WorkPackage::Exporter::Result
+  def error?
+    false
   end
 end

--- a/app/models/work_package/exporter/success.rb
+++ b/app/models/work_package/exporter/success.rb
@@ -28,37 +28,16 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module WorkPackage::Exporter
-  def self.for_list(type)
-    @for_list[type]
+class WorkPackage::Exporter::Success < WorkPackage::Exporter::Result
+  attr_accessor :format,
+                :title,
+                :content,
+                :mime_type
+
+  def initialize(format:, title:, content:, mime_type:)
+    self.format = format
+    self.title = title
+    self.content = content
+    self.mime_type = mime_type
   end
-
-  def self.register_for_list(type, exporter)
-    @for_list ||= {}
-
-    @for_list[type] = exporter
-  end
-
-  def self.list_formats
-    @for_list.keys
-  end
-
-  def self.for_single(type)
-    @for_single[type]
-  end
-
-  def self.register_for_single(type, exporter)
-    @for_single ||= {}
-
-    @for_single[type] = exporter
-  end
-
-  def self.single_formats
-    @for_single.keys
-  end
-
-  register_for_list(:csv, WorkPackage::Exporter::CSV)
-  register_for_list(:pdf, WorkPackage::Exporter::PDF)
-
-  register_for_single(:pdf, WorkPackage::Exporter::PDF)
 end

--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -44,6 +45,18 @@ module WorkPackage::PdfExport::Common
     else
       value.to_s
     end
+  end
+
+  def success(content)
+    WorkPackage::Exporter::Success
+      .new format: :csv,
+           title: title,
+           content: content,
+           mime_type: 'application/pdf'
+  end
+
+  def error(message)
+    WorkPackage::Exporter::Error.new message
   end
 
   def cell_padding

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,24 +28,16 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackage::PdfExport::WorkPackageListToPdf
+class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PdfExport::Common
 
-  attr_accessor :work_packages,
-                :pdf,
-                :project,
-                :query,
-                :results,
+  attr_accessor :pdf,
                 :options
 
-  def initialize(work_packages, project, query, results, options = {})
-    @cell_padding = options.delete(:cell_padding)
+  def initialize(object, options = {})
+    super
 
-    self.work_packages = work_packages
-    self.project = project
-    self.query = query
-    self.results = results
-    self.options = options
+    @cell_padding = options.delete(:cell_padding)
 
     self.pdf = get_pdf(current_language)
 
@@ -58,7 +51,13 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
 
     write_footers!
 
-    pdf
+    success(pdf.render)
+  rescue Prawn::Errors::CannotFit
+    error(I18n.t(:error_pdf_export_too_many_columns))
+  end
+
+  def project
+    query.project
   end
 
   def write_title!
@@ -94,7 +93,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
   end
 
   def column_widths
-    widths = query.columns.map do |col|
+    widths = valid_export_columns.map do |col|
       if col.name == :subject || text_column?(col)
         4.0
       else
@@ -107,7 +106,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
   end
 
   def description_colspan
-    query.columns.size
+    valid_export_columns.size
   end
 
   def text_column?(column)
@@ -120,7 +119,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
   end
 
   def data_headers
-    query.columns.map(&:caption).map do |caption|
+    valid_export_columns.map(&:caption).map do |caption|
       pdf.make_cell caption, font_style: :bold, background_color: 'CCCCCC'
     end
   end
@@ -129,7 +128,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
     previous_group = nil
 
     work_packages.flat_map do |work_package|
-      values = query.columns.map do |column|
+      values = valid_export_columns.map do |column|
         make_column_value work_package, column
       end
 
@@ -147,7 +146,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf
 
         result.insert 0, [
           pdf.make_cell(label, font_style: :bold,
-                               colspan: query.columns.size,
+                               colspan: valid_export_columns.size,
                                background_color: 'DDDDDD')
         ]
       end

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,14 +28,14 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackage::PdfExport::WorkPackageToPdf
+class WorkPackage::PdfExport::WorkPackageToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PdfExport::Common
 
-  attr_accessor :work_package,
-                :pdf
+  attr_accessor :pdf
 
   def initialize(work_package)
-    self.work_package = work_package
+    super
+
     self.pdf = get_pdf(current_language)
   end
 
@@ -45,7 +46,7 @@ class WorkPackage::PdfExport::WorkPackageToPdf
     write_attachments!
     write_footers!
 
-    pdf
+    success(pdf.render)
   end
 
   def make_attribute_row(first_attribute, second_attribute)
@@ -75,7 +76,8 @@ class WorkPackage::PdfExport::WorkPackageToPdf
   def make_attribute_cells(attribute, label_options: {}, value_options: {})
     label = pdf.make_cell(
       WorkPackage.human_attribute_name(attribute) + ':',
-      label_options)
+      label_options
+    )
 
     value_content = field_value work_package, attribute
     value = pdf.make_cell(value_content.to_s, value_options)
@@ -146,10 +148,14 @@ class WorkPackage::PdfExport::WorkPackageToPdf
   end
 
   def write_title!
-    pdf.title = "#{work_package.project} - ##{work_package.type} #{work_package.id}"
+    pdf.title = title
     pdf.font style: :bold, size: 11
     pdf.text "#{work_package.project} - #{work_package.type} # #{work_package.id}: #{work_package.subject}"
     pdf.move_down 20
+  end
+
+  def title
+    "#{work_package.project} - ##{work_package.type} #{work_package.id}"
   end
 
   def write_attributes!


### PR DESCRIPTION
Removes the relation columns (`RelationToTypeColumn`, `RelationOfTypeColumn`) from the exports as they would always be blank (https://community.openproject.com/projects/openproject/work_packages/25472)

To avoid having to spread this information throughout the various exporters, the PR provides a common interface the exporters. Doing this, we can streamline the code in the `WorkPackagesController`. Unfortunately, I didn't get around to clean up the PDF exporter internally, so it is still pretty messy there.

The exporters make use of a registration mechanism that the xls plugin will then also employ. 