### PR TITLE
limit query selection dropdown height

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -272,6 +272,9 @@
     top:   24px
     right: 22px
     color: #999999
+  .ui-widget-content.-inplace
+    max-height: 55vh
+    overflow-x: scroll
 
   input[type="search"]::-webkit-search-cancel-button
     display: none


### PR DESCRIPTION
Limits the height of the query selection dropdown and allows scrolling:

![image](https://user-images.githubusercontent.com/617519/27173033-9aeda030-51b7-11e7-8207-e065509dfbb0.png)

https://community.openproject.com/projects/openproject/work_packages/25572

I did not address the color inconsistency mentioned in the ticket as this is fixed in dev and not that urgent. 