### PR TITLE
fix bulk destroy for wps of more than one project

### DIFF
--- a/app/views/work_packages/bulk/destroy.html.erb
+++ b/app/views/work_packages/bulk/destroy.html.erb
@@ -81,11 +81,10 @@ See doc/COPYRIGHT.rdoc for more details.
             concat content_tag :i, '', class: 'button--icon icon-delete'
             concat content_tag :span, l(:button_delete), class: 'button--text'
             end %>
-      <%= link_to project_work_packages_path(@project),
-          title: l(:button_cancel),
-          class: 'button -with-icon icon-cancel' do %>
-            <%= l(:button_cancel) %>
-          <% end %>
+      <%= link_to_function l(:button_cancel),
+                           "history.back()",
+                           title: l(:button_cancel),
+                           class: 'button -with-icon icon-cancel'%>
   </section>
 
 <% end %>


### PR DESCRIPTION
In the scenario of destroying work packages from multiple projects at once, @project is undefined. As such, we cannot render a project specific path. But we can simply go back in history.

https://community.openproject.com/projects/openproject/work_packages/25569