### PR TITLE
[25573] Implement basic health check

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,68 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+# Does NOT inherit from ApplicationController by design
+# so we're free from any before_actions
+class HealthCheckController < ActionController::Base
+  ##
+  # perform a check select on the database and return with HTTP 200 if it
+  # succeeded or HTTP 500 if it failed for some reason
+  def application
+    send_db_ping
+    render text: 'ALIVE', status: 200
+  rescue => e
+    Rails.logger.error "Error during health check: #{e}"
+    render text: 'ERROR', status: 500
+  end
+
+  ##
+  # perform a check to determine whether any delayed jobs are not being run
+  def delayed_jobs
+    never_ran = Delayed::Job.where('run_at <= ?', 5.minutes.ago).count
+
+    if never_ran > 0
+      render text: "#{never_ran} delayed jobs were never executed.", status: 500
+    else
+      render nothing: true, status: 200
+    end
+  rescue => e
+    Rails.logger.error "Error during delayed_job health check: #{e}"
+    render text: 'Internal error', status: 500
+  end
+
+  # Do not log the checks into the default log.
+  def logger
+    @logger ||= Logger.new(StringIO.new)
+  end
+
+  # Simplest database alive check
+  def send_db_ping
+    ActiveRecord::Base.connection.execute('SELECT 1;')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,14 @@ OpenProject::Application.routes.draw do
     get '/logout', action: 'logout', as: 'signout'
   end
 
+  # Health check
+  # Keep previous route from openproject-check
+  get 'check', to: 'health_check#application'
+  scope 'health_check', controller: 'health_check' do
+    get '/application', action: 'application'
+    get '/jobs', action: 'delayed_jobs'
+  end
+
   namespace :api do
     namespace :v2 do
       resources :authentication

--- a/spec/controllers/health_check_controller_spec.rb
+++ b/spec/controllers/health_check_controller_spec.rb
@@ -1,0 +1,81 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe HealthCheckController, type: :controller do
+  describe '#application' do
+    let(:request) { get :application }
+
+    context 'when okay' do
+      it 'returns 200 OK' do
+        request
+
+        expect(response.status).to eq(200)
+        expect(response.body).to match /ALIVE/
+      end
+    end
+
+    context 'when database error' do
+      it 'returns 200 OK' do
+        expect(controller).to receive(:send_db_ping).and_raise('ERROR!')
+
+        request
+
+        expect(response.status).to eq(500)
+        expect(response.body).to match /ERROR/
+      end
+    end
+  end
+
+  describe '#jobs' do
+    let(:request) { get :delayed_jobs }
+
+    context 'when okay' do
+      it 'returns 200 OK' do
+        expect(Delayed::Job).to receive_message_chain(:where, :count).and_return 0
+
+        request
+
+        expect(response.status).to eq(200)
+        expect(response.body).to be_empty
+      end
+    end
+
+    context 'when unfinished jobs exist' do
+      it 'returns 200 OK' do
+        expect(Delayed::Job).to receive_message_chain(:where, :count).and_return 10
+
+        request
+
+        expect(response.status).to eq(500)
+        expect(response.body).to include '10 delayed jobs were never executed.'
+      end
+    end
+  end
+end

--- a/spec/routing/health_check_routing_spec.rb
+++ b/spec/routing/health_check_routing_spec.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe HealthCheckController, type: :routing do
+  it 'should route health check routes' do
+    expect(get('/check')).to route_to(controller: 'health_check', action: 'application')
+    expect(get('/health_check/application')).to route_to(controller: 'health_check', action: 'application')
+    expect(get('/health_check/jobs')).to route_to(controller: 'health_check', action: 'delayed_jobs')
+  end
+end


### PR DESCRIPTION
This takes over the functionality of https://github.com/finnlabs/openproject-check/tree/stable/7, letting it keep the `/check` syntax for consistency with current deployments and adds two health checks:

`/health_check/application`: Does a simple DB ping to check whether it's still active
`/health_check/jobs`: Counts delayed jobs that should have ran in the past with no current attempts