### PR TITLE
deal with wildcard in http accept language header

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -153,6 +153,7 @@ module Redmine
     ##
     # Returns the given language if it is valid or nil otherwise.
     def find_language(lang)
+      return nil unless lang =~ /[a-z-]+/i
       valid_languages.detect { |l| l =~ /#{lang}/i } if lang.present?
     end
 

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -150,6 +150,12 @@ module OpenProject
       it 'can be found by uppercase if it is active' do
         expect(find_language(:DE)).to eql :de
       end
+
+      it 'is nil if non valid string is passed' do
+        expect(find_language('*')).to be_nil
+        expect(find_language('78445')).to be_nil
+        expect(find_language('/)(')).to be_nil
+      end
     end
 
     describe 'link_translation' do

--- a/spec/services/set_localization_service_spec.rb
+++ b/spec/services/set_localization_service_spec.rb
@@ -106,6 +106,12 @@ describe SetLocalizationService do
 
         it_behaves_like "falls back to the instane's default language"
       end
+
+      context 'with wildcard header set' do
+        let(:http_accept_language) { '*' }
+
+        it_behaves_like "falls back to the instane's default language"
+      end
     end
   end
 
@@ -116,6 +122,12 @@ describe SetLocalizationService do
 
     context 'with no header set' do
       let(:http_accept_header) { nil }
+
+      it_behaves_like "falls back to the instane's default language"
+    end
+
+    context 'with a wildcard header set' do
+      let(:http_accept_language) { '*' }
 
       it_behaves_like "falls back to the instane's default language"
     end


### PR DESCRIPTION
Having a * in the HTTP_ACCEPT_LANGUAGE header is valid, but OP did not
deal with it correctly. On top of that, it accepted every input from
that header and turned it into a regexp.

Fixes errors like:
![image](https://user-images.githubusercontent.com/617519/27280950-26bdb354-54ea-11e7-9f66-76c309561295.png)
