### PR TITLE
Change layouting rules  for main-menu versus right content to be flex based in order to get proper full height columns.

### DIFF
--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -39,7 +39,7 @@ body
 
 #wrapper
   @include default-transition
-  @include varprop(background-color, main-menu-bg-color)
+  @include varprop(background-color, body-background)
   background-size: $main-menu-width 100%
   min-height: 100%
   height: auto
@@ -51,6 +51,7 @@ body
 
 
 #main
+  display: flex
   width:    100%
   z-index:  20
   overflow: auto
@@ -66,40 +67,45 @@ body
     border-bottom-style: solid
     @include varprop(border-bottom-color, footer-bg-color)
 
+    #content-wrapper
+      &.hidden-navigation
+        margin-left: $main-menu-folded-width
+        width: calc(100% - #{$main-menu-folded-width})
+
+      &.nosidebar
+        padding: 0
+        width:    100%
+        margin-left: 0
+
+      &.nomenus
+        top: 0
+        padding: 0
+        width: 100%
+        margin-left: 0
+
   &.nomenus
     padding-bottom: 0
     overflow: hidden
 
-    %absolute-layout-mode &
-      top:    0
 
-#content
+#content-wrapper
   @include default-transition
-  margin: 0 0 0 $main-menu-width
+  margin: 0 0 0 0
   padding: 10px 20px
   width: auto
-  overflow: hidden
   height: auto
   background-color: #fff
-  z-index: 10
+  width: 100%
 
   %absolute-layout-mode &
     position:   absolute
-    width:      calc(100% - #{$main-menu-width})
     height:     100%
-
-  &.hidden-navigation
-    margin-left: $main-menu-folded-width
-
-    %absolute-layout-mode &
-      width:    calc(100% - #{$main-menu-folded-width})
+    width: calc(100% - #{$main-menu-width})
+    margin-left: $main-menu-width
 
   &.nosidebar
     margin-left: 0
     padding: 20px 40px
-
-    %absolute-layout-mode &
-      width:    100%
 
   &.nomenus
     margin:     0
@@ -115,6 +121,16 @@ body
     height: 0
     clear: both
     visibility: hidden
+
+#content
+  padding: 0
+  margin: 0 0 0 0
+  overflow: hidden
+  width: 100%
+  height: 100%
+  z-index: 10
+  background-color: #fff
+
 
 .-draggable
   cursor: move

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -37,7 +37,6 @@
   background: none repeat scroll 0 0
   @include varprop(background-color, body-background)
   border: none
-  margin: 0 0 0 ($main-menu-width - $main-menu-item-border-width)
   width: auto
   overflow: hidden
   position: relative
@@ -47,8 +46,6 @@
     padding-left: 33px
     ul
       margin: 0
-  &.hidden-navigation
-    margin-left: $main-menu-folded-width
 
   a
     font-size: 12px
@@ -67,7 +64,7 @@
     display: block
 
 ul.breadcrumb
-  margin: 0 0 0 13px
+  margin: 0 0 0 0
   padding: 0
   list-style: none
   list-style-position: outside

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -34,9 +34,8 @@ $toggler-width: 40px
   float: left
   left: 0
   border-right: $main-menu-border-width solid $main-menu-border-color
-  position: absolute
   // min-height is full height minus header and footer.
-  min-height: calc(100% - 55px - 55px)
+  min-height: calc(100vh - 55px - 55px)
   @include varprop(background-color, main-menu-bg-color)
   @include default-transition
   @include breakpoint(680px down)
@@ -47,7 +46,9 @@ $toggler-width: 40px
     height: calc(100% - 40px)
   %absolute-layout-mode &
     position: relative
-    height:   100%
+    // In WP list, the footer is just a 5px border:
+    min-height: calc(100vh - 55px - 5px)
+  
     #menu-sidebar
       +allow-vertical-scrolling
       -ms-overflow-style: -ms-autohiding-scrollbar

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -32,6 +32,7 @@
 
   #main-menu
     position: absolute !important
+    min-height: initial !important
     height: initial !important
     overflow: auto
     z-index: 11

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -35,15 +35,37 @@
       overflow-y: scroll !important
 
       #main,
+      #content-wrapper,
       #content
         position: relative !important
+        width: 100%
+        margin-left: 0
+
+
+      #content-wrapper,
+      #content
+        height: 100% !important
+        overflow: visible
 
       #main
         padding-bottom: 0
 
-      #content
-        height: 100% !important
-        overflow: visible
+        #content-wrapper
+          &.hidden-navigation
+            margin-left: 0
+            width: 100%
+
+          &.nosidebar
+            padding: 0
+            width:    100%
+            margin-left: 0
+
+          &.nomenus
+            top: 0
+            padding: 0
+            width: 100%
+            margin-left: 0
+
 
       .work-packages--show-view
         padding: 0 0 0 5px
@@ -128,4 +150,3 @@
       margin: 0 !important
       padding: 8px 0 !important
       font-size: 1rem
-

--- a/app/assets/stylesheets/layout/_work_package_table.sass
+++ b/app/assets/stylesheets/layout/_work_package_table.sass
@@ -31,6 +31,7 @@
 .controller-work_packages.full-create
   @extend %absolute-layout-mode
 
+  #content-wrapper,
   #content
     padding: 0
 
@@ -239,6 +240,7 @@
   .controller-work_packages.action-index
     #main
       overflow: overlay
+    #content-wrapper,
     #content
       overflow-y: auto
 
@@ -254,7 +256,3 @@
         -webkit-column-break-inside: avoid
         page-break-inside: avoid
         break-inside: avoid
-
-
-
-

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -34,6 +34,7 @@ body.controller-work_packages.full-create
 
   // Fix selenium scrolling the #content which shouldn't be possible
   // This appears to be caused by somehow setting the scrollTop to move to an element.
+  #content-wrapper,
   #content
     overflow: visible
 

--- a/app/assets/stylesheets/layout/_zen_mode.sass
+++ b/app/assets/stylesheets/layout/_zen_mode.sass
@@ -2,7 +2,7 @@ body.zen-mode
   #top-menu,
   #main-menu
     display: none
-  #content
+  #content-wrapper
     margin-left: 0px
 
   &.controller-work_packages
@@ -12,5 +12,7 @@ body.zen-mode
       #main
         top: 0px
         height: 100%
-      #content
-        width: 100%
+
+        #content-wrapper
+          width: 100%
+          margin-left: 0

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -129,33 +129,36 @@ See doc/COPYRIGHT.rdoc for more details.
             </div>
           </div>
         <% end %>
-        <% if show_decoration %>
-          <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>"
-               ng-class="{ 'hidden-navigation': !showNavigation }">
-            <%= you_are_here_info %>
-            <%= full_breadcrumb %>
-            <%= call_hook :view_layouts_base_breadcrumb %>
-          </div>
-        <% end %>
-        <%= render_flash_messages %>
-        <notifications></notifications>
-        <div id="content" class="<%= initial_classes %>"
+        <div id="content-wrapper" class="<%= initial_classes %>"
              ng-class="{ 'hidden-navigation': !showNavigation }">
-          <h1 class="hidden-for-sighted"><%= l(:label_content) %></h1>
-          <%= content_for :content_body %>
-          <% unless local_assigns[:no_action_menu] %>
-            <!-- Action menu -->
-            <%= render partial: 'layouts/action_menu' %>
-            <%= yield %>
+          <% if show_decoration %>
+            <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>"
+                 ng-class="{ 'hidden-navigation': !showNavigation }">
+              <%= you_are_here_info %>
+              <%= full_breadcrumb %>
+              <%= call_hook :view_layouts_base_breadcrumb %>
+            </div>
           <% end %>
-          <%= call_hook :view_layouts_base_content %>
+          <%= render_flash_messages %>
+          <notifications></notifications>
+          <div id="content" class="<%= initial_classes %>"
+               ng-class="{ 'hidden-navigation': !showNavigation }">
+            <h1 class="hidden-for-sighted"><%= l(:label_content) %></h1>
+            <%= content_for :content_body %>
+            <% unless local_assigns[:no_action_menu] %>
+              <!-- Action menu -->
+              <%= render partial: 'layouts/action_menu' %>
+              <%= yield %>
+            <% end %>
+            <%= call_hook :view_layouts_base_content %>
+            <% unless local_assigns[:no_action_menu] %>
+              <div style="clear:both;">&nbsp;</div>
+            <% end %>
+          </div>
           <% unless local_assigns[:no_action_menu] %>
             <div style="clear:both;">&nbsp;</div>
           <% end %>
         </div>
-        <% unless local_assigns[:no_action_menu] %>
-          <div style="clear:both;">&nbsp;</div>
-        <% end %>
       </div>
       <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
     </div>


### PR DESCRIPTION
These are hefty changes in our lay outing. I started this refactoring as we ran into these two bugs:

- https://community.openproject.com/projects/openproject/work_packages/25608/activity
- https://community.openproject.com/projects/openproject/work_packages/25599/relations

I am pretty sure that this PR will trigger other bugs to come up due to its complexity.

For reviewing/testing this PR I found that at least the following combinations have to be tested:

All test cases need to be checked for:

- Side menu expanded
- Side menu collapsed
- No menu (i.e. global stuff)
- Zen Mode (in WPs)

Screen sizes:

- Large desktop (that allows for displaying split screen and timelines)
- Medium desktop (so that in WP list the activity and relations are collapsed)
- Mobile (Side menu should not have a full column and instead overlap #main)

Specials stuff:
- The WP List / Timelines work in a different lay outing mode (position: absolute)
- From that exception medium desktops have an exception from that exception (setting position: relative again) when showing a WP in full screen (so not in split view).

Breadcrumbs:

There are multiple types of breadcrumbs that had all some complex lay outing rules that now should get simplified.
