### PR TITLE
avoid side effects on calls to attribute_groups

### DIFF
--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -111,7 +111,13 @@ module API
             return nil if type.nil?
 
             @attribute_groups ||= begin
-              type.attribute_groups.map do |group|
+              # It's important to deep_dup the attribute_groups
+              # as the operations would otherwise alter type's
+              # attribute_groups leading to unexpected side effects
+              type
+                .attribute_groups
+                .deep_dup
+                .map do |group|
                 group[1].map! do |prop|
                   if type.passes_attribute_constraint?(prop, project: project)
                     convert_property(prop)

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -97,4 +97,19 @@ describe ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
       expect(subject.assignable_custom_field_values(version_cf)).to be_nil
     end
   end
+
+  describe '#attribute_groups' do
+    it "has no side effects on type's #attribute_groups" do
+      before = [["People", ["assignee", "responsible"]],
+                ["Estimates and time", ["estimated_time", "spent_time"]],
+                ["Details", ["category", "date", "priority", "version"]],
+                ["Other", ["percentage_done"]]]
+
+      type.attribute_groups = before
+
+      subject.attribute_groups
+
+      expect(type.attribute_groups).to eql before
+    end
+  end
 end


### PR DESCRIPTION
Without the deep_dup, the call to attribute_groups used to alter the type's attribute_groups deeply nested attribute_groups property. As a result, the second call to attribute_groups would be different from the first one. This became most apparent when rending the schema for a couple of work packages all sharing the same type. As the type was reused to render the schema, but the project might have changed, only the first schema for the type was accurate, while subsequent schemas for that type lacked attributes.

https://community.openproject.com/projects/openproject/work_packages/25594