### PR TITLE
mimic AR join alias calculation for query

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -75,50 +75,48 @@ class Query < ActiveRecord::Base
                     sortable: "#{WorkPackage.table_name}.id",
                     groupable: false),
     QueryColumn.new(:project,
-                    sortable: "#{Project.table_name}.name",
+                    sortable: "name",
                     groupable: true),
     QueryColumn.new(:subject,
                     sortable: "#{WorkPackage.table_name}.subject"),
     QueryColumn.new(:type,
-                    sortable: "#{::Type.table_name}.position",
+                    sortable: "position",
                     groupable: true),
     QueryColumn.new(:parent,
-                    sortable: ["#{WorkPackage.table_name}.root_id",
-                               "#{WorkPackage.table_name}.lft"],
+                    sortable: ["root_id",
+                               "lft"],
                     default_order: 'asc'),
     QueryColumn.new(:status,
-                    sortable: "#{Status.table_name}.position",
+                    sortable: "position",
                     groupable: true),
     QueryColumn.new(:priority,
-                    sortable: "#{IssuePriority.table_name}.position",
+                    sortable: "position",
                     default_order: 'desc',
                     groupable: true),
     QueryColumn.new(:author,
-                    sortable: ["#{User.table_name}.lastname",
-                               "#{User.table_name}.firstname",
-                               "#{WorkPackage.table_name}.author_id"],
+                    sortable: ["lastname",
+                               "firstname",
+                               "id"],
                     groupable: true),
     QueryColumn.new(:assigned_to,
-                    sortable: ["#{User.table_name}.lastname",
-                               "#{User.table_name}.firstname",
-                               "#{WorkPackage.table_name}.assigned_to_id"],
+                    sortable: ["lastname",
+                               "firstname",
+                               "id"],
                     groupable: true),
     QueryColumn.new(:responsible,
-                    sortable: ["#{User.table_name}.lastname",
-                               "#{User.table_name}.firstname",
-                               "#{WorkPackage.table_name}.responsible_id"],
-                    groupable: true,
-                    join: 'LEFT OUTER JOIN users as responsible ON ' +
-                          "(#{WorkPackage.table_name}.responsible_id = responsible.id)"),
+                    sortable: ["lastname",
+                               "firstname",
+                               "id"],
+                    groupable: true),
     QueryColumn.new(:updated_at,
                     sortable: "#{WorkPackage.table_name}.updated_at",
                     default_order: 'desc'),
     QueryColumn.new(:category,
-                    sortable: "#{Category.table_name}.name",
+                    sortable: "name",
                     groupable: true),
     QueryColumn.new(:fixed_version,
-                    sortable: ["#{Version.table_name}.effective_date",
-                               "#{Version.table_name}.name"],
+                    sortable: ["effective_date",
+                               "name"],
                     default_order: 'desc',
                     groupable: true),
     # Put empty start_dates in the far future rather than in the far past
@@ -386,18 +384,6 @@ class Query < ActiveRecord::Base
     column_names.empty?
   end
 
-  ##
-  # Returns the columns involved in this query, including those only needed for sorting or grouping
-  # puposes, not only the ones displayed (see :columns).
-  def involved_columns
-    columns = self.columns.map(&:name)
-
-    columns << group_by.to_sym if group_by
-    columns += sort_criteria.map { |x| x.first.to_sym }
-
-    columns.uniq
-  end
-
   def sort_criteria=(arg)
     if arg.is_a?(Hash)
       arg = arg.keys.sort.map { |k| arg[k] }
@@ -408,13 +394,6 @@ class Query < ActiveRecord::Base
 
   def sort_criteria
     read_attribute(:sort_criteria) || []
-  end
-
-  def sort_criteria_sql
-    criteria = SortHelper::SortCriteria.new
-    criteria.available_criteria = sortable_key_by_column_name
-    criteria.criteria = sort_criteria
-    criteria.to_sql
   end
 
   def sort_criteria_key(arg)
@@ -446,13 +425,6 @@ class Query < ActiveRecord::Base
 
   def sorted?
     sort_criteria.any?
-  end
-
-  # Returns the SQL sort order that should be prepended for grouping
-  def group_by_sort_order
-    if grouped? && (column = group_by_column)
-      Array(column.sortable).map { |s| "#{s} #{column.default_order}" }.join(',')
-    end
   end
 
   # Returns true if the query is a grouped query

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -70,15 +70,11 @@ class ::Query::Results
   end
 
   def work_packages
-    includes = ([:status, :project] +
-      includes_for_columns(query.involved_columns) + (options[:include] || [])).uniq
-
     WorkPackage
       .visible
       .where(query.statement)
       .where(options[:conditions])
-      .includes(includes)
-      .joins((query.group_by_column ? query.group_by_column.join : nil))
+      .includes(all_includes)
       .order(order_option)
       .references(:projects)
   end
@@ -88,7 +84,7 @@ class ::Query::Results
   # If there is a reason: This is a somewhat DRY way of using the sort criteria.
   # If there is no reason: The :work_package method can die over time and be replaced by this one.
   def sorted_work_packages
-    work_packages.order(query.sort_criteria_sql)
+    work_packages.order(sort_criteria_sql)
   end
 
   def versions
@@ -133,7 +129,7 @@ class ::Query::Results
   end
 
   def order_option
-    order_option = [query.group_by_sort_order, options[:order]].reject(&:blank?).join(', ')
+    order_option = [group_by_sort_order].reject(&:blank?).join(', ')
     order_option = nil if order_option.blank?
 
     order_option
@@ -141,15 +137,15 @@ class ::Query::Results
 
   private
 
+  def all_includes
+    (%i(status project) +
+      includes_for_columns(include_columns) +
+      (options[:include] || [])).uniq
+  end
+
   def includes_for_columns(column_names)
     column_names = Array(column_names)
-    includes = (WorkPackage.reflections.keys.map(&:to_sym) & column_names.map(&:to_sym))
-
-    if column_names.any? { |column| custom_field_column?(column) }
-      includes << { custom_values: :custom_field }
-    end
-
-    includes
+    (WorkPackage.reflections.keys.map(&:to_sym) & column_names.map(&:to_sym))
   end
 
   def custom_field_column?(name)
@@ -202,5 +198,96 @@ class ::Query::Results
 
   def transform_custom_field_keys(custom_field, groups)
     groups.transform_keys { |key| custom_field.cast_value(key) }
+  end
+
+  ##
+  # Returns the columns that need to be included to allow:
+  # * sorting
+  # * grouping
+  def include_columns
+    columns = query.sort_criteria.map { |x| x.first.to_sym }
+
+    columns << query.group_by.to_sym if query.group_by
+
+    columns.uniq
+  end
+
+  def sort_criteria_sql
+    criteria = SortHelper::SortCriteria.new
+    criteria.available_criteria = aliased_sorting_by_column_name
+    criteria.criteria = query.sort_criteria
+    criteria.to_sql
+  end
+
+  def aliased_sorting_by_column_name
+    sorting_by_column_name = query.sortable_key_by_column_name
+
+    aliases = include_aliases
+
+    reflection_includes.each do |inc|
+      sorting_by_column_name[inc.to_s] = Array(sorting_by_column_name[inc.to_s]).map { |column| "#{aliases[inc]}.#{column}" }
+    end
+
+    sorting_by_column_name
+  end
+
+  # Returns the SQL sort order that should be prepended for grouping
+  def group_by_sort_order
+    if query.grouped? && (column = query.group_by_column)
+      aliases = include_aliases
+
+      Array(column.sortable).map do |s|
+        aliased_group_by_sort_order(s, column, aliases[column.name])
+      end.join(',')
+    end
+  end
+
+  def aliased_group_by_sort_order(sortable, column, alias_name)
+    if alias_name
+      "#{alias_name}.#{sortable} #{column.default_order}"
+    else
+      "#{sortable} #{column.default_order}"
+    end
+  end
+
+  # To avoid naming conflicts, joined tables are aliased if they are joined
+  # more than once. Here, joining tables that are referenced by multiple
+  # columns are of particular interest.
+  #
+  # Mirroring the way AR creates aliases for included/joined tables: Normally,
+  # included/joined associations are not aliased and as such, they simply use
+  # the table name. But if an association is joined/included that relies on a
+  # table which an already joined/included association also relies upon, that
+  # name is already taken in the DB query. Therefore, the #alias_candidate
+  # method is used which will concatenate the pluralized association name with
+  # the table name the association is defined for.
+  #
+  # There is no handling for cases when the same association is joined/included
+  # multiple times as the rest of the code should prevent that.
+  def include_aliases
+    counts = Hash.new do |h, key|
+      h[key] = 0
+    end
+
+    reflection_includes.each_with_object({}) do |inc, hash|
+      reflection = WorkPackage.reflections[inc.to_s]
+      table_name = reflection.klass.table_name
+
+      hash[inc] = reflection_alias(reflection, counts[table_name])
+
+      counts[table_name] += 1
+    end
+  end
+
+  def reflection_includes
+    WorkPackage.reflections.keys.map(&:to_sym) & all_includes.map(&:to_sym)
+  end
+
+  def reflection_alias(reflection, count)
+    if count.zero?
+      reflection.klass.table_name
+    else
+      reflection.alias_candidate(WorkPackage.table_name)
+    end
   end
 end

--- a/app/models/query_column.rb
+++ b/app/models/query_column.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -33,7 +34,6 @@ class QueryColumn
                 :groupable,
                 :summable,
                 :available,
-                :join,
                 :default_order
   alias_method :summable?, :summable
   include Redmine::I18n
@@ -49,8 +49,6 @@ class QueryColumn
     end
 
     self.available = options.fetch(:available, true)
-
-    self.join = options.delete(:join)
 
     @caption_key = options[:caption] || name.to_s
   end
@@ -112,7 +110,7 @@ class QueryColumn
 
     # Explicitly checking for true because apparently, we do not want
     # truish values to count here.
-    if (value == true)
+    if value == true
       name.to_s
     else
       value

--- a/frontend/app/components/wp-query/url-params-helper.test.ts
+++ b/frontend/app/components/wp-query/url-params-helper.test.ts
@@ -126,7 +126,6 @@ describe('UrlParamsHelper', function() {
       let decodedQueryParams = UrlParamsHelper.buildV3GetQueryFromJsonParams(params);
 
       let expected = {
-        'columns[]': ['type', 'status', 'soße'],
         showSums: true,
         timelineVisible: true,
         showHierarchies: true,

--- a/frontend/app/components/wp-query/url-params-helper.ts
+++ b/frontend/app/components/wp-query/url-params-helper.ts
@@ -111,7 +111,7 @@ export class UrlParamsHelperService {
   public buildV3GetQueryFromJsonParams(updateJson:any) {
     var queryData:any = {
       pageSize: this.PaginationService.getPerPage()
-    }
+    };
 
     if (!updateJson) {
       return queryData;
@@ -119,9 +119,6 @@ export class UrlParamsHelperService {
 
     var properties = JSON.parse(updateJson);
 
-    if (properties.c) {
-      queryData["columns[]"] = properties.c.map((column:any) => column);
-    }
     if (!!properties.s) {
       queryData.showSums = properties.s;
     }


### PR DESCRIPTION
Instead of statically defining the table name used for sorting (which is also employed when grouping), the query now mimics the relevant parts of AR's table alias calculation and assigns those dynamically to the columns defined for sorting.

There is unfortunately no interface to retrieve an alias from an AR scope. 

Currently, the functionality is limited to query columns representing associations. Therefore, the columns representing WorkPackage attributes still need to reference the `WorkPackage.table_name` in their columns. This is done, because some of those columns define complex order statements as opposed to just specifying a column. The same is true for custom fields.

On the bright side, this PR removes a lot of joins we no longer need to have as we do not care for the query columns any more for inclusions as the WP Representer will eager load all that is required later on.

https://community.openproject.com/projects/openproject/work_packages/25605

### TODO

- [x] Write tests
- [x] Look into whether plugins need to be adapted
 - no plugin sorts on a association (Apparently, Budgets are not sortable/groupable for whatever reasons)
- [x] remove the columns from the front end v3 query params calculation

### Caveat

This will probably not merge in cleanly into dev as the column definitions have been moved out of the `Query` class.