### PR TITLE
[25495] Cancel clicks to hrefs with nothing but a hash

### DIFF
--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -216,6 +216,7 @@ openprojectModule
         $rootScope:ng.IRootScopeService,
         $state:ng.ui.IStateService,
         $window:ng.IWindowService) => {
+
     // Our application is still a hybrid one, meaning most routes are still
     // handled by Rails. As such, we disable the default link-hijacking that
     // Angular's HTML5-mode turns on.
@@ -241,6 +242,12 @@ openprojectModule
         console.error("Tried to parse ui-route link but failed with: " + e);
         return true;
       }
+    });
+
+    // Prevent angular handling clicks on href="#" links from other libraries
+    // (especially jquery-ui and its datepicker) from routing to <base url>/#
+    angular.element('body').on('click', 'a[href="#"]', function(evt) {
+      evt.preventDefault();
     });
 
     $rootScope.$on('$stateChangeStart', (event, toState, toParams) => {


### PR DESCRIPTION
Clicking on an unhandled link with `href="#"`, you end up on the homepage. This was observed in 25495
while using the datepicker due to the following problems:

1. The datepicker library we use adds links with a hash href `href="#"` to each date field in the datepicker

2. The datepicker adds an event that cancels the default handling of these fields

3. When quickly updating the page, the datepicker instance events are unregistered before its actually fully closed

4. The href="#"  event bubbles up, and angular handles it. Due to the way our base url works, it routes the URL to @<root>/#@ which results in going to the homepage.

An issue on the angular project (https://github.com/angular/angular.js/issues/5519) suggests that this can be solved by removing the trailing slash of the `<base>` tag. That is correct, but once a relative URL is added to the base tag, the trailing slash is non-optional, and either angular or ui-router fail to detect the routes with it removed. Thus, this is not a viable option and I chose to cancel events specifically to these empty hrefs.

Anyone interested in testing this simply add a `<a href="#">foo</a>` somewhere to the body and observe the behavior in the release branch.

Resources:

https://github.com/angular/angular.js/issues/5519
https://stackoverflow.com/questions/22610336/