### PR TITLE
render empty href on invalid list cf

### DIFF
--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -60,9 +61,13 @@ module API
                 if custom_value && custom_value.value.present?
                   title = link_value_title(custom_value)
 
+                  # only use ids for url
+                  href = if custom_value.value.to_i.to_s == custom_value.value
+                           api_v3_paths.send(path_method, custom_value.value)
+                         end
                   [{
                     title: title,
-                    href: api_v3_paths.send(path_method, custom_value.value)
+                    href: href
                   }]
                 else
                   []

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -345,6 +345,24 @@ describe ::API::V3::Utilities::CustomFieldInjector do
           let(:link) { cf_path }
         end
       end
+
+      context 'value is some invalid string' do
+        let(:value) { 'some invalid string' }
+        let(:raw_value) { 'some invalid string' }
+        let(:typed_value) { 'some invalid string not found' }
+
+        it 'has an empty href' do
+          expect(subject)
+            .to be_json_eql(nil.to_json)
+            .at_path("_links/#{cf_path}/href")
+        end
+
+        it 'has the invalid value as title' do
+          expect(subject)
+            .to be_json_eql(typed_value.to_json)
+            .at_path("_links/#{cf_path}/title")
+        end
+      end
     end
 
     context 'string custom field' do


### PR DESCRIPTION
Before, invalid list custom values (those whose value do not reference a custom option, e.g. because the value could not be found on migration, had an href like:

`/api/v3/custom_options/the invalid value` (whitespace included)

which is an invalid reference to a custom option. As the payload is send to the back end as the user attempts to update a work package, the back end will complain about such an href leading to:
https://community.openproject.com/projects/openproject/work_packages/25535

With the fix, the title is still present but the href is empty.  