### PR TITLE
[25626] Horizontal scrollbar in repository view

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -131,27 +131,6 @@ tr
   &.project
     td.name a
       white-space: nowrap
-    &.idnt td.project--hierarchy span
-      &.icon-context:before
-        padding: 9px 5px 0 0px
-    &.idnt-1 td.project--hierarchy
-      @include calc-indentation(0)
-    &.idnt-2 td.project--hierarchy
-      @include calc-indentation(1)
-    &.idnt-3 td.project--hierarchy
-      @include calc-indentation(2)
-    &.idnt-4 td.project--hierarchy
-      @include calc-indentation(3)
-    &.idnt-5 td.project--hierarchy
-      @include calc-indentation(4)
-    &.idnt-6 td.project--hierarchy
-      @include calc-indentation(5)
-    &.idnt-7 td.project--hierarchy
-      @include calc-indentation(6)
-    &.idnt-8 td.project--hierarchy
-      @include calc-indentation(7)
-    &.idnt-9 td.project--hierarchy
-      @include calc-indentation(8)
 
   &.issue
     white-space: nowrap
@@ -163,22 +142,6 @@ tr
         white-space: normal
       &.subject
         text-align: left
-    &.idnt td.subject .icon-context:before
-      padding: 0px 0 0 5px
-
-  &.entry
-    border: 1px solid #f8f8f8
-    td
-      white-space: nowrap
-      &.filename
-        width: 30%
-      &.size
-        text-align: right
-        font-size: 90%
-      &.revision, &.author
-        text-align: center
-      &.age
-        text-align: right
 
   div.expander
     cursor: pointer
@@ -187,11 +150,6 @@ tr
 
   &.open span .expand, &.closed span .collapse
     display: none
-
-  &.changeset td
-    &.author, &.committed_on
-      text-align: center
-      width: 15%
 
   [class*=reorder]
     .icon-context:before
@@ -231,35 +189,9 @@ td.hours
 th.hidden
   display: none
 
-#content tr.issue
-  &.idnt-1 td.subject
-    padding-left: 0.5em
-  &.idnt-2 td.subject
-    padding-left: 2em
-  &.idnt-3 td.subject
-    padding-left: 3.5em
-  &.idnt-4 td.subject
-    padding-left: 5em
-  &.idnt-5 td.subject
-    padding-left: 6.5em
-  &.idnt-6 td.subject
-    padding-left: 8em
-  &.idnt-7 td.subject
-    padding-left: 9.5em
-  &.idnt-8 td.subject
-    padding-left: 11em
-  &.idnt-9 td.subject
-    padding-left: 12.5em
-
 tr.context-menu-selection,
 tr.-checked
   background-color: $table-row-highlighting-color
-
-#issue_tree
-  table.issues
-    border: 0
-  td.checkbox
-    display: none
 
 #custom-options-table
   .custom-option-value

--- a/app/views/repositories/_dir_list_content.html.erb
+++ b/app/views/repositories/_dir_list_content.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
    depth = params[:depth].to_i %>
   <%  ent_path = replace_invalid_utf8(entry.path)   %>
   <%  ent_name = replace_invalid_utf8(entry.name)   %>
-  <tr id="<%= tr_id %>" class="<%= h params[:parent_id] %> entry <%= h(entry.kind) %>">
+  <tr id="<%= tr_id %>" class="<%= h params[:parent_id] %> <%= h(entry.kind) %>">
     <td class="filename" style="padding-left: <%=18 * depth%>px;">
       <% if entry.dir? %>
         <a class="icon-context dir-expander"

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -141,7 +141,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if show_diff %>
     <div class="generic-table--action-buttons">
       <button type="submit" class="button">
-        <%= op_icon('button--icon icon-compare') %>
+        <%= op_icon('button--icon icon-compare2') %>
         <span class="button--text"><%= t(:label_view_diff) %></span>
       </button>
     </div>


### PR DESCRIPTION
This removes the `entry` class from the repo table. Thus an unnecessary border is removed which caused an overflow. 
Further an incorrect icon class was changed and obsolete styling rules for tables were removed.

https://community.openproject.com/projects/openproject/work_packages/25626/activity