### PR TITLE
[25635] Work package info icon covers work package header on hover

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -58,6 +58,8 @@
   min-width: 40px
   // Center the th icon
   text-align: center !important
+  // Take care that the header can overlap the icon
+  z-index: 1
 
 // Details link column width
 .work-package-table


### PR DESCRIPTION
This avoids that the info icon overlaps the table header.

https://community.openproject.com/projects/openproject/work_packages/25635/activity