### PR TITLE
[25632] Ugly layout for long text custom fields in wp show

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -180,3 +180,6 @@ i
           column-span: all
           .attributes-key-value--key
             flex-basis: calc(16.65% - (4rem / 6))
+          .attributes-key-value--value-container
+            flex-basis: calc(83.35% + (4rem / 6))
+            max-width: calc(83.35% + (4rem / 6))

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -174,7 +174,9 @@ i
         page-break-inside: avoid
         break-inside: avoid
 
+      @supports (column-span: all)
         // Let some elements still span both columns
-        &.-span-all-columns
+        .attributes-key-value.-span-all-columns
           column-span: all
-
+          .attributes-key-value--key
+            flex-basis: calc(16.65% - (4rem / 6))


### PR DESCRIPTION
This handles the alignment of spanned attributes in the WP show view. Since FF does not support `column-span` we have to take care that the rule is not applied there.

https://community.openproject.com/projects/openproject/work_packages/25632/activity