### PR TITLE
[25618] Checkboxes in work package list (Boolean CF) are cut off

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -100,6 +100,7 @@ table.generic-table tbody tr.issue .checkbox
   pointer-events: none
 
   .inplace-edit
+    display: initial
     pointer-events: all
 
 .inplace-editing--container


### PR DESCRIPTION
Avoid border cut off for check boxes in WP table.

https://community.openproject.com/projects/openproject/work_packages/25618/activity