### PR TITLE
[25615] Render content of additional hierarchy rows

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -46,19 +46,6 @@
 .wp-table--hierarchy-td
   min-width: 0px !important
 
-// Highlight the additional hierarchy
-// so it becomes clear they're not part of the sort
-body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
-  @include varprop(color, gray-dark)
-  .wp-table--hierarchy-indicator
-    @include varprop(color, gray-dark)
-
-  // Fix padding on additional row/id field
-  // since we don't have the edit-span's padding here
-  .hierarchy-row--id-cell
-    padding-left: 5px !important
-
-
 .hierarchy-header--outer-span
   & > .dropdown-indicator
     width: 1em
@@ -82,6 +69,12 @@ body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
 .wp-table--cell-td.subject.-with-hierarchy
   .wp-table--cell-span
     padding-left: 0
+
+// Highlight additional hierarchy table rows
+// that are not part of the normal result list
+body:not(.accessibility-mode )
+  .wp-table--hierarchy-aditional-row
+    background: $table-row-additional-row-color
 
 .hierarchy-header--icon
   cursor: pointer

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -43,65 +43,65 @@ import {TypeResource} from './type-resource.service';
 import {RelationResourceInterface} from './relation-resource.service';
 
 interface WorkPackageResourceEmbedded {
-  activities: CollectionResourceInterface;
-  ancestors: WorkPackageResourceInterface[];
-  assignee: HalResource|any;
-  attachments: AttachmentCollectionResourceInterface;
-  author: HalResource|any;
-  availableWatchers: HalResource|any;
-  category: HalResource|any;
-  children: WorkPackageResourceInterface[];
-  parent: HalResource|any;
-  priority: HalResource|any;
-  project: HalResource|any;
-  relations: CollectionResourceInterface;
-  responsible: HalResource|any;
-  revisions: CollectionResourceInterface|any;
-  status: HalResource|any;
-  timeEntries: HalResource[]|any[];
-  type: TypeResource;
-  version: HalResource|any;
-  watchers: CollectionResourceInterface;
+  activities:CollectionResourceInterface;
+  ancestors:WorkPackageResourceInterface[];
+  assignee:HalResource | any;
+  attachments:AttachmentCollectionResourceInterface;
+  author:HalResource | any;
+  availableWatchers:HalResource | any;
+  category:HalResource | any;
+  children:WorkPackageResourceInterface[];
+  parent:HalResource | any;
+  priority:HalResource | any;
+  project:HalResource | any;
+  relations:CollectionResourceInterface;
+  responsible:HalResource | any;
+  revisions:CollectionResourceInterface | any;
+  status:HalResource | any;
+  timeEntries:HalResource[] | any[];
+  type:TypeResource;
+  version:HalResource | any;
+  watchers:CollectionResourceInterface;
   // For regular work packages
-  startDate: string;
-  dueDate: string;
+  startDate:string;
+  dueDate:string;
   // Only for milestones
-  date: string;
-  relatedBy: RelationResourceInterface|null;
+  date:string;
+  relatedBy:RelationResourceInterface | null;
 }
 
 interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
-  addAttachment(attachment: HalResource): ng.IPromise<any>;
-  addChild(child: HalResource): ng.IPromise<any>;
-  addComment(comment: HalResource): ng.IPromise<any>;
-  addRelation(relation: any): ng.IPromise<any>;
-  addWatcher(watcher: HalResource): ng.IPromise<any>;
-  changeParent(params: any): ng.IPromise<any>;
-  copy(): ng.IPromise<WorkPackageResource>;
-  delete(): ng.IPromise<any>;
-  logTime(): ng.IPromise<any>;
-  move(): ng.IPromise<any>;
-  removeWatcher(): ng.IPromise<any>;
-  self(): ng.IPromise<any>;
-  update(payload: any): ng.IPromise<any>;
-  updateImmediately(payload: any): ng.IPromise<any>;
-  watch(): ng.IPromise<any>;
+  addAttachment(attachment:HalResource):ng.IPromise<any>;
+  addChild(child:HalResource):ng.IPromise<any>;
+  addComment(comment:HalResource):ng.IPromise<any>;
+  addRelation(relation:any):ng.IPromise<any>;
+  addWatcher(watcher:HalResource):ng.IPromise<any>;
+  changeParent(params:any):ng.IPromise<any>;
+  copy():ng.IPromise<WorkPackageResource>;
+  delete():ng.IPromise<any>;
+  logTime():ng.IPromise<any>;
+  move():ng.IPromise<any>;
+  removeWatcher():ng.IPromise<any>;
+  self():ng.IPromise<any>;
+  update(payload:any):ng.IPromise<any>;
+  updateImmediately(payload:any):ng.IPromise<any>;
+  watch():ng.IPromise<any>;
 }
 
 interface WorkPackageLinksObject extends WorkPackageResourceLinks {
-  schema: HalResource;
+  schema:HalResource;
 }
 
-var $q: IQService;
-var $stateParams: any;
-var $timeout: ITimeoutService;
-var I18n: op.I18n;
-var states: States;
-var apiWorkPackages: ApiWorkPackagesService;
-var wpCacheService: WorkPackageCacheService;
-var schemaCacheService: SchemaCacheService;
-var NotificationsService: any;
-var wpNotificationsService: any;
+var $q:IQService;
+var $stateParams:any;
+var $timeout:ITimeoutService;
+var I18n:op.I18n;
+var states:States;
+var apiWorkPackages:ApiWorkPackagesService;
+var wpCacheService:WorkPackageCacheService;
+var schemaCacheService:SchemaCacheService;
+var NotificationsService:any;
+var wpNotificationsService:any;
 var AttachmentCollectionResource:any;
 var v3Path:any;
 
@@ -132,38 +132,46 @@ export class WorkPackageResource extends HalResource {
     return wp;
   }
 
-  public $embedded: WorkPackageResourceEmbedded;
-  public $links: WorkPackageLinksObject;
-  public $pristine: { [attribute: string]: any } = {};
-  public subject: string;
-  public updatedAt: Date;
-  public lockVersion: number;
-  public description: any;
-  public inFlight: boolean;
-  public activities: CollectionResourceInterface;
-  public attachments: AttachmentCollectionResourceInterface;
+  public $embedded:WorkPackageResourceEmbedded;
+  public $links:WorkPackageLinksObject;
+  public $pristine:{ [attribute:string]:any } = {};
+  public subject:string;
+  public updatedAt:Date;
+  public lockVersion:number;
+  public description:any;
+  public inFlight:boolean;
+  public activities:CollectionResourceInterface;
+  public attachments:AttachmentCollectionResourceInterface;
 
-  public pendingAttachments: UploadFile[] = [];
+  public pendingAttachments:UploadFile[] = [];
 
   private form:any;
   // Keep a reference to an embedded form schema,
   // if this work package currently has one.
-  private overriddenSchema:SchemaResource|null;
+  private overriddenSchema:SchemaResource | null;
 
   public get id():string {
     return this.$source.id || this.idFromLink;
   }
 
-  public static idFromLink(href: string): string {
+  public static idFromLink(href:string):string {
     return href.split('/').pop()!;
   }
 
-  public get idFromLink(): string {
+  public get idFromLink():string {
     if (this.href) {
       return WorkPackageResource.idFromLink(this.href);
     }
 
     return '';
+  }
+
+  /**
+   * Return the ids of all its ancestors, if any
+   */
+  public get ancestorIds():string {
+    const ancestors = (this as any).ancestors;
+    return ancestors.map((el:WorkPackageResource) => el.id.toString());
   }
 
   /**
@@ -177,25 +185,25 @@ export class WorkPackageResource extends HalResource {
     }
   }
 
-  public get isNew(): boolean {
+  public get isNew():boolean {
     return this.id === 'new';
   }
 
-  public get isMilestone(): boolean {
+  public get isMilestone():boolean {
     return this.schema.hasOwnProperty('date');
   }
 
   /**
    * Returns true if any field is in edition in this resource.
    */
-  public get dirty(): boolean {
+  public get dirty():boolean {
     return this.modifiedFields.length > 0;
   }
 
   /**
    * Returns all modified fields by comparing open $pristine fields.
    */
-  public get modifiedFields(): string[] {
+  public get modifiedFields():string[] {
     var modified:string[] = [];
 
     angular.forEach(this.$pristine, (value, key) => {
@@ -213,12 +221,12 @@ export class WorkPackageResource extends HalResource {
     return modified;
   }
 
-  public get isLeaf(): boolean {
+  public get isLeaf():boolean {
     var children = this.$links.children;
     return !(children && children.length > 0);
   }
 
-  public get isEditable(): boolean {
+  public get isEditable():boolean {
     return !!this.$links.update || this.isNew;
   }
 
@@ -228,7 +236,7 @@ export class WorkPackageResource extends HalResource {
    * If either the `addAttachment` link is provided or the resource is being created,
    * adding attachments is allowed.
    */
-  public get canAddAttachments(): boolean {
+  public get canAddAttachments():boolean {
     return !!this.$links.addAttachment || this.isNew;
   }
 
@@ -241,7 +249,10 @@ export class WorkPackageResource extends HalResource {
   protected $initialize(source:any) {
     super.$initialize(source);
 
-    var attachments:{$source:any, $loaded:boolean} = this.attachments || {$source: void 0, $loaded: false};
+    var attachments:{ $source:any, $loaded:boolean } = this.attachments || {
+        $source: void 0,
+        $loaded: false
+      };
     this.attachments = new AttachmentCollectionResource(
       attachments.$source,
       attachments.$loaded
@@ -275,21 +286,21 @@ export class WorkPackageResource extends HalResource {
    * Upload the pending attachments if the work package exists.
    * Do nothing, if the work package is being created.
    */
-  public uploadPendingAttachments():ng.IPromise<any>|void {
-   if (!this.pendingAttachments.length) {
-     return;
-   }
+  public uploadPendingAttachments():ng.IPromise<any> | void {
+    if (!this.pendingAttachments.length) {
+      return;
+    }
 
-   const attachments = this.pendingAttachments;
-   this.pendingAttachments = [];
-   return this.uploadAttachments(attachments);
+    const attachments = this.pendingAttachments;
+    this.pendingAttachments = [];
+    return this.uploadAttachments(attachments);
   }
 
   /**
    * Upload the given attachments, update the resource and notify the user.
    * Return an updated AttachmentCollectionResource.
    */
-  public uploadAttachments(files: UploadFile[]): IPromise<any> {
+  public uploadAttachments(files:UploadFile[]):IPromise<any> {
     const {uploads, finished} = this.attachments.upload(files);
     const message = I18n.t('js.label_upload_notification', this);
     const notification = NotificationsService.addWorkPackageUpload(message, uploads);
@@ -326,12 +337,13 @@ export class WorkPackageResource extends HalResource {
     return deferred.promise;
   }
 
-  public setAllowedValueFor(field:string, value:string|HalResource) {
+  public setAllowedValueFor(field:string, value:string | HalResource) {
     return this.allowedValuesFor(field).then(allowedValues => {
       let newValue;
 
       if ((value as HalResource)['$href']) {
-        newValue = _.find(allowedValues, (entry:any) => entry.$href === (value as HalResource).$href);
+        newValue = _.find(allowedValues,
+          (entry:any) => entry.$href === (value as HalResource).$href);
       } else if (allowedValues) {
         newValue = _.find(allowedValues, (entry:any) => entry === value);
       } else {
@@ -342,7 +354,7 @@ export class WorkPackageResource extends HalResource {
         (this as any)[field] = newValue;
       }
 
-      wpCacheService.updateWorkPackage(this);
+      wpCacheService.updateWorkPackage(this as any);
     });
   }
 
@@ -356,7 +368,7 @@ export class WorkPackageResource extends HalResource {
     return this.form;
   }
 
-  public updateForm(payload:{[attribute:string]: any}) {
+  public updateForm(payload:{ [attribute:string]:any }) {
     // Always resolve form to the latest form
     // This way, we won't have to actively reset it.
     // But store the existing form in case of an error.
@@ -435,7 +447,7 @@ export class WorkPackageResource extends HalResource {
 
               if (wasNew) {
                 this.uploadPendingAttachments();
-                wpCacheService.newWorkPackageCreated(this);
+                wpCacheService.newWorkPackageCreated(this as any);
               }
 
               // Remove only those pristine values that were submitted
@@ -448,7 +460,7 @@ export class WorkPackageResource extends HalResource {
           })
           .catch(error => {
             deferred.reject(error);
-            wpCacheService.updateWorkPackage(this);
+            wpCacheService.updateWorkPackage(this as any);
           })
           .finally(() => {
             this.inFlight = false;
@@ -462,7 +474,7 @@ export class WorkPackageResource extends HalResource {
     return deferred.promise;
   }
 
-  public storePristine(attribute: string) {
+  public storePristine(attribute:string) {
     if (this.$pristine.hasOwnProperty(attribute)) {
       return;
     }
@@ -470,7 +482,7 @@ export class WorkPackageResource extends HalResource {
     this.$pristine[attribute] = angular.copy(this[attribute]);
   }
 
-  public restoreFromPristine(attribute: string) {
+  public restoreFromPristine(attribute:string) {
     if (this.$pristine.hasOwnProperty(attribute)) {
       this[attribute] = this.$pristine[attribute];
       delete this.$pristine[attribute];
@@ -500,15 +512,15 @@ export class WorkPackageResource extends HalResource {
         var isArray = (schema[key].type || '').startsWith('[]');
 
         if (isArray) {
-          var links:{href:string}[] = [];
+          var links:{ href:string }[] = [];
           var val = this[key];
 
           if (val) {
             var elements = (val.forEach && val) || val.elements;
 
-            elements.forEach((link:{href:string}) => {
+            elements.forEach((link:{ href:string }) => {
               if (link.href) {
-                links.push({ href: link.href });
+                links.push({href: link.href});
               }
             });
           }
@@ -531,8 +543,8 @@ export class WorkPackageResource extends HalResource {
    * Return a promise that returns the linked resources as properties.
    * Return a rejected promise, if the resource is not a property of the work package.
    */
-  public updateLinkedResources(...resourceNames:string[]): ng.IPromise<any> {
-    const resources: {[id: string]: IPromise<HalResource>} = {};
+  public updateLinkedResources(...resourceNames:string[]):ng.IPromise<any> {
+    const resources:{ [id:string]:IPromise<HalResource> } = {};
 
     resourceNames.forEach(name => {
       const linked = this[name];
@@ -541,7 +553,7 @@ export class WorkPackageResource extends HalResource {
 
     const promise = $q.all(resources)
     promise.then(() => {
-      wpCacheService.updateWorkPackage(this);
+      wpCacheService.updateWorkPackage(this as any);
     });
 
     return promise;
@@ -554,10 +566,10 @@ export class WorkPackageResource extends HalResource {
    * Return a promise that returns the activities. Reject, if the work package has
    * no activities.
    */
-  public updateActivities(): IPromise<HalResource> {
+  public updateActivities():IPromise<HalResource> {
     return this
       .updateLinkedResources('activities')
-      .then((resources: any) => resources.activities);
+      .then((resources:any) => resources.activities);
   }
 
   /**
@@ -567,10 +579,10 @@ export class WorkPackageResource extends HalResource {
    * Return a promise that returns the attachments. Reject, if the work package has
    * no attachments.
    */
-  public updateAttachments(): IPromise<HalResource> {
+  public updateAttachments():IPromise<HalResource> {
     return this
       .updateLinkedResources('activities', 'attachments')
-      .then((resources: any) => resources.attachments);
+      .then((resources:any) => resources.attachments);
   }
 
   /**
@@ -595,14 +607,14 @@ export class WorkPackageResource extends HalResource {
       };
     } else if ($stateParams.parent_id) {
       this.$source._links['parent'] = {
-        href: v3Path.wp({ wp: $stateParams.parent_id })
+        href: v3Path.wp({wp: $stateParams.parent_id})
       };
     }
   }
 
   /**
    * Exclude the schema _link from the linkable Resources.
-  */
+   */
   public $linkableKeys():string[] {
     return _.without(super.$linkableKeys(), 'schema');
   }

--- a/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.controller.ts
+++ b/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.controller.ts
@@ -34,10 +34,12 @@ import {
   WorkPackageResourceInterface
 } from "../../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageRelationsHierarchyService} from "../../wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service";
+import {States} from '../../states.service';
 
 function wpContextMenuController($scope:any,
                                  $rootScope:ng.IRootScopeService,
                                  $state:ng.ui.IStateService,
+                                 states:States,
                                  WorkPackageContextMenuHelper:any,
                                  WorkPackageService:any,
                                  wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
@@ -49,8 +51,10 @@ function wpContextMenuController($scope:any,
 
   $scope.I18n = I18n;
 
-  if (!wpTableSelection.isSelected($scope.row.object.id)) {
-    wpTableSelection.setSelection($scope.row);
+  const wpId = $scope.workPackageId;
+  const workPackage = states.workPackages.get(wpId).value!;
+  if (!wpTableSelection.isSelected(wpId)) {
+    wpTableSelection.setSelection(wpId, $scope.rowIndex);
   }
 
   $scope.permittedActions = WorkPackageContextMenuHelper.getPermittedActions(getSelectedWorkPackages(), PERMITTED_CONTEXT_MENU_ACTIONS);
@@ -60,9 +64,6 @@ function wpContextMenuController($scope:any,
   };
 
   $scope.triggerContextMenuAction = function (action:any, link:any) {
-    let table:WorkPackageTable;
-    let wp:WorkPackageResourceInterface;
-
     switch (action) {
       case 'delete':
         deleteSelectedWorkPackages();
@@ -77,20 +78,15 @@ function wpContextMenuController($scope:any,
         break;
 
       case 'relation-precedes':
-        table = $scope.table;
-        wp = $scope.row.object;
-        table.timelineController.startAddRelationPredecessor(wp);
+        $scope.table.timelineController.startAddRelationPredecessor(workPackage);
         break;
 
       case 'relation-follows':
-        table = $scope.table;
-        wp = $scope.row.object;
-        table.timelineController.startAddRelationFollower(wp);
+        $scope.table.timelineController.startAddRelationFollower(workPackage);
         break;
 
       case 'relation-new-child':
-        wp = $scope.row.object;
-        wpRelationsHierarchyService.addNewChildWp(wp);
+        wpRelationsHierarchyService.addNewChildWp(workPackage);
         break;
 
       default:
@@ -145,15 +141,14 @@ function wpContextMenuController($scope:any,
   }
 
   function getSelectedWorkPackages() {
-    let workPackagefromContext = $scope.row.object;
     let selectedWorkPackages = wpTableSelection.getSelectedWorkPackages();
 
     if (selectedWorkPackages.length === 0) {
-      return [workPackagefromContext];
+      return [workPackage];
     }
 
-    if (selectedWorkPackages.indexOf(workPackagefromContext) === -1) {
-      selectedWorkPackages.push(workPackagefromContext);
+    if (selectedWorkPackages.indexOf(workPackage) === -1) {
+      selectedWorkPackages.push(workPackage);
     }
 
     return selectedWorkPackages;

--- a/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.html
+++ b/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.html
@@ -7,13 +7,13 @@
       </a>
     </li>
     <li ng-if="!row.object.isNew" class="open detailsViewMenuItem">
-      <a role="menuitem" focus ui-sref="work-packages.list.details.overview({workPackageId: row.object.id})">
+      <a role="menuitem" focus ui-sref="work-packages.list.details.overview({workPackageId: workPackageId})">
         <op-icon icon-classes="icon-action-menu icon-view-split"></op-icon>
         <span ng-bind="I18n.t('js.button_open_details')"/>
       </a>
     </li>
     <li ng-if="!row.object.isNew" class="openFullScreenView">
-      <a role="menuitem" ui-sref="work-packages.show({workPackageId: row.object.id})">
+      <a role="menuitem" ui-sref="work-packages.show({workPackageId: workPackageId})">
         <op-icon icon-classes="icon-action-menu icon-view-fullscreen"></op-icon>
         <span ng-bind="I18n.t('js.button_open_fullscreen')"/>
       </a>

--- a/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.test.ts
+++ b/frontend/app/components/context-menus/wp-context-menu/wp-context-menu.service.test.ts
@@ -26,6 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
+import {States} from '../../states.service';
 describe('workPackageContextMenu', () => {
   var container:any;
   var contextMenu;
@@ -34,6 +35,12 @@ describe('workPackageContextMenu', () => {
   var setSelection:any;
   var ngContextMenu;
   var wpTableSelection;
+  var states:States;
+  var workPackage:any = {
+    id: 123,
+    update: '/work_packages/123/edit',
+    move: '/work_packages/move/new?ids%5B%5D=123',
+  };
 
   beforeEach(angular.mock.module('ng-context-menu',
     'openproject',
@@ -60,11 +67,13 @@ describe('workPackageContextMenu', () => {
     container = angular.element('<div></div>');
   });
 
-  beforeEach(angular.mock.inject((_$rootScope_:any, _ngContextMenu_:any, _wpTableSelection_:any, $templateCache:any) => {
+  beforeEach(angular.mock.inject((_$rootScope_:any, _states_:States, _ngContextMenu_:any, _wpTableSelection_:any, $templateCache:any) => {
     wpTableSelection = _wpTableSelection_;
     $rootScope = _$rootScope_;
     ngContextMenu = _ngContextMenu_;
+    states = _states_;
 
+    states.workPackages.get('123').putValue(workPackage);
 
     sinon.stub(wpTableSelection, 'getSelectedWorkPackages').returns([]);
     sinon.stub(wpTableSelection, 'isSelected').returns(false);
@@ -81,17 +90,12 @@ describe('workPackageContextMenu', () => {
       templateUrl: 'work_package_context_menu.html'
     });
 
-    contextMenu.open({x: 0, y: 0});
+    contextMenu.open({x: 0, y: 0}, { workPackageId: '123', rowIndex: 1 });
   }));
 
   describe('when the context menu context contains one work package', () => {
     var I18n:any;
     var actions = ['edit', 'move'];
-    var workPackage:any = {
-      id: 123,
-      update: '/work_packages/123/edit',
-      move: '/work_packages/move/new?ids%5B%5D=123',
-    }
 
     var directListElements:any;
 
@@ -104,9 +108,6 @@ describe('workPackageContextMenu', () => {
     }));
 
     beforeEach(() => {
-      $rootScope.rows = [];
-      $rootScope.row = {object: workPackage};
-
       $rootScope.$digest();
 
       directListElements = container.find('.dropdown-menu > li:not(.folder)');
@@ -125,15 +126,15 @@ describe('workPackageContextMenu', () => {
     });
 
     it('sets the checked property of the row within the context to true', () => {
-      expect(setSelection).to.have.been.calledWith($rootScope.row);
+      expect(setSelection).to.have.been.calledWith('123', 1);
     });
 
     describe('when delete is permitted on a work package', () => {
       workPackage['delete'] = '/work_packages/bulk';
 
       beforeEach(() => {
+        $rootScope.wpId = '123';
         $rootScope.rows = [];
-        $rootScope.row = {object: workPackage};
         $rootScope.$digest();
 
         directListElements = container.find('.dropdown-menu > li:not(.folder)');

--- a/frontend/app/components/states.service.ts
+++ b/frontend/app/components/states.service.ts
@@ -13,7 +13,10 @@ import {QueryFormResource} from './api/api-v3/hal-resources/query-form-resource.
 import {QueryResource} from './api/api-v3/hal-resources/query-resource.service';
 import {SchemaResource} from './api/api-v3/hal-resources/schema-resource.service';
 import {TypeResource} from './api/api-v3/hal-resources/type-resource.service';
-import {WorkPackageResource} from './api/api-v3/hal-resources/work-package-resource.service';
+import {
+  WorkPackageResource,
+  WorkPackageResourceInterface
+} from './api/api-v3/hal-resources/work-package-resource.service';
 import {
   GroupObject,
   WorkPackageCollectionResource
@@ -39,7 +42,7 @@ export class States extends StatesGroup {
 
   name = "MainStore";
   /* /api/v3/work_packages */
-  workPackages = multiInput<WorkPackageResource>();
+  workPackages = multiInput<WorkPackageResourceInterface>();
 
   /* /api/v3/schemas */
   schemas = multiInput<SchemaResource>();
@@ -53,7 +56,7 @@ export class States extends StatesGroup {
   // Work Package query states
   query = new QueryStates();
 
-  tableRendering = new TableRenderingStates(this.table);
+  tableRendering = new TableRenderingStates(this);
 
   // Updater states on user input
   updates = new UserUpdaterStates(this);
@@ -111,10 +114,8 @@ export class TableState extends StatesGroup {
   // Expanded relation columns
   relationColumns = input<WorkPackageTableRelationColumns>();
 
-  // Required data for the table to load
-  // currently, this contains only relations
-  requiredDataLoaded = input<null>();
-
+  // Required work packages to be rendered by hierarchy mode + relation columns
+  additionalRequiredWorkPackages = input<null>();
 }
 
 export class QueryStates {
@@ -147,17 +148,17 @@ export class QueryAvailableDataStates {
 }
 
 export class TableRenderingStates {
-  constructor(private table:TableState) {
+  constructor(private states:States) {
   }
 
   // State when all required input states for the current query are ready
   private combinedTableStates = combine(
-    this.table.rows,
-    this.table.columns,
-    this.table.sum,
-    this.table.groupBy,
-    this.table.sortBy,
-    this.table.requiredDataLoaded
+    this.states.table.rows,
+    this.states.table.columns,
+    this.states.table.sum,
+    this.states.table.groupBy,
+    this.states.table.sortBy,
+    this.states.table.additionalRequiredWorkPackages
   );
 
   onQueryUpdated = derive(this.combinedTableStates, ($, input) => $.mapTo(null));

--- a/frontend/app/components/work-packages/work-package-cache.service.test.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.test.ts
@@ -60,7 +60,7 @@ describe('WorkPackageCacheService', () => {
   }));
 
   it('should return a work package after the list has been initialized', function(done:any) {
-    wpCacheService.updateWorkPackageList(dummyWorkPackages);
+    wpCacheService.updateWorkPackageList(dummyWorkPackages as any);
 
     let workPackage: WorkPackageResource;
     scopedObservable($rootScope, wpCacheService.loadWorkPackage('1').values$())

--- a/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -22,8 +22,8 @@ export class GroupedRenderPass extends PlainRenderPass {
    */
   protected doRender() {
     let currentGroup:GroupObject | null = null;
-    this.workPackageTable.rows.forEach((wpId:string) => {
-      let row = this.workPackageTable.rowIndex[wpId];
+    this.workPackageTable.originalRows.forEach((wpId:string) => {
+      let row = this.workPackageTable.originalRowIndex[wpId];
       let nextGroup = this.matchingGroup(row.object);
 
       if (nextGroup && currentGroup !== nextGroup) {

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -52,8 +52,8 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
    * Render the hierarchy table into the document fragment
    */
   protected doRender() {
-    this.workPackageTable.rows.forEach((wpId:string) => {
-      const row:WorkPackageTableRow = this.workPackageTable.rowIndex[wpId];
+    this.workPackageTable.originalRows.forEach((wpId:string) => {
+      const row:WorkPackageTableRow = this.workPackageTable.originalRowIndex[wpId];
       const workPackage:WorkPackageResourceInterface = row.object;
 
       // If we need to defer this row, skip it for now
@@ -94,7 +94,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
     // Will only defer is parent is
     // 1. existent in the table results
     // 1. yet to be rendered
-    if (this.workPackageTable.rowIndex[parent.id] === undefined || this.rendered[parent.id]) {
+    if (this.workPackageTable.originalRowIndex[parent.id] === undefined || this.rendered[parent.id]) {
       return false;
     }
 
@@ -117,7 +117,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
     // run them through the callback
     deferredChildren.forEach((child:WorkPackageResourceInterface) => {
       // Callback on the child itself
-      const row:WorkPackageTableRow = this.workPackageTable.rowIndex[child.id];
+      const row:WorkPackageTableRow = this.workPackageTable.originalRowIndex[child.id];
       this.insertUnderParent(row, child.parent);
 
       // Descend into any children the child WP might have and callback

--- a/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/plain/plain-render-pass.ts
@@ -13,9 +13,9 @@ export class PlainRenderPass extends PrimaryRenderPass {
    * The actual render function of this renderer.
    */
   protected doRender():void {
-    this.workPackageTable.rows.forEach((wpId:string) => {
-      let row = this.workPackageTable.rowIndex[wpId];
-      let [tr, _hidden] = this.rowBuilder.buildEmpty(row.object);
+    this.workPackageTable.originalRows.forEach((wpId:string) => {
+      let row = this.workPackageTable.originalRowIndex[wpId];
+      let [tr,] = this.rowBuilder.buildEmpty(row.object);
       row.element = tr;
       this.appendRow(row.object, tr);
       this.tableBody.appendChild(tr);

--- a/frontend/app/components/wp-fast-table/builders/relations/relation-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/relations/relation-row-builder.ts
@@ -99,7 +99,7 @@ export class RelationRowBuilder extends SingleRowBuilder {
    */
   public appendRelationLabel(jRow:JQuery, from:WorkPackageResourceInterface, relation:RelationResource, columnId:string, type:RelationColumnType) {
     const denormalized = relation.denormalized(from);
-    let typeLabel;
+    let typeLabel = '';
 
     // Add the relation label if this is a "Relations for <WP Type>" column
     if (type === 'toType') {

--- a/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -84,7 +84,7 @@ export class SingleRowBuilder {
    * @param workPackage
    * @returns {any}
    */
-  public createEmptyRow(workPackage:WorkPackageResource) {
+  public createEmptyRow(workPackage:WorkPackageResourceInterface) {
     const identifier = this.classIdentifier(workPackage);
     let tr = document.createElement('tr');
     tr.dataset['workPackageId'] = workPackage.id;
@@ -100,7 +100,7 @@ export class SingleRowBuilder {
     return tr;
   }
 
-  public classIdentifier(workPackage:WorkPackageResource) {
+  public classIdentifier(workPackage:WorkPackageResourceInterface) {
     return `wp-row-${workPackage.id}`;
   }
 

--- a/frontend/app/components/wp-fast-table/handlers/row/click-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/click-handler.ts
@@ -41,6 +41,7 @@ export class RowClickHandler implements TableEventHandler {
     // Locate the row from event
     let element = target.closest(this.SELECTOR);
     let wpId = element.data('workPackageId');
+    let classIdentifier = element.data('classIdentifier');
 
     if (!wpId) {
       return true;
@@ -54,22 +55,22 @@ export class RowClickHandler implements TableEventHandler {
     // The current row is the last selected work package
     // not matter what other rows are (de-)selected below.
     // Thus save that row for the details view button.
-    let row = table.rowObject(wpId);
+    let [index, row] = table.findRenderedRow(classIdentifier);
     this.states.focusedWorkPackage.putValue(wpId);
 
     // Update single selection if no modifier present
     if (!(evt.ctrlKey || evt.metaKey || evt.shiftKey)) {
-      this.wpTableSelection.setSelection(row);
+      this.wpTableSelection.setSelection(wpId, index);
     }
 
     // Multiple selection if shift present
     if (evt.shiftKey) {
-      this.wpTableSelection.setMultiSelectionFrom(table.rows, row);
+      this.wpTableSelection.setMultiSelectionFrom(table.renderedRows, wpId, index);
     }
 
     // Single selection expansion if ctrl / cmd(mac)
     if (evt.ctrlKey || evt.metaKey) {
-      this.wpTableSelection.toggleRow(row.workPackageId);
+      this.wpTableSelection.toggleRow(wpId);
     }
 
     return false;

--- a/frontend/app/components/wp-fast-table/handlers/row/context-menu-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/context-menu-handler.ts
@@ -47,8 +47,8 @@ export class ContextMenuHandler implements TableEventHandler {
       return false;
     }
 
-    let row = table.rowObject(element.data('workPackageId'));
-    this.contextMenu.activate('WorkPackageContextMenu', evt, {row: row, table: table});
+    let [index,] = table.findRenderedRow(element.data('workPackageId'));
+    this.contextMenu.activate('WorkPackageContextMenu', evt, {workPackageId: wpId, rowIndex: index, table: table});
     return false;
   }
 }

--- a/frontend/app/components/wp-fast-table/handlers/row/context-menu-keyboard-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/context-menu-keyboard-handler.ts
@@ -9,7 +9,7 @@ export class ContextMenuKeyboardHandler implements TableEventHandler {
   // Injections
   public contextMenu:ContextMenuService;
 
-  constructor(table: WorkPackageTable) {
+  constructor(private table:WorkPackageTable) {
     injectorBridge(this);
   }
 
@@ -25,7 +25,7 @@ export class ContextMenuKeyboardHandler implements TableEventHandler {
     return jQuery(table.tbody);
   }
 
-  public handleEvent(table: WorkPackageTable, evt:JQueryEventObject):boolean {
+  public handleEvent(table:WorkPackageTable, evt:JQueryEventObject):boolean {
     let target = jQuery(evt.target);
 
     if (!(evt.keyCode === keyCodes.F10 && evt.shiftKey && evt.altKey)) {
@@ -36,13 +36,14 @@ export class ContextMenuKeyboardHandler implements TableEventHandler {
     evt.stopPropagation();
 
     // Locate the row from event
-    let element = target.closest(this.SELECTOR);
-    let row = table.rowObject(element.data('workPackageId'));
+    const element = target.closest(this.SELECTOR);
+    const wpId = element.data('workPackageId');
+    const [index,] = table.findRenderedRow(element.data('workPackageId'));
 
     // Set position args to open at element
     let position = { of: target };
 
-    this.contextMenu.activate('WorkPackageContextMenu', evt, { row: row }, position);
+    this.contextMenu.activate('WorkPackageContextMenu', evt, { workPackageId: wpId, rowIndex: index, table: this.table}, position);
     return false;
   }
 }

--- a/frontend/app/components/wp-fast-table/handlers/row/double-click-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/double-click-handler.ts
@@ -41,7 +41,7 @@ export class RowDoubleClickHandler implements TableEventHandler {
 
     // Locate the row from event
     let element = target.closest(this.SELECTOR);
-    let row = table.rowObject(element.data('workPackageId'));
+    let wpId = element.data('workPackageId');
 
     // Ignore links
     if (target.is('a') || target.parent().is('a')) {
@@ -49,11 +49,11 @@ export class RowDoubleClickHandler implements TableEventHandler {
     }
 
     // Save the currently focused work package
-    this.states.focusedWorkPackage.putValue(row.workPackageId);
+    this.states.focusedWorkPackage.putValue(wpId);
 
     this.$state.go(
       'work-packages.show',
-       { workPackageId: row.workPackageId }
+       { workPackageId: wpId }
     );
 
     return false;

--- a/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -16,7 +16,7 @@ export class ColumnsTransformer {
       .filter(() => this.wpTableColumns.hasRelationColumns() === false)
       .takeUntil(this.states.table.stopAllSubscriptions)
       .subscribe(() => {
-        if (table.rows.length > 0) {
+        if (table.originalRows.length > 0) {
 
           var t0 = performance.now();
           // Redraw the table section, ignore timeline

--- a/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -21,7 +21,10 @@ export class HierarchyTransformer {
       .map((state) => state.isEnabled)
       .distinctUntilChanged()
       .subscribe(() => {
-        table.redrawTableAndTimeline();
+        // We don't have to reload all results when _disabling_ the hierarchy mode.
+        if (!this.wpTableHierarchies.isEnabled) {
+          table.redrawTableAndTimeline();
+        }
     });
 
     let lastValue = this.wpTableHierarchies.isEnabled;

--- a/frontend/app/components/wp-fast-table/handlers/state/selection-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/selection-transformer.ts
@@ -22,7 +22,7 @@ export class SelectionTransformer {
 
     // Bind CTRL+A to select all work packages
     Mousetrap.bind(['command+a', 'ctrl+a'], (e) => {
-      this.wpTableSelection.selectAll(table.rows);
+      this.wpTableSelection.selectAll(table.renderedRows);
 
       e.preventDefault();
       return false;

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
@@ -28,9 +28,10 @@ export function hasChildrenInTable(workPackage:WorkPackageResourceInterface, tab
     return false; // Work Package has no children at all
   }
 
-  // If any visible children in the table
-  return !!_.find(workPackage.children, (child:WorkPackageResourceInterface) => {
-    const childId = child.idFromLink!;
-    return table.rowIndex[childId] !== undefined;
+  // Return if this work package is in the ancestor chain of any of the work packages
+  return !!_.find(table.rows, (wpId:string) => {
+    const row = table.rowIndex[wpId].object;
+
+    return row.ancestorIds.indexOf(workPackage.id.toString()) >= 0;
   });
 }

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
@@ -29,8 +29,8 @@ export function hasChildrenInTable(workPackage:WorkPackageResourceInterface, tab
   }
 
   // Return if this work package is in the ancestor chain of any of the work packages
-  return !!_.find(table.rows, (wpId:string) => {
-    const row = table.rowIndex[wpId].object;
+  return !!_.find(table.originalRows, (wpId:string) => {
+    const row = table.originalRowIndex[wpId].object;
 
     return row.ancestorIds.indexOf(workPackage.id.toString()) >= 0;
   });

--- a/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
@@ -1,0 +1,111 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {opServicesModule} from '../../../angular-modules';
+import {States} from '../../states.service';
+import {WorkPackageTableRelationColumns} from '../wp-table-relation-columns';
+import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
+import {WorkPackageTableColumnsService} from './wp-table-columns.service';
+import {TableStateStates, WorkPackageTableBaseService} from './wp-table-base.service';
+import {RelationResource} from '../../api/api-v3/hal-resources/relation-resource.service';
+import {
+  QueryColumn, queryColumnTypes, RelationQueryColumn,
+  TypeRelationQueryColumn
+} from '../../wp-query/query-column';
+import {IQService} from 'angular';
+import {HalRequestService} from '../../api/api-v3/hal-request/hal-request.service';
+import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
+import {
+  RelationsStateValue,
+  WorkPackageRelationsService
+} from '../../wp-relations/wp-relations.service';
+import {WorkPackageTableHierarchiesService} from './wp-table-hierarchy.service';
+
+export type RelationColumnType = 'toType' | 'ofType';
+
+export class WorkPackageTableAdditionalElementsService {
+
+  constructor(public states:States,
+              public wpTableHierarchies:WorkPackageTableHierarchiesService,
+              public wpTableColumns:WorkPackageTableColumnsService,
+              public $q:IQService,
+              public halRequest:HalRequestService,
+              public wpCacheService:WorkPackageCacheService,
+              public wpRelations:WorkPackageRelationsService) {
+  }
+
+  public initialize(rows:WorkPackageResourceInterface[]) {
+    // Add relations to the stack
+    Promise.all([
+      this.requireInvolvedRelations(rows.map(el => el.id)),
+      this.requireHierarchyElements(rows)
+    ]).then((results:string[][]) => {
+      this.loadAdditional(_.flatten(results));
+    });
+  }
+
+  private loadAdditional(wpIds:string[]) {
+    this.wpCacheService.loadWorkPackages(wpIds)
+      .then(() => {
+        this.states.table.additionalRequiredWorkPackages.putValue(null, 'All required work packages are loaded');
+      });
+  }
+
+  /**
+   * Requires both the relation resource of the given work package ids as well
+   * as the `to` work packages returned from the relations
+   */
+  private requireInvolvedRelations(rows:string[]):Promise<string[]> {
+
+    if (!this.wpTableColumns.hasRelationColumns()) {
+      return Promise.resolve([]);
+    }
+    return this.wpRelations
+      .requireInvolved(rows)
+      .then((relations) => {
+        const ids = relations.map(relation => [relation.ids.from, relation.ids.to]);
+        return _.flatten(ids);
+      });
+  }
+
+  /**
+   * Return the id of all ancestors for visible rows in the table.
+   * @param rows
+   * @return {string[]}
+   */
+  private requireHierarchyElements(rows:WorkPackageResourceInterface[]):Promise<string[]> {
+    if (!this.wpTableHierarchies.isEnabled) {
+      return Promise.resolve([]);
+    }
+
+    const ids = _.flatten(rows.map(el => el.ancestorIds));
+    return Promise.resolve(ids);
+  }
+}
+
+opServicesModule.service('wpTableAdditionalElements', WorkPackageTableAdditionalElementsService);

--- a/frontend/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
@@ -1,17 +1,18 @@
 import {QueryResource} from '../../api/api-v3/hal-resources/query-resource.service';
-import {InputState} from "reactivestates";
-import {opServicesModule} from "../../../angular-modules";
-import {States} from "../../states.service";
+import {opServicesModule} from '../../../angular-modules';
+import {States} from '../../states.service';
 import {
-  TableStateStates, WorkPackageQueryStateService,
+  TableStateStates,
+  WorkPackageQueryStateService,
   WorkPackageTableBaseService
 } from './wp-table-base.service';
-import { WorkPackageTableHierarchies } from "../wp-table-hierarchies";
+import {WorkPackageTableHierarchies} from '../wp-table-hierarchies';
+import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
 
 export class WorkPackageTableHierarchiesService extends WorkPackageTableBaseService implements WorkPackageQueryStateService {
   protected stateName = 'hierarchies' as TableStateStates;
 
-  constructor(public states:States) {
+  constructor(public states:States, public wpCacheService:WorkPackageCacheService) {
     super(states);
   }
 
@@ -26,29 +27,31 @@ export class WorkPackageTableHierarchiesService extends WorkPackageTableBaseServ
 
   public applyToQuery(query:QueryResource) {
     query.showHierarchies = this.isEnabled;
-    return false;
+
+    // We need to visibly load the ancestors when the mode is activated.
+    return this.isEnabled;
   }
 
   /**
    * Return whether the current hierarchy mode is active
    */
-   public get isEnabled():boolean {
+  public get isEnabled():boolean {
     return this.currentState.isEnabled;
-   }
+  }
 
-   public setEnabled(active:boolean = true) {
-     const state = this.currentState;
-     state.current = active;
+  public setEnabled(active:boolean = true) {
+    const state = this.currentState;
+    state.current = active;
 
-     this.state.putValue(state);
-   }
+    this.state.putValue(state);
+  }
 
-   /**
-    * Toggle the hierarchy state
-    */
-   public toggleState() {
+  /**
+   * Toggle the hierarchy state
+   */
+  public toggleState() {
     this.setEnabled(!this.isEnabled);
-   }
+  }
 
   /**
    * Return whether the given wp ID is collapsed.

--- a/frontend/app/components/wp-fast-table/state/wp-table-relation-columns.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-relation-columns.service.ts
@@ -61,13 +61,6 @@ export class WorkPackageTableRelationColumnsService extends WorkPackageTableBase
 
   public initialize(workPackages:WorkPackageResourceInterface[]) {
     this.initializeState();
-
-    if (this.wpTableColumns.hasRelationColumns()) {
-      this.requireInvolved(workPackages.map(el => el.id))
-        .then(() => this.states.table.requiredDataLoaded.putValue(null));
-    } else {
-      this.states.table.requiredDataLoaded.putValue(null);
-    }
   }
 
   /**
@@ -184,21 +177,6 @@ export class WorkPackageTableRelationColumnsService extends WorkPackageTableBase
     this.state.putValue(current);
 
     return current;
-  }
-
-  /**
-   * Requires both the relation resource of the given work package ids as well
-   * as the `to` work packages returned from the relations
-   */
-  private requireInvolved(workPackageIds:string[]) {
-    return this.wpRelations
-      .requireInvolved(workPackageIds)
-      .then((relations) => {
-        const involvedIDs = relations.map(relation => [relation.ids.from, relation.ids.to]);
-        return this.wpCacheService.loadWorkPackages(
-          _.uniq(_.flatten(involvedIDs))
-        );
-      });
   }
 }
 

--- a/frontend/app/components/wp-fast-table/state/wp-table-selection.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-selection.service.ts
@@ -3,6 +3,7 @@ import {opServicesModule} from '../../../angular-modules';
 import {WPTableRowSelectionState, WorkPackageTableRow} from '../wp-table.interfaces';
 import {WorkPackageResource} from '../../api/api-v3/hal-resources/work-package-resource.service';
 import {InputState} from "reactivestates";
+import {RenderedRow} from '../builders/primary-render-pass';
 
 export class WorkPackageTableSelection {
 
@@ -23,11 +24,13 @@ export class WorkPackageTableSelection {
   /**
    * Select all work packages
    */
-  public selectAll(rows: string[]) {
+  public selectAll(rows: RenderedRow[]) {
     const state:WPTableRowSelectionState = this._emptyState;
 
-    rows.forEach((workPackageId:string) => {
-      state.selected[workPackageId] = true;
+    rows.forEach((row) => {
+      if (row.workPackageId) {
+        state.selected[row.workPackageId] = true;
+      }
     });
 
     this.selectionState.putValue(state);
@@ -109,12 +112,12 @@ export class WorkPackageTableSelection {
   /**
    * Override current selection with the given work package id.
    */
-  public setSelection(row:WorkPackageTableRow) {
+  public setSelection(wpId:string, position:number) {
     let state:WPTableRowSelectionState = {
       selected: {},
-      activeRowIndex: row.position
+      activeRowIndex: position
     };
-    state.selected[row.workPackageId] = true;
+    state.selected[wpId] = true;
 
     this.selectionState.putValue(state);
   }
@@ -123,21 +126,21 @@ export class WorkPackageTableSelection {
    * Select a number of rows from the current `activeRowIndex`
    * to the selected target.
    * (aka shift click expansion)
-   * @param rows Current visible rows
-   * @param selected Selection target
    */
-  public setMultiSelectionFrom(rows:string[], selected:WorkPackageTableRow) {
+  public setMultiSelectionFrom(rows:RenderedRow[], wpId:string, position:number) {
     let state = this.currentState;
 
     if (this.selectionCount === 0) {
-      state.selected[selected.workPackageId] = true;
-      state.activeRowIndex = selected.position;
+      state.selected[wpId] = true;
+      state.activeRowIndex = position;
     } else if (state.activeRowIndex !== null) {
-      let start = Math.min(selected.position, state.activeRowIndex);
-      let end = Math.max(selected.position, state.activeRowIndex);
+      let start = Math.min(position, state.activeRowIndex);
+      let end = Math.max(position, state.activeRowIndex);
 
-      rows.forEach((workPackageId, i) => {
-        state.selected[workPackageId] = i >= start && i <= end;
+      rows.forEach((row, i) => {
+        if (row.workPackageId) {
+          state.selected[row.workPackageId] = i >= start && i <= end;
+        }
       });
     }
 

--- a/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
+++ b/frontend/app/components/wp-inline-create/inline-create-row-builder.ts
@@ -64,7 +64,7 @@ export class InlineCreateRowBuilder extends SingleRowBuilder {
    * @param workPackage
    * @returns {any}
    */
-  public createEmptyRow(workPackage:WorkPackageResource) {
+  public createEmptyRow(workPackage:WorkPackageResourceInterface) {
     const identifier = this.classIdentifier(workPackage);
     const tr = document.createElement('tr');
     tr.id = rowId(workPackage.id);

--- a/frontend/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/app/components/wp-list/wp-states-initialization.service.ts
@@ -16,6 +16,7 @@ import {WorkPackageCacheService} from '../work-packages/work-package-cache.servi
 import {WorkPackageTableRelationColumnsService} from '../wp-fast-table/state/wp-table-relation-columns.service';
 import {WorkPackagesListChecksumService} from './wp-list-checksum.service';
 import {WorkPackageTableSortByService} from '../wp-fast-table/state/wp-table-sort-by.service';
+import {WorkPackageTableAdditionalElementsService} from '../wp-fast-table/state/wp-table-additional-elements.service';
 
 export class WorkPackageStatesInitializationService {
   constructor(protected states:States,
@@ -28,6 +29,7 @@ export class WorkPackageStatesInitializationService {
               protected wpTableHierarchies:WorkPackageTableHierarchiesService,
               protected wpTableRelationColumns:WorkPackageTableRelationColumnsService,
               protected wpTablePagination:WorkPackageTablePaginationService,
+              protected wpTableAdditionalElements:WorkPackageTableAdditionalElementsService,
               protected wpCacheService:WorkPackageCacheService,
               protected wpListChecksumService:WorkPackagesListChecksumService,
               protected AuthorisationService:any) {
@@ -71,7 +73,7 @@ export class WorkPackageStatesInitializationService {
 
   public updateFromResults(results:WorkPackageCollectionResource) {
     // Clear table required data states
-    this.states.table.requiredDataLoaded.clear();
+    this.states.table.additionalRequiredWorkPackages.clear('Clearing additional WPs before updating rows');
 
     if (results.schemas) {
       _.each(results.schemas.elements, (schema:SchemaResource) => {
@@ -93,6 +95,8 @@ export class WorkPackageStatesInitializationService {
 
     this.wpTableRelationColumns.initialize(results.elements);
 
+    this.wpTableAdditionalElements.initialize(results.elements);
+
     this.AuthorisationService.initModelAuth('work_packages', results.$links);
   }
 
@@ -112,9 +116,6 @@ export class WorkPackageStatesInitializationService {
   private clearStates() {
     const reason = 'Clearing states before re-initialization.';
 
-    // Clear table required data states
-    this.states.table.requiredDataLoaded.clear(reason);
-
     // Clear immediate input states
     this.states.table.rows.clear(reason);
     this.states.table.columns.clear(reason);
@@ -123,6 +124,7 @@ export class WorkPackageStatesInitializationService {
     this.states.table.sum.clear(reason);
     this.states.table.results.clear(reason);
     this.states.table.groups.clear(reason);
+    this.states.table.additionalRequiredWorkPackages.clear(reason);
 
     // Clear rendered state
     this.states.table.rendered.clear(reason);

--- a/frontend/app/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/app/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -26,7 +26,6 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 import {WorkPackageResourceInterface} from './../../api/api-v3/hal-resources/work-package-resource.service';
-import {States} from "../../states.service";
 import {WorkPackageTableTimelineService} from "../../wp-fast-table/state/wp-table-timeline.service";
 
 angular
@@ -38,8 +37,7 @@ function WorkPackageContextMenuHelper(
   UrlParamsHelper:any,
   wpTableTimeline:WorkPackageTableTimelineService,
   PathHelper:any,
-  I18n: op.I18n,
-  states: States) {
+  I18n: op.I18n) {
 
   const BULK_ACTIONS = [
     {


### PR DESCRIPTION
Renders additional hierarchy elements as regular citizens of the table.
To this end, we need to load all ancestors when the hierarchy mode is enabled.

This PR combines the WP loading of the relation columns service with the required WPs of additional hierarchies into a separate service.

Additionally, whenever the hierarchy mode is turned on, we now need to visibly refresh the results.

**TODOS**

- [x] Selection of additional hierarchy elements are broken.

https://community.openproject.com/projects/openproject/work_packages/25615