### PR TITLE
[25661] Exclude hierarchy relation types

### DIFF
--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.directive.ts
@@ -14,7 +14,7 @@ export class WorkPackageRelationsCreateController {
   public selectedWpId:string;
   public externalFormToggle: boolean;
   public fixedRelationType:string;
-  public relationTypes = RelationResource.LOCALIZED_RELATION_TYPES(true);
+  public relationTypes = RelationResource.LOCALIZED_RELATION_TYPES(false);
 
   public canAddChildren = !!this.workPackage.addChild;
   public canLinkChildren = !!this.workPackage.changeParent;


### PR DESCRIPTION
This regression was caused by a refactoring for the relation columns
feature.