### PR TITLE
Fix/update wp to be in details pane

### DIFF
--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -51,6 +51,8 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
     if (!focusedWP) {
       focusState.putValue(wpId);
       this.wpTableSelection.setRowState(wpId, true);
+    } else if (!this.wpTableSelection.isSelected(wpId)) {
+      this.wpTableSelection.setRowState(wpId, true);
     }
 
     scopedObservable(

--- a/frontend/app/components/wp-fast-table/state/wp-table-selection.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-selection.service.ts
@@ -2,18 +2,20 @@ import {States} from '../../states.service';
 import {opServicesModule} from '../../../angular-modules';
 import {WPTableRowSelectionState, WorkPackageTableRow} from '../wp-table.interfaces';
 import {WorkPackageResource} from '../../api/api-v3/hal-resources/work-package-resource.service';
-import {InputState} from "reactivestates";
+import {InputState} from 'reactivestates';
 
 export class WorkPackageTableSelection {
 
-  public selectionState: InputState<WPTableRowSelectionState>;
+  public selectionState:InputState<WPTableRowSelectionState>;
 
-  constructor(public states: States) {
+  constructor(public states:States) {
     this.selectionState = states.table.selection;
 
     if (this.selectionState.isPristine()) {
       this.reset();
     }
+
+    this.observeToUpdateFocused();
   }
 
   public isSelected(workPackageId:string) {
@@ -23,7 +25,7 @@ export class WorkPackageTableSelection {
   /**
    * Select all work packages
    */
-  public selectAll(rows: string[]) {
+  public selectAll(rows:string[]) {
     const state:WPTableRowSelectionState = this._emptyState;
 
     rows.forEach((workPackageId:string) => {
@@ -150,6 +152,21 @@ export class WorkPackageTableSelection {
       selected: {},
       activeRowIndex: null
     };
+  }
+
+  /**
+   * Put the first row that is eligible to be displayed in the details view into
+   * the focused state if no manual selection has been made yet.
+   */
+  private observeToUpdateFocused() {
+    this
+      .states.table.rendered
+      .values$()
+      .map(state => _.find(state.renderedOrder, row => row.workPackageId))
+      .filter(fullRow => !!fullRow && _.isEmpty(this.currentState.selected))
+      .subscribe(fullRow => {
+        this.states.focusedWorkPackage.putValue(fullRow!.workPackageId!);
+      });
   }
 }
 

--- a/frontend/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/app/components/wp-fast-table/wp-fast-table.ts
@@ -20,8 +20,8 @@ export class WorkPackageTable {
   public states:States;
   public I18n:op.I18n;
 
-  public rows: string[] = [];
-  public rowIndex:{[id: string]: WorkPackageTableRow} = {};
+  public rows:string[] = [];
+  public rowIndex:{[id:string]:WorkPackageTableRow} = {};
 
   // WP rows builder
   // Ordered by priority
@@ -69,11 +69,6 @@ export class WorkPackageTable {
 
     // Draw work packages
     this.redrawTableAndTimeline();
-
-    // Preselect first work package as focused
-    if (this.rows.length && this.states.focusedWorkPackage.isPristine()) {
-      this.states.focusedWorkPackage.putValue(this.rows[0]);
-    }
   }
 
   /**


### PR DESCRIPTION
Observe rerendering the table to keep the details view candidate up to date. Only full work package rows are eligible to be opened in the split view for now which leaves out hierarchy rows.

https://community.openproject.com/projects/openproject/work_packages/25656

To get this to work also when clicking the button without selecting a work package and then rerendering the table (e.g. resorting), the row of the work package that is opened in the details view is selected if it is focused but not selected. 

:warning: When merging into dev, https://github.com/opf/openproject/pull/5701/files#diff-2bc2d9a0081cd3242c5fbbe808522781R165 needs to be adapted (remove `renderedOrder`) :warning: 