### PR TITLE
[25676] Only use visible work packages for the timeline row order

### DIFF
--- a/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
@@ -87,8 +87,10 @@ export class WorkPackageTableAdditionalElementsService {
     }
     return this.wpRelations
       .requireInvolved(rows)
-      .then((relations) => {
-        const ids = relations.map(relation => [relation.ids.from, relation.ids.to]);
+      .then(() => {
+        const ids = this.getInvolvedWorkPackages(rows.map(id => {
+          return this.wpRelations.getRelationsForWorkPackage(id).value!;
+        }));
         return _.flatten(ids);
       });
   }
@@ -105,6 +107,22 @@ export class WorkPackageTableAdditionalElementsService {
 
     const ids = _.flatten(rows.map(el => el.ancestorIds));
     return Promise.resolve(ids);
+  }
+
+  /**
+   * From a set of relations state values, return all involved IDs.
+   * @param states
+   * @return {string[]}
+   */
+  private getInvolvedWorkPackages(states:RelationsStateValue[]) {
+    const ids:string[] = [];
+    _.each(states, (relations:RelationsStateValue) => {
+      _.each(relations, (resource:RelationResource) => {
+        ids.push(resource.ids.from, resource.ids.to);
+      });
+    });
+
+    return ids;
   }
 }
 

--- a/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -117,7 +117,8 @@ export class WorkPackageTimelineTableController {
       .takeUntil(this.states.table.stopAllSubscriptions)
       .filter(() => this.initialized)
       .subscribe((orderedRows) => {
-        this.workPackageIdOrder = orderedRows;
+        // Remember all visible rows in their order of appearance.
+        this.workPackageIdOrder = orderedRows.filter(row => !row.hidden);
         this.refreshView();
       });
 


### PR DESCRIPTION
Fixes
https://community.openproject.com/projects/openproject/work_packages/25676

Additionally, only conditionally loads relation that are not loaded into states, this will make subsequent requests with TL open much faster.
