### PR TITLE
Fix/flex based layout for side menu and main content

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -220,3 +220,8 @@ tr.-checked
     width: calc(100% - 5rem)
   .icon-toggle:before
     vertical-align: middle
+
+// Exceptions for summary reports where multiple tables are used in one view.
+body.action-report
+  .generic-table--container
+    height: auto

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -96,6 +96,9 @@ body
   height: auto
   background-color: #fff
   width: 100%
+  // As this is a flex item we need to set min-width to 0 so that its children's
+  // overflow settings will be respected.
+  min-width: 0
 
   %absolute-layout-mode &
     position:   absolute

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -102,6 +102,8 @@ body
     height:     100%
     width: calc(100% - #{$main-menu-width})
     margin-left: $main-menu-width
+    // Needed for Safari
+    left: 0
 
   &.nosidebar
     margin-left: 0
@@ -115,12 +117,6 @@ body
       width:    100%
       height:   100%
 
-  &:after
-    content: "."
-    display: block
-    height: 0
-    clear: both
-    visibility: hidden
 
 #content
   padding: 0

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -39,10 +39,7 @@ body
 
 #wrapper
   @include default-transition
-  // we need to define the next two lines twice as `varprop` cannot handle this
-  // multiple variables in one line.
-  background: linear-gradient(to bottom, $main-menu-bg-color 0%, $main-menu-bg-color 100%) no-repeat
-  background: linear-gradient(to bottom, var(--main-menu-bg-color) 0%, var(--main-menu-bg-color) 100%) no-repeat
+  @include varprop(background-color, body-background)
   background-size: $main-menu-width 100%
   min-height: 100%
   height: auto
@@ -54,6 +51,7 @@ body
 
 
 #main
+  display: flex
   width:    100%
   z-index:  20
   overflow: auto
@@ -69,40 +67,45 @@ body
     border-bottom-style: solid
     @include varprop(border-bottom-color, footer-bg-color)
 
+    #content-wrapper
+      &.hidden-navigation
+        margin-left: $main-menu-folded-width
+        width: calc(100% - #{$main-menu-folded-width})
+
+      &.nosidebar
+        padding: 0
+        width:    100%
+        margin-left: 0
+
+      &.nomenus
+        top: 0
+        padding: 0
+        width: 100%
+        margin-left: 0
+
   &.nomenus
     padding-bottom: 0
     overflow: hidden
 
-    %absolute-layout-mode &
-      top:    0
 
-#content
+#content-wrapper
   @include default-transition
-  margin: 0 0 0 $main-menu-width
+  margin: 0 0 0 0
   padding: 10px 20px
   width: auto
-  overflow: hidden
   height: auto
   background-color: #fff
-  z-index: 10
+  width: 100%
 
   %absolute-layout-mode &
     position:   absolute
-    width:      calc(100% - #{$main-menu-width})
     height:     100%
-
-  &.hidden-navigation
-    margin-left: $main-menu-folded-width
-
-    %absolute-layout-mode &
-      width:    calc(100% - #{$main-menu-folded-width})
+    width: calc(100% - #{$main-menu-width})
+    margin-left: $main-menu-width
 
   &.nosidebar
     margin-left: 0
     padding: 20px 40px
-
-    %absolute-layout-mode &
-      width:    100%
 
   &.nomenus
     margin:     0
@@ -118,6 +121,16 @@ body
     height: 0
     clear: both
     visibility: hidden
+
+#content
+  padding: 0
+  margin: 0 0 0 0
+  overflow: hidden
+  width: 100%
+  height: 100%
+  z-index: 10
+  background-color: #fff
+
 
 .-draggable
   cursor: move

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -39,16 +39,9 @@ body
 
 #wrapper
   @include default-transition
-  @include varprop(background-color, body-background)
-  background-size: $main-menu-width 100%
   min-height: 100%
   height: auto
   position: relative
-  &.nosidebar, &.nomenus
-    background: none
-  &.hidden-navigation
-    background-size: $main-menu-folded-width 100%
-
 
 #main
   display: flex

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -128,7 +128,7 @@ body
   overflow: hidden
   width: 100%
   z-index: 10
-  background-color: #fff
+  background-color: $body-background
 
   %absolute-layout-mode &
     height: 100%

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -127,9 +127,11 @@ body
   margin: 0 0 0 0
   overflow: hidden
   width: 100%
-  height: 100%
   z-index: 10
   background-color: #fff
+
+  %absolute-layout-mode &
+    height: 100%
 
 
 .-draggable

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -40,9 +40,9 @@
     padding-bottom: 0 !important
     position: relative !important
     top: 0 !important
+    min-height: calc(100vH - #{$header-height-mobile} - #{$footer-height})
 
   #main
-    min-height: calc(100vH - $header-height-mobile)
     height: initial !important
     overflow: auto !important
 

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -36,12 +36,13 @@
     -webkit-overflow-scrolling: touch
 
   #main,
-  #content
+  #content-wrapper
     padding-bottom: 0 !important
     position: relative !important
     top: 0 !important
 
   #main
+    min-height: calc(100vH - $header-height-mobile)
     height: initial !important
     overflow: auto !important
 
@@ -51,12 +52,12 @@
   #wrapper
     background: #fff !important
 
-  #content
+  #content-wrapper
     height: 100% !important
     margin: 0 !important
     padding: 20px !important
     width: 100% !important
-  #main-menu ~ #content
+  #main-menu ~ #content-wrapper
     padding: 2rem 20px 0 20px !important
     margin-bottom: 20px !important
 

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -37,7 +37,6 @@
   background: none repeat scroll 0 0
   @include varprop(background-color, body-background)
   border: none
-  margin: 0 0 0 ($main-menu-width - $main-menu-item-border-width)
   width: auto
   overflow: hidden
   position: relative
@@ -47,8 +46,6 @@
     padding-left: 33px
     ul
       margin: 0
-  &.hidden-navigation
-    margin-left: $main-menu-folded-width
 
   a
     font-size: 12px
@@ -67,7 +64,7 @@
     display: block
 
 ul.breadcrumb
-  margin: 0 0 0 13px
+  margin: 0 0 0 0
   padding: 0
   list-style: none
   list-style-position: outside

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -41,9 +41,8 @@
   overflow: hidden
   position: relative
   &.nosidebar
-    margin-left: 0
-    // (Contents 40px) - (icons 7px)
-    padding-left: 33px
+    // 7px of the icon to align breadcrumb with content
+    margin-left: -7px
     ul
       margin: 0
 

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -47,7 +47,7 @@ $toggler-width: 40px
   %absolute-layout-mode &
     position: relative
     // In WP list, the footer is just a 5px border:
-    min-height: calc(100vh - 55px - 5px)
+    height: calc(100vh - 55px - 5px)
 
     #menu-sidebar
       +allow-vertical-scrolling

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -199,7 +199,7 @@ $toggler-width: 40px
     border-style: solid
     border-color: $main-menu-item-border-color
     height: $main-menu-item-height
-    width: calc($main-menu-width - 1px)
+    width: calc(#{$main-menu-width} - 1px)
 
     @include varprop(background-color, main-menu-bg-color)
     @include default-transition

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -47,7 +47,7 @@ $toggler-width: 40px
   %absolute-layout-mode &
     position: relative
     // In WP list, the footer is just a 5px border:
-    min-height: calc(100vh - 55px - 5px)
+    height: calc(100vh - 55px - 5px)
 
     #menu-sidebar
       +allow-vertical-scrolling
@@ -197,7 +197,6 @@ $toggler-width: 40px
   #toggle-project-menu
     border: $main-menu-item-border-width solid $main-menu-item-border-color
     height: $main-menu-item-height
-    width: $main-menu-width
     @include varprop(background-color, main-menu-bg-color)
     @include default-transition
     &:hover

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -206,7 +206,7 @@ $toggler-width: 40px
     &:hover
       @include varprop(background, main-menu-bg-hover-background)
     &.show
-      width: $main-menu-folded-width
+      width: calc(#{$main-menu-folded-width} - 1px)
       a.navigation-toggler
         height: 100%
         padding: 0 10px 0 0

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -47,7 +47,7 @@ $toggler-width: 40px
   %absolute-layout-mode &
     position: relative
     // In WP list, the footer is just a 5px border:
-    height: calc(100vh - 55px - 5px)
+    min-height: calc(100vh - 55px - 5px)
 
     #menu-sidebar
       +allow-vertical-scrolling

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -34,6 +34,10 @@ $toggler-width: 40px
   float: left
   left: 0
   border-right: $main-menu-border-width solid $main-menu-border-color
+
+  // min-height is full height minus header and footer.
+  min-height: calc(100vh - 55px - 55px)
+
   @include varprop(background-color, main-menu-bg-color)
   @include default-transition
 
@@ -42,7 +46,9 @@ $toggler-width: 40px
     height: calc(100% - 40px)
   %absolute-layout-mode &
     position: relative
-    height:   100%
+    // In WP list, the footer is just a 5px border:
+    min-height: calc(100vh - 55px - 5px)
+
     #menu-sidebar
       +allow-vertical-scrolling
       -ms-overflow-style: -ms-autohiding-scrollbar

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -195,8 +195,12 @@ $toggler-width: 40px
     float: left
 
   #toggle-project-menu
-    border: $main-menu-item-border-width solid $main-menu-item-border-color
+    border-width: $main-menu-item-border-width 0 $main-menu-item-border-width $main-menu-item-border-width
+    border-style: solid
+    border-color: $main-menu-item-border-color
     height: $main-menu-item-height
+    width: calc($main-menu-width - 1px)
+
     @include varprop(background-color, main-menu-bg-color)
     @include default-transition
     &:hover

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -32,6 +32,7 @@
 
   #main-menu
     position: absolute !important
+    min-height: initial !important
     height: initial !important
     overflow: auto
     z-index: 11

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -32,13 +32,15 @@
 
   #main-menu
     position: absolute !important
-    min-height: initial !important
-    height: initial !important
-    overflow: auto
+    min-height: 0
     z-index: 11
+    border-bottom: 1px solid $main-menu-border-color
+    %absolute-layout-mode &
+      height: auto
 
   .hidden-navigation #main-menu
     overflow: hidden
+    border-bottom: 0
 
   .main-item-wrapper a
     width: 100%

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -35,15 +35,37 @@
       overflow-y: scroll !important
 
       #main,
+      #content-wrapper,
       #content
         position: relative !important
+        width: 100%
+        margin-left: 0
+
+
+      #content-wrapper,
+      #content
+        height: 100% !important
+        overflow: visible
 
       #main
         padding-bottom: 0
 
-      #content
-        height: 100% !important
-        overflow: visible
+        #content-wrapper
+          &.hidden-navigation
+            margin-left: 0
+            width: 100%
+
+          &.nosidebar
+            padding: 0
+            width:    100%
+            margin-left: 0
+
+          &.nomenus
+            top: 0
+            padding: 0
+            width: 100%
+            margin-left: 0
+
 
       .work-packages--show-view
         padding: 0 0 0 5px

--- a/app/assets/stylesheets/layout/_work_package_table.sass
+++ b/app/assets/stylesheets/layout/_work_package_table.sass
@@ -31,6 +31,7 @@
 .controller-work_packages.full-create
   @extend %absolute-layout-mode
 
+  #content-wrapper,
   #content
     padding: 0
 
@@ -239,5 +240,19 @@
   .controller-work_packages.action-index
     #main
       overflow: overlay
+    #content-wrapper,
     #content
       overflow-y: auto
+
+// Implement two column layout for WP full screen view
+@media screen and (min-width: 90rem)
+  .action-show .attributes-group,
+  .full-create .attributes-group
+    .-columns-2
+      column-count: 2
+      column-gap: 4rem
+
+      .attributes-key-value
+        -webkit-column-break-inside: avoid
+        page-break-inside: avoid
+        break-inside: avoid

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -34,6 +34,7 @@ body.controller-work_packages.full-create
 
   // Fix selenium scrolling the #content which shouldn't be possible
   // This appears to be caused by somehow setting the scrollTop to move to an element.
+  #content-wrapper,
   #content
     overflow: visible
 

--- a/app/assets/stylesheets/layout/_zen_mode.sass
+++ b/app/assets/stylesheets/layout/_zen_mode.sass
@@ -2,7 +2,7 @@ body.zen-mode
   #top-menu,
   #main-menu
     display: none
-  #content
+  #content-wrapper
     margin-left: 0px
 
   &.controller-work_packages
@@ -12,5 +12,7 @@ body.zen-mode
       #main
         top: 0px
         height: 100%
-      #content
-        width: 100%
+
+        #content-wrapper
+          width: 100%
+          margin-left: 0

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -129,33 +129,36 @@ See doc/COPYRIGHT.rdoc for more details.
             </div>
           </div>
         <% end %>
-        <% if show_decoration %>
-          <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>"
-               ng-class="{ 'hidden-navigation': !showNavigation }">
-            <%= you_are_here_info %>
-            <%= full_breadcrumb %>
-            <%= call_hook :view_layouts_base_breadcrumb %>
-          </div>
-        <% end %>
-        <%= render_flash_messages %>
-        <notifications></notifications>
-        <div id="content" class="<%= initial_classes %>"
+        <div id="content-wrapper" class="<%= initial_classes %>"
              ng-class="{ 'hidden-navigation': !showNavigation }">
-          <h1 class="hidden-for-sighted"><%= l(:label_content) %></h1>
-          <%= content_for :content_body %>
-          <% unless local_assigns[:no_action_menu] %>
-            <!-- Action menu -->
-            <%= render partial: 'layouts/action_menu' %>
-            <%= yield %>
+          <% if show_decoration %>
+            <div id="breadcrumb" class="<%= initial_classes %><%= show_breadcrumb ? ' -show' : '' %>"
+                 ng-class="{ 'hidden-navigation': !showNavigation }">
+              <%= you_are_here_info %>
+              <%= full_breadcrumb %>
+              <%= call_hook :view_layouts_base_breadcrumb %>
+            </div>
           <% end %>
-          <%= call_hook :view_layouts_base_content %>
+          <%= render_flash_messages %>
+          <notifications></notifications>
+          <div id="content" class="<%= initial_classes %>"
+               ng-class="{ 'hidden-navigation': !showNavigation }">
+            <h1 class="hidden-for-sighted"><%= l(:label_content) %></h1>
+            <%= content_for :content_body %>
+            <% unless local_assigns[:no_action_menu] %>
+              <!-- Action menu -->
+              <%= render partial: 'layouts/action_menu' %>
+              <%= yield %>
+            <% end %>
+            <%= call_hook :view_layouts_base_content %>
+            <% unless local_assigns[:no_action_menu] %>
+              <div style="clear:both;">&nbsp;</div>
+            <% end %>
+          </div>
           <% unless local_assigns[:no_action_menu] %>
             <div style="clear:both;">&nbsp;</div>
           <% end %>
         </div>
-        <% unless local_assigns[:no_action_menu] %>
-          <div style="clear:both;">&nbsp;</div>
-        <% end %>
       </div>
       <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>
     </div>

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -57,7 +57,7 @@ module OpenProject
       'h4-font-size'                                         => "calc($h3-font-size * 0.75)",
       'h4-font-color'                                        => "$body-font-color",
       'header-height'                                        => "55px",
-      'header-height-mobile'                                 => "45px",
+      'header-height-mobile'                                 => "55px",
       'header-bg-color'                                      => "$primary-color",
       'header-home-link-bg'                                  => '#{image-url("logo_openproject_white_big.png") no-repeat 20px 0}',
       'header-border-bottom-color'                           => "$primary-color",


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/25677/activity

I am pretty sure that this PR will trigger other bugs to come up due to its complexity.

For reviewing/testing this PR I found that at least the following combinations have to be tested:

All test cases need to be checked for:

- Side menu expanded
- Side menu collapsed
- No menu (i.e. global stuff)
- Zen Mode (in WPs)

Screen sizes:

- Large desktop (that allows for displaying split screen and timelines)
- Medium desktop (so that in WP list the activity and relations are collapsed)
- Mobile (Side menu should not have a full column and instead overlap #main)

Specials stuff:
- The WP List / Timelines work in a different lay outing mode (position: absolute)
- From that exception medium desktops have an exception from that exception (setting position: relative again) when showing a WP in full screen (so not in split view).

Breadcrumbs:

There are multiple types of breadcrumbs that had all some complex lay outing rules that now should get simplified.
