### PR TITLE
[25666] Reset states of additional elements so they can be refreshed

### DIFF
--- a/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
@@ -46,8 +46,6 @@ import {
 } from '../../wp-relations/wp-relations.service';
 import {WorkPackageTableHierarchiesService} from './wp-table-hierarchy.service';
 
-export type RelationColumnType = 'toType' | 'ofType';
-
 export class WorkPackageTableAdditionalElementsService {
 
   constructor(public states:States,
@@ -86,7 +84,7 @@ export class WorkPackageTableAdditionalElementsService {
       return Promise.resolve([]);
     }
     return this.wpRelations
-      .requireInvolved(rows)
+      .load(rows)
       .then(() => {
         const ids = this.getInvolvedWorkPackages(rows.map(id => {
           return this.wpRelations.getRelationsForWorkPackage(id).value!;

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -115,7 +115,7 @@ export class WorkPackageTableTimelineRelations {
       .subscribe(list => {
         // ... make sure that the corresponding relations are loaded ...
         const wps = _.compact(list.map(row => row.workPackageId) as string[]);
-        this.wpRelations.requireInvolved(wps);
+        this.wpRelations.requireLoaded(wps);
 
         wps.forEach(wpId => {
           const relationsForWorkPackage = this.wpRelations.getRelationsForWorkPackage(wpId);


### PR DESCRIPTION
Since relations are only loaded when required, we should clear those states so that upon table reloading:

1. Relations to additional elements are cleared and refreshed

2. Work packages of those relations are cleared and refreshed to avoid 409 conflicts.

https://community.openproject.com/projects/openproject/work_packages/25666/activity?query_id=931