### PR TITLE
[25453] Replace the default outline in columns focus

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -187,3 +187,11 @@ i
           .attributes-key-value--value-container
             flex-basis: calc(83.35% + (4rem / 6))
             max-width: calc(83.35% + (4rem / 6))
+
+  @supports (column-span: all)
+    // Remove the outline on focus since that breaks the column in chrome
+    // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=565116
+    body:not(.accessibility-mode)
+      .attributes-key-value--value-container
+        *:focus
+          outline: 1px solid $gray


### PR DESCRIPTION
Replace the shadow outline in chrome on the two-columns single-view  with a 1px outline that doesn't break columns layout while still _hinting_ where the user's focus is in the default mode.

![anim3](https://user-images.githubusercontent.com/459462/27628597-d603af9c-5bef-11e7-86c3-0252bd2aab55.gif)

Sort of a hack, but the bug on chromium doesn't appear to be solved anytime soon. **It does not affect the accessibility mode, where a different outline is used that also doesn't appear to exhibit the bug**

https://bugs.chromium.org/p/chromium/issues/detail?id=565116
https://stackoverflow.com/questions/24701316

https://community.openproject.com/projects/openproject/work_packages/25453/
