### PR TITLE
Fix/cache query representers

### DIFF
--- a/lib/api/utilities/representer_to_json_cache.rb
+++ b/lib/api/utilities/representer_to_json_cache.rb
@@ -29,27 +29,30 @@
 #++
 
 module API
-  module V3
-    module Queries
-      module Schemas
-        class SubprojectFilterDependencyRepresenter <
-          FilterDependencyRepresenter
-
-          def json_cache_key
-            super + [filter.project.id]
+  module Utilities
+    module RepresenterToJsonCache
+      def to_json(*)
+        if json_cacheable?
+          OpenProject::Cache.fetch(*json_representer_name_cache_key, *json_cache_key) do
+            super
           end
-
-          def href_callback
-            params = [ancestor: { operator: '=', values: [filter.project.id.to_s] }]
-            escaped = CGI.escape(::JSON.dump(params))
-
-            "#{api_v3_paths.projects}?filters=#{escaped}"
-          end
-
-          def type
-            "[]Project"
-          end
+        else
+          super
         end
+      end
+
+      def json_cacheable?
+        true
+      end
+
+      def json_cache_key
+        raise NotImplementedError
+      end
+
+      private
+
+      def json_representer_name_cache_key
+        self.class.name.to_s.split('::') + ['json', I18n.locale]
       end
     end
   end

--- a/lib/api/v3/queries/columns/query_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_column_representer.rb
@@ -33,6 +33,8 @@ module API
     module Queries
       module Columns
         class QueryColumnRepresenter < ::API::Decorators::Single
+          include API::Utilities::RepresenterToJsonCache
+
           self_link path: 'query_column',
                     id_attribute: ->(*) { converted_name },
                     title_getter: ->(*) { represented.caption }
@@ -55,6 +57,10 @@ module API
 
           def convert_attribute(attribute)
             ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
+          end
+
+          def json_cache_key
+            [represented.name, represented.caption]
           end
         end
       end

--- a/lib/api/v3/queries/columns/query_relation_of_type_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_relation_of_type_column_representer.rb
@@ -39,6 +39,10 @@ module API
 
           property :relation_type
         end
+
+        def json_cache_key
+          [represented.name]
+        end
       end
     end
   end

--- a/lib/api/v3/queries/columns/query_relation_to_type_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_relation_to_type_column_representer.rb
@@ -43,6 +43,10 @@ module API
           def _type
             'QueryColumn::RelationToType'
           end
+
+          def json_cache_key
+            [represented.name, represented.type.cache_key]
+          end
         end
       end
     end

--- a/lib/api/v3/queries/group_bys/query_group_by_representer.rb
+++ b/lib/api/v3/queries/group_bys/query_group_by_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,9 +33,10 @@ module API
     module Queries
       module GroupBys
         class QueryGroupByRepresenter < ::API::Decorators::Single
+          include API::Utilities::RepresenterToJsonCache
+
           self_link id_attribute: ->(*) { converted_name },
                     title_getter: ->(*) { represented.caption }
-
           def initialize(model, *_)
             super(model, current_user: nil, embed_links: true)
           end
@@ -57,6 +59,10 @@ module API
 
           def convert_attribute(attribute)
             ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
+          end
+
+          def json_cache_key
+            [represented.name, represented.caption]
           end
         end
       end

--- a/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assigned_to_filter_dependency_representer.rb
@@ -35,6 +35,14 @@ module API
         class AssignedToFilterDependencyRepresenter <
           PrincipalFilterDependencyRepresenter
 
+          def json_cache_key
+            if filter.project
+              super + [Setting.work_package_group_assignment?, filter.project.id]
+            else
+              super + [Setting.work_package_group_assignment?]
+            end
+          end
+
           private
 
           def filter_query

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -35,6 +35,10 @@ module API
         class CategoryFilterDependencyRepresenter <
           FilterDependencyRepresenter
 
+          def json_cache_key
+            super + [filter.project.id]
+          end
+
           def href_callback
             # This filter is only available inside projects
             api_v3_paths.categories(filter.project.identifier)

--- a/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
@@ -55,6 +55,10 @@ module API
                                            value_required?
                                          }
 
+          def json_cache_key
+            super + [filter.custom_field.cache_key]
+          end
+
           private
 
           def type

--- a/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
@@ -47,7 +47,7 @@ module API
                                          value_representer: CustomOptions::CustomOptionRepresenter,
                                          link_factory: ->(value) {
                                            {
-                                             href: api_v3_paths.custom_option(value),
+                                             href: api_v3_paths.custom_option(value.id),
                                              title: value.to_s
                                            }
                                          },

--- a/lib/api/v3/queries/schemas/date_time_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/date_time_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)

--- a/lib/api/v3/queries/schemas/filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,6 +33,8 @@ module API
     module Queries
       module Schemas
         class FilterDependencyRepresenter < ::API::Decorators::SchemaRepresenter
+          include API::Utilities::RepresenterToJsonCache
+
           def initialize(filter, operator, form_embedded: false)
             self.operator = operator
 
@@ -71,6 +74,10 @@ module API
             end
           end
 
+          def json_cache_key
+            [operator.to_sym, I18n.locale]
+          end
+
           private
 
           def value_required?
@@ -78,7 +85,7 @@ module API
           end
 
           def type
-            raise NotImplementedError, 'Subclass has to implement #href_callback'
+            raise NotImplementedError, 'Subclass has to implement #type'
           end
 
           def href_callback

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -35,6 +35,10 @@ module API
         class GroupFilterDependencyRepresenter <
           PrincipalFilterDependencyRepresenter
 
+          def json_cache_key
+            super + (filter.project.present? ? [filter.project.id] : [])
+          end
+
           private
 
           def filter_query

--- a/lib/api/v3/queries/schemas/id_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/id_filter_dependency_representer.rb
@@ -35,6 +35,10 @@ module API
         class IdFilterDependencyRepresenter <
           FilterDependencyRepresenter
 
+          def json_cache_key
+            super + (filter.project.present? ? [filter.project.id] : [])
+          end
+
           def href_callback
             if filter.project
               api_v3_paths.work_packages_by_project(filter.project.id)

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_api.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_api.rb
@@ -66,7 +66,7 @@ module API
                 filter_class = Query.find_registered_filter(ar_name)
 
                 if filter_class
-                  filter = filter_class.new
+                  filter = filter_class.new context: OpenStruct.new(project: nil)
                   filter.name = ar_name
 
                   single_representer.new(filter,

--- a/lib/api/v3/queries/schemas/status_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/status_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -11,7 +12,7 @@
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
+# modif it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
 #

--- a/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -33,6 +34,10 @@ module API
       module Schemas
         class TypeFilterDependencyRepresenter <
           FilterDependencyRepresenter
+
+          def json_cache_key
+            super + (filter.project.present? ? [filter.project.id] : [])
+          end
 
           def href_callback
             if filter.project.nil?

--- a/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
@@ -35,6 +35,10 @@ module API
         class UserFilterDependencyRepresenter <
           PrincipalFilterDependencyRepresenter
 
+          def json_cache_key
+            super + (filter.project.present? ? [filter.project.id] : [])
+          end
+
           private
 
           def filter_query

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -35,6 +35,10 @@ module API
         class VersionFilterDependencyRepresenter <
           FilterDependencyRepresenter
 
+          def json_cache_key
+            super + (filter.project.present? ? [filter.project.id] : [])
+          end
+
           def href_callback
             order = "sortBy=#{to_query [%i(name asc)]}"
 

--- a/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
+++ b/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,6 +33,8 @@ module API
     module Queries
       module SortBys
         class QuerySortByRepresenter < ::API::Decorators::Single
+          include API::Utilities::RepresenterToJsonCache
+
           self_link id_attribute: ->(*) { self_link_params },
                     title_getter: ->(*) { represented.name }
 
@@ -63,6 +66,10 @@ module API
 
           def _type
             'QuerySortBy'
+          end
+
+          def json_cache_key
+            [represented.column_caption, represented.direction_name]
           end
         end
       end

--- a/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter do
+describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:column) { Query.available_columns.detect { |column| column.name == :status } }
@@ -84,6 +84,51 @@ describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter do
         is_expected
           .to be_json_eql('Assignee'.to_json)
           .at_path('name')
+      end
+    end
+  end
+
+  describe 'caching' do
+    before do
+      # fill the cache
+      representer.to_json
+    end
+
+    it 'is cached' do
+      expect(representer)
+        .not_to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the caption (cf rename)' do
+      allow(column)
+        .to receive(:caption)
+        .and_return('blubs')
+
+      expect(representer)
+        .to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the name' do
+      allow(column)
+        .to receive(:name)
+        .and_return('blubs')
+
+      expect(representer)
+        .to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the locale' do
+      expect(representer)
+        .to receive(:to_hash)
+
+      I18n.with_locale(:de) do
+        representer.to_json
       end
     end
   end

--- a/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
@@ -27,7 +27,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryRelationOfTypeColumnRepresenter do
+describe ::API::V3::Queries::Columns::QueryRelationOfTypeColumnRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:type) { { name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: :relation1 } }
@@ -60,13 +60,47 @@ describe ::API::V3::Queries::Columns::QueryRelationOfTypeColumnRepresenter do
     it 'has relationType attribute' do
       is_expected
         .to be_json_eql(type[:sym].to_json)
-              .at_path('relationType')
+        .at_path('relationType')
     end
 
     it 'has name attribute' do
       is_expected
         .to be_json_eql("#{I18n.t(type[:name])} relations".to_json)
         .at_path('name')
+    end
+  end
+
+  describe 'caching' do
+    before do
+      # fill the cache
+      representer.to_json
+    end
+
+    it 'is cached' do
+      expect(representer)
+        .not_to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the name' do
+      allow(column)
+        .to receive(:name)
+        .and_return('blubs')
+
+      expect(representer)
+        .to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the locale' do
+      expect(representer)
+        .to receive(:to_hash)
+
+      I18n.with_locale(:de) do
+        representer.to_json
+      end
     end
   end
 end

--- a/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
@@ -1,4 +1,5 @@
 #-- copyright
+#
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
@@ -28,7 +29,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::GroupBys::QueryGroupByRepresenter do
+describe ::API::V3::Queries::GroupBys::QueryGroupByRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:column) { Query.available_columns.detect { |column| column.name == :status } }
@@ -84,6 +85,51 @@ describe ::API::V3::Queries::GroupBys::QueryGroupByRepresenter do
         is_expected
           .to be_json_eql('Assignee'.to_json)
           .at_path('name')
+      end
+    end
+  end
+
+  describe 'caching' do
+    before do
+      # fill the cache
+      representer.to_json
+    end
+
+    it 'is cached' do
+      expect(representer)
+        .not_to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the caption (cf rename)' do
+      allow(column)
+        .to receive(:caption)
+        .and_return('blubs')
+
+      expect(representer)
+        .to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the name' do
+      allow(column)
+        .to receive(:name)
+        .and_return('blubs')
+
+      expect(representer)
+        .to receive(:to_hash)
+
+      representer.to_json
+    end
+
+    it 'busts the cache on changes to the locale' do
+      expect(representer)
+        .to receive(:to_hash)
+
+      I18n.with_locale(:de) do
+        representer.to_json
       end
     end
   end

--- a/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
@@ -67,6 +67,40 @@ describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::NotEquals }
 
           it_behaves_like 'filter dependency'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
@@ -28,11 +28,12 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::CategoryFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::CategoryFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::CategoryFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::CategoryFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -72,6 +73,50 @@ describe ::API::V3::Queries::Schemas::CategoryFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::None }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
@@ -28,11 +28,12 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::DateFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::DateFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::DueDateFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::DueDateFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -103,6 +104,41 @@ describe ::API::V3::Queries::Schemas::DateFilterDependencyRepresenter do
           let(:type) { '[2]Date' }
 
           it_behaves_like 'filter dependency'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
@@ -28,13 +28,14 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::FloatFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::FloatFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
   let(:custom_field) { FactoryGirl.build_stubbed(:float_wp_custom_field) }
   let(:filter) do
-    filter = Queries::WorkPackages::Filter::CustomFieldFilter.new(context: project)
+    filter = Queries::WorkPackages::Filter::CustomFieldFilter.new(context: query)
     filter.custom_field = custom_field
     filter
   end
@@ -88,6 +89,41 @@ describe ::API::V3::Queries::Schemas::FloatFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::All }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
@@ -103,6 +103,50 @@ describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter do
 
             it_behaves_like 'filter dependency with allowed link'
           end
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::IdFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::IdFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
@@ -82,6 +82,50 @@ describe ::API::V3::Queries::Schemas::IdFilterDependencyRepresenter do
 
             it_behaves_like 'filter dependency with allowed link'
           end
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
@@ -28,11 +28,12 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::IntegerFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::IntegerFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::DoneRatioFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::DoneRatioFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -83,6 +84,40 @@ describe ::API::V3::Queries::Schemas::IntegerFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::All }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
@@ -28,11 +28,12 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::PriorityFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::PriorityFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::PriorityFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::PriorityFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -60,6 +61,40 @@ describe ::API::V3::Queries::Schemas::PriorityFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::NotEquals }
 
           it_behaves_like 'filter dependency with allowed link'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::ProjectFilter.new }
@@ -71,6 +71,40 @@ describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::None }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::RoleFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::RoleFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::RoleFilter.new }
@@ -71,6 +71,40 @@ describe ::API::V3::Queries::Schemas::RoleFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::None }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::StatusFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::StatusFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::StatusFilter.new }
@@ -77,6 +77,40 @@ describe ::API::V3::Queries::Schemas::StatusFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::All }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
@@ -28,11 +28,12 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::SubprojectFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::SubprojectFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
-  let(:filter) { Queries::WorkPackages::Filter::SubprojectFilter.new(context: project) }
+  let(:query) { FactoryGirl.build_stubbed(:query, project: project) }
+  let(:filter) { Queries::WorkPackages::Filter::SubprojectFilter.new(context: query) }
   let(:form_embedded) { false }
 
   let(:instance) do
@@ -71,6 +72,50 @@ describe ::API::V3::Queries::Schemas::SubprojectFilterDependencyRepresenter do
           let(:operator) { Queries::Operators::None }
 
           it_behaves_like 'filter dependency empty'
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
@@ -85,6 +85,50 @@ describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter do
 
             it_behaves_like 'filter dependency with allowed link'
           end
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed :project }
@@ -88,6 +88,50 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
 
             it_behaves_like 'filter dependency with allowed link'
           end
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
+describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter, clear_cache: true do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { FactoryGirl.build_stubbed(:project) }
@@ -101,6 +101,50 @@ describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
 
             it_behaves_like 'filter dependency with allowed link'
           end
+        end
+      end
+    end
+
+    describe 'caching' do
+      let(:operator) { Queries::Operators::Equals }
+      let(:other_project) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        # fill the cache
+        instance.to_json
+      end
+
+      it 'is cached' do
+        expect(instance)
+          .not_to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different operator' do
+        instance.send(:operator=, Queries::Operators::NotEquals)
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on a different project' do
+        query.project = other_project
+
+        expect(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+      end
+
+      it 'busts the cache on changes to the locale' do
+        expect(instance)
+          .to receive(:to_hash)
+
+        I18n.with_locale(:de) do
+          instance.to_json
         end
       end
     end

--- a/spec/support/shared/clear_cache.rb
+++ b/spec/support/shared/clear_cache.rb
@@ -28,29 +28,11 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Queries
-      module Schemas
-        class SubprojectFilterDependencyRepresenter <
-          FilterDependencyRepresenter
-
-          def json_cache_key
-            super + [filter.project.id]
-          end
-
-          def href_callback
-            params = [ancestor: { operator: '=', values: [filter.project.id.to_s] }]
-            escaped = CGI.escape(::JSON.dump(params))
-
-            "#{api_v3_paths.projects}?filters=#{escaped}"
-          end
-
-          def type
-            "[]Project"
-          end
-        end
-      end
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    clear_cache = example.metadata[:clear_cache]
+    if clear_cache
+      Rails.cache.clear
     end
   end
 end


### PR DESCRIPTION
As most query representers (at least the nested ones like SortBy, GroupBy, Column, FilterInstanceSchema) are not user specific, the can be cached efficiently. By overriding the representer's `to_json` method, the caching can be integrated quite well and the caching is very efficient. 

On a project with a lot of custom fields, leading to a lot of columns and filters, this brought down the request for the query form from 3 sec to 500 ms. 

This fixes the root cause of https://community.openproject.com/projects/openproject/work_packages/25654.

It would still make sense to have some type of loading indicator e.g. on the first request, slow servers, high latency networks... but I'd like to handle this in a different PR.