### PR TITLE
Expire sessions in warden auth scope

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,7 @@ class ApplicationController < ActionController::Base
   include I18n
   include Redmine::I18n
   include HookHelper
+  include ::OpenProject::Authentication::SessionExpiry
 
   layout 'base'
 
@@ -675,13 +676,7 @@ class ApplicationController < ActionController::Base
   private
 
   def session_expired?
-    !api_request? && current_user.logged? &&
-      (session_ttl_enabled? && (session[:updated_at].nil? ||
-                               (session[:updated_at] + Setting.session_ttl.to_i.minutes) < Time.now))
-  end
-
-  def session_ttl_enabled?
-    Setting.session_ttl_enabled? && Setting.session_ttl.to_i >= 5
+    !api_request? && current_user.logged? && session_ttl_expired?
   end
 
   def permitted_params

--- a/lib/open_project/authentication/session_expiry.rb
+++ b/lib/open_project/authentication/session_expiry.rb
@@ -1,0 +1,20 @@
+module OpenProject
+  module Authentication
+    module SessionExpiry
+      def session_ttl_enabled?
+        Setting.session_ttl_enabled? && Setting.session_ttl.to_i >= 5
+      end
+
+      def session_ttl_minutes
+        Setting.session_ttl.to_i.minutes
+      end
+
+      def session_ttl_expired?
+        # Only when the TTL setting exists
+        return false unless session_ttl_enabled?
+
+        session[:updated_at].nil? || (session[:updated_at] + session_ttl_minutes) < Time.now
+      end
+    end
+  end
+end

--- a/lib/open_project/authentication/strategies/warden/session.rb
+++ b/lib/open_project/authentication/strategies/warden/session.rb
@@ -1,3 +1,5 @@
+require 'open_project/authentication/session_expiry'
+
 module OpenProject
   module Authentication
     module Strategies
@@ -7,8 +9,10 @@ module OpenProject
         # not been unified in terms of Warden strategies and is only locally
         # applied to the API v3.
         class Session < ::Warden::Strategies::Base
+          include ::OpenProject::Authentication::SessionExpiry
+
           def valid?
-            session
+            session && !session_ttl_expired?
           end
 
           def authenticate!

--- a/spec/features/security/session_ttl_spec.rb
+++ b/spec/features/security/session_ttl_spec.rb
@@ -1,0 +1,72 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Session TTL',
+         with_settings: {session_ttl_enabled?: true, session_ttl: '10'},
+         type: :feature do
+  let!(:user) {FactoryGirl.create :admin}
+  let!(:work_package) {FactoryGirl.create :work_package}
+
+  before do
+    login_with(user.login, user.password)
+  end
+
+  def expire!
+    page.set_rack_session(updated_at: Time.now - 1.hour)
+  end
+
+  describe 'outdated TTL on Rails request' do
+    it 'expires on the next Rails request' do
+      visit '/my/account'
+      expect(page).to have_selector('.form--field-container', text: user.login)
+
+      # Expire the session
+      expire!
+
+      visit '/'
+      expect(page).to have_selector('.action-login')
+    end
+  end
+
+  describe 'outdated TTL on API request' do
+    it 'expires on the next APIv3 request' do
+      visit "/api/v3/work_packages/#{work_package.id}"
+
+      body = JSON.parse(page.body)
+      expect(body['id']).to eq(work_package.id)
+
+      # Expire the session
+      expire!
+      visit "/api/v3/work_packages/#{work_package.id}"
+
+      expect(page.body).to eq('unauthorized')
+    end
+  end
+end


### PR DESCRIPTION
This vulnerability has been assigned to the identifier [CVE-2017-11667](https://nvd.nist.gov/vuln/detail/CVE-2017-11667).