### PR TITLE
Extract base cache state from relations and work packages services

### DIFF
--- a/frontend/app/components/api/api-paths/api-paths.config.ts
+++ b/frontend/app/components/api/api-paths/api-paths.config.ts
@@ -36,6 +36,7 @@ function apiPathsProviderConfig(apiPathsProvider:ApiPathsServiceProvider) {
   }];
   const workPackages = ['work_packages{/wp}', {
     form: 'form',
+    relations: 'relations',
     availableProjects: 'available_projects'
   }, {
     project: projects

--- a/frontend/app/components/api/api-v3/hal-resource-dms/relations-dm.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-dms/relations-dm.service.ts
@@ -35,8 +35,20 @@ import {buildApiV3Filter} from '../api-v3-filter-builder';
 export class RelationsDmService {
 
   constructor(private halRequest:HalRequestService,
+              private v3Path:any,
               private $q:ng.IQService) {
 
+  }
+
+  public load(workPackageId:string):ng.IPromise<RelationResource[]> {
+    return this.halRequest.get(
+      this.v3Path.wp.relations({wp: workPackageId}),
+      {},
+      {
+        caching: {enabled: false}
+      }).then((collection:CollectionResource) => {
+        return collection.elements;
+    });
   }
 
   public loadInvolved(workPackageIds:string[]):ng.IPromise<RelationResource[]> {

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -41,6 +41,8 @@ import {States} from '../../../states.service';
 import {SchemaResource} from './schema-resource.service';
 import {TypeResource} from './type-resource.service';
 import {RelationResourceInterface} from './relation-resource.service';
+import {WorkPackageCreateService} from '../../../wp-create/wp-create.service';
+import {WorkPackageNotificationService} from '../../../wp-edit/wp-notification.service';
 
 interface WorkPackageResourceEmbedded {
   activities:CollectionResourceInterface;
@@ -101,36 +103,14 @@ var apiWorkPackages:ApiWorkPackagesService;
 var wpCacheService:WorkPackageCacheService;
 var schemaCacheService:SchemaCacheService;
 var NotificationsService:any;
-var wpNotificationsService:any;
+var wpNotificationsService:WorkPackageNotificationService;
+var wpCreate:WorkPackageCreateService;
 var AttachmentCollectionResource:any;
 var v3Path:any;
 
 export class WorkPackageResource extends HalResource {
   // Add index signature for getter this[attr]
   [attribute:string]:any;
-
-  public static fromCreateForm(form:any) {
-    var wp = new WorkPackageResource(form.payload.$plain(), true);
-
-    wp.initializeNewResource(form);
-    return wp;
-  }
-
-  /**
-   * Create a copy resource from other and the new work package form
-   * @param otherForm The work package form of another work package
-   * @param form Work Package create form
-   */
-  public static copyFrom(otherForm:any, form:any) {
-    var wp = new WorkPackageResource(otherForm.payload.$plain(), true);
-
-    // Override values from form payload
-    wp.lockVersion = form.payload.lockVersion;
-
-    wp.initializeNewResource(form);
-
-    return wp;
-  }
 
   public $embedded:WorkPackageResourceEmbedded;
   public $links:WorkPackageLinksObject;
@@ -273,7 +253,7 @@ export class WorkPackageResource extends HalResource {
           this.updateAttachments();
         })
         .catch((error:any) => {
-          wpNotificationsService.handleErrorResponse(error, this);
+          wpNotificationsService.handleErrorResponse(error, this as any);
           this.attachments.elements.push(attachment);
         });
     }
@@ -311,7 +291,7 @@ export class WorkPackageResource extends HalResource {
         return this.updateAttachments();
       })
       .catch(error => {
-        wpNotificationsService.handleRawError(error, this);
+        wpNotificationsService.handleRawError(error, this as any);
       });
   }
 
@@ -447,7 +427,7 @@ export class WorkPackageResource extends HalResource {
 
               if (wasNew) {
                 this.uploadPendingAttachments();
-                wpCacheService.newWorkPackageCreated(this as any);
+                wpCreate.newWorkPackageCreated(this as any);
               }
 
               // Remove only those pristine values that were submitted
@@ -657,6 +637,7 @@ function wpResource(...args:any[]) {
     states,
     apiWorkPackages,
     wpCacheService,
+    wpCreate,
     schemaCacheService,
     NotificationsService,
     wpNotificationsService,
@@ -673,6 +654,7 @@ wpResource.$inject = [
   'states',
   'apiWorkPackages',
   'wpCacheService',
+  'wpCreate',
   'schemaCacheService',
   'NotificationsService',
   'wpNotificationsService',

--- a/frontend/app/components/states/state-cache.service.ts
+++ b/frontend/app/components/states/state-cache.service.ts
@@ -1,0 +1,132 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+import {SchemaCacheService} from './../schemas/schema-cache.service';
+import {InputState, MultiInputState, State} from 'reactivestates';
+import {Observable, Subject} from 'rxjs';
+import {opWorkPackagesModule} from '../../angular-modules';
+import {
+  WorkPackageResourceInterface
+} from '../api/api-v3/hal-resources/work-package-resource.service';
+import {ApiWorkPackagesService} from '../api/api-work-packages/api-work-packages.service';
+import {States} from '../states.service';
+import {WorkPackageNotificationService} from './../wp-edit/wp-notification.service';
+import IScope = angular.IScope;
+import IPromise = angular.IPromise;
+import {WorkPackageCollectionResourceInterface} from '../api/api-v3/hal-resources/wp-collection-resource.service';
+import {SchemaResource} from '../api/api-v3/hal-resources/schema-resource.service';
+
+export abstract class StateCacheService<T> {
+  private cacheDurationInMs:number;
+
+  constructor(private holdValuesForSeconds:number = 120) {
+    this.cacheDurationInMs = holdValuesForSeconds * 1000;
+  }
+
+  public state(id:string):State<T> {
+    return this.multiState.get(id);
+  }
+
+  /**
+   * Update the value due to application changes.
+   *
+   * @param id The value's identifier.
+   * @param val<T> The value.
+   */
+  public updateValue(id:string, val:T) {
+    this.multiState.get(id).putValue(val);
+  }
+
+  /**
+   * Require the value to be loaded either when forced or the value is stale
+   * according to the cache interval specified for this service.
+   *
+   * @param id The value's identifier.
+   * @param force Load the value anyway.
+   */
+  public require(id:string, force:boolean = false):Promise<T> {
+    const state = this.multiState.get(id);
+
+    // Refresh when stale or being forced
+    if (this.stale(state) || force) {
+      state.clear();
+      return this.load(id);
+    }
+
+    return Promise.resolve(state.value);
+  }
+
+  /**
+   * Require the states of the given ids to be loaded if they're empty or stale,
+   * or all when force is given.
+   * @param ids Ids to require
+   * @param force Load the values anyway
+   * @return {Promise<undefined>} An empty promise to mark when the set of states is filled.
+   */
+  public requireAll(ids:string[], force:boolean = false):Promise<undefined> {
+    let idsToRequest:string[];
+
+    if (force) {
+      idsToRequest = ids;
+    } else {
+      idsToRequest = ids.filter((id:string) => this.stale(this.multiState.get(id)));
+    }
+
+    if (idsToRequest.length === 0) {
+      return Promise.resolve();
+    }
+
+    return this.loadAll(idsToRequest);
+  }
+
+  /**
+   * Returns whether the state
+   * @param state
+   * @return {boolean}
+   */
+  protected stale(state:InputState<T>):boolean {
+    return state.isPristine() || state.isValueOlderThan(this.cacheDurationInMs);
+  }
+
+  /**
+   * Returns the internal state object
+   */
+  protected abstract get multiState():MultiInputState<T>;
+
+  /**
+   * Load a single value into the cache state.
+   * Subclassses need to ensure it gets loaded and resolve or reject the promise
+   * @param id The identifier of the value object of type T.
+   */
+  protected abstract load(id:string):Promise<T>;
+
+  /**
+   * Load a set of required values, fill the results into the appropriate states
+   * and return a promise when all values are inserted.
+   */
+  protected abstract loadAll(ids:string[]):Promise<undefined>;
+}

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -39,12 +39,13 @@ import IScope = angular.IScope;
 import IPromise = angular.IPromise;
 import {WorkPackageCollectionResourceInterface} from '../api/api-v3/hal-resources/wp-collection-resource.service';
 import {SchemaResource} from '../api/api-v3/hal-resources/schema-resource.service';
+import {StateCacheService} from '../states/state-cache.service';
 
 function getWorkPackageId(id:number | string):string {
   return (id || "__new_work_package__").toString();
 }
 
-export class WorkPackageCacheService {
+export class WorkPackageCacheService extends StateCacheService<WorkPackageResourceInterface> {
 
   private newWorkPackageCreatedSubject = new Subject<WorkPackageResourceInterface>();
 
@@ -54,6 +55,7 @@ export class WorkPackageCacheService {
               private wpNotificationsService:WorkPackageNotificationService,
               private schemaCacheService:SchemaCacheService,
               private apiWorkPackages:ApiWorkPackagesService) {
+    super();
   }
 
   newWorkPackageCreated(wp:WorkPackageResourceInterface) {
@@ -61,7 +63,7 @@ export class WorkPackageCacheService {
   }
 
   updateWorkPackage(wp:WorkPackageResourceInterface) {
-    this.updateWorkPackageList([wp]);
+    this.updateValue(wp.id, wp);
   }
 
   updateWorkPackageList(list:WorkPackageResourceInterface[]) {
@@ -101,52 +103,12 @@ export class WorkPackageCacheService {
   }
 
   /**
-   * Load an array of work package ids into states, unless they already exist.
+   * Wrapper around `require(id)`.
    *
-   * @param workPackageIds
+   * @deprecated
    */
-  loadWorkPackages(workPackageIds:string[]):Promise<void> {
-    const needToLoad:string[] = [];
-
-    workPackageIds.forEach((id:string) => {
-      if (this.states.workPackages.get(id).isPristine()) {
-        needToLoad.push(id);
-      }
-    });
-
-    if (needToLoad.length === 0) {
-      return this.$q.resolve();
-    }
-
-    this.apiWorkPackages
-      .loadWorkPackagesCollectionsFor(_.uniq(workPackageIds))
-      .then((pagedResults:WorkPackageCollectionResourceInterface[]) => {
-
-        _.each(pagedResults, (results) => {
-          if (results.schemas) {
-            _.each(results.schemas.elements, (schema:SchemaResource) => {
-              this.states.schemas.get(schema.href as string).putValue(schema);
-            });
-          }
-
-          if (results.elements) {
-            this.updateWorkPackageList(results.elements);
-          }
-        });
-      });
-
-    // Wait until all desired IDs have a value in their respective state
-    return Observable
-      .forkJoin(needToLoad.map(id => this.states.workPackages.get(id).valuesPromise()))
-      .mapTo(undefined)
-      .toPromise();
-  }
-
   loadWorkPackage(workPackageId:string, forceUpdate = false):State<WorkPackageResourceInterface> {
-    const state = this.states.workPackages.get(getWorkPackageId(workPackageId));
-    if (forceUpdate) {
-      state.clear();
-    }
+    const state = this.state(workPackageId);
 
     // Several services involved in the creation of work packages
     // use this method to resolve the latest created work package,
@@ -155,24 +117,50 @@ export class WorkPackageCacheService {
       return state;
     }
 
-    state.putFromPromiseIfPristine(() => {
-      const deferred = this.$q.defer();
-
-      this.apiWorkPackages.loadWorkPackageById(workPackageId, forceUpdate)
-        .then((workPackage:WorkPackageResourceInterface) => {
-          this.schemaCacheService.ensureLoaded(workPackage).then(() => {
-            deferred.resolve(workPackage);
-          });
-        });
-
-      return deferred.promise;
-    });
-
+    this.require(workPackageId, forceUpdate);
     return state;
   }
 
   onNewWorkPackage():Observable<WorkPackageResourceInterface> {
     return this.newWorkPackageCreatedSubject.asObservable();
+  }
+
+  protected loadAll(ids:string[]) {
+    return new Promise<undefined>((resolve, reject) => {
+      this.apiWorkPackages
+        .loadWorkPackagesCollectionsFor(_.uniq(ids))
+        .then((pagedResults:WorkPackageCollectionResourceInterface[]) => {
+          _.each(pagedResults, (results) => {
+            if (results.schemas) {
+              _.each(results.schemas.elements, (schema:SchemaResource) => {
+                this.states.schemas.get(schema.href as string).putValue(schema);
+              });
+            }
+
+            if (results.elements) {
+              this.updateWorkPackageList(results.elements);
+            }
+
+            resolve(undefined);
+          });
+        }, reject);
+    });
+  }
+
+  protected load(id:string) {
+    return new Promise<WorkPackageResourceInterface>((resolve, reject) => {
+      this.apiWorkPackages.loadWorkPackageById(id, true)
+        .then((workPackage:WorkPackageResourceInterface) => {
+          this.schemaCacheService.ensureLoaded(workPackage).then(() => {
+            this.updateValue(id, workPackage);
+            resolve(workPackage);
+          }, reject);
+        }, reject);
+    });
+  }
+
+  protected get multiState() {
+    return this.states.workPackages;
   }
 
 }

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -47,8 +47,6 @@ function getWorkPackageId(id:number | string):string {
 
 export class WorkPackageCacheService extends StateCacheService<WorkPackageResourceInterface> {
 
-  private newWorkPackageCreatedSubject = new Subject<WorkPackageResourceInterface>();
-
   /*@ngInject*/
   constructor(private states:States,
               private $q:angular.IQService,
@@ -58,12 +56,12 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
     super();
   }
 
-  newWorkPackageCreated(wp:WorkPackageResourceInterface) {
-    this.newWorkPackageCreatedSubject.next(wp);
+  public updateValue(id:string, val:WorkPackageResourceInterface) {
+    this.updateWorkPackageList([val]);
   }
 
   updateWorkPackage(wp:WorkPackageResourceInterface) {
-    this.updateValue(wp.id, wp);
+    this.updateWorkPackageList([wp]);
   }
 
   updateWorkPackageList(list:WorkPackageResourceInterface[]) {
@@ -119,10 +117,6 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
 
     this.require(workPackageId, forceUpdate);
     return state;
-  }
-
-  onNewWorkPackage():Observable<WorkPackageResourceInterface> {
-    return this.newWorkPackageCreatedSubject.asObservable();
   }
 
   protected loadAll(ids:string[]) {

--- a/frontend/app/components/wp-fast-table/builders/relation-cell-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/relation-cell-builder.ts
@@ -29,7 +29,7 @@ export class RelationCellbuilder {
 
     // Get current expansion and value state
     const expanded = this.wpTableRelationColumns.getExpandFor(workPackage.id) === column.id;
-    const relationState = this.wpRelations.getRelationsForWorkPackage(workPackage.id).value;
+    const relationState = this.wpRelations.state(workPackage.id).value;
     const relations = this.wpTableRelationColumns.relationsForColumn(workPackage,
       relationState,
       column);

--- a/frontend/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
@@ -51,7 +51,7 @@ export class RelationsRenderPass {
       // If the work package has no relations, ignore
       const workPackage = row.workPackage;
       const fromId = workPackage.id;
-      const state = this.wpRelations.getRelationsForWorkPackage(fromId);
+      const state = this.wpRelations.state(fromId);
       if (!state.hasValue() || _.size(state.value!) === 0) {
         return;
       }

--- a/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
@@ -68,7 +68,7 @@ export class WorkPackageTableAdditionalElementsService {
   }
 
   private loadAdditional(wpIds:string[]) {
-    this.wpCacheService.loadWorkPackages(wpIds)
+    this.wpCacheService.requireAll(wpIds)
       .then(() => {
         this.states.table.additionalRequiredWorkPackages.putValue(null, 'All required work packages are loaded');
       });
@@ -84,10 +84,10 @@ export class WorkPackageTableAdditionalElementsService {
       return Promise.resolve([]);
     }
     return this.wpRelations
-      .load(rows)
+      .requireAll(rows, true)
       .then(() => {
         const ids = this.getInvolvedWorkPackages(rows.map(id => {
-          return this.wpRelations.getRelationsForWorkPackage(id).value!;
+          return this.wpRelations.state(id).value!;
         }));
         return _.flatten(ids);
       });

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -92,7 +92,7 @@ export class WorkPackageInlineCreateController {
     });
 
     // Remove temporary rows on creation of new work package
-    scopedObservable(this.$scope, this.wpCacheService.onNewWorkPackage())
+    scopedObservable(this.$scope, this.wpCreate.onNewWorkPackage())
       .subscribe((wp:WorkPackageResourceInterface) => {
 
         if (this.currentWorkPackage === wp) {

--- a/frontend/app/components/wp-relations/wp-relations.directive.ts
+++ b/frontend/app/components/wp-relations/wp-relations.directive.ts
@@ -52,7 +52,7 @@ export class WorkPackageRelationsController {
               protected wpCacheService:WorkPackageCacheService) {
 
     scopedObservable(this.$scope,
-      this.wpRelations.getRelationsForWorkPackage(this.workPackage.id).values$())
+      this.wpRelations.state(this.workPackage.id).values$())
       .subscribe((relations:RelationsStateValue) => {
         this.loadedRelations(relations);
       });
@@ -62,7 +62,7 @@ export class WorkPackageRelationsController {
       this.wpCacheService.loadWorkPackage(this.workPackage.id).values$())
       .subscribe((wp:WorkPackageResourceInterface) => {
         this.workPackage = wp;
-        this.wpRelations.require(wp);
+        this.wpRelations.require(wp.id);
       });
   }
 

--- a/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -115,10 +115,10 @@ export class WorkPackageTableTimelineRelations {
       .subscribe(list => {
         // ... make sure that the corresponding relations are loaded ...
         const wps = _.compact(list.map(row => row.workPackageId) as string[]);
-        this.wpRelations.requireLoaded(wps);
+        this.wpRelations.requireAll(wps);
 
         wps.forEach(wpId => {
-          const relationsForWorkPackage = this.wpRelations.getRelationsForWorkPackage(wpId);
+          const relationsForWorkPackage = this.wpRelations.state(wpId);
           this.workPackagesWithRelations[wpId] = relationsForWorkPackage;
 
           // ... once they are loaded, display them.

--- a/spec/features/work_packages/table/filter_spec.rb
+++ b/spec/features/work_packages/table/filter_spec.rb
@@ -208,6 +208,8 @@ describe 'filter work packages', js: true do
     it 'allows filtering, saving and retrieving the saved filter' do
       filters.open
 
+      expect(page).to have_selector('#add_filter_select option', text: list_cf.name, wait: 10)
+
       filters.add_filter_by(list_cf.name,
                             'is not',
                             list_cf.custom_options.last.value,


### PR DESCRIPTION
This handles the implicit expiry of items after a given time interval. It will automatically fetch work packages in the `require` and `requireAll` methods when their caching time has expired.

You can play with the parameter of the state cache constructor to get a feeling how this works. When switching between WPs in the split view, there will be a minor delay until the work package is loaded should it have been stale.