### PR TITLE
add loading indicator to query settings dropdown menu

### DIFF
--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -119,7 +119,8 @@
 .dropdown .dropdown-menu,
 .toolbar .legacy-actions-more
   LI > A,
-  LABEL
+  LABEL,
+  .menu-item
     display: block
     @include varprop(color, context-menu-unselected-font-color)
     text-decoration: none

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
@@ -1,7 +1,14 @@
 <div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar" id="settingsDropdown">
   <!-- The hrefs with empty URLs are necessary for IE10 to focus these links
   properly. Thus, don't remove the hrefs or the empty URLs! -->
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" ng-if="loading">
+    <li>
+      <span class="menu-item">
+        {{ text.loading }}
+      </span>
+    </li>
+  </ul>
+  <ul class="dropdown-menu" ng-if="!loading">
     <li>
       <a class="menu-item" href="" ng-click="showColumnsModal($event)">
         <op-icon icon-classes="icon-action-menu icon-columns"></op-icon>

--- a/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
@@ -29,7 +29,6 @@
 /*jshint expr: true*/
 
 var reactivestates = require("reactivestates");
-var input = reactivestates.input;
 
 describe('optionsDropdown Directive', function() {
   var compile,
@@ -75,14 +74,46 @@ describe('optionsDropdown Directive', function() {
 
     query = {
       id: 5
-    }
+    };
+
+    var queryValues = {
+      takeUntil: function(condition) {
+        return {
+          subscribe: function(func) {
+            func(query);
+          }
+        }
+      }
+    };
 
     form = {}
 
+    var formValues = {
+      takeUntil: function(condition) {
+        return {
+          subscribe: function(func) {
+            func(form);
+          }
+        }
+      }
+    };
+
     states = {
       query: {
-        resource: input(query),
-        form: input(form)
+        resource: {
+          values$: function() {
+                     return queryValues;
+                   }
+        },
+        form: {
+          values$: function() {
+                     return formValues;
+                   }
+        }
+
+      },
+      table: {
+        stopAllSubscriptions: [false]
       }
     };
 


### PR DESCRIPTION
Adds a loading indicator to the query setting dropdown in cases where the form takes unusually long to load.

![image](https://user-images.githubusercontent.com/617519/27678384-4f0c09d2-5cb5-11e7-91c2-dcddfb7b7a57.png)

With the performance improvements in #5711 this should happen less often which is why I did not spent a lot of time to make the loading indicator look good. However there might still be cases (e.g. low bandwidth, server problems) where having the indicator will be better than the user running into errors like:
https://community.openproject.com/projects/openproject/work_packages/25654