### PR TITLE
Fix/link on inline create success message

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -410,7 +410,7 @@ export class WorkPackageResource extends HalResource {
     });
   }
 
-  public save() {
+  public save():ng.IPromise<WorkPackageResourceInterface> {
     var deferred = $q.defer();
     this.inFlight = true;
     const wasNew = this.isNew;

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -356,7 +356,7 @@ export class WorkPackageResource extends HalResource {
     return this.form;
   }
 
-  public updateForm(payload:{[attribute:string]: any}) {
+  public updateForm(payload:{[attribute:string]:any}) {
     // Always resolve form to the latest form
     // This way, we won't have to actively reset it.
     // But store the existing form in case of an error.
@@ -462,7 +462,7 @@ export class WorkPackageResource extends HalResource {
     return deferred.promise;
   }
 
-  public storePristine(attribute: string) {
+  public storePristine(attribute:string) {
     if (this.$pristine.hasOwnProperty(attribute)) {
       return;
     }
@@ -470,7 +470,7 @@ export class WorkPackageResource extends HalResource {
     this.$pristine[attribute] = angular.copy(this[attribute]);
   }
 
-  public restoreFromPristine(attribute: string) {
+  public restoreFromPristine(attribute:string) {
     if (this.$pristine.hasOwnProperty(attribute)) {
       this[attribute] = this.$pristine[attribute];
       delete this.$pristine[attribute];

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -142,14 +142,14 @@ export class WorkPackageEditForm {
     this.closeAllEditFields();
 
     this.workPackage.save()
-      .then(() => {
+      .then(savedWorkPackage => {
         _.each(this.activeFields, (handler:WorkPackageEditFieldHandler) => {
           handler.deactivate();
         });
-        deferred.resolve(this.workPackage);
+        deferred.resolve(savedWorkPackage);
 
-        this.wpNotificationsService.showSave(this.workPackage, isInitial);
-        this.editContext.onSaved(this.workPackage);
+        this.wpNotificationsService.showSave(savedWorkPackage, isInitial);
+        this.editContext.onSaved(savedWorkPackage);
 
         this.stopEditing();
 

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -75,7 +75,7 @@ export class WorkPackageEditForm {
 
     this.subscription = this.wpCacheService.loadWorkPackage(workPackageId).values$()
       .takeUntil(this.states.table.stopAllSubscriptions)
-      .subscribe((wp: WorkPackageResourceInterface) => {
+      .subscribe((wp:WorkPackageResourceInterface) => {
         this.workPackage = wp;
       });
   }


### PR DESCRIPTION
The created message link needs to use the newly created work package (the one returned on the POST request) in order to have the correct id set.

https://community.openproject.com/projects/openproject/work_packages/25702