### PR TITLE
fix author filter for projectless users

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -122,6 +122,14 @@ class Principal < ActiveRecord::Base
     order(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s))
   end
 
+  def self.me
+    where(id: User.current.id)
+  end
+
+  def self.in_visible_project(user = User.current)
+    in_project(Project.visible(user))
+  end
+
   def status_name
     # Only Users should have another status than active.
     # User defines the status values and other classes like Principal

--- a/app/models/queries/work_packages/filter/principal_loader.rb
+++ b/app/models/queries/work_packages/filter/principal_loader.rb
@@ -54,11 +54,9 @@ class Queries::WorkPackages::Filter::PrincipalLoader
   def principal_values
     if project
       project.principals.sort
-    elsif visible_projects.any?
-      user_or_principal = Setting.work_package_group_assignment? ? Principal : User
-      user_or_principal.active_or_registered.in_project(visible_projects).sort
     else
-      []
+      user_or_principal = Setting.work_package_group_assignment? ? Principal : User
+      user_or_principal.active_or_registered.in_visible_project.sort
     end
   end
 
@@ -66,9 +64,5 @@ class Queries::WorkPackages::Filter::PrincipalLoader
 
   def principals_by_class
     @principals_by_class ||= principal_values.group_by(&:class)
-  end
-
-  def visible_projects
-    @visible_projects ||= Project.visible
   end
 end

--- a/lib/api/v3/principals/principals_api.rb
+++ b/lib/api/v3/principals/principals_api.rb
@@ -32,8 +32,9 @@ module API
       class PrincipalsAPI < ::API::OpenProjectAPI
         resource :principals do
           get do
-            scope = Principal.includes(:preference, :members)
-                             .where(members: { project_id: Project.visible(current_user) })
+            scope = Principal.in_visible_project(current_user)
+                             .or(Principal.me)
+                             .includes(:preference)
                              .order_by_name
 
             representer = Users::UserCollectionRepresenter

--- a/spec/models/queries/work_packages/filter/principal_loader_spec.rb
+++ b/spec/models/queries/work_packages/filter/principal_loader_spec.rb
@@ -76,13 +76,8 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
     let(:matching_principals) { [user_1, group_1] }
 
     before do
-      allow(Project)
-        .to receive(:visible)
-        .and_return visible_projects
-
       allow(Principal)
-        .to receive_message_chain(:active_or_registered, :in_project)
-        .with(visible_projects)
+        .to receive_message_chain(:active_or_registered, :in_visible_project)
         .and_return(matching_principals)
     end
 

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -129,5 +129,14 @@ describe 'API v3 Principals resource', type: :request do
         let(:response) { last_response }
       end
     end
+
+    context 'user without a project membership' do
+      let(:user) { FactoryGirl.create(:user) }
+
+      # The user herself
+      it_behaves_like 'API V3 collection response', 1, 1, 'User' do
+        let(:response) { last_response }
+      end
+    end
   end
 end


### PR DESCRIPTION
As the principals returned by the principals API where limited to those that are members in projects the user can see, users not having any project would not be returned. This is intended in so far as to prevent getting all users easily. But the user herself should be visible in any case.

https://community.openproject.com/projects/openproject/work_packages/25682