### PR TITLE
Feature/toggle between hierarchy and group by

### DIFF
--- a/app/assets/stylesheets/fonts/_openproject_icon_font.sass
+++ b/app/assets/stylesheets/fonts/_openproject_icon_font.sass
@@ -77,7 +77,6 @@
   padding: 0 10px 0 0
   font-size: 15px
   line-height: 5px
-  vertical-align: -40%
 
 @mixin icon-sub-menu-rules
   padding: 0

--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -114,7 +114,7 @@
     list-style: none
     padding: 0
     margin: 0
-    line-height: 18px
+    line-height: 20px
 
 .dropdown .dropdown-menu,
 .toolbar .legacy-actions-more
@@ -132,6 +132,13 @@
       background-color: #F0F0F0
       @include varprop(color, context-menu-hover-font-color)
       cursor: pointer
+
+    .icon-hierarchy
+      padding-right: 5px
+      font-size: 20px
+
+    .no-icon
+      margin-left: 19.09px //for whatever reasons it is the right dimension
 
   LI > A.inactive
     color: #999999

--- a/frontend/app/components/common/focus-within/focus-within.directive.ts
+++ b/frontend/app/components/common/focus-within/focus-within.directive.ts
@@ -45,10 +45,10 @@ function focusWithinDirective($timeout:ng.ITimeoutService) {
 
       scopedObservable(
           scope,
-          focusedObservable.delay(50)
+          focusedObservable
         )
-        .filter(delayed => delayed === focusedObservable.getValue())
-        .subscribe((focused) => {
+        .auditTime(50)
+        .subscribe(focused => {
            element.toggleClass('-focus', focused);
         });
 

--- a/frontend/app/components/context-menus/column-context-menu/column-context-menu.controller.ts
+++ b/frontend/app/components/context-menus/column-context-menu/column-context-menu.controller.ts
@@ -46,20 +46,20 @@ function ColumnContextMenuController($scope:any,
 
   $scope.I18n = I18n;
   $scope.text = {
-    group_by: I18n.t('js.work_packages.query.group'),
-    group_by_disabled_by_hierarchy: I18n.t('js.work_packages.query.group_by_disabled_by_hierarchy')
+    sortAscending: I18n.t('js.work_packages.query.sort_ascending'),
+    sortDescending: I18n.t('js.work_packages.query.sort_descending'),
+    groupBy: I18n.t('js.work_packages.query.group'),
+    moveLeft: I18n.t('js.work_packages.query.move_column_left'),
+    moveRight: I18n.t('js.work_packages.query.move_column_right'),
+    hide: I18n.t('js.work_packages.query.hide_column'),
+    insert: I18n.t('js.work_packages.query.insert_columns')
   };
 
   $scope.$watch('column', function () {
     // fall back to 'id' column as the default
     $scope.column = $scope.column || {name: 'id', sortable: true};
     $scope.isGroupable = wpTableGroupBy.isGroupable($scope.column) && !wpTableGroupBy.isCurrentlyGroupedBy($scope.column);
-    $scope.isGroupableDisabled = wpTableHierarchies.isEnabled;
-    $scope.isSortable = wpTableSortBy.isSortable($scope.column)
-  });
-
-  wpTableHierarchies.observeOnScope($scope).subscribe(() => {
-    $scope.isGroupableDisabled = wpTableHierarchies.isEnabled;
+    $scope.isSortable = wpTableSortBy.isSortable($scope.column);
   });
 
   // context menu actions

--- a/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
+++ b/frontend/app/components/context-menus/column-context-menu/column-context-menu.template.html
@@ -5,55 +5,52 @@
     <li ng-if="isSortable">
       <a class="menu-item" focus href="" ng-click="sortAscending()">
         <op-icon icon-classes="icon-action-menu icon-sort-ascending"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.sort_ascending')"/>
+        <span ng-bind="text.sortAscending"/>
       </a>
     </li>
 
     <li ng-if="isSortable">
       <a class="menu-item" href="" ng-click="sortDescending()">
         <op-icon icon-classes="icon-action-menu icon-sort-descending"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.sort_descending')"/>
+        <span ng-bind="text.sortDescending"/>
       </a>
     </li>
 
     <li ng-if="isGroupable">
       <a class="menu-item"
-         ng-class="{'inactive': isGroupableDisabled }"
          focus="focusFeature('group')"
          href=""
-         ng-attr-title="{{ isGroupableDisabled ? text.group_by_disabled_by_hierarchy : text.group_by }}"
-         ng-disabled="isGroupableDisabled"
-         ng-click="isGroupableDisabled || groupBy()">
+         ng-click="groupBy()">
         <op-icon icon-classes="icon-action-menu icon-group-by"></op-icon>
-        <span ng-bind="text.group_by"/>
+        <span ng-bind="text.groupBy"/>
       </a>
     </li>
 
     <li ng-if="canMoveLeft()">
       <a class="menu-item" focus="focusFeature('moveLeft')" href="" ng-click="moveLeft()">
         <op-icon icon-classes="icon-action-menu icon-column-left"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.move_column_left')"/>
+        <span ng-bind="text.moveLeft"/>
       </a>
     </li>
 
     <li ng-if="canMoveRight()">
       <a class="menu-item" focus="focusFeature('moveRight')" href="" ng-click="moveRight()">
         <op-icon icon-classes="icon-action-menu icon-column-right"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.move_column_right')"/>
+        <span ng-bind="text.moveRight"/>
       </a>
     </li>
 
     <li ng-if="canBeHidden()">
       <a class="menu-item" focus="focusFeature('hide')" href="" ng-click="hideColumn()">
         <op-icon icon-classes="icon-action-menu icon-delete"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.hide_column')"/>
+        <span ng-bind="text.hide"/>
       </a>
     </li>
 
     <li>
       <a class="menu-item" focus="focusFeature('insert')" href="" ng-click="insertColumns()">
         <op-icon icon-classes="icon-action-menu icon-columns"></op-icon>
-        <span ng-bind="I18n.t('js.work_packages.query.insert_columns')"/>
+        <span ng-bind="text.insert"/>
       </a>
     </li>
   </ul>

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.controller.ts
@@ -217,10 +217,6 @@ function SettingsDropdownMenuController($scope:IMyScope,
   };
 
   $scope.showGroupingModal = function (event:JQueryEventObject) {
-    if ($scope.displayHierarchies) {
-      return;
-    }
-
     event.stopPropagation();
     showModal.call(groupingModal);
     updateFocusInModal('selected_columns_new');
@@ -233,10 +229,6 @@ function SettingsDropdownMenuController($scope:IMyScope,
   };
 
   $scope.toggleHierarchies = function () {
-    if (!!$scope.isGrouped) {
-      return;
-    }
-
     const isEnabled = wpTableHierarchies.isEnabled;
     wpTableHierarchies.setEnabled(!isEnabled);
   };

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
@@ -37,7 +37,7 @@
     </li>
     <li>
       <a ng-if="displayHierarchies" class="menu-item" href ng-click="toggleHierarchies($event)">
-        <op-icon ng-if="displayHierarchies" icon-classes="icon-action-menu icon-checkmark"></op-icon>
+        <op-icon ng-if="displayHierarchies" icon-classes="icon-action-menu icon-hierarchy"></op-icon>
         <span ng-bind="::I18n.t('js.toolbar.settings.hide_hierarchy')"></span>
       </a>
       <a ng-if="!displayHierarchies"
@@ -45,10 +45,13 @@
          class="menu-item"
          href
          ng-click="toggleHierarchies($event)">
-        <op-icon ng-if="!displayHierarchies" icon-classes="icon-action-menu no-icon"></op-icon>
+        <op-icon ng-if="!displayHierarchies" icon-classes="icon-action-menu icon-no-hierarchy"></op-icon>
         <span ng-bind="::I18n.t('js.toolbar.settings.display_hierarchy')"></span>
+      </a>
     </li>
+
     <li class="dropdown-divider"></li>
+
     <li><a class="menu-item" href="" ng-click="saveQuery($event)"
            inaccessible-by-tab="saveQueryInvalid()"
            ng-class="{'inactive': saveQueryInvalid()}">
@@ -85,12 +88,20 @@
       <op-icon icon-classes="icon-action-menu icon-settings"></op-icon>
       {{ I18n.t('js.toolbar.settings.page_settings') }}</a>
     </li>
+
     <li class="dropdown-divider" ng-if="queryCustomFields || configureFormLink"></li>
-    <li ng-if="queryCustomFields"><a class="menu-item" href="{{queryCustomFields.href}}">
-      <i class="icon-action-menu icon-custom-fields"></i>{{ queryCustomFields.name }}</a>
+
+    <li ng-if="queryCustomFields">
+      <a class="menu-item" href="{{queryCustomFields.href}}">
+        <op-icon icon-classes="icon-action-menu icon-custom-fields"></op-icon>
+        {{ queryCustomFields.name }}
+      </a>
     </li>
-    <li ng-if="configureFormLink"><a class="menu-item" href="{{configureFormLink.href}}">
-      <i class="icon-action-menu icon-settings3"></i>{{ configureFormLink.name }}</a>
+    <li ng-if="configureFormLink">
+      <a class="menu-item" href="{{configureFormLink.href}}">
+        <op-icon icon-classes="icon-action-menu icon-settings3"></op-icon>
+        {{ configureFormLink.name }}
+      </a>
     </li>
   </ul>
 </div>

--- a/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
+++ b/frontend/app/components/context-menus/settings-menu/settings-menu.service.html
@@ -20,8 +20,6 @@
     <li>
        <a class="menu-item"
           href
-          ng-disabled="displayHierarchies"
-          ng-class="{'inactive': displayHierarchies}"
           ng-attr-title="{{ text.group_by_title() }}"
           ng-click="showGroupingModal($event)">
          <op-icon icon-classes="icon-action-menu icon-group-by"></op-icon>
@@ -42,9 +40,7 @@
         <op-icon ng-if="displayHierarchies" icon-classes="icon-action-menu icon-checkmark"></op-icon>
         <span ng-bind="::I18n.t('js.toolbar.settings.hide_hierarchy')"></span>
       </a>
-      <a ng-disabled="isGrouped"
-         ng-class="{'inactive': !!isGrouped}"
-         ng-if="!displayHierarchies"
+      <a ng-if="!displayHierarchies"
          ng-attr-title="{{ text.hierarchy_title() }}"
          class="menu-item"
          href

--- a/frontend/app/components/routing/wp-list/wp-list.controller.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.controller.ts
@@ -147,7 +147,7 @@ function WorkPackagesListController($scope:any,
 
         // Update the page, if the change requires it
         if (triggerUpdate) {
-          updateResultsVisibly(true);
+          wpTableRefresh.request(true, 'Query updated by user');
         }
       });
   }
@@ -160,12 +160,13 @@ function WorkPackagesListController($scope:any,
     wpTableRefresh.state
       .values$('Refresh listener in wp-list.controller')
       .takeUntil(scopeDestroyed$($scope))
+      .auditTime(20)
       .subscribe((refreshVisibly:boolean) => {
         if (refreshVisibly) {
-          debugLog("Refreshing work package results visibly.");
+          debugLog('Refreshing work package results visibly.');
           updateResultsVisibly();
         } else {
-          debugLog("Refreshing work package results in the background.");
+          debugLog('Refreshing work package results in the background.');
           updateResults();
         }
       });
@@ -189,7 +190,7 @@ function WorkPackagesListController($scope:any,
     if (visibleLink.length) {
       visibleLink.focus();
     }
-  }
+  };
 
   function updateResults() {
     return wpListService.reloadCurrentResultsList();

--- a/frontend/app/components/wp-fast-table/state/wp-table-group-by.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-group-by.service.ts
@@ -42,8 +42,8 @@ import {QueryColumn} from '../../wp-query/query-column';
 export class WorkPackageTableGroupByService extends WorkPackageTableBaseService implements WorkPackageQueryStateService {
   protected stateName = 'groupBy' as TableStateStates;
 
-  constructor(protected states: States) {
-    super(states)
+  constructor(protected states:States) {
+    super(states);
   }
 
   public initialize(query:QueryResource) {
@@ -76,13 +76,20 @@ export class WorkPackageTableGroupByService extends WorkPackageTableBaseService 
   }
 
   public isGroupable(column:QueryColumn):boolean {
-    return !!_.find(this.available, candidate => candidate.id === column.id)
+    return !!_.find(this.available, candidate => candidate.id === column.id);
   }
 
-  public set(groupBy:QueryGroupByResource) {
+  public set(groupBy:QueryGroupByResource|undefined) {
     let currentState = this.currentState;
 
     currentState.current = groupBy;
+
+    // hierarchies and group by are mutually exclusive
+    if (groupBy) {
+      var hierarchy = this.states.table.hierarchies.value!;
+      hierarchy.current = false;
+      this.states.table.hierarchies.putValue(hierarchy);
+    }
 
     this.state.putValue(currentState);
   }

--- a/frontend/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
@@ -12,7 +12,8 @@ import {WorkPackageCacheService} from '../../work-packages/work-package-cache.se
 export class WorkPackageTableHierarchiesService extends WorkPackageTableBaseService implements WorkPackageQueryStateService {
   protected stateName = 'hierarchies' as TableStateStates;
 
-  constructor(public states:States, public wpCacheService:WorkPackageCacheService) {
+  constructor(public states:States,
+              public wpCacheService:WorkPackageCacheService) {
     super(states);
   }
 
@@ -42,6 +43,13 @@ export class WorkPackageTableHierarchiesService extends WorkPackageTableBaseServ
   public setEnabled(active:boolean = true) {
     const state = this.currentState;
     state.current = active;
+
+    // hierarchies and group by are mutually exclusive
+    if (active) {
+      var groupBy = this.states.table.groupBy.value!;
+      groupBy.current = undefined;
+      this.states.table.groupBy.putValue(groupBy);
+    }
 
     this.state.putValue(state);
   }

--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.html
@@ -3,7 +3,6 @@
     <span
        class="hierarchy-header--icon"
        ng-click="toggleHierarchy($event)"
-       ng-if="!isHierarchyDisabled"
        ng-attr-title="{{ text.toggleHierarchy }}"
        tabindex="-1"
        aria-hidden="true">

--- a/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
+++ b/frontend/tests/unit/tests/work_packages/controllers/menus/options-dropdown-menu-controller-test.js
@@ -335,7 +335,7 @@ describe('optionsDropdown Directive', function() {
 
         var item = getHierarchyMenuItem();
 
-        expect(angular.element(item).find('.no-icon').length).to.eq(1);
+        expect(angular.element(item).find('.icon-no-hierarchy').length).to.eq(1);
       });
 
       it('displays active if the service tells it to', function() {
@@ -346,17 +346,7 @@ describe('optionsDropdown Directive', function() {
         // named differently if active
         var item = getMenuItem(I18n.t('js.toolbar.settings.hide_hierarchy'));
 
-        expect(angular.element(item).find('.icon-checkmark').length).to.eq(1);
-      });
-
-      it('is inactive if the query is grouped', function() {
-        wpTableGroupBy['isEnabled'] = true;
-
-        compile();
-
-        var item = getHierarchyMenuItem();
-
-        expect(angular.element(item).filter('.inactive').length).to.eq(1);
+        expect(angular.element(item).find('.icon-hierarchy').length).to.eq(1);
       });
 
       it('forwards to the service on click', function() {

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -28,52 +28,43 @@
 
 module Components
   module WorkPackages
-    class SettingsMenu
+    class GroupBy
       include Capybara::DSL
       include RSpec::Matchers
 
-      def open_and_save_query(name)
-        open!
-        find("#{selector} .menu-item", text: 'Save', match: :prefer_exact).click
-        page.within('.ng-modal-inner') do
-          find('#save-query-name').set name
-          click_on 'Save'
+      def enable_via_header(name)
+        open_table_column_context_menu(name)
+
+        within_column_context_menu do
+          click_link('Group by')
         end
       end
 
-      def open_and_choose(name)
-        open!
-        choose(name)
+      def enable_via_menu(name)
+        SettingsMenu.new.open_and_choose('Group by ...')
+
+        select name, from: 'selected_columns_new'
+        click_button 'Apply'
       end
 
-      def open!
-        click_on 'work-packages-settings-button'
-        expect_open
-      end
+      def expect_not_grouped_by(name)
+        open_table_column_context_menu(name)
 
-      def expect_open
-        expect(page).to have_selector(selector)
-      end
-
-      def expect_closed
-        expect(page).to have_no_selector(selector)
-      end
-
-      def choose(target)
-        find("#{selector} .menu-item", text: target).click
-      end
-
-      def expect_options(options)
-        expect_open
-        options.each do |text|
-          expect(page).to have_selector("#{selector} a", text: text)
+        within_column_context_menu do
+          expect(page).to have_content('Group by')
         end
       end
 
       private
 
-      def selector
-        '#settingsDropdown'
+      def open_table_column_context_menu(name)
+        page.find(".generic-table--sort-header ##{name.downcase}").click
+      end
+
+      def within_column_context_menu
+        page.within('#column-context-menu') do
+          yield
+        end
       end
     end
   end

--- a/spec/support/components/work_packages/hierarchies.rb
+++ b/spec/support/components/work_packages/hierarchies.rb
@@ -33,8 +33,13 @@ module Components
       include RSpec::Matchers
 
       def enable_hierarchy
-        find('#work-packages-settings-button').click
-        page.find('#settingsDropdown a.menu-item', text: 'Display hierarchy').click
+        SettingsMenu.new.open_and_choose('Display hierarchy')
+      end
+
+      alias_method :enable_via_menu, :enable_hierarchy
+
+      def enable_via_header
+        page.find('.wp-table--table-header .icon-no-hierarchy').click
       end
 
       def disable_hierarchy
@@ -45,6 +50,16 @@ module Components
 
       def expect_no_hierarchies
         expect(page).to have_no_selector('.wp-table--hierarchy-span')
+      end
+
+      alias_method :expect_mode_disabled, :expect_no_hierarchies
+
+      def expect_mode_enabled
+        expect(page).to have_selector('.wp-table--table-header .icon-hierarchy')
+      end
+
+      def expect_mode_disabled
+        expect(page).to have_selector('.wp-table--table-header .icon-no-hierarchy')
       end
 
       def expect_leaf_at(*work_packages)

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -162,8 +162,8 @@ module Pages
     end
 
     def click_setting_item(label)
-      find('#work-packages-settings-button').click
-      find('#settingsDropdown .menu-item', text: label).click
+      ::Components::WorkPackages::SettingsMenu
+        .new.open_and_choose(label)
     end
 
     def save_as(name)


### PR DESCRIPTION
Allows toggling between hierarchy and group by mode. 

https://community.openproject.com/projects/openproject/work_packages/25300

It additionally fixes the alignment of the icons in the query menu (and uses the hierarchy icon there)

![image](https://user-images.githubusercontent.com/617519/27694759-4b4f9010-5ced-11e7-9c31-d64fd173e73b.png)

### TODO

- [x] If one of the modes (hierarchy or group by) is activated when the other is selected, two requests to the back end are fired and the table is painted two times. This is because two states watched for changed by the wp-list controller are pushed to. Options:
  * Delay fetching the query on state updates to see if other updates will render fetching for the first update superfluous
  * ~~Fetch for both, but ignore the results of the first (no table repaint, no dependent state pushes) if an update has been noticed in the meantime~~
  * ~~Come up with a joined state to only have one state to push to.~~
  * ~~Implement a transaction mechanism for states~~
- [x] Integration tests
