### PR TITLE
Upgrade buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/pkgr/pkgr-buildpack-imagemagick.git
-https://github.com/heroku/heroku-buildpack-nodejs.git#v71
-https://github.com/pkgr/heroku-buildpack-ruby.git
+https://github.com/heroku/heroku-buildpack-nodejs.git#v106
+https://github.com/pkgr/heroku-buildpack-ruby.git#v164-1


### PR DESCRIPTION
Upgrade nodejs and ruby buildpacks to the latest version. It [went fine](https://packager.io/gh/opf/openproject/build_runs/1821) on Packager.io. Should be good to merge, unless you are close to a release (ideally we'd have at least 1 week before the next release to make sure everything still works as expected on all dependent projects).

/cc @oliverguenther @machisuji 