### PR TITLE
[25711] Icon in flash messages displaced

### DIFF
--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -304,9 +304,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   .close-handler
     float: none
     position: absolute
-    top: rem-calc(11)
     right: rem-calc(11)
-    font-size: 1rem
     cursor: pointer
 
   &::before


### PR DESCRIPTION
This fixes the alignment of the close icon in flash messages.

https://community.openproject.com/projects/openproject/work_packages/25711/activity