### PR TITLE
[25686] Fix close icon alignment in error messages

### DIFF
--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -297,6 +297,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   ul
     font-size: $nm-font-size
     margin: 0 0 0 30px
+    display: inline-block
 
   h2, p
     @extend .hidden-for-sighted

--- a/app/views/common/_error_base.html.erb
+++ b/app/views/common/_error_base.html.erb
@@ -34,7 +34,6 @@ See doc/COPYRIGHT.rdoc for more details.
   <% else %>
     <%= error_message %>
   <% end %>
-  <span class="close-handler" role="button" tabindex="0" aria-label="{{ ::I18n.t('js.close_popup_title') }}">
-    <%= op_icon('icon-close') %>
-  </span>
+  <i class="icon-close close-handler" role="button" tabindex="0" aria-label="{{ ::I18n.t('js.close_popup_title') }}">
+  </i>
 </div>


### PR DESCRIPTION
The changes introduced in https://github.com/opf/openproject/pull/5724 caused a unwanted effect within error messages. When an unordered list is shown the icon is not in the same line any more. Further the structure of the error message and the general flash messages differ. This makes it harder to handle the same styling rules.

This PR takes care of these two issues.

