### PR TITLE
[25704] Allow activities to be filtered for comments-only

### DIFF
--- a/app/assets/stylesheets/content/work_packages/tabs/_activities.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_activities.sass
@@ -81,6 +81,19 @@
   list-style-type: none
   margin: 0
 
+// Position first date with comment toggler
+.activity-date.-with-toggler
+  display: flex
+  // Align span and button in center
+  align-items: center
+  // Let button stretch to the far right
+  align-content: stretch
+
+  .activity-date--label
+    flex: 1
+  .activity-comments--toggler
+    margin: 0
+
 .work-package-details-activities-activity:not(:last-child)
   margin-bottom: 10px
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -186,6 +186,8 @@ en:
     label_subject: "Subject"
     label_this_week: "this week"
     label_today: "today"
+    label_activity_show_only_comments: "Show activities with comments only"
+    label_activity_show_all: "Show all activities"
     label_total_progress: "%{percent}% Total progress"
     label_visible_for_others: "Page visible for others"
     label_updated_on: "updated on"

--- a/frontend/app/components/wp-panels/activity-panel/activity-panel-default.directive.html
+++ b/frontend/app/components/wp-panels/activity-panel/activity-panel-default.directive.html
@@ -1,14 +1,24 @@
 <work-package-comment work-package="vm.workPackage"
                       activities="vm.activities">
 
+
   <div class="detail-activity">
     <ul class="work-package-details-activities-list">
-      <li ng-repeat="activity in vm.activities"
+      <li ng-repeat="activity in vm.visibleAcitivities()"
           class="work-package-details-activities-activity"
-
           ng-init="inf = vm.info(activity, $index)">
 
-        <h3 class="activity-date" ng-if="inf.isNextDate" ng-bind="inf.date"></h3>
+        <h3 class="activity-date"
+            ng-class="{'-with-toggler': $first}"
+            ng-if="inf.isNextDate">
+          <span class="activity-date--label" ng-bind="inf.date"></span>
+          <accessible-by-keyboard execute="vm.toggleComments()"
+                                  ng-if="$first"
+                                  link-class="activity-comments--toggler button -small -transparent"
+                                  link-aria-label="{{ vm.togglerText }}">
+            <span ng-bind="vm.togglerText"></span>
+          </accessible-by-keyboard>
+        </h3>
 
           <activity-entry work-package="vm.workPackage"
                           activity="activity"

--- a/frontend/app/components/wp-panels/activity-panel/activity-panel.directive.ts
+++ b/frontend/app/components/wp-panels/activity-panel/activity-panel.directive.ts
@@ -34,14 +34,26 @@ import {WorkPackageCacheService} from "../../work-packages/work-package-cache.se
 export class ActivityPanelController {
 
   public workPackage:WorkPackageResourceInterface;
+
   public activities:any[] = [];
   public reverse:boolean;
 
+  public onlyComments:boolean = false;
+  public togglerText:string;
+  public text:any;
+
   constructor(public $scope:ng.IScope,
               public wpCacheService:WorkPackageCacheService,
+              public I18n:op.I18n,
               public wpActivity:any) {
 
     this.reverse = wpActivity.order === 'asc';
+
+    this.text = {
+      commentsOnly: I18n.t('js.label_activity_show_only_comments'),
+      showAll: I18n.t('js.label_activity_show_all')
+    };
+    this.togglerText = this.text.commentsOnly;
 
     scopedObservable(
       $scope,
@@ -52,6 +64,24 @@ export class ActivityPanelController {
           this.activities = activities;
         });
       });
+  }
+
+  public visibleAcitivities() {
+    if (!this.onlyComments) {
+      return this.activities;
+    }
+
+    return this.activities.filter((activity:any) => !!_.get(activity, 'comment.html'));
+  }
+
+  public toggleComments() {
+    this.onlyComments = !this.onlyComments;
+
+    if (this.onlyComments) {
+      this.togglerText = this.text.showAll;
+    } else {
+      this.togglerText = this.text.commentsOnly;
+    }
   }
 
   public info(activity:any, index:any) {

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Components
+  module WorkPackages
+    class Activities
+      include Capybara::DSL
+      include RSpec::Matchers
+
+      attr_reader :work_package
+
+      def initialize(work_package)
+        @work_package = work_package
+      end
+
+      def hover_action(journal_id, action)
+        retry_block do
+          # Focus type edit to expose buttons
+          activity = page.find("#activity-#{journal_id} .work-package-details-activities-activity-contents")
+          page.driver.browser.action.move_to(activity.native).perform
+
+          # Click the corresponding action button
+          case action
+          when :quote
+            page.find("#activity-#{journal_id} .comments-icons .icon-quote").click
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a simply toggler to the activity tab that allows filtering all activities for only those with a comment set.

This was on the wish list for a customer but is so trivial that I did  this in a quiet minute since I very much appreciate the idea.

![anim3](https://user-images.githubusercontent.com/459462/27739508-259b1f5c-5daf-11e7-9eb5-068e47449968.gif)

https://community.openproject.com/work_packages/25704