### PR TITLE
[25706] Custom attribute help texts

### DIFF
--- a/app/assets/stylesheets/content/_help_texts.sass
+++ b/app/assets/stylesheets/content/_help_texts.sass
@@ -26,42 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+.attribute-help-text--modal
+  .modal--footer
+    text-align: left
+    display: flex
+    justify-content: space-between
 
-// Hide modal content forwarded from rails
-.modal-wrapper--content
-  display: none
+  // Avoid large right margin for conditional button
+  .help-text--edit-button
+    margin-right: 0
 
-.ngdialog-theme-openproject
-  display: flex
-  align-items: center
-  justify-content: center
-
-  .ngdialog-overlay
-    z-index: 99
-
-  .modal--header .icon-context
-    @include varprop(background, header-bg-color)
-    @include varprop(color, header-item-font-color)
-
-  .ngdialog-content
-    background: $body-background
-    min-width: 200px
-    max-width: 600px
-    z-index: 100
-    // Required for close icon
-    position: relative
-
-  .ngdialog-body
-    margin-top: 2rem
-    min-height: 50px
-
-  .ngdialog-close
-    cursor: pointer
-    position: absolute
-    right: 0
-    top: 0
-
-    &:before
-      @include icon-font-common
-      @extend .icon-context
-      @extend .icon-close:before

--- a/app/assets/stylesheets/content/_index.sass
+++ b/app/assets/stylesheets/content/_index.sass
@@ -59,3 +59,4 @@
 @import content/projects_list
 @import content/datepicker
 @import content/focus_within
+@import content/help_texts

--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -74,7 +75,7 @@ class AttributeHelpTextsController < ApplicationController
   end
 
   def index
-    @texts_by_type = AttributeHelpText.all.group_by(&:attribute_scope)
+    @texts_by_type = AttributeHelpText.all_by_scope
   end
 
   protected

--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -1,0 +1,112 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class AttributeHelpTextsController < ApplicationController
+  layout 'admin'
+  menu_item :attribute_help_texts
+
+  before_action :require_admin
+  before_action :find_entry, only: %i(edit update destroy)
+  before_action :find_type_scope
+
+  def new
+    @attribute_help_text = AttributeHelpText.new type: @attribute_scope
+  end
+
+  def edit; end
+
+  def update
+    @attribute_help_text.attributes = permitted_params.attribute_help_text
+
+    if @attribute_help_text.save
+      flash[:notice] = t(:notice_successful_update)
+      redirect_to attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)
+    else
+      render action: 'edit'
+    end
+  end
+
+  def create
+    @attribute_help_text = AttributeHelpText.new permitted_params.attribute_help_text
+
+    if @attribute_help_text.save
+      flash[:notice] = t(:notice_successful_create)
+      redirect_to attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)
+    else
+      render action: 'new'
+    end
+  end
+
+  def destroy
+    if @attribute_help_text.destroy
+      flash[:notice] = t(:notice_successful_delete)
+    else
+      flash[:error] = t(:error_can_not_delete_entry)
+    end
+
+    redirect_to attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)
+  end
+
+  def index
+    @texts_by_type = AttributeHelpText.all.group_by(&:attribute_scope)
+  end
+
+  protected
+
+  def default_breadcrumb
+    if action_name == 'index'
+      t('attribute_help_texts.label_plural')
+    else
+      ActionController::Base.helpers.link_to(t('attribute_help_texts.label_plural'), attribute_help_texts_path)
+    end
+  end
+
+  def show_local_breadcrumb
+    true
+  end
+
+  private
+
+  def find_entry
+    @attribute_help_text = AttributeHelpText.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+
+  def find_type_scope
+    name = params.fetch(:name, 'WorkPackage')
+    submodule = AttributeHelpText.available_types.find { |mod| mod == name }
+
+    if submodule.nil?
+      render_404
+    end
+
+    @attribute_scope = AttributeHelpText.const_get(submodule)
+  end
+end

--- a/app/helpers/attribute_help_texts_helper.rb
+++ b/app/helpers/attribute_help_texts_helper.rb
@@ -1,0 +1,40 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module AttributeHelpTextsHelper
+  def selectable_attributes(instance)
+    available = instance.class.available_attributes
+    used = AttributeHelpText.used_attributes(instance.type)
+
+    available.reject! { |k, | used.include? k }
+
+    available.map { |k, v| [v, k] }
+  end
+end

--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -1,0 +1,30 @@
+
+class AttributeHelpText < ActiveRecord::Base
+  def self.available_types
+    subclasses.map { |child| child.name.demodulize }
+  end
+
+  def self.used_attributes(scope)
+    where(type: scope)
+      .select(:attribute_name)
+      .distinct
+      .pluck(:attribute_name)
+  end
+
+  validates_presence_of :help_text
+  validates_uniqueness_of :attribute_name, scope: :type
+
+  def attribute_caption
+    self.class.available_attributes[attribute_name]
+  end
+
+  def attribute_scope
+    raise 'not implemented'
+  end
+
+  def type_caption
+    raise 'not implemented'
+  end
+end
+
+require_dependency 'attribute_help_text/work_package'

--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -4,8 +4,8 @@ class AttributeHelpText < ActiveRecord::Base
     subclasses.map { |child| child.name.demodulize }
   end
 
-  def self.used_attributes(scope)
-    where(type: scope)
+  def self.used_attributes(type)
+    where(type: type)
       .select(:attribute_name)
       .distinct
       .pluck(:attribute_name)
@@ -19,7 +19,7 @@ class AttributeHelpText < ActiveRecord::Base
   validates_uniqueness_of :attribute_name, scope: :type
 
   def attribute_caption
-    self.class.available_attributes[attribute_name]
+    @caption ||= self.class.available_attributes[attribute_name]
   end
 
   def attribute_scope

--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -11,6 +11,10 @@ class AttributeHelpText < ActiveRecord::Base
       .pluck(:attribute_name)
   end
 
+  def self.all_by_scope
+    all.group_by(&:attribute_scope)
+  end
+
   validates_presence_of :help_text
   validates_uniqueness_of :attribute_name, scope: :type
 

--- a/app/models/attribute_help_text/work_package.rb
+++ b/app/models/attribute_help_text/work_package.rb
@@ -1,6 +1,12 @@
 class AttributeHelpText::WorkPackage < AttributeHelpText
   def self.available_attributes
-    Hash[::Query.new.available_columns.map { |c| [c.name.to_s, c.caption] }]
+    attributes = ::Type.translated_work_package_form_attributes
+
+    # Status and project are currently special attribute that we need to add
+    attributes['status'] = WorkPackage.human_attribute_name 'status'
+    attributes['project'] = WorkPackage.human_attribute_name 'project'
+
+    attributes
   end
 
   validates_inclusion_of :attribute_name, in: available_attributes.keys

--- a/app/models/attribute_help_text/work_package.rb
+++ b/app/models/attribute_help_text/work_package.rb
@@ -1,0 +1,15 @@
+class AttributeHelpText::WorkPackage < AttributeHelpText
+  def self.available_attributes
+    Hash[::Query.new.available_columns.map { |c| [c.name.to_s, c.caption] }]
+  end
+
+  validates_inclusion_of :attribute_name, in: available_attributes.keys
+
+  def attribute_scope
+    'WorkPackage'
+  end
+
+  def type_caption
+    I18n.t(:label_work_package)
+  end
+end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -57,6 +57,10 @@ class PermittedParams
     permitted_attributes[key].concat(params)
   end
 
+  def attribute_help_text
+    params.require(:attribute_help_text).permit(*self.class.permitted_attributes[:attribute_help_text])
+  end
+
   def auth_source
     params.require(:auth_source).permit(*self.class.permitted_attributes[:auth_source])
   end
@@ -446,6 +450,11 @@ class PermittedParams
   def self.permitted_attributes
     @whitelisted_params ||= begin
       params = {
+        attribute_help_text: [
+          :type,
+          :attribute_name,
+          :help_text
+        ],
         auth_source: [
           :name,
           :host,

--- a/app/views/attribute_help_texts/_form.html.erb
+++ b/app/views/attribute_help_texts/_form.html.erb
@@ -1,0 +1,47 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+<%= error_messages_for 'attribute_help_text' %>
+
+<section class="form--section" id="custom_field_form">
+  <div class="form--field -required">
+    <% if local_assigns[:editing] %>
+      <%= f.select :attribute_name,
+                   [[@attribute_help_text.attribute_caption, @attribute_help_text.attribute_name]],
+                   {},
+                   disabled: true
+      %>
+    <% else %>
+      <%= f.select :attribute_name, selectable_attributes(@attribute_help_text) %>
+    <% end %>
+  </div>
+  <div class="form--field -required">
+    <%= f.text_area :help_text, :cols => 100, :rows => 25, :class => 'wiki-edit' %>
+    <%= wikitoolbar_for("#{f.object_name}_help_text") %>
+  </div>
+</section>

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -1,0 +1,100 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<% entries = @texts_by_type[tab[:name]] || [] %>
+<% if entries.any? %>
+  <div class="generic-table--container">
+    <div class="generic-table--results-container">
+      <table class="generic-table">
+        <colgroup>
+          <col highlight-col>
+          <col highlight-col>
+          <col highlight-col>
+          <col>
+        </colgroup>
+        <thead>
+          <tr>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span>
+                    <%= AttributeHelpText.human_attribute_name(:attribute_name) %>
+                  </span>
+                </div>
+              </div>
+            </th>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span>
+                    <%= AttributeHelpText.human_attribute_name(:help_text) %>
+                  </span>
+                </div>
+              </div>
+            </th>
+            <th>
+              <div class="generic-table--empty-header"></div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% entries.each do |attribute_help_text| -%>
+            <tr class="attribute-help-text--entry">
+              <td>
+                <%= link_to h(attribute_help_text.attribute_caption),
+                            edit_attribute_help_text_path(attribute_help_text) %>
+              </td>
+              <td>
+                <a class="icon" href="#">
+                  <%= op_icon('icon icon-help2') %>
+                  <%= t(:'attribute_help_texts.show_preview') %>
+                </a>
+              </td>
+              <td class="buttons">
+                <%= delete_link attribute_help_text_path(attribute_help_text) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% else %>
+  <%= no_results_box %>
+<% end %>
+
+<div class="generic-table--action-buttons">
+  <%= link_to new_attribute_help_text_path(name: tab[:name]),
+              { class: 'attribute-help-texts--create-button button -alt-highlight',
+                aria: {label: t(:'attribute_help_texts.add_new')},
+                title: t(:'attribute_help_texts.add_new')} do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('activerecord.models.attribute_help_text') %></span>
+  <% end %>
+</div>

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -71,10 +71,12 @@ See doc/COPYRIGHT.rdoc for more details.
                             edit_attribute_help_text_path(attribute_help_text) %>
               </td>
               <td>
-                <a class="icon" href="#">
-                  <%= op_icon('icon icon-help2') %>
-                  <%= t(:'attribute_help_texts.show_preview') %>
-                </a>
+                <attribute-help-text
+                  help-text-id="<%= attribute_help_text.id %>"
+                  attribute="'<%= attribute_help_text.attribute_name %>'"
+                  attribute-scope="<%= attribute_help_text.attribute_scope %>"
+                  additional-label="<%= t(:'attribute_help_texts.show_preview') %>">
+                </attribute-help-text>
               </td>
               <td class="buttons">
                 <%= delete_link attribute_help_text_path(attribute_help_text) %>

--- a/app/views/attribute_help_texts/edit.html.erb
+++ b/app/views/attribute_help_texts/edit.html.erb
@@ -1,0 +1,44 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<% html_title t(:label_administration), l(:'attribute_help_texts.edit', attribute_caption: @attribute_help_text.attribute_caption) %>
+<% local_assigns[:additional_breadcrumb] = link_to(@attribute_help_text.type_caption,
+                                                   attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)),
+                                            t(:'attribute_help_texts.edit', attribute_caption: @attribute_help_text.attribute_caption) %>
+<%= breadcrumb_toolbar t(:'attribute_help_texts.edit', attribute_caption: @attribute_help_text.attribute_caption)
+%>
+
+<%= labelled_tabular_form_for @attribute_help_text,
+                              as: 'attribute_help_text',
+                              url: { action: :update },
+                              html: {id: 'attribute_help_text_form'} do |f| %>
+  <%= render partial: 'form', locals: { f: f, editing: true } %>
+  <%= hidden_field_tag 'attribute_scope', @attribute_help_text.attribute_scope %>
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+<% end %>

--- a/app/views/attribute_help_texts/index.html.erb
+++ b/app/views/attribute_help_texts/index.html.erb
@@ -1,0 +1,42 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+<%= toolbar title: t(:'attribute_help_texts.label_plural') %>
+
+<div class="notification-box -info">
+  <div class="notification-box--content">
+    <p><%= t('attribute_help_texts.text_overview') %></p>
+  </div>
+</div>
+
+<%= render_tabs [
+      { name: 'WorkPackage', partial: 'attribute_help_texts/tab', label: :label_work_package },
+   ]
+%>
+
+<% html_title(t(:label_administration), t(:'attribute_help_texts.label_plural')) -%>

--- a/app/views/attribute_help_texts/new.html.erb
+++ b/app/views/attribute_help_texts/new.html.erb
@@ -1,0 +1,44 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<% html_title t(:label_administration), t(:'attribute_help_texts.add_new') %>
+<% local_assigns[:additional_breadcrumb] = link_to(@attribute_help_text.type_caption,
+                                                   attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)),
+                                           t(:'attribute_help_texts.add_new') %>
+<%= breadcrumb_toolbar t(:'attribute_help_texts.add_new')
+%>
+
+<%= labelled_tabular_form_for @attribute_help_text,
+                              as: 'attribute_help_text',
+                              url: { action: :create },
+                              html: {id: 'attribute_help_text_form'} do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <%= f.hidden_field :type, value: @attribute_help_text.type %>
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+<% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -162,6 +162,11 @@ Redmine::MenuManager.map :admin_menu do |menu|
             icon: 'icon2 icon-custom-fields',
             html: { class: 'custom_fields' }
 
+  menu.push :attribute_help_texts,
+            { controller: '/attribute_help_texts' },
+            caption: :'attribute_help_texts.label_plural',
+            icon: 'icon2 icon-help2'
+
   menu.push :enumerations,
             { controller: '/enumerations' },
             icon: 'icon2 icon-enumerations'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,13 @@ en:
     is_active: currently displayed
     is_inactive: currently not displayed
 
+  attribute_help_texts:
+    text_overview: 'In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute.'
+    label_plural: 'Attribute help texts'
+    show_preview: 'Preview text'
+    add_new: 'Add help text'
+    edit: "Edit help text for %{attribute_caption}"
+
   auth_sources:
     index:
       no_results_content_title: There are currently no authentication modes.
@@ -297,6 +304,9 @@ en:
         file: "File"
         filename: "File"
         filesize: "Size"
+      attribute_help_text:
+        attribute_name: 'Attribute'
+        help_text: 'Help text'
       auth_source:
         account: "Account"
         attr_firstname: "Firstname attribute"
@@ -543,6 +553,7 @@ en:
 
     models:
       attachment: "File"
+      attribute_help_text: "Attribute help text"
       board: "Forum"
       comment: "Comment"
       custom_field: "Custom field"
@@ -868,6 +879,7 @@ en:
   enumeration_reported_project_statuses: "Reported project status"
 
   error_can_not_archive_project: "This project cannot be archived"
+  error_can_not_delete_entry: "Unable to delete entry"
   error_can_not_delete_custom_field: "Unable to delete custom field"
   error_can_not_delete_type: "This type contains work packages and cannot be deleted."
   error_can_not_delete_standard_type: "Standard types cannot be deleted."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -42,6 +42,7 @@ en:
     button_add_watcher: "Add watcher"
     button_back_to_list_view: "Back to list view"
     button_cancel: "Cancel"
+    button_close: "Close"
     button_check_all: "Check all"
     button_configure-form: "Configure form"
     button_confirm: "Confirm"
@@ -131,6 +132,7 @@ en:
     label_contains: "contains"
     label_created_on: "created on"
     label_edit_comment: "Edit this comment"
+    label_edit_this_entry: "Edit this entry"
     label_equals: "is"
     label_expand: "Expand"
     label_expanded: "expanded"
@@ -219,6 +221,9 @@ en:
     label_wait: "Please wait for configuration..."
     label_upload_counter: "%{done} of %{count} files finished"
     label_validation_error: "The work package could not be saved due to the following errors:"
+
+    help_texts:
+      show_modal: 'Show attribute help text entry'
 
     password_confirmation:
       field_description: 'You need to enter your account password to confirm this change.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -381,6 +381,8 @@ OpenProject::Application.routes.draw do
     post 'design/colors' => 'custom_styles#update_colors', as: 'update_design_colors'
     resource :custom_style, only: [:update, :show, :create], path: 'design'
 
+    resources :attribute_help_texts, only: %i(index new create edit update destroy)
+
     resources :groups do
       member do
         get :autocomplete_for_user

--- a/db/migrate/20170703075208_add_attribute_help_texts.rb
+++ b/db/migrate/20170703075208_add_attribute_help_texts.rb
@@ -1,0 +1,11 @@
+class AddAttributeHelpTexts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :attribute_help_texts do |t|
+      t.text :help_text, null: false
+      t.string :type, null: false
+      t.string :attribute_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/docs/api/apiv3-documentation.apib
+++ b/docs/api/apiv3-documentation.apib
@@ -12,6 +12,7 @@ FORMAT: 1A
 <!-- include(apiv3/endpoints/configuration.apib) -->
 <!-- include(apiv3/endpoints/custom-options.apib) -->
 <!-- include(apiv3/endpoints/forms.apib) -->
+<!-- include(apiv3/endpoints/help_texts.apib) -->
 <!-- include(apiv3/endpoints/principals.apib) -->
 <!-- include(apiv3/endpoints/priorities.apib) -->
 <!-- include(apiv3/endpoints/projects.apib) -->

--- a/docs/api/apiv3/endpoints/help_texts.apib
+++ b/docs/api/apiv3/endpoints/help_texts.apib
@@ -4,6 +4,7 @@
 |  Link         | Description               | Type          | Constraints | Supported operations |
 |:-------------:|-------------------------- | ------------- | ----------- | -------------------- |
 | self          | This help text            | HelpText      | not null    | READ                 |
+| editText      | Edit the help text entry  | text/htm      | Admin       | READ                 |
 
 ## Local Properties
 | Property           | Description                 | Type                 | Constraints | Supported operations |
@@ -87,6 +88,10 @@
                 "_links": {
                     "self": {
                         "href": "/api/v3/help_texts/1",
+                    },
+                    "editText": {
+                        "type": "text/html",
+                        "href": "/admin/attribute_help_texts/1/edit",
                     }
                 },
                 "id": 1,

--- a/docs/api/apiv3/endpoints/help_texts.apib
+++ b/docs/api/apiv3/endpoints/help_texts.apib
@@ -1,0 +1,110 @@
+# Group Help texts
+
+## Linked Properties
+|  Link         | Description               | Type          | Constraints | Supported operations |
+|:-------------:|-------------------------- | ------------- | ----------- | -------------------- |
+| self          | This help text            | HelpText      | not null    | READ                 |
+
+## Local Properties
+| Property           | Description                 | Type                 | Constraints | Supported operations |
+| :---------:        | --------------------------- | -------------------- | ----------- | -------------------- |
+| id                 | Help text id                | Integer              | x > 0       | READ                 |
+| attribute          | Attribute name              | String               |             | READ                 |
+| attributeCaption   | Attribute caption           | String               |             | READ                 |
+| helpText           | Help text content           | Formattable          |             | READ                 |
+
+## Help texts [/api/v3/help_texts]
+
++ Model
+    + Body
+
+            {
+                "_links":
+                {
+                    "self":
+                    {
+                        "href": "/api/v3/help_texts"
+                    }
+                },
+                "total": 2,
+                "count": 2,
+                "_type": "Collection",
+                "_embedded":
+                {
+                    "elements": [
+                        {
+                            "_type": "HelpText",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/help_texts/1",
+                                }
+                            },
+                            "id": 1,
+                            "attribute": 'id',
+                            "attributeCaption": 'ID',
+                            "scope": 'WorkPackage',
+                            "helpText": {
+                                "format": "textile",
+                                "raw": "Help text for id attribute.",
+                                "html": "<p>Help text for id attribute.</p>"
+                            }
+                        },
+                        {
+                            "_type": "HelpText",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/help_texts/2",
+                                }
+                            },
+                            "id": 2,
+                            "attribute": 'status',
+                            "attributeCaption": 'Status',
+                            "scope": 'WorkPackage',
+                            "helpText": {
+                                "format": "textile",
+                                "raw": "Help text for status attribute.",
+                                "html": "<p>Help text for status attribute.</p>"
+                            }
+                        }
+                    ]
+                }
+            }
+
+## List all help texts [GET]
+
++ Response 200 (application/hal+json)
+
+    [Help texts][]
+
+
+## Help text [/api/v3/help_texts/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "HelpText",
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/help_texts/1",
+                    }
+                },
+                "id": 1,
+                "attribute": 'id',
+                "attributeCaption": 'ID',
+                "scope": 'WorkPackage',
+                "helpText": {
+                    "format": "textile",
+                    "raw": "Help text for id attribute.",
+                    "html": "<p>Help text for id attribute.</p>"
+                }
+            }
+
+## View help text [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... Help text id
+
++ Response 200 (application/hal+json)
+
+    [Help text][]

--- a/frontend/app/components/api/api-paths/api-paths.config.ts
+++ b/frontend/app/components/api/api-paths/api-paths.config.ts
@@ -51,6 +51,8 @@ function apiPathsProviderConfig(apiPathsProvider:ApiPathsServiceProvider) {
   }];
   const root = [''];
 
+  const helpTexts = ['help_texts{/id}'];
+
   const config = {
     wp: workPackages,
     wps: workPackages,
@@ -59,6 +61,7 @@ function apiPathsProviderConfig(apiPathsProvider:ApiPathsServiceProvider) {
     types,
     queries,
     configuration,
+    help_texts: helpTexts,
     root
   };
 

--- a/frontend/app/components/api/api-v3/hal-resource-dms/help-text-dm.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-dms/help-text-dm.service.ts
@@ -1,12 +1,12 @@
 //-- copyright
 // OpenProject is a project management system.
-// Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License version 3.
 //
 // OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2006-2013 Jean-Philippe Lang
 // Copyright (C) 2010-2013 the ChiliProject Team
 //
 // This program is free software; you can redistribute it and/or
@@ -26,42 +26,24 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {opApiModule} from '../../../../angular-modules';
+import {RootResource} from '../hal-resources/root-resource.service';
+import {HalRequestService} from '../hal-request/hal-request.service';
+import {HelpTextResourceInterface} from '../hal-resources/help-text-resource.service';
+import {CollectionResourceInterface} from '../hal-resources/collection-resource.service';
 
-// Hide modal content forwarded from rails
-.modal-wrapper--content
-  display: none
+export class HelpTextDmService {
+  constructor(protected halRequest:HalRequestService,
+              protected v3Path:any) {
+  }
 
-.ngdialog-theme-openproject
-  display: flex
-  align-items: center
-  justify-content: center
+  public loadAll():ng.IPromise<CollectionResourceInterface> {
+    return this.halRequest.get(this.v3Path.help_texts());
+  }
 
-  .ngdialog-overlay
-    z-index: 99
+  public load(helpTextId:string):ng.IPromise<HelpTextResourceInterface> {
+    return this.halRequest.get(this.v3Path.help_texts({ id: helpTextId}));
+  }
+}
 
-  .modal--header .icon-context
-    @include varprop(background, header-bg-color)
-    @include varprop(color, header-item-font-color)
-
-  .ngdialog-content
-    background: $body-background
-    min-width: 200px
-    max-width: 600px
-    z-index: 100
-    // Required for close icon
-    position: relative
-
-  .ngdialog-body
-    margin-top: 2rem
-    min-height: 50px
-
-  .ngdialog-close
-    cursor: pointer
-    position: absolute
-    right: 0
-    top: 0
-
-    &:before
-      @include icon-font-common
-      @extend .icon-context
-      @extend .icon-close:before
+opApiModule.service('helpTextDm', HelpTextDmService);

--- a/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.config.ts
+++ b/frontend/app/components/api/api-v3/hal-resource-types/hal-resource-types.config.ts
@@ -83,7 +83,8 @@ function halResourceTypesConfig(halResourceTypes:HalResourceTypesService) {
     QueryFilterInstanceSchema: 'QueryFilterInstanceSchemaResource',
     QueryFilter: 'QueryFilterResource',
     Root: 'RootResource',
-    QueryOperator: 'QueryOperatorResource'
+    QueryOperator: 'QueryOperatorResource',
+    HelpText: 'HelpTextResource'
   });
 }
 

--- a/frontend/app/components/api/api-v3/hal-resources/help-text-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/help-text-resource.service.ts
@@ -1,12 +1,12 @@
 //-- copyright
 // OpenProject is a project management system.
-// Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License version 3.
 //
 // OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2006-2013 Jean-Philippe Lang
 // Copyright (C) 2010-2013 the ChiliProject Team
 //
 // This program is free software; you can redistribute it and/or
@@ -26,42 +26,25 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {HalResource} from './hal-resource.service';
+import {UserResource} from './user-resource.service';
+import {opApiModule} from '../../../../angular-modules';
+import {HalLink} from '../hal-link/hal-link.service';
 
-// Hide modal content forwarded from rails
-.modal-wrapper--content
-  display: none
+export class HelpTextResource extends HalResource {
 
-.ngdialog-theme-openproject
-  display: flex
-  align-items: center
-  justify-content: center
+  public id:string;
+  public attribute:string;
+  public attributeCaption:string;
+  public scope:string;
+}
 
-  .ngdialog-overlay
-    z-index: 99
+export interface HelpTextResourceInterface extends HelpTextResource {
+  editText?:HalLink;
+}
 
-  .modal--header .icon-context
-    @include varprop(background, header-bg-color)
-    @include varprop(color, header-item-font-color)
+function helpTextResource() {
+  return HelpTextResource;
+}
 
-  .ngdialog-content
-    background: $body-background
-    min-width: 200px
-    max-width: 600px
-    z-index: 100
-    // Required for close icon
-    position: relative
-
-  .ngdialog-body
-    margin-top: 2rem
-    min-height: 50px
-
-  .ngdialog-close
-    cursor: pointer
-    position: absolute
-    right: 0
-    top: 0
-
-    &:before
-      @include icon-font-common
-      @extend .icon-context
-      @extend .icon-close:before
+opApiModule.factory('HelpTextResource', helpTextResource);

--- a/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
@@ -37,6 +37,7 @@ import {AttributeHelpTextsService} from './attribute-help-text.service';
 export class AttributeHelpTextController {
   // Attribute to show help text for
   public attribute:string;
+  public optionaltitle?:string
   // Scope to search for
   public attributeScope:string;
   // Load single id entry if given
@@ -61,6 +62,15 @@ export class AttributeHelpTextController {
     this.$scope.text = {
       'close': I18n.t('js.button_close'),
       'edit': I18n.t('js.label_edit_this_entry')
+    };
+
+    // Override the keyboard close handler for the dialog
+    // so we can avoid it bubbling to the then focused element handler.
+    this.$scope.close = (event:JQueryEventObject) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      this.$scope.closeThisDialog();
     };
 
     if (this.helpTextId) {

--- a/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
@@ -1,0 +1,114 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import IAugmentedJQuery = angular.IAugmentedJQuery;
+import {IDialogService} from 'ng-dialog';
+import {IDialogScope} from 'ng-dialog';
+import {opUiComponentsModule} from '../../../angular-modules';
+import {HelpTextResourceInterface} from '../../api/api-v3/hal-resources/help-text-resource.service';
+import {HelpTextDmService} from '../../api/api-v3/hal-resource-dms/help-text-dm.service';
+import {AttributeHelpTextsService} from './attribute-help-text.service';
+
+export class AttributeHelpTextController {
+  // Attribute to show help text for
+  public attribute:string;
+  // Scope to search for
+  public attributeScope:string;
+  // Load single id entry if given
+  public helpTextId?:string;
+  public additionalLabel?:string;
+
+  public exists:boolean = false;
+  public text:any;
+
+  constructor(protected $element:IAugmentedJQuery,
+              protected $scope:angular.IScope,
+              protected helpTextDm:HelpTextDmService,
+              protected attributeHelpTexts:AttributeHelpTextsService,
+              protected $q:angular.IQService,
+              protected ngDialog:IDialogService,
+              protected I18n:op.I18n) {
+
+    this.text = {
+      open_dialog: I18n.t('js.help_texts.show_modal')
+    };
+
+    this.$scope.text = {
+      'close': I18n.t('js.button_close'),
+      'edit': I18n.t('js.label_edit_this_entry')
+    };
+
+    if (this.helpTextId) {
+      this.exists = true;
+    } else {
+      // Need to load the promise to find out if the attribute exists
+      this.load().then((resource) => {
+        this.exists = !!resource;
+        return resource;
+      });
+    }
+  }
+
+  public handleClick() {
+    this.load().then((resource) => {
+      this.renderModal(resource);
+    });
+  }
+
+  private load() {
+    if (this.helpTextId) {
+      return this.helpTextDm.load(this.helpTextId);
+    } else {
+      return this.attributeHelpTexts.require(this.attribute, this.attributeScope);
+    }
+  }
+
+  private renderModal(resource:HelpTextResourceInterface) {
+    this.$scope.resource = resource;
+    this.ngDialog.open({
+      closeByEscape: true,
+      showClose: true,
+      closeByDocument: true,
+      scope: <IDialogScope> this.$scope,
+      template: '/components/common/help-texts/help-text.modal.html',
+      className: 'ngdialog-theme-openproject'
+    });
+  }
+}
+
+opUiComponentsModule.component('attributeHelpText', {
+  templateUrl: '/components/common/help-texts/help-text.directive.html',
+  controller: AttributeHelpTextController,
+  controllerAs: '$ctrl',
+  bindings: {
+    attribute: '<',
+    attributeScope: '@',
+    helpTextId: '@?',
+    additionalLabel: '@?'
+  }
+});

--- a/frontend/app/components/common/help-texts/attribute-help-text.service.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.service.ts
@@ -1,0 +1,71 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import IAugmentedJQuery = angular.IAugmentedJQuery;
+import {opUiComponentsModule} from '../../../angular-modules';
+import {HelpTextResourceInterface} from '../../api/api-v3/hal-resources/help-text-resource.service';
+import {HelpTextDmService} from '../../api/api-v3/hal-resource-dms/help-text-dm.service';
+import {input} from 'reactivestates';
+import {CollectionResourceInterface} from '../../api/api-v3/hal-resources/collection-resource.service';
+
+export class AttributeHelpTextsService {
+  private helpTexts = input<HelpTextResourceInterface[]>();
+
+  constructor(private helpTextDm:HelpTextDmService,
+              private $q:ng.IQService) {
+  }
+
+  /**
+   * Search for a given attribute help text
+   *
+   * @param attribute
+   * @param scope
+   */
+  public require(attribute:string, scope:string):ng.IPromise<HelpTextResourceInterface|undefined> {
+    const deferred = this.$q.defer<HelpTextResourceInterface|undefined>();
+
+    if (this.helpTexts.isPristine()) {
+      this.helpTextDm.loadAll()
+        .then((resources:CollectionResourceInterface) => {
+          this.helpTexts.putValue(resources.elements as any);
+          deferred.resolve(this.find(attribute, scope));
+        });
+    } else {
+      deferred.resolve(this.find(attribute, scope));
+    }
+
+    return deferred.promise;
+  }
+
+  private find(attribute:string, scope:string):HelpTextResourceInterface|undefined {
+    const value = this.helpTexts.getValueOr([]);
+    return _.find(value, (element) => element.scope === scope && element.attribute === attribute);
+  }
+}
+
+opUiComponentsModule.service('attributeHelpTexts', AttributeHelpTextsService);

--- a/frontend/app/components/common/help-texts/help-text.directive.html
+++ b/frontend/app/components/common/help-texts/help-text.directive.html
@@ -1,0 +1,7 @@
+<accessible-by-keyboard execute="$ctrl.handleClick()"
+                        ng-if="$ctrl.exists"
+                        link-aria-label="{{ ::$ctrl.text.open_dialog }}"
+                        link-class="icon help-text--entry help-text--for-{{ ::$ctrl.attribute }}">
+  <op-icon icon-classes="icon icon-help2"></op-icon>
+  {{ $ctrl.additionalLabel }}
+</accessible-by-keyboard>

--- a/frontend/app/components/common/help-texts/help-text.modal.html
+++ b/frontend/app/components/common/help-texts/help-text.modal.html
@@ -1,0 +1,26 @@
+<div class="attribute-help-text--modal">
+  <div>
+    <div class="modal--header">
+      <span class="icon-context icon-help2"></span>
+      <h2 ng-bind="::resource.attributeCaption"></h2>
+    </div>
+
+    <div class="modal--main" ng-bind-html="::resource.helpText.html">
+    </div>
+
+    <div class="modal--footer">
+      <button class="help-text--close-button button -highlight"
+              ng-click="closeThisDialog()"
+              ng-bind="::text.close"
+              ng-attr-title="{{ ::text.close }}">
+      </button>
+      <a class="help-text--edit-button button"
+         ng-if="resource.editText"
+         ng-attr-href="{{ resource.editText && resource.editText.$link.href }}"
+         ng-attr-title="{{ ::text.edit }}">
+        <op-icon icon-classes="button--icon icon-edit"></op-icon>
+        <span class="button--text" ng-bind="::text.edit"></span>
+      </a>
+    </div>
+  </div>
+</div>

--- a/frontend/app/components/common/help-texts/help-text.modal.html
+++ b/frontend/app/components/common/help-texts/help-text.modal.html
@@ -5,12 +5,15 @@
       <h2 ng-bind="::resource.attributeCaption"></h2>
     </div>
 
-    <div class="modal--main" ng-bind-html="::resource.helpText.html">
+    <div class="modal--main"
+         tabindex="0"
+         ng-bind-html="::resource.helpText.html">
     </div>
 
     <div class="modal--footer">
       <button class="help-text--close-button button -highlight"
               ng-click="closeThisDialog()"
+              data-click-on-keypress="[13, 32]"
               ng-bind="::text.close"
               ng-attr-title="{{ ::text.close }}">
       </button>

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -20,6 +20,7 @@
              wp-replacement-label="descriptor.name">
           {{ descriptor.label }}
           <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
+          <attribute-help-text attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
         </div>
         <div
             wp-edit-field="descriptor.name"
@@ -70,6 +71,7 @@
 
           {{ descriptor.label }}
           <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
+          <attribute-help-text attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
         </div>
         <div
             ng-if="!descriptor.multiple"
@@ -82,8 +84,9 @@
         <div
             class="attributes-key-value--key"
             ng-if="descriptor.multiple"
-            ng-bind="descriptor.label"
             wp-replacement-label="descriptor.label">
+          {{ descriptor.label }}
+          <attribute-help-text attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
         </div>
         <div
             ng-if="descriptor.multiple"

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -20,7 +20,7 @@
              wp-replacement-label="descriptor.name">
           {{ descriptor.label }}
           <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
-          <attribute-help-text attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
+          <attribute-help-text title-text="descriptor.label" attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
         </div>
         <div
             wp-edit-field="descriptor.name"

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -98,6 +98,10 @@ export class WorkPackageSingleViewController {
     return group.members.length === 0;
   }
 
+  public helpTextLabel(attribute:string) {
+    return this.I18n.t('js.')
+  }
+
   /*
    * Returns the work package label
    */

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-replacement-label.directive.html
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-replacement-label.directive.html
@@ -1,4 +1,4 @@
 <ng-transclude
-  ng-click="vm.activate()"
+  ng-click="vm.activate($event)"
   tabindex="-1">
 </ng-transclude>

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-replacement-label.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-replacement-label.directive.ts
@@ -37,8 +37,15 @@ export class WorkPackageReplacementLabelController {
     protected $element:ng.IAugmentedJQuery) {
   }
 
-  public activate() {
+  public activate(evt:JQueryEventObject) {
+    // Skip clicks on help texts
+    const target = jQuery(evt.target);
+    if (target.closest('.help-text--entry').length) {
+      return true;
+    }
+
     this.formCtrl.fields[this.fieldName].activate();
+    return false;
   }
 }
 

--- a/lib/api/v3/help_texts/help_text_collection_representer.rb
+++ b/lib/api/v3/help_texts/help_text_collection_representer.rb
@@ -28,12 +28,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module AttributeHelpTextsHelper
-  def selectable_attributes(instance)
-    available = instance.class.available_attributes
-    used = AttributeHelpText.used_attributes(instance.type)
-
-    available.reject! { |k,| used.include? k }
-    available.map { |k, v| [v, k] }
+module API
+  module V3
+    module HelpTexts
+      class HelpTextCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        element_decorator ::API::V3::HelpTexts::HelpTextRepresenter
+      end
+    end
   end
 end

--- a/lib/api/v3/help_texts/help_text_representer.rb
+++ b/lib/api/v3/help_texts/help_text_representer.rb
@@ -28,12 +28,35 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module AttributeHelpTextsHelper
-  def selectable_attributes(instance)
-    available = instance.class.available_attributes
-    used = AttributeHelpText.used_attributes(instance.type)
+module API
+  module V3
+    module HelpTexts
+      class HelpTextRepresenter < ::API::Decorators::Single
+        include API::V3::Utilities
 
-    available.reject! { |k,| used.include? k }
-    available.map { |k, v| [v, k] }
+        self_link path: :help_text,
+                  id_attribute: :id,
+                  title_getter: ->(*) { nil }
+
+        property :id
+        property :attribute_name,
+                 as: :attribute,
+                 getter: ->(*) {
+                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
+                 }
+        property :attribute_caption
+        property :attribute_scope,
+                 as: :scope
+        property :help_text,
+                 exec_context: :decorator,
+                 getter: ->(*) {
+                   ::API::Decorators::Formattable.new(represented.help_text)
+                 }
+
+        def _type
+          'HelpText'
+        end
+      end
+    end
   end
 end

--- a/lib/api/v3/help_texts/help_texts_api.rb
+++ b/lib/api/v3/help_texts/help_texts_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,12 +26,34 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module AttributeHelpTextsHelper
-  def selectable_attributes(instance)
-    available = instance.class.available_attributes
-    used = AttributeHelpText.used_attributes(instance.type)
+require_dependency 'api/v3/help_texts/help_text_representer'
+require_dependency 'api/v3/help_texts/help_text_collection_representer'
 
-    available.reject! { |k,| used.include? k }
-    available.map { |k, v| [v, k] }
+module API
+  module V3
+    module HelpTexts
+      class HelpTextsAPI < ::API::OpenProjectAPI
+        resources :help_texts do
+          get do
+            @entries = AttributeHelpText.all
+            HelpTextCollectionRepresenter.new(@entries, api_v3_paths.help_texts, current_user: current_user)
+          end
+
+          params do
+            requires :id, type: Integer, desc: 'Help text id'
+          end
+          route_param :id do
+            before do
+              @help_text = AttributeHelpText.find(params[:id])
+              raise API::Errors::NotFound unless @help_text
+            end
+
+            get do
+              HelpTextRepresenter.new(@help_text, current_user: current_user)
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -39,6 +39,7 @@ module API
       mount ::API::V3::Categories::CategoriesAPI
       mount ::API::V3::Configuration::ConfigurationAPI
       mount ::API::V3::CustomOptions::CustomOptionsAPI
+      mount ::API::V3::HelpTexts::HelpTextsAPI
       mount ::API::V3::Principals::PrincipalsAPI
       mount ::API::V3::Priorities::PrioritiesAPI
       mount ::API::V3::Projects::ProjectsAPI

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -111,6 +111,14 @@ module API
             "#{root}/custom_options/#{id}"
           end
 
+          def self.help_texts
+            "#{root}/help_texts"
+          end
+
+          def self.help_text(id)
+            "#{root}/help_texts/#{id}"
+          end
+
           def self.my_preferences
             "#{root}/my_preferences"
           end

--- a/spec/controllers/attribute_help_texts_controller_spec.rb
+++ b/spec/controllers/attribute_help_texts_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe AttributeHelpTextsController, type: :controller do
+  let(:model) { FactoryGirl.build :work_package_help_text }
+  before do
+    expect(controller).to receive(:require_admin)
+  end
+
+  describe '#index' do
+    before do
+      allow(AttributeHelpText).to receive(:all).and_return [model]
+
+      get :index
+    end
+
+    it do
+      expect(response).to be_success
+      expect(assigns(:texts_by_type)).to eql('WorkPackage' => [model])
+    end
+  end
+
+  describe '#edit' do
+    context 'when not found'
+    before do
+      get :edit, params: { id: 1234 }
+    end
+
+    it do
+      expect(response.status).to eq 404
+    end
+  end
+
+  context 'when found' do
+    before do
+      allow(AttributeHelpText).to receive(:find).and_return(model)
+
+      get :edit
+    end
+
+    it do
+      expect(response).to be_success
+      expect(assigns(:attribute_help_text)).to eql model
+    end
+  end
+
+  describe '#update' do
+    before do
+      allow(AttributeHelpText).to receive(:find).and_return(model)
+      expect(model).to receive(:save).and_return(success)
+      put :update,
+          params: {
+            attribute_help_text: {
+              help_text: 'my new help text'
+            }
+          }
+    end
+
+    context 'when save is failure' do
+      let(:success) { false }
+      it 'fails to update the announcement' do
+        expect(response).to be_success
+        expect(response).to render_template 'edit'
+      end
+    end
+
+    context 'when save is success' do
+      let(:success) { true }
+      it 'edits the announcement' do
+        expect(response).to redirect_to action: :index, tab: 'WorkPackage'
+        expect(controller).to set_flash[:notice].to I18n.t(:notice_successful_update)
+
+        expect(model.help_text).to eq('my new help text')
+      end
+    end
+  end
+end

--- a/spec/factories/attribute_help_text_factory.rb
+++ b/spec/factories/attribute_help_text_factory.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :work_package_help_text, class: AttributeHelpText::WorkPackage do
     type 'AttributeHelpText::WorkPackage'
     help_text 'Attribute help text'
-    attribute_name 'id'
+    attribute_name 'status'
   end
 end

--- a/spec/factories/attribute_help_text_factory.rb
+++ b/spec/factories/attribute_help_text_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :work_package_help_text, class: AttributeHelpText::WorkPackage do
+    type 'AttributeHelpText::WorkPackage'
+    help_text 'Attribute help text'
+    attribute_name 'id'
+  end
+end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -1,0 +1,90 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Attribute help texts', type: :feature, js: true do
+  let(:admin) { FactoryGirl.create(:admin) }
+
+  describe 'Work package help texts' do
+    before do
+      login_as(admin)
+      visit attribute_help_texts_path
+    end
+
+    it 'allows CRUD to attribute help texts' do
+      expect(page).to have_selector('.generic-table--no-results-container')
+
+      # Create help text
+      # -> new
+      page.find('.attribute-help-texts--create-button').click
+
+      # Set attributes
+      # -> create
+      select 'Status', from: 'attribute_help_text_attribute_name'
+      fill_in 'Help text', with: 'My attribute help text'
+      click_button 'Save'
+
+      # Should now show on index for editing
+      expect(page).to have_selector('.attribute-help-text--entry td', text: 'Status')
+      instance = AttributeHelpText.last
+      expect(instance.attribute_scope).to eq 'WorkPackage'
+      expect(instance.attribute_name).to eq 'status'
+      expect(instance.help_text).to eq 'My attribute help text'
+
+      # -> edit
+      page.find('.attribute-help-text--entry td a', text: 'Status').click
+      expect(page).to have_selector('#attribute_help_text_attribute_name[disabled]')
+      fill_in 'Help text', with: ''
+      click_button 'Save'
+
+      # Handle errors
+      expect(page).to have_selector('#errorExplanation', text: "Help text can't be blank.")
+      fill_in 'Help text', with: 'New help text'
+      click_button 'Save'
+
+      # On index again
+      expect(page).to have_selector('.attribute-help-text--entry td', text: 'Status')
+      instance.reload
+      expect(instance.help_text).to eq 'New help text'
+
+      # Create new, status is now blocked
+      page.find('.attribute-help-texts--create-button').click
+      expect(page).to have_selector('#attribute_help_text_attribute_name option', text: 'ID')
+      expect(page).to have_no_selector('#attribute_help_text_attribute_name option', text: 'Status')
+      visit attribute_help_texts_path
+
+      # Destroy
+      page.find('.attribute-help-text--entry a.icon-delete').click
+      page.driver.browser.switch_to.alert.accept
+
+      expect(page).to have_selector('.generic-table--no-results-container')
+      expect(AttributeHelpText.count).to be_zero
+    end
+  end
+end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -91,7 +91,7 @@ describe 'Attribute help texts', type: :feature, js: true do
 
       # Create new, status is now blocked
       page.find('.attribute-help-texts--create-button').click
-      expect(page).to have_selector('#attribute_help_text_attribute_name option', text: 'ID')
+      expect(page).to have_selector('#attribute_help_text_attribute_name option', text: 'Assignee')
       expect(page).to have_no_selector('#attribute_help_text_attribute_name option', text: 'Status')
       visit attribute_help_texts_path
 

--- a/spec/features/work_packages/attribute_help_texts_spec.rb
+++ b/spec/features/work_packages/attribute_help_texts_spec.rb
@@ -1,0 +1,83 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package attribute help texts', type: :feature, js: true do
+  let(:project) { FactoryGirl.create :project }
+  let(:work_package) { FactoryGirl.create :work_package, project: project }
+
+  let(:instance) do
+    FactoryGirl.create :work_package_help_text,
+                       attribute_name: :status,
+                       help_text: 'Some *help text* for status.'
+  end
+
+  let(:modal) { AttributeHelpTextModal.new(instance) }
+  let(:wp_page) { Pages::FullWorkPackage.new work_package }
+
+  before do
+    work_package
+    instance
+    login_as(user)
+
+    wp_page.visit!
+    wp_page.ensure_page_loaded
+  end
+
+  shared_examples 'allows to view help texts' do
+    it 'shows an indicator for whatever help text exists' do
+      expect(page).to have_selector('.attributes-key-value--key .help-text--for-status')
+
+      # Open help text modal
+      modal.open!
+      expect(modal.modal_container).to have_selector('strong', text: 'help text')
+      modal.expect_edit(admin: user.admin?)
+
+      modal.close!
+    end
+  end
+
+  describe 'as admin' do
+    let(:user) { FactoryGirl.create(:admin) }
+    it_behaves_like 'allows to view help texts'
+  end
+
+  describe 'as regular user' do
+    let(:view_wps_role) do
+      FactoryGirl.create :role, permissions: [:view_work_packages]
+    end
+    let(:user) do
+      FactoryGirl.create :user,
+                         member_in_project: project,
+                         member_through_role: view_wps_role
+    end
+
+    it_behaves_like 'allows to view help texts'
+  end
+end

--- a/spec/lib/api/v3/help_texts/help_text_collection_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_collection_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,12 +26,34 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module AttributeHelpTextsHelper
-  def selectable_attributes(instance)
-    available = instance.class.available_attributes
-    used = AttributeHelpText.used_attributes(instance.type)
+require 'spec_helper'
 
-    available.reject! { |k,| used.include? k }
-    available.map { |k, v| [v, k] }
+describe ::API::V3::HelpTexts::HelpTextCollectionRepresenter do
+  let!(:help_texts) do
+    [
+      FactoryGirl.build_stubbed(:work_package_help_text, attribute_name: 'id'),
+      FactoryGirl.build_stubbed(:work_package_help_text, attribute_name: 'status')
+    ]
+  end
+
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+
+  def self_link
+    'a link that is provided'
+  end
+
+  let(:representer) do
+    described_class.new(help_texts,
+                        self_link,
+                        current_user: user)
+  end
+
+  context 'generation' do
+    subject(:collection) { representer.to_json }
+
+    it_behaves_like 'unpaginated APIv3 collection',
+                    2,
+                    'a link that is provided',
+                    'HelpText'
   end
 end

--- a/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
@@ -35,8 +35,8 @@ describe ::API::V3::HelpTexts::HelpTextRepresenter do
 
   let(:help_text) do
     FactoryGirl.build_stubbed :work_package_help_text,
-                              attribute_name: :id,
-                              help_text: 'This is a help text for *id* attribute.'
+                              attribute_name: 'status',
+                              help_text: 'This is a help text for *status* attribute.'
   end
 
   let(:representer) { described_class.new help_text, current_user: user }
@@ -55,12 +55,12 @@ describe ::API::V3::HelpTexts::HelpTextRepresenter do
       },
       "id" => help_text.id,
       "scope" => "WorkPackage",
-      "attribute" => "id",
-      "attributeCaption" => "ID",
+      "attribute" => "status",
+      "attributeCaption" => "Status",
       "helpText" => {
         "format" => 'textile',
-        "raw" => 'This is a help text for *id* attribute.',
-        "html" => '<p>This is a help text for <strong>id</strong> attribute.</p>'
+        "raw" => 'This is a help text for *status* attribute.',
+        "html" => '<p>This is a help text for <strong>status</strong> attribute.</p>'
       }
     }
   end

--- a/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
@@ -29,6 +29,8 @@
 require 'spec_helper'
 
 describe ::API::V3::HelpTexts::HelpTextRepresenter do
+  include ::API::V3::Utilities::PathHelper
+
   let(:user) { FactoryGirl.build_stubbed :admin }
 
   let(:help_text) do
@@ -45,6 +47,10 @@ describe ::API::V3::HelpTexts::HelpTextRepresenter do
       "_links" => {
         "self" => {
           "href" => "/api/v3/help_texts/#{help_text.id}"
+        },
+        "editText" => {
+          "href" => edit_attribute_help_text_path(help_text.id),
+          "type" => "text/html"
         }
       },
       "id" => help_text.id,

--- a/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,12 +26,41 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module AttributeHelpTextsHelper
-  def selectable_attributes(instance)
-    available = instance.class.available_attributes
-    used = AttributeHelpText.used_attributes(instance.type)
+require 'spec_helper'
 
-    available.reject! { |k,| used.include? k }
-    available.map { |k, v| [v, k] }
+describe ::API::V3::HelpTexts::HelpTextRepresenter do
+  let(:user) { FactoryGirl.build_stubbed :admin }
+
+  let(:help_text) do
+    FactoryGirl.build_stubbed :work_package_help_text,
+                              attribute_name: :id,
+                              help_text: 'This is a help text for *id* attribute.'
+  end
+
+  let(:representer) { described_class.new help_text, current_user: user }
+
+  let(:result) do
+    {
+      "_type" => "HelpText",
+      "_links" => {
+        "self" => {
+          "href" => "/api/v3/help_texts/#{help_text.id}"
+        }
+      },
+      "id" => help_text.id,
+      "scope" => "WorkPackage",
+      "attribute" => "id",
+      "attributeCaption" => "ID",
+      "helpText" => {
+        "format" => 'textile',
+        "raw" => 'This is a help text for *id* attribute.',
+        "html" => '<p>This is a help text for <strong>id</strong> attribute.</p>'
+      }
+    }
+  end
+
+  it 'serializes the relation correctly' do
+    data = JSON.parse representer.to_json
+    expect(data).to eq result
   end
 end

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -19,10 +19,10 @@ describe AttributeHelpText::WorkPackage, type: :model do
 
   describe 'validations' do
     before do
-      allow(described_class).to receive(:available_attributes).and_return(id: 'ID')
+      allow(described_class).to receive(:available_attributes).and_return(status: 'Status')
     end
 
-    let(:attribute_name) { 'id' }
+    let(:attribute_name) { 'status' }
     let(:help_text) { 'foobar' }
 
     subject { described_class.new attribute_name: attribute_name, help_text: help_text }

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe AttributeHelpText::WorkPackage, type: :model do
+  describe '.available_attributes' do
+    subject { described_class.available_attributes }
+    it 'returns an array of potential attributes' do
+      expect(subject).to be_a Hash
+    end
+  end
+
+  describe '.used_attributes' do
+    let!(:instance) { FactoryGirl.create :work_package_help_text }
+    subject { described_class.used_attributes instance.type }
+
+    it 'returns used attributes' do
+      expect(subject).to eq([instance.attribute_name])
+    end
+  end
+
+  describe 'validations' do
+    before do
+      allow(described_class).to receive(:available_attributes).and_return(id: 'ID')
+    end
+
+    let(:attribute_name) { 'id' }
+    let(:help_text) { 'foobar' }
+
+    subject { described_class.new attribute_name: attribute_name, help_text: help_text }
+
+    context 'help_text is nil' do
+      let(:help_text) { nil }
+
+      it 'validates presence of help text' do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:help_text].count).to eql(1)
+        expect(subject.errors[:help_text].first)
+          .to eql(I18n.t('activerecord.errors.messages.blank'))
+      end
+    end
+
+    context 'attribute_name is nil' do
+      let(:attribute_name) { nil }
+
+      it 'validates presence of attribute name' do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:attribute_name].count).to eql(1)
+        expect(subject.errors[:attribute_name].first)
+          .to eql(I18n.t('activerecord.errors.messages.inclusion'))
+      end
+    end
+
+    context 'attribute_name is invalid' do
+      let(:attribute_name) { 'foobar' }
+
+      it 'validates inclusion of attribute name' do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:attribute_name].count).to eql(1)
+        expect(subject.errors[:attribute_name].first)
+          .to eql(I18n.t('activerecord.errors.messages.inclusion'))
+      end
+    end
+  end
+
+  describe 'instance' do
+    subject { FactoryGirl.build :work_package_help_text }
+
+    it 'provides a caption of its type' do
+      expect(subject.attribute_scope).to eq 'WorkPackage'
+      expect(subject.type_caption).to eq I18n.t(:label_work_package)
+    end
+  end
+end

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -39,7 +39,7 @@ describe 'API v3 Help texts resource' do
 
   let!(:help_texts) do
     [
-      FactoryGirl.create(:work_package_help_text, attribute_name: 'id'),
+      FactoryGirl.create(:work_package_help_text, attribute_name: 'assignee'),
       FactoryGirl.create(:work_package_help_text, attribute_name: 'status')
     ]
   end

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -1,0 +1,93 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Help texts resource' do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryGirl.create(:admin)
+  end
+
+  let!(:help_texts) do
+    [
+      FactoryGirl.create(:work_package_help_text, attribute_name: 'id'),
+      FactoryGirl.create(:work_package_help_text, attribute_name: 'status')
+    ]
+  end
+
+  describe 'help_texts' do
+    describe '#get' do
+      let(:get_path) { api_v3_paths.help_texts }
+      subject(:response) { last_response }
+
+      context 'logged in user' do
+        before do
+          allow(User).to receive(:current).and_return current_user
+
+          get get_path
+        end
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'HelpText'
+      end
+    end
+  end
+
+  describe 'help_texts/:id' do
+    describe '#get' do
+      let(:help_text) { help_texts.first }
+      let(:get_path) { api_v3_paths.help_text help_text.id }
+
+      subject(:response) { last_response }
+
+      context 'logged in user' do
+        before do
+          allow(User).to receive(:current).and_return(current_user)
+
+          get get_path
+        end
+
+        context 'valid type id' do
+          it { expect(response.status).to eq(200) }
+        end
+
+        context 'invalid type id' do
+          let(:get_path) { api_v3_paths.type 'bogus' }
+
+          it_behaves_like 'not found' do
+            let(:id) { 'bogus' }
+            let(:type) { 'HelpText' }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/attribute_help_text_spec.rb
+++ b/spec/routing/attribute_help_text_spec.rb
@@ -1,0 +1,48 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe AttributeHelpTextsController, type: :routing do
+  it 'should route CRUD to the controller' do
+    expect(get('/admin/attribute_help_texts'))
+      .to route_to(controller: 'attribute_help_texts', action: 'index')
+
+    expect(get('/admin/attribute_help_texts/1/edit'))
+      .to route_to(controller: 'attribute_help_texts', action: 'edit', id: '1')
+
+    expect(post('/admin/attribute_help_texts'))
+      .to route_to(controller: 'attribute_help_texts', action: 'create')
+
+    expect(put('/admin/attribute_help_texts/1'))
+      .to route_to(controller: 'attribute_help_texts', action: 'update', id: '1')
+
+    expect(delete('/admin/attribute_help_texts/1'))
+      .to route_to(controller: 'attribute_help_texts', action: 'destroy', id: '1')
+  end
+end


### PR DESCRIPTION
Allows users to define custom help text per scope (currently, work packages only).

**TODOS**

- [X] Implement backend CRUD view to create global help texts
- [x] Implement global API to retrieve all texts
- [x] Create frontend directive to render help text in modal, given scope and attribute.
- [x] Render preview in backend using directive

**Out of scope**

- Override global help texts locally (i.e., per work package type). This is blocked by [#25706](https://community.openproject.com/projects/openproject/work_packages/25706)

**Open for discussion**

- The API is neither authenticated nor json-cached. I wanted to wait regarding the requirements on  authentication.
- Do we want to show a help text for the column dropdown as well ? I did not restrict the potential attribute values derived from `Query.available_columns`, it would thus be possible to add a help text. If this is not wanted, we should find a sane way to get all applicable attributes.

https://community.openproject.com/work_packages/25706