### PR TITLE
[25725] Show activity toggler only when relevant

### DIFF
--- a/frontend/app/components/wp-panels/activity-panel/activity-panel-default.directive.html
+++ b/frontend/app/components/wp-panels/activity-panel/activity-panel-default.directive.html
@@ -4,16 +4,16 @@
 
   <div class="detail-activity">
     <ul class="work-package-details-activities-list">
-      <li ng-repeat="activity in vm.visibleAcitivities()"
+      <li ng-repeat="activity in vm.visibleActivities()"
           class="work-package-details-activities-activity"
-          ng-init="inf = vm.info(activity, $index)">
+          ng-init="inf = vm.info(activity, $index); showToggler = vm.showToggler()">
 
         <h3 class="activity-date"
-            ng-class="{'-with-toggler': $first}"
+            ng-class="{'-with-toggler': $first && showToggler}"
             ng-if="inf.isNextDate">
           <span class="activity-date--label" ng-bind="inf.date"></span>
           <accessible-by-keyboard execute="vm.toggleComments()"
-                                  ng-if="$first"
+                                  ng-if="$first && showToggler"
                                   link-class="activity-comments--toggler button -small -transparent"
                                   link-aria-label="{{ vm.togglerText }}">
             <span ng-bind="vm.togglerText"></span>

--- a/frontend/app/components/wp-panels/activity-panel/activity-panel.directive.ts
+++ b/frontend/app/components/wp-panels/activity-panel/activity-panel.directive.ts
@@ -66,11 +66,24 @@ export class ActivityPanelController {
       });
   }
 
-  public visibleAcitivities() {
+  public showToggler() {
+    const count_all = this.activities.length;
+    const count_with_comments = this.activitiesWithComments.length;
+
+    return count_all > 1 &&
+      count_with_comments > 0 &&
+      count_with_comments < this.activities.length;
+  }
+
+  public visibleActivities() {
     if (!this.onlyComments) {
       return this.activities;
+    } else {
+      return this.activitiesWithComments;
     }
+  }
 
+  public get activitiesWithComments() {
     return this.activities.filter((activity:any) => !!_.get(activity, 'comment.html'));
   }
 


### PR DESCRIPTION
Show the toggler only when:

1. At least two activities exist
2. At least one activity with comment exists
3. The number of activity with comments are fewer than the total

https://community.openproject.com/work_packages/25725