### PR TITLE
[25734] Remove select background override

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -32,7 +32,7 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
   border: $content-form-input-border
   border-radius: 2px
   font-size: 0.9rem
-  &:hover, &:focus
+  &:focus
     border: $content-form-input-hover-border
 
   vertical-align: middle
@@ -520,7 +520,7 @@ select
   margin-bottom: 0rem
   font-size: 0.9rem
 
-  &:hover, &:focus, &:active
+  &:focus, &:active
     border-color: #999
 
 input[readonly].-clickable
@@ -531,6 +531,16 @@ input[readonly].-clickable
   @extend %input-style
   line-height: normal
   padding: rem-concat-list($select-element-padding)
+  background: white
+  -webkit-appearance: menulist
+  -moz-appearance: menulist
+
+  &:hover
+    background: white
+
+  &[disabled]
+    background-color: #eceeef
+    cursor: not-allowed
 
   &.parent-select
     height: 100%

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -531,9 +531,6 @@ input[readonly].-clickable
   @extend %input-style
   line-height: normal
   padding: rem-concat-list($select-element-padding)
-  // TODO: Temporary fix, for sure it will be fixed with next foundation-app release v1.1.1
-  // remove background image after/if upgrade
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20version%3D%221.1%22%20width%3D%2232%22%20height%3D%2224%22%20viewBox%3D%220%200%2032%2024%22%3E%3Cpolygon%20points%3D%220%2C0%2032%2C0%2016%2C24%22%20style%3D%22fill%3A%20black%22%3E%3C/polygon%3E%3C/svg%3E")
 
   &.parent-select
     height: 100%

--- a/app/assets/stylesheets/openproject/_settings.scss
+++ b/app/assets/stylesheets/openproject/_settings.scss
@@ -366,9 +366,9 @@ $form-padding: 0.375rem;
 
 // Select menus
 // $select-color: #000;
-$select-background: #fff;
-$select-background-hover: smartscale($select-background, 0%);
-// $select-arrow: true;
+// $select-background: #fff;
+// $select-background-hover: smart-scale($select-background, 5%);
+$select-arrow: false;
 // $select-arrow-color: $select-color;
 
 // Labels


### PR DESCRIPTION
Remove the override from 986683ddacce4ecaa8fe567c5d56f2d3e68d686d and
disable arrow backgrounds for IE10/11.

https://community.openproject.com/wp/25734

[ci skip]