### PR TITLE
Allow overriding Setting.protocol in packager rake task

### DIFF
--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -60,8 +60,16 @@ namespace :packager do
     # Persist configuration
     Setting.sys_api_enabled = 1
     Setting.sys_api_key = ENV['SYS_API_KEY']
-    Setting.protocol = ENV.fetch('SERVER_PROTOCOL', Setting.protocol)
     Setting.host_name = ENV.fetch('SERVER_HOSTNAME', Setting.host_name)
+
+    # Allow overriding the protocol setting from ENV
+    # to allow instances where SSL is terminated earlier to respect that setting
+    Setting.protocol =
+      if ENV['SERVER_PROTOCOL_FORCE_HTTPS']
+        'https'
+      else
+        ENV.fetch('SERVER_PROTOCOL', Setting.protocol)
+      end
 
     # Run customization step, if it is defined.
     # Use to define custom postinstall steps required after each configure,


### PR DESCRIPTION
When an instance is SSL termination, server/ssl will be false and Setting.protocol will be set to http.
However, the instance's protocol SHOULD be set to https since that is used for link generation

This PR allows to override the ENV coming from packager when the instance is behind ssl termination using `SERVER_PROTOCOL_FORCE_HTTPS`

[ci skip]