### PR TITLE
[25757] Avoid link hover effect in modal header

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -165,8 +165,6 @@ ul.export-options
 .ngdialog-theme-openproject .ngdialog-close
   @include varprop(line-height, header-height)
   @include varprop(color, body-font-color)
-  &:hover
-    @include varprop(color, content-link-color)
 
 
 .modal--header

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -164,8 +164,7 @@ ul.export-options
 .modal-wrapper .ngdialog-close,
 .ngdialog-theme-openproject .ngdialog-close
   @include varprop(line-height, header-height)
-  @include varprop(color, body-font-color)
-
+  @include varprop(color, header-item-font-color)
 
 .modal--header
   display: flex


### PR DESCRIPTION
Avoid a hover effect for the close icon in modals. Otherwise the color may change to blue on blue and is thus hard to read.

https://community.openproject.com/projects/openproject/work_packages/25757/activity
