### PR TITLE
[25758] Icon missing in Admin/Design

### DIFF
--- a/app/views/custom_styles/show.html.erb
+++ b/app/views/custom_styles/show.html.erb
@@ -160,7 +160,7 @@ See doc/COPYRIGHT.rdoc for more details.
         </div>
       <% end %>
 
-      <button type="submit" class="button">Save</button>
+      <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
 
     </fieldset>
   </section>


### PR DESCRIPTION
Add the `checkmark` icon to the save button in Admin/Design.

https://community.openproject.com/projects/openproject/work_packages/25758/activity