### PR TITLE
[25753] Restore project indent levels

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$project-table--start-indentation: 0.5em
+$project-table--start-indentation: 1em
 $project-table--child-indentation: 1.1em
 $project-table--icon-distance: 5px
 
@@ -131,6 +131,27 @@ tr
   &.project
     td.name a
       white-space: nowrap
+    &.idnt td.project--hierarchy span
+      &.icon-context:before
+        padding: 9px 5px 0 0px
+    &.idnt-1 td.project--hierarchy
+      @include calc-indentation(0)
+    &.idnt-2 td.project--hierarchy
+      @include calc-indentation(1)
+    &.idnt-3 td.project--hierarchy
+      @include calc-indentation(2)
+    &.idnt-4 td.project--hierarchy
+      @include calc-indentation(3)
+    &.idnt-5 td.project--hierarchy
+      @include calc-indentation(4)
+    &.idnt-6 td.project--hierarchy
+      @include calc-indentation(5)
+    &.idnt-7 td.project--hierarchy
+      @include calc-indentation(6)
+    &.idnt-8 td.project--hierarchy
+      @include calc-indentation(7)
+    &.idnt-9 td.project--hierarchy
+      @include calc-indentation(8)
 
   &.issue
     white-space: nowrap


### PR DESCRIPTION
And slightly increases the initial padding to indent the first child

<img width="555" alt="bildschirmfoto 2017-07-10 um 08 28 41" src="https://user-images.githubusercontent.com/459462/28005260-f43818d2-6549-11e7-9433-e40a6381ad7f.png">


https://community.openproject.com/projects/openproject/work_packages/25753