### PR TITLE
show disabled select boxes with a grey background and a "forbidden" cursor

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -524,6 +524,11 @@ select
   &:hover, &:focus, &:active
     border-color: #999
 
+select
+  &[disabled=disabled]
+    background-color: $inplace-edit--bg-color--disabled
+    cursor: not-allowed
+
 input[readonly].-clickable
   cursor: pointer
   background: white


### PR DESCRIPTION
Second Approach to solve 
https://community.openproject.com/projects/openproject/work_packages/25734/activity

… while not going back to browser styles.

Alternative to PR 
https://github.com/opf/openproject/pull/5731