### PR TITLE
Fix `all_languages` being included in other modules not referencing

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -33,6 +33,15 @@ module Redmine
       base.extend Redmine::I18n
     end
 
+    def self.all_languages
+      @@all_languages ||= begin
+        Dir.glob(Rails.root.join('config/locales/*.yml'))
+          .map { |f| File.basename(f).split('.').first }
+          .reject! { |l| /\Ajs-/.match(l.to_s) }
+          .map(&:to_sym)
+      end
+    end
+
     def l(*args)
       case args.size
       when 1
@@ -142,12 +151,7 @@ module Redmine
     end
 
     def all_languages
-      @@all_languages ||= begin
-        Dir.glob(Rails.root.join('config/locales/*.yml'))
-        .map { |f| File.basename(f).split('.').first }
-        .reject! { |l| /\Ajs-/.match(l.to_s) }
-        .map(&:to_sym)
-      end
+      Redmine::I18n.all_languages
     end
 
     ##


### PR DESCRIPTION
the translations overridden definition.

https://github.com/opf/openproject-translations/pull/43
https://community.openproject.com/projects/openproject/work_packages/25783/activity?query_id=936