### PR TITLE
[25802] When all timeline columns are removed lines and info icon don't align properly

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -36,6 +36,7 @@
 .work-package-table--container table.generic-table tbody td
   padding-left: 0
   line-height: 24px
+  height: 40px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable


### PR DESCRIPTION
This sets a height to WP cells. Thus it is assured that the rows always have the same (required) height for the timeline.

https://community.openproject.com/projects/openproject/work_packages/25802/activity