### PR TITLE
[25715] Even short subjects get truncated when many columns are displayed

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -206,7 +206,7 @@ html.-supports-sticky-headers
 
 .generic-table--header-outer,
 .generic-table--sort-header-outer,
-  padding:      0 6px
+  padding:      0 12px 0 6px
   line-height:  $generic-table--header-height
   z-index:      1
   border-bottom: 1px solid $table-row-border-color
@@ -238,20 +238,18 @@ html.-supports-sticky-headers
   white-space: nowrap
   width:   100%
   clear:   both
-  display: block
   min-width: 40px
-
-  & > a,
-  & > span
-    display: block
-    font-weight: bold
-    overflow: hidden
-    text-overflow: ellipsis
+  display: flex
 
   & > a
-    float: left
+    flex: 1 1 0
     width: 100%
-    padding-right: 30px
+    font-weight: bold
+
+  & > op-icon
+    flex: 0 0 0
+    padding-left: 15px
+
 
 .generic-table--sort-header-outer
   .dropdown-indicator
@@ -260,7 +258,6 @@ html.-supports-sticky-headers
     min-width: 1em
     visibility: hidden
     position: relative
-    right: 15px
 
   &:hover .dropdown-indicator
     visibility: visible

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -72,9 +72,6 @@ body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
     visibility: visible
 
 // Style hierarchy column differently
-.hierarchy-header--sort-title
-  display: inline-block
-  padding-right: 30px
 
 // Padding for the hierarchy mode
 .wp-table--cell-td.subject:not(.-with-hierarchy)
@@ -87,6 +84,7 @@ body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
 .hierarchy-header--icon
   cursor: pointer
   display: inline-block
+  flex: 0 0 0
   width: 20px
 
   i:before

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -60,6 +60,7 @@ body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
 
 
 .hierarchy-header--outer-span
+  white-space: nowrap
   & > .dropdown-indicator
     width: 1em
     text-align: right
@@ -72,8 +73,8 @@ body:not(.accessibility-mode ) .wp-table--hierarchy-aditional-row
 
 // Style hierarchy column differently
 .hierarchy-header--sort-title
-  width: calc(100% - 48px)
   display: inline-block
+  padding-right: 30px
 
 // Padding for the hierarchy mode
 .wp-table--cell-td.subject:not(.-with-hierarchy)

--- a/frontend/app/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/app/components/wp-table/sort-header/sort-header.directive.html
@@ -1,5 +1,5 @@
 <div class="generic-table--sort-header-outer">
-  <span class="hierarchy-header--outer-span" ng-if="isHierarchyColumn">
+  <span class="generic-table--sort-header" ng-if="isHierarchyColumn">
     <span
        class="hierarchy-header--icon"
        ng-click="toggleHierarchy($event)"
@@ -10,7 +10,6 @@
       <op-icon icon-classes="icon {{ hierarchyIcon }}"></op-icon>
     </span>
     <a href="javascript://"
-       class="hierarchy-header--sort-title"
        ng-if="sortable"
        ng-class="[directionClass && 'sort', directionClass]"
        lang-attribute


### PR DESCRIPTION
Avoid a truncation of the subject table header. This occurred when there were only small subjects.

https://community.openproject.com/projects/openproject/work_packages/25715/activity