### PR TITLE
[25676] Do not override parent collapsed state

### DIFF
--- a/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -52,6 +52,11 @@ export class HierarchyTransformer {
     return (classNames.match(/__collapsed-group-\d+/g) || []).join(' ');
    });
 
+    // Mark which rows were hidden by some other hierarchy group
+    // (e.g., by a collapsed parent)
+    const collapsed:{[index:number]: boolean} = {};
+
+
    // Hide all collapsed hierarchies
    _.each(state.collapsed, (isCollapsed:boolean, wpId:string) => {
      // Toggle the root style
@@ -69,7 +74,10 @@ export class HierarchyTransformer {
        const index = jQuery(el).index();
 
        // Update the hidden state
-       rendered[index].hidden = isCollapsed;
+       if (collapsed[index] !== true) {
+         rendered[index].hidden = isCollapsed;
+         collapsed[index] = isCollapsed;
+       }
      });
    });
 


### PR DESCRIPTION
When expanding/collapsing hierarchies, we iterate the collapsed
groups index to collapse groups quickly through CSS selectors.

When a parent group is collapsed, but a child group is expanded,
members of that group were incorrectly marked visible even though they
were hidden by the parent.

https://community.openproject.com/projects/openproject/work_packages/25676