### PR TITLE
ensure attachment metadata to be in one part

### DIFF
--- a/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
+++ b/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
@@ -31,16 +31,16 @@ import IQService = angular.IQService;
 import IPromise = angular.IPromise;
 
 export interface UploadFile extends File {
-  description?: string;
+  description?:string;
 }
 
 export interface UploadResult {
-  uploads: IPromise<any>[];
-  finished: IPromise<any>;
+  uploads:IPromise<any>[];
+  finished:IPromise<any>;
 }
 
 export class OpenProjectFileUploadService {
-  constructor(protected $q: IQService,
+  constructor(protected $q:IQService,
               protected Upload:any) {
   }
 
@@ -48,20 +48,22 @@ export class OpenProjectFileUploadService {
    * Upload multiple files using `ngFileUpload` and return a single promise.
    * Ignore directories.
    */
-  public upload(url: string, files: UploadFile[]): UploadResult {
+  public upload(url:string, files:UploadFile[]):UploadResult {
     files = _.filter(files, (file:UploadFile) => file.type !== 'directory');
-    const uploads = _.map(files, (file: UploadFile) => {
-      const params = {
-        fields: {
-          metadata: {
-            description: file.description,
-            fileName: file.name,
-          }
-        },
-        file, url
+    const uploads = _.map(files, (file:UploadFile) => {
+      const metadata = {
+        description: file.description,
+        fileName: file.name
       };
 
-      return this.Upload.upload(params);
+      // need to wrap the metadata into a JSON ourselves as ngFileUpload
+      // will otherwise break up the metadata into individual parts
+      const data =  {
+        metadata: JSON.stringify(metadata),
+        file
+      };
+
+      return this.Upload.upload({data, url});
     });
     const finished = this.$q.all(uploads);
     return {uploads, finished};


### PR DESCRIPTION
The metadata was broken up into the individual keys where each part's name followed the schema `metadata[KEY]` and the value then was the only contents:

![image](https://user-images.githubusercontent.com/617519/28271999-84893b1c-6b0a-11e7-8a48-5adae0877ca8.png)

The api however expects a single part named `metadata` (apart from the `file`-part) with a JSON object inside.

When transforming the object to JSON before passing it to `Upload.upload` the breaking up of the metadata can no longer happen:

![image](https://user-images.githubusercontent.com/617519/28272025-9bfc2ba6-6b0a-11e7-93ce-55d100f77a2b.png)

The commit additionally adapts the parameters to the changes in [ngFileUpload 8.0.1](https://github.com/danialfarid/ng-file-upload/releases/tag/8.0.1).

https://community.openproject.com/projects/openproject/work_packages/24916