### PR TITLE
Fix/custom field lacking options

### DIFF
--- a/app/assets/javascripts/custom-fields.js
+++ b/app/assets/javascripts/custom-fields.js
@@ -179,23 +179,22 @@
     }
   };
 
-  var rowDummyIdCounter = 500;
-
   var duplicateRow = function() {
+    var count = $("#custom-options-table tr.custom-option-row").length;
     var row = $("#custom-options-table tr.custom-option-row:last");
     var dup = row.clone();
 
-    var value = dup.find(".custom-option-value");
+    var value = dup.find(".custom-option-value input");
 
-    rowDummyIdCounter++;
-
-    value.attr("name", "custom_field[custom_options][new-" + rowDummyIdCounter + "][value]");
+    value.attr("name", "custom_field[custom_options_attributes][" + count + "][value]");
     value.val("");
 
     var defaultValue = dup.find(".custom-option-default-value");
 
-    defaultValue.attr("name", "custom_field[custom_options][new-" + rowDummyIdCounter + "][default_value]");
+    defaultValue.attr("name", "custom_field[custom_options_attributes][" + count + "][default_value]");
     defaultValue.prop("checked", false);
+
+    dup.find(".custom-option-id").remove()
 
     dup.find(".move-up-custom-option").click(moveUpRow);
     dup.find(".sort-up-custom-option").click(moveRowToTheTop);
@@ -207,8 +206,6 @@
       .find(".delete-custom-option")
       .attr("href", "#")
       .click(removeOption);
-
-    dup.attr("id", "custom-option-row-" + rowDummyIdCounter);
 
     row.after(dup);
 

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -32,11 +33,14 @@ class CustomField < ActiveRecord::Base
 
   has_many :custom_values, dependent: :delete_all
   has_many :custom_options, -> { order(position: :asc) }, dependent: :delete_all
+  accepts_nested_attributes_for :custom_options
 
   acts_as_list scope: 'type = \'#{self.class}\''
 
-  validates_presence_of :field_format
-
+  validates :field_format, presence: true
+  validates :custom_options,
+            presence: { message: I18n.t(:'activerecord.errors.models.custom_field.at_least_one_custom_option') },
+            if: ->(*) { field_format == 'list' }
   validates :name, presence: true, length: { maximum: 30 }
 
   validate :uniqueness_of_name_with_scope
@@ -55,7 +59,8 @@ class CustomField < ActiveRecord::Base
 
   validates :min_length, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :max_length, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :min_length, numericality: { less_than_or_equal_to: :max_length, message: :smaller_than_or_equal_to_max_length }, unless: Proc.new { |cf| cf.max_length.blank? }
+  validates :min_length, numericality: { less_than_or_equal_to: :max_length, message: :smaller_than_or_equal_to_max_length },
+                         unless: Proc.new { |cf| cf.max_length.blank? }
 
   before_validation :check_searchability
 
@@ -182,7 +187,11 @@ class CustomField < ActiveRecord::Base
 
   def self.customized_class
     name =~ /\A(.+)CustomField\z/
-    begin; $1.constantize; rescue nil; end
+    begin
+      $1.constantize
+    rescue
+      nil
+    end
   end
 
   # to move in project_custom_field

--- a/app/models/custom_option.rb
+++ b/app/models/custom_option.rb
@@ -38,9 +38,21 @@ class CustomOption < ActiveRecord::Base
 
   validates :value, presence: true, length: { maximum: 255 }
 
+  before_destroy :assure_at_least_one_option
+
   def to_s
     value
   end
 
   alias :name :to_s
+
+  protected
+
+  def assure_at_least_one_option
+    return if CustomOption.where(custom_field_id: custom_field_id).where.not(id: id).count > 0
+
+    errors[:base] << I18n.t(:'activerecord.errors.models.custom_field.at_least_one_custom_option')
+
+    throw :abort
+  end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -475,7 +475,8 @@ class PermittedParams
         color: [
           :name,
           :hexcode,
-          :move_to],
+          :move_to
+        ],
         custom_field: [
           :editable,
           :field_format,
@@ -493,15 +494,19 @@ class PermittedParams
           :default_value,
           :possible_values,
           :multi_value,
-          type_ids: []],
+          { custom_options_attributes: %i(id value default_value position) },
+          type_ids: []
+        ],
         enumeration: [
           :active,
           :is_default,
           :move_to,
           :name,
-          :reassign_to_id],
+          :reassign_to_id
+        ],
         group: [
-          :lastname],
+          :lastname
+        ],
         membership: [
           :project_id,
           role_ids: []],

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -98,16 +98,16 @@ See doc/COPYRIGHT.rdoc for more details.
             </td>
             <td>
               <span class="reorder-icons">
-                <a title="Move to the top" rel="nofollow" href="#" class="sort-up-custom-option">
+                <a title="<%= t(:label_sort_highest) %>" rel="nofollow" href="#" class="sort-up-custom-option">
                   <%= op_icon('icon-context icon-sort-up icon-small') %>
                 </a>
-                <a title="Move up" rel="nofollow" href="#" class="move-up-custom-option">
+                <a title="<%= t(:label_sort_higher) %>" rel="nofollow" href="#" class="move-up-custom-option">
                   <%= op_icon('icon-context icon-arrow-up2 icon-small') %>
                 </a>
-                <a title="Move down" rel="nofollow" href="#" class="move-down-custom-option">
+                <a title="<%= t(:label_sort_lower) %>" rel="nofollow" href="#" class="move-down-custom-option">
                   <%= op_icon('icon-context icon-arrow-down2 icon-small') %>
                 </a>
-                <a title="Move to the bottom" rel="nofollow" href="#" class="sort-down-custom-option">
+                <a title="<%= t(:label_sort_lowest) %>" rel="nofollow" href="#" class="sort-down-custom-option">
                   <%= op_icon('icon-context icon-sort-down icon-small') %>
                 </a>
               </span>
@@ -116,7 +116,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <%= link_to t(:button_delete),
                   delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
                   method: :delete,
-                  data: { confirm: "Deleting an option will delete oll of its occurrences (e.g. in work packages). Are you sure you want to delete it? " },
+                  data: { confirm: t(:'custom_fields.confirm_destroy_option') },
                   class: 'icon icon-delete delete-custom-option' %>
             </td>
           </tr>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -1,3 +1,35 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<% custom_field = f.object %>
+<% custom_field.custom_options.build if custom_field.custom_options.empty? %>
+
 <div class="generic-table--container">
   <div class="generic-table--results-container">
     <table class="generic-table" id="custom-options-table">
@@ -42,56 +74,53 @@
           </th>
         </tr>
       </thead>
-      <% custom_options = [OpenStruct.new(id: 0, value: "", default_value: false)] if custom_options.empty? %>
-      <% custom_options.each_with_index do |custom_option, i| %>
-        <tr
-          id="custom-option-row-<%= i + 1 %>"
-          draggable="true"
-          class="custom-option-row -draggable"
-          ondrop="CustomFields.drop(event)"
-          ondragstart="CustomFields.drag(event)"
-          ondragover="CustomFields.allowDrop(event)"
-        >
-          <td>
-            <span class="icon icon-table icon-toggle"></span>
-            <input class="form--text-field custom-option-value"
-              type="text"
-              name="custom_field[custom_options][<%= custom_option.id %>][value]"
-              value="<%= custom_option.value %>"
-            >
-          </td>
-          <td>
-            <input
-              class="form--check-box custom-option-default-value"
-              type="checkbox"
-              <%= custom_option.default_value ? 'checked="checked"' : '' %>
-              name="custom_field[custom_options][<%= custom_option.id %>][default_value]"
-            >
-          </td>
-          <td>
-            <span class="reorder-icons">
-              <a title="Move to the top" rel="nofollow" href="#" class="sort-up-custom-option">
-                <%= op_icon('icon-context icon-sort-up icon-small') %>
-              </a>
-              <a title="Move up" rel="nofollow" href="#" class="move-up-custom-option">
-                <%= op_icon('icon-context icon-arrow-up2 icon-small') %>
-              </a>
-              <a title="Move down" rel="nofollow" href="#" class="move-down-custom-option">
-                <%= op_icon('icon-context icon-arrow-down2 icon-small') %>
-              </a>
-              <a title="Move to the bottom" rel="nofollow" href="#" class="sort-down-custom-option">
-                <%= op_icon('icon-context icon-sort-down icon-small') %>
-              </a>
-            </span>
-          </td>
-          <td>
-            <%= link_to t(:button_delete),
-                delete_option_of_custom_field_path(id: @custom_field.id || 0, option_id: custom_option.id),
-                method: :delete,
-                data: { confirm: "Deleting an option will delete oll of its occurrences (e.g. in work packages). Are you sure you want to delete it? " },
-                class: 'icon icon-delete delete-custom-option' %>
-          </td>
-        </tr>
+
+      <% custom_field.custom_options.each_with_index do |custom_option, i| %>
+        <%= f.fields_for :custom_options, custom_option do |co_f| %>
+          <tr
+            draggable="true"
+            class="custom-option-row -draggable"
+            ondrop="CustomFields.drop(event)"
+            ondragstart="CustomFields.drag(event)"
+            ondragover="CustomFields.allowDrop(event)"
+          >
+            <td>
+              <span class="icon icon-table icon-toggle"></span>
+              <%= co_f.hidden_field :id, class: 'custom-option-id' %>
+              <%= co_f.text_field :value,
+                                  container_class: 'custom-option-value',
+                                  no_label: true %>
+            </td>
+            <td>
+              <%= co_f.check_box :default_value,
+                                 container_class: 'custom-option-default-value',
+                                 no_label: true %>
+            </td>
+            <td>
+              <span class="reorder-icons">
+                <a title="Move to the top" rel="nofollow" href="#" class="sort-up-custom-option">
+                  <%= op_icon('icon-context icon-sort-up icon-small') %>
+                </a>
+                <a title="Move up" rel="nofollow" href="#" class="move-up-custom-option">
+                  <%= op_icon('icon-context icon-arrow-up2 icon-small') %>
+                </a>
+                <a title="Move down" rel="nofollow" href="#" class="move-down-custom-option">
+                  <%= op_icon('icon-context icon-arrow-down2 icon-small') %>
+                </a>
+                <a title="Move to the bottom" rel="nofollow" href="#" class="sort-down-custom-option">
+                  <%= op_icon('icon-context icon-sort-down icon-small') %>
+                </a>
+              </span>
+            </td>
+            <td>
+              <%= link_to t(:button_delete),
+                  delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
+                  method: :delete,
+                  data: { confirm: "Deleting an option will delete oll of its occurrences (e.g. in work packages). Are you sure you want to delete it? " },
+                  class: 'icon icon-delete delete-custom-option' %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
     </table>
 

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -26,8 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= error_messages_for 'custom_field' %>
-
 <section class="form--section" id="custom_field_form">
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name, required: true, container_class: '-middle' %>
@@ -79,11 +77,11 @@ See doc/COPYRIGHT.rdoc for more details.
   <% end %>
 
   <% if @custom_field.new_record? || @custom_field.field_format == 'list' %>
-    <fieldset class="form--fieldset">
+    <fieldset class="form--fieldset" id="custom_field_possible_values_attributes">
       <legend class="form--fieldset-legend"><%= I18n.t("activerecord.attributes.custom_field.possible_values") %></legend>
-      <div class="form--field" id="custom_field_possible_values_attributes">
-          <%= render partial: "custom_fields/custom_options", locals: { custom_options: @custom_field.custom_options, f: f } %>
-          <a id="add-custom-option" href="#" class="icon icon-add"><%= t(:button_add) %></a>
+      <div class="form--field">
+        <%= render partial: "custom_fields/custom_options", locals: { custom_field: @custom_field, f: f } %>
+        <a id="add-custom-option" href="#" class="icon icon-add"><%= t(:button_add) %></a>
       </div>
     </fieldset>
   <% end %>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -31,8 +31,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% local_assigns[:additional_breadcrumb] =  link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        @custom_field.name %>
-<%= breadcrumb_toolbar @custom_field.name
-%>
+<%= breadcrumb_toolbar @custom_field.name %>
+
+<%= error_messages_for 'custom_field' %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                               url: custom_field_path(@custom_field),

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -30,8 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title l(:label_administration), l(:label_custom_field_new) %>
 <% local_assigns[:additional_breadcrumb] = link_to(l(@custom_field.type_name), custom_fields_path(tab: @custom_field.type)),
                        l(:label_custom_field_new) %>
-<%= breadcrumb_toolbar l(:label_custom_field_new)
-%>
+<%= breadcrumb_toolbar l(:label_custom_field_new) %>
+<%= error_messages_for 'custom_field' %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                                              url: custom_fields_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,8 @@ en:
         before_or_equal_to: "must be before or equal to %{date}."
         could_not_be_copied: "could not be (fully) copied."
       models:
+        custom_field:
+          at_least_one_custom_option: "At least one option needs to be available."
         enterprise_token:
           unreadable: "can't be read. Are you sure it is a support token?"
         project:
@@ -599,6 +601,7 @@ en:
     content: "Content"
     created_at: "Created on"
     created_on: "Created on"
+    custom_options: "Possible values"
     custom_values: "Custom fields"
     date: "Date"
     default_columns: "Default columns"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     is_enabled_globally: 'Is enabled globally'
     enabled_in_project: 'Enabled in project'
     contained_in_type: 'Contained in type'
+    confirm_destroy_option: "Deleting an option will delete oll of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
     tab:
       no_results_title_text: There are currently no custom fields.
       no_results_content_text: Create a new custom field

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -24,24 +24,24 @@ describe 'custom fields', js: true do
 
       expect(page).to have_selector('.custom-option-row', count: 1)
       within all(".custom-option-row").last do
-        find("input.custom-option-value").set "Windows"
-        find("input.custom-option-default-value").set true
+        find(".custom-option-value input").set "Windows"
+        find(".custom-option-default-value input").set true
       end
 
       click_on "add-custom-option"
 
       expect(page).to have_selector('.custom-option-row', count: 2)
       within all(".custom-option-row").last do
-        find("input.custom-option-value").set "Linux"
+        find(".custom-option-value input").set "Linux"
       end
 
       click_on "add-custom-option"
 
       expect(page).to have_selector('.custom-option-row', count: 3)
       within all(".custom-option-row").last do
-        find("input.custom-option-value").set "Solaris"
+        find(".custom-option-value input").set "Solaris"
 
-        click_on "Move to the top"
+        click_on "Move to top"
       end
 
       click_on "Save"
@@ -51,13 +51,13 @@ describe 'custom fields', js: true do
       click_on "Operating System"
 
       expect(page).to have_selector('.custom-option-row', count: 3)
-      values = all(".custom-option-value")
+      values = all(".custom-option-value input")
 
       expect(values[0].value).to eql("Solaris")
       expect(values[1].value).to eql("Windows")
       expect(values[2].value).to eql("Linux")
 
-      defaults = all(".custom-option-default-value")
+      defaults = all(".custom-option-default-value input")
 
       expect(defaults[0]).not_to be_checked
       expect(defaults[1]).to be_checked
@@ -87,14 +87,14 @@ describe 'custom fields', js: true do
 
       expect(page).to have_selector('.custom-option-row', count: 5)
       within all(".custom-option-row").last do
-        find("input.custom-option-value").set "Sega"
+        find(".custom-option-value input").set "Sega"
       end
 
       click_on "add-custom-option"
 
       expect(page).to have_selector('.custom-option-row', count: 6)
       within all(".custom-option-row").last do
-        find("input.custom-option-value").set "Atari"
+        find(".custom-option-value input").set "Atari"
       end
 
       click_on "Save"
@@ -103,7 +103,7 @@ describe 'custom fields', js: true do
       expect(page).to have_text("Platform")
       expect(page).to have_selector('.custom-option-row', count: 6)
 
-      values = all(".custom-option-value").map(&:value)
+      values = all(".custom-option-value input").map(&:value)
 
       expect(values).to eq ["Playstation", "Xbox", "Nintendo", "PC", "Sega", "Atari"]
     end
@@ -112,7 +112,7 @@ describe 'custom fields', js: true do
       expect(page).to have_text("Platform")
 
       expect(page).to have_selector('.custom-option-row', count: 4)
-      rows = all(".custom-option-value")
+      rows = all(".custom-option-value input")
 
       expect(rows[0].value).to eql("Playstation")
       expect(rows[1].value).to eql("Xbox")
@@ -123,13 +123,13 @@ describe 'custom fields', js: true do
 
       find("#custom_field_multi_value").set true
 
-      defaults = all(".custom-option-default-value")
+      defaults = all(".custom-option-default-value input")
 
       defaults[0].set true
       defaults[2].set true
 
       within all(".custom-option-row").first do
-        click_on "Move to the bottom"
+        click_on "Move to bottom"
       end
 
       click_on "Save"
@@ -139,14 +139,14 @@ describe 'custom fields', js: true do
 
       expect(find("#custom_field_multi_value")).to be_checked
 
-      new_rows = all(".custom-option-value")
+      new_rows = all(".custom-option-value input")
 
       expect(new_rows[0].value).to eql("Sega")
       expect(new_rows[1].value).to eql("Nintendo")
       expect(new_rows[2].value).to eql("PC")
       expect(new_rows[3].value).to eql("Playstation")
 
-      new_defaults = all(".custom-option-default-value")
+      new_defaults = all(".custom-option-default-value input")
 
       expect(new_defaults[0]).not_to be_checked
       expect(new_defaults[1]).to be_checked
@@ -173,7 +173,7 @@ describe 'custom fields', js: true do
 
         expect(page).to have_text("Option 'Xbox' and its 3 occurrences were deleted.")
 
-        rows = all(".custom-option-value")
+        rows = all(".custom-option-value input")
 
         expect(rows.size).to eql(3)
 

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -172,9 +172,8 @@ describe CustomFieldFormBuilder do
         custom_field = resource.custom_field
 
         custom_field.field_format = 'list'
+        custom_field.custom_options.build value: 'my_option', position: 1
         custom_field.save!
-
-        custom_field.custom_options.create! value: 'my_option', position: 1
       end
 
       it_behaves_like 'wrapped in container', 'select-container' do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -136,6 +136,31 @@ describe CustomField, type: :model do
       end
       it { expect(field).not_to be_valid }
     end
+
+    describe "WITH a list field
+              WITHOUT a custom option" do
+      before do
+        field.field_format = 'list'
+      end
+
+      it 'is not valid' do
+        expect(field)
+          .to be_invalid
+      end
+    end
+
+    describe "WITH a list field
+              WITH a custom option" do
+      before do
+        field.field_format = 'list'
+        field.custom_options.build(value: 'some value')
+      end
+
+      it 'is valid' do
+        expect(field)
+          .to be_valid
+      end
+    end
   end
 
   describe '#accessor_name' do

--- a/spec/models/custom_option_spec.rb
+++ b/spec/models/custom_option_spec.rb
@@ -28,9 +28,19 @@
 
 require 'spec_helper'
 
-describe CustomField, type: :model do
-  let(:custom_field) { FactoryGirl.create(:list_wp_custom_field) }
+describe CustomOption, type: :model do
+  let(:custom_field) do
+    cf = FactoryGirl.build(:wp_custom_field, field_format: 'list')
+    cf.custom_options.build(value: 'some value')
+
+    cf
+  end
+
   let(:custom_option) { custom_field.custom_options.first }
+
+  before do
+    custom_field.save!
+  end
 
   describe 'saving' do
     it "updates the custom_field's timestamp" do
@@ -38,6 +48,37 @@ describe CustomField, type: :model do
       sleep 1
       custom_option.touch
       expect(custom_field.reload.updated_at).not_to eql(timestamp_before)
+    end
+  end
+
+  describe '.destroy' do
+    context 'with more than one option for the cf' do
+      before do
+        FactoryGirl.create(:custom_option, custom_field: custom_field)
+      end
+
+      it 'removes the option' do
+        custom_option.destroy
+
+        expect(CustomOption.where(id: custom_option.id).count)
+          .to eql 0
+      end
+    end
+
+    context 'with only one option for the cf' do
+      before do
+        custom_option.destroy
+      end
+
+      it 'reports an error' do
+        expect(custom_option.errors[:base])
+          .to match_array [I18n.t(:'activerecord.errors.models.custom_field.at_least_one_custom_option')]
+      end
+
+      it 'does not remove the custom option' do
+        expect(CustomOption.where(id: custom_option.id).count)
+          .to eql 1
+      end
     end
   end
 end


### PR DESCRIPTION
Enforces always having at least one custom option for list typed custom fields:
* create
* update
* destroy (of option)

And by that should fix: https://community.openproject.com/projects/openproject/work_packages/25833

It additionally:
* replaces the hand written replacement for `accepts_nested_attributes_for` by `accepts_nested_attributes_for`
* introduces i18n on some operations in the cf administration