### PR TITLE
Change link URL of logo to HTTPS

### DIFF
--- a/docs/installation/univention/README.md
+++ b/docs/installation/univention/README.md
@@ -8,4 +8,4 @@ Univention App Center is the marketplace in [Univention Corporate Server (UCS)](
 2. Install OpenProject via Univention App Center
 3. Add user accounts
 
-<a href="http://www.univention.de/appid/openproject"> <img alt="Available in Univention App Center" src="https://www.univention.de/wp-content/uploads/2016/03/download_f_univention_app_center_logo.svg" width="200" height="65"/></a>
+<a href="https://www.univention.com/appid/openproject"> <img alt="Available in Univention App Center" src="https://www.univention.de/wp-content/uploads/2016/03/download_f_univention_app_center_logo.svg" width="200" height="65"/></a>


### PR DESCRIPTION
The link should be the same as in the text and use HTTPS. Only with HTTPS the
referrer is kept in the request accordingly.

And since the page is english, the target should also be the english site.