### PR TITLE
Fix/author and assignee workflows

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -65,7 +65,7 @@ table
     .hours-dec
       font-size: 0.9em
 
-  &.workflow-table
+  &.workflow-table.generic-table
     margin-bottom: 16px
     overflow-x: hidden
     tbody

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -57,7 +58,8 @@ class Status < ActiveRecord::Base
   def self.update_work_package_done_ratios
     if WorkPackage.use_status_for_done_ratio?
       Status.where(['default_done_ratio >= 0']).each do |status|
-        WorkPackage.where(['status_id = ?', status.id])
+        WorkPackage
+          .where(['status_id = ?', status.id])
           .update_all(['done_ratio = ?', status.default_done_ratio])
       end
     end
@@ -107,7 +109,7 @@ class Status < ActiveRecord::Base
   private
 
   def check_integrity
-    raise "Can't delete status" if WorkPackage.where(['status_id=?', id]).any?
+    raise "Can't delete status" if WorkPackage.where(status_id: id).exists?
   end
 
   # Deletes associated workflows

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -73,7 +73,7 @@ class WorkPackage < ActiveRecord::Base
     where(project_id: Project.allowed_to(args.first || User.current, :view_work_packages))
   }
 
-  scope :in_status, -> (*args) do
+  scope :in_status, ->(*args) do
                       where(status_id: (args.first.respond_to?(:id) ? args.first.id : args.first))
                     end
 
@@ -390,7 +390,7 @@ class WorkPackage < ActiveRecord::Base
   end
 
   def to_s
-    "#{(kind.is_standard) ? '' : "#{kind.name}"} ##{id}: #{subject}"
+    "#{kind.is_standard ? '' : kind.name} ##{id}: #{subject}"
   end
 
   # Return true if the work_package is closed, otherwise false
@@ -475,7 +475,7 @@ class WorkPackage < ActiveRecord::Base
   # >>> issues.rb >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # Overrides Redmine::Acts::Customizable::InstanceMethods#available_custom_fields
   def available_custom_fields
-    (project && type) ? (project.all_work_package_custom_fields & type.custom_fields) : []
+    project && type ? (project.all_work_package_custom_fields & type.custom_fields) : []
   end
 
   def status_id=(sid)
@@ -525,8 +525,8 @@ class WorkPackage < ActiveRecord::Base
   # see Redmine::Acts::Journalized::Permissions#journal_editable_by
   def editable_by?(user)
     project = self.project
-    allowed = user.allowed_to? :edit_work_package_notes, project,  global: project.present?
-    allowed = user.allowed_to? :edit_own_work_package_notes, project,  global: project.present?  unless allowed
+    allowed = user.allowed_to? :edit_work_package_notes, project, global: project.present?
+    allowed = user.allowed_to? :edit_own_work_package_notes, project, global: project.present? unless allowed
     allowed
   end
 
@@ -569,6 +569,84 @@ class WorkPackage < ActiveRecord::Base
   # the user is create a work package in
   def self.allowed_target_projects_on_create(user)
     Project.allowed_to(user, :add_work_packages)
+  end
+
+  # Unassigns issues from +version+ if it's no longer shared with issue's project
+  def self.update_versions_from_sharing_change(version)
+    # Update issues assigned to the version
+    update_versions(["#{WorkPackage.table_name}.fixed_version_id = ?", version.id])
+  end
+
+  # Unassigns issues from versions that are no longer shared
+  # after +project+ was moved
+  def self.update_versions_from_hierarchy_change(project)
+    moved_project_ids = project.self_and_descendants.reload.map(&:id)
+    # Update issues of the moved projects and issues assigned to a version of a moved project
+    update_versions(
+      ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
+       moved_project_ids,
+       moved_project_ids]
+    )
+  end
+
+  # Extracted from the ReportsController.
+  def self.by_type(project)
+    count_and_group_by project: project,
+                       field: 'type_id',
+                       joins: ::Type.table_name
+  end
+
+  def self.by_version(project)
+    count_and_group_by project: project,
+                       field: 'fixed_version_id',
+                       joins: Version.table_name
+  end
+
+  def self.by_priority(project)
+    count_and_group_by project: project,
+                       field: 'priority_id',
+                       joins: IssuePriority.table_name
+  end
+
+  def self.by_category(project)
+    count_and_group_by project: project,
+                       field: 'category_id',
+                       joins: Category.table_name
+  end
+
+  def self.by_assigned_to(project)
+    count_and_group_by project: project,
+                       field: 'assigned_to_id',
+                       joins: User.table_name
+  end
+
+  def self.by_responsible(project)
+    count_and_group_by project: project,
+                       field: 'responsible_id',
+                       joins: User.table_name
+  end
+
+  def self.by_author(project)
+    count_and_group_by project: project,
+                       field: 'author_id',
+                       joins: User.table_name
+  end
+
+  def self.by_subproject(project)
+    return unless project.descendants.active.any?
+
+    ActiveRecord::Base.connection.select_all(
+      "select    s.id as status_id,
+        s.is_closed as closed,
+        i.project_id as project_id,
+        count(i.id) as total
+      from
+        #{WorkPackage.table_name} i, #{Status.table_name} s
+      where
+        i.status_id=s.id
+        and i.project_id IN (#{project.descendants.active.map(&:id).join(',')})
+      group by s.id, s.is_closed, i.project_id"
+    ).to_a
   end
 
   protected
@@ -726,79 +804,6 @@ class WorkPackage < ActiveRecord::Base
     end
   end
 
-  # Unassigns issues from +version+ if it's no longer shared with issue's project
-  def self.update_versions_from_sharing_change(version)
-    # Update issues assigned to the version
-    update_versions(["#{WorkPackage.table_name}.fixed_version_id = ?", version.id])
-  end
-
-  # Unassigns issues from versions that are no longer shared
-  # after +project+ was moved
-  def self.update_versions_from_hierarchy_change(project)
-    moved_project_ids = project.self_and_descendants.reload.map(&:id)
-    # Update issues of the moved projects and issues assigned to a version of a moved project
-    update_versions(
-      ["#{Version.table_name}.project_id IN (?) OR #{WorkPackage.table_name}.project_id IN (?)",
-       moved_project_ids,
-       moved_project_ids])
-  end
-
-  # Extracted from the ReportsController.
-  def self.by_type(project)
-    count_and_group_by project: project,
-                       field: 'type_id',
-                       joins: ::Type.table_name
-  end
-
-  def self.by_version(project)
-    count_and_group_by project: project,
-                       field: 'fixed_version_id',
-                       joins: Version.table_name
-  end
-
-  def self.by_priority(project)
-    count_and_group_by project: project,
-                       field: 'priority_id',
-                       joins: IssuePriority.table_name
-  end
-
-  def self.by_category(project)
-    count_and_group_by project: project,
-                       field: 'category_id',
-                       joins: Category.table_name
-  end
-
-  def self.by_assigned_to(project)
-    count_and_group_by project: project,
-                       field: 'assigned_to_id',
-                       joins: User.table_name
-  end
-
-  def self.by_responsible(project)
-    count_and_group_by project: project,
-                       field: 'responsible_id',
-                       joins: User.table_name
-  end
-
-  def self.by_author(project)
-    count_and_group_by project: project,
-                       field: 'author_id',
-                       joins: User.table_name
-  end
-
-  def self.by_subproject(project)
-    ActiveRecord::Base.connection.select_all(
-      "select    s.id as status_id,
-        s.is_closed as closed,
-        i.project_id as project_id,
-        count(i.id) as total
-      from
-        #{WorkPackage.table_name} i, #{Status.table_name} s
-      where
-        i.status_id=s.id
-        and i.project_id IN (#{project.descendants.active.map(&:id).join(',')})
-      group by s.id, s.is_closed, i.project_id").to_a if project.descendants.active.any?
-  end
   # End ReportsController extraction
   # <<< issues.rb <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -925,7 +930,8 @@ class WorkPackage < ActiveRecord::Base
         i.status_id=s.id
         and #{where}
         and i.project_id=#{project.id}
-      group by s.id, s.is_closed, j.id").to_a
+      group by s.id, s.is_closed, j.id"
+    ).to_a
   end
   private_class_method :count_and_group_by
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -55,6 +55,29 @@ class Workflow < ActiveRecord::Base
     result
   end
 
+  # Gets all work flows originating from the provided status
+  # that:
+  #   * are defined for the type
+  #   * are defined for any of the roles
+  #
+  # Workflows specific to author or assignee are ignored unless author and/or assignee are set to true. In
+  # such a case, those work flows are additionally returned.
+  def self.from_status(old_status_id, type_id, role_ids, author = false, assignee = false)
+    workflows = Workflow
+                .where(old_status_id: old_status_id, type_id: type_id, role_id: role_ids)
+
+    if author && assignee
+      workflows
+    elsif author || assignee
+      workflows
+        .merge(Workflow.where(author: author).or(Workflow.where(assignee: assignee)))
+    else
+      workflows
+        .where(author: author)
+        .where(assignee: assignee)
+    end
+  end
+
   # Find potential statuses the user could be allowed to switch issues to
   def self.available_statuses(project, user = User.current)
     Workflow

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -36,7 +37,8 @@ class Workflow < ActiveRecord::Base
 
   # Returns workflow transitions count by type and role
   def self.count_by_type_and_role
-    counts = connection.select_all("SELECT role_id, type_id, count(id) AS c FROM #{Workflow.table_name} GROUP BY role_id, type_id")
+    counts = connection
+             .select_all("SELECT role_id, type_id, count(id) AS c FROM #{Workflow.table_name} GROUP BY role_id, type_id")
     roles = Role.order('builtin, position')
     types = ::Type.order('position')
 
@@ -55,7 +57,8 @@ class Workflow < ActiveRecord::Base
 
   # Find potential statuses the user could be allowed to switch issues to
   def self.available_statuses(project, user = User.current)
-    Workflow.includes(:new_status)
+    Workflow
+      .includes(:new_status)
       .where(role_id: user.roles_for_project(project).map(&:id))
       .map(&:new_status)
       .compact

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -29,76 +29,59 @@
 require 'spec_helper'
 
 describe Status, type: :model do
-  describe '#find_new_statuses_allowed_to and #new_statuses_allowed_to' do
+  describe '.new_statuses_allowed' do
     let(:role) { FactoryGirl.create(:role) }
     let(:type) { FactoryGirl.create(:type) }
-    let(:user) { FactoryGirl.create(:user) }
-    let(:statuses) { (1..5).map { |_i| FactoryGirl.create(:status) } }
+    let(:statuses) { (1..4).map { |_i| FactoryGirl.create(:status) } }
     let(:status) { statuses[0] }
-    let(:workflow_a) {
+    let(:workflow_a) do
       FactoryGirl.create(:workflow, role_id: role.id,
                                     type_id: type.id,
                                     old_status_id: statuses[0].id,
                                     new_status_id: statuses[1].id,
                                     author: false,
                                     assignee: false)
-    }
-    let(:workflow_b) {
+    end
+    let(:workflow_b) do
       FactoryGirl.create(:workflow, role_id: role.id,
                                     type_id: type.id,
                                     old_status_id: statuses[0].id,
                                     new_status_id: statuses[2].id,
                                     author: true,
                                     assignee: false)
-    }
-    let(:workflow_c) {
+    end
+    let(:workflow_c) do
       FactoryGirl.create(:workflow, role_id: role.id,
                                     type_id: type.id,
                                     old_status_id: statuses[0].id,
                                     new_status_id: statuses[3].id,
                                     author: false,
                                     assignee: true)
-    }
-    let(:workflow_d) {
-      FactoryGirl.create(:workflow, role_id: role.id,
-                                    type_id: type.id,
-                                    old_status_id: statuses[0].id,
-                                    new_status_id: statuses[4].id,
-                                    author: true,
-                                    assignee: true)
-    }
-    let(:workflows) { [workflow_a, workflow_b, workflow_c, workflow_d] }
+    end
+    let(:workflows) { [workflow_a, workflow_b, workflow_c] }
 
     before do
       workflows
     end
 
     it 'should respect workflows w/o author and w/o assignee' do
-      expect(status.new_statuses_allowed_to([role], type, false, false))
-        .to match_array([statuses[1]])
-      expect(status.find_new_statuses_allowed_to([role], type, false, false))
+      expect(Status.new_statuses_allowed(status, [role], type, false, false))
         .to match_array([statuses[1]])
     end
 
     it 'should respect workflows w/ author and w/o assignee' do
-      expect(status.new_statuses_allowed_to([role], type, true, false))
-        .to match_array([statuses[1], statuses[2]])
-      expect(status.find_new_statuses_allowed_to([role], type, true, false))
+      expect(Status.new_statuses_allowed(status, [role], type, true, false))
         .to match_array([statuses[1], statuses[2]])
     end
 
     it 'should respect workflows w/o author and w/ assignee' do
-      expect(status.new_statuses_allowed_to([role], type, false, true))
-        .to match_array([statuses[1], statuses[3]])
-      expect(status.find_new_statuses_allowed_to([role], type, false, true))
+      expect(Status.new_statuses_allowed(status, [role], type, false, true))
         .to match_array([statuses[1], statuses[3]])
     end
 
     it 'should respect workflows w/ author and w/ assignee' do
-      expect(status.new_statuses_allowed_to([role], type, true, true))
-        .to match_array([statuses[1], statuses[2], statuses[3], statuses[4]])
-      expect(status.find_new_statuses_allowed_to([role], type, true, true))
-        .to match_array([statuses[1], statuses[2], statuses[3], statuses[4]])
+      expect(Status.new_statuses_allowed(status, [role], type, true, true))
+        .to match_array([statuses[1], statuses[2], statuses[3]])
     end
   end
 end


### PR DESCRIPTION
Fixes querying for workflows specific to author and assignee when determining the new statuses available for a work package.

`WorkPackage#new_statuses_allowed_to`  now returns an AR::Scope and generally speaking, a lot more is handled within the DB. The duplicity of having a `#new_statuses_allowed_to` and `#find_new_statuses_allowed_to` as we can rely on the sql cache.

The fix only consists of the last commit. The first commit removes the borders from the workflow table where the legend is:

![image](https://user-images.githubusercontent.com/617519/28423764-3c6f4060-6d6c-11e7-8d91-71c767ebdc6c.png)

as opposed to

![image](https://user-images.githubusercontent.com/617519/28423791-4f5b7306-6d6c-11e7-8939-12de467aaf68.png)

https://community.openproject.com/projects/openproject/work_packages/25875

