### PR TITLE
read operations for time_entries via api v3

### DIFF
--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -39,7 +40,7 @@ class Enumeration < ActiveRecord::Base
   before_destroy :check_integrity
 
   validates_presence_of :name
-  validates_uniqueness_of :name, scope: [:type, :project_id]
+  validates_uniqueness_of :name, scope: %i(type project_id)
   validates_length_of :name, maximum: 30
 
   scope :shared, -> { where(project_id: nil) }
@@ -62,7 +63,7 @@ class Enumeration < ActiveRecord::Base
     # Creates a fake default scope so Enumeration.default will check
     # it's type.  STI subclasses will automatically add their own
     # types to the finder.
-    if self.descends_from_active_record?
+    if descends_from_active_record?
       where(is_default: true, type: 'Enumeration').first
     else
       # STI classes are
@@ -103,9 +104,8 @@ class Enumeration < ActiveRecord::Base
     objects_count != 0
   end
 
-  # Is this enumeration overriding a system level enumeration?
-  def is_override?
-    !parent.nil?
+  def shared?
+    parent_id.nil?
   end
 
   alias :destroy_without_reassign :destroy
@@ -127,10 +127,10 @@ class Enumeration < ActiveRecord::Base
 
   # Does the +new+ Hash override the previous Enumeration?
   def self.overridding_change?(new, previous)
-    if (same_active_state?(new['active'], previous.active)) && same_custom_values?(new, previous)
-      return false
+    if same_active_state?(new['active'], previous.active) && same_custom_values?(new, previous)
+      false
     else
-      return true
+      true
     end
   end
 
@@ -151,13 +151,11 @@ class Enumeration < ActiveRecord::Base
     new == previous
   end
 
-  private
-
   # This is not a performant method.
   def self.sort_by_ancestor_last(entries)
     ancestor_relationships = entries.map { |entry| [entry, entry.ancestors] }
 
-    ancestor_relationships.sort { |one, two|
+    ancestor_relationships.sort do |one, two|
       if one.last.include?(two.first)
         -1
       elsif two.last.include?(one.first)
@@ -165,11 +163,13 @@ class Enumeration < ActiveRecord::Base
       else
         0
       end
-    }.map(&:first)
+    end.map(&:first)
   end
 
+  private
+
   def check_integrity
-    raise "Can't delete enumeration" if self.in_use?
+    raise "Can't delete enumeration" if in_use?
   end
 end
 

--- a/app/models/queries/time_entries.rb
+++ b/app/models/queries/time_entries.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+module Queries::TimeEntries
+  query = Queries::TimeEntries::TimeEntryQuery
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
-  end
+  Queries::Register.filter query, Queries::TimeEntries::Filters::UserFilter
+  Queries::Register.filter query, Queries::TimeEntries::Filters::WorkPackageFilter
+  Queries::Register.filter query, Queries::TimeEntries::Filters::ProjectFilter
 end

--- a/app/models/queries/time_entries/filters/project_filter.rb
+++ b/app/models/queries/time_entries/filters/project_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::ProjectFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::Project.visible.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :project_id
   end
 end

--- a/app/models/queries/time_entries/filters/time_entry_filter.rb
+++ b/app/models/queries/time_entries/filters/time_entry_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+class Queries::TimeEntries::Filters::TimeEntryFilter < Queries::Filters::Base
+  self.model = TimeEntry
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+  def human_name
+    TimeEntry.human_attribute_name(name)
   end
 end

--- a/app/models/queries/time_entries/filters/user_filter.rb
+++ b/app/models/queries/time_entries/filters/user_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::UserFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::Principal.in_visible_project.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :user_id
   end
 end

--- a/app/models/queries/time_entries/filters/work_package_filter.rb
+++ b/app/models/queries/time_entries/filters/work_package_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::WorkPackageFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::WorkPackage.visible.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :work_package_id
   end
 end

--- a/app/models/queries/time_entries/time_entry_query.rb
+++ b/app/models/queries/time_entries/time_entry_query.rb
@@ -26,32 +26,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+class Queries::TimeEntries::TimeEntryQuery < Queries::BaseQuery
+  def self.model
+    TimeEntry
+  end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+  def default_scope
+    TimeEntry.visible(User.current)
   end
 end

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -53,7 +53,7 @@ class TimeEntry < ActiveRecord::Base
   validate :validate_project_is_set
   validate :validate_consistency_of_work_package_id
 
-  scope :visible, -> (*args) {
+  scope :visible, ->(*args) {
     # TODO: check whether the visibility should also be influenced by the work
     # package the time entry is assigned to.  Currently a work package can
     # switch projects. But as the time entry is still part of it's original
@@ -112,6 +112,14 @@ class TimeEntry < ActiveRecord::Base
     scope = TimeEntry.visible(User.current)
     scope = scope.where(project_id: project.hierarchy.map(&:id)) if project
     scope.includes(:project).maximum(:spent_on)
+  end
+
+  def authoritativ_activity
+    if activity.shared?
+      activity
+    else
+      activity.root
+    end
   end
 
   private

--- a/app/models/time_entry_activity.rb
+++ b/app/models/time_entry_activity.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -42,5 +43,19 @@ class TimeEntryActivity < Enumeration
 
   def transfer_relations(to)
     time_entries.update_all("activity_id = #{to.id}")
+  end
+
+  def activated_projects
+    scope = Project.all
+
+    scope = if active?
+              scope
+                .where.not(id: children.select(:project_id))
+            else
+              scope
+                .where('1=0')
+            end
+
+    scope.or(Project.where(id: children.where(active: true).select(:project_id)))
   end
 end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -30,6 +30,7 @@ module API
   module V3
     class WorkPackageCollectionFromQueryService
       include Utilities::PathHelper
+      include ::API::Utilities::ParamsHelper
 
       def initialize(query, user)
         self.query = query

--- a/docs/api/apiv3-documentation.apib
+++ b/docs/api/apiv3-documentation.apib
@@ -25,6 +25,7 @@ FORMAT: 1A
 <!-- include(apiv3/endpoints/schemas.apib) -->
 <!-- include(apiv3/endpoints/statuses.apib) -->
 <!-- include(apiv3/endpoints/string-objects.apib) -->
+<!-- include(apiv3/endpoints/time_entries.apib) -->
 <!-- include(apiv3/endpoints/types.apib) -->
 <!-- include(apiv3/endpoints/user-preferences.apib) -->
 <!-- include(apiv3/endpoints/users.apib) -->

--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -1,0 +1,320 @@
+# Group Time Entries
+
+## Actions
+| Link                | Description                                                          | Condition                                                        |
+|:-------------------:| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+
+None yet
+
+## Linked Properties
+| Link          | Description                                                                                                                             | Type                | Constraints           | Supported operations | Condition                                 |
+| :-----------: | --------------------------------------------------------------                                                                          | -------------       | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This time entry                                                                                                                         | TimeEntry           | not null              | READ                 |                                           |
+| project       | The project the time entry is bundled in. The project might be different from the work package's project once the workPackage is moved. | Project             | not null              | READ / WRITE         |                                           |
+| workPackage   | The work package the time entry is created on                                                                                           | WorkPackage         | not null              | READ                 |                                           |
+| user          | The user the time entry tracks expenditures for                                                                                         | User                | not null              |  READ                |                                           |
+| activity      | The time entry activity the time entry is categorized as                                                                                | TimeEntriesActivity | not null              | READ                 |                                           |
+
+## Local Properties
+
+| Property     | Description                                               | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | --------------------------------------------------------- | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | Time entries' id                                          | Integer  | x > 0                                                | READ                 |                                                             |
+| comment      | A text provided by the user detailing the time entry      | String   | max 255 characters                                   | READ                 |                                                             |
+| spentOn      | The date the expenditure is booked for                    | Date     |                                                      | READ                 |                                                             |
+| hours        | The time quantifiying the expenditure                     | Time     |                                                      | READ                 |                                                             |
+| createdAt    | The time the time entry was created                       | DateTime |                                                      | READ                 |                                                             |
+| updatedAT    | The time the time entry was last updated                  | DateTime |                                                      | READ                 |                                                             |
+
+Please note that custom fields are not yet supported by the api although the backend supports them.
+
+## Time entry [/api/v3/time_entries/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "TimeEntry",
+                "id": 1,
+                "comment": "Some text explaing why the time entry was created",
+                "spentOn": "2015-03-20",
+                "hours": "PT5H",
+                "createdAt": "2015-03-20T12:56:56Z",
+                "updatedAt": "2015-03-20T12:56:56Z",
+                "_embedded": {
+                    "project": {
+                      ...
+                    },
+                    "workPackage": {
+                      ...
+                    },
+                    "user": {
+                      ...
+                    },
+                    "activity": {
+                      ...
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/time_entries/1"
+                    },
+                    "project": {
+                        "href": "/api/v3/projects/1",
+                        "title": "Some project"
+                    },
+                    "workPackage": {
+                        "href": "/api/v3/work_packages/1",
+                        "title": "Some work package"
+                    },
+                    "user": {
+                        "href": "/api/v3/users/2",
+                        "title": "Some user"
+                    },
+                    "activity": {
+                        "href": "/api/v3/time_entries/activities/18",
+                        "title": "Some time entry activity"
+                    }
+                }
+            }
+
+## View time entry [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... time entry id
+
++ Response 200 (application/hal+json)
+
+    [Time entry][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the time entry does not exist or if the user does not have permission to view them.
+
+    **Required permission** `view time entries` in the project the time entry is assigned to
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
+## Time entries [/api/v3/time_entries{?offset,pageSize,filters,sortBy}]
+
++ Model
+    + Body
+
+            {
+              "_type": "Collection",
+              "total": 39,
+              "count": 2,
+              "pageSize": 2,
+              "offset": 1,
+              "_embedded": {
+                  "elements": [
+                      {
+                          "_type": "TimeEntry",
+                          "id": 5,
+                          "comment": "Some comment",
+                          "spentOn": "2015-03-20",
+                          "hours": "PT5H",
+                          "createdAt": "2015-03-20T12:56:56Z",
+                          "updatedAt": "2015-03-20T12:56:56Z",
+                          "_links": {
+                              "self": {
+                                  "href": "/api/v3/time_entries/1"
+                              },
+                              "project": {
+                                  "href": "/api/v3/projects/1",
+                                  "title": "Some project"
+                              },
+                              "workPackage": {
+                                  "href": "/api/v3/work_packages/1",
+                                  "title": "Some work package"
+                              },
+                              "user": {
+                                  "href": "/api/v3/users/2",
+                                  "title": "Some user"
+                              },
+                              "activity": {
+                                  "href": "/api/v3/time_entries/activities/18",
+                                  "title": "Some time entry activity"
+                              }
+                          }
+                      },
+                      {
+                          "_type": "TimeEntry",
+                          "id": 10,
+                          "comment": "Another comment",
+                          "spentOn": "2015-03-21",
+                          "hours": "PT7H",
+                          "createdAt": "2015-03-20T12:56:56Z",
+                          "updatedAt": "2015-03-20T12:56:56Z",
+                          "_links": {
+                              "self": {
+                                  "href": "/api/v3/time_entries/2"
+                              },
+                              "project": {
+                                  "href": "/api/v3/projects/42",
+                                  "title": "Some other project"
+                              },
+                              "workPackage": {
+                                  "href": "/api/v3/work_packages/541",
+                                  "title": "Some other work package"
+                              },
+                              "user": {
+                                  "href": "/api/v3/users/6",
+                                  "title": "Some other project"
+                              },
+                              "activity": {
+                                  "href": "/api/v3/time_entries/activities/14",
+                                  "title": "some other time entry activity"
+                              }
+                          }
+                      }
+                  ]
+              },
+              "_links": {
+                  "self": {
+                      "href": "/api/v3/time_entries?offset=1&pageSize=2"
+                  },
+                  "jumpTo": {
+                      "href": "/api/v3/time_entries?offset=%7Boffset%7D&pageSize=2",
+                      "templated": true
+                  },
+                  "changeSize": {
+                      "href": "/api/v3/time_entries?offset=1&pageSize=%7Bsize%7D",
+                      "templated": true
+                  },
+                  "nextByOffset": {
+                      "href": "/api/v3/time_entries?offset=2&pageSize=2"
+                  }
+              }
+            }
+
+## List Time entries [GET]
+
+Lists time entries. The time entries returned depend on the filters provided and also on the permission of the requesting user.
+
++ Parameters
+    + offset = `1` (optional, integer, `25`) ... Page number inside the requested collection.
+
+    + pageSize (optional, integer, `25`) ... Number of elements to display per page.
+
+    + filters (optional, string, `[{ "work_package": { "operator": "=", "values": ["1", "2"] } }, { "project": { "operator": "=", "values": ["1"] } }]`) ... JSON specifying filter conditions.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported filters are:
+      + work_package: Filter time entries by work package
+      + project: Filter time entries by project
+      + user: Filter time entries by users
+
++ Response 200 (application/hal+json)
+
+    [Time entries][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request parameters e.g. filters
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": [
+                  "Filters Invalid filter does not exist."
+                ]
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client is not logged in and login is required.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to view this resource."
+            }
+
+# Group Time Entry Activities
+
+Time entries are classified by an activity which is one item of a set of user defined activities (e.g. Design, Specification, Development).
+
+## Actions
+
+None
+
+## Linked Properties
+| Link          | Description                                                    | Type                | Constraints           | Supported operations | Condition                                 |
+| :-----------: | -------------------------------------------------------------- | -------------       | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This time entry activity                                       | TimeEntriesActivity | not null              | READ                 |                                           |
+| projects      | List of projects the time entry is active in                   | []Project           | not null              | READ / WRITE         |                                           |
+
+## Local Properties
+
+| Property     | Description                                                  | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | ---------------------------------------------------------    | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | Time entries' id                                             | Integer  | x > 0                                                | READ                 |                                                             |
+| name         | The human readable name chosen for this activity             | String   | max 30 characters                                    | READ                 |                                                             |
+| position     | The rank the activity has in a list of activities            | Date     |                                                      | READ                 |                                                             |
+| default      | Flag to signal whether this activity is the default activity | Boolean  |                                                      | READ                 |                                                             |
+
+
+## Time entries activity [/api/v3/time_entries/activity/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "TimeEntriesActivity",
+                "id": 18,
+                "name": "a autem",
+                "position": 10,
+                "default": false,
+                "_embedded": {
+                    "projects": [
+                      ...
+                    ]
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/time_entries/activities/18",
+                        "title": "a autem"
+                    },
+                    "projects": [
+                        {
+                            "href": "/api/v3/projects/seeded_project",
+                            "title": "Seeded Project"
+                        },
+                        {
+                            "href": "/api/v3/projects/working-project",
+                            "title": "Working Project"
+                        }
+                    ]
+                }
+            }
+## View time entries activity[GET]
+
++ Parameters
+    + id (required, integer, `1`) ... time entries activity id
+
++ Response 200 (application/hal+json)
+
+    [Time entries activity][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the activity does not exist or if the user does not have permission to view them.
+
+    **Required permission** `view time entries`, `log time`, `edit time entries`, `edit own time entries` or `manage project activities` in any project
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }

--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -15,6 +15,8 @@ None yet
 | user          | The user the time entry tracks expenditures for                                                                                         | User                | not null              |  READ                |                                           |
 | activity      | The time entry activity the time entry is categorized as                                                                                | TimeEntriesActivity | not null              | READ                 |                                           |
 
+Depending on custom fields defined for time entries, additional properties might exist.
+
 ## Local Properties
 
 | Property     | Description                                               | Type     | Constraints                                          | Supported operations | Condition                                                   |
@@ -26,7 +28,7 @@ None yet
 | createdAt    | The time the time entry was created                       | DateTime |                                                      | READ                 |                                                             |
 | updatedAT    | The time the time entry was last updated                  | DateTime |                                                      | READ                 |                                                             |
 
-Please note that custom fields are not yet supported by the api although the backend supports them.
+Depending on custom fields defined for time entries, additional properties might exist.
 
 ## Time entry [/api/v3/time_entries/{id}]
 
@@ -41,6 +43,7 @@ Please note that custom fields are not yet supported by the api although the bac
                 "hours": "PT5H",
                 "createdAt": "2015-03-20T12:56:56Z",
                 "updatedAt": "2015-03-20T12:56:56Z",
+                "customField12": 5,
                 "_embedded": {
                     "project": {
                       ...
@@ -74,7 +77,10 @@ Please note that custom fields are not yet supported by the api although the bac
                     "activity": {
                         "href": "/api/v3/time_entries/activities/18",
                         "title": "Some time entry activity"
-                    }
+                    },
+                    "customField4": {
+                        "href": "/api/v3/users/5",
+                        "title" "Some other user"
                 }
             }
 

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -185,7 +185,7 @@ module API
         def associated_resources_default_getter(name,
                                                 representer)
 
-          representer ||= default_representer(name)
+          representer ||= default_representer(name.to_s.singularize)
 
           ->(*) do
             return unless represented.send(name)

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -109,7 +109,7 @@ module API
       end
 
       def authorize_by_with_raise(callable)
-        is_authorized = callable.call
+        is_authorized = callable.respond_to?(:call) ? callable.call : callable
 
         return true if is_authorized
 
@@ -129,7 +129,7 @@ module API
       # checks whether the user has
       # any of the provided permission in any of the provided
       # projects
-      def authorize_any(permissions, projects: nil, global: false, user: current_user)
+      def authorize_any(permissions, projects: nil, global: false, user: current_user, &block)
         raise ArgumentError if projects.nil? && !global
 
         projects = Array(projects)
@@ -145,8 +145,7 @@ module API
           end
         end
 
-        raise API::Errors::Unauthorized unless authorized
-        authorized
+        authorize_by_with_raise(authorized, &block)
       end
 
       def raise_invalid_query_on_service_failure

--- a/lib/api/utilities/params_helper.rb
+++ b/lib/api/utilities/params_helper.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,30 +29,10 @@
 #++
 
 module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+  module Utilities
+    module ParamsHelper
+      def to_i_or_nil(string)
+        string ? string.to_i : nil
       end
     end
   end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -50,6 +51,7 @@ module API
       mount ::API::V3::Roles::RolesAPI
       mount ::API::V3::Statuses::StatusesAPI
       mount ::API::V3::StringObjects::StringObjectsAPI
+      mount ::API::V3::TimeEntries::TimeEntriesAPI
       mount ::API::V3::Types::TypesAPI
       mount ::API::V3::Users::UsersAPI
       mount ::API::V3::UserPreferences::UserPreferencesAPI

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -45,16 +46,18 @@ module API
       end
 
       link :user do
+        next unless current_user.logged?
         {
           href: api_v3_paths.user(current_user.id),
           title: current_user.name
-        } if current_user.logged?
+        }
       end
 
       link :userPreferences do
+        next unless current_user.logged?
         {
           href: api_v3_paths.my_preferences
-        } if current_user.logged?
+        }
       end
 
       link :priorities do
@@ -72,6 +75,12 @@ module API
       link :statuses do
         {
           href: api_v3_paths.statuses
+        }
+      end
+
+      link :time_entries do
+        {
+          href: api_v3_paths.time_entries
         }
       end
 

--- a/lib/api/v3/time_entries/time_entries_activity_representer.rb
+++ b/lib/api/v3/time_entries/time_entries_activity_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,28 +30,44 @@
 
 module API
   module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
+    module TimeEntries
+      class TimeEntriesActivityRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+
+        self_link
+
+        property :id
+
+        property :name
+
+        property :position
+
+        property :is_default,
+                 as: :default
+
+        associated_resources :projects,
+                             link: ->(*) {
+                               active_projects.map do |project|
+                                 {
+                                   href: api_v3_paths.project(project.identifier),
+                                   title: project.name
+                                 }
+                               end
+                             },
+                             getter: ->(*) {
+                               active_projects.map do |project|
+                                 Projects::ProjectRepresenter.new(project, current_user: current_user)
+                               end
+                             }
+
+        def _type
+          'TimeEntriesActivity'
         end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
+        def active_projects
+          represented
+            .activated_projects
+            .visible
         end
       end
     end

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -61,9 +61,9 @@ module API
             end
 
             get do
-              TimeEntryRepresenter.new(@time_entry,
-                                       current_user: current_user,
-                                       embed_links: true)
+              TimeEntryRepresenter.create(@time_entry,
+                                          current_user: current_user,
+                                          embed_links: true)
             end
           end
 

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module TimeEntries
+      class TimeEntriesAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
+        resources :time_entries do
+          get do
+            query = ::API::V3::ParamsToQueryService
+                    .new(TimeEntry, current_user)
+                    .call(params)
+
+            if query.valid?
+              TimeEntryCollectionRepresenter.new(query.results,
+                                                 api_v3_paths.time_entries,
+                                                 page: to_i_or_nil(params[:offset]),
+                                                 per_page: to_i_or_nil(params[:pageSize]),
+                                                 current_user: current_user)
+            else
+              raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+            end
+          end
+
+          params do
+            requires :id, desc: 'Time entry\'s id'
+          end
+
+          route_param :id do
+            before do
+              @time_entry = TimeEntry
+                            .visible
+                            .find(params[:id])
+            end
+
+            get do
+              TimeEntryRepresenter.new(@time_entry,
+                                       current_user: current_user,
+                                       embed_links: true)
+            end
+          end
+
+          mount ::API::V3::TimeEntries::TimeEntriesActivityAPI
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/time_entries/time_entry_collection_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_collection_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,29 +30,9 @@
 
 module API
   module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+    module TimeEntries
+      class TimeEntryCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        element_decorator ::API::V3::TimeEntries::TimeEntryRepresenter
       end
     end
   end

--- a/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_representer.rb
@@ -34,6 +34,21 @@ module API
       class TimeEntryRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
 
+        class << self
+          def create_class(work_package)
+            injector_class = ::API::V3::Utilities::CustomFieldInjector
+            injector_class.create_value_representer(work_package,
+                                                    self)
+          end
+
+          def create(work_package, current_user:, embed_links: false)
+            create_class(work_package)
+              .new(work_package,
+                   current_user: current_user,
+                   embed_links: embed_links)
+          end
+        end
+
         self_link title_getter: ->(*) { nil }
 
         defaults render_nil: true

--- a/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_representer.rb
@@ -1,0 +1,95 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module TimeEntries
+      class TimeEntryRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+
+        self_link title_getter: ->(*) { nil }
+
+        defaults render_nil: true
+
+        property :id
+
+        property :comments,
+                 as: :comment
+
+        property :spent_on,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_date(represented.spent_on, allow_nil: true)
+                 end
+
+        property :hours,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_duration_from_hours(represented.hours)
+                 end
+
+        property :created_at,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_datetime(represented.created_on, allow_nil: true)
+                 end
+
+        property :updated_at,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_datetime(represented.updated_on, allow_nil: true)
+                 end
+
+        associated_resource :project
+
+        associated_resource :work_package,
+                            link_title_attribute: :subject
+
+        associated_resource :user
+
+        associated_resource :activity,
+                            representer: TimeEntriesActivityRepresenter,
+                            v3_path: :time_entries_activity,
+                            getter: associated_resource_default_getter(:authoritativ_activity, TimeEntriesActivityRepresenter),
+                            link: ->(*) {
+                              activity = represented.authoritativ_activity
+                              {
+                                href: api_v3_paths.time_entries_activity(activity.id),
+                                title: activity.name
+                              }
+                            }
+
+        def _type
+          'TimeEntry'
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -33,6 +33,8 @@ module API
   module V3
     module Users
       class UsersAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
         helpers do
           def user_transition(allowed)
             if allowed
@@ -50,10 +52,6 @@ module API
             unless current_user.admin?
               fail ::API::Errors::Unauthorized
             end
-          end
-
-          def to_i_or_nil(string)
-            string ? string.to_i : nil
           end
         end
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -279,6 +279,18 @@ module API
             "#{root}/string_objects?value=#{val}"
           end
 
+          def self.time_entries
+            "#{root}/time_entries"
+          end
+
+          def self.time_entry(entry_id)
+            "#{root}/time_entries/#{entry_id}"
+          end
+
+          def self.time_entries_activity(activity_id)
+            "#{root}/time_entries/activities/#{activity_id}"
+          end
+
           def self.types
             "#{root}/types"
           end

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -30,11 +30,7 @@ module API
   module V3
     module WorkPackages
       class WatchersAPI < ::API::OpenProjectAPI
-        helpers do
-          def to_i_or_nil(string)
-            string ? string.to_i : nil
-          end
-        end
+        helpers ::API::Utilities::ParamsHelper
 
         get '/available_watchers' do
           authorize(:add_work_package_watchers, context: @work_package.project)

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -28,11 +28,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json'
-require 'roar/json/collection'
-require 'roar/json/hal'
-
 module API
   module V3
     module WorkPackages

--- a/spec/lib/api/v3/support/link_examples.rb
+++ b/spec/lib/api/v3/support/link_examples.rb
@@ -100,6 +100,10 @@ shared_examples_for 'has an empty link collection' do
   it { is_expected.to be_json_eql([].to_json).at_path("_links/#{link}") }
 end
 
+shared_examples_for 'has a link collection' do
+  it { is_expected.to be_json_eql(hrefs.to_json).at_path("_links/#{link}") }
+end
+
 shared_examples_for 'has no link' do
   it { is_expected.not_to have_json_path("_links/#{link}") }
 

--- a/spec/lib/api/v3/support/property_examples.rb
+++ b/spec/lib/api/v3/support/property_examples.rb
@@ -26,32 +26,24 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+shared_examples_for 'property' do |name|
+  it "has the #{name} property" do
+    is_expected
+      .to be_json_eql(value.to_json)
+      .at_path(name.to_s)
+  end
+end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
+shared_examples_for 'date property' do |name|
+  it_behaves_like 'has ISO 8601 date only' do
+    let(:json_path) { name.to_s }
+    let(:date) { value }
+  end
+end
 
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+shared_examples_for 'datetime property' do |name|
+  it_behaves_like 'has UTC ISO 8601 date and time' do
+    let(:json_path) { name.to_s }
+    let(:date) { value }
   end
 end

--- a/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
@@ -1,0 +1,100 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::TimeEntries::TimeEntriesActivityRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:activity) do
+    FactoryGirl.build_stubbed(:time_entry_activity)
+  end
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) do
+    described_class.new(activity, current_user: user, embed_links: true)
+  end
+
+  subject { representer.to_json }
+
+  describe '_links' do
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.time_entries_activity activity.id }
+      let(:title) { activity.name }
+    end
+
+    # returns the projects where it (and it's children) is active
+    it_behaves_like 'has a link collection' do
+      let(:project1) { FactoryGirl.build_stubbed(:project) }
+      let(:project2) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        allow(activity)
+          .to receive_message_chain(:activated_projects, :visible)
+          .and_return([project1,
+                       project2])
+      end
+
+      let(:link) { 'projects' }
+      let(:hrefs) do
+        [
+          {
+            href: api_v3_paths.project(project1.identifier),
+            title: project1.name
+          },
+          {
+            href: api_v3_paths.project(project2.identifier),
+            title: project2.name
+          }
+        ]
+      end
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'TimeEntriesActivity' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { activity.id }
+    end
+
+    it_behaves_like 'property', :name do
+      let(:value) { activity.name }
+    end
+
+    it_behaves_like 'property', :position do
+      let(:value) { activity.position }
+    end
+
+    it_behaves_like 'property', :default do
+      let(:value) { activity.is_default }
+    end
+  end
+end

--- a/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -1,0 +1,144 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:time_entry) do
+    FactoryGirl.build_stubbed(:time_entry,
+                              comments: 'blubs',
+                              spent_on: Date.today,
+                              created_on: DateTime.now - 6.hours,
+                              updated_on: DateTime.now - 3.hours,
+                              hours: 5,
+                              activity: activity,
+                              project: project,
+                              user: user)
+  end
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:work_package) { time_entry.work_package }
+  let(:activity) { FactoryGirl.build_stubbed(:time_entry_activity) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) do
+    described_class.new(time_entry, current_user: user, embed_links: true)
+  end
+
+  subject { representer.to_json }
+
+  describe '_links' do
+    it_behaves_like 'has an untitled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.time_entry time_entry.id }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'project' }
+      let(:href) { api_v3_paths.project project.id }
+      let(:title) { project.name }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'workPackage' }
+      let(:href) { api_v3_paths.work_package work_package.id }
+      let(:title) { work_package.subject }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'user' }
+      let(:href) { api_v3_paths.user user.id }
+      let(:title) { user.name }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'activity' }
+      let(:href) { api_v3_paths.time_entries_activity activity.id }
+      let(:title) { activity.name }
+    end
+
+    context 'for a non shared (project specific) activity' do
+      let(:activity) do
+        activity = FactoryGirl.build_stubbed(:time_entry_activity,
+                                             project: project,
+                                             parent: parent_activity)
+        allow(activity)
+          .to receive(:root)
+          .and_return(parent_activity)
+
+        activity
+      end
+      let(:parent_activity) do
+        FactoryGirl.build_stubbed(:time_entry_activity)
+      end
+
+      it_behaves_like 'has a titled link' do
+        let(:link) { 'activity' }
+        let(:href) { api_v3_paths.time_entries_activity parent_activity.id }
+        let(:title) { parent_activity.name }
+      end
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'TimeEntry' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { time_entry.id }
+    end
+
+    it_behaves_like 'property', :comment do
+      let(:value) { time_entry.comments }
+    end
+
+    context 'with an empty comment' do
+      let(:time_entry) { FactoryGirl.build_stubbed(:time_entry) }
+      it_behaves_like 'property', :comment do
+        let(:value) { time_entry.comments }
+      end
+    end
+
+    it_behaves_like 'date property', :spentOn do
+      let(:value) { time_entry.spent_on }
+    end
+
+    it_behaves_like 'property', :hours do
+      let(:value) { 'PT5H' }
+    end
+
+    it_behaves_like 'datetime property', :createdAt do
+      let(:value) { time_entry.created_on }
+    end
+
+    it_behaves_like 'datetime property', :updatedAt do
+      let(:value) { time_entry.updated_on }
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -454,6 +454,26 @@ describe ::API::V3::Utilities::PathHelper do
     end
   end
 
+  context 'time_entry paths' do
+    describe '.time_entries' do
+      subject { helper.time_entries }
+
+      it_behaves_like 'api v3 path', '/time_entries'
+    end
+
+    describe '.time_entry' do
+      subject { helper.time_entry 42 }
+
+      it_behaves_like 'api v3 path', '/time_entries/42'
+    end
+
+    describe '.time_entries_activity' do
+      subject { helper.time_entries_activity 42 }
+
+      it_behaves_like 'api v3 path', '/time_entries/activities/42'
+    end
+  end
+
   describe 'types paths' do
     describe '#types' do
       subject { helper.types }

--- a/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
+++ b/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,36 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+require 'spec_helper'
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
+describe Queries::TimeEntries::Filters::WorkPackageFilter, type: :model do
+  let(:work_package1) { FactoryGirl.build_stubbed(:work_package) }
+  let(:work_package2) { FactoryGirl.build_stubbed(:work_package) }
 
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
+  before do
+    allow(WorkPackage)
+      .to receive_message_chain(:visible, :pluck)
+      .with(:id)
+      .and_return([work_package1.id, work_package2.id])
+  end
 
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :work_package_id }
+    let(:type) { :list_optional }
+    let(:name) { TimeEntry.human_attribute_name(:work_package) }
+
+    describe '#allowed_values' do
+      it 'is a list of the possible values' do
+        expected = [[work_package1.id, work_package1.id.to_s], [work_package2.id, work_package2.id.to_s]]
+
+        expect(instance.allowed_values).to match_array(expected)
       end
     end
+  end
+
+  it_behaves_like 'list_optional query filter' do
+    let(:attribute) { :work_package_id }
+    let(:model) { TimeEntry }
+    let(:valid_values) { [work_package1.id.to_s] }
   end
 end

--- a/spec/models/queries/time_entries/time_entry_query_spec.rb
+++ b/spec/models/queries/time_entries/time_entry_query_spec.rb
@@ -1,0 +1,137 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::TimeEntries::TimeEntryQuery, type: :model do
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:base_scope) { TimeEntry.visible(user) }
+  let(:instance) { described_class.new }
+
+  before do
+    login_as(user)
+  end
+
+  context 'without a filter' do
+    describe '#results' do
+      it 'is the same as getting all the time entries' do
+        expect(instance.results.to_sql).to eql base_scope.to_sql
+      end
+    end
+  end
+
+  context 'with a user filter' do
+    before do
+      allow(Principal)
+        .to receive_message_chain(:in_visible_project, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('user_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.user_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('user_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with a project filter' do
+    before do
+      allow(Project)
+        .to receive_message_chain(:visible, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('project_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.project_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('project_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with a work_package filter' do
+    before do
+      allow(WorkPackage)
+        .to receive_message_chain(:visible, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('work_package_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.work_package_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('work_package_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/time_entry_spec.rb
+++ b/spec/models/time_entry_spec.rb
@@ -1,0 +1,113 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe TimeEntry, type: :model do
+  let(:activity) do
+    FactoryGirl.build(:time_entry_activity)
+  end
+
+  describe '#activated_projects' do
+    let(:project1) { FactoryGirl.create(:project) }
+
+    context 'project specific activity' do
+      before do
+        activity.project = project1
+        activity.save!
+      end
+
+      context 'when the activity is active' do
+        it 'returns the project if the activity is active' do
+          expect(activity.activated_projects)
+            .to match_array [project1]
+        end
+      end
+
+      context 'when the activity is inactive' do
+        before do
+          activity.update_attribute(:active, false)
+        end
+
+        it 'is empty if the activity is inactive' do
+          expect(activity.activated_projects)
+            .to be_empty
+        end
+      end
+    end
+
+    context 'system activity' do
+      let(:project2) { FactoryGirl.create(:project) }
+      let(:project3) { FactoryGirl.create(:project) }
+
+      let(:child_activity_active) do
+        FactoryGirl.create(:time_entry_activity,
+                           parent: activity,
+                           project: project1)
+      end
+      let(:child_activity_inactive) do
+        FactoryGirl.create(:time_entry_activity,
+                           parent: activity,
+                           project: project2,
+                           active: false)
+      end
+
+      before do
+        child_activity_active
+        child_activity_inactive
+        project3
+      end
+
+      context 'when the activity is active' do
+        before do
+          activity.active = true
+          activity.save!
+        end
+
+        it 'returns all projects except for those that have inactive child activities' do
+          expect(activity.activated_projects)
+            .to match_array([project1, project3])
+        end
+      end
+
+      context 'when the activity is inactive' do
+        before do
+          activity.active = false
+          activity.save!
+        end
+
+        it 'returns only those projects, that have active child activities' do
+          expect(activity.activated_projects)
+            .to match_array([project1])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/time_entry_activity_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_activity_resource_spec.rb
@@ -1,0 +1,105 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 time_entry_activity resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:activity) { FactoryGirl.create(:time_entry_activity) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_time_entries) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET /api/v3/time_entries/activities/:id' do
+    let(:path) { api_v3_paths.time_entries_activity(activity.id) }
+
+    context 'for a visible root activity' do
+      before do
+        activity
+
+        get path
+      end
+
+      it 'returns 200 OK' do
+        expect(subject.status)
+          .to eql(200)
+      end
+
+      it 'returns the time entry' do
+        expect(subject.body)
+          .to be_json_eql('TimeEntriesActivity'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql(activity.id.to_json)
+          .at_path('id')
+      end
+    end
+
+    context 'for non shared activities' do
+      before do
+        activity.project_id = 234
+        activity.save(validate: false)
+
+        get path
+      end
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { [] }
+
+      before do
+        activity
+
+        get path
+      end
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/time_entry_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_resource_spec.rb
@@ -54,6 +54,12 @@ describe 'API v3 time_entry resource', type: :request do
   let(:other_project) { other_work_package.project }
   let(:role) { FactoryGirl.create(:role, permissions: permissions) }
   let(:permissions) { %i(view_time_entries view_work_packages) }
+  let(:custom_field) { FactoryGirl.create(:time_entry_custom_field) }
+  let(:custom_value) do
+    CustomValue.create(custom_field: custom_field,
+                       value: '1234',
+                       customized: time_entry)
+  end
 
   subject(:response) { last_response }
 
@@ -68,6 +74,7 @@ describe 'API v3 time_entry resource', type: :request do
       before do
         time_entry
         invisible_time_entry
+        custom_value
 
         get path
       end
@@ -88,6 +95,10 @@ describe 'API v3 time_entry resource', type: :request do
         expect(subject.body)
           .to be_json_eql(time_entry.id.to_json)
           .at_path('_embedded/elements/0/id')
+
+        expect(subject.body)
+          .to be_json_eql(custom_value.value.to_json)
+          .at_path("_embedded/elements/0/customField#{custom_field.id}/raw")
       end
     end
 
@@ -259,6 +270,7 @@ describe 'API v3 time_entry resource', type: :request do
 
     before do
       time_entry
+      custom_value
 
       get path
     end
@@ -276,6 +288,10 @@ describe 'API v3 time_entry resource', type: :request do
       expect(subject.body)
         .to be_json_eql(time_entry.id.to_json)
         .at_path('id')
+
+      expect(subject.body)
+        .to be_json_eql(custom_value.value.to_json)
+        .at_path("customField#{custom_field.id}/raw")
     end
 
     context 'when lacking permissions' do

--- a/spec/requests/api/v3/time_entry_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_resource_spec.rb
@@ -1,0 +1,290 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 time_entry resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:time_entry) do
+    FactoryGirl.create(:time_entry, project: project, work_package: work_package, user: current_user)
+  end
+  let(:other_time_entry) do
+    FactoryGirl.create(:time_entry, project: project, work_package: work_package, user: other_user)
+  end
+  let(:other_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:invisible_time_entry) do
+    FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: other_user)
+  end
+  let(:project) { work_package.project }
+  let(:work_package) { FactoryGirl.create(:work_package) }
+  let(:other_work_package) { FactoryGirl.create(:work_package) }
+  let(:other_project) { other_work_package.project }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_time_entries view_work_packages) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET api/v3/time_entries' do
+    let(:path) { api_v3_paths.time_entries }
+
+    context 'without params' do
+      before do
+        time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      it 'responds 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'returns a collection of time entries containing only the visible time entries' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'with pageSize and offset' do
+      let(:path) { api_v3_paths.time_entries + '?pageSize=1&offset=2' }
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      it 'returns a slice of the visible time entries' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('2')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('count')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by user' do
+      let(:invisible_time_entry) do
+        FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: other_user)
+      end
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      let(:path) do
+        filter = [{ 'user' => {
+          'operator' => '=',
+          'values' => [other_user.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by work package' do
+      let(:unwanted_work_package) do
+        FactoryGirl.create(:work_package, project: project, type: project.types.first)
+      end
+
+      let(:other_time_entry) do
+        FactoryGirl.create(:time_entry, project: project, work_package: unwanted_work_package, user: current_user)
+      end
+
+      let(:path) do
+        filter = [{ 'work_package' => {
+          'operator' => '=',
+          'values' => [work_package.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by project' do
+      let(:other_time_entry) do
+        FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: current_user)
+      end
+
+      before do
+        FactoryGirl.create(:member,
+                           roles: [role],
+                           project: other_project,
+                           user: current_user)
+
+        time_entry
+        other_time_entry
+
+        get path
+      end
+
+      let(:path) do
+        filter = [{ 'project' => {
+          'operator' => '=',
+          'values' => [other_project.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'invalid filter' do
+      let(:path) do
+        filter = [{ 'bogus' => {
+          'operator' => '=',
+          'values' => ['1']
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      before do
+        time_entry
+
+        get path
+      end
+
+      it 'returns an error' do
+        expect(subject.status).to eq(400)
+
+        expect(subject.body)
+          .to be_json_eql('urn:openproject-org:api:v3:errors:InvalidQuery'.to_json)
+          .at_path('errorIdentifier')
+      end
+    end
+  end
+
+  describe 'GET /api/v3/time_entries/:id' do
+    let(:path) { api_v3_paths.time_entry(time_entry.id) }
+
+    before do
+      time_entry
+
+      get path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql(200)
+    end
+
+    it 'returns the time entry' do
+      expect(subject.body)
+        .to be_json_eql('TimeEntry'.to_json)
+        .at_path('_type')
+
+      expect(subject.body)
+        .to be_json_eql(time_entry.id.to_json)
+        .at_path('id')
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { [] }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end

--- a/spec_legacy/unit/enumeration_spec.rb
+++ b/spec_legacy/unit/enumeration_spec.rb
@@ -104,13 +104,4 @@ describe Enumeration, type: :model do
     assert @low_priority.respond_to?(:parent)
     assert @low_priority.respond_to?(:children)
   end
-
-  it 'should is override' do
-    # Defaults to off
-    assert !@low_priority.is_override?
-
-    # Setup as an override
-    @low_priority.parent = FactoryGirl.create :priority
-    assert @low_priority.is_override?
-  end
 end


### PR DESCRIPTION
Introduces the endpoints:
* GET /api/v3/time_entries
* GET /api/v3/time_entries/:id
* GET /api/v3/time_entries/activities/:id

The index action for time entries can be queried by the following
filters:
* project_id
* user_id
* work_package_id

The implementation is exposing the database structure mostly one to one
with the exception of some renaming and the hiding of the activities'
complexity, where only the activity used systemwide is referenced
regardless of whether a project specific override exists or not.

https://community.openproject.com/projects/openproject/work_packages/25906

### TODO
- [x] Documentation
- [x] handle ToDos in code
- [x] Document custom fields 