### PR TITLE
lets the help text modal look like the wp modals

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -190,6 +190,43 @@ ul.export-options
   margin: 1em 0
   padding: 0 1.5rem
 
+  &.-formattable
+    p:last-of-type
+      margin-bottom: 0px
+
 .modal--footer
   margin: 1em 0
   padding: 0 1.5rem
+
+.ngdialog-theme-openproject.-light
+
+  .modal--header
+    background-color: $body-background
+    padding: 0
+    margin: 0 1.5rem
+    margin-top: 1.5rem
+    height: 33px
+    border-bottom: 1px solid #dddddd
+
+    h2
+      color: $body-font-color
+      color: var(--body-font-color)
+      font-weight: normal
+      font-size: 18px
+      line-height: 25px
+      padding-bottom: 8px
+
+  .ngdialog-close
+    color: $body-font-color
+    color: var(--body-font-color)
+    padding-right: 0.75rem
+    margin-top: 1.5rem
+    line-height: 25px
+
+.ngdialog-theme-openproject.-wide
+
+  .ngdialog-content
+    width: 40%
+
+  .modal--footer
+    justify-content: inherit

--- a/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
@@ -106,7 +106,7 @@ export class AttributeHelpTextController {
       closeByDocument: true,
       scope: <IDialogScope> this.$scope,
       template: '/components/common/help-texts/help-text.modal.html',
-      className: 'ngdialog-theme-openproject'
+      className: 'ngdialog-theme-openproject -light -wide'
     });
   }
 }

--- a/frontend/app/components/common/help-texts/help-text.modal.html
+++ b/frontend/app/components/common/help-texts/help-text.modal.html
@@ -1,11 +1,10 @@
 <div class="attribute-help-text--modal">
   <div>
     <div class="modal--header">
-      <span class="icon-context icon-help2"></span>
       <h2 class="ellipsis" ng-bind="::resource.attributeCaption"></h2>
     </div>
 
-    <div class="modal--main"
+    <div class="modal--main -formattable"
          tabindex="0"
          ng-bind-html="::resource.helpText.html">
     </div>


### PR DESCRIPTION
Lets the help text modals look like the modals used for the wp/query:

![image](https://user-images.githubusercontent.com/617519/28460343-e2c79f70-6e11-11e7-98ed-896454e36ca1.png)

as opposed to before:

![image](https://user-images.githubusercontent.com/617519/28460370-083e5c12-6e12-11e7-857d-60546640b418.png)

https://community.openproject.com/projects/openproject/work_packages/25828
