### PR TITLE
adapt help text modal style

### DIFF
--- a/app/assets/stylesheets/content/_help_texts.sass
+++ b/app/assets/stylesheets/content/_help_texts.sass
@@ -31,15 +31,13 @@
   .modal--header > h2
     width: calc(100% - 80px)
 
-  .modal--footer
-    text-align: left
-    display: flex
-    justify-content: space-between
-
   // Set max height of the modal body
   .modal--main
     max-height: 50vh
     overflow-y: auto
+
+    &:focus
+      outline-style: none
 
   // Avoid large right margin for conditional button
   .help-text--edit-button

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -208,13 +208,21 @@ ul.export-options
     height: 33px
     border-bottom: 1px solid #dddddd
 
+    *
+      background-color: $body-background
+      line-height: 25px
+      font-size: 18px
+      padding-bottom: 6px
+
     h2
       color: $body-font-color
       color: var(--body-font-color)
       font-weight: normal
-      font-size: 18px
-      line-height: 25px
-      padding-bottom: 8px
+
+    .icon-context
+      @include varprop(color, content-icon-color)
+      font-size: 1rem
+      margin-right: 0
 
   .ngdialog-close
     color: $body-font-color
@@ -222,6 +230,9 @@ ul.export-options
     padding-right: 0.75rem
     margin-top: 1.5rem
     line-height: 25px
+
+  .modal--footer
+    margin: 1em 0 0.5em 0
 
 .ngdialog-theme-openproject.-wide
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -132,7 +132,6 @@ en:
     label_contains: "contains"
     label_created_on: "created on"
     label_edit_comment: "Edit this comment"
-    label_edit_this_entry: "Edit this entry"
     label_equals: "is"
     label_expand: "Expand"
     label_expanded: "expanded"

--- a/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.directive.ts
@@ -37,7 +37,7 @@ import {AttributeHelpTextsService} from './attribute-help-text.service';
 export class AttributeHelpTextController {
   // Attribute to show help text for
   public attribute:string;
-  public optionaltitle?:string
+  public optionaltitle?:string;
   // Scope to search for
   public attributeScope:string;
   // Load single id entry if given
@@ -60,17 +60,17 @@ export class AttributeHelpTextController {
     };
 
     this.$scope.text = {
-      'close': I18n.t('js.button_close'),
-      'edit': I18n.t('js.label_edit_this_entry')
+      'edit': I18n.t('js.button_edit'),
+      'close': I18n.t('js.button_close')
     };
 
-    // Override the keyboard close handler for the dialog
-    // so we can avoid it bubbling to the then focused element handler.
+    // Prevent event bubbling so that we can e.g.
+    // avoid it bubbling to the newly focused element handler on close.
     this.$scope.close = (event:JQueryEventObject) => {
       event.preventDefault();
       event.stopPropagation();
 
-      this.$scope.closeThisDialog();
+      this.ngDialog.close('');
     };
 
     if (this.helpTextId) {
@@ -102,7 +102,7 @@ export class AttributeHelpTextController {
     this.$scope.resource = resource;
     this.ngDialog.open({
       closeByEscape: true,
-      showClose: true,
+      showClose: false,
       closeByDocument: true,
       scope: <IDialogScope> this.$scope,
       template: '/components/common/help-texts/help-text.modal.html',

--- a/frontend/app/components/common/help-texts/help-text.modal.html
+++ b/frontend/app/components/common/help-texts/help-text.modal.html
@@ -1,6 +1,7 @@
 <div class="attribute-help-text--modal">
   <div>
     <div class="modal--header">
+      <span class="icon-context icon-help1"></span>
       <h2 class="ellipsis" ng-bind="::resource.attributeCaption"></h2>
     </div>
 
@@ -10,12 +11,6 @@
     </div>
 
     <div class="modal--footer">
-      <button class="help-text--close-button button -highlight"
-              ng-click="closeThisDialog()"
-              data-click-on-keypress="[13, 32]"
-              ng-bind="::text.close"
-              ng-attr-title="{{ ::text.close }}">
-      </button>
       <a class="help-text--edit-button button"
          ng-if="resource.editText"
          ng-attr-href="{{ resource.editText && resource.editText.$link.href }}"
@@ -25,4 +20,10 @@
       </a>
     </div>
   </div>
+
+  <a class="ngdialog-close"
+     href=""
+     title="{{ ::text.close }}"
+     ng-click="close($event)">
+  </a>
 </div>

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -32,7 +32,7 @@ describe 'Attribute help texts' do
   let(:admin) { FactoryGirl.create(:admin) }
 
   let(:instance) { AttributeHelpText.last }
-  let(:modal) { AttributeHelpTextModal.new(instance) }
+  let(:modal) { Components::AttributeHelpTextModal.new(instance) }
 
   let(:relation_columns_allowed) { true }
 

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -26,48 +26,52 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-class AttributeHelpTextModal
-  include Capybara::DSL
-  include RSpec::Matchers
+module Components
+  class AttributeHelpTextModal
+    include Capybara::DSL
+    include RSpec::Matchers
 
-  attr_reader :help_text, :context
+    attr_reader :help_text, :context
 
-  def initialize(help_text, context: nil)
-    @context = context
-    @help_text = help_text
-  end
-
-  def container
-    if context
-      page.find(context)
-    else
-      page
+    def initialize(help_text, context: nil)
+      @context = context
+      @help_text = help_text
     end
-  end
 
-  def modal_container
-    container.find('.attribute-help-text--modal')
-  end
-
-  def open!
-    container.find(".help-text--for-#{help_text.attribute_name}").click
-    expect(page).to have_selector('.attribute-help-text--modal .modal--header', text: help_text.attribute_caption)
-  end
-
-  def close!
-    page.find('.help-text--close-button').click
-    expect(page).to have_no_selector('.attribute-help-text--modal .modal--header', text: help_text.attribute_caption)
-  end
-
-  def expect_edit(admin:)
-    if admin
-      expect(page).to have_selector('.help-text--edit-button')
-    else
-      expect(page).to have_no_selector('.help-text--edit-button')
+    def container
+      if context
+        page.find(context)
+      else
+        page
+      end
     end
-  end
 
-  def edit_button
-    page.find('.help-text--edit-button')
+    def modal_container
+      container.find('.attribute-help-text--modal')
+    end
+
+    def open!
+      container.find(".help-text--for-#{help_text.attribute_name}").click
+      expect(page).to have_selector('.attribute-help-text--modal .modal--header', text: help_text.attribute_caption)
+    end
+
+    def close!
+      within modal_container do
+        page.find('.ngdialog-close').click
+      end
+      expect(page).to have_no_selector('.attribute-help-text--modal .modal--header', text: help_text.attribute_caption)
+    end
+
+    def expect_edit(admin:)
+      if admin
+        expect(page).to have_selector('.help-text--edit-button')
+      else
+        expect(page).to have_no_selector('.help-text--edit-button')
+      end
+    end
+
+    def edit_button
+      page.find('.help-text--edit-button')
+    end
   end
 end

--- a/spec/features/work_packages/attribute_help_texts_spec.rb
+++ b/spec/features/work_packages/attribute_help_texts_spec.rb
@@ -38,7 +38,7 @@ describe 'Work package attribute help texts', type: :feature, js: true do
                        help_text: 'Some *help text* for status.'
   end
 
-  let(:modal) { AttributeHelpTextModal.new(instance) }
+  let(:modal) { Components::AttributeHelpTextModal.new(instance) }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
 
   before do


### PR DESCRIPTION
In order to allow using the keyboard to trigger the close button, the ngDialog close functionality is disabled and a custom close button (the X) is added which is tabbable.

The rest is as specified in https://community.openproject.com/projects/openproject/work_packages/25912

* Remove close button
* Change label to "Edit" (EN), "Bearbeiten" (DE)
* Decrease space between button and bottom.
* Remove blue border/highlight-effect around text
* Restore help/info icon left to header text