### PR TITLE
Resolve design variables to allow clearer placeholders for input fields

### DIFF
--- a/app/assets/javascripts/colors.js
+++ b/app/assets/javascripts/colors.js
@@ -44,7 +44,16 @@
       }
 
       func = function () {
-        preview.css('background-color', input.val());
+        let previewColor = '';
+
+        if(input.val() && input.val().length > 0) {
+          previewColor = input.val();
+        } else if (input.attr('placeholder') &&
+                   input.attr('placeholder').length > 0) {
+          previewColor = input.attr('placeholder')
+        }
+
+        preview.css('background-color', previewColor);
       };
 
       input.keyup(func).change(func).focus(func);

--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -47,7 +47,7 @@ class DesignColor < ActiveRecord::Base
 
   class << self
     def defaults
-      OpenProject::Design.variables
+      OpenProject::Design.resolved_variables
     end
 
     def setables

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -218,6 +218,9 @@ module OpenProject
       'table-timeline--row-height'                           => '41px'
     }.freeze
 
+    # Regular expression for references of other variables.
+    VARIABLE_NAME_RGX = /\$([\w-]+)/
+
     ##
     # Returns the name of the color scheme.
     # To be overridden by a plugin
@@ -244,6 +247,22 @@ module OpenProject
     # To be used in the sass variable definition file
     def self.variables
       DEFAULTS
+    end
+
+    ##
+    # Return the value after resolving all variables to values.
+    def self.resolved_variables
+      resolved_variables = DEFAULTS.dup
+
+      DEFAULTS.each do |var_name, value|
+        puts "///// #{var_name} => #{value} /////"
+        resolved_variables[var_name] = resolve_value(value)
+      end
+      resolved_variables
+    end
+
+    def self.resolve_value(variable_value)
+      variable_value.gsub(VARIABLE_NAME_RGX) { resolve_value(DEFAULTS[$1]) }
     end
 
     ##

--- a/spec/lib/open_project/design_spec.rb
+++ b/spec/lib/open_project/design_spec.rb
@@ -1,0 +1,60 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenProject::Design do
+  it 'detects variable names in strings' do
+    expect('$bla' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('$bla-asdf' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('$bla-asdf-12' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('$bla-asdf12' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('$12' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('12' =~ described_class::VARIABLE_NAME_RGX).to be_falsey
+    expect('asdf' =~ described_class::VARIABLE_NAME_RGX).to be_falsey
+    expect('bla $blub' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+    expect('bla($blub 1px)' =~ described_class::VARIABLE_NAME_RGX).to be_truthy
+  end
+
+  context 'default variables set' do
+    before do
+      stub_const("OpenProject::Design::DEFAULTS",
+                 'variable_1' => 'one',
+                 'variable_2' => 'two',
+                 'variable_1_2' => 'foo $variable_1 bar $variable_2')
+    end
+
+    it '#resolved_variables' do
+      expect(described_class.resolved_variables).to be_eql(
+        'variable_1' => 'one',
+        'variable_2' => 'two',
+        'variable_1_2' => 'foo one bar two'
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR covers two issues in `/admin/design`.

1. When a variable has its default value and that value was derived/built using another variable, then this derived/resolved value is shown was not shown as a placeholder. Now the placeholder is shown.
2. The color preview in the input field did not show the color if the input field was empty but the default value was shown as placeholder. Now the preview is shown.

https://community.openproject.com/projects/openproject/work_packages/25957/activity