### PR TITLE
reload newly created wp after file upload completed

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -295,6 +295,22 @@ export class WorkPackageResource extends HalResource {
       });
   }
 
+  /**
+   * Uploads the attachments and reloads the work package when done
+   * Reloading is skipped if no attachment is added
+   */
+  private uploadAttachmentsAndReload() {
+    const attachmentUpload = this.uploadPendingAttachments();
+
+    if (attachmentUpload) {
+      attachmentUpload.then((attachmentsResource) => {
+        if (attachmentsResource.count > 0) {
+          wpCacheService.loadWorkPackage(this.id, true);
+        }
+      });
+    }
+  }
+
   public allowedValuesFor(field:string):ng.IPromise<HalResource[]> {
     var deferred = $q.defer();
 
@@ -426,7 +442,7 @@ export class WorkPackageResource extends HalResource {
               this.updateActivities();
 
               if (wasNew) {
-                this.uploadPendingAttachments();
+                this.uploadAttachmentsAndReload();
                 wpCreate.newWorkPackageCreated(this as any);
               }
 
@@ -532,7 +548,7 @@ export class WorkPackageResource extends HalResource {
       resources[name] = linked ? linked.$update() : $q.reject();
     });
 
-    const promise = $q.all(resources)
+    const promise = $q.all(resources);
     promise.then(() => {
       wpCacheService.updateWorkPackage(this as any);
     });


### PR DESCRIPTION
The reload is necessary to ensure that attachments, referenced to be embedded inside the description can be correclty referenced in the backend when the textile rendering happens. That way, the embedded images are correctly displayed after the file upload completes.

There might be a phase where broken images are displayed. I find this acceptable and refrained from improving the solution.

The solution itself is a hack working around the wrong ordering of the file upload and the work package creation. As such, I didn't deem it necessary to improve the solution any further. E.g. the reload happens regardless of whether it is actually necessary as the code does not check whether an image is actually referenced. The only check is for the existence of an attachment.

https://community.openproject.com/projects/openproject/work_packages/25930