### PR TITLE
[25960] Hide non-writable fields in edit mode

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -61,7 +61,8 @@
     <div class="-columns-2">
       <div class="attributes-key-value"
            ng-class="{'-span-all-columns': descriptor.spanAll }"
-           ng-repeat="descriptor in group.members track by descriptor.name">
+           ng-repeat="descriptor in group.members track by descriptor.name"
+           ng-if="!$ctrl.shouldHideField(descriptor)">
         <div
             class="attributes-key-value--key"
             ng-if="!descriptor.multiple"

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -33,6 +33,8 @@ import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-
 import {DisplayField} from '../../wp-display/wp-display-field/wp-display-field.module';
 import {WorkPackageDisplayFieldService} from '../../wp-display/wp-display-field/wp-display-field.service';
 import {WorkPackageCacheService} from '../work-package-cache.service';
+import {WorkPackageEditFieldController} from "../../wp-edit/wp-edit-field/wp-edit-field.directive";
+import {WorkPackageEditFieldGroupController} from "../../wp-edit/wp-edit-field/wp-edit-field-group.directive";
 
 interface FieldDescriptor {
   name:string;
@@ -49,6 +51,7 @@ interface GroupDescriptor {
 }
 
 export class WorkPackageSingleViewController {
+  public wpEditFieldGroup:WorkPackageEditFieldGroupController;
   public workPackage:WorkPackageResourceInterface;
 
   // Grouped fields returned from API
@@ -94,6 +97,15 @@ export class WorkPackageSingleViewController {
   public shouldHideGroup(group:GroupDescriptor) {
     // Hide if the group is empty
     return group.members.length === 0;
+  }
+
+  /**
+   * Hide read-only fields, but only when in the create mode
+   * @param {FieldDescriptor} field
+   */
+  public shouldHideField(descriptor:FieldDescriptor) {
+    const field = descriptor.field || descriptor.fields![0];
+    return this.wpEditFieldGroup.inEditMode && !field.writable;
   }
 
   /*
@@ -223,7 +235,13 @@ function wpSingleViewDirective() {
       workPackage: '=?'
     },
 
-    require: ['wpSingleView'],
+    require: ['^wpEditFieldGroup'],
+    link: (scope:any,
+           element:ng.IAugmentedJQuery,
+           attrs:any,
+           controllers: [WorkPackageEditFieldGroupController]) => {
+      scope.$ctrl.wpEditFieldGroup = controllers[0];
+    },
     bindToController: true,
     controller: WorkPackageSingleViewController,
     controllerAs: '$ctrl'

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -307,7 +307,6 @@ describe 'form configuration', type: :feature, js: true do
 
         wp_page.expect_group('Estimates and time') do
           expect(page).to have_selector('.wp-edit-field.estimatedTime')
-          expect(page).to have_selector('.wp-edit-field.spentTime')
         end
 
         find('#work-packages--edit-actions-cancel').click


### PR DESCRIPTION
The new edit mode activates all fields it finds - which makes sense.
However, non-editable fields should never be created in the first place.

There's a PR for costs that does nothing but add a spec for this case:
https://github.com/finnlabs/openproject-costs/pull/297

https://community.openproject.com/wp/25960