### PR TITLE
[25768] Parse/Output estimated hours with seconds precision

### DIFF
--- a/frontend/app/components/input/transformers/transform-duration.directive.ts
+++ b/frontend/app/components/input/transformers/transform-duration.directive.ts
@@ -40,8 +40,7 @@ function transformDuration(TimezoneService:any) {
       ngModelController.$parsers.push(function(value:any):Duration|void {
         if (!isNaN(value)) {
           let floatValue = parseFloat(value);
-          let minutes = Number(moment.duration(floatValue, 'hours').asMinutes().toFixed(2));
-          return moment.duration(minutes, 'minutes');
+          return moment.duration(floatValue, 'hours');
         }
       });
 

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -78,7 +78,7 @@ module API
         def self.format_duration_from_hours(hours, allow_nil: false)
           return nil if hours.nil? && allow_nil
 
-          Duration.new(hours_and_minutes(hours)).iso8601
+          Duration.new(seconds: hours * 3600).iso8601
         end
 
         def self.parse_duration_to_hours(duration, property_name, allow_nil: false)
@@ -93,15 +93,6 @@ module API
                                                        duration)
           end
         end
-
-        def self.hours_and_minutes(hours)
-          hours = hours.to_f
-          minutes = (hours - hours.to_i) * 60
-
-          { hours: hours.to_i, minutes: minutes }
-        end
-
-        private_class_method :hours_and_minutes
       end
     end
   end

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -119,8 +119,8 @@ describe :DateTimeFormatter do
       expect(subject.format_duration_from_hours(5.5)).to eql('PT5H30M')
     end
 
-    it 'omits seconds' do
-      expect(subject.format_duration_from_hours(5.501)).to eql('PT5H30M')
+    it 'includes seconds' do
+      expect(subject.format_duration_from_hours(5.501)).to eql('PT5H30M3S')
     end
 
     it 'formats ints' do


### PR DESCRIPTION
Was truncated to minutes before.

I also looked into how estimated_hours are stored: As the hours value as float/double. It would make more sense to store them simply as integer seconds when we no longer round to minutes, but I did not pursue that further.

https://community.openproject.com/wp/25768