### PR TITLE
Fix typo in translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,7 @@ en:
     is_enabled_globally: 'Is enabled globally'
     enabled_in_project: 'Enabled in project'
     contained_in_type: 'Contained in type'
-    confirm_destroy_option: "Deleting an option will delete oll of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
+    confirm_destroy_option: "Deleting an option will delete all of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
     tab:
       no_results_title_text: There are currently no custom fields.
       no_results_content_text: Create a new custom field


### PR DESCRIPTION
Fix typo for confirm_destroy_option string.

https://community.openproject.com/projects/openproject/work_packages/25983/activity