### PR TITLE
Remove form handling in WP resource

### DIFF
--- a/frontend/app/components/angular/angular-injector-bridge.functions.ts
+++ b/frontend/app/components/angular/angular-injector-bridge.functions.ts
@@ -17,6 +17,7 @@
    * factory.
    *
    * @param injectable The target to inject into
+ * @deprecated Use $injectFields instead
    */
   export function injectorBridge(injectable:any) {
     let $injector = $currentInjector();

--- a/frontend/app/components/angular/angular-injector-bridge.functions.ts
+++ b/frontend/app/components/angular/angular-injector-bridge.functions.ts
@@ -17,7 +17,7 @@
    * factory.
    *
    * @param injectable The target to inject into
- * @deprecated Use $injectFields instead
+   * @deprecated Use $injectFields instead
    */
   export function injectorBridge(injectable:any) {
     let $injector = $currentInjector();

--- a/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/error-resource.service.ts
@@ -28,6 +28,7 @@
 
 import {HalResource} from './hal-resource.service';
 import {opApiModule} from '../../../../angular-modules';
+import {FormResourceInterface} from './form-resource.service';
 
 export const v3ErrorIdentifierQueryInvalid = 'urn:openproject-org:api:v3:errors:InvalidQuery';
 export const v3ErrorIdentifierMultipleErrors = 'urn:openproject-org:api:v3:errors:MultipleErrors';
@@ -37,6 +38,28 @@ export class ErrorResource extends HalResource {
   public message:string;
   public details:any;
   public errorIdentifier:string;
+
+  public isValidationError:boolean = false;
+
+  public static fromFormResponse(form:FormResourceInterface):ErrorResource|null {
+    const errors = _.values(form.validationErrors);
+    const count = errors.length;
+
+    if (count === 0) {
+      return null;
+    }
+
+    let resource ;
+    if (count === 1)  {
+      resource = new ErrorResource(errors[0], true);
+    } else {
+      resource = new ErrorResource({});
+      resource.errorIdentifier = v3ErrorIdentifierMultipleErrors;
+      resource.errors = errors;
+    }
+    resource.isValidationError = true;
+    return resource;
+  }
 
   public get errorMessages():string[] {
     if (this.isMultiErrorMessage()) {

--- a/frontend/app/components/api/api-v3/hal-resources/form-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/form-resource.service.ts
@@ -29,14 +29,16 @@
 import {HalResource} from './hal-resource.service';
 import {SchemaResource} from './schema-resource.service';
 import {opApiModule} from '../../../../angular-modules';
+import {ErrorResource} from './error-resource.service';
 
 interface FormResourceEmbedded {
 }
 
 export class FormResource extends HalResource {
 
-  public $embedded: FormResourceEmbedded;
-  public schema: SchemaResource;
+  public $embedded:FormResourceEmbedded;
+  public schema:SchemaResource;
+  public validationErrors:{ [attribute:string]:ErrorResource };
 }
 
 function formResource() {

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -178,7 +178,7 @@ export class HalResource {
     return new clone(_.cloneDeep(this.$source), this.$loaded);;
   }
 
-  protected $initialize(source:any) {
+  public $initialize(source:any) {
     this.$source = source.$source || source;
     initializeResource(this);
   }

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -69,7 +69,7 @@ export class HalResource {
   public $embedded:any = {};
   public $self:ng.IPromise<HalResource>;
 
-  private _name:string;
+  public _name:string;
 
   public get $isHal():boolean {
     return true;

--- a/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/hal-resource.service.ts
@@ -71,6 +71,18 @@ export class HalResource {
 
   public _name:string;
 
+  public static idFromLink(href:string):string {
+    return href.split('/').pop()!;
+  }
+
+  public get idFromLink():string {
+    if (this.$href) {
+      return HalResource.idFromLink(this.$href);
+    }
+
+    return '';
+  }
+
   public get $isHal():boolean {
     return true;
   }

--- a/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-schema-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-filter-instance-schema-resource.service.ts
@@ -56,7 +56,7 @@ export class QueryFilterInstanceSchemaResource extends SchemaResource {
     return this.operator.allowedValues;
   }
 
-  protected $initialize(source:any) {
+  public $initialize(source:any) {
     super.$initialize(source);
 
     if (source._dependencies) {

--- a/frontend/app/components/api/api-v3/hal-resources/query-filter-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-filter-resource.service.ts
@@ -46,14 +46,6 @@ export class QueryFilterResource extends HalResource {
   public set id(newId:string) {
     this.$source.id = newId;
   }
-
-  public get idFromLink():string {
-    if (this.href) {
-      return this.href.split('/').pop()!;
-    }
-
-    return '';
-  }
 }
 
 function queryFilterResource() {

--- a/frontend/app/components/api/api-v3/hal-resources/query-operator-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-operator-resource.service.ts
@@ -35,19 +35,19 @@ interface QueryOperatorResourceEmbedded {
 interface QueryOperatorResourceLinks {
 }
 
-
 export class QueryOperatorResource extends HalResource {
 
-  public $embedded: QueryOperatorResourceEmbedded;
-  public $links: QueryOperatorResourceLinks;
+  public $embedded:QueryOperatorResourceEmbedded;
+  public $links:QueryOperatorResourceLinks;
 
   public get id():string {
     return this.$source.id || this.idFromLink;
   }
 
   public get idFromLink():string {
-    if (this.href) {
-      return decodeURIComponent(this.href.split('/').pop()!);
+    if (this.$href) {
+      const idPart = HalResource.idFromLink(this.$href);
+      return decodeURIComponent(idPart);
     }
 
     return '';

--- a/frontend/app/components/api/api-v3/hal-resources/query-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/query-resource.service.ts
@@ -62,7 +62,7 @@ export class QueryResource extends HalResource {
   public public:boolean;
   public project:ProjectResource;
 
-  protected $initialize(source:any) {
+  public $initialize(source:any) {
     super.$initialize(source);
 
     this.filters = source.filters.map((filter:Object) => new QueryFilterInstanceResource(filter));

--- a/frontend/app/components/api/api-v3/hal-resources/schema-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/schema-resource.service.ts
@@ -41,7 +41,7 @@ export class SchemaResource extends HalResource {
     return states.schemas.get(this.href as string);
   }
 
-  protected $initialize(source:any) {
+  public $initialize(source:any) {
     super.$initialize(source);
 
     initializeSchemaResource(this);

--- a/frontend/app/components/api/api-v3/hal-resources/type-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/type-resource.service.ts
@@ -50,6 +50,10 @@ export class TypeResource extends HalResource {
     });
   }
 
+  public idFromLink():string {
+    return this.$href!.split('/').pop()!;
+  }
+
   public get state() {
     return states.types.get(this.href as string);
   }

--- a/frontend/app/components/api/api-v3/hal-resources/type-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/type-resource.service.ts
@@ -50,10 +50,6 @@ export class TypeResource extends HalResource {
     });
   }
 
-  public idFromLink():string {
-    return this.$href!.split('/').pop()!;
-  }
-
   public get state() {
     return states.types.get(this.href as string);
   }

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -389,16 +389,6 @@ export class WorkPackageResource extends HalResource {
     this['updateImmediately'] = this.$links.updateImmediately = (payload) => {
       return apiWorkPackages.createWorkPackage(payload);
     };
-
-    if (this.parent) {
-      this.$source._links['parent'] = {
-        href: this.parent.href
-      };
-    } else if ($stateParams.parent_id) {
-      this.$source._links['parent'] = {
-        href: v3Path.wp({wp: $stateParams.parent_id})
-      };
-    }
   }
 
   /**

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -130,18 +130,6 @@ export class WorkPackageResource extends HalResource {
     return this.$source.id || this.idFromLink;
   }
 
-  public static idFromLink(href:string):string {
-    return href.split('/').pop()!;
-  }
-
-  public get idFromLink():string {
-    if (this.href) {
-      return WorkPackageResource.idFromLink(this.href);
-    }
-
-    return '';
-  }
-
   /**
    * Return the ids of all its ancestors, if any
    */

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -124,6 +124,7 @@ export class WorkPackageResource extends HalResource {
   public attachments:AttachmentCollectionResourceInterface;
 
   public pendingAttachments:UploadFile[] = [];
+  public overriddenSchema?:SchemaResource;
 
   public get id():string {
     return this.$source.id || this.idFromLink;

--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -73,7 +73,7 @@ export interface WorkPackageResourceEmbedded {
   relatedBy:RelationResourceInterface | null;
 }
 
-interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
+export interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
   addAttachment(attachment:HalResource):ng.IPromise<any>;
   addChild(child:HalResource):ng.IPromise<any>;
   addComment(comment:HalResource):ng.IPromise<any>;

--- a/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
+++ b/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
@@ -27,8 +27,10 @@
 // ++
 
 import {wpDirectivesModule} from "../../../angular-modules";
+import {WorkPackageEditFieldGroupController} from '../../wp-edit/wp-edit-field/wp-edit-field-group.directive';
 
 export class EditActionsBarController {
+  public wpEditFieldGroup:WorkPackageEditFieldGroupController;
   public text:any;
   public onSave:Function;
   public onCancel:Function;
@@ -38,7 +40,7 @@ export class EditActionsBarController {
     this.text = {
       save: I18n.t('js.button_save'),
       cancel: I18n.t('js.button_cancel')
-    }
+    };
   }
 
   public save():void {
@@ -47,9 +49,11 @@ export class EditActionsBarController {
     }
 
     this.saving = true;
-    this.onSave().finally(() => {
-      this.saving = false;
-    });
+    this.wpEditFieldGroup
+      .saveWorkPackage()
+      .finally(() => {
+        this.saving = false;
+      });
   }
 
   public cancel():void {
@@ -61,6 +65,13 @@ function editActionsBar() {
   return {
     restrict: 'E',
     templateUrl: '/components/common/edit-actions-bar/edit-actions-bar.directive.html',
+    require: '^wpEditFieldGroup',
+    link: function (scope:ng.IScope,
+                    element:ng.IAugmentedJQuery,
+                    attrs:ng.IAttributes,
+                    controller:WorkPackageEditFieldGroupController) {
+      scope.$ctrl.wpEditFieldGroup = controller;
+    },
 
     scope: {
       onSave: '&',

--- a/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
+++ b/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
@@ -57,6 +57,7 @@ export class EditActionsBarController {
   }
 
   public cancel():void {
+    this.wpEditFieldGroup.form.editMode = false;
     this.onCancel();
   }
 }

--- a/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
+++ b/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
@@ -57,7 +57,7 @@ export class EditActionsBarController {
   }
 
   public cancel():void {
-    this.wpEditFieldGroup.form.editMode = false;
+    this.wpEditFieldGroup.inEditMode = false;
     this.onCancel();
   }
 }

--- a/frontend/app/components/routing/main/work-packages.new.html
+++ b/frontend/app/components/routing/main/work-packages.new.html
@@ -24,12 +24,12 @@
   </div>
 
   <wp-edit-field-group work-package="$ctrl.newWorkPackage"
+                       success-state="$ctrl.successState"
                        in-edit-mode="true">
     <wp-subject work-package="$ctrl.newWorkPackage"></wp-subject>
     <wp-single-view work-package="$ctrl.newWorkPackage"></wp-single-view>
+    <edit-actions-bar
+        on-cancel="$ctrl.cancelAndBackToList()"
+    ></edit-actions-bar>
   </wp-edit-field-group>
-  <edit-actions-bar
-      on-save="$ctrl.saveWorkPackage()"
-      on-cancel="$ctrl.cancelAndBackToList()"
-  ></edit-actions-bar>
 </div>

--- a/frontend/app/components/routing/main/work-packages.new.html
+++ b/frontend/app/components/routing/main/work-packages.new.html
@@ -23,7 +23,7 @@
     </ul>
   </div>
 
-  <wp-edit-field-group work-package-id="$ctrl.newWorkPackage.id"
+  <wp-edit-field-group work-package="$ctrl.newWorkPackage"
                        in-edit-mode="true">
     <wp-subject work-package="$ctrl.newWorkPackage"></wp-subject>
     <wp-single-view work-package="$ctrl.newWorkPackage"></wp-single-view>

--- a/frontend/app/components/routing/wp-details/wp.list.details.html
+++ b/frontend/app/components/routing/wp-details/wp.list.details.html
@@ -46,7 +46,7 @@
     </span>
 
 
-      <wp-edit-field-group work-package-id="$ctrl.workPackage.id">
+      <wp-edit-field-group work-package="$ctrl.workPackage">
         <wp-subject></wp-subject>
         <div class="work-package-details-tab" ui-view></div>
       </wp-edit-field-group>

--- a/frontend/app/components/routing/wp-list/wp.list.new.html
+++ b/frontend/app/components/routing/wp-list/wp.list.new.html
@@ -14,7 +14,7 @@
         </div>
         {{ $ctrl.header }}
       </h2>
-      <wp-edit-field-group work-package-id="$ctrl.newWorkPackage.id" in-edit-mode="true">
+      <wp-edit-field-group work-package="$ctrl.newWorkPackage" in-edit-mode="true">
         <wp-subject work-package="$ctrl.newWorkPackage"></wp-subject>
         <wp-single-view work-package="$ctrl.newWorkPackage"></wp-single-view>
       </wp-edit-field-group>

--- a/frontend/app/components/routing/wp-list/wp.list.new.html
+++ b/frontend/app/components/routing/wp-list/wp.list.new.html
@@ -2,29 +2,30 @@
     class="work-packages--details"
     ng-if="$ctrl.newWorkPackage"
 >
-  <div class="work-packages--details-content -create-mode">
-    <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="focusAnchorLabel"></span>
-    <div has-edit-mode="true"
-         wp-edit-form="$ctrl.newWorkPackage"
-         wp-edit-form-on-save="$ctrl.refreshAfterSave(workPackage, 'work-packages.list.details.overview')">
-      <h2>
-        <div class="work-packages-show-view-button wp--details--switch-fullscreen hidden-for-accessibility"
-             ng-click="$ctrl.switchToFullscreen()">
-          <span class="icon-context icon-to-fullscreen"></span>
-        </div>
-        {{ $ctrl.header }}
-      </h2>
-      <wp-edit-field-group work-package="$ctrl.newWorkPackage" in-edit-mode="true">
-        <wp-subject work-package="$ctrl.newWorkPackage"></wp-subject>
-        <wp-single-view work-package="$ctrl.newWorkPackage"></wp-single-view>
-      </wp-edit-field-group>
+  <wp-edit-field-group work-package="$ctrl.newWorkPackage"
+                       success-state="$ctrl.successState"
+                       in-edit-mode="true">
+    <div class="work-packages--details-content -create-mode">
+      <span class="hidden-for-sighted" tabindex="-1" focus ng-bind="focusAnchorLabel"></span>
+      <div has-edit-mode="true"
+           wp-edit-form="$ctrl.newWorkPackage"
+           wp-edit-form-on-save="$ctrl.refreshAfterSave(workPackage, 'work-packages.list.details.overview')">
+        <h2>
+          <div class="work-packages-show-view-button wp--details--switch-fullscreen hidden-for-accessibility"
+               ng-click="$ctrl.switchToFullscreen()">
+            <span class="icon-context icon-to-fullscreen"></span>
+          </div>
+          {{ $ctrl.header }}
+        </h2>
+          <wp-subject work-package="$ctrl.newWorkPackage"></wp-subject>
+          <wp-single-view work-package="$ctrl.newWorkPackage"></wp-single-view>
+      </div>
     </div>
-  </div>
 
-  <div class="work-packages--details-toolbar-container">
-    <edit-actions-bar
-        on-save="$ctrl.saveWorkPackage()"
-        on-cancel="$ctrl.cancelAndBackToList()"
-    ></edit-actions-bar>
-  </div>
+    <div class="work-packages--details-toolbar-container">
+      <edit-actions-bar
+          on-cancel="$ctrl.cancelAndBackToList()"
+      ></edit-actions-bar>
+    </div>
+  </wp-edit-field-group>
 </div>

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -1,4 +1,4 @@
-<div wp-edit-field-group work-package-id="$ctrl.workPackage.id"
+<div wp-edit-field-group work-package="$ctrl.workPackage"
      class="work-packages--show-view"
      ng-if="$ctrl.workPackage">
     <div class="toolbar-container">
@@ -46,7 +46,7 @@
     <div class="work-packages-full-view--split-container">
       <div class="work-packages-full-view--split-left">
         <div class="work-packages--panel-inner">
-          <wp-single-view></wp-single-view>
+          <wp-single-view work-package="$ctrl.workPackage"></wp-single-view>
         </div>
       </div>
       <div class="work-packages-full-view--split-right">

--- a/frontend/app/components/schemas/schema-cache.service.ts
+++ b/frontend/app/components/schemas/schema-cache.service.ts
@@ -48,17 +48,13 @@ export class SchemaCacheService {
    * @return A promise with the loaded schema.
    */
   ensureLoaded(workPackage:WorkPackageResource):PromiseLike<any> {
-    if (workPackage.hasOverriddenSchema) {
-      return this.$q.resolve();
-    }
-
     const state = this.state(workPackage);
 
-    if (!state.hasValue()) {
-      this.load(workPackage);
+    if (state.hasValue()) {
+      return this.$q.when(state.value);
+    } else {
+      return this.load(workPackage).valuesPromise();
     }
-
-    return state.valuesPromise();
   }
 
   /**

--- a/frontend/app/components/states.service.ts
+++ b/frontend/app/components/states.service.ts
@@ -64,9 +64,6 @@ export class States extends StatesGroup {
   // Current focused work package (e.g, row preselected for details button)
   focusedWorkPackage = input<string>();
 
-  // Open editing forms
-  editing = multiInput<WorkPackageEditForm>();
-
 }
 
 export class TableState extends StatesGroup {

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -69,6 +69,12 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
       const wp = i;
       const workPackageId = getWorkPackageId(wp.id);
 
+      // If the work package is new, ignore the schema
+      if (wp.isNew) {
+        this.multiState.get(workPackageId).putValue(wp);
+        continue;
+      }
+
       // Ensure the schema is loaded
       // so that no consumer needs to call schema#$load manually
       this.schemaCacheService.ensureLoaded(wp).then(() => {

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -65,18 +65,14 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
   }
 
   updateWorkPackageList(list:WorkPackageResourceInterface[]) {
-    for (var wp of list) {
+    for (var i of list) {
+      const wp = i;
       const workPackageId = getWorkPackageId(wp.id);
-      const wpState = this.multiState.get(workPackageId);
-      const lastValue = wpState.value;
-      const wpForPublish = lastValue && lastValue.dirty
-        ? lastValue // dirty, use current wp
-        : wp; // not dirty or unknown, use new wp
 
       // Ensure the schema is loaded
       // so that no consumer needs to call schema#$load manually
       this.schemaCacheService.ensureLoaded(wp).then(() => {
-        wpState.putValue(wpForPublish);
+        this.multiState.get(workPackageId).putValue(wp);
       });
     }
   }
@@ -92,7 +88,7 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
         this.wpNotificationsService.showSave(workPackage);
         deferred.resolve(workPackage);
       })
-      .catch((error) => {
+      .catch((error:any) => {
         this.wpNotificationsService.handleErrorResponse(error, workPackage);
         deferred.reject(workPackage);
       });

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.test.js
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.test.js
@@ -95,7 +95,8 @@ describe('workPackageCommentDirectiveTest', function() {
         $link: {
           href: 'addComment'
         }
-      }
+      },
+      $plain: function() { return {}; }
     };
 
     scope.workPackage = workPackage;

--- a/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
+++ b/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
@@ -26,23 +26,27 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {WorkPackageResource} from '../../api/api-v3/hal-resources/work-package-resource.service';
-import {WikiTextareaEditField} from '../../wp-edit/field-types/wp-edit-wiki-textarea-field.module';
 import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
+import {WikiTextareaEditField} from '../../wp-edit/field-types/wp-edit-wiki-textarea-field.module';
+import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageCommentField extends WikiTextareaEditField {
 
   public fieldVal = { raw: '' };
+  public isBusy:boolean = false;
 
-  constructor(workPackage:WorkPackageResourceInterface, protected I18n:op.I18n) {
-    super(workPackage, 'comment', {name: I18n.t('js.label_comment')} as any);
+  constructor(public workPackage:WorkPackageResourceInterface, protected I18n:op.I18n) {
+    super(new WorkPackageChangeset(workPackage), 'comment', {name: I18n.t('js.label_comment')} as any);
 
     this.initializeFieldValue();
-    this.workPackage = workPackage;
   }
 
   public get value() {
     return this.fieldVal;
+  }
+
+  public set value(val:any) {
+    this.fieldVal.raw = val;
   }
 
   public get required() {
@@ -52,7 +56,7 @@ export class WorkPackageCommentField extends WikiTextareaEditField {
   public initializeFieldValue(withText?:string):void {
     if (!withText) {
       this.fieldVal.raw = '';
-      return
+      return;
     }
 
     if (this.fieldVal.raw.length > 0) {

--- a/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
+++ b/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
@@ -31,13 +31,21 @@ import {WikiTextareaEditField} from '../../wp-edit/field-types/wp-edit-wiki-text
 import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageCommentField extends WikiTextareaEditField {
-
+  public _value:any;
   public isBusy:boolean = false;
 
   constructor(public workPackage:WorkPackageResourceInterface, protected I18n:op.I18n) {
     super(new WorkPackageChangeset(workPackage), 'comment', {name: I18n.t('js.label_comment')} as any);
 
     this.initializeFieldValue();
+  }
+
+  public get value() {
+    return this._value;
+  }
+
+  public set value(val:any) {
+    this._value = val;
   }
 
   public get required() {

--- a/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
+++ b/frontend/app/components/work-packages/work-package-comment/wp-comment-field.module.ts
@@ -32,7 +32,6 @@ import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageCommentField extends WikiTextareaEditField {
 
-  public fieldVal = { raw: '' };
   public isBusy:boolean = false;
 
   constructor(public workPackage:WorkPackageResourceInterface, protected I18n:op.I18n) {
@@ -41,29 +40,21 @@ export class WorkPackageCommentField extends WikiTextareaEditField {
     this.initializeFieldValue();
   }
 
-  public get value() {
-    return this.fieldVal;
-  }
-
-  public set value(val:any) {
-    this.fieldVal.raw = val;
-  }
-
   public get required() {
     return true;
   }
 
   public initializeFieldValue(withText?:string):void {
     if (!withText) {
-      this.fieldVal.raw = '';
+      this.rawValue = '';
       return;
     }
 
-    if (this.fieldVal.raw.length > 0) {
-      this.fieldVal.raw += '\n';
+    if (this.rawValue.length > 0) {
+      this.rawValue += '\n';
     }
 
-    this.fieldVal.raw += withText;
+    this.rawValue += withText;
   }
 
 }

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/models/work-package-field-model.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/models/work-package-field-model.ts
@@ -4,6 +4,7 @@ import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/wo
 import {MarkupModel} from './markup-model';
 import {WorkPackageCacheService} from '../../work-package-cache.service';
 import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageFieldModel implements IApplyAttachmentMarkup {
   public wpCacheService:WorkPackageCacheService;
@@ -36,8 +37,10 @@ export class WorkPackageFieldModel implements IApplyAttachmentMarkup {
     let value = this.workPackage[this.attribute] || { raw: '', html: '' };
     value.raw = this.contentToInsert;
 
-    this.workPackage[this.attribute] = value;
-    this.workPackage
+    const changeset = new WorkPackageChangeset(this.workPackage);
+    changeset.setValue(this.attribute, value);
+
+    changeset
       .save()
       .then((wp) => {
         // Refresh the work package some time later as there is no way to tell

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -74,10 +74,6 @@ export class WorkPackageSingleViewController {
               protected wpEditing:WorkPackageEditingService,
               protected wpDisplayField:WorkPackageDisplayFieldService,
               protected wpCacheService:WorkPackageCacheService) {
-
-    $scope.$on('$destroy', () => {
-      this.form.destroy();
-    });
   }
 
   public initialize() {

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -211,7 +211,7 @@ export class WorkPackageSingleViewController {
       multiple: false
     };
 
-    if (this.workPackage.isMilestone) {
+    if (resource.schema.hasOwnProperty('date')) {
       object.field = this.displayField(resource, 'date');
     } else {
       object.fields = [this.displayField(resource, 'startDate'), this.displayField(resource, 'dueDate')];

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -96,7 +96,7 @@ export class WorkPackageSingleViewController {
 
     this.form = this.prepareEditForm();
 
-    scopedObservable(this.$scope, this.form.editResource)
+    scopedObservable(this.$scope, this.form.editState.values$())
       .subscribe((resource:HalResource) => {
         // Prepare the fields that are required always
         this.specialFields = this.getFields(resource, ['project', 'status']);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -94,6 +94,9 @@ export class WorkPackageSingleViewController {
 
     scopedObservable(this.$scope, this.form.editResource)
       .subscribe((resource:HalResource) => {
+        // Prepare the fields that are required always
+        this.specialFields = this.getFields(resource, ['project', 'status']);
+
         // Get attribute groups if they are available (in project context)
         const attributeGroups = resource.schema._attributeGroups;
 
@@ -102,7 +105,6 @@ export class WorkPackageSingleViewController {
           return;
         }
 
-        this.specialFields = this.getFields(resource, ['project', 'status']);
         this.groupedFields = attributeGroups.map((groups:any[]) => {
           return {
             name: groups[0],

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -34,9 +34,10 @@ import {DisplayField} from '../../wp-display/wp-display-field/wp-display-field.m
 import {WorkPackageDisplayFieldService} from '../../wp-display/wp-display-field/wp-display-field.service';
 import {WorkPackageCacheService} from '../work-package-cache.service';
 import {WorkPackageEditFieldGroupController} from "../../wp-edit/wp-edit-field/wp-edit-field-group.directive";
-import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
+import {
+  WorkPackageEditingService
+} from '../../wp-edit-form/work-package-editing-service';
 import {States} from '../../states.service';
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
 
 interface FieldDescriptor {
   name:string;
@@ -88,7 +89,7 @@ export class WorkPackageSingleViewController {
     }
 
     scopedObservable(this.$scope, this.wpEditing.temporaryEditResource(this.workPackage.id).values$())
-      .subscribe((resource:HalResource) => {
+      .subscribe((resource:WorkPackageResourceInterface) => {
         // Prepare the fields that are required always
         this.specialFields = this.getFields(resource, ['project', 'status']);
 
@@ -157,7 +158,7 @@ export class WorkPackageSingleViewController {
    * Maps the grouped fields into their display fields.
    * May return multiple fields (for the date virtual field).
    */
-  private getFields(resource:HalResource, fieldNames:string[]):FieldDescriptor[] {
+  private getFields(resource:WorkPackageResourceInterface, fieldNames:string[]):FieldDescriptor[] {
     const descriptors:FieldDescriptor[] = [];
 
     fieldNames.forEach((fieldName:string) => {
@@ -189,7 +190,7 @@ export class WorkPackageSingleViewController {
    * 'date' field vs. all other types which should display a
    * combined 'start' and 'due' date field.
    */
-  private getDateField(resource:HalResource):FieldDescriptor {
+  private getDateField(resource:WorkPackageResourceInterface):FieldDescriptor {
     let object:any = {
       name: 'date',
       label: this.I18n.t('js.work_packages.properties.date'),
@@ -206,7 +207,7 @@ export class WorkPackageSingleViewController {
     return object;
   }
 
-  private displayField(resource:HalResource, name:string):DisplayField {
+  private displayField(resource:WorkPackageResourceInterface, name:string):DisplayField {
     return this.wpDisplayField.getField(
       resource,
       name,

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -79,7 +79,11 @@ export class WorkPackageSingleViewController {
               protected wpDisplayField:WorkPackageDisplayFieldService,
               protected wpCacheService:WorkPackageCacheService) {
 
-    $scope.$on('$destroy', () => this.wpEditing.stopEditing(this.workPackage.id));
+    $scope.$on('$destroy', () => {
+      if (this.form && this.form.changeset.empty) {
+        this.wpEditing.stopEditing(this.workPackage.id);
+      }
+    });
   }
 
   public initialize() {

--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -40,8 +40,8 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
       this.$scope,
       this.wpCacheService.loadWorkPackage(stateParams.copiedFromWorkPackageId).values$())
       .subscribe((wp: WorkPackageResourceInterface) => {
-        this.createCopyFrom(wp).then((newWorkPackage: WorkPackageResourceInterface) => {
-          deferred.resolve(newWorkPackage);
+        this.createCopyFrom(wp).then((changeset:WorkPackageChangeset) => {
+          deferred.resolve(changeset);
         });
       });
 

--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -39,7 +39,8 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
     scopedObservable(
       this.$scope,
       this.wpCacheService.loadWorkPackage(stateParams.copiedFromWorkPackageId).values$())
-      .subscribe((wp: WorkPackageResourceInterface) => {
+      .take(1)
+      .subscribe((wp:WorkPackageResourceInterface) => {
         this.createCopyFrom(wp).then((changeset:WorkPackageChangeset) => {
           deferred.resolve(changeset);
         });
@@ -49,7 +50,7 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
   }
 
   private createCopyFrom(wp:WorkPackageResourceInterface) {
-    const changeset = new WorkPackageChangeset(wp);
+    const changeset = this.wpEditing.changesetFor(wp);
     return changeset.getForm().then((form:any) => {
       return this.wpCreate.copyWorkPackage(form, wp.project.identifier);
     });

--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -30,6 +30,7 @@ import {wpDirectivesModule} from "../../angular-modules";
 import {scopedObservable} from "../../helpers/angular-rx-utils";
 import {WorkPackageResourceInterface} from "../api/api-v3/hal-resources/work-package-resource.service";
 import {WorkPackageCreateController} from "../wp-create/wp-create.controller";
+import {WorkPackageChangeset} from '../wp-edit-form/work-package-changeset';
 
 export class WorkPackageCopyController extends WorkPackageCreateController {
   protected newWorkPackageFromParams(stateParams:any) {
@@ -48,7 +49,8 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
   }
 
   private createCopyFrom(wp:WorkPackageResourceInterface) {
-    return wp.getForm().then((form:any) => {
+    const changeset = new WorkPackageChangeset(wp);
+    return changeset.getForm().then((form:any) => {
       return this.wpCreate.copyWorkPackage(form, wp.project.identifier);
     });
   }

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -148,6 +148,12 @@ export class WorkPackageCreateController {
   protected newWorkPackageFromParams(stateParams:any) {
     const type = parseInt(stateParams.type);
 
+    // If there is an open edit for this type, continue it
+    const form = this.states.editing.get('new').value;
+    if (form) {
+      return this.$q.when(form.changeset);
+    }
+
     return this.wpCreate.createNewTypedWorkPackage(stateParams.projectPath, type);
   }
 

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -91,16 +91,22 @@ export class WorkPackageCreateController {
               protected RootDm:RootDmService) {
 
     this.newWorkPackageFromParams($state.params)
-      .then(wp => {
-        this.newWorkPackage = wp;
-        wpCacheService.updateWorkPackage(wp);
+      .then((changeset:WorkPackageChangeset) => {
+        this.newWorkPackage = changeset.workPackage;
+        wpCacheService.updateWorkPackage(changeset.workPackage);
+
+        const formState = this.states.editing.get(changeset.workPackage.id);
+        this.form = new WorkPackageEditForm(changeset.workPackage, changeset);
+        formState.putValue(this.form);
 
         scopedObservable(this.$scope,
-          this.states.editing.get(wp.id).values$())
+          formState.values$())
           .subscribe(form => {
             this.form = form;
 
-            this.form.editContext.successState = this.successState;
+            if (this.form.editContext) {
+              this.form.editContext.successState = this.successState;
+            }
 
             if ($state.params['parent_id']) {
               this.form.changeset.setValue(

--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -137,7 +137,7 @@ export class WorkPackageCreateController {
 
       const hasChanges = !changeset.empty;
       const typeEmpty = (!changeType && !type);
-      const typeMatches = (changeType && changeType.idFromLink() === type.toString());
+      const typeMatches = (changeType && changeType.idFromLink === type.toString());
 
       if (hasChanges && (typeEmpty || typeMatches)) {
         return this.$q.when(changeset);

--- a/frontend/app/components/wp-create/wp-create.service.ts
+++ b/frontend/app/components/wp-create/wp-create.service.ts
@@ -36,6 +36,8 @@ import {
   WorkPackageResourceInterface
 } from '../api/api-v3/hal-resources/work-package-resource.service';
 import {input, State} from 'reactivestates';
+import {WorkPackageEditingService} from '../wp-edit-form/work-package-editing-service';
+import {WorkPackageChangeset} from '../wp-edit-form/work-package-changeset';
 
 export class WorkPackageCreateService {
   protected form:ng.IPromise<HalResource>;
@@ -69,10 +71,10 @@ export class WorkPackageCreateService {
   }
 
   public fromCreateForm(form:any) {
-    var wp = new WorkPackageResource(form.payload.$plain(), true);
-
+    var wp = new WorkPackageResource(form.payload.$plain(), true) as any;
     wp.initializeNewResource(form);
-    return wp as any;
+
+    return new WorkPackageChangeset(wp, form);
   }
 
   /**

--- a/frontend/app/components/wp-create/wp-create.service.ts
+++ b/frontend/app/components/wp-create/wp-create.service.ts
@@ -83,14 +83,14 @@ export class WorkPackageCreateService {
    * @param form Work Package create form
    */
   public copyFrom(otherForm:any, form:any) {
-    var wp = new WorkPackageResource(otherForm.payload.$plain(), true);
+    var wp = new WorkPackageResource(otherForm.payload.$plain(), true) as any;
 
     // Override values from form payload
     wp.lockVersion = form.payload.lockVersion;
 
     wp.initializeNewResource(form);
 
-    return wp as any;
+    return new WorkPackageChangeset(wp, form);
   }
 
   public copyWorkPackage(copyFromForm:any, projectIdentifier?:string) {

--- a/frontend/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/app/components/wp-edit-form/display-field-renderer.ts
@@ -3,6 +3,8 @@ import {WorkPackageDisplayFieldService} from '../wp-display/wp-display-field/wp-
 import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {DisplayField} from '../wp-display/wp-display-field/wp-display-field.module';
 import {MultipleLinesStringObjectsDisplayField} from '../wp-display/field-types/wp-display-multiple-lines-string-objects-field.module';
+import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
+import {WorkPackageChangeset} from './work-package-changeset';
 
 export const editableClassName = '-editable';
 export const requiredClassName = '-required';

--- a/frontend/app/components/wp-edit-form/single-view-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/single-view-edit-context.ts
@@ -114,7 +114,7 @@ export class SingleViewEditContext implements WorkPackageEditContext {
     ctrl.deactivate(focus);
   }
 
-  public requireVisible(fieldName:string):PromiseLike<undefined> {
+  public requireVisible(fieldName:string):Promise<undefined> {
     const deferred = this.$q.defer<undefined>();
 
     const interval = setInterval(() => {

--- a/frontend/app/components/wp-edit-form/single-view-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/single-view-edit-context.ts
@@ -136,16 +136,4 @@ export class SingleViewEditContext implements WorkPackageEditContext {
   private async fieldCtrl(name:string):Promise<WorkPackageEditFieldController> {
     return this.fieldGroup.waitForField(name);
   }
-
-  public onSaved(workPackage:WorkPackageResourceInterface, isInitial?:boolean) {
-    this.wpTableRefresh.request(false, `Saved work package ${workPackage.id}`);
-
-    if (isInitial && this.successState) {
-      this.$state.go(this.successState, { workPackageId: workPackage.id })
-        .then(() => {
-           this.wpTableSelection.focusOn(workPackage.id);
-           this.wpNotificationsService.showSave(workPackage, true);
-        });
-    }
-  }
 }

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -119,10 +119,6 @@ export class TableRowEditContext implements WorkPackageEditContext {
     return 'subject';
   }
 
-  public onSaved(workPackage:WorkPackageResourceInterface) {
-    this.wpTableRefresh.request(false, `Saved work package ${workPackage.id}`);
-  }
-
   // Ensure the given field is visible.
   // We may want to look into MutationObserver if we need this in several places.
   private waitForContainer(fieldName:string):PromiseLike<undefined> {

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -110,7 +110,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
     }
   }
 
-  public requireVisible(fieldName:string):PromiseLike<undefined> {
+  public requireVisible(fieldName:string):Promise<undefined> {
     this.wpTableColumns.addColumn(fieldName);
     return this.waitForContainer(fieldName);
   }
@@ -121,7 +121,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
 
   // Ensure the given field is visible.
   // We may want to look into MutationObserver if we need this in several places.
-  private waitForContainer(fieldName:string):PromiseLike<undefined> {
+  private waitForContainer(fieldName:string):Promise<undefined> {
     const deferred = this.$q.defer<undefined>();
 
     const interval = setInterval(() => {

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -87,7 +87,10 @@ export class TableRowEditContext implements WorkPackageEditContext {
 
     return promise.then(() => {
       // Assure the element is visible
-      return this.$timeout(() => fieldHandler);
+      return this.$timeout(() => {
+        fieldHandler.focus();
+        return fieldHandler;
+      });
     });
   }
 

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -114,13 +114,13 @@ export class WorkPackageChangeset {
     return this.changes.hasOwnProperty(key);
   }
 
-  public getForm():PromiseLike<FormResourceInterface> {
+  public getForm():Promise<FormResourceInterface> {
     this.wpForm.putFromPromiseIfPristine(() => this.updateForm());
 
     if (this.wpForm.hasValue()) {
       return Promise.resolve(this.wpForm.value);
     } else {
-      return this.wpForm.valuesPromise();
+      return new Promise((resolve,) => this.wpForm.valuesPromise().then(resolve));
     }
   }
 

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -72,7 +72,9 @@ export class WorkPackageChangeset {
   }
 
   public startEditing(key:string) {
-    this.changes[key] = _.cloneDeep(this.workPackage[key]);
+    if (!this.isOverridden(key)) {
+      this.changes[key] = _.cloneDeep(this.workPackage[key]);
+    }
   }
 
   public reset(key:string) {
@@ -149,7 +151,6 @@ export class WorkPackageChangeset {
 
     var deferred = this.$q.defer();
 
-    console.trace("UPDATING FORM");
     this.workPackage.$links.update(payload)
       .then((form:FormResourceInterface) => {
         this.wpForm.putValue(form);

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -42,6 +42,7 @@ import {
   ImmutableWorkPackageResource,
   WorkPackageEditingService
 } from './work-package-editing-service';
+import {ErrorResource} from '../api/api-v3/hal-resources/error-resource.service';
 
 export class WorkPackageChangeset {
   // Injections
@@ -146,6 +147,13 @@ export class WorkPackageChangeset {
       .then((form:FormResourceInterface) => {
         this.wpForm.putValue(form);
         this.buildResource();
+
+        // Reject errors when occurring in form validation
+        const errors = ErrorResource.fromFormResponse(form);
+        if (errors !== null) {
+          return deferred.reject(errors);
+        }
+
         deferred.resolve(form);
       })
       .catch((error:any) => {
@@ -194,7 +202,10 @@ export class WorkPackageChangeset {
           .catch(error => {
             // Update the resource anyway
             this.buildResource();
-            deferred.reject(error);
+            deferred.reject({
+              errorsOnForm: false,
+              error: error
+            });
           });
       })
       .catch(deferred.reject);

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -75,9 +75,6 @@ export class WorkPackageChangeset {
     this.buildResource();
   }
 
-  public startEditing(key:string) {
-  }
-
   public reset(key:string) {
     delete this.changes[key];
   }

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -38,10 +38,7 @@ import {WorkPackageCacheService} from '../work-packages/work-package-cache.servi
 import {WorkPackageCreateService} from '../wp-create/wp-create.service';
 import {input} from 'reactivestates';
 import {WorkPackageNotificationService} from '../wp-edit/wp-notification.service';
-import {
-  ImmutableWorkPackageResource,
-  WorkPackageEditingService
-} from './work-package-editing-service';
+import {WorkPackageEditingService} from './work-package-editing-service';
 import {ErrorResource} from '../api/api-v3/hal-resources/error-resource.service';
 
 export class WorkPackageChangeset {
@@ -61,7 +58,7 @@ export class WorkPackageChangeset {
   public wpForm = input<FormResourceInterface>();
 
   // The current editing resource
-  public resource:ImmutableWorkPackageResource|null;
+  public resource:WorkPackageResourceInterface|null;
 
   constructor(public workPackage:WorkPackageResourceInterface, form?:FormResourceInterface) {
     $injectFields(
@@ -320,7 +317,7 @@ export class WorkPackageChangeset {
       resource.overriddenSchema = this.schema;
     }
 
-    this.resource = (resource as ImmutableWorkPackageResource);
+    this.resource = (resource as WorkPackageResourceInterface);
     this.wpEditing.updateValue(this.workPackage.id, this);
   }
 }

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -55,20 +55,20 @@ export class WorkPackageChangeset {
   // The current editing resource state
   public resource = input<HalResource>();
 
-  constructor(public workPackage:WorkPackageResourceInterface) {
+  constructor(public workPackage:WorkPackageResourceInterface, form?:FormResourceInterface) {
     $injectFields(
       this, 'wpNotificationsService', '$q', 'schemaCacheService',
       'wpCacheService', 'wpCreate'
     );
 
-    if (this.workPackage.isNew) {
-      // New work packages have no schema set yet, so update the form immediately to get one
-      this.updateForm();
-    } else {
-      // Start with a resource from the current work package knowledge.
-      const payload = this.mergeWithPayload(workPackage.$plain);
-      this.buildResource(payload);
+    // New work packages have no schema set yet, so update the form immediately to get one
+    if (form !== undefined) {
+      this.wpForm.putValue(form);
     }
+
+    // Start with a resource from the current work package knowledge.
+    const payload = this.mergeWithPayload(workPackage.$plain);
+    this.buildResource(payload);
   }
 
   public startEditing(key:string) {

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -35,11 +35,12 @@ import {SchemaCacheService} from '../schemas/schema-cache.service';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
 import {WorkPackageCreateService} from '../wp-create/wp-create.service';
 import {input, InputState} from 'reactivestates';
+import {WorkPackageNotificationService} from '../wp-edit/wp-notification.service';
 
 export class WorkPackageChangeset {
   // Injections
   public $q:ng.IQService;
-  public NotificationsService:any;
+  public wpNotificationsService:WorkPackageNotificationService;
   public schemaCacheService:SchemaCacheService;
   public wpCacheService:WorkPackageCacheService;
   public wpCreate:WorkPackageCreateService;
@@ -56,7 +57,7 @@ export class WorkPackageChangeset {
 
   constructor(public workPackage:WorkPackageResourceInterface) {
     $injectFields(
-      this, 'NotificationsService', '$q', 'schemaCacheService',
+      this, 'wpNotificationsService', '$q', 'schemaCacheService',
       'wpCacheService', 'wpCreate'
     );
 
@@ -153,6 +154,7 @@ export class WorkPackageChangeset {
       })
       .catch((error:any) => {
         this.wpForm.putValue(oldForm);
+        this.wpNotificationsService.handleErrorResponse(error, this.workPackage);
         deferred.reject(error);
       });
 

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -61,9 +61,14 @@ export class WorkPackageChangeset {
       'wpCacheService', 'wpCreate'
     );
 
-    // Start with a resource from the current work package knowledge.
-    const payload = this.mergeWithPayload(workPackage.$plain);
-    this.buildResource(payload);
+    if (this.workPackage.isNew) {
+      // New work packages have no schema set yet, so update the form immediately to get one
+      this.updateForm();
+    } else {
+      // Start with a resource from the current work package knowledge.
+      const payload = this.mergeWithPayload(workPackage.$plain);
+      this.buildResource(payload);
+    }
   }
 
   public startEditing(key:string) {
@@ -185,6 +190,7 @@ export class WorkPackageChangeset {
               this.workPackage.updateActivities();
 
               if (wasNew) {
+                this.workPackage.overriddenSchema = undefined;
                 this.workPackage.uploadAttachmentsAndReload();
                 this.wpCreate.newWorkPackageCreated(this.workPackage);
               }

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -1,0 +1,267 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
+import {FormResourceInterface} from '../api/api-v3/hal-resources/form-resource.service';
+import {$injectFields} from '../angular/angular-injector-bridge.functions';
+import {debugLog} from '../../helpers/debug_output';
+import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
+import {SchemaCacheService} from '../schemas/schema-cache.service';
+import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
+import {WorkPackageCreateService} from '../wp-create/wp-create.service';
+import {input, InputState} from 'reactivestates';
+
+export class WorkPackageChangeset {
+  // Injections
+  public $q:ng.IQService;
+  public NotificationsService:any;
+  public schemaCacheService:SchemaCacheService;
+  public wpCacheService:WorkPackageCacheService;
+  public wpCreate:WorkPackageCreateService;
+
+  // The changeset to be applied to the work package
+  private changes:{[attribute:string]:any} = {};
+  public inFlight:boolean = false;
+
+  // The current work package form
+  public wpForm:FormResourceInterface|null;
+
+  // The current editing resource state
+  public resource:InputState<HalResource> = input<HalResource>();
+
+  constructor(public workPackage:WorkPackageResourceInterface) {
+    $injectFields(
+      this, 'NotificationsService', '$q', 'schemaCacheService',
+      'wpCacheService', 'wpCreate'
+    );
+
+    // Start with a resource from the current work package knowledge.
+    const payload = this.mergeWithPayload(workPackage.$plain);
+    this.buildResource(payload);
+  }
+
+  public startEditing(key:string) {
+    this.changes[key] = _.cloneDeep(this.workPackage[key]);
+  }
+
+  public reset(key:string) {
+    delete this.changes[key];
+  }
+
+  public clear() {
+    this.changes = {};
+  }
+
+  public get empty() {
+    return _.isEmpty(this.changes);
+  }
+
+  /**
+   * Retrieve the editing value for the given attribute
+   *
+   * @param {string} key The attribute to read
+   * @return {any} Either the value from the overriden change, or the default value
+   */
+  public value(key:string) {
+    if (this.isOverridden(key)) {
+      return this.changes[key];
+    } else {
+      return this.workPackage[key];
+    }
+  }
+
+  public setValue(key:string, val:any) {
+    this.changes[key] = val;
+  }
+
+  /**
+   * Return whether a change value exist for the given attribute key.
+   * @param {string} key
+   * @return {boolean}
+   */
+  public isOverridden(key:string) {
+    return this.changes.hasOwnProperty(key);
+  }
+
+  public getForm():ng.IPromise<FormResourceInterface> {
+    if (this.wpForm) {
+      return this.$q.when(this.wpForm);
+    }
+
+    return this.updateForm().catch(error => {
+      this.NotificationsService.addError(error.message);
+    });
+  }
+
+  /**
+   * Update the form resource from the API.
+   * @return {angular.IPromise<any>}
+   */
+  public updateForm():ng.IPromise<FormResourceInterface> {
+    // Always resolve form to the latest form
+    // This way, we won't have to actively reset it.
+    // But store the existing form in case of an error.
+    // Because if we get an error, the object returned is not a form
+    // and thus lacks the links the implementation depends upon.
+    const oldForm = this.wpForm;
+
+    // Create the payload from the current changes,
+    // and extend it with the current lock version
+    // -- This is the place to add additional logic when the lockVersion changed in between --
+    let payload = { lockVersion: this.workPackage.lockVersion, _links: {} };
+    this.mergeWithPayload(payload)
+
+    var deferred = this.$q.defer();
+
+    this.workPackage.$links.update(payload)
+      .then((form) => {
+        this.wpForm = form;
+        const payload = this.mergeWithPayload(form.payload.$source);
+        this.buildResource(payload);
+        deferred.resolve(form);
+      })
+      .catch((error:any) => {
+        this.wpForm = oldForm;
+        deferred.reject(error);
+      });
+
+    return deferred.promise;
+  }
+
+
+  public save():ng.IPromise<WorkPackageResourceInterface> {
+    const deferred = this.$q.defer();
+
+    this.inFlight = true;
+    const wasNew = this.workPackage.isNew;
+    this.updateForm()
+      .then((form) => {
+        const payload = this.resource.value!.$source;
+
+        this.workPackage.$links.updateImmediately(payload)
+          .then((savedWp:WorkPackageResourceInterface) => {
+            // Remove the current form and schema, otherwise old form data
+            // might still be used for the next edit field to be edited
+            this.wpForm = null;
+
+            // Initialize any potentially new HAL values
+            this.workPackage.$initialize(savedWp);
+
+            // Ensure the schema is loaded before updating
+            this.schemaCacheService.ensureLoaded(this.workPackage).then(() => {
+              this.workPackage.updateActivities();
+
+              if (wasNew) {
+                this.workPackage.uploadAttachmentsAndReload();
+                this.wpCreate.newWorkPackageCreated(this.workPackage);
+              }
+
+              this.wpCacheService.updateWorkPackage(this.workPackage);
+              deferred.resolve(this.workPackage);
+            });
+          })
+          .catch(error => {
+            // Update the resource anyway
+            this.buildResource(payload);
+            deferred.reject(error);
+          });
+      })
+      .catch(deferred.reject);
+
+    return deferred.promise.finally(() => this.inFlight = false);
+  }
+
+  /**
+   * Merge the current changes into the payload resource.
+   *
+   * @param {FormResourceInterface} form
+   * @return {any}
+   */
+  private mergeWithPayload(plainPayload:any) {
+    const reference = this.wpForm ? this.wpForm.payload.$source : this.workPackage.$source;
+
+    _.each(this.changes, (val:any, key:string) => {
+      const fieldSchema = this.schema[key];
+      if (!(typeof(fieldSchema) === 'object' && fieldSchema.writable === true)) {
+        debugLog(`Trying to write ${key} but is not writable in schema`);
+        return;
+      }
+
+      // Override in _links if it is a linked property
+      if (reference._links[key]) {
+        plainPayload._links[key] = this.getLinkedValue(val, fieldSchema);
+      } else {
+        plainPayload[key] = this.changes[key];
+      }
+    });
+
+    return plainPayload;
+  }
+
+  /**
+   * Extract the link(s) in the given changed value
+   */
+  private getLinkedValue(val:any, fieldSchema:op.FieldSchema) {
+    var isArray = (fieldSchema.type || '').startsWith('[]');
+
+    if (isArray) {
+      var links:{ href:string }[] = [];
+
+      if (val) {
+        var elements = (val.forEach && val) || val.elements;
+
+        elements.forEach((link:{ href:string }) => {
+          if (link.href) {
+            links.push({href: link.href});
+          }
+        });
+      }
+
+      return links;
+    } else {
+      return { href: _.get(val, 'href', null) };
+    }
+  }
+
+  /**
+   * Get the best schema currently available, either the default WP schema (must exist).
+   * If loaded, return the form schema, which provides better information on writable status
+   * and contains available values.
+   */
+  public get schema() {
+    return this.wpForm ? this.wpForm.schema : this.workPackage.schema;
+  }
+
+  private buildResource(payload:any) {
+    const resource = new HalResource(payload, true);
+    resource.schema = this.schema;
+
+    this.resource.putValue(resource);
+  }
+}
+

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -138,6 +138,7 @@ export class WorkPackageChangeset {
 
     var deferred = this.$q.defer();
 
+    console.trace("UPDATING FORM");
     this.workPackage.$links.update(payload)
       .then((form) => {
         this.wpForm = form;

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -105,8 +105,10 @@ export class WorkPackageChangeset {
   public setValue(key:string, val:any) {
     this.changes[key] = val;
 
-    // Update the form for fields that may alter the form itself.
-    if (key === 'project' || key === 'type') {
+    // Update the form for fields that may alter the form itself
+    // when the work package is new. Otherwise, the save request afterwards
+    // will update the form automatically.
+    if (this.workPackage.isNew && (key === 'project' || key === 'type')) {
       this.updateForm();
     }
   }

--- a/frontend/app/components/wp-edit-form/work-package-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-context.ts
@@ -60,11 +60,6 @@ export interface WorkPackageEditContext {
   firstField(names:string[]):string;
 
   /**
-   * Callback after a work package is saved through the form
-   */
-  onSaved(workPackage:WorkPackageResource, isInitial?:boolean):void;
-
-  /**
    * ui-state to redirect to after successful saving
    */
   successState:string;

--- a/frontend/app/components/wp-edit-form/work-package-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-context.ts
@@ -47,7 +47,7 @@ export interface WorkPackageEditContext {
   /**
    * Show this required field. E.g., add the necessary column
    */
-  requireVisible(fieldName:string):PromiseLike<undefined>;
+  requireVisible(fieldName:string):Promise<undefined>;
 
   /**
    * Reset the field and re-render the current WPs value.

--- a/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
@@ -106,9 +106,7 @@ export class WorkPackageEditFieldHandler {
    * Handle a user submitting the field (e.g, ng-change)
    */
   public handleUserSubmit() {
-    if (this.form.editMode) {
-      this.form.updateForm();
-    } else {
+    if (!this.form.editMode) {
       this.form.submit();
     }
   }
@@ -142,8 +140,7 @@ export class WorkPackageEditFieldHandler {
    * Cancel any pending changes
    */
   public reset() {
-    this.workPackage.restoreFromPristine(this.fieldName);
-    delete this.workPackage.$pristine[this.fieldName];
+    this.form.changeset.reset(this.fieldName);
     this.deactivate(true);
   }
 

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -159,6 +159,9 @@ export class WorkPackageEditForm {
   public activateMissingFields() {
     this.changeset.getForm().then((form:any) => {
       _.each(form.validationErrors, (val:any, key:string) => {
+        if (key === 'id') {
+          return;
+        }
         this.activateWhenNeeded(key);
       });
     });

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -113,8 +113,6 @@ export class WorkPackageEditForm {
    * @param noWarnings Ignore warnings if the field cannot be opened
    */
   public activate(fieldName:string, noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
-    this.changeset.startEditing(fieldName);
-
     return this.buildField(fieldName).then((field:EditField) => {
       if (!field.writable && !noWarnings) {
         this.wpNotificationsService.showEditingBlockedError(field.displayName);

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -173,6 +173,7 @@ export class WorkPackageEditForm {
         deferred.resolve(savedWorkPackage);
 
         this.wpNotificationsService.showSave(savedWorkPackage, isInitial);
+        this.editMode = false;
         this.editContext.onSaved(savedWorkPackage, isInitial);
       })
       .catch((error) => {

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -210,20 +210,22 @@ export class WorkPackageEditForm {
   }
 
   protected handleErroneousAttributes(error:any) {
-    const attributes = error.getInvolvedAttributes();
+    // Get attributes withe errors
+    const erroneousAttributes = error.getInvolvedAttributes();
+    // Get valid attributes
+    const validFields = _.difference(_.keys(this.activeFields), erroneousAttributes);
+
     // Save erroneous fields for when new fields appear
     this.errorsPerAttribute = error.getMessagesPerAttribute();
-    if (attributes.length === 0) {
+    if (erroneousAttributes.length === 0) {
       return;
     }
 
-    // Iterate all erroneous fields and close these that are valid
-    const validFields = _.keys(this.activeFields);
-
     // Accumulate errors for the given response
-    _.each(attributes, (fieldName:string) => {
+    _.each(erroneousAttributes, (fieldName:string) => {
       this.editContext.requireVisible(fieldName).then(() => {
         this.activateWhenNeeded(fieldName);
+        this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
       });
     });
 

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -98,11 +98,6 @@ export class WorkPackageEditForm {
       .subscribe((wp:WorkPackageResourceInterface) => {
         this.workPackage = wp;
         this.changeset.workPackage = wp;
-
-        // Reset the current form if the work package is not new
-        if (!wp.isNew) {
-          this.changeset.wpForm.clear();
-        }
       });
 
     this.formSubscription = this.editResource.subscribe(() => {

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -84,7 +84,7 @@ export class WorkPackageEditForm {
         this.changeset.workPackage = wp;
 
         // Reset the current form
-        this.changeset.wpForm = null;
+        this.changeset.wpForm.clear();
       });
 
     this.formSubscription = this.editResource.subscribe(() => {
@@ -218,8 +218,6 @@ export class WorkPackageEditForm {
   protected handleErroneousAttributes(error:any) {
     // Get attributes withe errors
     const erroneousAttributes = error.getInvolvedAttributes();
-    // Get valid attributes
-    const validFields = _.difference(_.keys(this.activeFields), erroneousAttributes);
 
     // Save erroneous fields for when new fields appear
     this.errorsPerAttribute = error.getMessagesPerAttribute();
@@ -233,11 +231,6 @@ export class WorkPackageEditForm {
         this.activateWhenNeeded(fieldName);
         this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
       });
-    });
-
-    // Now close remaining fields (valid)
-    _.each(validFields, (fieldName:string) => {
-      this.activeFields[fieldName].deactivate();
     });
 
     // Focus the first field that are still remaining
@@ -265,8 +258,7 @@ export class WorkPackageEditForm {
             ) as EditField;
 
             resolve(field);
-          })
-        .catch(reject);
+          });
     });
   }
 

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -296,7 +296,7 @@ export class WorkPackageEditForm {
           resolve(field);
         })
         .catch((error) => {
-          console.error('Failed to build edit field:' + error);
+          console.error('Failed to build edit field: %o', error);
           this.wpNotificationsService.handleRawError(error);
         });
     });

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -80,10 +80,11 @@ export class WorkPackageEditForm {
     this.wpSubscription = this.states.workPackages.get(workPackage.id)
       .values$()
       .subscribe((wp:WorkPackageResourceInterface) => {
-        debugLog("Refreshing work package and form");
         this.workPackage = wp;
         this.changeset.workPackage = wp;
-        this.changeset.updateForm();
+
+        // Reset the current form
+        this.changeset.wpForm = null;
       });
 
     this.formSubscription = this.editResource.subscribe(() => {

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -42,7 +42,7 @@ import {debugLog} from '../../helpers/debug_output';
 import {WorkPackageChangeset} from './work-package-changeset';
 import {FormResourceInterface} from '../api/api-v3/hal-resources/form-resource.service';
 import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
-import {InputState, State} from 'reactivestates';
+import {derive, InputState, State} from 'reactivestates';
 import {Observable} from 'rxjs';
 
 export const activeFieldContainerClassName = 'wp-inline-edit--active-field';
@@ -100,7 +100,7 @@ export class WorkPackageEditForm {
         this.changeset.workPackage = wp;
       });
 
-    this.formSubscription = this.editResource.subscribe(() => {
+    this.formSubscription = this.editState.values$().subscribe(() => {
       debugLog("Refreshing active edit fields after form update.");
       _.each(this.activeFields, (_handler, name) => this.refresh(name!));
     });
@@ -123,8 +123,10 @@ export class WorkPackageEditForm {
     });
   }
 
-  public get editResource():Observable<HalResource> {
-    return this.changeset.resource.values$();
+  public get editState():State<WorkPackageResourceInterface> {
+    return derive(this.changeset.resource, $ =>
+      $.map((v) => v || this.workPackage)
+    );
   }
 
   public refresh(fieldName:string) {

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -229,7 +229,10 @@ export class WorkPackageEditForm {
     _.each(erroneousAttributes, (fieldName:string) => {
       this.editContext.requireVisible(fieldName).then(() => {
         this.activateWhenNeeded(fieldName);
-        this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
+
+        if (this.activeFields[fieldName]) {
+          this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
+        }
       });
     });
 
@@ -258,7 +261,11 @@ export class WorkPackageEditForm {
             ) as EditField;
 
             resolve(field);
-          });
+          })
+        .catch((error) => {
+          console.error("Failed to build edit field:" + error);
+          this.wpNotificationsService.handleRawError(error);
+        });
     });
   }
 
@@ -266,11 +273,16 @@ export class WorkPackageEditForm {
     const promise = this.editContext.activateField(this,
       field,
       this.errorsPerAttribute[fieldName] || []);
-    return promise.then((fieldHandler) => {
-      this.lastActiveField = fieldName;
-      this.activeFields[fieldName] = fieldHandler;
-      return fieldHandler;
-    });
+    return promise
+      .then((fieldHandler) => {
+        this.lastActiveField = fieldName;
+        this.activeFields[fieldName] = fieldHandler;
+        return fieldHandler;
+      })
+      .catch((error) => {
+        console.error("Failed to render edit field:" + error);
+        this.wpNotificationsService.handleRawError(error);
+      });
   }
 }
 

--- a/frontend/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/app/components/wp-edit-form/work-package-editing-service.ts
@@ -38,7 +38,12 @@ export class WorkPackageEditingService {
 
   public startEditing(workPackage:WorkPackageResourceInterface, editContext:WorkPackageEditContext, editAll:boolean = false):WorkPackageEditForm {
     const state = this.editState(workPackage.id);
-    const form = state.getValueOr(new WorkPackageEditForm(workPackage, editContext, editAll));
+    let form = state.value;
+
+    if (!form) {
+      form = new WorkPackageEditForm(workPackage, editContext, editAll);
+    }
+
     form.editContext = editContext;
     form.editMode = editAll;
     state.putValue(form);

--- a/frontend/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/app/components/wp-edit-form/work-package-editing-service.ts
@@ -28,13 +28,19 @@
 
 import {wpServicesModule} from '../../angular-modules';
 import {WorkPackageEditForm} from './work-package-edit-form';
-import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
+import {
+  WorkPackageResource,
+  WorkPackageResourceEmbedded,
+  WorkPackageResourceInterface, WorkPackageResourceLinks
+} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {WorkPackageEditContext} from './work-package-edit-context';
 import {WorkPackageChangeset} from './work-package-changeset';
 import {StateCacheService} from '../states/state-cache.service';
 import {combine, deriveRaw, multiInput, State, StatesGroup} from 'reactivestates';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
 import {Observable} from 'rxjs';
+import {SchemaResource} from '../api/api-v3/hal-resources/schema-resource.service';
+import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
 
 class WPChangesetStates extends StatesGroup {
   name = 'WP-Changesets';
@@ -45,11 +51,6 @@ class WPChangesetStates extends StatesGroup {
     super();
     this.initializeMembers();
   }
-}
-
-export interface ImmutableWorkPackageResource extends WorkPackageResourceInterface {
-  // Add readonly index signature
-  readonly[attribute:string]:any;
 }
 
 export class WorkPackageEditingService extends StateCacheService<WorkPackageChangeset> {
@@ -91,7 +92,7 @@ export class WorkPackageEditingService extends StateCacheService<WorkPackageChan
    *
    * @return {State<WorkPackageResourceInterface>}
    */
-  public temporaryEditResource(id:string):State<ImmutableWorkPackageResource> {
+  public temporaryEditResource(id:string):State<WorkPackageResourceInterface> {
     const combined = combine(this.wpCacheService.state(id), this.state(id));
 
     return deriveRaw(combined,

--- a/frontend/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/app/components/wp-edit-form/work-package-editing-service.ts
@@ -31,24 +31,26 @@ import {wpServicesModule} from '../../angular-modules';
 import {WorkPackageEditForm} from './work-package-edit-form';
 import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {WorkPackageEditContext} from './work-package-edit-context';
+import {WorkPackageChangeset} from './work-package-changeset';
 
 export class WorkPackageEditingService {
   constructor(public states:States, public $q:ng.IQService) {
   }
 
-  public startEditing(workPackage:WorkPackageResourceInterface, editContext:WorkPackageEditContext, editAll:boolean = false):WorkPackageEditForm {
+  /**
+   * Start editing the work package with a given edit context
+   * @param {WorkPackageResourceInterface} workPackage
+   * @param {WorkPackageEditContext} editContext
+   * @param {boolean} editAll
+   * @param {WorkPackageChangeset} changeset
+   * @return {WorkPackageEditForm}
+   */
+  public startEditing(workPackage:WorkPackageResourceInterface,
+                      editContext:WorkPackageEditContext,
+                      editAll:boolean = false,
+                      changeset?:WorkPackageChangeset):WorkPackageEditForm {
     const state = this.editState(workPackage.id);
-    let form = state.value;
-
-    if (!form) {
-      form = new WorkPackageEditForm(workPackage, editContext, editAll);
-    }
-
-    form.editContext = editContext;
-    form.editMode = editAll;
-    state.putValue(form);
-
-    return form;
+    return WorkPackageEditForm.continue(state, workPackage, editContext, editAll, changeset);
   }
 
   public stopEditing(workPackageId:string) {

--- a/frontend/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/app/components/wp-edit-form/work-package-editing-service.ts
@@ -36,9 +36,9 @@ export class WorkPackageEditingService {
   constructor(public states:States, public $q:ng.IQService) {
   }
 
-  public startEditing(workPackageId:string, editContext:WorkPackageEditContext, editAll:boolean = false):WorkPackageEditForm {
-    const state = this.editState(workPackageId);
-    const form = state.getValueOr(new WorkPackageEditForm(workPackageId, editContext, editAll));
+  public startEditing(workPackage:WorkPackageResourceInterface, editContext:WorkPackageEditContext, editAll:boolean = false):WorkPackageEditForm {
+    const state = this.editState(workPackage.id);
+    const form = state.getValueOr(new WorkPackageEditForm(workPackage, editContext, editAll));
     form.editContext = editContext;
     form.editMode = editAll;
     state.putValue(form);
@@ -49,8 +49,8 @@ export class WorkPackageEditingService {
   public stopEditing(workPackageId:string) {
     const state = this.editState(workPackageId);
 
-    if (state.hasValue()) {
-      state.value!.stopEditing();
+    if (state.value) {
+      state.value.destroy();
     }
   }
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -1,10 +1,10 @@
 <input type="checkbox"
        class="wp-inline-edit--field wp-inline-edit--boolean-field"
        wp-edit-field-requirements="vm.field.schema"
-       ng-model="vm.workPackage[vm.fieldName]"
+       ng-model="vm.field.value"
        ng-false-value="false"
        ng-change="vm.handleUserSubmit()"
        ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
-       ng-disabled="vm.workPackage.inFlight"
+       ng-disabled="vm.field.inFlight"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-date-field.directive.html
@@ -3,14 +3,14 @@
   on-change="vm.handleUserSubmit()"
   on-change="vm.handleUserSubmit()">
 
-  <input ng-model="vm.workPackage[vm.fieldName]"
+  <input ng-model="vm.field.value"
          type="text"
          class="wp-inline-edit--field"
          transform-date-value
          ng-blur="vm.onlyInAccessibilityMode(vm.handleUserBlur)"
          ng-keydown="vm.handleUserSubmitOnEnter($event)"
          ng-required="vm.field.required"
-         ng-disabled="vm.workPackage.inFlight"
+         ng-disabled="vm.field.inFlight"
          ng-attr-id="{{vm.htmlId}}" />
 
 </op-date-picker>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.directive.html
@@ -2,11 +2,11 @@
        step="0.01"
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
-       ng-model="vm.workPackage[vm.fieldName]"
+       ng-model="vm.field.value"
        transform-duration-value
        ng-required="vm.field.required"
        ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-keydown="vm.handleUserSubmitOnEnter($event)"
-       ng-disabled="vm.workPackage.inFlight"
+       ng-disabled="vm.field.inFlight"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-duration-field.module.ts
@@ -27,7 +27,13 @@
 // ++
 
 import {EditField} from "../wp-edit-field/wp-edit-field.module";
+import moment = require('moment');
 
 export class DurationEditField extends EditField {
-  public template:string = '/components/wp-edit/field-types/wp-edit-duration-field.directive.html'
+
+  protected parseValue(val:moment.Moment) {
+    return val.toISOString();
+  }
+
+  public template:string = '/components/wp-edit/field-types/wp-edit-duration-field.directive.html';
 }

--- a/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-float-field.directive.html
@@ -1,11 +1,11 @@
 <input type="text"
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
-       ng-model="vm.workPackage[vm.fieldName]"
+       ng-model="vm.field.value"
        ng-required="vm.field.required"
        ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-keydown="vm.handleUserSubmitOnEnter($event)"
        transform-float-value
-       ng-disabled="vm.workPackage.inFlight"
+       ng-disabled="vm.field.inFlight"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-integer-field.directive.html
@@ -1,10 +1,10 @@
 <input type="number"
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
-       ng-model="vm.workPackage[vm.fieldName]"
+       ng-model="vm.field.value"
        ng-required="vm.field.required"
        ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
        ng-keydown="vm.handleUserSubmitOnEnter($event)"
-       ng-disabled="vm.workPackage.inFlight"
+       ng-disabled="vm.field.inFlight"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -9,7 +9,7 @@
     ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
     ng-required="vm.field.required"
     ng-focus="vm.handleUserFocus()"
-    ng-disabled="vm.workPackage.inFlight"
+    ng-disabled="vm.field.inFlight"
     ng-attr-id="{{vm.htmlId}}"
     ng-change="vm.handleUserSubmit()"
   >
@@ -31,7 +31,7 @@
     ng-options="value as (value.name || value.value) for value in vm.field.options track by value.href"
     ng-required="vm.field.required"
     ng-focus="vm.handleUserFocus()"
-    ng-disabled="vm.workPackage.inFlight"
+    ng-disabled="vm.field.inFlight"
     ng-attr-id="{{vm.htmlId}}"
     multiple=""
     size=5

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -119,7 +119,7 @@ export class MultiSelectEditField extends EditField {
     }
     else {
       // If no value but required
-      this.currentValueInvalid == this.schema.required;
+      this.currentValueInvalid = !!this.schema.required;
     }
   }
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -72,7 +72,7 @@ export class MultiSelectEditField extends EditField {
   public get value() {
     const val = this.changeset.value(this.name);
 
-    if (this.isMultiselect) {
+    if (!Array.isArray(val) || this.isMultiselect) {
       return val;
     } else {
       return val[0];
@@ -93,7 +93,7 @@ export class MultiSelectEditField extends EditField {
 
   public isValueMulti() {
     const val = this.changeset.value(this.name);
-    return val.length > 1;
+    return val && val.length > 1;
   }
 
   public toggleMultiselect() {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -27,9 +27,9 @@
 // ++
 
 import {EditField} from '../wp-edit-field/wp-edit-field.module';
-import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 import {CollectionResource} from '../../api/api-v3/hal-resources/collection-resource.service';
 import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
+import {$injectFields} from '../../angular/angular-injector-bridge.functions';
 
 export class MultiSelectEditField extends EditField {
   public options:any[];
@@ -38,17 +38,17 @@ export class MultiSelectEditField extends EditField {
   public isMultiselect: boolean;
 
   // Dependencies
-  protected I18n:op.I18n = <op.I18n> MultiSelectEditField.$injector.get('I18n');
+  public I18n:op.I18n;
 
   public currentValueInvalid:boolean = false;
 
   protected initialize() {
+    $injectFields(this, 'I18n');
     this.isMultiselect = this.isValueMulti();
 
-    const I18n:any = this.$injector.get('I18n');
     this.text = {
-      requiredPlaceholder: I18n.t('js.placeholders.selection'),
-      placeholder: I18n.t('js.placeholders.default'),
+      requiredPlaceholder: this.I18n.t('js.placeholders.selection'),
+      placeholder: this.I18n.t('js.placeholders.default'),
       save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
       cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
     };
@@ -70,23 +70,30 @@ export class MultiSelectEditField extends EditField {
   }
 
   public get value() {
+    const val = this.changeset.value(this.name);
+
     if (this.isMultiselect) {
-      return this.resource[this.name];
+      return val;
     } else {
-      return this.resource[this.name][0];
+      return val[0];
     }
   }
 
   public set value(val) {
+    this.changeset.setValue(this.name, this.parseValue(val));
+  }
+
+  protected parseValue(val:any) {
     if (Array.isArray(val)) {
-      this.resource[this.name] = val;
+      return val;
     } else {
-      this.resource[this.name] = [val];
+      return [val];
     }
   }
 
   public isValueMulti() {
-    return this.resource[this.name].length > 1;
+    const val = this.changeset.value(this.name);
+    return val.length > 1;
   }
 
   public toggleMultiselect() {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -42,9 +42,7 @@ export class MultiSelectEditField extends EditField {
 
   public currentValueInvalid:boolean = false;
 
-  constructor(workPackage:WorkPackageResourceInterface, fieldName:string, schema:op.FieldSchema) {
-    super(workPackage, fieldName, schema);
-
+  protected initialize() {
     this.isMultiselect = this.isValueMulti();
 
     const I18n:any = this.$injector.get('I18n');

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.directive.html
@@ -6,7 +6,7 @@
         ng-change="vm.handleUserSubmit()"
         ng-required="vm.field.required"
         ng-focus="vm.handleUserFocus()"
-        ng-disabled="vm.workPackage.inFlight"
+        ng-disabled="vm.field.inFlight"
         ng-attr-id="{{vm.htmlId}}"
         role="listbox">
   <option value=""

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -36,8 +36,6 @@ export class SelectEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text:{requiredPlaceholder:string, placeholder:string};
 
-  public currentValueInvalid:boolean = false;
-
   protected initialize() {
     const I18n:any = this.$injector.get('I18n');
     this.text = {
@@ -86,11 +84,10 @@ export class SelectEditField extends EditField {
 
     this.options = availableValues;
     this.addEmptyOption();
-    this.checkCurrentValueValidity();
   }
 
-  private checkCurrentValueValidity() {
-    this.currentValueInvalid = !!(
+  public get currentValueInvalid():boolean {
+    return !!(
       (this.value && !_.some(this.options, (option:HalResource) => (option.href === this.value.href)))
       ||
       (!this.value && this.schema.required)

--- a/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-select-field.module.ts
@@ -38,9 +38,7 @@ export class SelectEditField extends EditField {
 
   public currentValueInvalid:boolean = false;
 
-  constructor(workPackage:WorkPackageResourceInterface, fieldName:string, schema:op.FieldSchema) {
-    super(workPackage, fieldName, schema);
-
+  protected initialize() {
     const I18n:any = this.$injector.get('I18n');
     this.text = {
       requiredPlaceholder: I18n.t('js.placeholders.selection'),

--- a/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-text-field.directive.html
@@ -1,10 +1,10 @@
 <input type="text"
        class="wp-inline-edit--field"
        wp-edit-field-requirements="vm.field.schema"
-       ng-model="vm.workPackage[vm.fieldName]"
+       ng-model="vm.field.value"
        ng-required="vm.field.required"
        ng-focus="vm.handleUserFocus()"
-       ng-disabled="vm.workPackage.inFlight"
+       ng-disabled="vm.field.inFlight"
        ng-keydown="vm.handleUserSubmitOnEnter($event)"
        focus="vm.field.name === 'subject'"
        ng-attr-id="{{vm.htmlId}}" />

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -10,7 +10,7 @@
           ng-hide="vm.field.isPreview"
           ng-required="vm.field.required"
           ng-disabled="vm.field.isBusy || vm.field.inFlight"
-          ng-model="vm.field.fieldVal.raw"
+          ng-model="vm.field.rawValue"
           ng-attr-id="{{vm.htmlId}}">  </textarea>
     <div class="inplace-edit--preview" ng-show="vm.field.isPreview && !vm.field.isBusy">
         <span bind-unescaped-html="vm.field.previewHtml"></span>

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html
@@ -9,7 +9,7 @@
           name="value"
           ng-hide="vm.field.isPreview"
           ng-required="vm.field.required"
-          ng-disabled="vm.field.isBusy || vm.workPackage.inFlight"
+          ng-disabled="vm.field.isBusy || vm.field.inFlight"
           ng-model="vm.field.fieldVal.raw"
           ng-attr-id="{{vm.htmlId}}">  </textarea>
     <div class="inplace-edit--preview" ng-show="vm.field.isPreview && !vm.field.isBusy">

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -88,7 +88,7 @@ export class WikiTextareaEditField extends EditField {
 
     if (this.isPreview) {
       this.isBusy = true;
-      this.resource.form.$load().then((form:any) => {
+      this.changeset.getForm().then((form:any) => {
         const link = form.previewMarkup.$link;
         this.$http({
           method: link.method,

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -43,7 +43,6 @@ export class WikiTextareaEditField extends EditField {
   protected I18n:op.I18n;
 
   // Values used in template
-  public fieldVal:any;
   public isBusy:boolean = false;
   public isPreview:boolean = false;
   public previewHtml:string;
@@ -54,12 +53,20 @@ export class WikiTextareaEditField extends EditField {
   protected initialize() {
     $injectFields(this, '$sce', '$http', 'TextileService', '$timeout', 'I18n');
 
-    this.fieldVal = this.value;
     this.text = {
       attachmentLabel: this.I18n.t('js.label_formattable_attachment_hint'),
       save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
       cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
     };
+  }
+
+  public get rawValue() {
+    const formatted = this.value;
+    return _.get(formatted, 'raw', '');
+  }
+
+  public set rawValue(val:string) {
+    this.value = { raw: val };
   }
 
   public get isFormattable() {
@@ -82,7 +89,7 @@ export class WikiTextareaEditField extends EditField {
     this.isPreview = !this.isPreview;
     this.previewHtml = '';
 
-    if (!this.fieldVal.raw) {
+    if (!this.rawValue) {
       return;
     }
 
@@ -93,7 +100,7 @@ export class WikiTextareaEditField extends EditField {
         this.$http({
           method: link.method,
           url: link.href,
-          data: this.fieldVal.raw,
+          data: this.rawValue,
           headers: {'Content-Type': 'text/plain; charset=UTF-8'}
         })
           .then(result => {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -46,27 +46,16 @@ export class WikiTextareaEditField extends EditField {
   public isBusy:boolean = false;
   public isPreview:boolean = false;
   public previewHtml:string;
-  public _value:any;
-
   public text:Object;
-
 
   protected initialize() {
     $injectFields(this, '$sce', '$http', 'TextileService', '$timeout', 'I18n');
 
     this.text = {
       attachmentLabel: this.I18n.t('js.label_formattable_attachment_hint'),
-      save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
-      cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
+      save: this.I18n.t('js.inplace.button_save', {attribute: this.schema.name}),
+      cancel: this.I18n.t('js.inplace.button_cancel', {attribute: this.schema.name})
     };
-  }
-
-  public get value() {
-    return this._value;
-  }
-
-  public set value(val:any) {
-    this._value = val;
   }
 
   public get rawValue() {
@@ -75,14 +64,14 @@ export class WikiTextareaEditField extends EditField {
   }
 
   public set rawValue(val:string) {
-    this.value = { raw: val };
+    this.value = {raw: val};
   }
 
   public get isFormattable() {
     return true;
   }
 
-  public isEmpty(): boolean {
+  public isEmpty():boolean {
     return !(this.value && this.value.raw);
   }
 

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -46,6 +46,7 @@ export class WikiTextareaEditField extends EditField {
   public isBusy:boolean = false;
   public isPreview:boolean = false;
   public previewHtml:string;
+  public _value:any;
 
   public text:Object;
 
@@ -58,6 +59,14 @@ export class WikiTextareaEditField extends EditField {
       save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
       cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name })
     };
+  }
+
+  public get value() {
+    return this._value;
+  }
+
+  public set value(val:any) {
+    this._value = val;
   }
 
   public get rawValue() {

--- a/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-wiki-textarea-field.module.ts
@@ -28,6 +28,7 @@
 
 import {EditField} from '../wp-edit-field/wp-edit-field.module';
 import {WorkPackageResource} from '../../api/api-v3/hal-resources/work-package-resource.service';
+import {$injectFields, $injectNow} from '../../angular/angular-injector-bridge.functions';
 
 export class WikiTextareaEditField extends EditField {
 
@@ -35,14 +36,11 @@ export class WikiTextareaEditField extends EditField {
   public template:string = '/components/wp-edit/field-types/wp-edit-wiki-textarea-field.directive.html';
 
   // Dependencies
-  protected $sce:ng.ISCEService = <ng.ISCEService> WikiTextareaEditField.$injector.get('$sce');
-  protected $http:ng.IHttpService = <ng.IHttpService> WikiTextareaEditField.$injector.get('$http');
-  protected TextileService:ng.IServiceProvider = <ng.ISCEProvider> WikiTextareaEditField.$injector.get('TextileService');
-  protected $timeout:ng.ITimeoutService = <ng.ITimeoutService> WikiTextareaEditField.$injector.get('$timeout');
-  protected I18n:op.I18n = <op.I18n> WikiTextareaEditField.$injector.get('I18n');
-
-  // wp resource
-  protected workPackage:WorkPackageResource;
+  protected $sce:ng.ISCEService;
+  protected $http:ng.IHttpService;
+  protected TextileService:ng.IServiceProvider;
+  protected $timeout:ng.ITimeoutService;
+  protected I18n:op.I18n;
 
   // Values used in template
   public fieldVal:any;
@@ -50,14 +48,13 @@ export class WikiTextareaEditField extends EditField {
   public isPreview:boolean = false;
   public previewHtml:string;
 
-  public text: Object;
+  public text:Object;
 
 
-  constructor(workPackage:WorkPackageResource, fieldName:string, schema:op.FieldSchema) {
-    super(workPackage, fieldName, schema);
+  protected initialize() {
+    $injectFields(this, '$sce', '$http', 'TextileService', '$timeout', 'I18n');
 
-    this.fieldVal = workPackage[fieldName];
-    this.workPackage = workPackage;
+    this.fieldVal = this.value;
     this.text = {
       attachmentLabel: this.I18n.t('js.label_formattable_attachment_hint'),
       save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
@@ -91,7 +88,7 @@ export class WikiTextareaEditField extends EditField {
 
     if (this.isPreview) {
       this.isBusy = true;
-      this.workPackage.getForm().then((form:any) => {
+      this.resource.form.$load().then((form:any) => {
         const link = form.previewMarkup.$link;
         this.$http({
           method: link.method,

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
@@ -37,7 +37,7 @@ import {scopeDestroyed$} from '../../../helpers/angular-rx-utils';
 import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 
 export class WorkPackageEditFieldGroupController {
-  public workPackageId:string;
+  public workPackage:WorkPackageResourceInterface
   public inEditMode:boolean;
   public fields:{ [attribute:string]:WorkPackageEditFieldController } = {};
   private registeredFields = input<string[]>();
@@ -67,11 +67,11 @@ export class WorkPackageEditFieldGroupController {
   }
 
   public $onInit() {
-    this.states.workPackages.get(this.workPackageId)
+    this.states.workPackages.get(this.workPackage.id)
       .values$()
       .takeUntil(scopeDestroyed$(this.$scope))
       .subscribe((wp) => {
-        _.each(this.fields, (ctrl) => this.update(ctrl, wp));
+        _.each(this.fields, (ctrl) => this.updateDisplayField(ctrl, wp));
       });
 
     if (this.inEditMode) {
@@ -93,9 +93,9 @@ export class WorkPackageEditFieldGroupController {
       field.activateOnForm(form, true);
     } else {
       this.states.workPackages
-        .get(this.workPackageId)
+        .get(this.workPackage.id)
         .valuesPromise()
-        .then(wp => this.update(field, wp!));
+        .then(wp => this.updateDisplayField(field, wp!));
     }
   }
 
@@ -109,15 +109,15 @@ export class WorkPackageEditFieldGroupController {
   }
 
   public start() {
-    const form = this.wpEditing.startEditing(this.workPackageId, this.editContext, true);
+    const form = this.wpEditing.startEditing(this.workPackage, this.editContext, true);
     _.each(this.fields, ctrl => form.activate(ctrl.fieldName));
   }
 
   public stop() {
-    this.wpEditing.stopEditing(this.workPackageId);
+    this.wpEditing.stopEditing(this.workPackage.id);
   }
 
-  private update(field:WorkPackageEditFieldController, wp:WorkPackageResourceInterface) {
+  private updateDisplayField(field:WorkPackageEditFieldController, wp:WorkPackageResourceInterface) {
     field.workPackage = wp;
     field.render();
   }
@@ -127,7 +127,7 @@ export class WorkPackageEditFieldGroupController {
   }
 
   private get editingForm():WorkPackageEditForm | undefined {
-    const state = this.wpEditing.editState(this.workPackageId);
+    const state = this.wpEditing.editState(this.workPackage.id);
     return state.value;
   }
 
@@ -149,7 +149,7 @@ opWorkPackagesModule.directive('wpEditFieldGroup', function() {
     controller: WorkPackageEditFieldGroupController,
     bindToController: true,
     scope: {
-      workPackageId: '=',
+      workPackage: '=',
       inEditMode: '=?'
     }
   };

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
@@ -126,7 +126,7 @@ export class WorkPackageEditFieldGroupController {
     return new SingleViewEditContext(this);
   }
 
-  private get editingForm():WorkPackageEditForm | undefined {
+  public get editingForm():WorkPackageEditForm | undefined {
     const state = this.wpEditing.editState(this.workPackage.id);
     return state.value;
   }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -42,6 +42,8 @@ import {
 } from '../../wp-edit-form/display-field-renderer';
 import {WorkPackageEditFieldGroupController} from './wp-edit-field-group.directive';
 import {ClickPositionMapper} from '../../common/set-click-position/set-click-position';
+import {WorkPackageEditFieldHandler} from '../../wp-edit-form/work-package-edit-field-handler';
+import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
 
 export class WorkPackageEditFieldController {
   public wpEditFieldGroup:WorkPackageEditFieldGroupController;
@@ -62,6 +64,7 @@ export class WorkPackageEditFieldController {
               protected wpNotificationsService:WorkPackageNotificationService,
               protected ConfigurationService:any,
               protected contextMenu:ContextMenuService,
+              protected wpEditing:WorkPackageEditingService,
               protected wpCacheService:WorkPackageCacheService,
               protected ENTER_KEY:any,
               protected I18n:op.I18n) {
@@ -102,9 +105,10 @@ export class WorkPackageEditFieldController {
     event.stopImmediatePropagation();
   }
 
-  public activate(noWarnings:boolean = false) {
+  public activate(noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
     // Get any existing edit state for this work package
-    const form = this.startEditing();
+    const editContext = new SingleViewEditContext(this.wpEditFieldGroup);
+    const form = this.wpEditing.startEditing(this.workPackage, editContext, false);
 
     return this.activateOnForm(form, noWarnings);
   }
@@ -137,23 +141,6 @@ export class WorkPackageEditFieldController {
 
   public get editContainer() {
     return this.$element.find('.__d_edit_container');
-  }
-
-  /**
-   * Start (or continue) editing the work package and update the edit context.
-   *
-   * @return {WorkPackageEditForm}
-   */
-  private startEditing():WorkPackageEditForm {
-    const editContext = new SingleViewEditContext(this.wpEditFieldGroup);
-    let state = this.states.editing.get(this.workPackage.id);
-    let form = state.value || new WorkPackageEditForm(this.workPackage.id, editContext, this.wpEditFieldGroup.inEditMode);
-    form.editContext = editContext;
-    form.editMode = this.wpEditFieldGroup.inEditMode;
-
-    state.putValue(form);
-
-    return form;
   }
 
   public reset(workPackage:WorkPackageResourceInterface) {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -76,7 +76,7 @@ export class WorkPackageEditFieldController {
   }
 
   public render() {
-    const el = this.fieldRenderer.render(this.workPackage, this.fieldName, this.displayPlaceholder);
+    const el = this.fieldRenderer.render(this.resource, this.fieldName, this.displayPlaceholder);
     this.displayContainer[0].innerHTML = '';
     this.displayContainer[0].appendChild(el);
   }
@@ -91,9 +91,19 @@ export class WorkPackageEditFieldController {
     }
   }
 
+  public get resource() {
+    const form = this.wpEditFieldGroup.editingForm;
+
+    if (form && form.editState.hasValue()) {
+      return form.editState.value!;
+    }
+
+    return this.workPackage;
+  }
+
   public get isEditable() {
-    const fieldSchema = this.workPackage.schema[this.fieldName] as op.FieldSchema;
-    return this.workPackage.isEditable && fieldSchema && fieldSchema.writable;
+    const fieldSchema = this.resource.schema[this.fieldName] as op.FieldSchema;
+    return this.resource.isEditable && fieldSchema && fieldSchema.writable;
   }
 
   public activateIfEditable(event:JQueryEventObject) {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -92,13 +92,9 @@ export class WorkPackageEditFieldController {
   }
 
   public get resource() {
-    const form = this.wpEditFieldGroup.editingForm;
-
-    if (form && form.editState.hasValue()) {
-      return form.editState.value!;
-    }
-
-    return this.workPackage;
+    return this.wpEditing
+      .temporaryEditResource(this.workPackage.id)
+      .getValueOr(this.workPackage);
   }
 
   public get isEditable() {
@@ -116,11 +112,7 @@ export class WorkPackageEditFieldController {
   }
 
   public activate(noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
-    // Get any existing edit state for this work package
-    const editContext = new SingleViewEditContext(this.wpEditFieldGroup);
-    const form = this.wpEditing.startEditing(this.workPackage, editContext, false);
-
-    return this.activateOnForm(form, noWarnings);
+    return this.activateOnForm(this.wpEditFieldGroup.form, noWarnings);
   }
 
   public activateOnForm(form:WorkPackageEditForm, noWarnings:boolean = false) {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.module.ts
@@ -26,16 +26,56 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {HalResource} from '../../api/api-v3/hal-resources/hal-resource.service';
-import {Field} from '../../wp-field/wp-field.module';
-import {FieldFactory} from '../../wp-field/wp-field.module';
+import {Field, FieldFactory} from '../../wp-field/wp-field.module';
+import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export class EditField extends Field {
   public template:string;
+
+  constructor(public changeset:WorkPackageChangeset,
+              public name:string,
+              public schema:op.FieldSchema) {
+    super(changeset.workPackage, name, schema);
+    this.initialize();
+  }
+
+  public get inFlight() {
+    return this.changeset.inFlight;
+  }
+
+  public get value() {
+    return this.changeset.value(this.name);
+  }
+
+  public set value(value:any) {
+    this.changeset.setValue(this.name, this.parseValue(value));
+  }
+
+  /**
+   * Initialize the field after constructor was called.
+   */
+  protected initialize() {
+  }
+
+  /**
+   * Parse the value from the model for setting
+   */
+  protected parseValue(val:any) {
+    return val;
+  }
 }
 
-export class EditFieldFactory extends FieldFactory{
+export class EditFieldFactory extends FieldFactory {
 
-  protected static fields = {};
-  protected static classes = {};
+  public static create(changeset:WorkPackageChangeset,
+                       fieldName:string,
+                       schema:op.FieldSchema):EditField {
+    let type = this.getType(schema.type);
+    let fieldClass = this.classes[type];
+
+    return new fieldClass(changeset, fieldName, schema);
+  }
+
+  protected static fields:{ [field:string]:string } = {};
+  protected static classes:{ [type:string]:typeof EditField } = {};
 }

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.service.ts
@@ -29,10 +29,16 @@
 import {EditFieldFactory} from './wp-edit-field.module';
 import {EditField} from "./wp-edit-field.module";
 import {WorkPackageFieldService} from "../../wp-field/wp-field.service"
+import {WorkPackageEditForm} from '../../wp-edit-form/work-package-edit-form';
+import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageEditFieldService extends WorkPackageFieldService  {
   public static get fieldFactory() {
     return EditFieldFactory;
+  }
+
+  public getField(changeset:WorkPackageChangeset, fieldName:string, schema:op.FieldSchema):EditField {
+    return (this.constructor as typeof WorkPackageEditFieldService).fieldFactory.create(changeset, fieldName, schema);
   }
 }
 

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -15,7 +15,6 @@ import {PrimaryRenderPass, RowRenderInfo} from '../../primary-render-pass';
 import {States} from '../../../../states.service';
 import {$injectFields} from '../../../../angular/angular-injector-bridge.functions';
 import {WorkPackageTableHierarchies} from '../../../wp-table-hierarchies';
-import {RenderInfo} from '../../../../wp-table/timeline/wp-timeline';
 
 export class HierarchyRenderPass extends PrimaryRenderPass {
   public states:States;

--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -13,6 +13,7 @@ import {UiStateLinkBuilder} from '../../ui-state-link-builder';
 import {QueryColumn} from '../../../../wp-query/query-column';
 import {SingleRowBuilder} from '../../rows/single-row-builder';
 import {States} from '../../../../states.service';
+import {WorkPackageChangeset} from '../../../../wp-edit-form/work-package-changeset';
 
 export const indicatorCollapsedClass = '-hierarchy-collapsed';
 export const hierarchyCellClassName = 'wp-table--hierarchy-span';
@@ -46,9 +47,9 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
    * Refresh a single row after structural changes.
    * Remembers and re-adds the hierarchy indicator if neccessary.
    */
-  public refreshRow(workPackage:WorkPackageResourceInterface, editForm:WorkPackageEditForm|undefined, jRow:JQuery):JQuery {
+  public refreshRow(workPackage:WorkPackageResourceInterface, changeset:WorkPackageChangeset, jRow:JQuery):JQuery {
     // Remove any old hierarchy
-    const newRow = super.refreshRow(workPackage, editForm, jRow);
+    const newRow = super.refreshRow(workPackage, changeset, jRow);
     newRow.find(`.wp-table--hierarchy-span`).remove();
     this.appendHierarchyIndicator(workPackage, newRow);
 

--- a/frontend/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -6,6 +6,7 @@ import {TimelineRenderPass} from './timeline/timeline-render-pass';
 import {SingleRowBuilder} from './rows/single-row-builder';
 import {RelationRenderInfo, RelationsRenderPass} from './relations/relations-render-pass';
 import {timeOutput} from '../../../helpers/debug_output';
+import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
 
 export type RenderedRowType = 'primary' | 'relations';
 
@@ -30,6 +31,7 @@ export interface RowRenderInfo {
 export type RenderedRow = { classIdentifier:string, workPackageId:string|null, hidden:boolean };
 
 export abstract class PrimaryRenderPass {
+  public wpEditing:WorkPackageEditingService;
   public states:States;
   public I18n:op.I18n;
 
@@ -47,7 +49,7 @@ export abstract class PrimaryRenderPass {
 
   constructor(public workPackageTable:WorkPackageTable,
               public rowBuilder:SingleRowBuilder) {
-    $injectFields(this, 'states', 'I18n');
+    $injectFields(this, 'states', 'I18n', 'wpEditing');
 
   }
 
@@ -88,7 +90,7 @@ export abstract class PrimaryRenderPass {
   public refresh(row:RowRenderInfo, workPackage:WorkPackageResourceInterface, body:HTMLElement) {
     let oldRow = jQuery(body).find(`.${row.classIdentifier}`);
     let replacement:JQuery|null = null;
-    let editing = undefined; // TODO this.states.editing.get(row.workPackage!.id).value;
+    let editing = this.wpEditing.changesetFor(workPackage);
 
     switch(row.renderType) {
       case 'primary':

--- a/frontend/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -88,7 +88,7 @@ export abstract class PrimaryRenderPass {
   public refresh(row:RowRenderInfo, workPackage:WorkPackageResourceInterface, body:HTMLElement) {
     let oldRow = jQuery(body).find(`.${row.classIdentifier}`);
     let replacement:JQuery|null = null;
-    let editing = this.states.editing.get(row.workPackage!.id).value;
+    let editing = undefined; // TODO this.states.editing.get(row.workPackage!.id).value;
 
     switch(row.renderType) {
       case 'primary':

--- a/frontend/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
+++ b/frontend/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
@@ -11,6 +11,7 @@ import {WorkPackageRelationsService} from '../../../wp-relations/wp-relations.se
 import {WorkPackageEditForm} from '../../../wp-edit-form/work-package-edit-form';
 import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
 import {RelationResource} from '../../../api/api-v3/hal-resources/relation-resource.service';
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 
 export interface RelationRenderInfo extends RowRenderInfo {
   data:{
@@ -102,9 +103,9 @@ export class RelationsRenderPass {
 
   public refreshRelationRow(renderedRow:RelationRenderInfo,
                             workPackage:WorkPackageResourceInterface,
-                            editing:WorkPackageEditForm | undefined,
+                            changeset:WorkPackageChangeset,
                             oldRow:JQuery) {
-    const newRow = this.relationRowBuilder.refreshRow(workPackage, editing, oldRow);
+    const newRow = this.relationRowBuilder.refreshRow(workPackage, changeset, oldRow);
     this.relationRowBuilder.appendRelationLabel(newRow,
       renderedRow.belongsTo!,
       renderedRow.data.relation,

--- a/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -12,6 +12,7 @@ import {WorkPackageTable} from '../../wp-fast-table';
 import {isRelationColumn, QueryColumn} from '../../../wp-query/query-column';
 import {RelationCellbuilder} from '../relation-cell-builder';
 import {WorkPackageEditForm} from '../../../wp-edit-form/work-package-edit-form';
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 
 // Work package table row entries
 export const tableRowClassName = 'wp-table--row';
@@ -107,7 +108,7 @@ export class SingleRowBuilder {
   /**
    * Refresh a row that is currently being edited, that is, some edit fields may be open
    */
-  public refreshRow(workPackage:WorkPackageResourceInterface, editForm:WorkPackageEditForm|undefined, jRow:JQuery):JQuery {
+  public refreshRow(workPackage:WorkPackageResourceInterface, changeset:WorkPackageChangeset, jRow:JQuery):JQuery {
     // Detach all current edit cells
     const cells = jRow.find(`.${wpCellTdClassName}`).detach();
 
@@ -118,7 +119,7 @@ export class SingleRowBuilder {
       const oldTd = cells.filter(`td.${column.id}`);
 
       // Skip the replacement of the column if this is being edited.
-      if (this.isColumnBeingEdited(editForm, column)) {
+      if (this.isColumnBeingEdited(changeset, column)) {
         newCells.push(oldTd[0]);
         return;
       }
@@ -132,8 +133,8 @@ export class SingleRowBuilder {
     return jRow;
   }
 
-  protected isColumnBeingEdited(editForm:WorkPackageEditForm | undefined, column:QueryColumn) {
-    return editForm && editForm.activeFields[column.id];
+  protected isColumnBeingEdited(changeset:WorkPackageChangeset, column:QueryColumn) {
+    return changeset && changeset.isOverridden(column.id);
   }
 
   protected buildEmptyRow(workPackage:WorkPackageResourceInterface, row:HTMLElement):[HTMLElement, boolean] {

--- a/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -54,12 +54,13 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
     const rowElement = target.closest(`.${tableRowClassName}`);
     // Get the work package we're editing
     const workPackageId = rowElement.data('workPackageId');
+    const workPackage = this.states.workPackages.get(workPackageId).value!;
     // Get the row context
     const classIdentifier = rowElement.data('classIdentifier');
 
     // Get any existing edit state for this work package
     const editContext = new TableRowEditContext(workPackageId, classIdentifier);
-    const form = this.wpEditing.startEditing(workPackageId, editContext);
+    const form = this.wpEditing.startEditing(workPackage, editContext);
 
     // Get the position where the user clicked.
     const positionOffset = ClickPositionMapper.getPosition(evt);

--- a/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../wp-edit-form/display-field-renderer';
 import {WorkPackageEditingService} from '../../../wp-edit-form/work-package-editing-service';
 import {ClickPositionMapper} from '../../../common/set-click-position/set-click-position';
+import {WorkPackageEditForm} from '../../../wp-edit-form/work-package-edit-form';
 
 export class EditCellHandler extends ClickOrEnterHandler implements TableEventHandler {
   // Injections
@@ -60,7 +61,7 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
 
     // Get any existing edit state for this work package
     const editContext = new TableRowEditContext(workPackageId, classIdentifier);
-    const form = this.wpEditing.startEditing(workPackage, editContext);
+    const form = WorkPackageEditForm.createInContext(editContext, workPackage, false);
 
     // Get the position where the user clicked.
     const positionOffset = ClickPositionMapper.getPosition(evt);

--- a/frontend/app/components/wp-field/wp-field.module.ts
+++ b/frontend/app/components/wp-field/wp-field.module.ts
@@ -40,10 +40,6 @@ export class Field {
     return this.resource[this.name];
   }
 
-  public set value(value) {
-    this.resource[this.name] = value;
-  }
-
   public get type():string {
     return (this.constructor as typeof Field).type;
   }
@@ -86,20 +82,20 @@ export class FieldFactory {
   public static defaultType:string;
 
   protected static fields:{[field:string]: string} = {};
-  protected static classes:{[type:string]: typeof Field} = {};
+  protected static classes:{[type:string]: any} = {};
 
   public static register(fieldClass:typeof Field, fields:string[] = []) {
     fields.forEach((field:string) => this.fields[field] = fieldClass.type);
     this.classes[fieldClass.type] = fieldClass;
   }
 
-  public static create(workPackage:HalResource,
+  public static create(resource:any,
                        fieldName:string,
                        schema:op.FieldSchema):Field {
     let type = this.getType(schema.type);
     let fieldClass = this.classes[type];
 
-    return new fieldClass(workPackage, fieldName, schema);
+    return new fieldClass(resource, fieldName, schema);
   }
 
   public static getClassFor(fieldName:string):typeof Field {

--- a/frontend/app/components/wp-field/wp-field.service.ts
+++ b/frontend/app/components/wp-field/wp-field.service.ts
@@ -42,7 +42,7 @@ export class WorkPackageFieldService {
   constructor(protected $injector:ng.auto.IInjectorService) {
   }
 
-  public getField(resource:HalResource, fieldName:string, schema:op.FieldSchema):Field {
+  public getField(resource:any, fieldName:string, schema:op.FieldSchema):Field {
     return (this.constructor as typeof WorkPackageFieldService).fieldFactory.create(resource, fieldName, schema);
   }
 
@@ -50,7 +50,7 @@ export class WorkPackageFieldService {
     return (this.constructor as typeof WorkPackageFieldService).fieldFactory.getType(name);
   }
 
-  public addFieldType(fieldClass:typeof Field, displayType:string, fields:string[]) {
+  public addFieldType(fieldClass:any, displayType:string, fields:string[]) {
     fieldClass.type = displayType;
     fieldClass.$injector = this.$injector;
     (this.constructor as typeof WorkPackageFieldService).fieldFactory.register(fieldClass, fields);

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -115,7 +115,7 @@ export class WorkPackageInlineCreateController {
         const rowElement = this.$element.find(`.${inlineCreateRowClassName}`);
 
         if (rowElement.length && this.currentWorkPackage) {
-          this.rowBuilder.refreshRow(this.currentWorkPackage, this.workPackageEditForm, rowElement);
+          this.rowBuilder.refreshRow(this.currentWorkPackage, this.workPackageEditForm!.changeset, rowElement);
         }
     });
 

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -35,15 +35,14 @@ import {QueryFilterInstanceResource} from '../api/api-v3/hal-resources/query-fil
 import {WorkPackageCreateService} from "../wp-create/wp-create.service";
 import {WorkPackageCacheService} from "../work-packages/work-package-cache.service";
 import {
-  InlineCreateRowBuilder, inlineCreateCancelClassName,
+  inlineCreateCancelClassName,
+  InlineCreateRowBuilder,
   inlineCreateRowClassName
 } from "./inline-create-row-builder";
 import {scopeDestroyed$, scopedObservable} from "../../helpers/angular-rx-utils";
 import {States} from "../states.service";
 import {WorkPackageEditForm} from "../wp-edit-form/work-package-edit-form";
 import {WorkPackageTable} from "../wp-fast-table/wp-fast-table";
-import {WorkPackageTableRow} from "../wp-fast-table/wp-table.interfaces";
-import {WorkPackageTableTimelineService} from "../wp-fast-table/state/wp-table-timeline.service";
 import {TimelineRowBuilder} from '../wp-fast-table/builders/timeline/timeline-row-builder';
 import {TableRowEditContext} from '../wp-edit-form/table-row-edit-context';
 import {WorkPackageChangeset} from '../wp-edit-form/work-package-changeset';
@@ -149,8 +148,8 @@ export class WorkPackageInlineCreateController {
         this.wpCacheService.updateWorkPackage(this.currentWorkPackage!);
 
         // Set editing context to table
-        const editContext = new TableRowEditContext(wp.id, this.rowBuilder.classIdentifier(wp));
-        this.workPackageEditForm = this.wpEditing.startEditing(wp, editContext, false, changeset);
+        const context = new TableRowEditContext(wp.id, this.rowBuilder.classIdentifier(wp));
+        this.workPackageEditForm = WorkPackageEditForm.createInContext(context, wp, false);
 
         const row = this.rowBuilder.buildNew(wp, this.workPackageEditForm);
         this.timelineBuilder.insert('new', this.table.timelineBody);
@@ -203,7 +202,7 @@ export class WorkPackageInlineCreateController {
 
   public removeWorkPackageRow() {
     this.currentWorkPackage = null;
-    this.states.editing.get('new').clear();
+    this.wpEditing.stopEditing('new');
     this.states.workPackages.get('new').clear();
     this.$element.find('.wp-row-new').remove();
     jQuery(this.table.timelineBody).find('.wp-row-new-timeline').remove();

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -147,7 +147,7 @@ export class WorkPackageInlineCreateController {
 
         // Set editing context to table
         const editContext = new TableRowEditContext(wp.id, this.rowBuilder.classIdentifier(wp));
-        this.workPackageEditForm = new WorkPackageEditForm('new', editContext);
+        this.workPackageEditForm = new WorkPackageEditForm(wp, editContext);
         this.states.editing.get(wp.id).putValue(this.workPackageEditForm);
 
 

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -150,6 +150,7 @@ export class WorkPackageInlineCreateController {
         // Set editing context to table
         const context = new TableRowEditContext(wp.id, this.rowBuilder.classIdentifier(wp));
         this.workPackageEditForm = WorkPackageEditForm.createInContext(context, wp, false);
+        this.workPackageEditForm.changeset.clear();
 
         const row = this.rowBuilder.buildNew(wp, this.workPackageEditForm);
         this.timelineBuilder.insert('new', this.table.timelineBody);

--- a/frontend/app/components/wp-panels/overview-panel/overview-panel.directive.html
+++ b/frontend/app/components/wp-panels/overview-panel/overview-panel.directive.html
@@ -1,4 +1,4 @@
-<wp-single-view work-package="$ctrl.workPackage" ng-if="$ctrl-workPackage"></wp-single-view>
+<wp-single-view work-package="$ctrl.workPackage" ng-if="$ctrl.workPackage"></wp-single-view>
 
 <div class="attributes-group" ng-if="$ctrl.workPackage">
   <div class="attributes-group--header">

--- a/frontend/app/components/wp-panels/overview-panel/overview-panel.directive.html
+++ b/frontend/app/components/wp-panels/overview-panel/overview-panel.directive.html
@@ -1,4 +1,4 @@
-<wp-single-view></wp-single-view>
+<wp-single-view work-package="$ctrl.workPackage" ng-if="$ctrl-workPackage"></wp-single-view>
 
 <div class="attributes-group" ng-if="$ctrl.workPackage">
   <div class="attributes-group--header">

--- a/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -140,8 +140,8 @@ export class TimelineCellRenderer {
       return 'both'; // irrelevant
     }
 
-    renderInfo.changeset!.startEditing("startDate");
-    renderInfo.changeset!.startEditing("dueDate");
+    renderInfo.changeset.startEditing("startDate");
+    renderInfo.changeset.startEditing("dueDate");
     let direction:"left" | "right" | "both" | "create" | "dragright";
 
     // Update the cursor and maybe set start/due values
@@ -178,7 +178,7 @@ export class TimelineCellRenderer {
     // if (!jQuery(ev.target).hasClass(classNameLeftHandle) && renderInfo.workPackage.dueDate) {
     // }
 
-    this.updateLabels(true, labels, renderInfo.changeset!);
+    this.updateLabels(true, labels, renderInfo.changeset);
 
     return direction;
   }
@@ -338,7 +338,7 @@ export class TimelineCellRenderer {
     containerRight.appendChild(labelFarRight);
 
     const labels = new WorkPackageCellLabels(labelCenter, labelLeft, labelRight, labelFarRight);
-    this.updateLabels(false, labels, renderInfo.changeset!);
+    this.updateLabels(false, labels, renderInfo.changeset);
 
     return labels;
   }

--- a/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -144,8 +144,6 @@ export class TimelineCellRenderer {
     }
 
     const changeset = renderInfo.changeset;
-    changeset.startEditing("startDate");
-    changeset.startEditing("dueDate");
     let direction:"left" | "right" | "both" | "create" | "dragright";
 
     // Update the cursor and maybe set start/due values

--- a/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -64,13 +64,13 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
   /**
    * Handle movement by <delta> days of milestone.
    */
-  public onDaysMoved(wp:WorkPackageResourceInterface,
+  public onDaysMoved(changeset:WorkPackageChangeset,
                      dayUnderCursor:Moment,
                      delta:number,
                      direction:'left' | 'right' | 'both' | 'create' | 'dragright') {
 
-    const initialDate = wp.date;
-    let dates: CellMilestoneMovement = {};
+    const initialDate = changeset.workPackage.date;
+    let dates:CellMilestoneMovement = {};
 
     if (initialDate) {
       dates.date = moment(initialDate).add(delta, 'days');

--- a/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -9,6 +9,7 @@ import {
   WorkPackageCellLabels
 } from './wp-timeline-cell';
 import Moment = moment.Moment;
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 
 interface CellMilestoneMovement {
   // Target value to move milestone to
@@ -52,19 +53,12 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
    * For generic work packages, assigns start and due date.
    *
    */
-  public assignDateValues(wp:WorkPackageResourceInterface,
+  public assignDateValues(changeset:WorkPackageChangeset,
                           labels:WorkPackageCellLabels,
                           dates:CellMilestoneMovement) {
 
-    this.assignDate(wp, 'date', dates.date!);
-    this.updateLabels(true, labels, wp!);
-  }
-
-  /**
-   * Restore the original date, if any was set.
-   */
-  public onCancel(wp:WorkPackageResourceInterface) {
-    wp.restoreFromPristine('date');
+    this.assignDate(changeset, 'date', dates.date!);
+    this.updateLabels(true, labels, changeset);
   }
 
   /**
@@ -75,8 +69,8 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
                      delta:number,
                      direction:'left' | 'right' | 'both' | 'create' | 'dragright') {
 
-    const initialDate = wp.$pristine['date'];
-    let dates:CellMilestoneMovement = {};
+    const initialDate = wp.date;
+    let dates: CellMilestoneMovement = {};
 
     if (initialDate) {
       dates.date = moment(initialDate).add(delta, 'days');
@@ -98,8 +92,8 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
       return 'both'; // irrelevant
     }
 
-    let direction:'left' | 'right' | 'both' | 'create' | 'dragright' = 'both';
-    renderInfo.workPackage.storePristine('date');
+    let direction: "left" | "right" | "both" | "create" | "dragright" = "both";
+    renderInfo.changeset!.startEditing('date');
     this.forceCursor('ew-resize');
 
     if (dateForCreate) {
@@ -108,29 +102,30 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
       return direction;
     }
 
-    this.updateLabels(true, labels, renderInfo.workPackage);
+    this.updateLabels(true, labels, renderInfo.changeset!);
 
     return direction;
   }
 
-  public update(timelineCell:HTMLElement, element:HTMLDivElement, renderInfo:RenderInfo):boolean {
-    const wp = renderInfo.workPackage;
-    const viewParams = renderInfo.viewParams;
-    const date = moment(wp.date as any);
+  public update(element: HTMLDivElement, renderInfo: RenderInfo): boolean {
+    const changeset = renderInfo.changeset || new WorkPackageChangeset(renderInfo.workPackage);
 
-    // abort if no start or due date
-    if (!wp.date) {
+    const viewParams = renderInfo.viewParams;
+    const date = moment(changeset.value('dueDate'));
+
+    // abort if no date
+    if (!date) {
       return false;
     }
 
     const diamond = jQuery('.diamond', element)[0];
 
-    element.style.width = 15 + 'px';
-    element.style.height = 15 + 'px';
-    diamond.style.width = 15 + 'px';
-    diamond.style.height = 15 + 'px';
-    diamond.style.marginLeft = -(15 / 2) + (renderInfo.viewParams.pixelPerDay / 2) + 'px';
-    diamond.style.backgroundColor = this.typeColor(wp);
+    element.style.width = 15 + "px";
+    element.style.height = 15 + "px";
+    diamond.style.width = 15 + "px";
+    diamond.style.height = 15 + "px";
+    diamond.style.marginLeft = -(15 / 2) + (renderInfo.viewParams.pixelPerDay / 2) + "px";
+    diamond.style.backgroundColor = this.typeColor(renderInfo.workPackage);
 
     // offset left
     const offsetStart = date.diff(viewParams.dateDisplayStart, 'days');
@@ -200,19 +195,22 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     containerRight.appendChild(labelFarRight);
 
     const labels = new WorkPackageCellLabels(null, labelLeft, labelRight, labelFarRight);
-    this.updateLabels(false, labels, renderInfo.workPackage);
+    this.updateLabels(false, labels, renderInfo.changeset!);
 
     return labels;
   }
 
-  protected updateLabels(activeDragNDrop:boolean, labels:WorkPackageCellLabels, workPackage:WorkPackageResourceInterface) {
+  protected updateLabels(activeDragNDrop:boolean,
+                         labels:WorkPackageCellLabels,
+                         changeset:WorkPackageChangeset) {
 
     if (!this.TimezoneService) {
       this.TimezoneService = $injectNow('TimezoneService');
     }
 
-    const subject:string = workPackage.subject;
-    const date:Moment | null = workPackage.date ? moment(workPackage.date) : null;
+    const subject:string = changeset.value('subject');
+    const dateStr = changeset.value('date');
+    const date:Moment | null = dateStr ? moment(dateStr) : null;
 
     if (!activeDragNDrop) {
       // normal display

--- a/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -93,7 +93,6 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     }
 
     let direction: "left" | "right" | "both" | "create" | "dragright" = "both";
-    renderInfo.changeset.startEditing('date');
     this.forceCursor('ew-resize');
 
     if (dateForCreate) {

--- a/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -93,7 +93,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     }
 
     let direction: "left" | "right" | "both" | "create" | "dragright" = "both";
-    renderInfo.changeset!.startEditing('date');
+    renderInfo.changeset.startEditing('date');
     this.forceCursor('ew-resize');
 
     if (dateForCreate) {
@@ -102,7 +102,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
       return direction;
     }
 
-    this.updateLabels(true, labels, renderInfo.changeset!);
+    this.updateLabels(true, labels, renderInfo.changeset);
 
     return direction;
   }
@@ -195,7 +195,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     containerRight.appendChild(labelFarRight);
 
     const labels = new WorkPackageCellLabels(null, labelLeft, labelRight, labelFarRight);
-    this.updateLabels(false, labels, renderInfo.changeset!);
+    this.updateLabels(false, labels, renderInfo.changeset);
 
     return labels;
   }

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -210,18 +210,18 @@ export function registerWorkPackageMouseHandler(this: void,
     mouseDownStartDay = null;
     dateStates = {};
 
-    renderer.onMouseDownEnd(labels, renderInfo.changeset);
-
     // const renderInfo = getRenderInfo();
     if (cancelled) {
       renderInfo.changeset.clear();
       renderer.update(bar, renderInfo);
+      renderer.onMouseDownEnd(labels, renderInfo.changeset);
       workPackageTimeline.refreshView();
     } else if (!renderInfo.changeset.empty) {
       // Persist the changes
       saveWorkPackage(renderInfo.changeset)
         .finally(() => {
           renderInfo.changeset.clear();
+          renderer.onMouseDownEnd(labels, renderInfo.changeset);
           workPackageTimeline.refreshView();
         });
     }

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -149,7 +149,6 @@ export function registerWorkPackageMouseHandler(this: void,
     // abort if mouse leaves cell
     cell.onmouseleave = () => {
       placeholderForEmptyCell.remove();
-      deactivate(true);
     };
 
     // create logic

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -78,7 +78,7 @@ export function registerWorkPackageMouseHandler(this: void,
 
   function applyDateValues(renderInfo:RenderInfo, dates:{[name:string]: Moment}) {
     // Let the renderer decide which fields we change
-    renderer.assignDateValues(renderInfo.changeset!, labels, dates);
+    renderer.assignDateValues(renderInfo.changeset, labels, dates);
   }
 
   function getCursorOffsetInDaysFromLeft(renderInfo:RenderInfo, ev:MouseEvent) {
@@ -174,7 +174,7 @@ export function registerWorkPackageMouseHandler(this: void,
         const dayUnderCursor = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayCurrent, 'days');
         const widthInDays = offsetDayCurrent - offsetDayStart;
         const moved = renderer.onDaysMoved(wp, dayUnderCursor, widthInDays, mouseDownType);
-        renderer.assignDateValues(renderInfo.changeset!, labels, moved);
+        renderer.assignDateValues(renderInfo.changeset, labels, moved);
         wpCacheService.updateWorkPackage(wp);
         renderer.update(bar, renderInfo);
       };
@@ -211,7 +211,7 @@ export function registerWorkPackageMouseHandler(this: void,
     mouseDownStartDay = null;
     dateStates = {};
 
-    renderer.onMouseDownEnd(labels, renderInfo.changeset!);
+    renderer.onMouseDownEnd(labels, renderInfo.changeset);
 
     // const renderInfo = getRenderInfo();
     const wp = renderInfo.workPackage;
@@ -221,10 +221,10 @@ export function registerWorkPackageMouseHandler(this: void,
       workPackageTimeline.refreshView();
     } else {
       // Persist the changes
-      saveWorkPackage(renderInfo.changeset!);
+      saveWorkPackage(renderInfo.changeset);
     }
 
-    delete renderInfo.changeset;
+    renderInfo.changeset.clear();
   }
 
   function saveWorkPackage(changeset:WorkPackageChangeset) {

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -27,7 +27,6 @@
 // ++
 
 import * as moment from 'moment';
-import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
 import {keyCodes} from '../../../common/keyCodes.enum';
 import {LoadingIndicatorService} from '../../../common/loading-indicator/loading-indicator.service';
 import {WorkPackageCacheService} from '../../../work-packages/work-package-cache.service';
@@ -36,6 +35,8 @@ import {WorkPackageTimelineTableController} from '../container/wp-timeline-conta
 import {RenderInfo, timelineElementCssClass} from '../wp-timeline';
 import {TimelineCellRenderer} from './timeline-cell-renderer';
 import {WorkPackageCellLabels} from './wp-timeline-cell';
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
+import {WorkPackageNotificationService} from '../../../wp-edit/wp-notification.service';
 import Moment = moment.Moment;
 
 const classNameBar = 'bar';
@@ -44,19 +45,21 @@ export const classNameRightHandle = 'rightHandle';
 export const classNameBarLabel = 'bar-label';
 
 
-export function registerWorkPackageMouseHandler(this:void,
-                                                getRenderInfo:() => RenderInfo,
-                                                workPackageTimeline:WorkPackageTimelineTableController,
-                                                wpCacheService:WorkPackageCacheService,
-                                                wpTableRefresh:WorkPackageTableRefreshService,
-                                                loadingIndicator:LoadingIndicatorService,
-                                                cell:HTMLElement,
-                                                bar:HTMLDivElement,
+export function registerWorkPackageMouseHandler(this: void,
+                                                getRenderInfo: () => RenderInfo,
+                                                workPackageTimeline: WorkPackageTimelineTableController,
+                                                wpCacheService: WorkPackageCacheService,
+                                                wpTableRefresh: WorkPackageTableRefreshService,
+                                                wpNotificationsService: WorkPackageNotificationService,
+                                                loadingIndicator: LoadingIndicatorService,
+                                                cell: HTMLElement,
+                                                bar: HTMLDivElement,
                                                 labels:WorkPackageCellLabels,
-                                                renderer:TimelineCellRenderer,
-                                                renderInfo:RenderInfo) {
+                                                renderer: TimelineCellRenderer,
+                                                renderInfo: RenderInfo) {
 
   let mouseDownStartDay:number | null = null; // also flag to signal active drag'n'drop
+  renderInfo.changeset = new WorkPackageChangeset(renderInfo.workPackage);
 
   let dateStates:any;
   let placeholderForEmptyCell:HTMLElement;
@@ -73,14 +76,9 @@ export function registerWorkPackageMouseHandler(this:void,
   // handles initial creation of start/due values
   cell.onmousemove = handleMouseMoveOnEmptyCell;
 
-  function applyDateValues(dates:{ [name:string]:Moment }) {
-    const wp = renderInfo.workPackage;
-
+  function applyDateValues(renderInfo:RenderInfo, dates:{[name:string]: Moment}) {
     // Let the renderer decide which fields we change
-    renderer.assignDateValues(wp, labels, dates);
-
-    // Update the work package to refresh dates columns
-    wpCacheService.updateWorkPackage(wp);
+    renderer.assignDateValues(renderInfo.changeset!, labels, dates);
   }
 
   function getCursorOffsetInDaysFromLeft(renderInfo:RenderInfo, ev:MouseEvent) {
@@ -124,8 +122,9 @@ export function registerWorkPackageMouseHandler(this:void,
       const dayUnderCursor = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayCurrent, 'days');
 
       dateStates = renderer.onDaysMoved(renderInfo.workPackage, dayUnderCursor, days, direction);
-      applyDateValues(dateStates);
-    };
+      applyDateValues(renderInfo, dateStates);
+      renderer.update(bar, renderInfo);
+    }
   }
 
   function keyPressFn(ev:JQueryEventObject) {
@@ -162,7 +161,7 @@ export function registerWorkPackageMouseHandler(this:void,
       const clickStart = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayStart, 'days');
       const dateForCreate = clickStart.format('YYYY-MM-DD');
       const mouseDownType = renderer.onMouseDown(ev, dateForCreate, renderInfo, labels, bar);
-      renderer.update(cell, bar, renderInfo);
+      renderer.update(bar, renderInfo);
 
       if (mouseDownType === 'create') {
         deactivate(false);
@@ -175,9 +174,9 @@ export function registerWorkPackageMouseHandler(this:void,
         const dayUnderCursor = renderInfo.viewParams.dateDisplayStart.clone().add(offsetDayCurrent, 'days');
         const widthInDays = offsetDayCurrent - offsetDayStart;
         const moved = renderer.onDaysMoved(wp, dayUnderCursor, widthInDays, mouseDownType);
-        renderer.assignDateValues(wp, labels, moved);
+        renderer.assignDateValues(renderInfo.changeset!, labels, moved);
         wpCacheService.updateWorkPackage(wp);
-
+        renderer.update(bar, renderInfo);
       };
 
       cell.onmouseleave = () => {
@@ -212,36 +211,30 @@ export function registerWorkPackageMouseHandler(this:void,
     mouseDownStartDay = null;
     dateStates = {};
 
-    renderer.onMouseDownEnd(labels, renderInfo.workPackage);
+    renderer.onMouseDownEnd(labels, renderInfo.changeset!);
 
     // const renderInfo = getRenderInfo();
     const wp = renderInfo.workPackage;
     if (cancelled) {
-      // cancelled
-      renderer.onCancel(wp);
       wpCacheService.updateWorkPackage(wp);
+      renderer.update(bar, renderInfo);
       workPackageTimeline.refreshView();
     } else {
       // Persist the changes
-      saveWorkPackage(wp);
+      saveWorkPackage(renderInfo.changeset!);
     }
+
+    delete renderInfo.changeset;
   }
 
-  function saveWorkPackage(workPackage:WorkPackageResourceInterface) {
-    if (!(workPackage.dirty || workPackage.isNew)) {
-      return;
-    }
-
-    loadingIndicator.table.promise = wpCacheService.saveWorkPackage(workPackage)
+  function saveWorkPackage(changeset:WorkPackageChangeset) {
+    loadingIndicator.table.promise = changeset.save()
       .then(() => {
-        wpTableRefresh.request(true, `Moved work package ${workPackage.id} through timeline`);
+        wpTableRefresh.request(true, `Moved work package ${changeset.workPackage.id} through timeline`);
       })
-      .catch(() => {
-        if (!workPackage.isNew) {
-          // Reset the changes on error
-          renderer.onCancel(workPackage);
-        }
-
+      .catch((error) => {
+        changeset.clear();
+        wpNotificationsService.handleErrorResponse(error, renderInfo.workPackage);
         workPackageTimeline.refreshView();
       });
   }

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -217,7 +217,7 @@ export function registerWorkPackageMouseHandler(this: void,
       renderInfo.changeset.clear();
       renderer.update(bar, renderInfo);
       workPackageTimeline.refreshView();
-    } else {
+    } else if (!renderInfo.changeset.empty) {
       // Persist the changes
       saveWorkPackage(renderInfo.changeset)
         .finally(() => {

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
@@ -25,7 +25,6 @@
 //
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
-import {injectorBridge} from '../../../angular/angular-injector-bridge.functions';
 import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
 import {LoadingIndicatorService} from '../../../common/loading-indicator/loading-indicator.service';
 import {States} from '../../../states.service';
@@ -36,6 +35,8 @@ import {RenderInfo} from '../wp-timeline';
 import {TimelineCellRenderer} from './timeline-cell-renderer';
 import {TimelineMilestoneCellRenderer} from './timeline-milestone-cell-renderer';
 import {registerWorkPackageMouseHandler} from './wp-timeline-cell-mouse-handler';
+import {WorkPackageNotificationService} from '../../../wp-edit/wp-notification.service';
+import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
 
 export const classNameLeftLabel = 'labelLeft';
 export const classNameRightContainer = 'containerRight';
@@ -56,6 +57,7 @@ export class WorkPackageCellLabels {
 export class WorkPackageTimelineCell {
   public wpCacheService:WorkPackageCacheService;
   public wpTableRefresh:WorkPackageTableRefreshService;
+  public wpNotificationsService:WorkPackageNotificationService;
   public states:States;
   public loadingIndicator:LoadingIndicatorService;
 
@@ -64,7 +66,6 @@ export class WorkPackageTimelineCell {
   private elementShape:string;
 
   private timelineCell:JQuery;
-
   private labels:WorkPackageCellLabels;
 
   constructor(public workPackageTimeline:WorkPackageTimelineTableController,
@@ -72,7 +73,8 @@ export class WorkPackageTimelineCell {
               public latestRenderInfo:RenderInfo,
               public classIdentifier:string,
               public workPackageId:string) {
-    injectorBridge(this);
+    $injectFields(this, 'loadingIndicator', 'wpCacheService', 'wpNotificationsService',
+      'wpTableRefresh', 'states', 'TimezoneService');
   }
 
   getMarginLeftOfLeftSide():number {
@@ -148,6 +150,7 @@ export class WorkPackageTimelineCell {
         this.workPackageTimeline,
         this.wpCacheService,
         this.wpTableRefresh,
+        this.wpNotificationsService,
         this.loadingIndicator,
         cell[0],
         this.wpElement,
@@ -175,12 +178,12 @@ export class WorkPackageTimelineCell {
     const cell = this.lazyInit(renderer, renderInfo);
 
     // Render the upgrade from renderInfo
-    const shouldBeDisplayed = renderer.update(cell[0], this.wpElement as HTMLDivElement, renderInfo);
+    const shouldBeDisplayed = renderer.update(
+      this.wpElement as HTMLDivElement,
+      renderInfo);
     if (!shouldBeDisplayed) {
       this.clear();
     }
   }
 
 }
-
-WorkPackageTimelineCell.$inject = ['loadingIndicator', 'wpCacheService', 'wpTableRefresh', 'states', 'TimezoneService'];

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cells-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cells-renderer.ts
@@ -33,6 +33,7 @@ import {WorkPackageTimelineTableController} from '../container/wp-timeline-conta
 import {$injectFields} from '../../../angular/angular-injector-bridge.functions';
 import {WorkPackageTimelineCell} from './wp-timeline-cell';
 import {RenderedRow} from '../../../wp-fast-table/builders/primary-render-pass';
+import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 
 export class WorkPackageTimelineCellsRenderer {
   // Injections
@@ -134,9 +135,11 @@ export class WorkPackageTimelineCellsRenderer {
   }
 
   private renderInfoFor(wpId:string):RenderInfo {
+    const wp = this.states.workPackages.get(wpId).value!;
     return {
       viewParams: this.wpTimeline.viewParameters,
-      workPackage: this.states.workPackages.get(wpId).value!
+      workPackage: wp,
+      changeset: new WorkPackageChangeset(wp)
     } as RenderInfo;
   }
 }

--- a/frontend/app/components/wp-table/timeline/wp-timeline.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline.ts
@@ -106,7 +106,7 @@ export class TimelineViewParameters {
 export interface RenderInfo {
   viewParams:TimelineViewParameters;
   workPackage:WorkPackageResourceInterface;
-  changeset?:WorkPackageChangeset;
+  changeset:WorkPackageChangeset;
 }
 
 /**

--- a/frontend/app/components/wp-table/timeline/wp-timeline.ts
+++ b/frontend/app/components/wp-table/timeline/wp-timeline.ts
@@ -32,6 +32,7 @@ import {
   WorkPackageResourceInterface
 } from '../../api/api-v3/hal-resources/work-package-resource.service';
 import Moment = moment.Moment;
+import {WorkPackageChangeset} from '../../wp-edit-form/work-package-changeset';
 
 export const timelineElementCssClass = 'timeline-element';
 export const timelineGridElementCssClass = 'wp-timeline--grid-element';
@@ -105,6 +106,7 @@ export class TimelineViewParameters {
 export interface RenderInfo {
   viewParams:TimelineViewParameters;
   workPackage:WorkPackageResourceInterface;
+  changeset?:WorkPackageChangeset;
 }
 
 /**

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -178,7 +178,7 @@ describe 'Inline editing work packages', js: true do
       expect(wp_table.row(work_package)).to have_selector('.wp-table--cell-container.-error', count: 2)
 
       cf_text = wp_table.edit_field(work_package, :customField2)
-      cf_text.update('my custom text')
+      cf_text.update('my custom text', expect_failure: true)
 
       cf_list            = wp_table.edit_field(work_package, :customField1)
       cf_list.field_type = 'select'

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -93,9 +93,6 @@ describe 'Switching types in work package table', js: true do
         message: "#{cf_req_text.name} can't be blank."
       )
 
-      # Old text field should disappear
-      expect { text_field.display_element }.to raise_error(Capybara::ElementNotFound)
-
       # Required CF requires activation
       req_text_field.activate!
       req_text_field.set_value 'Required'


### PR DESCRIPTION
Refactor the WP resource usage to avoid any modifications to it using the form resource. 

- [x] A `WorkPackageResource` is now always the last known state from the API and can be updated regardless of any active editing.
- [x] Removes all means to get/update the form in the work package resource
- [x] Removes the need to override the work package schema if the form is loaded

**TODOS**

- [X] Adapt timeline to use a changeset to update dates when moving in the timeline.
- [x] Fix tests  (In progress)
- [X] Test attachments

Fixes
https://community.openproject.com/wp/25972
https://community.openproject.com/wp/25495
https://community.openproject.com/wp/26023

https://community.openproject.com/wp/26019 in 539a0a9eb1afa327ccddcb59d3ec984512dbe60d