### PR TITLE
[25979] Toggle membership form elements and compile response  …

### DIFF
--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -86,21 +86,22 @@ module Members
     def edit_link
       link_to_function(
         op_icon('icon icon-edit'),
-        edit_javascript,
+        toggle_javascript,
+        class: toggle_item_class_name,
         title: t(:button_edit)
       )
     end
 
-    def edit_javascript
-      "jQuery('##{roles_css_id}').hide(); jQuery('##{roles_css_id}-form').show();"
-    end
-
-    def cancel_edit_javascript
-      "jQuery('##{roles_css_id}').show(); jQuery('##{roles_css_id}-form').hide();"
+    def toggle_javascript
+      "jQuery('.#{toggle_item_class_name}').toggle();"
     end
 
     def roles_css_id
       "member-#{member.id}-roles"
+    end
+
+    def toggle_item_class_name
+      "member-#{member.id}--edit-toggle-item"
     end
 
     def delete_link

--- a/app/cells/views/members/role_form/show.erb
+++ b/app/cells/views/members/role_form/show.erb
@@ -4,7 +4,7 @@
 <form action="<%= form_url %>"
       method="post"
       id="<%= row.roles_css_id %>-form"
-      class="hol"
+      class="hol <%= row.toggle_item_class_name %>"
       style="display:none"
       accept-charset="UTF-8"
 >
@@ -19,6 +19,6 @@
   <%= hidden_field_tag "member[role_ids][]", "" %>
   <p>
     <%= submit_tag t(:button_change), class: "button -highlight -small" %>
-    <%= link_to_function t(:button_cancel), row.cancel_edit_javascript, class: 'button -small' %>
+    <%= link_to_function t(:button_cancel), row.toggle_javascript, class: 'button -small' %>
   </p>
 </form>

--- a/app/views/groups/change_memberships.js.erb
+++ b/app/views/groups/change_memberships.js.erb
@@ -31,7 +31,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <% content = escape_javascript render(partial: 'memberships') %>
   <% flash_message = escape_javascript render(partial: "members/common_notice",
                                               locals: { message: l(:notice_successful_update) }) %>
-  jQuery('#tab-content-memberships').html('<%= content %>');
+  var compiledContent = OpenProject.Helpers.Angular.compile('<%= content %>');
+  jQuery('#tab-content-memberships').html(compiledContent);
+
   jQuery('#tab-content-memberships').prepend('<%= flash_message %>');
 <% else %>
   alert('<%= escape_javascript(l(:notice_failed_to_save_members, errors: @membership.errors.full_messages.join(', '))).html_safe %>');

--- a/app/views/groups/destroy_memberships.js.erb
+++ b/app/views/groups/destroy_memberships.js.erb
@@ -30,5 +30,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <% content = escape_javascript render(partial: 'memberships') %>
 <% flash_message = escape_javascript render(partial: "members/common_notice",
                                             locals: { message: l(:notice_successful_delete) }) %>
-jQuery('#tab-content-memberships').html('<%= content %>');
+var compiledContent = OpenProject.Helpers.Angular.compile('<%= content %>');
+jQuery('#tab-content-memberships').html(compiledContent);
 jQuery('#tab-content-memberships').prepend('<%= flash_message %>');

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -73,10 +73,14 @@ See doc/COPYRIGHT.rdoc for more details.
                     <%= link_to_project membership.project %>
                   </td>
                   <td class="roles">
-                    <span id="member-<%= membership.id %>-roles"><%=h membership.roles.sort.collect(&:to_s).join(', ') %></span>
+                    <span id="member-<%= membership.id %>-roles"
+                          class="member-<%= membership.id %>--edit-toggle-item">
+                      <%=h membership.roles.sort.collect(&:to_s).join(', ') %>
+                    </span>
                     <%= labelled_tabular_form_for(:membership, remote: true,
                                                   url: user_membership_path(user_id: @user, id: membership),
                                                   html: { id: "member-#{membership.id}-roles-form",
+                                                          class: "member-#{membership.id}--edit-toggle-item",
                                                           style: 'display:none;'},
                                                   method: :patch) do |f| %>
                       <div>
@@ -95,15 +99,15 @@ See doc/COPYRIGHT.rdoc for more details.
                       </div>
                       <p><%= submit_tag l(:button_change), class: 'user-memberships--edit-submit-button button -highlight -small' %>
                         <%= link_to_function l(:button_cancel),
-                                             "jQuery('#member-#{membership.id}-roles').show(); jQuery('#member-#{membership.id}-roles-form').hide();",
+                                             "jQuery('.member-#{membership.id}--edit-toggle-item').toggle();",
                   class: 'button -small' %></p>
                     <% end %>
                   </td>
                   <%= call_hook(:view_users_memberships_table_row, user: @user, membership: membership, roles: roles, projects: projects )%>
                   <td class="buttons">
                     <%= link_to_function icon_wrapper('icon icon-edit', t(:button_edit)),
-                                         "jQuery('#member-#{membership.id}-roles').hide(); jQuery('#member-#{membership.id}-roles-form').show();",
-                                         class: 'user-memberships--edit-button' %>
+                                         "jQuery('.member-#{membership.id}--edit-toggle-item').toggle();",
+                                         class: "member-#{membership.id}--edit-toggle-item user-memberships--edit-button" %>
                     <%= link_to(icon_wrapper('icon icon-remove', t(:button_remove)),
                                 user_membership_path(user_id: @user, id: membership),
                                 remote: true,

--- a/app/views/users/memberships/update_or_create.js.erb
+++ b/app/views/users/memberships/update_or_create.js.erb
@@ -28,9 +28,10 @@ See doc/COPYRIGHT.rdoc for more details.
 ++#%>
 
 (function($) {
-  var memberships = $("<%= escape_javascript(render(partial: 'users/memberships')) %>");
+  <% content = escape_javascript render(partial: 'users/memberships') %>
 
-  $('#tab-content-memberships').html(memberships);
+  var compiledContent = OpenProject.Helpers.Angular.compile('<%= content %>');
+  jQuery('#tab-content-memberships').html(compiledContent);
 
   <% if @membership.errors.empty? %>
     var notice = $("<%= escape_javascript(render(partial: 'members/common_notice',


### PR DESCRIPTION
This fixes two issues:

1. Toggles the form elements with a class selector so the impermanent
memberships plugin can extend it.

2. Compiles the response html so subsequent datepickers are shown


The fix is made both for the project member form as well as the global user form.

https://community.openproject.com/wp/25979
https://github.com/opf/openproject/pull/5802
