### PR TITLE
explicitly set author to be nonwritable in wp schema

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -159,7 +159,8 @@ module API
                  type: 'DateTime'
 
           schema :author,
-                 type: 'User'
+                 type: 'User',
+                 writable: false
 
           schema_with_allowed_link :project,
                                    type: 'Project',


### PR DESCRIPTION
While the author is writable, one can set it to the current user. It should not be marked as writable as the backend makes that assignment already. But because of this behaviour we cannot rely on the default behaviour for determining whether a property is writable

https://community.openproject.com/projects/openproject/work_packages/26001