### PR TITLE
be robust if no custom style icon exist

### DIFF
--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -62,66 +62,27 @@ class CustomStylesController < ApplicationController
   end
 
   def logo_download
-    @custom_style = CustomStyle.current
-    if @custom_style && @custom_style.logo
-      expires_in 1.years, public: true, must_revalidate: false
-      send_file(@custom_style.logo.local_file.path)
-    else
-      head :not_found
-    end
+    file_download(:logo_path)
   end
 
   def favicon_download
-    @custom_style = CustomStyle.current
-    if @custom_style && @custom_style.favicon
-      expires_in 1.years, public: true, must_revalidate: false
-      send_file(@custom_style.favicon.local_file.path)
-    else
-      head :not_found
-    end
+    file_download(:favicon_path)
   end
 
   def touch_icon_download
-    @custom_style = CustomStyle.current
-    if @custom_style && @custom_style.touch_icon
-      expires_in 1.years, public: true, must_revalidate: false
-      send_file(@custom_style.touch_icon.local_file.path)
-    else
-      head :not_found
-    end
+    file_download(:touch_icon_path)
   end
 
   def logo_delete
-    @custom_style = CustomStyle.current
-    if @custom_style.nil?
-      return render_404
-    end
-
-    @custom_style.remove_logo!
-    @custom_style.save
-    redirect_to custom_style_path
+    file_delete(:remove_logo!)
   end
 
   def favicon_delete
-    @custom_style = CustomStyle.current
-    if @custom_style.nil?
-      return render_404
-    end
-
-    @custom_style.remove_favicon!
-    @custom_style.save
-    redirect_to custom_style_path
+    file_delete(:remove_favicon!)
   end
 
   def touch_icon_delete
-    @custom_style = CustomStyle.current
-    if @custom_style.nil?
-      return render_404
-    end
-
-    @custom_style.remove_touch_icon!
-    @custom_style.save
-    redirect_to custom_style_path
+    file_delete(:remove_touch_icon!)
   end
 
   def update_colors
@@ -159,5 +120,26 @@ class CustomStylesController < ApplicationController
 
   def custom_style_params
     params.require(:custom_style).permit(:logo, :remove_logo, :favicon, :remove_favicon, :touch_icon, :remove_touch_icon)
+  end
+
+  def file_download(path_method)
+    @custom_style = CustomStyle.current
+    if @custom_style && @custom_style.send(path_method)
+      expires_in 1.years, public: true, must_revalidate: false
+      send_file(@custom_style.send(path_method))
+    else
+      head :not_found
+    end
+  end
+
+  def file_delete(remove_method)
+    @custom_style = CustomStyle.current
+    if @custom_style.nil?
+      return render_404
+    end
+
+    @custom_style.send(remove_method)
+    @custom_style.save
+    redirect_to custom_style_path
   end
 end

--- a/app/models/custom_style.rb
+++ b/app/models/custom_style.rb
@@ -19,4 +19,14 @@ class CustomStyle < ActiveRecord::Base
   def digest
     updated_at.to_i
   end
+
+  %i(favicon touch_icon logo).each do |name|
+    define_method "#{name}_path" do
+      image = send(name)
+
+      if image.readable?
+        image.local_file.path
+      end
+    end
+  end
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -44,7 +44,7 @@ module FileUploader
   end
 
   def readable?
-    File.readable? local_file
+    file && File.readable?(local_file)
   end
 
   module ClassMethods

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -161,8 +161,17 @@ describe CustomStylesController, type: :controller do
         end
       end
 
-      context "when no logo is present" do
+      context "when no custom style is present" do
         let(:custom_style) { nil }
+
+        it 'renders with error' do
+          expect(controller).to_not receive(:send_file)
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when no logo is present" do
+        let(:custom_style) { FactoryGirl.build_stubbed(:custom_style) }
 
         it 'renders with error' do
           expect(controller).to_not receive(:send_file)
@@ -219,8 +228,17 @@ describe CustomStylesController, type: :controller do
         end
       end
 
-      context "when no logo is present" do
+      context "when no custom style is present" do
         let(:custom_style) { nil }
+
+        it 'renders with error' do
+          expect(controller).to_not receive(:send_file)
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when no favicon is present" do
+        let(:custom_style) { FactoryGirl.build(:custom_style) }
 
         it 'renders with error' do
           expect(controller).to_not receive(:send_file)
@@ -277,8 +295,17 @@ describe CustomStylesController, type: :controller do
         end
       end
 
-      context "when no touch icon is present" do
+      context "when no custom style is present" do
         let(:custom_style) { nil }
+
+        it 'renders with error' do
+          expect(controller).to_not receive(:send_file)
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when no touch icon is present" do
+        let(:custom_style) { FactoryGirl.build(:custom_style) }
 
         it 'renders with error' do
           expect(controller).to_not receive(:send_file)

--- a/spec/factories/custom_style_factory.rb
+++ b/spec/factories/custom_style_factory.rb
@@ -27,6 +27,8 @@
 #++
 
 FactoryGirl.define do
+  factory :custom_style
+
   factory :custom_style_with_logo, class: CustomStyle do
     logo do
       Rack::Test::UploadedFile.new(


### PR DESCRIPTION
Despite a custom style being present, individual image properties (logo, touch_icon, favicon) might not be set. We therefore have to check for those separately.

This also refactors the controller to avoid duplication

https://community.openproject.com/projects/openproject/work_packages/26008