### PR TITLE
fix displaying "Invalid date" in timeline label

### DIFF
--- a/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -411,10 +411,10 @@ export class TimelineCellRenderer {
 
     if (!activeDragNDrop) {
       // normal display
-      if (labels.labelLeft) {
+      if (labels.labelLeft && start) {
         labels.labelLeft.textContent = this.TimezoneService.formattedDate(start);
       }
-      if (labels.labelRight) {
+      if (labels.labelRight && due) {
         labels.labelRight.textContent = this.TimezoneService.formattedDate(due);
       }
       if (labels.labelFarRight) {


### PR DESCRIPTION
Fixes having "Invalid date" displayed if a date (start or due) is not present: 
![image](https://user-images.githubusercontent.com/617519/28873256-2a5ed6da-778d-11e7-894c-a18027abb71e.png)
https://community.openproject.com/projects/openproject/work_packages/26018

I first implemented having a "-" (dash) displayed in such cases:
![image](https://user-images.githubusercontent.com/617519/28873060-343a287c-778c-11e7-9ab6-1133f50173f3.png)

but found that to be weird. I therefor decided to just remove such labels altogether:

![image](https://user-images.githubusercontent.com/617519/28873078-4c1f8ec8-778c-11e7-9d79-dd760ad43949.png)

This is by the way the same behaviour we have upon dragging.
