### PR TITLE
Feature/time entries api create

### DIFF
--- a/app/contracts/time_entries/base_contract.rb
+++ b/app/contracts/time_entries/base_contract.rb
@@ -1,6 +1,8 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -23,38 +25,25 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module WorkPackages
-      class ParseParamsService < API::V3::ParseResourceParamsService
-        def initialize(user)
-          super(user, WorkPackage, ::API::V3::WorkPackages::WorkPackagePayloadRepresenter)
-        end
+require 'model_contract'
 
-        private
-
-        def parse_attributes(request_body)
-          ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
-            .create_class(struct)
-            .new(struct, current_user: current_user)
-            .from_hash(Hash(request_body))
-            .to_h
-            .reverse_merge(lock_version: nil)
-        end
-
-        def struct
-          ParsingStruct.new
-        end
-
-        class ParsingStruct < OpenStruct
-          def available_custom_fields
-            @available_custom_fields ||= WorkPackageCustomField.all.to_a
-          end
-        end
-      end
+module TimeEntries
+  class BaseContract < ::ModelContract
+    def self.model
+      TimeEntry
     end
+
+    attribute :project_id
+    attribute :work_package_id
+    attribute :activity_id
+    attribute :hours
+    attribute :comments
+    attribute :spent_on
+    attribute :tyear
+    attribute :tmonth
+    attribute :tweek
   end
 end

--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -31,10 +31,10 @@
 class TimelogController < ApplicationController
   menu_item :issues
 
-  before_action :disable_api, except: [:index, :destroy]
-  before_action :find_work_package, only: [:new, :create]
-  before_action :find_project, only: [:new, :create]
-  before_action :find_time_entry, only: [:show, :edit, :update, :destroy]
+  before_action :disable_api, except: %i[index destroy]
+  before_action :find_work_package, only: %i[new create]
+  before_action :find_project, only: %i[new create]
+  before_action :find_time_entry, only: %i[show edit update destroy]
   before_action :authorize, except: [:index]
   before_action :find_optional_project, only: [:index]
   accept_key_auth :index, :show, :create, :update, :destroy
@@ -121,9 +121,7 @@ class TimelogController < ApplicationController
                    .includes(:project,
                              :activity,
                              :user,
-                             work_package: [:type,
-                                            :assigned_to,
-                                            :priority])
+                             work_package: %i[type assigned_to priority])
                    .references(:projects)
                    .where(cond.conditions)
                    .distinct(false)
@@ -152,9 +150,19 @@ class TimelogController < ApplicationController
   end
 
   def create
-    @time_entry = new_time_entry(@project, @issue, permitted_params.time_entry.to_h)
+    combined_params = permitted_params
+                      .time_entry
+                      .to_h
+                      .reverse_merge(project: @project,
+                                     work_package_id: @issue)
 
-    save_time_entry_and_respond @time_entry
+    call = TimeEntries::CreateService
+           .new(user: current_user)
+           .call(combined_params)
+
+    @time_entry = call.result
+
+    respond_for_saving call.success?
   end
 
   def edit

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -231,25 +231,10 @@ class Changeset < ActiveRecord::Base
   end
 
   def log_time(work_package, hours)
-    time_entry = TimeEntry.new(
-      user: user,
-      hours: hours,
-      work_package: work_package,
-      spent_on: commit_date,
-      comments: l(:text_time_logged_by_changeset, value: text_tag, locale: Setting.default_language)
-    )
-    time_entry.activity = log_time_activity unless log_time_activity.nil?
-
-    unless time_entry.save
-      logger.warn("TimeEntry could not be created by changeset #{id}: #{time_entry.errors.full_messages}") if logger
-    end
-    time_entry
-  end
-
-  def log_time_activity
-    if Setting.commit_logtime_activity_id.to_i > 0
-      TimeEntryActivity.find_by(id: Setting.commit_logtime_activity_id.to_i)
-    end
+    Changesets::LogTimeService
+      .new(user: user, changeset: self)
+      .call(work_package, hours)
+      .result
   end
 
   def split_comments

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -53,11 +53,7 @@ class TimeEntry < ActiveRecord::Base
   validate :validate_project_is_set
   validate :validate_consistency_of_work_package_id
 
-
   scope :on_work_packages, ->(work_packages) { where(work_package_id: work_packages) }
-
-  after_initialize :set_default_activity
-  before_validation :set_default_project
 
   def self.visible(*args)
     # TODO: check whether the visibility should also be influenced by the work
@@ -67,19 +63,6 @@ class TimeEntry < ActiveRecord::Base
     # user lacks the view_work_packages permission in the moved to project.
     joins(:project)
       .merge(Project.allowed_to(args.first || User.current, :view_time_entries))
-  end
-
-  def set_default_activity
-    if new_record? && activity.nil?
-      if default_activity = TimeEntryActivity.default
-        self.activity_id = default_activity.id
-      end
-      self.hours = nil if hours == 0
-    end
-  end
-
-  def set_default_project
-    self.project ||= work_package.project if work_package
   end
 
   def hours=(h)
@@ -125,8 +108,10 @@ class TimeEntry < ActiveRecord::Base
 
   private
 
+  # TODO: move to contract
+
   def validate_hours_are_in_range
-    errors.add :hours, :invalid if hours && hours < 0
+    errors.add :hours, :invalid if hours&.negative?
   end
 
   def validate_project_is_set

--- a/app/services/changesets/log_time_service.rb
+++ b/app/services/changesets/log_time_service.rb
@@ -1,0 +1,80 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Changesets
+  class LogTimeService
+    def initialize(user:, changeset:)
+      self.user = user
+      self.changeset = changeset
+    end
+
+    def call(work_package, hours)
+      service_result = TimeEntries::CreateService
+                       .new(user: user)
+                       .call(combined_parameters(work_package, hours))
+
+      log_error(service_result)
+
+      service_result
+    end
+
+    private
+
+    attr_accessor :user,
+                  :changeset
+
+    def combined_parameters(work_package, hours)
+      params = {
+        hours: hours,
+        work_package: work_package,
+        spent_on: changeset.commit_date,
+        comments: I18n.t(:text_time_logged_by_changeset, value: changeset.text_tag, locale: Setting.default_language)
+      }
+
+      activity = log_time_activity
+
+      params[:activity] = activity if activity.present?
+
+      params
+    end
+
+    def log_error(service_result)
+      unless service_result.success?
+        logger&.warn("TimeEntry could not be created by changeset #{id}: #{service_result.errors.full_messages}")
+      end
+    end
+
+    def log_time_activity
+      if Setting.commit_logtime_activity_id.to_i.positive?
+        TimeEntryActivity.find_by(id: Setting.commit_logtime_activity_id.to_i)
+      end
+    end
+  end
+end

--- a/app/services/time_entries/create_service.rb
+++ b/app/services/time_entries/create_service.rb
@@ -1,0 +1,74 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module TimeEntries
+  class CreateService
+    include Concerns::Contracted
+
+    attr_reader :user
+
+    def initialize(user:)
+      @user = user
+      self.contract_class = TimeEntries::CreateContract
+    end
+
+    def call(params)
+      time_entry = TimeEntry.new
+
+      time_entry.attributes = params
+
+      assign_defaults(time_entry)
+      use_project_activity(time_entry)
+
+      success, errors = validate_and_save(time_entry, user)
+
+      ServiceResult.new(success: success,
+                        errors: errors,
+                        result: time_entry)
+    end
+
+    private
+
+    def assign_defaults(time_entry)
+      time_entry.user ||= user
+      time_entry.activity ||= TimeEntryActivity.default
+      time_entry.hours = nil if time_entry.hours&.zero?
+      time_entry.project ||= time_entry.work_package.project if time_entry.work_package
+    end
+
+    def use_project_activity(time_entry)
+      if time_entry.activity&.shared? && time_entry.project
+        project_activity = time_entry.project.time_entry_activities.find_by(parent_id: time_entry.activity_id) ||
+                           time_entry.activity
+        time_entry.activity = project_activity
+      end
+    end
+  end
+end

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -70,17 +70,6 @@ See docs/COPYRIGHT.rdoc for more details.
                   </div>
                 </div>
               </th>
-              <% TimeEntryActivity.new.available_custom_fields.each do |value| %>
-                <th>
-                  <div class="generic-table--sort-header-outer">
-                    <div class="generic-table--sort-header">
-                      <span <% if value.is_required? %> class="-required" <%end%>>
-                        <%= h value.name %>
-                      </span>
-                    </div>
-                  </div>
-                </th>
-              <% end %>
             </tr>
           </thead>
           <% @project.activities(true).each do |enumeration| %>
@@ -95,12 +84,6 @@ See docs/COPYRIGHT.rdoc for more details.
                   <%= h(enumeration) %>
                 </td>
                 <td><%= checked_image !enumeration.project %></td>
-                <% enumeration.custom_field_values.each do |value| %>
-                  <td>
-                    <%= hidden_custom_field_label_tag "enumerations[#{enumeration.id}]", value %>
-                    <%= custom_field_tag "enumerations[#{enumeration.id}]", value %>
-                  </td>
-                <% end %>
               </tr>
             <% end %>
           <% end %>

--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -245,6 +245,93 @@ Lists time entries. The time entries returned depend on the filters provided and
                 "message": "You are not authorized to view this resource."
             }
 
+## Create Time entry [POST]
+
+Creates a new time entry applying the attributes provided in the body. Please note that while there is a fixed set of attributes, custom fields can extend a time entries' attributes and are accepted by the endpoint.
+
+There is no form and schema resource for time entries, yet.
+
++ Request Create time entry
+
+    + Body
+
+            {
+                "_links": {
+                  "project": {
+                    "href": "/api/v3/projects/34"
+                  },
+                  "activity": {
+                    "href": "/api/v3/time_entries/activities/18",
+                  },
+                  "workPackage": {
+                    "href": "/api/v3/work_packages/5"
+                  },
+                  "customField4": {
+                    "href": "/api/v3/users/5"
+                  },
+                  "customField51": {
+                    "href": "/api/v3/custom_options/11"
+                  }
+                },
+                "hours": 'PT5H',
+                "comment": "some comment",
+                "spentOn": "2017-07-28",
+                "customField1": {
+                  raw: 'some text custom field value'
+                },
+                "customField8": 5
+            }
+
++ Response 201
+
+    [Time entry][]
+
++ Response 400 (application/hal+json)
+
+    Occurs when the client did not send a valid JSON object in the request body.
+
+    + Body
+
+            {
+                "_type": "Error",
+                 "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
+                "message": "The request body was not a single JSON object."
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** Log time
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }
+
++ Response 422 (application/hal+json)
+
+    Returned if:
+
+    * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
+                "message": "Work package is invalid.",
+                "_embedded": {
+                    "details": {
+                        "attribute"=>"workPackage"
+                    }
+                }
+            }
+
+
 # Group Time Entry Activities
 
 Time entries are classified by an activity which is one item of a set of user defined activities (e.g. Design, Specification, Development).

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -40,7 +40,7 @@ module API
       end
 
       def from_hash(hash, *args)
-        return super unless hash['_links']
+        return super unless hash && hash['_links']
 
         copied_hash = hash.deep_dup
 

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -49,6 +49,26 @@ module API
             end
           end
 
+          post do
+            params = API::V3::ParseResourceParamsService
+                     .new(current_user, TimeEntry, TimeEntryRepresenter)
+                     .call(request_body)
+                     .result
+
+            result = ::TimeEntries::CreateService
+                     .new(user: current_user)
+                     .call(params)
+
+            if result.success?
+              new_entry = result.result
+              TimeEntryRepresenter.create(new_entry,
+                                          current_user: current_user,
+                                          embed_links: true)
+            else
+              fail ::API::Errors::ErrorBase.create_and_merge_errors(result.errors)
+            end
+          end
+
           params do
             requires :id, desc: 'Time entry\'s id'
           end

--- a/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_representer.rb
@@ -47,13 +47,22 @@ module API
         property :spent_on,
                  exec_context: :decorator,
                  getter: ->(*) do
-                   datetime_formatter.format_date(represented.spent_on, allow_nil: true)
+                   datetime_formatter.format_date(represented.spent_on, allow_nil: false)
+                 end,
+                 setter: ->(fragment:, **) do
+                   represented.spent_on = datetime_formatter.parse_date(fragment,
+                                                                        'spentOn',
+                                                                        allow_nil: false)
                  end
 
         property :hours,
                  exec_context: :decorator,
                  getter: ->(*) do
                    datetime_formatter.format_duration_from_hours(represented.hours)
+                 end,
+                 setter: ->(fragment:, **) do
+                   represented.hours = datetime_formatter.parse_duration_to_hours(fragment,
+                                                                                  'hours')
                  end
 
         property :created_at,
@@ -85,6 +94,16 @@ module API
                                 href: api_v3_paths.time_entries_activity(activity.id),
                                 title: activity.name
                               }
+                            },
+                            setter: ->(fragment:, **) {
+                              ::API::Decorators::LinkObject
+                                .new(represented,
+                                     path: :time_entries_activity,
+                                     property_name: :time_entries_activity,
+                                     namespace: 'time_entries/activities',
+                                     getter: :activity_id,
+                                     setter: :"activity_id=")
+                                .from_hash(fragment)
                             }
 
         def _type

--- a/lib/api/v3/work_packages/create_work_packages.rb
+++ b/lib/api/v3/work_packages/create_work_packages.rb
@@ -42,6 +42,7 @@ module API
           parameters = ::API::V3::WorkPackages::ParseParamsService
                        .new(current_user)
                        .call(request_body)
+                       .result
 
           result = create_work_package(current_user,
                                        work_package,

--- a/lib/api/v3/work_packages/form_helper.rb
+++ b/lib/api/v3/work_packages/form_helper.rb
@@ -65,6 +65,7 @@ module API
           ::API::V3::WorkPackages::ParseParamsService
             .new(current_user)
             .call(request_body)
+            .result
         end
       end
     end

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -89,6 +89,7 @@ module API
               parameters = ::API::V3::WorkPackages::ParseParamsService
                            .new(current_user)
                            .call(request_body)
+                           .result
 
               call = ::WorkPackages::UpdateService
                      .new(

--- a/spec/contracts/time_entries/create_contract_spec.rb
+++ b/spec/contracts/time_entries/create_contract_spec.rb
@@ -1,0 +1,174 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe TimeEntries::CreateContract do
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user) do |user|
+      allow(user)
+        .to receive(:allowed_to?) do |permission, permission_project|
+        permissions.include?(permission) && time_entry_project == permission_project
+      end
+    end
+  end
+  let(:other_user) { FactoryBot.build_stubbed(:user) }
+  let(:time_entry_work_package) do
+    FactoryBot.build_stubbed(:work_package,
+                             project: time_entry_project)
+  end
+  let(:time_entry_project) { FactoryBot.build_stubbed(:project) }
+  let(:time_entry_user) { current_user }
+  let(:time_entry_activity) { FactoryBot.build_stubbed(:time_entry_activity) }
+  let(:time_entry_spent_on) { Date.today }
+  let(:time_entry_hours) { 5 }
+  let(:time_entry_comments) { "A comment" }
+  let(:time_entry) do
+    TimeEntry.new(project: time_entry_project,
+                  work_package: time_entry_work_package,
+                  user: time_entry_user,
+                  activity: time_entry_activity,
+                  spent_on: time_entry_spent_on,
+                  hours: time_entry_hours,
+                  comments: time_entry_comments)
+  end
+  let(:permissions) { %i(log_time) }
+
+  subject(:contract) { described_class.new(time_entry, current_user) }
+
+  def expect_valid(valid, symbols = {})
+    expect(contract.validate).to eq(valid)
+
+    symbols.each do |key, arr|
+      expect(contract.errors.symbols_for(key)).to match_array arr
+    end
+  end
+
+  shared_examples 'is valid' do
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
+  it_behaves_like 'is valid'
+
+  context 'when user is not allowed to log time' do
+    let(:permissions) { [] }
+
+    it 'is invalid' do
+      expect_valid(false, base: %i(error_unauthorized))
+    end
+  end
+
+  context 'when time_entry user is not contract user' do
+    let(:time_entry_user) { other_user }
+
+    it 'is invalid' do
+      expect_valid(false, user_id: %i(invalid))
+    end
+  end
+
+  context 'when the work_package is within a differnt project than the provided project' do
+    let(:time_entry_work_package) { FactoryBot.build_stubbed(:work_package) }
+
+    it 'is invalid' do
+      expect_valid(false, work_package_id: %i(invalid))
+    end
+  end
+
+  context 'when the project is nil' do
+    let(:time_entry_project) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, project_id: %i(invalid blank))
+    end
+  end
+
+  context 'when the user is nil' do
+    let(:time_entry_user) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, user_id: %i(blank invalid))
+    end
+  end
+
+  context 'when activity is nil' do
+    let(:time_entry_activity) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, activity_id: %i(blank))
+    end
+  end
+
+  context 'when spent_on is nil' do
+    let(:time_entry_spent_on) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, spent_on: %i(blank))
+    end
+  end
+
+  context 'when hours is nil' do
+    let(:time_entry_hours) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(blank))
+    end
+  end
+
+  context 'when hours is smaller negative' do
+    let(:time_entry_hours) { -1 }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(invalid))
+    end
+  end
+
+  context 'when hours is nil' do
+    let(:time_entry_hours) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(blank))
+    end
+  end
+
+  context 'when comment is longer than 255' do
+    let(:time_entry_comments) { "a" * 256 }
+
+    it 'is invalid' do
+      expect_valid(false, comments: %i(too_long))
+    end
+  end
+
+  context 'when comment is nil' do
+    let(:time_entry_comments) { nil }
+
+    it_behaves_like 'is valid'
+  end
+end

--- a/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -1,0 +1,163 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:time_entry) do
+    FactoryBot.build_stubbed(:time_entry,
+                              comments: 'blubs',
+                              spent_on: Date.today - 3.days,
+                              created_on: DateTime.now - 6.hours,
+                              updated_on: DateTime.now - 3.hours,
+                              activity: activity,
+                              project: project,
+                              user: user)
+  end
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:project2) { FactoryBot.build_stubbed(:project) }
+  let(:work_package) { time_entry.work_package }
+  let(:work_package2) { FactoryBot.build_stubbed(:work_package) }
+  let(:activity) { FactoryBot.build_stubbed(:time_entry_activity) }
+  let(:activity2) { FactoryBot.build_stubbed(:time_entry_activity) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:user2) { FactoryBot.build_stubbed(:user) }
+  let(:representer) do
+    described_class.create(time_entry, current_user: user, embed_links: true)
+  end
+  let(:custom_field13) do
+    FactoryBot.build_stubbed(:time_entry_custom_field, field_format: 'user', id: 13)
+  end
+  let(:custom_field11) do
+    FactoryBot.build_stubbed(:time_entry_custom_field, field_format: 'text', id: 11)
+  end
+
+  let(:hash) do
+    {
+      "_links" => {
+        "project" => {
+          "href" => api_v3_paths.project(project2.id)
+        },
+        "activity" => {
+          "href" => api_v3_paths.time_entries_activity(activity2.id)
+        },
+        "workPackage" => {
+          "href" => api_v3_paths.work_package(work_package2.id)
+
+        },
+        "customField13" => {
+          "href" => api_v3_paths.user(user2.id)
+        }
+      },
+      "hours" => 'PT5H',
+      "comment" => "some comment",
+      "spentOn" => "2017-07-28",
+      "customField11" => {
+        "raw" => "some text"
+      }
+    }
+  end
+
+  before do
+    allow(time_entry)
+      .to receive(:available_custom_fields)
+      .and_return([custom_field11, custom_field13])
+  end
+
+  describe '_links' do
+    context 'activity' do
+      it 'updates the activity' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.activity_id)
+          .to eql(activity2.id)
+      end
+    end
+
+    context 'project' do
+      it 'updates the project' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.project_id)
+          .to eql(project2.id)
+      end
+    end
+
+    context 'workPackage' do
+      it 'updates the work_package' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.work_package_id)
+          .to eql(work_package2.id)
+      end
+    end
+
+    context 'linked custom field' do
+      it 'updates the custom value' do
+        time_entry = representer.from_hash(hash)
+
+        expect(time_entry.custom_field_values.detect { |cv| cv.custom_field_id == custom_field13.id }.value)
+          .to eql(user2.id.to_s)
+      end
+    end
+  end
+
+  describe 'properties' do
+    context 'spentOn' do
+      it 'updates spent_on' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.spent_on)
+          .to eql(Date.parse("2017-07-28"))
+      end
+    end
+
+    context 'hours' do
+      it 'updates hours' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.hours)
+          .to eql(5.0)
+      end
+    end
+
+    context 'comment' do
+      it 'updates comment' do
+        time_entry = representer.from_hash(hash)
+        expect(time_entry.comments)
+          .to eql('some comment')
+      end
+    end
+
+    context 'property custom field' do
+      it 'updates the custom value' do
+        time_entry = representer.from_hash(hash)
+
+        expect(time_entry.custom_field_values.detect { |cv| cv.custom_field_id == custom_field11.id }.value)
+          .to eql("some text")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/time_entry_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_resource_spec.rb
@@ -60,6 +60,9 @@ describe 'API v3 time_entry resource', type: :request do
                        value: '1234',
                        customized: time_entry)
   end
+  let(:activity) do
+    FactoryBot.create(:time_entry_activity)
+  end
 
   subject(:response) { last_response }
 
@@ -211,9 +214,9 @@ describe 'API v3 time_entry resource', type: :request do
 
       before do
         FactoryBot.create(:member,
-                           roles: [role],
-                           project: other_project,
-                           user: current_user)
+                          roles: [role],
+                          project: other_project,
+                          user: current_user)
 
         time_entry
         other_time_entry
@@ -302,6 +305,136 @@ describe 'API v3 time_entry resource', type: :request do
       it 'returns 404 NOT FOUND' do
         expect(subject.status)
           .to eql(404)
+      end
+    end
+  end
+
+  describe 'POST api/v3/time_entries' do
+    let(:permissions) { %i(view_time_entries log_time view_work_packages) }
+    let(:path) { api_v3_paths.time_entries }
+    let(:params) do
+      {
+        "_links": {
+          "project": {
+            "href": api_v3_paths.project(project.id)
+          },
+          "activity": {
+            "href": api_v3_paths.time_entries_activity(activity.id)
+          },
+          "workPackage": {
+            "href": api_v3_paths.work_package(work_package.id)
+          }
+        },
+        "hours": 'PT5H',
+        "comment": "some comment",
+        "spentOn": "2017-07-28",
+        "customField#{custom_field.id}": {
+          raw: 'some cf text'
+        }
+      }
+    end
+    let(:additional_setup) { ->{} }
+
+    before do
+      work_package
+
+      additional_setup.call
+
+      post path, params.to_json, 'CONTENT_TYPE' => 'application/json'
+    end
+
+    it 'responds 201 CREATED' do
+      expect(subject.status).to eq(201)
+    end
+
+    it 'creates another time entry with the provided values' do
+      expect(TimeEntry.count)
+        .to eql 1
+
+      new_entry = TimeEntry.first
+
+      expect(new_entry.user)
+        .to eql current_user
+
+      expect(new_entry.project)
+        .to eql project
+
+      expect(new_entry.activity)
+        .to eql activity
+
+      expect(new_entry.work_package)
+        .to eql work_package
+
+      expect(new_entry.hours)
+        .to eql 5.0
+
+      expect(new_entry.comments)
+        .to eql "some comment"
+
+      expect(new_entry.spent_on)
+        .to eql Date.parse("2017-07-28")
+
+      expect(new_entry.send(:"custom_field_#{custom_field.id}"))
+        .to eql 'some cf text'
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { %i(view_time_entries view_work_packages) }
+
+      it 'returns 403' do
+        expect(subject.status)
+          .to eql(403)
+      end
+    end
+
+    context 'when sending an activity the project overrides' do
+      let(:project_activity) do
+        params = activity.attributes.except('id')
+        params['parent_id'] = activity.id
+        project.create_time_entry_activity_if_needed(params)
+
+        project.time_entry_activities.first
+      end
+      let(:additional_setup) { -> { project_activity } }
+
+      it 'creates the time entry with the project activity' do
+        new_entry = TimeEntry.first
+
+        expect(new_entry.activity)
+          .to eql project_activity
+      end
+    end
+
+    context 'when sending invalid params' do
+      let(:params) do
+        {
+          "_links": {
+            "project": {
+              "href": api_v3_paths.project(project.id)
+            },
+            "activity": {
+              "href": api_v3_paths.time_entries_activity(activity.id)
+            },
+            "workPackage": {
+              "href": api_v3_paths.work_package(work_package.id + 1)
+            }
+          },
+          "hours": 'PT5H',
+          "comment": "some comment",
+          "spentOn": "2017-07-28",
+          "customField#{custom_field.id}": {
+            raw: 'some cf text'
+          }
+        }
+      end
+
+      it 'returns 422 and complains about work packages' do
+        expect(subject.status)
+          .to eql(422)
+
+        expect(subject.body)
+          .to be_json_eql("Work package is invalid.".to_json)
+          .at_path("message")
       end
     end
   end

--- a/spec/services/time_entries/create_service_spec.rb
+++ b/spec/services/time_entries/create_service_spec.rb
@@ -1,0 +1,250 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe TimeEntries::CreateService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:activity) { FactoryBot.build_stubbed(:time_entry_activity, project: project) }
+  let!(:default_activity) { FactoryBot.build_stubbed(:time_entry_activity, project: project, is_default: true) }
+  let(:work_package) { FactoryBot.build_stubbed(:work_package) }
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:spent_on) { Date.today.to_s }
+  let(:hours) { 5.0 }
+  let(:comments) { 'some comment' }
+  let(:contract_instance) do
+    contract = double('contract_instance')
+    allow(contract)
+      .to receive(:validate)
+      .and_return(contract_valid)
+    allow(contract)
+      .to receive(:errors)
+      .and_return(contract_errors)
+    contract
+  end
+
+  let(:contract_errors) { double('contract_errors') }
+  let(:contract_valid) { true }
+  let(:time_entry_valid) { true }
+
+  let(:instance) { described_class.new(user: user) }
+  let(:time_entry_instance) { TimeEntry.new }
+  let(:expect_time_instance_save) do
+    expect(time_entry_instance)
+      .to receive(:save)
+      .and_return(time_entry_valid)
+  end
+
+  let(:params) { {} }
+
+  before do
+    allow(TimeEntries::CreateContract)
+      .to receive(:new)
+      .with(anything, user)
+      .and_return(contract_instance)
+
+    allow(TimeEntry)
+      .to receive(:new)
+      .and_return(time_entry_instance)
+
+    expect_time_instance_save
+  end
+
+  subject { instance.call(params) }
+
+  it 'creates a new time entry' do
+    expect(subject.result)
+      .to eql time_entry_instance
+  end
+
+  it 'is a success' do
+    is_expected
+      .to be_success
+  end
+
+  it "has the service's user assigned" do
+    subject
+
+    expect(time_entry_instance.user)
+      .to eql user
+  end
+
+  it 'assigns the default TimeEntryActivity' do
+    allow(TimeEntryActivity)
+      .to receive(:default)
+      .and_return(default_activity)
+
+    subject
+
+    expect(time_entry_instance.activity)
+      .to eql default_activity
+  end
+
+  context 'with params' do
+    let(:user2) { FactoryBot.build_stubbed(:user) }
+    let(:params) do
+      {
+        user: user2,
+        work_package: work_package,
+        project: project,
+        activity: activity,
+        spent_on: spent_on,
+        comments: comments,
+        hours: hours
+      }
+    end
+
+    let(:expected) do
+      {
+        user_id: user2.id,
+        work_package_id: work_package.id,
+        project_id: project.id,
+        activity_id: activity.id,
+        spent_on: Date.parse(spent_on),
+        comments: comments,
+        hours: hours
+      }.with_indifferent_access
+    end
+
+    it 'assigns the params' do
+      subject
+
+      attributes_of_interest = time_entry_instance
+                               .attributes
+                               .slice(*expected.keys)
+
+      expect(attributes_of_interest)
+        .to eql(expected)
+    end
+  end
+
+  context 'with hours == 0' do
+    let(:params) do
+      {
+        hours: 0
+      }
+    end
+
+    it 'sets hours to nil' do
+      subject
+
+      expect(time_entry_instance.hours)
+        .to be_nil
+    end
+  end
+
+  context 'with project not specified' do
+    let(:params) do
+      {
+        work_package: work_package
+      }
+    end
+
+    it 'sets the project to the work_package\'s project' do
+      subject
+
+      expect(time_entry_instance.project)
+        .to eql(work_package.project)
+    end
+  end
+
+  context 'with an invalid contract' do
+    let(:contract_valid) { false }
+    let(:expect_time_instance_save) do
+      expect(time_entry_instance)
+        .not_to receive(:save)
+    end
+
+    it 'returns failure' do
+      is_expected
+        .not_to be_success
+    end
+
+    it "returns the contract's errors" do
+      expect(subject.errors)
+        .to eql(contract_errors)
+    end
+  end
+
+  context 'with an invalid time_entry' do
+    let(:time_entry_valid) { false }
+
+    it 'returns failure' do
+      is_expected
+        .not_to be_success
+    end
+
+    it "returns the time_entry's errors" do
+      expect(subject.errors)
+        .to eql(time_entry_instance.errors)
+    end
+  end
+
+  context 'with a system activity' do
+    let!(:system_activity) { FactoryBot.build_stubbed(:time_entry_activity) }
+    let(:params) do
+      {
+        project: project,
+        activity: system_activity
+      }
+    end
+
+    context 'with no project activity existing' do
+      it 'sets the system activity' do
+        subject
+
+        expect(time_entry_instance.activity)
+          .to eql(system_activity)
+      end
+    end
+
+    context 'with a project activity existing' do
+      let!(:project_activity) { FactoryBot.build_stubbed(:time_entry_activity, parent: system_activity, project: project) }
+
+      before do
+        project_activities = [project_activity]
+
+        allow(project)
+          .to receive(:time_entry_activities)
+          .and_return(project_activities)
+
+        allow(project_activities)
+          .to receive(:find_by)
+          .with(parent_id: system_activity.id)
+          .and_return(project_activity)
+      end
+
+      it 'uses the project activity instead' do
+        subject
+
+        expect(time_entry_instance.activity)
+          .to eql(project_activity)
+      end
+    end
+  end
+end

--- a/spec_legacy/unit/changeset_spec.rb
+++ b/spec_legacy/unit/changeset_spec.rb
@@ -26,7 +26,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Changeset, type: :model do
   fixtures :all


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/26108/activity

Builds on #5776 to add the ability to create time entries via the api endpoint

```
POST /api/v3/time_entries
```

It furthermore aims to introduce the structure necessary to let controller actions (api and html) look like this (pseudocode)

```
cleaned_params = cleanup_params(params)

result = do_action(params)

render_response(result)
```