### PR TITLE
[26029] Provide custom unique name for pasted images

### DIFF
--- a/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
+++ b/frontend/app/components/api/op-file-upload/op-file-upload.service.ts
@@ -32,6 +32,7 @@ import IPromise = angular.IPromise;
 
 export interface UploadFile extends File {
   description?:string;
+  customName?:string;
 }
 
 export interface UploadResult {
@@ -53,7 +54,7 @@ export class OpenProjectFileUploadService {
     const uploads = _.map(files, (file:UploadFile) => {
       const metadata = {
         description: file.description,
-        fileName: this.getFileName(file)
+        fileName: file.customName || file.name
       };
 
       // need to wrap the metadata into a JSON ourselves as ngFileUpload
@@ -67,24 +68,6 @@ export class OpenProjectFileUploadService {
     });
     const finished = this.$q.all(uploads);
     return {uploads, finished};
-  }
-
-  private getFileName(file:UploadFile) {
-    if (file.name) {
-      return file.name;
-    }
-
-    let name = 'unnamed_upload';
-    try {
-      if (file.type.indexOf('image') === 0) {
-        name += '.' + file.type.split('/')[1];
-      }
-
-      return name;
-    } catch (e) {
-      console.error('Failed to get file name from mime type: ' + e);
-      return 'unnamed_upload';
-    }
   }
 }
 

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/models/paste-model.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/models/paste-model.ts
@@ -1,8 +1,7 @@
-import IAugmentedJQuery = angular.IAugmentedJQuery;
-import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
+import {UploadFile} from '../../../api/op-file-upload/op-file-upload.service';
 
 export class PasteModel {
-  public files:File[] = [];
+  public files:UploadFile[] = [];
 
   constructor(protected dataTransfer:DataTransfer) {
     this.extractFiles(dataTransfer.files);
@@ -11,6 +10,17 @@ export class PasteModel {
     // to support older versions of Chrome.
     if (this.files.length === 0) {
       this.extractItems(dataTransfer.items);
+    }
+
+    for (let i = 0; i < this.files.length; i++) {
+      const file = this.files[i];
+      const date = Date.now().toString();
+      const extension = file.type.split('/')[1];
+      const newName = `${date}-${i}.${extension}`;
+
+      if (!file.name || file.name.indexOf('image.') === 0) {
+        file.customName = newName;
+      }
     }
   }
 

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/models/single-attachment.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/models/single-attachment.ts
@@ -1,4 +1,8 @@
-import IAugmentedJQuery = angular.IAugmentedJQuery;
+import {UploadFile} from '../../../api/op-file-upload/op-file-upload.service';
+
+interface Attachment extends UploadFile {
+  downloadLocation?:any;
+}
 
 export class SingleAttachmentModel {
   protected imageFileExtensions:Array<string> = ['jpeg', 'jpg', 'gif', 'bmp', 'png'];
@@ -9,9 +13,9 @@ export class SingleAttachmentModel {
   public url:string;
 
 
-  constructor(protected attachment:any) {
+  constructor(protected attachment:Attachment) {
     if (angular.isDefined(attachment)) {
-      this.fileName = attachment.fileName || attachment.name;
+      this.fileName = attachment.customName || attachment.name;
       this.fileExtension = (this.fileName.split('.') as any[]).pop().toLowerCase();
       this.isAnImage = this.imageFileExtensions.indexOf(this.fileExtension) > -1;
       this.url = angular.isDefined(attachment.downloadLocation) ? attachment.downloadLocation.$link.href : '';

--- a/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
+++ b/frontend/app/components/work-packages/wp-attachments-formattable-field/wp-attachments-formattable.directive.ts
@@ -11,6 +11,7 @@ import {DropModel} from './models/drop-model';
 import {SingleAttachmentModel} from './models/single-attachment';
 import {WorkPackageSingleViewController} from '../wp-single-view/wp-single-view.directive';
 import {CommentFieldDirectiveController} from '../work-package-comment/work-package-comment.directive';
+import {UploadFile} from '../../api/op-file-upload/op-file-upload.service';
 
 export class WpAttachmentsFormattableController {
   constructor(protected $scope:ng.IScope,
@@ -103,7 +104,7 @@ export class WpAttachmentsFormattableController {
     return [viewMode, model];
   }
 
-  protected uploadAndInsert(files:File[], model:EditorModel | WorkPackageFieldModel) {
+  protected uploadAndInsert(files:UploadFile[], model:EditorModel | WorkPackageFieldModel) {
     const wp = this.$scope.workPackage as WorkPackageResourceInterface;
     if (wp.isNew) {
       return this.insertDelayedAttachments(files, model, wp);
@@ -155,11 +156,13 @@ export class WpAttachmentsFormattableController {
     }
   }
 
-  protected insertDelayedAttachments(files:File[], description:any, workPackage:WorkPackageResourceInterface):void {
+  protected insertDelayedAttachments(files:UploadFile[], description:any, workPackage:WorkPackageResourceInterface):void {
     for (var i = 0; i < files.length; i++) {
       var currentFile = new SingleAttachmentModel(files[i]);
       var insertMode = currentFile.isAnImage ? InsertMode.INLINE : InsertMode.ATTACHMENT;
-      description.insertAttachmentLink(files[i].name.replace(/ /g, '_'), insertMode, true);
+      const name = files[i].customName || files[i].name;
+
+      description.insertAttachmentLink(name.replace(/ /g, '_'), insertMode, true);
       workPackage.pendingAttachments.push((files[i]));
     }
 

--- a/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
+++ b/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
@@ -9,7 +9,7 @@
             ng-href="{{ ::attachment.downloadLocation.href || '#' }}"
             download>
 
-          {{ ::attachment.fileName || attachment.name }}
+          {{ ::attachment.fileName || attachment.customName || attachment.name }}
         </a>
       </span>
       <a


### PR DESCRIPTION
Chrome and Firefox paste images using the `image.<extension>` name.
Since we upload them with these name, the formattable directive inserts
an inline image link to `!image.<extension>`. If there are multiple of
this kind, only the first one is referenced.

https://community.openproject.com/wp/26029