### PR TITLE
[26038] Rebuild the resource when changeset is cancelled

### DIFF
--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -77,6 +77,7 @@ export class WorkPackageChangeset {
 
   public reset(key:string) {
     delete this.changes[key];
+    this.buildResource();
   }
 
   public clear() {


### PR DESCRIPTION
Otherwise, it will fallback to a value that was merged from the
changeset and display a false value.

Steps to reproduce:

1. Start editing subject with WP with a missing required CF
2. Submit -> Error due to missing CF
3. Cancel subject. Will show the modified subject instead of the old
version

https://community.openproject.com/wp/26038