### PR TITLE
fix milestone date edit in wp table

### DIFF
--- a/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
+++ b/frontend/app/components/api/api-v3/hal-resources/work-package-resource.service.ts
@@ -267,6 +267,14 @@ export class WorkPackageResource extends HalResource {
     }
   }
 
+  public getSchemaName(name:string):string {
+    if (this.isMilestone && (name === 'startDate' || name === 'dueDate')) {
+      return 'date';
+    } else {
+      return name;
+    }
+  }
+
   public allowedValuesFor(field:string):ng.IPromise<HalResource[]> {
     var deferred = $q.defer();
 

--- a/frontend/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/app/components/wp-edit-form/display-field-renderer.ts
@@ -26,7 +26,8 @@ export class DisplayFieldRenderer {
 
   public render(workPackage:WorkPackageResourceInterface, name:string, placeholder = cellEmptyPlaceholder):HTMLSpanElement {
     const span = document.createElement('span');
-    const fieldSchema = workPackage.schema[name];
+    const schemaName = workPackage.getSchemaName(name);
+    const fieldSchema = workPackage.schema[schemaName];
 
     // If the work package does not have that field, return an empty
     // span (e.g., for the table).
@@ -34,7 +35,7 @@ export class DisplayFieldRenderer {
       return span;
     }
 
-    const field = this.getField(workPackage, fieldSchema, name);
+    const field = this.getField(workPackage, fieldSchema, schemaName);
 
     this.setSpanAttributes(span, field, name, workPackage);
 

--- a/frontend/app/components/wp-edit-form/single-view-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/single-view-edit-context.ts
@@ -64,7 +64,7 @@ export class SingleViewEditContext implements WorkPackageEditContext {
       'FocusHelper', '$q', '$timeout', 'templateRenderer', '$state', 'wpNotificationsService', 'wpTableSelection');
   }
 
-  public async activateField(form:WorkPackageEditForm, field:EditField, errors:string[]):Promise<WorkPackageEditFieldHandler> {
+  public async activateField(form:WorkPackageEditForm, field:EditField, fieldName:string, errors:string[]):Promise<WorkPackageEditFieldHandler> {
     const ctrl = await this.fieldCtrl(field.name);
     const container = ctrl.editContainer;
 

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -60,11 +60,11 @@ export class TableRowEditContext implements WorkPackageEditContext {
   }
 
   public findContainer(fieldName:string):JQuery {
-    return this.rowContainer.find(`.${tdClassName}.${fieldName} .${editCellContainer}`);
+    return this.rowContainer.find(`.${tdClassName}.${fieldName} .${editCellContainer}`).first();
   }
 
-  public activateField(form:WorkPackageEditForm, field:EditField, errors:string[]):ng.IPromise<WorkPackageEditFieldHandler> {
-    const cell = this.findContainer(field.name);
+  public activateField(form:WorkPackageEditForm, field:EditField, fieldName:string, errors:string[]):ng.IPromise<WorkPackageEditFieldHandler> {
+    const cell = this.findContainer(fieldName);
 
     // Create a field handler for the newly active field
     const fieldHandler = new WorkPackageEditFieldHandler(

--- a/frontend/app/components/wp-edit-form/work-package-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-context.ts
@@ -37,7 +37,7 @@ export interface WorkPackageEditContext {
   /**
    * Activate the field, returning the element and associated field handler
    */
-  activateField(form:WorkPackageEditForm, field:EditField, errors:string[]):Promise<WorkPackageEditFieldHandler>;
+  activateField(form:WorkPackageEditForm, field:EditField, fieldName:string, errors:string[]):Promise<WorkPackageEditFieldHandler>;
 
   /**
    * Refresh an open field template, replacing its edit field.

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -286,7 +286,8 @@ export class WorkPackageEditForm {
     return new Promise((resolve, reject) => {
       this.changeset.getForm()
         .then((form:FormResourceInterface) => {
-          const fieldSchema = form.schema[fieldName];
+          const schemaName = this.workPackage.getSchemaName(fieldName);
+          const fieldSchema = form.schema[schemaName];
 
           if (!fieldSchema) {
             return reject();
@@ -294,7 +295,7 @@ export class WorkPackageEditForm {
 
           const field = this.wpEditField.getField(
             this.changeset,
-            fieldName,
+            schemaName,
             fieldSchema
           ) as EditField;
 
@@ -310,6 +311,7 @@ export class WorkPackageEditForm {
   private renderField(fieldName:string, field:EditField):Promise<WorkPackageEditFieldHandler> {
     const promise = this.editContext.activateField(this,
       field,
+      fieldName,
       this.errorsPerAttribute[fieldName] || []);
     return promise
       .then((fieldHandler) => {

--- a/frontend/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/cell-builder.ts
@@ -12,13 +12,12 @@ export class CellBuilder {
   private fieldRenderer = new DisplayFieldRenderer('table');
 
   public build(workPackage:WorkPackageResourceInterface, attribute:string) {
-    const name = this.correctDateAttribute(workPackage, attribute);
     const td = document.createElement('td');
-    td.classList.add(tdClassName, wpCellTdClassName, name);
+    td.classList.add(tdClassName, wpCellTdClassName, attribute);
 
     const container = document.createElement('span');
-    container.classList.add(editCellContainer, editFieldContainerClass, name);
-    const displayElement = this.fieldRenderer.render(workPackage, name);
+    container.classList.add(editCellContainer, editFieldContainerClass, attribute);
+    const displayElement = this.fieldRenderer.render(workPackage, attribute);
 
     container.appendChild(displayElement);
     td.appendChild(container);
@@ -27,22 +26,9 @@ export class CellBuilder {
   }
 
   public refresh(container:HTMLElement, workPackage:WorkPackageResourceInterface, attribute:string) {
-    const name = this.correctDateAttribute(workPackage, attribute);
-    const displayElement = this.fieldRenderer.render(workPackage, name);
+    const displayElement = this.fieldRenderer.render(workPackage, attribute);
 
     container.innerHTML = '';
     container.appendChild(displayElement);
-  }
-
-
-  /**
-   * Milestones should display the 'date' attribute for start and due dates
-   */
-  public correctDateAttribute(workPackage:WorkPackageResourceInterface, name:string):string {
-    if (workPackage.isMilestone && (name === 'dueDate' || name === 'startDate')) {
-      return 'date';
-    }
-
-    return name;
   }
 }


### PR DESCRIPTION
Fixes having the date input in the right table cell:

![image](https://user-images.githubusercontent.com/617519/28926515-4efc5df6-7868-11e7-851d-a6f15fcee10a.png)

The imlementation is probably overly complex as the problem was basically trying to find the cell the user clicked in. But the interfaces currently do not support providing the field the user clicked on or some such.

Given the release date, I took the coward's approach to just make matters worse.

https://community.openproject.com/projects/openproject/work_packages/26022