### PR TITLE
[26037] Don't initialize a changeset by copying

### DIFF
--- a/frontend/app/components/wp-create/wp-create.controller.ts
+++ b/frontend/app/components/wp-create/wp-create.controller.ts
@@ -89,6 +89,7 @@ export class WorkPackageCreateController {
       .then((changeset:WorkPackageChangeset) => {
         this.changeset = changeset;
         this.newWorkPackage = changeset.workPackage;
+        this.wpEditing.updateValue('new', changeset);
         wpCacheService.updateWorkPackage(changeset.workPackage);
 
         if ($state.params['parent_id']) {

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -70,9 +70,6 @@ export class WorkPackageChangeset {
     if (form !== undefined) {
       this.wpForm.putValue(form);
     }
-
-    // Start with a resource from the current work package knowledge.
-    this.buildResource();
   }
 
   public reset(key:string) {


### PR DESCRIPTION
As it turns out, copying the resource and defaulting to the form is REALLY expensive when doing that for more than one work package. In turn, using copying and immutable resources seems really infeasible if we want to keep a large number of data in the frontend.

Since creating a new empty changeset should be cheap (its convenient to simply have one available in the timeline), we don't really need to copy the resource from the work package, since the `temporaryEditResource` provided by wpEditing falls back to the work package anyway.

https://community.openproject.com/wp/26037