### PR TITLE
[26035] Don't clear stale cache states

### DIFF
--- a/frontend/app/components/states/state-cache.service.ts
+++ b/frontend/app/components/states/state-cache.service.ts
@@ -81,7 +81,6 @@ export abstract class StateCacheService<T> {
 
     // Refresh when stale or being forced
     if (this.stale(state) || force) {
-      state.clear();
       return this.load(id);
     }
 


### PR DESCRIPTION
When a state is stale, its value was cleared.
This causes e.g., a visual delay in the split screen beacuse a work package is no longer
present in the system.

If we instead only load the value, the stale value will be available for
the period of the request of the next one.

Regular value-subscriber of the state will thus receive the stale value
first, followed by the refreshed value.

https://community.openproject.com/wp/26035