### PR TITLE
[26033] Remove base path when checking for angular URLs

### DIFF
--- a/frontend/app/components/common/path-heleper/path-helper.functions.ts
+++ b/frontend/app/components/common/path-heleper/path-helper.functions.ts
@@ -1,0 +1,43 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+
+export namespace PathHelperFunctions {
+  export function removeBasePathFromLink(link:string) {
+    const basePath = (window as any).appBasePath;
+    const url = URI(link);
+
+    if (basePath && `/${url.segment(0)}` === basePath) {
+      // Remove the first segment
+      url.segment(0, '');
+      return url.toString();
+    }
+
+    return link;
+  }
+}

--- a/frontend/app/components/work-packages/work-package-more-menu.service.ts
+++ b/frontend/app/components/work-packages/work-package-more-menu.service.ts
@@ -28,6 +28,7 @@
 
 import {WorkPackageResource} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {States} from '../states.service';
+import {PathHelperFunctions} from "../common/path-heleper/path-helper.functions";
 
 var $state:ng.ui.IStateService;
 var $window:ng.IWindowService;
@@ -60,8 +61,9 @@ export class WorkPackageMoreMenuService {
         this.deleteSelectedWorkPackage();
         break;
       default:
-        if (this.isLinkToAnguluar(link)) {
-          $location.path(link);
+        const normalized = PathHelperFunctions.removeBasePathFromLink(link);
+        if (this.isLinkToAnguluar(normalized)) {
+          $location.path(normalized);
         } else {
           $window.location.href = link;
         }


### PR DESCRIPTION
The ui-router does not handle URLs with a base path, but instead the URLs are rewritten internally using the <base /> tag.

This causes some links of the more menu to be incorrectly judged as non-angular links, causing a full reload without the query params.

https://community.openproject.com/wp/26033