### PR TITLE
Fix/wp table switch to milestone

### DIFF
--- a/app/services/update_child_work_package_service.rb
+++ b/app/services/update_child_work_package_service.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,18 +29,18 @@
 #++
 
 class UpdateChildWorkPackageService < UpdateWorkPackageService
-  self.contract = WorkPackages::UpdateContract
-
   private
 
   def set_attributes(attributes)
-    super
+    ret_values = super
 
     if work_package.project_id_changed?
       set_fixed_version_to_nil
       reassign_category
       reassign_type
     end
+
+    ret_values
   end
 
   def set_fixed_version_to_nil

--- a/frontend/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/app/components/wp-edit-form/display-field-renderer.ts
@@ -4,7 +4,6 @@ import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-pac
 import {DisplayField} from '../wp-display/wp-display-field/wp-display-field.module';
 import {MultipleLinesStringObjectsDisplayField} from '../wp-display/field-types/wp-display-multiple-lines-string-objects-field.module';
 import {HalResource} from '../api/api-v3/hal-resources/hal-resource.service';
-import {WorkPackageChangeset} from './work-package-changeset';
 
 export const editableClassName = '-editable';
 export const requiredClassName = '-required';

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -300,6 +300,14 @@ export class WorkPackageChangeset {
     return this.wpForm.getValueOr(this.workPackage).schema;
   }
 
+  public getSchemaName(attribute:string):string {
+    if (this.schema.hasOwnProperty('date') && (attribute === 'startDate' || attribute === 'dueDate')) {
+      return 'date';
+    } else {
+      return attribute;
+    }
+  }
+
   private buildResource() {
     const hasForm = this.wpForm.hasValue();
     let payload:any = this.workPackage.$plain();

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -286,7 +286,7 @@ export class WorkPackageEditForm {
     return new Promise((resolve, reject) => {
       this.changeset.getForm()
         .then((form:FormResourceInterface) => {
-          const schemaName = this.workPackage.getSchemaName(fieldName);
+          const schemaName = this.changeset.getSchemaName(fieldName);
           const fieldSchema = form.schema[schemaName];
 
           if (!fieldSchema) {

--- a/lib/api/v3/work_packages/work_packages_shared_helpers.rb
+++ b/lib/api/v3/work_packages/work_packages_shared_helpers.rb
@@ -60,10 +60,12 @@ module API
 
         def create_work_package_form(work_package, contract_class:, form_class:, action: :update)
           write_work_package_attributes(work_package, request_body, reset_lock_version: true)
-          contract = contract_class.new(work_package, current_user)
-          contract.validate
 
-          api_errors = ::API::Errors::ErrorBase.create_errors(contract.errors)
+          result = SetAttributesWorkPackageService
+                   .new(user: current_user, work_package: work_package, contract: contract_class)
+                   .call({})
+
+          api_errors = ::API::Errors::ErrorBase.create_errors(result.errors)
 
           # errors for invalid data (e.g. validation errors) are handled inside the form
           if only_validation_errors(api_errors)

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -74,8 +74,8 @@ describe Journal::AggregatedJournal, type: :model do
 
   before do
     allow(User).to receive(:current).and_return(initial_author)
-    stub_const('WorkPackages::UpdateContract', NoopContract)
-    stub_const('WorkPackages::CreateNoteContract', NoopContract)
+    allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
+    allow(WorkPackages::CreateNoteContract).to receive(:new).and_return(NoopContract.new)
     work_package.save!
   end
 

--- a/spec/models/journal/aggregated_journal_spec.rb
+++ b/spec/models/journal/aggregated_journal_spec.rb
@@ -74,8 +74,8 @@ describe Journal::AggregatedJournal, type: :model do
 
   before do
     allow(User).to receive(:current).and_return(initial_author)
-    allow(UpdateWorkPackageService).to receive(:contract).and_return(NoopContract)
-    allow(AddWorkPackageNoteService).to receive(:contract).and_return(NoopContract)
+    stub_const('WorkPackages::UpdateContract', NoopContract)
+    stub_const('WorkPackages::CreateNoteContract', NoopContract)
     work_package.save!
   end
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -205,7 +205,7 @@ describe WorkPackage, type: :model do
 
       describe 'adding journal with a missing journal and an existing journal' do
         before do
-          allow(UpdateWorkPackageService).to receive(:contract).and_return(NoopContract)
+          stub_const('WorkPackages::UpdateContract', NoopContract)
           service = UpdateWorkPackageService.new(user: current_user, work_package: work_package)
           service.call(attributes: { journal_notes: 'note to be deleted' })
           work_package.reload

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -205,7 +205,7 @@ describe WorkPackage, type: :model do
 
       describe 'adding journal with a missing journal and an existing journal' do
         before do
-          stub_const('WorkPackages::UpdateContract', NoopContract)
+          allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
           service = UpdateWorkPackageService.new(user: current_user, work_package: work_package)
           service.call(attributes: { journal_notes: 'note to be deleted' })
           work_package.reload

--- a/spec/services/set_attributes_work_package_service_spec.rb
+++ b/spec/services/set_attributes_work_package_service_spec.rb
@@ -1,0 +1,263 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe SetAttributesWorkPackageService, type: :model do
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:project) do
+    p = FactoryGirl.build_stubbed(:project)
+    allow(p).to receive(:shared_versions).and_return([])
+
+    p
+  end
+  let(:work_package) do
+    wp = FactoryGirl.build_stubbed(:work_package, project: project)
+    wp.type = FactoryGirl.build_stubbed(:type)
+    wp.send(:clear_changes_information)
+
+    allow(wp)
+      .to receive(:valid?)
+      .and_return(work_package_valid)
+
+    wp
+  end
+  let(:mock_contract) do
+    double(WorkPackages::UpdateContract,
+           new: mock_contract_instance)
+  end
+  let(:mock_contract_instance) do
+    mock = mock_model(WorkPackages::UpdateContract)
+    allow(mock)
+      .to receive(:validate)
+      .and_return contract_valid
+
+    mock
+  end
+  let(:contract_valid) { true }
+  let(:work_package_valid) { true }
+  let(:instance) do
+    described_class.new(user: user,
+                        work_package: work_package,
+                        contract: mock_contract)
+  end
+
+  describe 'call' do
+    before do
+    end
+
+    shared_examples_for 'service call' do
+      subject { instance.call(call_attributes) }
+
+      it 'is successful' do
+        expect(subject.success?).to be_truthy
+      end
+
+      it 'sets the value' do
+        subject
+
+        attributes.each do |attribute, key|
+          expect(work_package.send(attribute)).to eql key
+        end
+      end
+
+      it 'does not persist the work_package' do
+        expect(work_package)
+          .not_to receive(:save)
+
+        subject
+      end
+
+      it 'has no errors' do
+        expect(subject.errors).to be_empty
+      end
+
+      context 'when the contract does not validate' do
+        let(:contract_valid) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it 'does not persist the changes' do
+          subject
+
+          expect(work_package).to_not receive(:save)
+        end
+
+        it "exposes the contract's errors" do
+          subject
+
+          expect(subject.errors).to eql mock_contract_instance.errors
+        end
+      end
+
+      context 'when the work package is invalid' do
+        let(:work_package_valid) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it 'leaves the value unchanged' do
+          subject
+
+          expect(work_package.changed?).to be_truthy
+        end
+
+        it "exposes the work_packages's errors" do
+          subject
+
+          expect(subject.errors).to eql work_package.errors
+        end
+      end
+    end
+
+    context 'update subject before calling the service' do
+      let(:call_attributes) { {} }
+      let(:attributes) { { subject: 'blubs blubs' } }
+
+      before do
+        work_package.attributes = attributes
+      end
+
+      it_behaves_like 'service call'
+    end
+
+    context 'updating subject via attributes' do
+      let(:call_attributes) { attributes }
+      let(:attributes) { { subject: 'blubs blubs' } }
+
+      it_behaves_like 'service call'
+    end
+
+    context 'when switching the type' do
+      let(:target_type) { FactoryGirl.build_stubbed(:type) }
+
+      context 'with a type that is no milestone' do
+        before do
+          allow(target_type)
+            .to receive(:is_milestone?)
+            .and_return(false)
+        end
+
+        it 'sets the start date to the due date' do
+          work_package.due_date = Date.today
+
+          instance.call(type: target_type)
+
+          expect(work_package.start_date).to be_nil
+        end
+      end
+
+      context 'with a type that is a milestone' do
+        before do
+          allow(target_type)
+            .to receive(:is_milestone?)
+            .and_return(true)
+        end
+
+        it 'sets the start date to the due date' do
+          date = Date.today
+          work_package.due_date = date
+
+          instance.call(type: target_type)
+
+          expect(work_package.start_date).to eql date
+        end
+
+        it 'set the due date to the start date if the due date is nil' do
+          date = Date.today
+          work_package.start_date = date
+
+          instance.call(type: target_type)
+
+          expect(work_package.due_date).to eql date
+        end
+      end
+    end
+
+    context 'when setting a parent' do
+      let(:parent) { FactoryGirl.build_stubbed(:work_package) }
+
+      context "with the parent being restricted in it's ability to be moved" do
+        let(:soonest_date) { Date.today + 3.days }
+
+        before do
+          allow(parent)
+            .to receive(:soonest_start)
+            .and_return(soonest_date)
+        end
+
+        it 'sets the start date to the earliest possible date' do
+          instance.call(parent: parent)
+
+          expect(work_package.start_date).to eql(Date.today + 3.days)
+        end
+      end
+
+      context 'with the parent being restricted but the attributes define a later date' do
+        let(:soonest_date) { Date.today + 3.days }
+
+        before do
+          allow(parent)
+            .to receive(:soonest_start)
+            .and_return(soonest_date)
+        end
+
+        it 'sets the dates to provided dates' do
+          instance.call(parent: parent, start_date: Date.today + 4.days, due_date: Date.today + 5.days)
+
+          expect(work_package.start_date).to eql(Date.today + 4.days)
+          expect(work_package.due_date).to eql(Date.today + 5.days)
+        end
+      end
+
+      context 'with the parent being restricted but the attributes define an earlier date' do
+        let(:soonest_date) { Date.today + 3.days }
+
+        before do
+          allow(parent)
+            .to receive(:soonest_start)
+            .and_return(soonest_date)
+        end
+
+        # This would be invalid but the dates should be set nevertheless
+        # so we can have a correct error handling.
+        it 'sets the dates to provided dates' do
+          instance.call(parent: parent, start_date: Date.today + 1.days, due_date: Date.today + 2.days)
+
+          expect(work_package.start_date).to eql(Date.today + 1.days)
+          expect(work_package.due_date).to eql(Date.today + 2.days)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/update_work_package_service_spec.rb
+++ b/spec/services/update_work_package_service_spec.rb
@@ -50,23 +50,33 @@ describe UpdateWorkPackageService, type: :model do
                                  work_package: work_package)
   end
 
-  describe '.contract' do
-    it 'uses the UpdateContract contract' do
-      expect(described_class.contract).to eql WorkPackages::UpdateContract
-    end
-  end
-
   describe 'call' do
-    let(:mock_contract) do
-      double(WorkPackages::UpdateContract,
-             new: mock_contract_instance)
+    let(:set_attributes_service) do
+      service = double("SetAttributesWorkPackageService",
+                       new: set_attributes_service_instance)
+
+      stub_const('SetAttributesWorkPackageService', service)
+
+      service
     end
-    let(:mock_contract_instance) do
-      mock_model(WorkPackages::UpdateContract)
+    let(:set_attributes_service_instance) do
+      instance = double("SetAttributesWorkPackageServiceInstance")
+
+      allow(instance)
+        .to receive(:call) do |attributes|
+        work_package.attributes = attributes
+
+        set_service_results
+      end
+
+      instance
     end
+    let(:errors) { double('errors') }
+    let(:set_service_results) { double('result', success?: true, errors: errors) }
+    let(:work_package_save_result) { true }
 
     before do
-      allow(described_class).to receive(:contract).and_return(mock_contract)
+      set_attributes_service
     end
 
     let(:send_notifications) { true }
@@ -77,8 +87,9 @@ describe UpdateWorkPackageService, type: :model do
         .with(send_notifications)
         .and_yield
 
-      allow(work_package).to receive(:save).and_return true
-      allow(mock_contract_instance).to receive(:validate).and_return true
+      allow(work_package)
+        .to receive(:save)
+        .and_return work_package_save_result
     end
 
     shared_examples_for 'service call' do
@@ -100,10 +111,9 @@ describe UpdateWorkPackageService, type: :model do
         expect(subject.errors).to be_empty
       end
 
-      context 'when the contract does not validate' do
-        before do
-          expect(mock_contract_instance).to receive(:validate).and_return false
-        end
+      context 'when setting the attributes is unsuccessful (invalid)' do
+        let(:errors) { double('errors') }
+        let(:set_service_results) { double('result', success?: false, errors: errors) }
 
         it 'is unsuccessful' do
           expect(subject.success?).to be_falsey
@@ -115,10 +125,7 @@ describe UpdateWorkPackageService, type: :model do
           expect(work_package).to_not receive(:save)
         end
 
-        it "exposes the contract's errors" do
-          errors = double('errors')
-          allow(mock_contract_instance).to receive(:errors).and_return(errors)
-
+        it 'exposes the errors' do
           subject
 
           expect(subject.errors).to eql errors
@@ -126,9 +133,7 @@ describe UpdateWorkPackageService, type: :model do
       end
 
       context 'when the saving is unsuccessful' do
-        before do
-          expect(work_package).to receive(:save).and_return false
-        end
+        let(:work_package_save_result) { false }
 
         it 'is unsuccessful' do
           expect(subject.success?).to be_falsey
@@ -141,12 +146,14 @@ describe UpdateWorkPackageService, type: :model do
         end
 
         it "exposes the work_packages's errors" do
-          errors = double('errors')
-          allow(work_package).to receive(:errors).and_return(errors)
+          saving_errors = double('saving_errors')
+          allow(work_package)
+            .to receive(:errors)
+            .and_return(saving_errors)
 
           subject
 
-          expect(subject.errors).to eql errors
+          expect(subject.errors).to eql saving_errors
         end
       end
     end
@@ -281,104 +288,6 @@ describe UpdateWorkPackageService, type: :model do
             .to receive(:reset_custom_values!)
 
           instance.call(attributes: { type: target_type })
-        end
-      end
-
-      context 'with a type that is no milestone' do
-        before do
-          allow(target_type)
-            .to receive(:is_milestone?)
-            .and_return(false)
-        end
-
-        it 'sets the start date to the due date' do
-          work_package.due_date = Date.today
-
-          instance.call(attributes: { type: target_type })
-
-          expect(work_package.start_date).to be_nil
-        end
-      end
-
-      context 'with a type that is a milestone' do
-        before do
-          allow(target_type)
-            .to receive(:is_milestone?)
-            .and_return(true)
-        end
-
-        it 'sets the start date to the due date' do
-          date = Date.today
-          work_package.due_date = date
-
-          instance.call(attributes: { type: target_type })
-
-          expect(work_package.start_date).to eql date
-        end
-
-        it 'set the due date to the start date if the due date is nil' do
-          date = Date.today
-          work_package.start_date = date
-
-          instance.call(attributes: { type: target_type })
-
-          expect(work_package.due_date).to eql date
-        end
-      end
-    end
-
-    context 'when setting a parent' do
-      let(:parent) { FactoryGirl.build_stubbed(:work_package) }
-
-      context "with the parent being restricted in it's ability to be moved" do
-        let(:soonest_date) { Date.today + 3.days }
-
-        before do
-          allow(parent)
-            .to receive(:soonest_start)
-            .and_return(soonest_date)
-        end
-
-        it 'sets the start date to the earliest possible date' do
-          instance.call(attributes: { parent: parent })
-
-          expect(work_package.start_date).to eql(Date.today + 3.days)
-        end
-      end
-
-      context 'with the parent being restricted but the attributes define a later date' do
-        let(:soonest_date) { Date.today + 3.days }
-
-        before do
-          allow(parent)
-            .to receive(:soonest_start)
-            .and_return(soonest_date)
-        end
-
-        it 'sets the dates to provided dates' do
-          instance.call(attributes: { parent: parent, start_date: Date.today + 4.days, due_date: Date.today + 5.days })
-
-          expect(work_package.start_date).to eql(Date.today + 4.days)
-          expect(work_package.due_date).to eql(Date.today + 5.days)
-        end
-      end
-
-      context 'with the parent being restricted but the attributes define an earlier date' do
-        let(:soonest_date) { Date.today + 3.days }
-
-        before do
-          allow(parent)
-            .to receive(:soonest_start)
-            .and_return(soonest_date)
-        end
-
-        # This would be invalid but the dates should be set nevertheless
-        # so we can have a correct error handling.
-        it 'sets the dates to provided dates' do
-          instance.call(attributes: { parent: parent, start_date: Date.today + 1.days, due_date: Date.today + 2.days })
-
-          expect(work_package.start_date).to eql(Date.today + 1.days)
-          expect(work_package.due_date).to eql(Date.today + 2.days)
         end
       end
     end

--- a/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
@@ -72,8 +72,9 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
     end
 
     it 'sends a mail' do
-      expect(Delayed::Job).to receive(:enqueue)
-                                .with(an_instance_of DeliverWorkPackageNotificationJob)
+      expect(Delayed::Job)
+        .to receive(:enqueue)
+        .with(an_instance_of DeliverWorkPackageNotificationJob)
       subject.perform
     end
   end
@@ -114,7 +115,7 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
       change = { subject: 'new subject' }
       note = { journal_notes: 'a comment' }
 
-      allow(UpdateWorkPackageService).to receive(:contract).and_return(NoopContract)
+      stub_const('WorkPackages::UpdateContract', NoopContract)
       service = UpdateWorkPackageService.new(user: author, work_package: work_package)
 
       expect(service.call(attributes: note)).to be_success

--- a/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
@@ -115,7 +115,7 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
       change = { subject: 'new subject' }
       note = { journal_notes: 'a comment' }
 
-      stub_const('WorkPackages::UpdateContract', NoopContract)
+      allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
       service = UpdateWorkPackageService.new(user: author, work_package: work_package)
 
       expect(service.call(attributes: note)).to be_success


### PR DESCRIPTION
Allows switching to a milestone type in cases where the due and start date are not equal. Instead of displaying the column, and by that force the user to do the manual work of matching the start to the due date, the form's payload is now returned with the date being set to the due date. To do that, the start date is set to the due date (unpersisted) before rendering the payload.

https://community.openproject.com/projects/openproject/work_packages/26027

### TODO
- [x] add tests for added service (extract tests from update service)