### PR TITLE
[26034] Set default CF values when switching types

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -81,7 +81,8 @@ class CustomField < ActiveRecord::Base
         ids.first
       end
     else
-      read_attribute :default_value
+      val = read_attribute :default_value
+      cast_value val
     end
   end
 

--- a/app/services/set_attributes_work_package_service.rb
+++ b/app/services/set_attributes_work_package_service.rb
@@ -62,6 +62,10 @@ class SetAttributesWorkPackageService
 
     unify_dates if work_package_now_milestone?
 
+    # Take over any default custom values
+    # for new custom fields
+    work_package.set_default_values! if custom_field_context_changed?
+
     reschedule(attributes)
   end
 
@@ -74,6 +78,10 @@ class SetAttributesWorkPackageService
   def unify_dates
     unified_date = work_package.due_date || work_package.start_date
     work_package.start_date = work_package.due_date = unified_date
+  end
+
+  def custom_field_context_changed?
+    work_package.type_id_changed? || work_package.project_id_changed?
   end
 
   def work_package_now_milestone?


### PR DESCRIPTION
Fixes switching to a type with a required CF with a default value set.  
https://community.openproject.com/wp/26034
