### PR TITLE
Fix filter spec by removing unsufficient cache_key

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -243,7 +243,7 @@ class CustomField < ActiveRecord::Base
   def cache_key
     tag = multi_value? ? "mv" : "sv"
 
-    ["work_package_custom_fields", id, tag].join("/")
+    super + '/' + tag
   end
 
   private


### PR DESCRIPTION
/cc @ulferts  and @machisuji . The custom field cache key was invalid, causing the spec to randomly fail because another CF list was cached, and not invalidated.