### PR TITLE
Dead page at User Filter

### DIFF
--- a/app/cells/views/user_filter/show.erb
+++ b/app/cells/views/user_filter/show.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= form_tag({}, method: :get) do %>
+<%= form_tag('/users', method: :get) do %>
    <% collapsed_class =  initially_visible? ? '' : 'collapsed' %>
   <fieldset class="simple-filters--container <%= collapsed_class %>">
     <legend><%= t(:label_filter_plural) %></legend>

--- a/app/cells/views/user_filter/show.erb
+++ b/app/cells/views/user_filter/show.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= form_tag('/users', method: :get) do %>
+<%= form_tag(users_path, method: :get) do %>
    <% collapsed_class =  initially_visible? ? '' : 'collapsed' %>
   <fieldset class="simple-filters--container <%= collapsed_class %>">
     <legend><%= t(:label_filter_plural) %></legend>


### PR DESCRIPTION
The form at: **Administration -> Users -> Apply (filter)** is leading to a dead page **(127.0.0.1:6000/xxx/xxx/xx)**

Adding the relative URL "/users" in form action, solved it for me.

I'm new to Rails and Ruby, probably there would be a better way to do this.