### PR TITLE
[24842] Show attribute group for different project contexts

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -37,7 +37,10 @@ See doc/COPYRIGHT.rdoc for more details.
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
     <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
     <% if @project %>
-    <meta name="current_project" data-project-id="<%= @project.id %>" data-project-identifier="<%= @project.identifier %>"/>
+    <meta name="current_project"
+          data-project-name="<%= h @project.name %>"
+          data-project-id="<%= @project.id %>"
+          data-project-identifier="<%= @project.identifier %>"/>
     <% end %>
     <meta name="current_menu_item" content="<%= current_menu_item %>" />
     <meta name="accessibility-mode" content="<%= current_user.impaired? %>" />

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,6 +36,9 @@ See doc/COPYRIGHT.rdoc for more details.
     <meta name="keywords" content="issue,bug,type" />
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
     <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
+    <% if @project %>
+    <meta name="current_project" data-project-id="<%= @project.id %>" data-project-identifier="<%= @project.identifier %>"/>
+    <% end %>
     <meta name="current_menu_item" content="<%= current_menu_item %>" />
     <meta name="accessibility-mode" content="<%= current_user.impaired? %>" />
     <%= csrf_meta_tags %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -35,7 +35,7 @@ Redmine::MenuManager.map :top_menu do |menu|
   # Redmine::MenuManager::TopMenuHelper#render_projects_top_menu_node
 
   menu.push :work_packages,
-            { controller: '/work_packages', project_id: nil, action: 'index' },
+            { controller: '/work_packages', project_id: nil, state: nil, action: 'index' },
             context: :modules,
             caption: I18n.t('label_work_package_plural'),
             if: Proc.new {

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -240,6 +240,12 @@ en:
       selection: 'Please select'
       relation_description: 'Click to add description for this relation'
 
+    project:
+      required_outside_context: 'You are not within a project context. Please choose the project context first in order to select type and status'
+      context: 'Project context'
+      work_package_belongs_to: 'This work package belongs to project %{projectname}.'
+      click_to_switch_context: 'Click here to open the work package in this project.'
+
     text_are_you_sure: "Are you sure?"
 
     types:

--- a/frontend/app/components/common/path-heleper/path-helper.service.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.js
@@ -82,6 +82,9 @@ function PathHelper() {
     projectWikiPath: function(projectId) {
       return PathHelper.projectPath(projectId) + '/wiki';
     },
+    projectWorkPackagePath: function(projectId, wpId) {
+      return PathHelper.projectWorkPackagesPath(projectId) + '/' + wpId;
+    },
     projectWorkPackagesPath: function(projectId) {
       return PathHelper.projectPath(projectId) + '/work_packages';
     },

--- a/frontend/app/components/projects/current-project.service.test.ts
+++ b/frontend/app/components/projects/current-project.service.test.ts
@@ -1,0 +1,74 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+import {CurrentProjectService} from './current-project.service';
+
+describe('currentProject service', function() {
+    var element:ng.IAugmentedJQuery;
+    var currentProject:CurrentProjectService;
+
+    beforeEach(angular.mock.module('openproject.filters',
+                                   'openproject.templates',
+                                   'openproject.services'));
+
+    beforeEach(angular.mock.inject((_currentProject_:CurrentProjectService) => {
+      currentProject = _currentProject_;
+    }));
+
+    describe('with no meta present', () => {
+      it('returns null values', () => {
+        expect(currentProject.projectId).to.be.null;
+        expect(currentProject.projectIdentifier).to.be.null;
+        expect(currentProject.apiv3Path).to.be.null;
+      });
+    });
+
+    describe('with a meta value present', () => {
+      beforeEach(() => {
+        var html = `
+          <meta name="current_project" data-project-id="1" data-project-identifier="foobar"/>
+        `;
+
+        element = angular.element(html);
+        angular.element(document.body).append(element);
+        currentProject.detect();
+      });
+
+      afterEach(angular.mock.inject(() => {
+        element.remove();
+      }));
+
+      it('returns correct values', () => {
+        expect(currentProject.projectId).to.eq('1');
+        expect(currentProject.projectIdentifier).to.eq('foobar')
+        expect(currentProject.apiv3Path).to.eq('/api/v3/projects/1');
+      });
+    });
+});

--- a/frontend/app/components/projects/current-project.service.test.ts
+++ b/frontend/app/components/projects/current-project.service.test.ts
@@ -55,7 +55,7 @@ describe('currentProject service', function() {
     describe('with a meta value present', () => {
       beforeEach(() => {
         var html = `
-          <meta name="current_project" data-name="Foo 1234" data-project-id="1" data-project-identifier="foobar"/>
+          <meta name="current_project" data-project-name="Foo 1234" data-project-id="1" data-project-identifier="foobar"/>
         `;
 
         element = angular.element(html);

--- a/frontend/app/components/projects/current-project.service.test.ts
+++ b/frontend/app/components/projects/current-project.service.test.ts
@@ -44,16 +44,18 @@ describe('currentProject service', function() {
 
     describe('with no meta present', () => {
       it('returns null values', () => {
-        expect(currentProject.projectId).to.be.null;
-        expect(currentProject.projectIdentifier).to.be.null;
+        expect(currentProject.id).to.be.null;
+        expect(currentProject.identifier).to.be.null;
+        expect(currentProject.name).to.be.null;
         expect(currentProject.apiv3Path).to.be.null;
+        expect(currentProject.inProjectContext).to.be.false;
       });
     });
 
     describe('with a meta value present', () => {
       beforeEach(() => {
         var html = `
-          <meta name="current_project" data-project-id="1" data-project-identifier="foobar"/>
+          <meta name="current_project" data-name="Foo 1234" data-project-id="1" data-project-identifier="foobar"/>
         `;
 
         element = angular.element(html);
@@ -66,8 +68,10 @@ describe('currentProject service', function() {
       }));
 
       it('returns correct values', () => {
-        expect(currentProject.projectId).to.eq('1');
-        expect(currentProject.projectIdentifier).to.eq('foobar')
+        expect(currentProject.inProjectContext).to.be.true;
+        expect(currentProject.id).to.eq('1');
+        expect(currentProject.name).to.eq('Foo 1234');
+        expect(currentProject.identifier).to.eq('foobar')
         expect(currentProject.apiv3Path).to.eq('/api/v3/projects/1');
       });
     });

--- a/frontend/app/components/projects/current-project.service.ts
+++ b/frontend/app/components/projects/current-project.service.ts
@@ -29,7 +29,7 @@
 import {opServicesModule} from '../../angular-modules';
 
 export class CurrentProjectService {
-  private current:{ id:string, identifier:string };
+  private current:{ id:string, identifier:string, name:string };
 
   constructor(private PathHelper:any) {
     this.detect();
@@ -37,6 +37,14 @@ export class CurrentProjectService {
 
   public get inProjectContext():boolean {
     return this.current !== undefined;
+  }
+
+  public get path():string|null {
+    if (this.current) {
+      return this.PathHelper.projectPath(this.current.identifier);
+    }
+
+    return null;
   }
 
   public get apiv3Path():string|null {
@@ -47,17 +55,21 @@ export class CurrentProjectService {
     return null;
   }
 
-  public get projectId():string|null {
-    if (this.current) {
-      return this.current.id.toString();
-    }
-
-    return null;
+  public get id():string|null {
+    return this.getCurrent('id');
   }
 
-  public get projectIdentifier():string|null {
-    if (this.current) {
-      return this.current.identifier;
+  public get name():string|null {
+    return this.getCurrent('name');
+  }
+
+  public get identifier():string|null {
+    return this.getCurrent('identifier');
+  }
+
+  private getCurrent(key:'id'|'identifier'|'name' ) {
+    if (this.current && this.current[key]) {
+      return this.current[key].toString();
     }
 
     return null;
@@ -71,6 +83,7 @@ export class CurrentProjectService {
     if (element.length) {
       this.current = {
         id: element.data('projectId'),
+        name: element.data('projectName'),
         identifier: element.data('projectIdentifier')
       };
     }

--- a/frontend/app/components/projects/current-project.service.ts
+++ b/frontend/app/components/projects/current-project.service.ts
@@ -1,0 +1,80 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {opServicesModule} from '../../angular-modules';
+
+export class CurrentProjectService {
+  private current:{ id:string, identifier:string };
+
+  constructor(private PathHelper:any) {
+    this.detect();
+  }
+
+  public get inProjectContext():boolean {
+    return this.current !== undefined;
+  }
+
+  public get apiv3Path():string|null {
+    if (this.current) {
+      return this.PathHelper.apiV3ProjectPath(this.current.id);
+    }
+
+    return null;
+  }
+
+  public get projectId():string|null {
+    if (this.current) {
+      return this.current.id.toString();
+    }
+
+    return null;
+  }
+
+  public get projectIdentifier():string|null {
+    if (this.current) {
+      return this.current.identifier;
+    }
+
+    return null;
+  }
+
+  /**
+   * Detect the current project from its meta tag.
+   */
+  public detect() {
+    const element = angular.element('meta[name=current_project]');
+    if (element.length) {
+      this.current = {
+        id: element.data('projectId'),
+        identifier: element.data('projectIdentifier')
+      };
+    }
+  }
+}
+
+opServicesModule.service('currentProject', CurrentProjectService);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -7,6 +7,30 @@
     <op-date-time date-time-value="$ctrl.workPackage.updatedAt"></op-date-time>.
   </div>
 
+  <div class="attributes-group -project-context" ng-if="$ctrl.projectContext.field">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container"></div>
+    </div>
+    <div class="">
+      <p ng-hide="$ctrl.projectContext.href" ng-bind="::$ctrl.text.project.required"></p>
+      <div class="attributes-key-value"
+           ng-class="{'-span-all-columns': descriptor.spanAll }"
+           ng-repeat="descriptor in $ctrl.projectContext.field track by descriptor.name">
+        <div class="attributes-key-value--key"
+             wp-replacement-label="descriptor.name">
+          {{ descriptor.label }}
+          <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
+          <attribute-help-text title-text="descriptor.label" attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
+        </div>
+        <div class="attributes-key-value--value-container">
+          <wp-edit-field work-package-id="$ctrl.workPackage.id" field-name="descriptor.name"></wp-edit-field>
+        </div>
+      </div>
+    </div>
+    </div>
+  </div>
+
+
   <div class="attributes-group -special-fields">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
@@ -26,6 +50,25 @@
           <wp-edit-field work-package-id="$ctrl.workPackage.id" field-name="descriptor.name"></wp-edit-field>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="attributes-group -project-context" ng-if="!$ctrl.workPackage.isNew && !$ctrl.projectContext.matches">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container">
+        <h3 class="attributes-group--header-text"
+            ng-bind="$ctrl.text.project.context"></h3>
+      </div>
+    </div>
+    <div class="">
+      <p>
+        <span ng-bind-html="$ctrl.projectContextText"></span>
+        <br/>
+        <a ng-href="{{ $ctrl.projectContext.href }}"
+           class="project-context--switch-link"
+           ng-bind="::$ctrl.text.project.switchTo">
+        </a>
+      </p>
     </div>
   </div>
 

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -101,7 +101,7 @@ export class WorkPackageSingleViewController {
           this.projectContext = { matches: false, href: null };
         } else {
           this.projectContext = {
-            href: this.PathHelper.projectWorkPackagePath(resource.project.identifier, this.workPackage.id),
+            href: this.PathHelper.projectWorkPackagePath(resource.project.idFromLink, this.workPackage.id),
             matches: resource.project.href === this.currentProject.apiv3Path
           };
         }

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -38,6 +38,7 @@ import {
   WorkPackageEditingService
 } from '../../wp-edit-form/work-package-editing-service';
 import {States} from '../../states.service';
+import {CurrentProjectService} from '../../projects/current-project.service';
 
 interface FieldDescriptor {
   name:string;
@@ -61,6 +62,11 @@ export class WorkPackageSingleViewController {
   public groupedFields:GroupDescriptor[] = [];
   // Special fields (project, type)
   public specialFields:FieldDescriptor[] = [];
+  public projectContext:{
+    matches:boolean,
+    href:string|null,
+    field?:FieldDescriptor[]
+  };
   public text:any;
   public scope:any;
 
@@ -70,6 +76,8 @@ export class WorkPackageSingleViewController {
               protected $rootScope:ng.IRootScopeService,
               protected $stateParams:ng.ui.IStateParamsService,
               protected I18n:op.I18n,
+              protected currentProject:CurrentProjectService,
+              protected PathHelper:any,
               protected states:States,
               protected wpEditing:WorkPackageEditingService,
               protected wpDisplayField:WorkPackageDisplayFieldService,
@@ -87,7 +95,20 @@ export class WorkPackageSingleViewController {
     scopedObservable(this.$scope, this.wpEditing.temporaryEditResource(this.workPackage.id).values$())
       .subscribe((resource:WorkPackageResourceInterface) => {
         // Prepare the fields that are required always
-        this.specialFields = this.getFields(resource, ['project', 'status']);
+        this.specialFields = this.getFields(resource, ['status']);
+
+        if (!resource.project) {
+          this.projectContext = { matches: false, href: null };
+        } else {
+          this.projectContext = {
+            href: this.PathHelper.projectWorkPackagePath(resource.project.identifier, this.workPackage.id),
+            matches: resource.project.href === this.currentProject.apiv3Path
+          };
+        }
+
+        if (this.workPackage.isNew && !this.currentProject.inProjectContext) {
+          this.projectContext.field = this.getFields(resource, ['project']);
+        }
 
         // Get attribute groups if they are available (in project context)
         const attributeGroups = resource.schema._attributeGroups;
@@ -132,8 +153,19 @@ export class WorkPackageSingleViewController {
     return `${label} #${this.workPackage.id}`;
   }
 
+  public get projectContextText():string {
+    let projectPath = this.currentProject.path;
+    let project = `<a href="${projectPath}">${this.workPackage.project.name}<a>`;
+    return this.I18n.t('js.project.work_package_belongs_to', { projectname: project });
+  }
+
   private setupI18nTexts() {
     this.text = {
+      project: {
+        required: this.I18n.t('js.project.required_outside_context'),
+        context: this.I18n.t('js.project.context'),
+        switchTo: this.I18n.t('js.project.click_to_switch_context'),
+      },
       dropFiles: this.I18n.t('js.label_drop_files'),
       dropFilesHint: this.I18n.t('js.label_drop_files_hint'),
       fields: {

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -47,7 +47,6 @@ describe 'new work package', js: true do
     loading_indicator_saveguard
     wp_page.subject_field.set(subject)
 
-    project_field.set_value project
     sleep 1
   end
 


### PR DESCRIPTION
* Adds a service to detect the current project context from a meta attribute.
* Use that information to decide whether a work package is in global, or a different project context.

https://community.openproject.com/wp/24842