### PR TITLE
Update installation documentation to use latest URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -229,6 +229,7 @@ group :development, :test do
   gem 'pry-rescue', '~> 1.4.5'
   gem 'pry-byebug', '~> 3.4.2', platforms: [:mri]
   gem 'pry-doc', '~> 0.10'
+  gem 'bootsnap', '~> 1.1.2', require: false
 end
 
 # API gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.1.2)
+      msgpack (~> 1.0)
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -350,6 +352,7 @@ GEM
     minisyntax (0.2.5)
     minitest (5.10.2)
     mixlib-shellout (2.1.0)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_test (0.1.2)
     mustermann (1.0.0)
@@ -618,6 +621,7 @@ DEPENDENCIES
   awesome_nested_set (~> 3.1.3)
   aws-sdk (~> 2.10.1)
   bcrypt (~> 3.1.6)
+  bootsnap (~> 1.1.2)
   bourbon (~> 4.3.4)
   capybara (~> 2.14.0)
   capybara-ng (~> 0.2.7)
@@ -729,4 +733,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GIT
 
 GIT
   remote: https://github.com/opf/openproject-translations.git
-  revision: e84bfaafff6beed10756cddbfed61cd8afd7932e
+  revision: 073e124f8a15c54bcdc5a1ad6c6966e47bd9ee54
   branch: dev
   specs:
     openproject-translations (7.0.0)

--- a/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
@@ -92,10 +92,10 @@
     cursor: ew-resize
 
     .leftHandle
-      cursor: w-resize
+      cursor: col-resize
 
     .rightHandle
-      cursor: e-resize
+      cursor: col-resize
 
 .active-selection-mode
 

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -102,11 +102,12 @@
     #projects-menu
       font-size: 15px
       .button--dropdown-text
-        // Viewport minus #account-nav-right minus padding.
-        max-width: calc(100vW - 110px - 49px)
+        // Viewport minus #account-nav-right when logged out minus padding
+        // (french: Connexion).
+        max-width: calc(100vW - 150px - 49px)
     .drop-down
-      // Viewport minus #account-nav-right
-      max-width: calc(100vW - 110px)
+      // Viewport minus #account-nav-right when logged out (french: Connexion)
+      max-width: calc(100vW - 150px)
       ul
         width: 100vw
         border: none

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -39,7 +40,7 @@ class Enumeration < ActiveRecord::Base
   before_destroy :check_integrity
 
   validates_presence_of :name
-  validates_uniqueness_of :name, scope: [:type, :project_id]
+  validates_uniqueness_of :name, scope: %i(type project_id)
   validates_length_of :name, maximum: 30
 
   scope :shared, -> { where(project_id: nil) }
@@ -62,7 +63,7 @@ class Enumeration < ActiveRecord::Base
     # Creates a fake default scope so Enumeration.default will check
     # it's type.  STI subclasses will automatically add their own
     # types to the finder.
-    if self.descends_from_active_record?
+    if descends_from_active_record?
       where(is_default: true, type: 'Enumeration').first
     else
       # STI classes are
@@ -103,9 +104,8 @@ class Enumeration < ActiveRecord::Base
     objects_count != 0
   end
 
-  # Is this enumeration overriding a system level enumeration?
-  def is_override?
-    !parent.nil?
+  def shared?
+    parent_id.nil?
   end
 
   alias :destroy_without_reassign :destroy
@@ -127,10 +127,10 @@ class Enumeration < ActiveRecord::Base
 
   # Does the +new+ Hash override the previous Enumeration?
   def self.overridding_change?(new, previous)
-    if (same_active_state?(new['active'], previous.active)) && same_custom_values?(new, previous)
-      return false
+    if same_active_state?(new['active'], previous.active) && same_custom_values?(new, previous)
+      false
     else
-      return true
+      true
     end
   end
 
@@ -151,13 +151,11 @@ class Enumeration < ActiveRecord::Base
     new == previous
   end
 
-  private
-
   # This is not a performant method.
   def self.sort_by_ancestor_last(entries)
     ancestor_relationships = entries.map { |entry| [entry, entry.ancestors] }
 
-    ancestor_relationships.sort { |one, two|
+    ancestor_relationships.sort do |one, two|
       if one.last.include?(two.first)
         -1
       elsif two.last.include?(one.first)
@@ -165,11 +163,13 @@ class Enumeration < ActiveRecord::Base
       else
         0
       end
-    }.map(&:first)
+    end.map(&:first)
   end
 
+  private
+
   def check_integrity
-    raise "Can't delete enumeration" if self.in_use?
+    raise "Can't delete enumeration" if in_use?
   end
 end
 

--- a/app/models/queries/time_entries.rb
+++ b/app/models/queries/time_entries.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+module Queries::TimeEntries
+  query = Queries::TimeEntries::TimeEntryQuery
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
-  end
+  Queries::Register.filter query, Queries::TimeEntries::Filters::UserFilter
+  Queries::Register.filter query, Queries::TimeEntries::Filters::WorkPackageFilter
+  Queries::Register.filter query, Queries::TimeEntries::Filters::ProjectFilter
 end

--- a/app/models/queries/time_entries/filters/project_filter.rb
+++ b/app/models/queries/time_entries/filters/project_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::ProjectFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::Project.visible.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :project_id
   end
 end

--- a/app/models/queries/time_entries/filters/time_entry_filter.rb
+++ b/app/models/queries/time_entries/filters/time_entry_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+class Queries::TimeEntries::Filters::TimeEntryFilter < Queries::Filters::Base
+  self.model = TimeEntry
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+  def human_name
+    TimeEntry.human_attribute_name(name)
   end
 end

--- a/app/models/queries/time_entries/filters/user_filter.rb
+++ b/app/models/queries/time_entries/filters/user_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::UserFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::Principal.in_visible_project.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :user_id
   end
 end

--- a/app/models/queries/time_entries/filters/work_package_filter.rb
+++ b/app/models/queries/time_entries/filters/work_package_filter.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,19 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
+class Queries::TimeEntries::Filters::WorkPackageFilter < Queries::TimeEntries::Filters::TimeEntryFilter
+  def allowed_values
+    @allowed_values ||= begin
+      # We don't care for the first value as we do not display the values visibly
+      ::WorkPackage.visible.pluck(:id).map { |id| [id, id.to_s] }
     end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def self.key
+    :work_package_id
   end
 end

--- a/app/models/queries/time_entries/time_entry_query.rb
+++ b/app/models/queries/time_entries/time_entry_query.rb
@@ -26,32 +26,12 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+class Queries::TimeEntries::TimeEntryQuery < Queries::BaseQuery
+  def self.model
+    TimeEntry
+  end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+  def default_scope
+    TimeEntry.visible(User.current)
   end
 end

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -53,7 +53,7 @@ class TimeEntry < ActiveRecord::Base
   validate :validate_project_is_set
   validate :validate_consistency_of_work_package_id
 
-  scope :visible, -> (*args) {
+  scope :visible, ->(*args) {
     # TODO: check whether the visibility should also be influenced by the work
     # package the time entry is assigned to.  Currently a work package can
     # switch projects. But as the time entry is still part of it's original
@@ -112,6 +112,14 @@ class TimeEntry < ActiveRecord::Base
     scope = TimeEntry.visible(User.current)
     scope = scope.where(project_id: project.hierarchy.map(&:id)) if project
     scope.includes(:project).maximum(:spent_on)
+  end
+
+  def authoritativ_activity
+    if activity.shared?
+      activity
+    else
+      activity.root
+    end
   end
 
   private

--- a/app/models/time_entry_activity.rb
+++ b/app/models/time_entry_activity.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -42,5 +43,19 @@ class TimeEntryActivity < Enumeration
 
   def transfer_relations(to)
     time_entries.update_all("activity_id = #{to.id}")
+  end
+
+  def activated_projects
+    scope = Project.all
+
+    scope = if active?
+              scope
+                .where.not(id: children.select(:project_id))
+            else
+              scope
+                .where('1=0')
+            end
+
+    scope.or(Project.where(id: children.where(active: true).select(:project_id)))
   end
 end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -30,6 +30,7 @@ module API
   module V3
     class WorkPackageCollectionFromQueryService
       include Utilities::PathHelper
+      include ::API::Utilities::ParamsHelper
 
       def initialize(query, user)
         self.query = query

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -19,6 +19,11 @@
     <%= static_link_to :professional_support %>
   </li>
   <li>
+    <%= link_to(t('homescreen.links.newsletter'), "#{OpenProject::Static::Links.links[:newsletter][:href]}/?utm_source=unknown&utm_medium=op-instance&utm_campaign=newsletter-home-screen",
+          { aria: {label: t('homescreen.links.newsletter')},
+            title: t('homescreen.links.newsletter')}) %>
+  </li>
+  <li>
     <%= static_link_to :blog %>
   </li>
   <li>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,6 +36,12 @@ See doc/COPYRIGHT.rdoc for more details.
     <meta name="keywords" content="issue,bug,type" />
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
     <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
+    <% if @project %>
+    <meta name="current_project"
+          data-project-name="<%= h @project.name %>"
+          data-project-id="<%= @project.id %>"
+          data-project-identifier="<%= @project.identifier %>"/>
+    <% end %>
     <meta name="current_menu_item" content="<%= current_menu_item %>" />
     <meta name="accessibility-mode" content="<%= current_user.impaired? %>" />
     <%= csrf_meta_tags %>

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -37,3 +37,21 @@ end
 
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+# Rails is not yet loaded here
+if ENV['RAILS_ENV'] == 'development'
+  $stderr.puts "Starting with bootstnap."
+
+  require 'bootsnap'
+
+  is_mac = RUBY_PLATFORM.include? 'darwin'
+  Bootsnap.setup(
+    cache_dir:            'tmp/cache', # Path to your cache
+    development_mode:     true,
+    load_path_cache:      true,        # Should we optimize the LOAD_PATH with a cache?
+    autoload_paths_cache: true,        # Should we optimize ActiveSupport autoloads with cache?
+    disable_trace:        false,       # Sets `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+    compile_cache_iseq:   is_mac,      # Should compile Ruby code into ISeq cache?
+    compile_cache_yaml:   is_mac       # Should compile YAML into a cache?
+  )
+end

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -35,7 +35,7 @@ Redmine::MenuManager.map :top_menu do |menu|
   # Redmine::MenuManager::TopMenuHelper#render_projects_top_menu_node
 
   menu.push :work_packages,
-            { controller: '/work_packages', project_id: nil, action: 'index' },
+            { controller: '/work_packages', project_id: nil, state: nil, action: 'index' },
             context: :modules,
             caption: I18n.t('label_work_package_plural'),
             if: Proc.new {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,6 +979,7 @@ en:
       forums: "Forums"
       blog: "OpenProject blog"
       boards: "Community forum"
+      newsletter: "Security alerts / Newsletter"
 
 
   instructions_after_registration: "You can sign in as soon as your account has been activated by clicking %{signin}."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -240,6 +240,12 @@ en:
       selection: 'Please select'
       relation_description: 'Click to add description for this relation'
 
+    project:
+      required_outside_context: 'You are not within a project context. Please choose the project context first in order to select type and status'
+      context: 'Project context'
+      work_package_belongs_to: 'This work package belongs to project %{projectname}.'
+      click_to_switch_context: 'Click here to open the work package in this project.'
+
     text_are_you_sure: "Are you sure?"
 
     types:

--- a/docs/api/apiv3-documentation.apib
+++ b/docs/api/apiv3-documentation.apib
@@ -25,6 +25,7 @@ FORMAT: 1A
 <!-- include(apiv3/endpoints/schemas.apib) -->
 <!-- include(apiv3/endpoints/statuses.apib) -->
 <!-- include(apiv3/endpoints/string-objects.apib) -->
+<!-- include(apiv3/endpoints/time_entries.apib) -->
 <!-- include(apiv3/endpoints/types.apib) -->
 <!-- include(apiv3/endpoints/user-preferences.apib) -->
 <!-- include(apiv3/endpoints/users.apib) -->

--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -1,0 +1,326 @@
+# Group Time Entries
+
+## Actions
+| Link                | Description                                                          | Condition                                                        |
+|:-------------------:| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+
+None yet
+
+## Linked Properties
+| Link          | Description                                                                                                                             | Type                | Constraints           | Supported operations | Condition                                 |
+| :-----------: | --------------------------------------------------------------                                                                          | -------------       | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This time entry                                                                                                                         | TimeEntry           | not null              | READ                 |                                           |
+| project       | The project the time entry is bundled in. The project might be different from the work package's project once the workPackage is moved. | Project             | not null              | READ / WRITE         |                                           |
+| workPackage   | The work package the time entry is created on                                                                                           | WorkPackage         | not null              | READ                 |                                           |
+| user          | The user the time entry tracks expenditures for                                                                                         | User                | not null              |  READ                |                                           |
+| activity      | The time entry activity the time entry is categorized as                                                                                | TimeEntriesActivity | not null              | READ                 |                                           |
+
+Depending on custom fields defined for time entries, additional properties might exist.
+
+## Local Properties
+
+| Property     | Description                                               | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | --------------------------------------------------------- | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | Time entries' id                                          | Integer  | x > 0                                                | READ                 |                                                             |
+| comment      | A text provided by the user detailing the time entry      | String   | max 255 characters                                   | READ                 |                                                             |
+| spentOn      | The date the expenditure is booked for                    | Date     |                                                      | READ                 |                                                             |
+| hours        | The time quantifiying the expenditure                     | Time     |                                                      | READ                 |                                                             |
+| createdAt    | The time the time entry was created                       | DateTime |                                                      | READ                 |                                                             |
+| updatedAT    | The time the time entry was last updated                  | DateTime |                                                      | READ                 |                                                             |
+
+Depending on custom fields defined for time entries, additional properties might exist.
+
+## Time entry [/api/v3/time_entries/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "TimeEntry",
+                "id": 1,
+                "comment": "Some text explaing why the time entry was created",
+                "spentOn": "2015-03-20",
+                "hours": "PT5H",
+                "createdAt": "2015-03-20T12:56:56Z",
+                "updatedAt": "2015-03-20T12:56:56Z",
+                "customField12": 5,
+                "_embedded": {
+                    "project": {
+                      ...
+                    },
+                    "workPackage": {
+                      ...
+                    },
+                    "user": {
+                      ...
+                    },
+                    "activity": {
+                      ...
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/time_entries/1"
+                    },
+                    "project": {
+                        "href": "/api/v3/projects/1",
+                        "title": "Some project"
+                    },
+                    "workPackage": {
+                        "href": "/api/v3/work_packages/1",
+                        "title": "Some work package"
+                    },
+                    "user": {
+                        "href": "/api/v3/users/2",
+                        "title": "Some user"
+                    },
+                    "activity": {
+                        "href": "/api/v3/time_entries/activities/18",
+                        "title": "Some time entry activity"
+                    },
+                    "customField4": {
+                        "href": "/api/v3/users/5",
+                        "title" "Some other user"
+                }
+            }
+
+## View time entry [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... time entry id
+
++ Response 200 (application/hal+json)
+
+    [Time entry][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the time entry does not exist or if the user does not have permission to view them.
+
+    **Required permission** `view time entries` in the project the time entry is assigned to
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
+## Time entries [/api/v3/time_entries{?offset,pageSize,filters,sortBy}]
+
++ Model
+    + Body
+
+            {
+              "_type": "Collection",
+              "total": 39,
+              "count": 2,
+              "pageSize": 2,
+              "offset": 1,
+              "_embedded": {
+                  "elements": [
+                      {
+                          "_type": "TimeEntry",
+                          "id": 5,
+                          "comment": "Some comment",
+                          "spentOn": "2015-03-20",
+                          "hours": "PT5H",
+                          "createdAt": "2015-03-20T12:56:56Z",
+                          "updatedAt": "2015-03-20T12:56:56Z",
+                          "_links": {
+                              "self": {
+                                  "href": "/api/v3/time_entries/1"
+                              },
+                              "project": {
+                                  "href": "/api/v3/projects/1",
+                                  "title": "Some project"
+                              },
+                              "workPackage": {
+                                  "href": "/api/v3/work_packages/1",
+                                  "title": "Some work package"
+                              },
+                              "user": {
+                                  "href": "/api/v3/users/2",
+                                  "title": "Some user"
+                              },
+                              "activity": {
+                                  "href": "/api/v3/time_entries/activities/18",
+                                  "title": "Some time entry activity"
+                              }
+                          }
+                      },
+                      {
+                          "_type": "TimeEntry",
+                          "id": 10,
+                          "comment": "Another comment",
+                          "spentOn": "2015-03-21",
+                          "hours": "PT7H",
+                          "createdAt": "2015-03-20T12:56:56Z",
+                          "updatedAt": "2015-03-20T12:56:56Z",
+                          "_links": {
+                              "self": {
+                                  "href": "/api/v3/time_entries/2"
+                              },
+                              "project": {
+                                  "href": "/api/v3/projects/42",
+                                  "title": "Some other project"
+                              },
+                              "workPackage": {
+                                  "href": "/api/v3/work_packages/541",
+                                  "title": "Some other work package"
+                              },
+                              "user": {
+                                  "href": "/api/v3/users/6",
+                                  "title": "Some other project"
+                              },
+                              "activity": {
+                                  "href": "/api/v3/time_entries/activities/14",
+                                  "title": "some other time entry activity"
+                              }
+                          }
+                      }
+                  ]
+              },
+              "_links": {
+                  "self": {
+                      "href": "/api/v3/time_entries?offset=1&pageSize=2"
+                  },
+                  "jumpTo": {
+                      "href": "/api/v3/time_entries?offset=%7Boffset%7D&pageSize=2",
+                      "templated": true
+                  },
+                  "changeSize": {
+                      "href": "/api/v3/time_entries?offset=1&pageSize=%7Bsize%7D",
+                      "templated": true
+                  },
+                  "nextByOffset": {
+                      "href": "/api/v3/time_entries?offset=2&pageSize=2"
+                  }
+              }
+            }
+
+## List Time entries [GET]
+
+Lists time entries. The time entries returned depend on the filters provided and also on the permission of the requesting user.
+
++ Parameters
+    + offset = `1` (optional, integer, `25`) ... Page number inside the requested collection.
+
+    + pageSize (optional, integer, `25`) ... Number of elements to display per page.
+
+    + filters (optional, string, `[{ "work_package": { "operator": "=", "values": ["1", "2"] } }, { "project": { "operator": "=", "values": ["1"] } }]`) ... JSON specifying filter conditions.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported filters are:
+      + work_package: Filter time entries by work package
+      + project: Filter time entries by project
+      + user: Filter time entries by users
+
++ Response 200 (application/hal+json)
+
+    [Time entries][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request parameters e.g. filters
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": [
+                  "Filters Invalid filter does not exist."
+                ]
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client is not logged in and login is required.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to view this resource."
+            }
+
+# Group Time Entry Activities
+
+Time entries are classified by an activity which is one item of a set of user defined activities (e.g. Design, Specification, Development).
+
+## Actions
+
+None
+
+## Linked Properties
+| Link          | Description                                                    | Type                | Constraints           | Supported operations | Condition                                 |
+| :-----------: | -------------------------------------------------------------- | -------------       | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This time entry activity                                       | TimeEntriesActivity | not null              | READ                 |                                           |
+| projects      | List of projects the time entry is active in                   | []Project           | not null              | READ / WRITE         |                                           |
+
+## Local Properties
+
+| Property     | Description                                                  | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | ---------------------------------------------------------    | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | Time entries' id                                             | Integer  | x > 0                                                | READ                 |                                                             |
+| name         | The human readable name chosen for this activity             | String   | max 30 characters                                    | READ                 |                                                             |
+| position     | The rank the activity has in a list of activities            | Date     |                                                      | READ                 |                                                             |
+| default      | Flag to signal whether this activity is the default activity | Boolean  |                                                      | READ                 |                                                             |
+
+
+## Time entries activity [/api/v3/time_entries/activity/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "TimeEntriesActivity",
+                "id": 18,
+                "name": "a autem",
+                "position": 10,
+                "default": false,
+                "_embedded": {
+                    "projects": [
+                      ...
+                    ]
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/time_entries/activities/18",
+                        "title": "a autem"
+                    },
+                    "projects": [
+                        {
+                            "href": "/api/v3/projects/seeded_project",
+                            "title": "Seeded Project"
+                        },
+                        {
+                            "href": "/api/v3/projects/working-project",
+                            "title": "Working Project"
+                        }
+                    ]
+                }
+            }
+## View time entries activity[GET]
+
++ Parameters
+    + id (required, integer, `1`) ... time entries activity id
+
++ Response 200 (application/hal+json)
+
+    [Time entries activity][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the activity does not exist or if the user does not have permission to view them.
+
+    **Required permission** `view time entries`, `log time`, `edit time entries`, `edit own time entries` or `manage project activities` in any project
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }

--- a/docs/installation/packaged/centos-7/README.md
+++ b/docs/installation/packaged/centos-7/README.md
@@ -2,28 +2,14 @@
 
 All steps are run with `sudo` to execute as the root user.
 
-**1. Import the packager.io repository signing key**
-
-Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
-
-```bash
-sudo rpm --import https://rpm.packager.io/key
-```
-
-**2. Add the OpenProject package source**
-
-Create the file `/etc/yum.repos.d/openproject.repo` with the following contents
-
+**1. Add the OpenProject package source**
 
 ```
-[openproject]
-name=Repository for opf/openproject-ce application.
-baseurl=https://rpm.packager.io/gh/opf/openproject-ce/centos7/stable/7
-enabled=1
+sudo wget -O /etc/yum.repos.d/openproject-ce.repo \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/el/7.repo
 ```
 
-
-**3. Install the OpenProject Community Edition package**
+**2. Install the OpenProject Community Edition package**
 
 Using the following command, yum will install the package and all required dependencies.
 

--- a/docs/installation/packaged/debian-7/README.md
+++ b/docs/installation/packaged/debian-7/README.md
@@ -7,7 +7,7 @@ All steps need to be run as `root`.
 Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
 
 ```bash
-wget -qO - https://deb.packager.io/key | sudo apt-key add -
+wget -qO- https://dl.packager.io/srv/opf/openproject-ce/key | sudo apt-key add -
 ```
 
 **2. Install apt-https suppport**
@@ -21,13 +21,10 @@ apt-get install apt-transport-https
 
 **3. Add the OpenProject package source**
 
-Create the file `/etc/apt/sources.list.d/openproject.list` with the following contents
-
-
 ```
-deb https://deb.packager.io/gh/opf/openproject-ce wheezy stable/7
+sudo wget -O /etc/apt/sources.list.d/openproject-ce.list \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/debian/7.repo
 ```
-
 
 **4. Install the OpenProject Community Edition package**
 

--- a/docs/installation/packaged/debian-8/README.md
+++ b/docs/installation/packaged/debian-8/README.md
@@ -7,7 +7,7 @@ All steps need to be run as `root`.
 Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
 
 ```bash
-wget -qO - https://deb.packager.io/key | sudo apt-key add -
+wget -qO- https://dl.packager.io/srv/opf/openproject-ce/key | sudo apt-key add -
 ```
 
 **2. Install apt-https suppport**
@@ -21,11 +21,9 @@ apt-get install apt-transport-https
 
 **3. Add the OpenProject package source**
 
-Create the file `/etc/apt/sources.list.d/openproject.list` with the following contents
-
-
 ```
-deb https://deb.packager.io/gh/opf/openproject-ce jessie stable/7
+sudo wget -O /etc/apt/sources.list.d/openproject-ce.list \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/debian/8.repo
 ```
 
 

--- a/docs/installation/packaged/sles-11/README.md
+++ b/docs/installation/packaged/sles-11/README.md
@@ -2,28 +2,17 @@
 
 All steps need to be run as `root`.
 
-
-**1. Import the packager.io repository signing key**
-
-Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
-
-```bash
-wget https://rpm.packager.io/key -O packager.key
-rpm --import packager.key
-```
-
-**2. Add the OpenProject package source**
-
-Add a named zypper repository source for OpenProject using the following commands:
+**1. Add the OpenProject package source**
 
 ```
-zypper addrepo "https://rpm.packager.io/gh/opf/openproject-ce/sles11/stable/7" "openproject"
+wget -O /etc/zypp/repos.d/openproject-ce.repo \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/sles/11.repo
 ```
 
 The package source is now registered as `openproject`.
 
 
-**3. Install the OpenProject Community Edition package**
+**2. Install the OpenProject Community Edition package**
 
 Using the following command, zypper will install the package and all required dependencies.
 

--- a/docs/installation/packaged/sles-12/README.md
+++ b/docs/installation/packaged/sles-12/README.md
@@ -2,28 +2,16 @@
 
 All steps need to be run as `root`.
 
-
-**1. Import the packager.io repository signing key**
-
-Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
-
-```bash
-wget https://rpm.packager.io/key -O packager.key
-rpm --import packager.key
-```
-
-**2. Add the OpenProject package source**
-
-Add a named zypper repository source for OpenProject using the following commands:
+**1. Add the OpenProject package source**
 
 ```
-zypper addrepo "https://rpm.packager.io/gh/opf/openproject-ce/sles12/stable/7" "openproject"
+wget -O /etc/zypp/repos.d/openproject-ce.repo \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/sles/12.repo
 ```
 
 The package source is now registered as `openproject`.
 
-
-**3. Install the OpenProject Community Edition package**
+**2. Install the OpenProject Community Edition package**
 
 Using the following command, zypper will install the package and all required dependencies.
 

--- a/docs/installation/packaged/ubuntu-14.04/README.md
+++ b/docs/installation/packaged/ubuntu-14.04/README.md
@@ -7,18 +7,15 @@ All steps are prepended with `sudo` to ensure execution as the root user.
 Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
 
 ```bash
-wget -qO - https://deb.packager.io/key | sudo apt-key add -
+wget -qO- https://dl.packager.io/srv/opf/openproject-ce/key | sudo apt-key add -
 ```
 
 **2. Add the OpenProject package source**
 
-Create the file `/etc/apt/sources.list.d/openproject.list` with the following contents
-
-
 ```
-deb https://deb.packager.io/gh/opf/openproject-ce trusty stable/7
+sudo wget -O /etc/apt/sources.list.d/openproject-ce.list \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/ubuntu/14.04.repo
 ```
-
 
 **3. Install the OpenProject Community Edition package**
 

--- a/docs/installation/packaged/ubuntu-16.04/README.md
+++ b/docs/installation/packaged/ubuntu-16.04/README.md
@@ -7,16 +7,14 @@ All steps are prepended with `sudo` to ensure execution as the root user.
 Import the PGP key used to sign our packages. Since we're using the _packager.io_ platform to distribute our packages, both package source and signing key are tied to their service.
 
 ```bash
-wget -qO - https://deb.packager.io/key | sudo apt-key add -
+wget -qO- https://dl.packager.io/srv/opf/openproject-ce/key | sudo apt-key add -
 ```
 
 **2. Add the OpenProject package source**
 
-Create the file `/etc/apt/sources.list.d/openproject.list` with the following contents
-
-
 ```
-deb https://deb.packager.io/gh/opf/openproject-ce xenial stable/7
+sudo wget -O /etc/apt/sources.list.d/openproject-ce.list \
+  https://dl.packager.io/srv/opf/openproject-ce/stable/7/installer/ubuntu/16.04.repo
 ```
 
 

--- a/frontend/app/components/common/path-heleper/path-helper.service.js
+++ b/frontend/app/components/common/path-heleper/path-helper.service.js
@@ -82,6 +82,9 @@ function PathHelper() {
     projectWikiPath: function(projectId) {
       return PathHelper.projectPath(projectId) + '/wiki';
     },
+    projectWorkPackagePath: function(projectId, wpId) {
+      return PathHelper.projectWorkPackagesPath(projectId) + '/' + wpId;
+    },
     projectWorkPackagesPath: function(projectId) {
       return PathHelper.projectPath(projectId) + '/work_packages';
     },

--- a/frontend/app/components/projects/current-project.service.test.ts
+++ b/frontend/app/components/projects/current-project.service.test.ts
@@ -1,0 +1,78 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/*jshint expr: true*/
+
+import {CurrentProjectService} from './current-project.service';
+
+describe('currentProject service', function() {
+    var element:ng.IAugmentedJQuery;
+    var currentProject:CurrentProjectService;
+
+    beforeEach(angular.mock.module('openproject.filters',
+                                   'openproject.templates',
+                                   'openproject.services'));
+
+    beforeEach(angular.mock.inject((_currentProject_:CurrentProjectService) => {
+      currentProject = _currentProject_;
+    }));
+
+    describe('with no meta present', () => {
+      it('returns null values', () => {
+        expect(currentProject.id).to.be.null;
+        expect(currentProject.identifier).to.be.null;
+        expect(currentProject.name).to.be.null;
+        expect(currentProject.apiv3Path).to.be.null;
+        expect(currentProject.inProjectContext).to.be.false;
+      });
+    });
+
+    describe('with a meta value present', () => {
+      beforeEach(() => {
+        var html = `
+          <meta name="current_project" data-project-name="Foo 1234" data-project-id="1" data-project-identifier="foobar"/>
+        `;
+
+        element = angular.element(html);
+        angular.element(document.body).append(element);
+        currentProject.detect();
+      });
+
+      afterEach(angular.mock.inject(() => {
+        element.remove();
+      }));
+
+      it('returns correct values', () => {
+        expect(currentProject.inProjectContext).to.be.true;
+        expect(currentProject.id).to.eq('1');
+        expect(currentProject.name).to.eq('Foo 1234');
+        expect(currentProject.identifier).to.eq('foobar')
+        expect(currentProject.apiv3Path).to.eq('/api/v3/projects/1');
+      });
+    });
+});

--- a/frontend/app/components/projects/current-project.service.ts
+++ b/frontend/app/components/projects/current-project.service.ts
@@ -1,0 +1,93 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {opServicesModule} from '../../angular-modules';
+
+export class CurrentProjectService {
+  private current:{ id:string, identifier:string, name:string };
+
+  constructor(private PathHelper:any) {
+    this.detect();
+  }
+
+  public get inProjectContext():boolean {
+    return this.current !== undefined;
+  }
+
+  public get path():string|null {
+    if (this.current) {
+      return this.PathHelper.projectPath(this.current.identifier);
+    }
+
+    return null;
+  }
+
+  public get apiv3Path():string|null {
+    if (this.current) {
+      return this.PathHelper.apiV3ProjectPath(this.current.id);
+    }
+
+    return null;
+  }
+
+  public get id():string|null {
+    return this.getCurrent('id');
+  }
+
+  public get name():string|null {
+    return this.getCurrent('name');
+  }
+
+  public get identifier():string|null {
+    return this.getCurrent('identifier');
+  }
+
+  private getCurrent(key:'id'|'identifier'|'name' ) {
+    if (this.current && this.current[key]) {
+      return this.current[key].toString();
+    }
+
+    return null;
+  }
+
+  /**
+   * Detect the current project from its meta tag.
+   */
+  public detect() {
+    const element = angular.element('meta[name=current_project]');
+    if (element.length) {
+      this.current = {
+        id: element.data('projectId'),
+        name: element.data('projectName'),
+        identifier: element.data('projectIdentifier')
+      };
+    }
+  }
+}
+
+opServicesModule.service('currentProject', CurrentProjectService);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -7,6 +7,30 @@
     <op-date-time date-time-value="$ctrl.workPackage.updatedAt"></op-date-time>.
   </div>
 
+  <div class="attributes-group -project-context" ng-if="$ctrl.projectContext.field">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container"></div>
+    </div>
+    <div class="">
+      <p ng-hide="$ctrl.projectContext.href" ng-bind="::$ctrl.text.project.required"></p>
+      <div class="attributes-key-value"
+           ng-class="{'-span-all-columns': descriptor.spanAll }"
+           ng-repeat="descriptor in $ctrl.projectContext.field track by descriptor.name">
+        <div class="attributes-key-value--key"
+             wp-replacement-label="descriptor.name">
+          {{ descriptor.label }}
+          <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
+          <attribute-help-text title-text="descriptor.label" attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
+        </div>
+        <div class="attributes-key-value--value-container">
+          <wp-edit-field work-package-id="$ctrl.workPackage.id" field-name="descriptor.name"></wp-edit-field>
+        </div>
+      </div>
+    </div>
+    </div>
+  </div>
+
+
   <div class="attributes-group -special-fields">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
@@ -26,6 +50,25 @@
           <wp-edit-field work-package-id="$ctrl.workPackage.id" field-name="descriptor.name"></wp-edit-field>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="attributes-group -project-context" ng-if="!$ctrl.workPackage.isNew && !$ctrl.projectContext.matches">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container">
+        <h3 class="attributes-group--header-text"
+            ng-bind="$ctrl.text.project.context"></h3>
+      </div>
+    </div>
+    <div class="">
+      <p>
+        <span ng-bind-html="$ctrl.projectContextText"></span>
+        <br/>
+        <a ng-href="{{ $ctrl.projectContext.href }}"
+           class="project-context--switch-link"
+           ng-bind="::$ctrl.text.project.switchTo">
+        </a>
+      </p>
     </div>
   </div>
 

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -38,6 +38,7 @@ import {
   WorkPackageEditingService
 } from '../../wp-edit-form/work-package-editing-service';
 import {States} from '../../states.service';
+import {CurrentProjectService} from '../../projects/current-project.service';
 
 interface FieldDescriptor {
   name:string;
@@ -61,6 +62,11 @@ export class WorkPackageSingleViewController {
   public groupedFields:GroupDescriptor[] = [];
   // Special fields (project, type)
   public specialFields:FieldDescriptor[] = [];
+  public projectContext:{
+    matches:boolean,
+    href:string|null,
+    field?:FieldDescriptor[]
+  };
   public text:any;
   public scope:any;
 
@@ -70,6 +76,8 @@ export class WorkPackageSingleViewController {
               protected $rootScope:ng.IRootScopeService,
               protected $stateParams:ng.ui.IStateParamsService,
               protected I18n:op.I18n,
+              protected currentProject:CurrentProjectService,
+              protected PathHelper:any,
               protected states:States,
               protected wpEditing:WorkPackageEditingService,
               protected wpDisplayField:WorkPackageDisplayFieldService,
@@ -87,7 +95,20 @@ export class WorkPackageSingleViewController {
     scopedObservable(this.$scope, this.wpEditing.temporaryEditResource(this.workPackage.id).values$())
       .subscribe((resource:WorkPackageResourceInterface) => {
         // Prepare the fields that are required always
-        this.specialFields = this.getFields(resource, ['project', 'status']);
+        this.specialFields = this.getFields(resource, ['status']);
+
+        if (!resource.project) {
+          this.projectContext = { matches: false, href: null };
+        } else {
+          this.projectContext = {
+            href: this.PathHelper.projectWorkPackagePath(resource.project.idFromLink, this.workPackage.id),
+            matches: resource.project.href === this.currentProject.apiv3Path
+          };
+        }
+
+        if (this.workPackage.isNew && !this.currentProject.inProjectContext) {
+          this.projectContext.field = this.getFields(resource, ['project']);
+        }
 
         // Get attribute groups if they are available (in project context)
         const attributeGroups = resource.schema._attributeGroups;
@@ -132,8 +153,19 @@ export class WorkPackageSingleViewController {
     return `${label} #${this.workPackage.id}`;
   }
 
+  public get projectContextText():string {
+    let projectPath = this.currentProject.path;
+    let project = `<a href="${projectPath}">${this.workPackage.project.name}<a>`;
+    return this.I18n.t('js.project.work_package_belongs_to', { projectname: project });
+  }
+
   private setupI18nTexts() {
     this.text = {
+      project: {
+        required: this.I18n.t('js.project.required_outside_context'),
+        context: this.I18n.t('js.project.context'),
+        switchTo: this.I18n.t('js.project.click_to_switch_context'),
+      },
       dropFiles: this.I18n.t('js.label_drop_files'),
       dropFilesHint: this.I18n.t('js.label_drop_files_hint'),
       fields: {

--- a/frontend/app/components/wp-fast-table/wp-table-editing.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-editing.ts
@@ -1,32 +1,31 @@
-import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
-import {
-  WorkPackageResource,
-  WorkPackageResourceInterface
-} from '../api/api-v3/hal-resources/work-package-resource.service';
-
-import {States} from '../states.service';
-import {injectorBridge} from '../angular/angular-injector-bridge.functions';
-
-import {WorkPackageTableRow} from './wp-table.interfaces';
-import {TableHandlerRegistry} from './handlers/table-handler-registry';
-import {locateRow} from './helpers/wp-table-row-helpers';
-import {PlainRowsBuilder} from './builders/modes/plain/plain-rows-builder';
-import {GroupedRowsBuilder} from './builders/modes/grouped/grouped-rows-builder';
-import {HierarchyRowsBuilder} from './builders/modes/hierarchy/hierarchy-rows-builder';
-import {RowsBuilder} from './builders/modes/rows-builder';
-import {WorkPackageTimelineTableController} from '../wp-table/timeline/container/wp-timeline-container.directive';
-import {PrimaryRenderPass, RenderedRow} from './builders/primary-render-pass';
-import {debugLog} from '../../helpers/debug_output';
+import {WorkPackageResourceInterface} from '../api/api-v3/hal-resources/work-package-resource.service';
 import {WorkPackageEditForm} from "../wp-edit-form/work-package-edit-form";
 import {TableRowEditContext} from "../wp-edit-form/table-row-edit-context";
+import {WorkPackageEditingService} from "../wp-edit-form/work-package-editing-service";
+import {$injectFields} from "../angular/angular-injector-bridge.functions";
 
 export class WorkPackageTableEditingContext {
+  public wpEditing:WorkPackageEditingService;
+
+  constructor() {
+    $injectFields(this, 'wpEditing');
+  }
 
   public forms:{[wpId:string]:WorkPackageEditForm} = {};
 
   public reset() {
     _.each(this.forms, (form) => form.destroy());
     this.forms = {};
+  }
+
+  public stopEditing(workPackageId:string) {
+    this.wpEditing.stopEditing(workPackageId);
+
+    const existing = this.forms[workPackageId];
+    if (existing) {
+      existing.destroy();
+      delete this.forms[workPackageId];
+    }
   }
 
   public startEditing(workPackage:WorkPackageResourceInterface, classIdentifier:string):WorkPackageEditForm {

--- a/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
+++ b/frontend/app/components/wp-inline-create/wp-inline-create.directive.ts
@@ -100,6 +100,7 @@ export class WorkPackageInlineCreateController {
 
         if (this.currentWorkPackage === wp) {
           // Remove this row and add another
+          this.table.editing.stopEditing('new');
           this.removeWorkPackageRow();
           this.addWorkPackageRow();
 
@@ -144,6 +145,7 @@ export class WorkPackageInlineCreateController {
       const wp = this.currentWorkPackage = changeset.workPackage;
       (this.currentWorkPackage as any).inlineCreated = true;
 
+      this.wpEditing.updateValue('new', changeset);
       this.wpCacheService.updateWorkPackage(this.currentWorkPackage!);
 
       // Set editing context to table
@@ -203,7 +205,7 @@ export class WorkPackageInlineCreateController {
 
   public removeWorkPackageRow() {
     this.currentWorkPackage = null;
-    this.wpEditing.stopEditing('new');
+    this.table.editing.stopEditing('new');
     this.states.workPackages.get('new').clear();
     this.$element.find('.wp-row-new').remove();
     jQuery(this.table.timelineBody).find('.wp-row-new-timeline').remove();

--- a/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -150,21 +150,21 @@ export class TimelineCellRenderer {
     if (jQuery(ev.target).hasClass(classNameLeftHandle)) {
       // only left
       direction = 'left';
-      this.forceCursor('w-resize');
+      this.workPackageTimeline.forceCursor('ew-resize');
       if (changeset.value('startDate') === null) {
         changeset.setValue('startDate', changeset.value('dueDate'));
       }
     } else if (jQuery(ev.target).hasClass(classNameRightHandle) || dateForCreate) {
       // only right
       direction = 'right';
-      this.forceCursor('e-resize');
+      this.workPackageTimeline.forceCursor('ew-resize');
       if (changeset.value('dueDate') === null) {
         changeset.setValue('dueDate', changeset.value('startDate'));
       }
     } else {
       // both
       direction = 'both';
-      this.forceCursor('ew-resize');
+      this.workPackageTimeline.forceCursor('ew-resize');
     }
 
     if (dateForCreate) {
@@ -352,14 +352,6 @@ export class TimelineCellRenderer {
     if (value) {
       changeset.setValue(attributeName, value.format('YYYY-MM-DD'));
     }
-  }
-
-  /**
-   * Force the cursor to the given cursor type.
-   */
-  protected forceCursor(cursor:string) {
-    jQuery('.hascontextmenu').css('cursor', cursor);
-    jQuery('.' + timelineElementCssClass).css('cursor', cursor);
   }
 
   /**

--- a/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -93,7 +93,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     }
 
     let direction:'both' | 'create' = 'both';
-    this.forceCursor('ew-resize');
+    this.workPackageTimeline.forceCursor('ew-resize');
 
     if (dateForCreate) {
       renderInfo.changeset.setValue('date', dateForCreate);

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -30,16 +30,16 @@ import * as moment from 'moment';
 import {keyCodes} from '../../../common/keyCodes.enum';
 import {LoadingIndicatorService} from '../../../common/loading-indicator/loading-indicator.service';
 import {WorkPackageCacheService} from '../../../work-packages/work-package-cache.service';
-import {WorkPackageTableRefreshService} from '../../wp-table-refresh-request.service';
-import {WorkPackageTimelineTableController} from '../container/wp-timeline-container.directive';
-import {RenderInfo, timelineElementCssClass} from '../wp-timeline';
-import {TimelineCellRenderer} from './timeline-cell-renderer';
-import {WorkPackageCellLabels} from './wp-timeline-cell';
 import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 import {WorkPackageNotificationService} from '../../../wp-edit/wp-notification.service';
+import {WorkPackageTableRefreshService} from '../../wp-table-refresh-request.service';
+import {WorkPackageTimelineTableController} from '../container/wp-timeline-container.directive';
+import {RenderInfo} from '../wp-timeline';
+import {TimelineCellRenderer} from './timeline-cell-renderer';
+import {WorkPackageCellLabels} from './wp-timeline-cell';
 import Moment = moment.Moment;
 
-const classNameBar = 'bar';
+export const classNameBar = 'bar';
 export const classNameLeftHandle = 'leftHandle';
 export const classNameRightHandle = 'rightHandle';
 export const classNameBarLabel = 'bar-label';
@@ -202,11 +202,8 @@ export function registerWorkPackageMouseHandler(this: void,
     jBody.off('mouseup');
     jBody.off('mousemove');
     jBody.off('keyup');
-    jQuery('.hascontextmenu').css('cursor', 'context-menu');
-    jQuery('.' + timelineElementCssClass).css('cursor', '');
-    jQuery('.' + classNameLeftHandle).css('cursor', 'w-resize');
-    jQuery('.' + classNameBar).css('cursor', 'ew-resize');
-    jQuery('.' + classNameRightHandle).css('cursor', 'e-resize');
+    workPackageTimeline.resetCursor();
+
     mouseDownStartDay = null;
     dateStates = {};
 

--- a/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -1,3 +1,4 @@
+import {Moment} from 'moment';
 // -- copyright
 // OpenProject is a project management system.
 // Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
@@ -32,19 +33,19 @@ import {TypeResource} from '../../../api/api-v3/hal-resources/type-resource.serv
 import {WorkPackageResourceInterface} from '../../../api/api-v3/hal-resources/work-package-resource.service';
 import {States} from '../../../states.service';
 import {WorkPackageNotificationService} from '../../../wp-edit/wp-notification.service';
-import {WorkPackageTableTimelineService} from '../../../wp-fast-table/state/wp-table-timeline.service';
-import {WorkPackageTableTimelineState} from '../../../wp-fast-table/wp-table-timeline';
-import {WorkPackagesTableController} from '../../wp-table.directive';
-import {timelineMarkerSelectionStartClass, TimelineViewParameters} from '../wp-timeline';
-import {WorkPackageTable} from '../../../wp-fast-table/wp-fast-table';
+import {RenderedRow} from '../../../wp-fast-table/builders/primary-render-pass';
 import {WorkPackageTableHierarchiesService} from '../../../wp-fast-table/state/wp-table-hierarchy.service';
+import {WorkPackageTableTimelineService} from '../../../wp-fast-table/state/wp-table-timeline.service';
+import {WorkPackageTable} from '../../../wp-fast-table/wp-fast-table';
+import {WorkPackageTableTimelineState} from '../../../wp-fast-table/wp-table-timeline';
+import {WorkPackageRelationsService} from '../../../wp-relations/wp-relations.service';
 
 import {selectorTimelineSide} from '../../wp-table-scroll-sync';
-import {WorkPackageTimelineCellsRenderer} from '../cells/wp-timeline-cells-renderer';
+import {WorkPackagesTableController} from '../../wp-table.directive';
 import {WorkPackageTimelineCell} from '../cells/wp-timeline-cell';
-import {WorkPackageRelationsService} from '../../../wp-relations/wp-relations.service';
-import {Moment} from "moment";
-import {RenderedRow} from '../../../wp-fast-table/builders/primary-render-pass';
+import {WorkPackageTimelineCellsRenderer} from '../cells/wp-timeline-cells-renderer';
+import {timelineElementCssClass, timelineMarkerSelectionStartClass, TimelineViewParameters} from '../wp-timeline';
+import {classNameBar, classNameLeftHandle, classNameRightHandle} from '../cells/wp-timeline-cell-mouse-handler';
 
 
 export class WorkPackageTimelineTableController {
@@ -259,6 +260,22 @@ export class WorkPackageTimelineTableController {
     const viewPortRight = scrollLeft + width;
     const daysUntilViewPortEnds = Math.ceil(viewPortRight / this.viewParameters.pixelPerDay) + 1;
     return this.viewParameters.dateDisplayStart.clone().add(daysUntilViewPortEnds, "days");
+  }
+
+  forceCursor(cursor:string) {
+    // TODO not working
+    jQuery('.' + timelineElementCssClass).css('cursor', cursor + ' !important');
+    jQuery('.hascontextmenu').css('cursor', cursor + ' !important');
+  }
+
+  resetCursor() {
+    // TODO not working
+    jQuery('.' + timelineElementCssClass).css('cursor', '');
+    jQuery('.hascontextmenu').css('cursor', 'context-menu');
+
+    // jQuery('.' + classNameLeftHandle).css('cursor', '');
+    // jQuery('.' + classNameBar).css('cursor', '');
+    // jQuery('.' + classNameRightHandle).css('cursor', '');
   }
 
   private resetSelectionMode() {

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -185,7 +185,7 @@ module API
         def associated_resources_default_getter(name,
                                                 representer)
 
-          representer ||= default_representer(name)
+          representer ||= default_representer(name.to_s.singularize)
 
           ->(*) do
             return unless represented.send(name)

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -109,7 +109,7 @@ module API
       end
 
       def authorize_by_with_raise(callable)
-        is_authorized = callable.call
+        is_authorized = callable.respond_to?(:call) ? callable.call : callable
 
         return true if is_authorized
 
@@ -129,7 +129,7 @@ module API
       # checks whether the user has
       # any of the provided permission in any of the provided
       # projects
-      def authorize_any(permissions, projects: nil, global: false, user: current_user)
+      def authorize_any(permissions, projects: nil, global: false, user: current_user, &block)
         raise ArgumentError if projects.nil? && !global
 
         projects = Array(projects)
@@ -145,8 +145,7 @@ module API
           end
         end
 
-        raise API::Errors::Unauthorized unless authorized
-        authorized
+        authorize_by_with_raise(authorized, &block)
       end
 
       def raise_invalid_query_on_service_failure

--- a/lib/api/utilities/params_helper.rb
+++ b/lib/api/utilities/params_helper.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -27,30 +29,10 @@
 #++
 
 module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+  module Utilities
+    module ParamsHelper
+      def to_i_or_nil(string)
+        string ? string.to_i : nil
       end
     end
   end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -50,6 +51,7 @@ module API
       mount ::API::V3::Roles::RolesAPI
       mount ::API::V3::Statuses::StatusesAPI
       mount ::API::V3::StringObjects::StringObjectsAPI
+      mount ::API::V3::TimeEntries::TimeEntriesAPI
       mount ::API::V3::Types::TypesAPI
       mount ::API::V3::Users::UsersAPI
       mount ::API::V3::UserPreferences::UserPreferencesAPI

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -45,16 +46,18 @@ module API
       end
 
       link :user do
+        next unless current_user.logged?
         {
           href: api_v3_paths.user(current_user.id),
           title: current_user.name
-        } if current_user.logged?
+        }
       end
 
       link :userPreferences do
+        next unless current_user.logged?
         {
           href: api_v3_paths.my_preferences
-        } if current_user.logged?
+        }
       end
 
       link :priorities do
@@ -72,6 +75,12 @@ module API
       link :statuses do
         {
           href: api_v3_paths.statuses
+        }
+      end
+
+      link :time_entries do
+        {
+          href: api_v3_paths.time_entries
         }
       end
 

--- a/lib/api/v3/time_entries/time_entries_activity_representer.rb
+++ b/lib/api/v3/time_entries/time_entries_activity_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,28 +30,44 @@
 
 module API
   module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
+    module TimeEntries
+      class TimeEntriesActivityRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+
+        self_link
+
+        property :id
+
+        property :name
+
+        property :position
+
+        property :is_default,
+                 as: :default
+
+        associated_resources :projects,
+                             link: ->(*) {
+                               active_projects.map do |project|
+                                 {
+                                   href: api_v3_paths.project(project.identifier),
+                                   title: project.name
+                                 }
+                               end
+                             },
+                             getter: ->(*) {
+                               active_projects.map do |project|
+                                 Projects::ProjectRepresenter.new(project, current_user: current_user)
+                               end
+                             }
+
+        def _type
+          'TimeEntriesActivity'
         end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
+        def active_projects
+          represented
+            .activated_projects
+            .visible
         end
       end
     end

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module TimeEntries
+      class TimeEntriesAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
+        resources :time_entries do
+          get do
+            query = ::API::V3::ParamsToQueryService
+                    .new(TimeEntry, current_user)
+                    .call(params)
+
+            if query.valid?
+              TimeEntryCollectionRepresenter.new(query.results,
+                                                 api_v3_paths.time_entries,
+                                                 page: to_i_or_nil(params[:offset]),
+                                                 per_page: to_i_or_nil(params[:pageSize]),
+                                                 current_user: current_user)
+            else
+              raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+            end
+          end
+
+          params do
+            requires :id, desc: 'Time entry\'s id'
+          end
+
+          route_param :id do
+            before do
+              @time_entry = TimeEntry
+                            .visible
+                            .find(params[:id])
+            end
+
+            get do
+              TimeEntryRepresenter.create(@time_entry,
+                                          current_user: current_user,
+                                          embed_links: true)
+            end
+          end
+
+          mount ::API::V3::TimeEntries::TimeEntriesActivityAPI
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/time_entries/time_entry_collection_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_collection_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -28,29 +30,9 @@
 
 module API
   module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
-
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
-
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+    module TimeEntries
+      class TimeEntryCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        element_decorator ::API::V3::TimeEntries::TimeEntryRepresenter
       end
     end
   end

--- a/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_representer.rb
@@ -1,0 +1,110 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module TimeEntries
+      class TimeEntryRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+
+        class << self
+          def create_class(work_package)
+            injector_class = ::API::V3::Utilities::CustomFieldInjector
+            injector_class.create_value_representer(work_package,
+                                                    self)
+          end
+
+          def create(work_package, current_user:, embed_links: false)
+            create_class(work_package)
+              .new(work_package,
+                   current_user: current_user,
+                   embed_links: embed_links)
+          end
+        end
+
+        self_link title_getter: ->(*) { nil }
+
+        defaults render_nil: true
+
+        property :id
+
+        property :comments,
+                 as: :comment
+
+        property :spent_on,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_date(represented.spent_on, allow_nil: true)
+                 end
+
+        property :hours,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_duration_from_hours(represented.hours)
+                 end
+
+        property :created_at,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_datetime(represented.created_on, allow_nil: true)
+                 end
+
+        property :updated_at,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_datetime(represented.updated_on, allow_nil: true)
+                 end
+
+        associated_resource :project
+
+        associated_resource :work_package,
+                            link_title_attribute: :subject
+
+        associated_resource :user
+
+        associated_resource :activity,
+                            representer: TimeEntriesActivityRepresenter,
+                            v3_path: :time_entries_activity,
+                            getter: associated_resource_default_getter(:authoritativ_activity, TimeEntriesActivityRepresenter),
+                            link: ->(*) {
+                              activity = represented.authoritativ_activity
+                              {
+                                href: api_v3_paths.time_entries_activity(activity.id),
+                                title: activity.name
+                              }
+                            }
+
+        def _type
+          'TimeEntry'
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -33,6 +33,8 @@ module API
   module V3
     module Users
       class UsersAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
         helpers do
           def user_transition(allowed)
             if allowed
@@ -50,10 +52,6 @@ module API
             unless current_user.admin?
               fail ::API::Errors::Unauthorized
             end
-          end
-
-          def to_i_or_nil(string)
-            string ? string.to_i : nil
           end
         end
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -279,6 +279,18 @@ module API
             "#{root}/string_objects?value=#{val}"
           end
 
+          def self.time_entries
+            "#{root}/time_entries"
+          end
+
+          def self.time_entry(entry_id)
+            "#{root}/time_entries/#{entry_id}"
+          end
+
+          def self.time_entries_activity(activity_id)
+            "#{root}/time_entries/activities/#{activity_id}"
+          end
+
           def self.types
             "#{root}/types"
           end

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -30,11 +30,7 @@ module API
   module V3
     module WorkPackages
       class WatchersAPI < ::API::OpenProjectAPI
-        helpers do
-          def to_i_or_nil(string)
-            string ? string.to_i : nil
-          end
-        end
+        helpers ::API::Utilities::ParamsHelper
 
         get '/available_watchers' do
           authorize(:add_work_package_watchers, context: @work_package.project)

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -28,11 +28,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json'
-require 'roar/json/collection'
-require 'roar/json/hal'
-
 module API
   module V3
     module WorkPackages

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -66,6 +66,10 @@ module OpenProject
               href: 'https://www.openproject.org/enterprise-edition/',
               label: :label_professional_support
             },
+            newsletter: {
+              href: 'https://www.openproject.org/newsletter',
+              label: 'homescreen.links.newsletter'
+            },
             blog: {
               href: 'https://www.openproject.org/blog',
               label: 'homescreen.links.blog'

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -109,6 +109,7 @@ module Redmine::MenuManager::TopMenu::HelpMenu
                   class: 'drop-down--help-headline',
                   title: l('top_menu.additional_resources')
     end
+    result << static_link_item(:newsletter, href_suffix: "/?utm_source=unknown&utm_medium=op-instance&utm_campaign=newsletter-home-screen")
     result << static_link_item(:blog)
     result << static_link_item(:release_notes)
     result << static_link_item(:report_bug)

--- a/spec/features/work_packages/new_work_package_spec.rb
+++ b/spec/features/work_packages/new_work_package_spec.rb
@@ -47,7 +47,6 @@ describe 'new work package', js: true do
     loading_indicator_saveguard
     wp_page.subject_field.set(subject)
 
-    project_field.set_value project
     sleep 1
   end
 

--- a/spec/lib/api/v3/support/link_examples.rb
+++ b/spec/lib/api/v3/support/link_examples.rb
@@ -100,6 +100,10 @@ shared_examples_for 'has an empty link collection' do
   it { is_expected.to be_json_eql([].to_json).at_path("_links/#{link}") }
 end
 
+shared_examples_for 'has a link collection' do
+  it { is_expected.to be_json_eql(hrefs.to_json).at_path("_links/#{link}") }
+end
+
 shared_examples_for 'has no link' do
   it { is_expected.not_to have_json_path("_links/#{link}") }
 

--- a/spec/lib/api/v3/support/property_examples.rb
+++ b/spec/lib/api/v3/support/property_examples.rb
@@ -26,32 +26,24 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+shared_examples_for 'property' do |name|
+  it "has the #{name} property" do
+    is_expected
+      .to be_json_eql(value.to_json)
+      .at_path(name.to_s)
+  end
+end
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
+shared_examples_for 'date property' do |name|
+  it_behaves_like 'has ISO 8601 date only' do
+    let(:json_path) { name.to_s }
+    let(:date) { value }
+  end
+end
 
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
-
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
-      end
-    end
+shared_examples_for 'datetime property' do |name|
+  it_behaves_like 'has UTC ISO 8601 date and time' do
+    let(:json_path) { name.to_s }
+    let(:date) { value }
   end
 end

--- a/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
@@ -1,0 +1,100 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::TimeEntries::TimeEntriesActivityRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:activity) do
+    FactoryGirl.build_stubbed(:time_entry_activity)
+  end
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) do
+    described_class.new(activity, current_user: user, embed_links: true)
+  end
+
+  subject { representer.to_json }
+
+  describe '_links' do
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.time_entries_activity activity.id }
+      let(:title) { activity.name }
+    end
+
+    # returns the projects where it (and it's children) is active
+    it_behaves_like 'has a link collection' do
+      let(:project1) { FactoryGirl.build_stubbed(:project) }
+      let(:project2) { FactoryGirl.build_stubbed(:project) }
+
+      before do
+        allow(activity)
+          .to receive_message_chain(:activated_projects, :visible)
+          .and_return([project1,
+                       project2])
+      end
+
+      let(:link) { 'projects' }
+      let(:hrefs) do
+        [
+          {
+            href: api_v3_paths.project(project1.identifier),
+            title: project1.name
+          },
+          {
+            href: api_v3_paths.project(project2.identifier),
+            title: project2.name
+          }
+        ]
+      end
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'TimeEntriesActivity' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { activity.id }
+    end
+
+    it_behaves_like 'property', :name do
+      let(:value) { activity.name }
+    end
+
+    it_behaves_like 'property', :position do
+      let(:value) { activity.position }
+    end
+
+    it_behaves_like 'property', :default do
+      let(:value) { activity.is_default }
+    end
+  end
+end

--- a/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -1,0 +1,216 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:time_entry) do
+    FactoryGirl.build_stubbed(:time_entry,
+                              comments: 'blubs',
+                              spent_on: Date.today,
+                              created_on: DateTime.now - 6.hours,
+                              updated_on: DateTime.now - 3.hours,
+                              hours: 5,
+                              activity: activity,
+                              project: project,
+                              user: user)
+  end
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:work_package) { time_entry.work_package }
+  let(:activity) { FactoryGirl.build_stubbed(:time_entry_activity) }
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) do
+    described_class.create(time_entry, current_user: user, embed_links: true)
+  end
+
+  subject { representer.to_json }
+
+  before do
+    allow(time_entry)
+      .to receive(:available_custom_fields)
+      .and_return([])
+  end
+
+  describe '_links' do
+    it_behaves_like 'has an untitled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.time_entry time_entry.id }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'project' }
+      let(:href) { api_v3_paths.project project.id }
+      let(:title) { project.name }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'workPackage' }
+      let(:href) { api_v3_paths.work_package work_package.id }
+      let(:title) { work_package.subject }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'user' }
+      let(:href) { api_v3_paths.user user.id }
+      let(:title) { user.name }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'activity' }
+      let(:href) { api_v3_paths.time_entries_activity activity.id }
+      let(:title) { activity.name }
+    end
+
+    context 'for a non shared (project specific) activity' do
+      let(:activity) do
+        activity = FactoryGirl.build_stubbed(:time_entry_activity,
+                                             project: project,
+                                             parent: parent_activity)
+        allow(activity)
+          .to receive(:root)
+          .and_return(parent_activity)
+
+        activity
+      end
+      let(:parent_activity) do
+        FactoryGirl.build_stubbed(:time_entry_activity)
+      end
+
+      it_behaves_like 'has a titled link' do
+        let(:link) { 'activity' }
+        let(:href) { api_v3_paths.time_entries_activity parent_activity.id }
+        let(:title) { parent_activity.name }
+      end
+    end
+
+    context 'custom value' do
+      let(:custom_field) do
+        FactoryGirl.build_stubbed(:time_entry_custom_field, field_format: 'user')
+      end
+      let(:custom_value) do
+        CustomValue.new(custom_field: custom_field,
+                        value: '1',
+                        customized: time_entry)
+      end
+      let(:user) do
+        FactoryGirl.build_stubbed(:user)
+      end
+
+      before do
+        allow(time_entry)
+          .to receive(:available_custom_fields)
+          .and_return([custom_field])
+
+        allow(time_entry)
+          .to receive(:"custom_field_#{custom_field.id}")
+          .and_return(user)
+
+        allow(time_entry)
+          .to receive(:custom_value_for)
+          .with(custom_field)
+          .and_return(custom_value)
+      end
+
+      it 'has the user linked' do
+        expect(subject)
+          .to be_json_eql(api_v3_paths.user(custom_value.value).to_json)
+          .at_path("_links/customField#{custom_field.id}/href")
+      end
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'TimeEntry' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { time_entry.id }
+    end
+
+    it_behaves_like 'property', :comment do
+      let(:value) { time_entry.comments }
+    end
+
+    context 'with an empty comment' do
+      let(:time_entry) { FactoryGirl.build_stubbed(:time_entry) }
+      it_behaves_like 'property', :comment do
+        let(:value) { time_entry.comments }
+      end
+    end
+
+    it_behaves_like 'date property', :spentOn do
+      let(:value) { time_entry.spent_on }
+    end
+
+    it_behaves_like 'property', :hours do
+      let(:value) { 'PT5H' }
+    end
+
+    it_behaves_like 'datetime property', :createdAt do
+      let(:value) { time_entry.created_on }
+    end
+
+    it_behaves_like 'datetime property', :updatedAt do
+      let(:value) { time_entry.updated_on }
+    end
+
+    context 'custom value' do
+      let(:custom_field) { FactoryGirl.build_stubbed(:time_entry_custom_field) }
+      let(:custom_value) do
+        CustomValue.new(custom_field: custom_field,
+                        value: '1234',
+                        customized: time_entry)
+      end
+
+      before do
+        allow(time_entry)
+          .to receive(:available_custom_fields)
+          .and_return([custom_field])
+
+        allow(time_entry)
+          .to receive(:"custom_field_#{custom_field.id}")
+          .and_return(custom_value.value)
+      end
+
+      it "has property for the custom field" do
+        expected = {
+          format: "textile",
+          html: "<p>#{custom_value.value}</p>",
+          raw: custom_value.value
+        }
+
+        is_expected
+          .to be_json_eql(expected.to_json)
+          .at_path("customField#{custom_field.id}")
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -454,6 +454,26 @@ describe ::API::V3::Utilities::PathHelper do
     end
   end
 
+  context 'time_entry paths' do
+    describe '.time_entries' do
+      subject { helper.time_entries }
+
+      it_behaves_like 'api v3 path', '/time_entries'
+    end
+
+    describe '.time_entry' do
+      subject { helper.time_entry 42 }
+
+      it_behaves_like 'api v3 path', '/time_entries/42'
+    end
+
+    describe '.time_entries_activity' do
+      subject { helper.time_entries_activity 42 }
+
+      it_behaves_like 'api v3 path', '/time_entries/activities/42'
+    end
+  end
+
   describe 'types paths' do
     describe '#types' do
       subject { helper.types }

--- a/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
+++ b/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -26,32 +28,36 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      module RelationsHelper
-        def filter_attributes(relation)
-          relation
-            .attributes
-            .with_indifferent_access
-            .reject { |_key, value| value.blank? }
-        end
+require 'spec_helper'
 
-        def representer
-          ::API::V3::Relations::RelationRepresenter
-        end
+describe Queries::TimeEntries::Filters::WorkPackageFilter, type: :model do
+  let(:work_package1) { FactoryGirl.build_stubbed(:work_package) }
+  let(:work_package2) { FactoryGirl.build_stubbed(:work_package) }
 
-        def project_id_for_relation(id)
-          relations = Relation.table_name
-          work_packages = WorkPackage.table_name
+  before do
+    allow(WorkPackage)
+      .to receive_message_chain(:visible, :pluck)
+      .with(:id)
+      .and_return([work_package1.id, work_package2.id])
+  end
 
-          Relation
-            .joins(:from)
-            .where("#{relations}.id" => id)
-            .pluck("#{work_packages}.project_id")
-            .first
-        end
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :work_package_id }
+    let(:type) { :list_optional }
+    let(:name) { TimeEntry.human_attribute_name(:work_package) }
+
+    describe '#allowed_values' do
+      it 'is a list of the possible values' do
+        expected = [[work_package1.id, work_package1.id.to_s], [work_package2.id, work_package2.id.to_s]]
+
+        expect(instance.allowed_values).to match_array(expected)
       end
     end
+  end
+
+  it_behaves_like 'list_optional query filter' do
+    let(:attribute) { :work_package_id }
+    let(:model) { TimeEntry }
+    let(:valid_values) { [work_package1.id.to_s] }
   end
 end

--- a/spec/models/queries/time_entries/time_entry_query_spec.rb
+++ b/spec/models/queries/time_entries/time_entry_query_spec.rb
@@ -1,0 +1,137 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::TimeEntries::TimeEntryQuery, type: :model do
+  let(:user) { FactoryGirl.build_stubbed(:user) }
+  let(:base_scope) { TimeEntry.visible(user) }
+  let(:instance) { described_class.new }
+
+  before do
+    login_as(user)
+  end
+
+  context 'without a filter' do
+    describe '#results' do
+      it 'is the same as getting all the time entries' do
+        expect(instance.results.to_sql).to eql base_scope.to_sql
+      end
+    end
+  end
+
+  context 'with a user filter' do
+    before do
+      allow(Principal)
+        .to receive_message_chain(:in_visible_project, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('user_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.user_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('user_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with a project filter' do
+    before do
+      allow(Project)
+        .to receive_message_chain(:visible, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('project_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.project_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('project_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with a work_package filter' do
+    before do
+      allow(WorkPackage)
+        .to receive_message_chain(:visible, :pluck)
+        .with(:id)
+        .and_return([1])
+      instance.where('work_package_id', '=', ['1'])
+    end
+
+    describe '#results' do
+      it 'is the same as handwriting the query' do
+        expected = base_scope
+                   .where(["time_entries.work_package_id IN (?)", ['1']])
+
+        expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+
+    describe '#valid?' do
+      it 'is true' do
+        expect(instance).to be_valid
+      end
+
+      it 'is invalid if the filter is invalid' do
+        instance.where('work_package_id', '=', [''])
+        expect(instance).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/time_entry_spec.rb
+++ b/spec/models/time_entry_spec.rb
@@ -1,0 +1,113 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe TimeEntry, type: :model do
+  let(:activity) do
+    FactoryGirl.build(:time_entry_activity)
+  end
+
+  describe '#activated_projects' do
+    let(:project1) { FactoryGirl.create(:project) }
+
+    context 'project specific activity' do
+      before do
+        activity.project = project1
+        activity.save!
+      end
+
+      context 'when the activity is active' do
+        it 'returns the project if the activity is active' do
+          expect(activity.activated_projects)
+            .to match_array [project1]
+        end
+      end
+
+      context 'when the activity is inactive' do
+        before do
+          activity.update_attribute(:active, false)
+        end
+
+        it 'is empty if the activity is inactive' do
+          expect(activity.activated_projects)
+            .to be_empty
+        end
+      end
+    end
+
+    context 'system activity' do
+      let(:project2) { FactoryGirl.create(:project) }
+      let(:project3) { FactoryGirl.create(:project) }
+
+      let(:child_activity_active) do
+        FactoryGirl.create(:time_entry_activity,
+                           parent: activity,
+                           project: project1)
+      end
+      let(:child_activity_inactive) do
+        FactoryGirl.create(:time_entry_activity,
+                           parent: activity,
+                           project: project2,
+                           active: false)
+      end
+
+      before do
+        child_activity_active
+        child_activity_inactive
+        project3
+      end
+
+      context 'when the activity is active' do
+        before do
+          activity.active = true
+          activity.save!
+        end
+
+        it 'returns all projects except for those that have inactive child activities' do
+          expect(activity.activated_projects)
+            .to match_array([project1, project3])
+        end
+      end
+
+      context 'when the activity is inactive' do
+        before do
+          activity.active = false
+          activity.save!
+        end
+
+        it 'returns only those projects, that have active child activities' do
+          expect(activity.activated_projects)
+            .to match_array([project1])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/time_entry_activity_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_activity_resource_spec.rb
@@ -1,0 +1,105 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 time_entry_activity resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:activity) { FactoryGirl.create(:time_entry_activity) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_time_entries) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET /api/v3/time_entries/activities/:id' do
+    let(:path) { api_v3_paths.time_entries_activity(activity.id) }
+
+    context 'for a visible root activity' do
+      before do
+        activity
+
+        get path
+      end
+
+      it 'returns 200 OK' do
+        expect(subject.status)
+          .to eql(200)
+      end
+
+      it 'returns the time entry' do
+        expect(subject.body)
+          .to be_json_eql('TimeEntriesActivity'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql(activity.id.to_json)
+          .at_path('id')
+      end
+    end
+
+    context 'for non shared activities' do
+      before do
+        activity.project_id = 234
+        activity.save(validate: false)
+
+        get path
+      end
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { [] }
+
+      before do
+        activity
+
+        get path
+      end
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/time_entry_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_resource_spec.rb
@@ -1,0 +1,306 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 time_entry resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:time_entry) do
+    FactoryGirl.create(:time_entry, project: project, work_package: work_package, user: current_user)
+  end
+  let(:other_time_entry) do
+    FactoryGirl.create(:time_entry, project: project, work_package: work_package, user: other_user)
+  end
+  let(:other_user) do
+    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:invisible_time_entry) do
+    FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: other_user)
+  end
+  let(:project) { work_package.project }
+  let(:work_package) { FactoryGirl.create(:work_package) }
+  let(:other_work_package) { FactoryGirl.create(:work_package) }
+  let(:other_project) { other_work_package.project }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_time_entries view_work_packages) }
+  let(:custom_field) { FactoryGirl.create(:time_entry_custom_field) }
+  let(:custom_value) do
+    CustomValue.create(custom_field: custom_field,
+                       value: '1234',
+                       customized: time_entry)
+  end
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET api/v3/time_entries' do
+    let(:path) { api_v3_paths.time_entries }
+
+    context 'without params' do
+      before do
+        time_entry
+        invisible_time_entry
+        custom_value
+
+        get path
+      end
+
+      it 'responds 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'returns a collection of time entries containing only the visible time entries' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+
+        expect(subject.body)
+          .to be_json_eql(custom_value.value.to_json)
+          .at_path("_embedded/elements/0/customField#{custom_field.id}/raw")
+      end
+    end
+
+    context 'with pageSize and offset' do
+      let(:path) { api_v3_paths.time_entries + '?pageSize=1&offset=2' }
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      it 'returns a slice of the visible time entries' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('2')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('count')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by user' do
+      let(:invisible_time_entry) do
+        FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: other_user)
+      end
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      let(:path) do
+        filter = [{ 'user' => {
+          'operator' => '=',
+          'values' => [other_user.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by work package' do
+      let(:unwanted_work_package) do
+        FactoryGirl.create(:work_package, project: project, type: project.types.first)
+      end
+
+      let(:other_time_entry) do
+        FactoryGirl.create(:time_entry, project: project, work_package: unwanted_work_package, user: current_user)
+      end
+
+      let(:path) do
+        filter = [{ 'work_package' => {
+          'operator' => '=',
+          'values' => [work_package.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      before do
+        time_entry
+        other_time_entry
+        invisible_time_entry
+
+        get path
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'filtering by project' do
+      let(:other_time_entry) do
+        FactoryGirl.create(:time_entry, project: other_project, work_package: other_work_package, user: current_user)
+      end
+
+      before do
+        FactoryGirl.create(:member,
+                           roles: [role],
+                           project: other_project,
+                           user: current_user)
+
+        time_entry
+        other_time_entry
+
+        get path
+      end
+
+      let(:path) do
+        filter = [{ 'project' => {
+          'operator' => '=',
+          'values' => [other_project.id]
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      it 'contains only the filtered time entries in the response' do
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(other_time_entry.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'invalid filter' do
+      let(:path) do
+        filter = [{ 'bogus' => {
+          'operator' => '=',
+          'values' => ['1']
+        } }]
+
+        "#{api_v3_paths.time_entries}?#{{ filters: filter.to_json }.to_query}"
+      end
+
+      before do
+        time_entry
+
+        get path
+      end
+
+      it 'returns an error' do
+        expect(subject.status).to eq(400)
+
+        expect(subject.body)
+          .to be_json_eql('urn:openproject-org:api:v3:errors:InvalidQuery'.to_json)
+          .at_path('errorIdentifier')
+      end
+    end
+  end
+
+  describe 'GET /api/v3/time_entries/:id' do
+    let(:path) { api_v3_paths.time_entry(time_entry.id) }
+
+    before do
+      time_entry
+      custom_value
+
+      get path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql(200)
+    end
+
+    it 'returns the time entry' do
+      expect(subject.body)
+        .to be_json_eql('TimeEntry'.to_json)
+        .at_path('_type')
+
+      expect(subject.body)
+        .to be_json_eql(time_entry.id.to_json)
+        .at_path('id')
+
+      expect(subject.body)
+        .to be_json_eql(custom_value.value.to_json)
+        .at_path("customField#{custom_field.id}/raw")
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { [] }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end

--- a/spec_legacy/unit/enumeration_spec.rb
+++ b/spec_legacy/unit/enumeration_spec.rb
@@ -104,13 +104,4 @@ describe Enumeration, type: :model do
     assert @low_priority.respond_to?(:parent)
     assert @low_priority.respond_to?(:children)
   end
-
-  it 'should is override' do
-    # Defaults to off
-    assert !@low_priority.is_override?
-
-    # Setup as an override
-    @low_priority.parent = FactoryGirl.create :priority
-    assert @low_priority.is_override?
-  end
 end


### PR DESCRIPTION
This will avoid unnecessary redirects, better analytics, and the new repo settings for CentOS/RHEL/SLES are more detailed (explicit `gpgcheck=0` since only package metadata are signed, and users might have configured their system to ensure rpm signing by default).