### PR TITLE
Fix alignment issues on WP full view

### DIFF
--- a/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
+++ b/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
@@ -2,7 +2,6 @@
   width: 90px
   height: 34px
   align-self: center
-  margin-top: -6px
   a
     padding: 0
     line-height: 32px

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -218,9 +218,14 @@ body.controller-work_packages.full-create
         // give subject full width
         width: 100%
 
-    .work-packages--subject-element .wp-inline-edit--field
-      height: 1.75rem
-      margin-top: 8px
+    .work-packages--subject-element
+      &.work-packages--details--subject
+        .work-packages--details--subject.-active
+          @media only screen and (max-width: 679px)
+            margin-top: 8px
+
+      .wp-inline-edit--field
+        height: 34px
 
   > .toolbar-container
     margin: 10px 0 5px 0

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -180,19 +180,23 @@ body.controller-work_packages.full-create
 .work-packages--show-view
   padding: 0 0 0 15px
 
+  .wp-show--header-container
+    @media only screen and (max-width: 679px)
+      width: 100%
+    @media only screen and (min-width: 679px)
+      flex: 1 1 auto
+      display: flex
+      margin-bottom: 6px
+
   .subject-header
     margin: 0
     padding: 0
-    min-height: 50px
-    width: initial
     align-self: center
-    flex-grow: 1
     /* Leave space for the back button */
-    max-width: calc(100% - 100px)
+    flex-basis: calc(100% - 90px)
     @media only screen and (max-width: 679px)
       // let use full width
-      width: 100%
-      max-width: 100%
+      flex-basis: 100%
 
     .wp-table--cell-span
       white-space: normal
@@ -246,9 +250,10 @@ body.controller-work_packages.full-create
   .wp-table--cell-span
     padding-right: 5px !important
 
-  .wp-edit-field--container.-active
-    margin-right: 80px !important
-    width: 95%
+  @media only screen and (min-width: 679px)
+    .wp-edit-field--container.-active
+      margin-right: 80px !important
+      width: 95%
 
   .inplace-edit--read-value--value-span
     white-space: nowrap

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -3,13 +3,20 @@
      ng-if="$ctrl.workPackage">
     <div class="toolbar-container">
       <div id="toolbar">
-        <div class="wp-show--back-button">
-            <accessible-by-keyboard execute="$ctrl.goToList()"
-                            link-class="work-packages-list-view-button button"
-                            link-aria-label="{{ ::$ctrl.text.goToList }}"
-                            link-title="{{ ::$ctrl.text.goToList }}">
-              <op-icon icon-classes="button--icon icon-back-up"></op-icon>
-          </accessible-by-keyboard>
+        <div class="wp-show--header-container">
+          <div class="wp-show--back-button">
+              <accessible-by-keyboard execute="$ctrl.goToList()"
+                              link-class="work-packages-list-view-button button"
+                              link-aria-label="{{ ::$ctrl.text.goToList }}"
+                              link-title="{{ ::$ctrl.text.goToList }}">
+                <op-icon icon-classes="button--icon icon-back-up"></op-icon>
+            </accessible-by-keyboard>
+          </div>
+          <ul class="subject-header">
+            <li class="subject-header-inner">
+              <wp-subject></wp-subject>
+            </li>
+          </ul>
         </div>
         <ul id="toolbar-items" class="toolbar-items">
           <li class="toolbar-item">
@@ -33,11 +40,6 @@
                     title="{{I18n.t('js.button_more')}}">
               <op-icon icon-classes="button--icon icon-show-more"></op-icon>
             </button>
-          </li>
-        </ul>
-        <ul class="subject-header">
-          <li class="subject-header-inner">
-            <wp-subject></wp-subject>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This fixes three issues:

- [x] Alignment of the WP subject (https://community.openproject.com/projects/openproject/work_packages/26073/activity)
- [x] Alignment of the WP back button on Safari on medium screens (https://community.openproject.com/projects/openproject/work_packages/26082/activity)
- [x] Width of the type input field on mobile screens (https://community.openproject.com/projects/openproject/work_packages/26084/activity)

This should not be merged before its carefully tested. I think I caught all exceptional cases, but I am not sure.