### PR TITLE
Restrict local cloning feature to http(s) and file urls

### DIFF
--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -31,6 +31,7 @@ require 'open_project/scm/adapters/git'
 
 class Repository::Git < Repository
   validates_presence_of :url
+  validate :validity_of_local_url
 
   def self.scm_adapter_class
     OpenProject::Scm::Adapters::Git
@@ -175,5 +176,17 @@ class Repository::Git < Repository
 
     changesets.where(['scmid IN (?)', revisions.map!(&:scmid)])
       .order('committed_on DESC')
+  end
+
+  private
+
+  def validity_of_local_url
+    parsed = URI.parse root_url.presence || url
+    if parsed.scheme == 'ssh'
+      errors.add :url, :must_not_be_ssh
+    end
+  rescue => e
+    Rails.logger.error "Failed to parse repository url for validation: #{e}"
+    errors.add :url, :invalid_url
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,8 @@ en:
         repository:
           not_available: "SCM vendor is not available"
           not_whitelisted: "is not allowed by the configuration."
+          invalid_url: "is not a valid repository URL or path."
+          must_not_be_ssh: "must not be an SSH url."
           no_directory: "is not a directory."
         work_package:
           is_not_a_valid_target_for_time_entries: "Work package #%{id} is not a valid target for reassigning the time entries."

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -64,7 +64,7 @@ module OpenProject
         end
 
         def scm_version_from_command_line
-          capture_out(%w[--version --no-color])
+          capture_out(%w[--version])
         end
 
         def git_binary_version
@@ -195,7 +195,10 @@ module OpenProject
         end
 
         def checkout?
-          checkout_uri =~ /\A\w+:\/\/.+\Z/ # check if it starts file:// or http(s):// etc
+          parsed = URI.parse checkout_uri
+          %w(file http https git).include? parsed.scheme
+        rescue => e
+          false
         end
 
         def checkout_path

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -31,8 +31,8 @@ require 'spec_helper'
 describe Repository::Git, type: :model do
   let(:encoding) { 'UTF-8' }
   let(:instance) { FactoryGirl.build(:repository_git, path_encoding: encoding) }
-  let(:adapter)  { instance.scm }
-  let(:config)   { {} }
+  let(:adapter) { instance.scm }
+  let(:config) { {} }
   let(:enabled_scm) { %w[git] }
 
   before do
@@ -99,7 +99,7 @@ describe Repository::Git, type: :model do
       context 'with string disabled types' do
         before do
           allow(OpenProject::Configuration).to receive(:default_override_source)
-            .and_return('OPENPROJECT_SCM_GIT_DISABLED__TYPES' => '[managed,local]')
+                                                 .and_return('OPENPROJECT_SCM_GIT_DISABLED__TYPES' => '[managed,local]')
 
           OpenProject::Configuration.load
           allow(adapter.class).to receive(:config).and_call_original
@@ -141,9 +141,43 @@ describe Repository::Git, type: :model do
     end
   end
 
+  describe 'URL validation' do
+    let(:instance) { FactoryGirl.build(:repository_git, url: url) }
+
+    shared_examples 'repository url is valid' do
+      it 'is valid' do
+        expect(instance).to be_valid
+      end
+    end
+
+    context 'file:// URLs' do
+      let(:url) { 'file:///foo/bar' }
+      it_behaves_like 'repository url is valid'
+    end
+
+    context 'absolute paths' do
+      let(:url) { 'file:///foo/bar' }
+      it_behaves_like 'repository url is valid'
+    end
+
+    context 'https URLs' do
+      let(:url) { 'https://localhost/git/foo' }
+      it_behaves_like 'repository url is valid'
+    end
+
+    context 'SSH URLs' do
+      let(:url) { 'ssh://-oProxyCommand=echo/wat' }
+
+      it 'is invalid' do
+        expect(instance).not_to be_valid
+        expect(instance.errors.full_messages).to eq(["URL must not be an SSH url."])
+      end
+    end
+  end
+
   describe 'with an actual repository' do
     with_git_repository do |repo_dir|
-      let(:url)      { repo_dir }
+      let(:url) { repo_dir }
       let(:instance) {
         FactoryGirl.create(:repository_git,
                            path_encoding: encoding,
@@ -383,7 +417,7 @@ describe Repository::Git, type: :model do
           Changeset.create(repository: instance,
                            committed_on: Time.now,
                            revision: 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
-                           scmid:    'abc7234cb2750b63f47bff735edc50a1c0a433c2',
+                           scmid: 'abc7234cb2750b63f47bff735edc50a1c0a433c2',
                            comments: 'test')
 
           event = find_events(user).first


### PR DESCRIPTION
7.2. allows cloning of unauthenticated git repositories. This PR restricts SSH checkout to avoid confusion around the missing options for authentication and to avoid CVE-2017-12426 for older git versions.