### PR TITLE
[26099] Default to 'all' status filter

### DIFF
--- a/app/cells/user_filter_cell.rb
+++ b/app/cells/user_filter_cell.rb
@@ -23,10 +23,10 @@ class UserFilterCell < RailsCell
 
     ##
     # Returns the selected status from the parameters
-    # or the default status to be filtered by (active)
+    # or the default status to be filtered by (all)
     # if no status is given.
     def status_param(params)
-      params[:status].presence || :active
+      params[:status].presence || 'all'
     end
 
     def filter_name(query, name)

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -54,15 +54,20 @@ feature 'invite user via email', type: :feature, js: true do
       expect(members_page).to have_added_user('finkelstein @openproject.com')
 
       expect(members_page).to have_user 'finkelstein @openproject.com'
+
+      # Should show the invited user on the default filter as well
+      members_page.visit!
+      expect(members_page).to have_user 'finkelstein @openproject.com'
+
     end
   end
 
   context 'with a registered user' do
     let!(:user) do
       FactoryGirl.create :user, mail: 'hugo@openproject.com',
-                                login: 'hugo@openproject.com',
-                                firstname: 'Hugo',
-                                lastname: 'Hurried'
+                         login: 'hugo@openproject.com',
+                         firstname: 'Hugo',
+                         lastname: 'Hurried'
     end
 
     scenario 'user lookup by email' do

--- a/spec_legacy/functional/users_controller_spec.rb
+++ b/spec_legacy/functional/users_controller_spec.rb
@@ -52,8 +52,6 @@ describe UsersController, type: :controller do
     assert_response :success
     assert_template 'index'
     refute_nil assigns(:users)
-    # active users only
-    assert_nil(assigns(:users).detect { |u| !u.active? })
   end
 
   it 'should index with name filter' do


### PR DESCRIPTION
This was changed in https://github.com/opf/openproject/pull/5800 and breaks the members page in several ways:

1. The default view no longer includes all members, which is confusing. It also doesn't show the filter button so there's no way to change the filter.
2. When adding a user, the filter is changed to `all statuses`.
3. When removing a user, the filter is reverted again to `:active` only.

https://community.openproject.com/wp/26099