### PR TITLE
[26151] Minimal optimizations for mobile WP view

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -58,7 +58,7 @@
     padding: 20px !important
     width: 100% !important
   #main-menu ~ #content-wrapper
-    padding: 2rem 20px 0 20px !important
+    padding: 2rem 15px 0 15px !important
 
   #breadcrumb,
   #sidebar,

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -158,3 +158,13 @@
           #main-menu
             height: initial
             min-height: calc(100vh - 55px - 5px)
+
+@include breakpoint(680px down)
+  body.controller-work_packages.action-show
+    .work-packages--show-view
+      padding-left: 0
+    .work-packages-full-view--split-container
+      .work-packages-full-view--split-left
+        padding: 0
+      .work-packages-full-view--split-right .work-packages--panel-inner
+        padding: 0 10px 0 10px

--- a/frontend/app/components/routing/wp-show/wp.show.html
+++ b/frontend/app/components/routing/wp-show/wp.show.html
@@ -27,7 +27,7 @@
           <li class="toolbar-item" ng-if="$ctrl.displayWatchButton">
             <wp-watcher-button work-package="$ctrl.workPackage"></wp-watcher-button>
           </li>
-          <li class="toolbar-item">
+          <li class="toolbar-item hidden-for-mobile">
             <wp-zen-mode-toggle-button>
             </wp-zen-mode-toggle-button>
           </li>


### PR DESCRIPTION
Increase space for mobile view and hide zen mode button.

![bildschirmfoto 2017-08-17 um 14 38 44](https://user-images.githubusercontent.com/7457313/29413964-8112dc2e-835e-11e7-8b8c-428234ad14ba.png)

https://community.openproject.com/projects/openproject/work_packages/26151/activity