### PR TITLE
[26113] Summary field in news too large

### DIFF
--- a/app/views/news/_form.html.erb
+++ b/app/views/news/_form.html.erb
@@ -33,8 +33,8 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="form--field">
   <%= f.text_area :summary,
                   cols: 60,
-                  rows: 3,
-                  class: 'wiki-edit wiki-toolbar',
+                  rows: 4,
+                  class: 'wiki-edit wiki-toolbar -small',
                   container_class: '-wide' %>
 </div>
 <div class="form--field">


### PR DESCRIPTION
Reduce height of news summary field.

https://community.openproject.com/projects/openproject/work_packages/26113/activity