### PR TITLE
[26163] Skip activation of edit field on link click

### DIFF
--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.directive.ts
@@ -126,8 +126,19 @@ export class WorkPackageEditFieldController {
   }
 
   public handleUserActivate(evt:JQueryEventObject|null) {
-    // Get the position where the user clicked.
-    const positionOffset = evt ? ClickPositionMapper.getPosition(evt) : 0;
+    let positionOffset = 0;
+
+    if (evt) {
+      // Skip activation if the user clicked on a link
+      const target = jQuery(evt.target);
+
+      if (target.closest('a', this.displayContainer[0]).length > 0) {
+        return true;
+      }
+
+      // Get the position where the user clicked.
+      positionOffset = ClickPositionMapper.getPosition(evt);
+    }
 
     this.activate()
       .then((handler) => {
@@ -135,6 +146,8 @@ export class WorkPackageEditFieldController {
         const input = handler.element.find('input');
         ClickPositionMapper.setPosition(input, positionOffset);
       });
+
+    return false;
   }
 
   public get displayContainer() {


### PR DESCRIPTION
Avoids a race condition that causes an internal error message on FF.

https://community.openproject.com/wp/26163