### PR TITLE
Run npm install on travis at all times

### DIFF
--- a/script/ci_setup.sh
+++ b/script/ci_setup.sh
@@ -55,13 +55,13 @@ if [ $1 != 'npm' ]; then
   run "bundle exec rake db:migrate"
 fi
 
+# We need npm 4.0 for a bugfix in cross-platform shrinkwrap
+# https://github.com/npm/npm/issues/14042
+run "npm install npm@4.0"
+
+run "for i in {1..3}; do npm install && break || sleep 15; done"
+
 if [ $1 != 'specs' ] && [ $1 != 'spec_legacy' ]; then
-  # We need npm 4.0 for a bugfix in cross-platform shrinkwrap
-  # https://github.com/npm/npm/issues/14042
-  run "npm install npm@4.0"
-
-  run "for i in {1..3}; do npm install && break || sleep 15; done"
-
   run "bundle exec rake assets:precompile"
 else
   # fake result of npm/asset run


### PR DESCRIPTION
Otherwise, downstream repos will fail on a lot of spec runs
due to foundation still being accessed.