### PR TITLE
Fix invalid value_objects being passed to representer

### DIFF
--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -78,8 +78,15 @@ module API
                       next unless represented.ar_object_filter?
 
                       represented.value_objects.map do |value_object|
+                        href = begin
+                          api_v3_paths.send(value_object.class.name.demodulize.underscore, value_object.id)
+                        rescue
+                          Rails.logger.error "Failed to get href for value_object #{value_object}"
+                          nil
+                        end
+
                         {
-                          href: api_v3_paths.send(value_object.class.name.demodulize.underscore, value_object.id),
+                          href: href,
                           title: value_object.name
                         }
                       end

--- a/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -93,6 +93,30 @@ describe ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
         .at_path('name')
     end
 
+    context 'with an invalid value_objects' do
+      let(:filter) do
+        Queries::WorkPackages::Filter::AssignedToFilter.new(operator: operator, values: values)
+      end
+      let(:values) { ['1'] }
+
+      before do
+        allow(filter)
+          .to receive(:value_objects)
+                .and_return([User.anonymous])
+      end
+
+      it "has a 'values' collection" do
+        expected = {
+          href: nil,
+          title: 'Anonymous'
+        }
+
+        is_expected
+          .to be_json_eql([expected].to_json)
+                .at_path('_links/values')
+      end
+    end
+
     context 'with a non ar object filter' do
       let(:values) { ['lorem ipsum'] }
       let(:filter) do


### PR DESCRIPTION
There are queries that seem to pass values not available in APIv3 path
helper to the instance representer.

```
  Original error: #<NoMethodError: undefined method `anonymous_user' for
  API::V3::Utilities::PathHelper::ApiV3Path:Class
  Did you mean?  anonymous?>

    Stacktrace:

        /opt/openproject/lib/api/v3/queries/filters/query_filter_instance_representer.rb:82:in
        `block (2 levels) in <class:QueryFilterInstanceRepresenter>'
                                        /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/delegation.rb:38:in
                                    `map'
                                        /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/delegation.rb:38:in
                                    `map'
                                        /opt/openproject/lib/api/v3/queries/filters/query_filter_instance_representer.rb:80:in
                                    `block in
                                    <class:QueryFilterInstanceRepresenter>'
```