### PR TITLE
[26169] Inconsistent translations strings for "Work package type" on several screen

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -133,9 +133,9 @@ class TypesController < ApplicationController
 
   def default_breadcrumb
     if action_name == 'index'
-      t(:label_type_plural)
+      t(:label_work_package_types)
     else
-      ActionController::Base.helpers.link_to(t(:label_type_plural), types_path)
+      ActionController::Base.helpers.link_to(t(:label_work_package_types), types_path)
     end
   end
 

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -94,7 +94,7 @@ module ProjectsHelper
         name: 'types',
         action: :manage_types,
         partial: 'projects/settings/types',
-        label: :label_type_plural
+        label: :label_work_package_types
       }
     ]
     tabs.select { |tab| User.current.allowed_to?(tab[:action], @project) }

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -36,7 +36,6 @@ See doc/COPYRIGHT.rdoc for more details.
                          class: "ignored-by-flash-activation" %>
 
 <fieldset class="form--fieldset" id="project_types">
-  <legend class="form--fieldset-legend"><%=l(:label_enabled_project_types)%></legend>
   <div class="form--fieldset-control">
     <span class="form--fieldset-control-container">
       (<%= check_all_links 'types-form' %>)

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -82,7 +82,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <div class="generic-table--sort-header-outer">
                 <div class="generic-table--sort-header">
                   <span>
-                    <%= Type.human_attribute_name(:is_default) %>
+                    <%= t(:label_active_in_new_projects) %>
                   </span>
                 </div>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1002,6 +1002,7 @@ en:
   label_accessibility: "Accessibility"
   label_account: "Account"
   label_active: "Active"
+  label_active_in_new_projects: "Active in new projects"
   label_activity: "Activity"
   label_add_edit_translations: "Add and edit translations"
   label_add_another_file: "Add another file"

--- a/features/projects/copy_project.feature
+++ b/features/projects/copy_project.feature
@@ -95,7 +95,7 @@ Feature: Project Settings
     And  I click on "Copy"
     Then I should see "Started to copy project"
     And  I go to the settings page of the project "copied-project"
-    And  I follow "Types" within "#content"
+    And  I follow "Work package types" within "#content"
     Then the "Phase1" checkbox should be checked
     And  the "Phase2" checkbox should be checked
 

--- a/spec/features/projects/projects_spec.rb
+++ b/spec/features/projects/projects_spec.rb
@@ -104,7 +104,7 @@ describe 'Projects', type: :feature do
     it "have the correct types checked for the project's types" do
       visit admin_index_path
       click_on 'Foo project'
-      click_on 'Types'
+      click_on 'Work package types'
 
       field_checked = find_field('Phase', visible: false)['checked']
       expect(field_checked).to be_truthy


### PR DESCRIPTION
Unify used strings for "Work package types".

https://community.openproject.com/projects/cern/work_packages/26169/activity