### PR TITLE
Extend syntax for linking users

### DIFF
--- a/app/assets/stylesheets/content/_links.sass
+++ b/app/assets/stylesheets/content/_links.sass
@@ -77,6 +77,10 @@ a.icon, a.icon-context
 a.icon:hover, a.icon-context:hover
   text-decoration: none
 
+a.user-mention:before
+  content: '@'
+  color: $gray-dark
+
 #content table th a.no-decoration-on-hover:hover, a.no-decoration-on-hover:hover
   text-decoration: none
 

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -39,17 +39,17 @@ class EnqueueWorkPackageNotificationJob < ApplicationJob
     # and our job here is done
     return nil unless raw_journal
 
-    journal = find_aggregated_journal
+    @journal = find_aggregated_journal
 
     # If we can't find the aggregated journal, it was superseded by a journal that aggregated ours.
     # In that case a job for the new journal will have been enqueued that is now responsible for
     # sending the notification. Our job here is done.
-    return nil unless journal
+    return nil unless @journal
 
     # Do not deliver notifications if a follow-up journal will already have sent a notification
     # on behalf of this job.
-    unless Journal::AggregatedJournal.hides_notifications?(journal.successor, journal)
-      deliver_notifications_for(journal)
+    unless Journal::AggregatedJournal.hides_notifications?(@journal.successor, @journal)
+      deliver_notifications_for(@journal)
     end
   end
 
@@ -76,6 +76,41 @@ class EnqueueWorkPackageNotificationJob < ApplicationJob
   end
 
   def notification_receivers(work_package)
-    (work_package.recipients + work_package.watcher_recipients).uniq
+    (work_package.recipients + work_package.watcher_recipients + mentioned).uniq
   end
+
+  def mentioned
+    mentioned_people = []
+
+    text = text_for_mentions
+    user_ids = text.scan(/\buser#([\d]+)\b/).first.to_a
+    user_login_names = text.scan(/\buser:(.+?)\b/).first.to_a
+
+    user_ids.each do |user_id|
+      if user = User.in_visible_project.find_by(id: user_id)
+        mentioned_people << user
+      end
+    end
+
+    user_login_names.each do |name|
+      if user = User.in_visible_project.find_by(login: name)
+        mentioned_people << user
+      end
+    end
+  end
+
+  def text_for_mentions
+    potential_text = ""
+    potential_text << @journal.notes if @journal.notes.present?
+
+    ["description", "subject"].each do |field|
+      if @journal.details[field].try(:any?)
+        from = @journal.details[field].first
+        to = @journal.details[field].second
+        potential_text << Redmine::Helpers::Diff.new(to, from).additions.join(' ')
+      end
+    end
+    potential_text
+  end
+
 end

--- a/app/workers/enqueue_work_package_notification_job.rb
+++ b/app/workers/enqueue_work_package_notification_job.rb
@@ -89,14 +89,18 @@ class EnqueueWorkPackageNotificationJob < ApplicationJob
     user_login_names = text.scan(/\buser:"(.+?)"/).first.to_a
 
     user_ids.each do |user_id|
-      if user = User.in_visible_project(@author).find_by(id: user_id)
-        mentioned_people << user unless user.mail_notification == 'none'
+      if user = User.find_by(id: user_id)
+        if @work_package.visible? user
+          mentioned_people << user unless user.mail_notification == 'none'
+        end
       end
     end
 
     user_login_names.each do |name|
-      if user = User.in_visible_project(@author).find_by(login: name)
-        mentioned_people << user unless user.mail_notification == 'none'
+      if user = User.find_by(login: name)
+        if @work_package.visible? user
+          mentioned_people << user unless user.mail_notification == 'none'
+        end
       end
     end
     mentioned_people

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -382,7 +382,7 @@ module OpenProject
               end
             when 'user'
               if user = User.in_visible_project.find_by(id: oid)
-                link = link_to_user(user, class: 'user')
+                link = link_to_user(user, class: 'user-mention')
               end
             end
           elsif sep == '##'
@@ -444,6 +444,10 @@ module OpenProject
                   .first
               if p
                 link = link_to_project(p, { only_path: only_path }, class: 'project')
+              end
+            when 'user'
+              if user = User.in_visible_project.find_by(login: name)
+                link = link_to_user(user, class: 'user-mention')
               end
             end
           end

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -334,7 +334,7 @@ module OpenProject
     #     identifier:version:1.0.0
     #     identifier:source:some/file
     def parse_redmine_links(text, project, obj, attr, only_path, options)
-      text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-_]+):)?(attachment|version|commit|source|export|message|project)?((#+|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |_m|
+      text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-_]+):)?(attachment|version|commit|source|export|message|project|user)?((#+|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |_m|
         leading = $1
         esc = $2
         project_prefix = $3
@@ -379,6 +379,10 @@ module OpenProject
             when 'project'
               if p = Project.visible.find_by(id: oid)
                 link = link_to_project(p, { only_path: only_path }, class: 'project')
+              end
+            when 'user'
+              if user = User.in_visible_project.find_by(id: oid)
+                link = link_to_user(user, class: 'user')
               end
             end
           elsif sep == '##'

--- a/lib/redmine/helpers/diff.rb
+++ b/lib/redmine/helpers/diff.rb
@@ -84,6 +84,18 @@ module Redmine
         end
         words.join(' ')
       end
+
+      def additions
+        added_changes = []
+        if @diff.diffs.try(:first).try(:any?)
+          @diff.diffs.first.each do |change|
+            if change.first == "+"
+              added_changes << change.third
+            end
+          end
+        end
+        added_changes
+      end
     end
   end
 end

--- a/lib/redmine/wiki_formatting/textile/formatter.rb
+++ b/lib/redmine/wiki_formatting/textile/formatter.rb
@@ -125,7 +125,7 @@ module Redmine
 
         # Turns all email addresses into clickable links (code from Rails).
         def inline_auto_mailto(text)
-          text.gsub!(/([\w\.!#\$%\-+.]+@[A-Za-z0-9\-]+(\.[A-Za-z0-9\-]+)+)/) do
+          text.gsub!(/((?<!user:)\b[\w\.!#\$%\-+.]+@[A-Za-z0-9\-]+(\.[A-Za-z0-9\-]+)+)/) do
             mail = $1
             if text.match(/<a\b[^>]*>(.*)(#{Regexp.escape(mail)})(.*)<\/a>/)
               mail

--- a/lib/redmine/wiki_formatting/textile/formatter.rb
+++ b/lib/redmine/wiki_formatting/textile/formatter.rb
@@ -125,7 +125,7 @@ module Redmine
 
         # Turns all email addresses into clickable links (code from Rails).
         def inline_auto_mailto(text)
-          text.gsub!(/((?<!user:)\b[\w\.!#\$%\-+.]+@[A-Za-z0-9\-]+(\.[A-Za-z0-9\-]+)+)/) do
+          text.gsub!(/((?<!user:")\b[\w\.!#\$%\-+.]+@[A-Za-z0-9\-]+(\.[A-Za-z0-9\-]+)+)/) do
             mail = $1
             if text.match(/<a\b[^>]*>(.*)(#{Regexp.escape(mail)})(.*)<\/a>/)
               mail

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -289,6 +289,47 @@ describe OpenProject::TextFormatting do
       end
     end
 
+    context 'User links' do
+      let(:role) do
+        FactoryGirl.create :role,
+                           permissions: [:view_work_packages, :edit_work_packages,
+                                         :browse_repository, :view_changesets, :view_wiki_pages]
+      end
+
+      let(:linked_project_member) do
+        FactoryGirl.create :user,
+                           member_in_project: project,
+                           member_through_role: role
+      end
+
+      context 'User link via ID' do
+        context 'when linked user visible for reader' do
+          subject { format_text("user##{linked_project_member.id}") }
+
+          it {
+            is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user')}</p>")
+          }
+        end
+
+        context 'when linked user not visible for reader' do
+          let(:role) { FactoryGirl.create(:non_member) }
+
+          subject { format_text("user##{linked_project_member.id}") }
+
+          it {
+            is_expected.to be_html_eql("<p>user##{linked_project_member.id}</p>")
+          }
+        end
+
+      end
+
+      # context 'User link via login name' do
+      #   subject { format_text("user:#{linked_user.login}") }
+      #
+      #   it { is_expected.to be_html_eql("<p>#{link_to(linked_user.name, user_url, class: 'user')}</p>") }
+      # end
+    end
+
     context 'Url links' do
       subject { format_text('http://foo.bar/FAQ#3') }
 

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -42,19 +42,19 @@ describe OpenProject::TextFormatting do
   describe '.format_text' do
     let(:project) { FactoryGirl.create :valid_project }
     let(:identifier) { project.identifier }
-    let(:project_member) {
+    let(:project_member) do
       FactoryGirl.create :user,
                          member_in_project: project,
                          member_through_role: FactoryGirl.create(:role,
                                                                  permissions: [:view_work_packages, :edit_work_packages,
                                                                                :browse_repository, :view_changesets, :view_wiki_pages])
-    }
-    let(:issue) {
+    end
+    let(:issue) do
       FactoryGirl.create :work_package,
                          project: project,
                          author: project_member,
                          type: project.types.first
-    }
+    end
 
     before do
       @project = project
@@ -79,16 +79,16 @@ describe OpenProject::TextFormatting do
                                   repository: repository,
                                   comments: 'This commit fixes #1, #2 and references #1 & #3'
       end
-      let(:changeset_link) {
+      let(:changeset_link) do
         link_to("r#{changeset1.revision}",
                 { controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset1.revision },
                 class: 'changeset', title: 'My very first commit')
-      }
-      let(:changeset_link2) {
+      end
+      let(:changeset_link2) do
         link_to("r#{changeset2.revision}",
                 { controller: 'repositories', action: 'revision', project_id: identifier, rev: changeset2.revision },
                 class: 'changeset', title: 'This commit fixes #1, #2 and references #1 & #3')
-      }
+      end
 
       before do
         allow(project).to receive(:repository).and_return(repository)
@@ -343,7 +343,6 @@ describe OpenProject::TextFormatting do
             it { is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>") }
           end
         end
-
 
         context 'when linked user not visible for reader' do
           let(:role) { FactoryGirl.create(:non_member) }

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -325,18 +325,33 @@ describe OpenProject::TextFormatting do
 
       context 'User link via login name' do
         context 'when linked user visible for reader' do
-          subject { format_text("user:#{linked_project_member.login}") }
+          context 'with a common login name' do
+            subject { format_text("user:\"#{linked_project_member.login}\"") }
 
-          it { is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>") }
+            it { is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>") }
+          end
+
+          context "with an email address as login name" do
+            let(:linked_project_member) do
+              FactoryGirl.create :user,
+                                 member_in_project: project,
+                                 member_through_role: role,
+                                 login: "foo@bar.com"
+            end
+            subject { format_text("user:\"#{linked_project_member.login}\"") }
+
+            it { is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>") }
+          end
         end
+
 
         context 'when linked user not visible for reader' do
           let(:role) { FactoryGirl.create(:non_member) }
 
-          subject { format_text("user:#{linked_project_member.login}") }
+          subject { format_text("user:\"#{linked_project_member.login}\"") }
 
           it {
-            is_expected.to be_html_eql("<p>user:#{linked_project_member.login}</p>")
+            is_expected.to be_html_eql("<p>user:\"#{linked_project_member.login}\"</p>")
           }
         end
       end

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -307,7 +307,7 @@ describe OpenProject::TextFormatting do
           subject { format_text("user##{linked_project_member.id}") }
 
           it {
-            is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user')}</p>")
+            is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>")
           }
         end
 
@@ -323,11 +323,23 @@ describe OpenProject::TextFormatting do
 
       end
 
-      # context 'User link via login name' do
-      #   subject { format_text("user:#{linked_user.login}") }
-      #
-      #   it { is_expected.to be_html_eql("<p>#{link_to(linked_user.name, user_url, class: 'user')}</p>") }
-      # end
+      context 'User link via login name' do
+        context 'when linked user visible for reader' do
+          subject { format_text("user:#{linked_project_member.login}") }
+
+          it { is_expected.to be_html_eql("<p>#{link_to(linked_project_member.name, { controller: :users, action: :show, id: linked_project_member.id }, class: 'user-mention')}</p>") }
+        end
+
+        context 'when linked user not visible for reader' do
+          let(:role) { FactoryGirl.create(:non_member) }
+
+          subject { format_text("user:#{linked_project_member.login}") }
+
+          it {
+            is_expected.to be_html_eql("<p>user:#{linked_project_member.login}</p>")
+          }
+        end
+      end
     end
 
     context 'Url links' do

--- a/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
@@ -256,7 +256,7 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
       allow(subject).to receive(:text_for_mentions).and_return(added_text)
     end
 
-    context "both users are members in at least one project" do
+    context "recipient is allowed to view the work package" do
       let(:author) do
         FactoryGirl.create(:user,
                            member_in_project: project,
@@ -281,7 +281,7 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
                                member_through_role: role,
                                login: "foo@bar.com")
           end
-          
+
           it "detects the user" do
             expect(subject.send(:mentioned).first).to eq recipient
           end
@@ -315,7 +315,11 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
       end
     end
 
-    context "users are not members of one common project" do
+    context "mentioned user is not allowed to view the work package" do
+      let(:recipient) do
+        FactoryGirl.create(:user,
+                           login: "foo@bar.com")
+      end
       let(:added_text) do
         "Hello user:#{recipient.login}, hey user##{recipient.id}"
       end

--- a/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/enqueue_work_package_notification_job_spec.rb
@@ -216,7 +216,6 @@ describe EnqueueWorkPackageNotificationJob, type: :model do
     end
   end
 
-
   describe "#text_for_mentions" do
     it "returns a text" do
       subject.perform

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/macros_spec.rb
@@ -27,7 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'legacy_spec_helper'
+require_relative '../../../../legacy_spec_helper'
 
 describe Redmine::WikiFormatting::Macros, type: :helper do
   include ApplicationHelper

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/null_formatter_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/null_formatter_spec.rb
@@ -27,7 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'legacy_spec_helper'
+require_relative '../../../../legacy_spec_helper'
 
 describe Redmine::WikiFormatting::NullFormatter::Formatter do
   before do

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
@@ -111,11 +111,24 @@ describe Redmine::WikiFormatting::Textile::Formatter do
     )
   end
 
+  it 'should inline auto link email addresses' do
+    assert_html_output(
+      'Mailto link to foo@bar.com' => 'Mailto link to <a class="email" href="mailto:foo@bar.com">foo@bar.com</a>'
+    )
+  end
+
+  it 'should ignore email addresses that are used as login names' do
+    assert_html_output(
+      'No mailto link to user:foo@bar.com' => 'No mailto link to user:foo@bar.com'
+    )
+  end
+
   it 'should ignore links inside macros' do
     assert_html_output(
       '{{embed_youtube(http://www.google.com)}}' =>         '{{embed_youtube(http://www.google.com)}}'
     )
   end
+
 
   it 'should blockquote' do
     # orig raw text

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
@@ -27,7 +27,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'legacy_spec_helper'
+require_relative '../../../../legacy_spec_helper'
 
 describe Redmine::WikiFormatting::Textile::Formatter do
   include Rails::Dom::Testing::Assertions

--- a/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
+++ b/spec_legacy/unit/lib/redmine/wiki_formatting/textile_formatter_spec.rb
@@ -119,7 +119,7 @@ describe Redmine::WikiFormatting::Textile::Formatter do
 
   it 'should ignore email addresses that are used as login names' do
     assert_html_output(
-      'No mailto link to user:foo@bar.com' => 'No mailto link to user:foo@bar.com'
+      'No mailto link to user:"foo@bar.com"' => 'No mailto link to user:"foo@bar.com"'
     )
   end
 


### PR DESCRIPTION
This is the first step in the effort to allow user names to trigger some sort of „mention“ notification. 