### PR TITLE
[25739] Use remote_file_url for copying attachment

### DIFF
--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -148,6 +148,8 @@ module Project::Copy
         new_issue = WorkPackage.new
         new_issue.copy_from(issue)
         new_issue.project = self
+        # Reassign author to the current user
+        new_issue.author = User.current
         # Reassign fixed_versions by name, since names are unique per
         # project and the versions for self are not yet saved
         if issue.fixed_version

--- a/app/uploaders/fog_file_uploader.rb
+++ b/app/uploaders/fog_file_uploader.rb
@@ -34,7 +34,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
   storage :fog
 
   def copy_to(attachment)
-    attachment.file = remote_file.url
+    attachment.remote_file_url = remote_file.url
   end
 
   def store_dir


### PR DESCRIPTION
Also sets the author to the current user that performed the copy