### PR TITLE
[25880] Allow locking of registered users without prior activation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,7 @@ class UsersController < ApplicationController
   before_action :find_user, only: [:show,
                                    :edit,
                                    :update,
+                                   :change_status_info,
                                    :change_status,
                                    :destroy,
                                    :deletion_info,
@@ -183,6 +184,12 @@ class UsersController < ApplicationController
     end
   rescue ::ActionController::RedirectBackError
     redirect_to controller: '/users', action: 'edit', id: @user
+  end
+
+  def change_status_info
+    @status_change = params[:change_action].to_sym
+
+    return render_400 unless %i(activate lock unlock).include? @status_change
   end
 
   def change_status

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -278,7 +278,7 @@ class UserMailer < BaseMailer
     @user           = user
     @activation_url = url_for(controller: '/users',
                               action:     :index,
-                              status:     User::STATUSES[:registered],
+                              status:     'registered',
                               sort:       'created_at:desc')
 
     open_project_headers 'Type' => 'Account'

--- a/app/views/user_mailer/account_activation_requested.html.erb
+++ b/app/views/user_mailer/account_activation_requested.html.erb
@@ -29,3 +29,13 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <p><%= t(:mail_body_account_activation_request, value: @user.login) %></p>
 <p><%= link_to @activation_url, @activation_url %></p>
+
+<p><%= t('mail.further_actions') %></p>
+<ul>
+  <li><%= link_to t(:label_activate_user), change_status_info_user_url(@user, change_action: :activate) %></li>
+  <li><%= link_to t(:label_lock_user), change_status_info_user_url(@user, change_action: :lock) %></li>
+  <% if Setting.users_deletable_by_admins? %>
+    <li><%= link_to t(:label_delete_user), deletion_info_user_url(@user) %></li>
+  <% end %>
+  <li><%= link_to t(:label_show_all_registered_users), users_url(status: 'registered') %></li>
+</ul>

--- a/app/views/user_mailer/account_activation_requested.text.erb
+++ b/app/views/user_mailer/account_activation_requested.text.erb
@@ -29,3 +29,13 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= t(:mail_body_account_activation_request, value: @user.login) %>
 <%= @activation_url %>
+
+
+<%= t('mail.further_actions') %>
+
+* <%= t(:label_activate_user) %>: <%= change_status_info_user_url(@user, change_action: :activate) %>
+* <%= t(:label_lock_user) %>: <%= change_status_info_user_url(@user, change_action: :lock) %>
+<% if Setting.users_deletable_by_admins? %>
+    * <%= t(:label_delete_user) %>: <%= deletion_info_user_url(@user) %>
+<% end %>
+* <%= t(:label_show_all_registered_users) %>: <%= users_url(status: 'registered')  %>

--- a/app/views/users/change_status_info.html.erb
+++ b/app/views/users/change_status_info.html.erb
@@ -1,0 +1,87 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See doc/COPYRIGHT.rdoc for more details.
+
+++#%>
+<% html_title(l(:label_administration), "#{ l(:label_change_status_of_user, username: @user.name)}") -%>
+<% local_assigns[:additional_breadcrumb] = @user.name %>
+
+<% new_status =  t("user.#{@status_change}") %>
+<%= labelled_tabular_form_for :user, url: change_status_user_path(@user, @status_change => '1'), html: { method: :post, class: 'form' } do %>
+    <section class="form--section">
+      <h3 class="form--section-title">
+        <%= @user.name %>:
+        <%= new_status %>
+      </h3>
+
+      <p>
+        <%= t('user.confirm_status_change', name: @user.name) %>
+      </p>
+
+      <div class="attributes-key-value">
+        <div class="attributes-key-value--key"><%= User.human_attribute_name :login %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -float">
+            <span><%= @user.login %></span>
+          </div>
+        </div>
+
+        <div class="attributes-key-value--key"><%= User.human_attribute_name :mail %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -float">
+            <span><%= @user.mail %></span>
+          </div>
+        </div>
+
+        <div class="attributes-key-value--key"><%= User.human_attribute_name :name %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -float">
+            <span><%= @user.name %></span>
+          </div>
+        </div>
+
+        <div class="attributes-key-value--key"><%= t(:label_current_status) %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -float">
+            <span class=""><%= full_user_status(@user, true) %></span>
+          </div>
+        </div>
+
+        <div class="attributes-key-value--key"><strong><%= t(:status_change) %></strong></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -float">
+            <strong><%= new_status %></strong>
+          </div>
+        </div>
+      </div>
+
+    </section>
+    <hr class="form--separator" />
+      <%= styled_button_tag '', class: '-highlight' do %>
+        <%= op_icon('button--icon icon-checkmark') %>
+        <span class="button--text"><%= new_status %></span>
+      <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1004,6 +1004,7 @@ en:
   label_accessibility: "Accessibility"
   label_account: "Account"
   label_active: "Active"
+  label_activate_user: 'Activate user'
   label_active_in_new_projects: "Active in new projects"
   label_activity: "Activity"
   label_add_edit_translations: "Add and edit translations"
@@ -1071,6 +1072,7 @@ en:
   label_change_plural: "Changes"
   label_change_properties: "Change properties"
   label_change_status: "Change status"
+  label_change_status_of_user: "Change status of #{username}"
   label_change_view_all: "View all changes"
   label_changes_details: "Details of all changes"
   label_changeset: "Changeset"
@@ -1117,6 +1119,7 @@ en:
   label_date_to: "To"
   label_day_plural: "days"
   label_default: "Default"
+  label_delete_user: "Delete user"
   label_delete_project: "Delete project"
   label_deleted: "deleted"
   label_deleted_custom_field: "(deleted custom field)"
@@ -1195,6 +1198,7 @@ en:
   label_internal: "Internal"
   label_invite_user: "Invite user"
   label_show_hide: "Show/hide"
+  label_show_all_registered_users: "Show all registered users"
   label_journal: "Journal"
   label_journal_diff: "Description Comparison"
   label_language: "Language"
@@ -1214,6 +1218,7 @@ en:
   label_less_than_ago: "less than days ago"
   label_list: "List"
   label_loading: "Loading..."
+  label_lock_user: 'Lock user'
   label_logged_as: "Logged in as"
   label_login: "Sign in"
   label_custom_logo: "Custom logo"
@@ -1546,6 +1551,9 @@ en:
 
   macro_execution_error: "Error executing the macro %{macro_name}"
   macro_unavailable: "Macro %{macro_name} cannot be displayed."
+
+  mail:
+    actions: 'Actions'
 
   mail_body_account_activation_request: "A new user (%{value}) has registered. The account is pending your approval:"
   mail_body_account_information: "Your account information"
@@ -2342,6 +2350,7 @@ en:
     blocked_num_failed_logins:
       one: "locked temporarily (one failed login attempt)"
       other: "locked temporarily (%{count} failed login attempts)"
+    confirm_status_change: "You are about to change the status of '%{name}'. Are you sure you want to continue?"
     deleted: "Deleted user"
     error_status_change_failed: "Changing the user status failed due to the following errors: %{errors}"
     invite: Invite user via email
@@ -2357,6 +2366,7 @@ en:
       mail_project_explanaition: "For unselected projects, you will only receive notifications about things you watch or you're involved in (e.g. work packages you're the author or assignee of)."
       mail_self_notified: "I want to be notified of changes that I make myself"
     status_user_and_brute_force: "%{user} and %{brute_force}"
+    status_change: "Status change"
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -481,6 +481,7 @@ OpenProject::Application.routes.draw do
 
     member do
       match '/edit/:tab' => 'users#edit', via: :get, as: 'tab_edit'
+      match '/change_status/:change_action' => 'users#change_status_info', via: :get, as: 'change_status_info'
       post :change_status
       post :resend_invitation
       get :deletion_info

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -254,6 +254,54 @@ describe UsersController, type: :controller do
     end
   end
 
+  describe '#change_status_info' do
+    let!(:registered_user) do
+      FactoryGirl.create(:user, status: User::STATUSES[:registered])
+    end
+
+    before do
+      as_logged_in_user admin do
+        get :change_status_info,
+            params: {
+              id: registered_user.id,
+              change_action: change_action
+            }
+      end
+    end
+
+    shared_examples 'valid status info' do
+      it 'renders the status info' do
+        expect(response).to be_success
+        expect(response).to render_template 'users/change_status_info'
+        expect(assigns(:user)).to eq(registered_user)
+        expect(assigns(:status_change)).to eq(change_action)
+      end
+    end
+
+    describe 'with valid activate' do
+      let(:change_action) { :activate }
+      it_behaves_like 'valid status info'
+    end
+
+    describe 'with valid unlock' do
+      let(:change_action) { :unlock }
+      it_behaves_like 'valid status info'
+    end
+
+    describe 'with valid lock' do
+      let(:change_action) { :lock }
+      it_behaves_like 'valid status info'
+    end
+
+    describe 'bogus status' do
+      let(:change_action) { :wtf }
+      it 'renders 400' do
+        expect(response.status).to eq(400)
+        expect(response).not_to render_template 'users/change_status_info'
+      end
+    end
+  end
+
   describe '#change_status',
            with_settings: {
              available_languages: %i(en de),

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -32,6 +32,13 @@ describe UsersController, type: :routing do
   describe 'routing' do
     describe 'users' do
       it {
+        expect(get('/users/1/change_status/foobar'))
+          .to route_to controller: 'users',
+                       action: 'change_status_info',
+                       id: '1',
+                       change_action: 'foobar'
+      }
+      it {
         expect(get('/users/1/deletion_info')).to route_to(controller: 'users',
                                                           action: 'deletion_info',
                                                           id: '1')


### PR DESCRIPTION
Adds helpers to the activation mail to activate and / or lock
the user.

If the instance allows deletion, it also shows this action.

A new route is introduced to confirm the status change of the new user.

https://community.openproject.com/wp/25880