### PR TITLE
[26246] Revert single click opens split view

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -62,7 +62,7 @@
 
 // Shrink column of details / inline-create icons
 .wp-table--context-menu-column
-  width: 40px
+  width: 60px
   // Center the th icon
   text-align: center !important
   // Take care that the header can overlap the icon
@@ -71,26 +71,35 @@
 
 // Hide the context menu button outside mobile
 html:not(.-browser-mobile)
-  .wp-table-context-menu-link
+  .wp-table--context-menu-td
+    width: 60px
+    // Override the default td line-height
+    line-height: initial !important
     @extend .hidden-for-sighted
 
-  .issue:hover .wp-table-context-menu-link,
-  .wp-table-context-menu-link:focus
+  .issue:hover .wp-table--context-menu-td,
+  .wp-table--context-menu-td:focus
     // override the hidden-for-sighted definition
     position: relative
-    left: -5px
+    left: 0
     width: initial
     height: initial
 
 
 // Show context menu button when hovering
-.wp-table-context-menu-link
+.wp-table--context-menu-td a
   vertical-align: -3px
   .icon:before
     @include varprop(color, content-link-color)
     padding: 0 0 0 0.25rem
   &:hover
     text-decoration: none
+
+.wp-table--details-link
+  padding-right: 5px
+
+.wp-table-context-menu-link
+  padding-left: 5px
 
 table.generic-table tbody tr.issue .checkbox
   overflow: visible

--- a/frontend/app/components/routing/wp-details/wp-details.controller.ts
+++ b/frontend/app/components/routing/wp-details/wp-details.controller.ts
@@ -54,6 +54,20 @@ export class WorkPackageDetailsController extends WorkPackageViewController {
     } else if (!this.wpTableSelection.isSelected(wpId)) {
       this.wpTableSelection.setRowState(wpId, true);
     }
+
+    scopedObservable(
+      $scope,
+      this.states.focusedWorkPackage.values$())
+      .map(wpId => wpId.toString())
+      .distinctUntilChanged()
+      .subscribe((newId) => {
+        if (wpId !== newId && $state.includes('work-packages.list.details')) {
+          $state.go(
+            ($state.current.name as string),
+            {workPackageId: newId, focus: false }
+          );
+        }
+      });
   }
 
   public close() {

--- a/frontend/app/components/wp-fast-table/builders/context-link-icon-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/context-link-icon-builder.ts
@@ -1,15 +1,20 @@
 import {$injectFields} from '../../angular/angular-injector-bridge.functions';
-import {opIconElement} from "../../../helpers/op-icon-builder";
-import {wpCellTdClassName} from "./cell-builder";
+import {opIconElement} from '../../../helpers/op-icon-builder';
+import {wpCellTdClassName} from './cell-builder';
+import {UiStateLinkBuilder} from './ui-state-link-builder';
+import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 
-export const contextMenuTdClassName = 'wp-table--context-menu-column';
+export const contextMenuTdClassName = 'wp-table--context-menu-td';
 export const contextMenuLinkClassName = 'wp-table-context-menu-link';
+export const contextColumnIcon = 'wp-table-context-menu-icon';
+export const detailsLinkClassName = 'wp-table--details-link';
 
 export class ContextLinkIconBuilder {
   // Injections
-  public I18n: op.I18n;
+  public I18n:op.I18n;
 
-  public text: any;
+  public text:any;
+  public uiStatebuilder = new UiStateLinkBuilder();
 
   constructor() {
     $injectFields(this, 'I18n');
@@ -19,17 +24,31 @@ export class ContextLinkIconBuilder {
     };
   }
 
-  public build(): HTMLElement {
+  public build(workPackage:WorkPackageResourceInterface):HTMLElement {
     // Append details button
     let td = document.createElement('td');
     td.classList.add(wpCellTdClassName, contextMenuTdClassName, 'hide-when-print');
 
-    // Enter the context menu arrow
-    let detailsLink = document.createElement('a');
-    detailsLink.classList.add(contextMenuLinkClassName);
-    detailsLink.appendChild(opIconElement('icon', 'icon-show-more-horizontal'));
-    td.appendChild(detailsLink);
+    let detailsLink = this.uiStatebuilder.linkToDetails(
+      workPackage.id,
+      this.text.button,
+      ''
+    );
 
+    detailsLink.classList.add(detailsLinkClassName, contextColumnIcon);
+    detailsLink.appendChild(opIconElement('icon', 'icon-info2'));
+
+    // Enter the context menu arrow
+    let contextMenu = document.createElement('a');
+    contextMenu.classList.add(contextMenuLinkClassName, contextColumnIcon);
+    contextMenu.appendChild(opIconElement('icon', 'icon-show-more-horizontal'));
+
+    // Wrap both icons in a span
+    let span = document.createElement('span');
+    span.appendChild(detailsLink);
+    span.appendChild(contextMenu);
+
+    td.appendChild(span);
     return td;
   }
 }

--- a/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -62,7 +62,7 @@ export class SingleRowBuilder {
     // Handle property types
     switch (column.id) {
       case internalContextMenuColumn.id:
-        return this.contextLinkBuilder.build();
+        return this.contextLinkBuilder.build(workPackage);
       default:
         return this.cellBuilder.build(workPackage, column.id);
     }

--- a/frontend/app/components/wp-fast-table/handlers/row/click-handler.ts
+++ b/frontend/app/components/wp-fast-table/handlers/row/click-handler.ts
@@ -42,25 +42,6 @@ export class RowClickHandler implements TableEventHandler {
       return true;
     }
 
-    // Count whether a double click occurs
-    this.clicks++;
-    if (this.clicks === 1) {
-      this.timer = setTimeout(() => {
-        this.clicks = 0;
-        this.handleSingle(table, evt);
-      }, 200);
-    } else {
-      clearTimeout(this.timer);
-      this.clicks = 0;
-      this.handleDoubleClick(table, evt);
-    }
-
-    return false;
-  }
-
-  private handleSingle(table:WorkPackageTable, evt:JQueryEventObject) {
-    let target = jQuery(evt.target);
-
     // Shortcut to any clicks within a cell
     // We don't want to handle these.
     if (target.parents(`.${tdClassName}`).length) {
@@ -87,10 +68,6 @@ export class RowClickHandler implements TableEventHandler {
     // Thus save that row for the details view button.
     let [index, row] = table.findRenderedRow(classIdentifier);
     this.states.focusedWorkPackage.putValue(wpId);
-    this.$state.go(
-      this.keepTab.currentDetailsState,
-      {workPackageId: wpId, focus: true}
-    );
 
     // Update single selection if no modifier present
     if (!(evt.ctrlKey || evt.metaKey || evt.shiftKey)) {
@@ -106,36 +83,6 @@ export class RowClickHandler implements TableEventHandler {
     if (evt.ctrlKey || evt.metaKey) {
       this.wpTableSelection.toggleRow(wpId);
     }
-
-    return false;
-  }
-
-  private handleDoubleClick(table:WorkPackageTable, evt:JQueryEventObject) {
-    let target = jQuery(evt.target);
-
-    // Shortcut to any clicks within a cell
-    // We don't want to handle these.
-    if (target.parents(`.${tdClassName}`).length) {
-      debugLog('Skipping click on inner cell');
-      return true;
-    }
-
-    // Locate the row from event
-    let element = target.closest(this.SELECTOR);
-    let wpId = element.data('workPackageId');
-
-    // Ignore links
-    if (target.is('a') || target.parent().is('a')) {
-      return true;
-    }
-
-    // Save the currently focused work package
-    this.states.focusedWorkPackage.putValue(wpId);
-
-    this.$state.go(
-      'work-packages.show',
-      {workPackageId: wpId}
-    );
 
     return false;
   }

--- a/frontend/app/components/wp-fast-table/handlers/table-handler-registry.ts
+++ b/frontend/app/components/wp-fast-table/handlers/table-handler-registry.ts
@@ -31,8 +31,10 @@ export class TableHandlerRegistry {
     t => new EditCellHandler(t),
     // Clicking on the details view
     t => new WorkPackageStateLinksHandler(t),
-    // (Double) Clicking on the row (not within a cell)
+    // Clicking on the row (not within a cell)
     t => new RowClickHandler(t),
+    // Double Clicking on the row (not within a cell)
+    t => new RowDoubleClickHandler(t),
     // Clicking on group headers
     t => new GroupRowHandler(t),
     // Right clicking on rows

--- a/spec/features/work_packages/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select_work_package_row_spec.rb
@@ -214,6 +214,7 @@ describe 'Select work package row', type: :feature, js:true, selenium: true do
     end
 
     it do
+      find('#work-packages-details-view-button').click
       split_wp = Pages::SplitWorkPackage.new(work_package_2)
       split_wp.expect_attributes Subject: work_package_2.subject
 

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -99,11 +99,17 @@ module Pages
     def open_split_view(work_package)
       split_page = SplitWorkPackage.new(work_package, project)
 
-      # The 'id' column should have enough space to be clicked
+      # Hover row to show split screen button
       row_element = row(work_package)
-      row_element.find('td.id').click
+      row_element.hover
+      row_element.find('.wp-table--details-link').click
 
       split_page
+    end
+
+    def click_on_row(work_package)
+      loading_indicator_saveguard
+      page.driver.browser.action.click(row(work_package).native).perform
     end
 
     def add_filter(label, operator, value)


### PR DESCRIPTION
Reverts the click part of https://github.com/opf/openproject/pull/5835
Does _not_ revert the context menu icon, but instead shows both.

No longer exposes the waiting problem to distinguish single from double clicks on table rows.

https://community.openproject.com/wp/26246

Also fixes:
https://community.openproject.com/wp/26123