### PR TITLE
Replace scopes with already defined names

### DIFF
--- a/app/helpers/my_helper.rb
+++ b/app/helpers/my_helper.rb
@@ -67,7 +67,7 @@ module MyHelper
     assigned_to_ids = [User.current.id] + User.current.group_ids
 
     WorkPackage.visible
-      .open
+      .with_status_open
       .where(assigned_to_id: assigned_to_ids)
   end
 end

--- a/app/models/issue_priority.rb
+++ b/app/models/issue_priority.rb
@@ -32,8 +32,6 @@ class IssuePriority < Enumeration
 
   OptionName = :enumeration_work_package_priorities
 
-  scope :active, -> { where(active: true) }
-
   def option_name
     OptionName
   end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -28,8 +28,6 @@
 #++
 
 class Principal < ActiveRecord::Base
-  extend Pagination::Model
-
   # Account statuses
   # Code accessing the keys assumes they are ordered, which they are since Ruby 1.9
   STATUSES = {
@@ -178,4 +176,7 @@ class Principal < ActiveRecord::Base
     self.mail ||= ''
     true
   end
+
+  extend Pagination::Model
+
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -556,7 +556,7 @@ class Project < ActiveRecord::Base
   # reduce the number of db queries when performing operations including the
   # project's versions.
   def assignable_versions
-    @all_shared_versions ||= shared_versions.open.to_a
+    @all_shared_versions ||= shared_versions.with_status_open.to_a
   end
 
   # Returns a hash of project users grouped by role

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -34,10 +34,7 @@ class Role < ActiveRecord::Base
   BUILTIN_NON_MEMBER = 1
   BUILTIN_ANONYMOUS  = 2
 
-  scope :givable, -> {
-    where('builtin = 0')
-      .order('position')
-  }
+
   scope :builtin, -> (*args) {
     compare = 'not' if args.first == true
     where("#{compare} builtin = 0")
@@ -65,6 +62,10 @@ class Role < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :name
   validates_length_of :name, maximum: 30
+
+  def self.givable
+    where('builtin = 0').order('position')
+  end
 
   def permissions
     # prefer map over pluck as we will probably always load

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,11 +86,6 @@ class User < Principal
   }, dependent: :destroy, class_name: 'Token'
   belongs_to :auth_source
 
-  # Active non-anonymous users scope
-  scope :not_builtin, -> {
-    where("#{User.table_name}.status <> #{STATUSES[:builtin]}")
-  }
-
   # Users blocked via brute force prevention
   # use lambda here, so time is evaluated on each query
   scope :blocked, -> { create_blocked_scope(self, true) }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -51,7 +51,6 @@ class Version < ActiveRecord::Base
   validates_inclusion_of :sharing, in: VERSION_SHARINGS
   validate :validate_start_date_before_effective_date
 
-  scope :open, -> { where(status: 'open') }
   scope :visible, ->(*args) {
     joins(:project)
       .merge(Project.allowed_to(args.first || User.current, :view_work_packages))
@@ -60,6 +59,10 @@ class Version < ActiveRecord::Base
   scope :systemwide, -> { where(sharing: 'system') }
 
   scope :order_by_name, -> { order("LOWER(#{Version.table_name}.name)") }
+
+  def self.with_status_open
+    where(status: 'open')
+  end
 
   # Returns true if +user+ or current user is allowed to view the version
   def visible?(user = User.current)
@@ -155,12 +158,12 @@ class Version < ActiveRecord::Base
 
   # Returns the total amount of open issues for this version.
   def open_issues_count
-    @open_issues_count ||= work_packages.merge(WorkPackage.open).size
+    @open_issues_count ||= work_packages.merge(WorkPackage.with_status_open).size
   end
 
   # Returns the total amount of closed issues for this version.
   def closed_issues_count
-    @closed_issues_count ||= work_packages.merge(WorkPackage.closed).size
+    @closed_issues_count ||= work_packages.merge(WorkPackage.with_status_closed).size
   end
 
   def wiki_page

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -88,12 +88,12 @@ class WorkPackage < ActiveRecord::Base
   }
 
   # >>> issues.rb >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-  scope :open, ->() {
+  scope :with_status_open, ->() {
     includes(:status)
       .where(statuses: { is_closed: false })
   }
 
-  scope :closed, ->() {
+  scope :with_status_closed, ->() {
     includes(:status)
       .where(statuses: { is_closed: true })
   }

--- a/app/views/my/blocks/_issueswatched.html.erb
+++ b/app/views/my/blocks/_issueswatched.html.erb
@@ -27,9 +27,9 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% watched = WorkPackage.visible.open.on_active_project.watched_by(user.id).recently_updated.with_limit(10) %>
+<% watched = WorkPackage.visible.with_status_open.on_active_project.watched_by(user.id).recently_updated.with_limit(10) %>
 
-<% watched_count = WorkPackage.visible.open.watched_by(user.id).count %>
+<% watched_count = WorkPackage.visible.with_status_open.watched_by(user.id).count %>
 
 <% if defined? block_name %>
   <%= content_for "#{block_name}-remove-block" %>

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -92,7 +92,7 @@ See doc/COPYRIGHT.rdoc for more details.
               <div class="form--field-container">
                 <%= styled_select_tag('work_package[fixed_version_id]', content_tag('option', l(:label_no_change_option), value: '') +
                                        content_tag('option', l(:label_none), value: 'none') +
-                                       version_options_for_select(@project.shared_versions.open.sort)) %>
+                                       version_options_for_select(@project.shared_versions.with_status_open.sort)) %>
               </div>
             </div>
           <% end %>

--- a/lib/pagination/model.rb
+++ b/lib/pagination/model.rb
@@ -36,11 +36,14 @@ module Pagination::Model
   end
 
   def self.extended(base)
-    base.scope :like, -> (q) {
-      s = "%#{q.to_s.strip.downcase}%"
-      base.where(['LOWER(name) LIKE :s', { s: s }])
-        .order('name')
-    }
+
+    unless base.respond_to? :like
+      base.scope :like, -> (q) {
+        s = "%#{q.to_s.strip.downcase}%"
+        base.where(['LOWER(name) LIKE :s', { s: s }])
+          .order('name')
+      }
+    end
 
     base.instance_eval do
       def paginate_scope!(scope, options = {})


### PR DESCRIPTION
The activerecord scope helpers output a warning when a scope's
name already exists in the module's method chain.

E.g., `Kernel#open` is overridden by some of the scopes, but that always
results in a warning.

A better way is to explicitly override the method in the model using a
class method.

This fixes the following warnings:

```
Creating scope :open. Overwriting existing method WorkPackage.open.
Creating scope :like. Overwriting existing method Principal.like.
Creating scope :not_builtin. Overwriting existing method User.not_builtin.
Creating scope :givable. Overwriting existing method Role.givable.
Creating scope :active. Overwriting existing method IssuePriority.active.
Creating scope :visible. Overwriting existing method TimeEntry.visible.
Creating scope :open. Overwriting existing method Version.open.
```