### PR TITLE
Add shared let(:foo) { }  helper for before-all initialized resources

### DIFF
--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -33,17 +33,14 @@ describe ::API::V3::WorkPackages::CreateProjectFormAPI do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 
-  let(:path) { api_v3_paths.create_work_package_form }
-  let(:status) { FactoryGirl.create(:default_status) }
-  let(:priority) { FactoryGirl.create(:default_priority) }
-  let(:user) { FactoryGirl.build(:admin) }
-  let(:project) { FactoryGirl.create(:project_with_types) }
+  shared_let(:path) { api_v3_paths.create_work_package_form }
+  shared_let(:status) { FactoryGirl.create(:default_status) }
+  shared_let(:priority) { FactoryGirl.create(:default_priority) }
+  shared_let(:user) { FactoryGirl.build(:admin) }
+  shared_let(:project) { FactoryGirl.create(:project_with_types) }
   let(:parameters) { {} }
 
   before do
-    status
-    priority
-    project
     login_as(user)
     post path, parameters.to_json, 'CONTENT_TYPE' => 'application/json'
   end

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -34,17 +34,10 @@ describe 'API v3 Work package form resource', type: :request do
   include Capybara::RSpecMatchers
   include API::V3::Utilities::PathHelper
 
-  before_all do
-    @project = FactoryGirl.create(:project, is_public: false)
-    @work_package = FactoryGirl.create(:work_package, project: @project)
-    @authorized_user = FactoryGirl.create(:user, member_in_project: @project)
-    @unauthorized_user = FactoryGirl.create(:user)
-  end
-
-  let(:project) { @project }
-  let(:work_package) { @work_package.reload }
-  let(:authorized_user) { @authorized_user }
-  let(:unauthorized_user) { @unauthorized_user }
+  shared_let(:project) { FactoryGirl.create(:project, is_public: false) }
+  shared_let(:work_package, reload: true) { FactoryGirl.create(:work_package, project: @project) }
+  shared_let(:authorized_user) { FactoryGirl.create(:user, member_in_project: @project) }
+  shared_let(:unauthorized_user) { FactoryGirl.create(:user) }
 
   describe '#post' do
     let(:post_path) { api_v3_paths.work_package_form work_package.id }

--- a/spec/support/shared_let.rb
+++ b/spec/support/shared_let.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+##
+# Using test-prof's before_all block to safely wrap shared data in a transaction,
+# shared_let acts similary to +let(:foo) { value }+ but initialized the value only once
+# Changes _within_ an example will be rolled back by database cleaner,
+# and the creation is rolled back in an after_all hook.
+#
+# Caveats: Set +reload: true+ if you plan to modify this value, otherwise Rails may still
+# have cached the local value. This will perform a database update, but is much faster
+# than creating new records (especially, work packages).
+def shared_let(key, reload: false, &block)
+  var = "@#{key}"
+
+  before_all do
+    # Use instance_eval so following blocks may reference earlier ones
+    result = instance_eval &block
+    instance_variable_set(var, result)
+  end
+
+  let(key) do
+    value = instance_variable_get(var)
+    value.reload if reload
+
+    value
+  end
+end
+


### PR DESCRIPTION
I recently added `test-prof` to add some helpers and diagnostics to the test suite. For example, it checks superfluous created factories through the env parameter `FDOC=1`. Through it, I was remembered that in our request and non-js-feature specs, each example creates _all_ objects in the `let(:foo) { FactoryGirl.. }` helpers again.

test-prof provides a simple `before_all` helper that executes the block in an additional transaction _before all_ examples, and a rollback _after all_ examples.

With it, we can implement a `shared_let(:object)` helper that creates the resource ONCE, and make it available through a regular `let(:object)`.

**Any changes within examples are rolled back, however Rails MAY have the record cached locally, so if you plan on changing values, use the `reload: true` option**. This causes a database request, but is much faster than, e.g., creating the record completely new.

⚠️  This does not (yet!) work for JS feature specs due to the separated threads for Rails and Capybara, that do not see the other transaction. This is fixed in Rails 5.1., so we may want to upgrade sometime soon for additional performance improvements. Until then, just don't use shared_let there, it will cause pain.