### PR TITLE
[26256] In custom field form labels for minimum and maximum length truncated unnecessarily

### DIFF
--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -42,10 +42,10 @@ See doc/COPYRIGHT.rdoc for more details.
       <small>(<%= t(:text_min_max_length_info ) %>)</small>
     </div>
     <div class="form--grouping-row">
-      <div class="form--field">
+      <div class="form--field -wide-label">
         <%= f.number_field :min_length, container_class: '-xslim' %>
       </div>
-      <div class="form--field">
+      <div class="form--field -wide-label">
         <%= f.number_field :max_length, container_class: '-xslim' %>
       </div>
     </div>

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                                              url: custom_fields_path,
-                                             html: {id: 'custom_field_form'} do |f| %>
+                                             html: {id: 'custom_field_form', class: "-wide-labels"} do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= hidden_field_tag 'type', @custom_field.type %>
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>


### PR DESCRIPTION
Increase space for labels within Admin/CF.

https://community.openproject.com/projects/openproject/work_packages/26256/activity