### PR TITLE
[26323] Missing localization for "Type" in work package type administration

### DIFF
--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
           title: t(:label_type_new)} do %>
       <%= op_icon('button--icon icon-add') %>
       <span class="button--text">
-        <%= t('activerecord.attributes.workpackage.type') %>
+        <%= t('activerecord.attributes.work_package.type') %>
       </button>
     <% end %>
   </li>
@@ -163,7 +163,7 @@ See doc/COPYRIGHT.rdoc for more details.
           <% end %>
         </tbody>
       </table>
-      
+
     </div>
   </div>
   <%= pagination_links_full @types %>


### PR DESCRIPTION
Fix typo for correct label

https://community.openproject.com/projects/openproject/work_packages/26323/activity