### PR TITLE
Bump ruby to 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@
 language: ruby
 
 rvm:
-  - 2.4.1
+  - 2.4.2
 
 sudo: false
 dist: trusty

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@
 
 source 'https://rubygems.org'
 
-ruby '~> 2.4.1'
+ruby '~> 2.4.2'
 
 gem 'actionpack-xml_parser', '~> 2.0.0'
 gem 'activemodel-serializers-xml', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -735,7 +735,7 @@ DEPENDENCIES
   will_paginate (~> 3.1.0)
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.15.4


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/09/14/sprintf-buffer-underrun-cve-2017-0898/
https://www.ruby-lang.org/en/news/2017/09/14/json-heap-exposure-cve-2017-14064/