### PR TITLE
[26348] Wrong alignment of subject line on small screens

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -81,11 +81,13 @@
         flex-direction: column
         // Safari
         height: initial
+        border-top: none
         .work-packages-full-view--split-left
-          padding-left: 15px
-          margin: 0
+          margin: 0 0 0 15px
+          padding-left: 0
           width: initial
           border: none
+          border-top: 1px solid #ccc
 
         .work-packages-full-view--split-right
           width: initial
@@ -102,6 +104,7 @@
 
     .toolbar-container
       margin-bottom: 1em
+      margin-left: 15px
       min-height: 36px
 
     .attributes-key-value--key,


### PR DESCRIPTION
Align WP back button and content on mobile

https://community.openproject.com/projects/openproject/work_packages/26348/activity