### PR TITLE
[26348, 26439] Alignment in WP full view

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -68,8 +68,6 @@
 
 
       .work-packages--show-view
-        padding: 0 0 0 5px
-
         &.edit-all-mode
           .work-packages-full-view--split-right
             display: none
@@ -82,10 +80,12 @@
         // Safari
         height: initial
         .work-packages-full-view--split-left
-          padding-left: 15px
           margin: 0
           width: initial
           border: none
+
+          .work-packages--panel-inner
+            padding: 5px 0 20px 0
 
         .work-packages-full-view--split-right
           width: initial
@@ -94,7 +94,7 @@
             margin: 0.75rem 0 2.5rem 0
 
           .work-packages--panel-inner
-            padding: 0 20px 0 15px
+            padding-left: 0
 
     // --------------- ALL WP VIEWS ---------------
     .work-packages-tabletimeline--table-side
@@ -162,9 +162,4 @@
 @include breakpoint(680px down)
   body.controller-work_packages.action-show
     .work-packages--show-view
-      padding-left: 0
-    .work-packages-full-view--split-container
-      .work-packages-full-view--split-left
-        padding: 0
-      .work-packages-full-view--split-right .work-packages--panel-inner
-        padding: 0 10px 0 10px
+      padding: 0

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -107,11 +107,7 @@ body.controller-work_packages.full-create
   border-right: 1px solid #ccc
   overflow-y: auto
   overflow-x: auto
-
-  // Don't cut border-left from editable description
-  width: calc(60% + 0.375rem)
-  margin-left: -0.375rem
-  padding-left: 0.375rem
+  width: 60%
 
   .work-packages--panel-inner
     padding: 5px 15px 20px 0px
@@ -134,7 +130,8 @@ body.controller-work_packages.full-create
   min-width: 420px
   overflow-y: auto
   overflow-x: auto
-  width: 40%
+  width: calc(40% + 15px)
+  margin-right: -15px
 
   .work-packages--panel-inner
     padding: 15px 15px 0px 15px
@@ -178,7 +175,7 @@ body.controller-work_packages.full-create
     display: none
 
 .work-packages--show-view
-  padding: 0 0 0 15px
+  padding: 0 15px
 
   .wp-show--header-container
     @media only screen and (max-width: 679px)
@@ -229,10 +226,6 @@ body.controller-work_packages.full-create
 
   > .toolbar-container
     margin: 10px 0 5px 0
-    padding-right: 15px
-    @media only screen and (max-width: 679px)
-      // use full width
-      padding-right: 0
 
 .work-packages--subject-type-row
   display: flex


### PR DESCRIPTION
This changes the alignment within the WP full view. Thus the toolbar is always aligned with the content (26348) and the right split screen is aligned with the content and the user icon (26349).

I tried to remove some complexity and special rules which we originally needed because the top border of the right side should have no distance to the screen end. However we should test this carefully before merge.

https://community.openproject.com/projects/openproject/work_packages/26349/activity
https://community.openproject.com/projects/openproject/work_packages/26348/activity