### PR TITLE
Move docker customization from CE to core

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,9 +157,6 @@ NumericLiterals:
 OneLineConditional:
   Enabled: false
 
-OpMethod:
-  Enabled: false
-
 ParameterLists:
   Enabled: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN echo "loglevel=info" >> /usr/local/etc/npmrc
 
 COPY Gemfile ./Gemfile
 COPY Gemfile.* ./
+COPY vendored-plugins ./vendored-plugins
 RUN chown -R app:app /usr/src/app
 
 USER app

--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,0 +1,37 @@
+FROM openproject/community:edge-base
+MAINTAINER operations@openproject.com
+
+ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject
+ENV RAILS_ENV=production
+ENV HEROKU=true
+ENV ATTACHMENTS_STORAGE_PATH=/var/db/openproject/files
+ENV RAILS_CACHE_STORE=memcache
+ENV SECRET_KEY_BASE=OVERWRITE_ME
+
+USER root
+RUN apt-get update -qq && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		memcached \
+		postfix \
+		postgresql \
+		apache2 \
+		supervisor && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod proxy proxy_http && rm -f /etc/apache2/sites-enabled/000-default.conf
+
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
+RUN rm -rf /var/lib/postgresql/9.4/main && mkdir -p /var/lib/postgresql/9.4/main && chown -R postgres:postgres /var/lib/postgresql/9.4
+RUN mkdir -p /var/db/openproject/{files,git,svn} && chown -R app:app /var/db/openproject
+
+COPY docker /usr/src/app/docker
+COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# ports
+EXPOSE 80 5432
+
+# volumes to export
+VOLUME ["/var/lib/postgresql/9.4/main", "/var/db/openproject"]
+
+CMD ["/usr/src/app/docker/entrypoint"]

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+PGDATA=${PGDATA:=/var/lib/postgresql/9.4/main}
+PGUSER=${PGUSER:=postgres}
+PGPASSWORD=${PGPASSWORD:=postgres}
+PGBIN="/usr/lib/postgresql/9.4/bin"
+
+if [ ! -z "$ATTACHMENTS_STORAGE_PATH" ]; then
+	mkdir -p "$ATTACHMENTS_STORAGE_PATH"
+	chown -R app:app "$ATTACHMENTS_STORAGE_PATH"
+fi
+
+dbhost=$(ruby -ruri -e 'puts URI(ENV.fetch("DATABASE_URL")).host')
+pwfile=$(mktemp)
+chown postgres $pwfile
+echo "$PGPASSWORD" > $pwfile
+
+indent() {
+	sed -u 's/^/       /'
+}
+
+migrate() {
+	pushd /usr/src/app
+	/etc/init.d/memcached start
+	rake db:migrate db:seed
+	/etc/init.d/memcached stop
+	chown app:app db/schema.rb
+	popd
+}
+
+if [ "$dbhost" = "127.0.0.1" ]; then
+	# initialize cluster if it does not exist yet
+	if [ -f "$PGDATA/PG_VERSION" ]; then
+		echo "-----> Database cluster already exists, not modifying."
+		/etc/init.d/postgresql start | indent
+		migrate | indent
+		/etc/init.d/postgresql stop | indent
+	else
+		echo "-----> Database cluster not found. Creating a new one in $PGDATA..."
+		chown -R postgres:postgres $PGDATA
+		su postgres -c "$PGBIN/initdb --pgdata=${PGDATA} --username=${PGUSER} --encoding=unicode --auth=trust --pwfile=$pwfile" | indent
+		rm -f $pwfile
+		/etc/init.d/postgresql start | indent
+		su postgres -c "$PGBIN/psql --command \"CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';\"" | indent
+		su postgres -c "$PGBIN/createdb -O openproject openproject" | indent
+		migrate | indent
+		/etc/init.d/postgresql stop | indent
+	fi
+else
+	echo "-----> You're using an external database. Not initializing a local database cluster."
+	migrate | indent
+fi
+
+echo "-----> Database setup finished."
+echo "       On first installation, the default admin credentials are login: admin, password: admin"
+
+echo "-----> Launching supervisord..."
+exec /usr/bin/supervisord

--- a/docker/proxy
+++ b/docker/proxy
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+[ -f /etc/apache2/sites-enabled/openproject.conf ] || erb -r time /usr/src/app/docker/proxy.conf.erb > /etc/apache2/sites-enabled/openproject.conf
+exec /usr/sbin/apache2ctl -DFOREGROUND

--- a/docker/proxy.conf.erb
+++ b/docker/proxy.conf.erb
@@ -1,0 +1,11 @@
+<VirtualHost *:80>
+  ServerName <%= ENV.fetch('SERVER_NAME') { "_default_" } %>
+  DocumentRoot /usr/src/app/public
+
+  ProxyRequests off
+
+  <Location />
+    ProxyPass http://127.0.0.1:8080/ retry=0
+    ProxyPassReverse http://127.0.0.1:8080/
+  </Location>
+</VirtualHost>

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,52 @@
+[supervisord]
+nodaemon=true
+
+[program:web]
+priority=4
+user=app
+directory=/usr/src/app
+command=./docker/web
+autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
+[program:worker]
+priority=5
+user=app
+directory=/usr/src/app
+command=./docker/worker
+autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
+[program:memcached]
+priority=100
+user=app
+command=/usr/bin/memcached
+autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
+[program:apache2]
+priority=2
+directory=/usr/src/app
+command=./docker/proxy
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
+[program:postfix]
+priority=100
+directory=/etc/postfix
+command=/usr/sbin/postfix -c /etc/postfix start
+startsecs=0
+autorestart=false
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
+[program:postgres]
+user=postgres
+priority=1
+command=/usr/lib/postgresql/9.4/bin/postgres -D /var/lib/postgresql/9.4/main -c config_file=/etc/postgresql/9.4/main/postgresql.conf
+autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -27,6 +27,15 @@ autorestart=true
 stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
 stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
+[program:cron]
+priority=100
+user=app
+directory=/usr/src/app
+command=./docker/cron
+autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
+
 [program:apache2]
 priority=2
 directory=/usr/src/app


### PR DESCRIPTION
PR on CE side: https://github.com/opf/openproject-ce/pull/10

Includes the changes by @naglis in https://github.com/opf/openproject-ce/pull/9

Adds an empty `vendored-plugins` to the core so that we can use the COPY command previously overridden in the Dockerfile by CE.