### PR TITLE
Allow nonref for debian 9

### DIFF
--- a/extra/Apache/OpenProjectRepoman.pm
+++ b/extra/Apache/OpenProjectRepoman.pm
@@ -90,7 +90,8 @@ sub parse_request {
     $content .= $buf;
   }
 
-  return decode_json($content);
+  my $json = JSON->new->allow_blessed->allow_nonref->convert_blessed;
+  return $json->decode($content);
 }
 
 ##
@@ -191,7 +192,8 @@ sub handler {
   };
 
 
-  print encode_json($response);
+  my $json = JSON->new->allow_blessed->allow_nonref->convert_blessed;
+  print $json->encode($response);
   return Apache2::Const::OK;
 }
 


### PR DESCRIPTION
Fixes Debian 9 support for OpenProject SVN repoman.

@crohr Tested this on Debian 8/9 and SLES 11. Good to merge from my side.