### PR TITLE
[26354] Fix overridden global regex

### DIFF
--- a/lib/redmine/wiki_formatting/textile/formatter.rb
+++ b/lib/redmine/wiki_formatting/textile/formatter.rb
@@ -75,35 +75,40 @@ module Redmine
           end
         end
 
-        AUTO_LINK_RE = %r{
-                        (                          # leading text
-                          <\w+.*?>|                # leading HTML tag, or
-                          [^=<>!:'"/]|             # leading punctuation, or
-                          \{\{\w+\(|               # inside a macro?
-                          ^                        # beginning of line
-                        )
-                        (
-                          (?:https?://)|           # protocol spec, or
-                          (?:s?ftps?://)|
-                          (?:www\.)                # www.*
-                        )
-                        (
-                          (\S+?)                   # url
-                          (\/)?                    # slash
-                        )
-                        ((?:&gt;)?|[^\w\=\/;\(\)]*?)               # post
-                        (?=<|\s|$)
-                       }x unless const_defined?(:AUTO_LINK_RE)
+
+        def auto_link_regexp
+          @auto_link_regexp ||= begin
+            %r{
+              (                          # leading text
+                <\w+.*?>|                # leading HTML tag, or
+                [^=<>!:'"/]|             # leading punctuation, or
+                \{\{\w+\(|               # inside a macro?
+                ^                        # beginning of line
+              )
+              (
+                (?:https?://)|           # protocol spec, or
+                (?:s?ftps?://)|
+                (?:www\.)                # www.*
+              )
+              (
+                (\S+?)                   # url
+                (\/)?                    # slash
+              )
+              ((?:&gt;)?|[^\w\=\/;\(\)]*?)               # post
+              (?=<|\s|$)
+             }x
+          end
+        end
 
         # Turns all urls into clickable links (code from Rails).
         def inline_auto_link(text)
-          text.gsub!(AUTO_LINK_RE) do
+          text.gsub!(auto_link_regexp) do
             all = $&
             leading = $1
             proto = $2
             url = $3
             post = $6
-            if leading =~ /<a\s/i || leading =~ /![<>=]?/ || leading =~ /\{\{\w+\(/
+            if url.nil? || leading =~ /<a\s/i || leading =~ /![<>=]?/ || leading =~ /\{\{\w+\(/
               # don't replace URLs that are already linked
               # and URLs prefixed with ! !> !< != (textile images)
               all


### PR DESCRIPTION
rails_autolink has its own `AUTO_LINK_RE` that, depending on the load
order may be defined before the textile formatter.

https://community.openproject.com/wp/26354