### PR TITLE
[26390] Fix coderay syntax highlighting

### DIFF
--- a/app/assets/stylesheets/openproject/_scm.sass
+++ b/app/assets/stylesheets/openproject/_scm.sass
@@ -25,8 +25,8 @@
  *
  * See doc/COPYRIGHT.rdoc for more details. ++*/
 
-//= require_self
-//= require coderay
+
+@import 'openproject/coderay'
 
 div.changeset-changes ul
   list-style-type: none

--- a/app/assets/stylesheets/openproject/coderay.scss
+++ b/app/assets/stylesheets/openproject/coderay.scss
@@ -29,11 +29,27 @@ See doc/COPYRIGHT.rdoc for more details.
 
 .CodeRay {
   background-color: hsl(0,0%,95%);
-  border: 1px solid silver;
+  // border: 1px solid silver;
   color: black;
 }
 .CodeRay pre {
   margin: 0px;
+}
+
+// Inline-block style for span.CodeRay
+code.CodeRay {
+  display: inline-block;
+}
+
+// Block style for code in pre
+pre code.CodeRay {
+  display: block;
+  // Pre has its own border, so hide coderay's here.
+  border: none;
+}
+
+.CodeRay span {
+  display: inline-block;
 }
 
 span.CodeRay { white-space: pre; border: 0px; padding: 2px; }


### PR DESCRIPTION
Coderay simply wasnt loaded anymore...

Also fixes some design flaws when using `<code> vs. <pre><code>..</pre>`

https://community.openproject.com/wp/26390