### PR TITLE
[26395] Url is not rendered in News overview (Core)

### DIFF
--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -53,7 +53,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <%= "(#{l(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %></h3>
     <p class="author"><%= authoring news.created_on, news.author %></p>
     <div class="wiki">
-      <%= format_text(news.summary.present? ? news.summary : truncate(news.description), object: news) %>
+      <%= format_text(news.summary.present? ? news.summary : truncate(news.description, length: 150, escape: false), object: news) %>
     </div>
   <% end %>
 <% else %>


### PR DESCRIPTION
Show links in news block correctly.

https://community.openproject.com/projects/cern/work_packages/26395/activity

Plugin PR: https://github.com/finnlabs/openproject-cern_landing_page/pull/6