### PR TITLE
[26412] Can not resize work package create form in split view

### DIFF
--- a/frontend/app/components/routing/wp-list/wp.list.new.html
+++ b/frontend/app/components/routing/wp-list/wp.list.new.html
@@ -27,5 +27,9 @@
           on-cancel="$ctrl.cancelAndBackToList()"
       ></edit-actions-bar>
     </div>
+
+    <div class="work-packages--details--resizer hidden-for-mobile">
+      <wp-resizer></wp-resizer>
+    </div>
   </wp-edit-field-group>
 </div>


### PR DESCRIPTION
Add wp-resizer to solit screen create form.

https://community.openproject.com/projects/openproject/work_packages/26412/activity