### PR TITLE
Fix/custom option cache

### DIFF
--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -130,8 +130,11 @@ class CustomFieldsController < ApplicationController
 
   def prepare_custom_option_position
     return unless params[:custom_field][:custom_options_attributes]
-    params[:custom_field][:custom_options_attributes].each_with_index do |(_id, attributes), index|
-      attributes[:position] = index + 1
+
+    index = 0
+
+    params[:custom_field][:custom_options_attributes].each do |_id, attributes|
+      attributes[:position] = (index = index + 1)
     end
   end
 

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -63,9 +63,16 @@ class CustomFieldsController < ApplicationController
   def edit; end
 
   def update
+    last_option_update_before = @custom_field.custom_options.map(&:updated_at).max
     @custom_field.attributes = get_custom_field_params
 
     if @custom_field.save
+      last_option_update_after = @custom_field.custom_options.map(&:updated_at).max
+
+      if last_option_update_after > last_option_update_before
+        @custom_field.touch # touch to invalidate cache
+      end
+
       flash[:notice] = t(:notice_successful_update)
       call_hook(:controller_custom_fields_edit_after_save, custom_field: @custom_field)
       redirect_back_or_default edit_custom_field_path(id: @custom_field.id)

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -63,16 +63,9 @@ class CustomFieldsController < ApplicationController
   def edit; end
 
   def update
-    last_update_before = @custom_field.custom_options.map(&:updated_at).max
     @custom_field.attributes = get_custom_field_params
 
     if @custom_field.save
-      last_update_after = @custom_field.custom_options.map(&:updated_at).max
-
-      if last_update_after.try { |date| date > (last_update_before || date) }
-        @custom_field.touch # touch to invalidate cache
-      end
-
       flash[:notice] = t(:notice_successful_update)
       call_hook(:controller_custom_fields_edit_after_save, custom_field: @custom_field)
       redirect_back_or_default edit_custom_field_path(id: @custom_field.id)

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -63,13 +63,13 @@ class CustomFieldsController < ApplicationController
   def edit; end
 
   def update
-    last_option_update_before = @custom_field.custom_options.map(&:updated_at).max
+    last_update_before = @custom_field.custom_options.map(&:updated_at).max
     @custom_field.attributes = get_custom_field_params
 
     if @custom_field.save
-      last_option_update_after = @custom_field.custom_options.map(&:updated_at).max
+      last_update_after = @custom_field.custom_options.map(&:updated_at).max
 
-      if last_option_update_after > last_option_update_before
+      if last_update_after.try { |date| date > (last_update_before || date) }
         @custom_field.touch # touch to invalidate cache
       end
 

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -32,7 +32,15 @@ class CustomField < ActiveRecord::Base
   include CustomField::OrderStatements
 
   has_many :custom_values, dependent: :delete_all
-  has_many :custom_options, -> { order(position: :asc) }, dependent: :delete_all
+  # WARNING: the inverse_of option is also required in order
+  # for the 'touch: true' option on the custom_field association in CustomOption
+  # to work as desired.
+  # Without it, the after_commit callbacks of acts_as_list will prevent the touch to happen.
+  # https://github.com/rails/rails/issues/26726
+  has_many :custom_options,
+           -> { order(position: :asc) },
+           dependent: :delete_all,
+           inverse_of: 'custom_field'
   accepts_nested_attributes_for :custom_options
 
   acts_as_list scope: 'type = \'#{self.class}\''

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -243,4 +243,43 @@ describe CustomField, type: :model do
       end
     end
   end
+
+  describe 'nested attributes for custom options' do
+    let(:option) { FactoryGirl.build(:custom_option) }
+    let(:options) { [option] }
+    let(:field) { FactoryGirl.build :custom_field, field_format: 'list', custom_options: options }
+
+    before do
+      field.save!
+    end
+
+    shared_examples_for 'saving updates field\'s updated_at' do
+      it 'updates updated_at' do
+        # mysql does not store milliseconds so we have to slow down the tests by orders of magnitude
+        timestamp_before = field.updated_at
+        sleep 1
+        field.save
+        expect(field.updated_at).not_to eql(timestamp_before)
+      end
+    end
+
+    context 'after adding a custom option' do
+      before do
+        field.attributes = { 'custom_options_attributes' => { '0' => option.attributes,
+                                                              '1' => { value: 'blubs' } } }
+      end
+
+      it_behaves_like 'saving updates field\'s updated_at'
+    end
+
+    context 'after changing a custom option' do
+      before do
+        attributes = option.attributes.merge(value: 'new_value')
+
+        field.attributes = { 'custom_options_attributes' => { '0' => attributes } }
+      end
+
+      it_behaves_like 'saving updates field\'s updated_at'
+    end
+  end
 end

--- a/spec/models/custom_option_spec.rb
+++ b/spec/models/custom_option_spec.rb
@@ -63,6 +63,13 @@ describe CustomOption, type: :model do
         expect(CustomOption.where(id: custom_option.id).count)
           .to eql 0
       end
+
+      it "updates the custom_field's timestamp" do
+        timestamp_before = custom_field.updated_at
+        sleep 1
+        custom_option.destroy
+        expect(custom_field.reload.updated_at).not_to eql(timestamp_before)
+      end
     end
 
     context 'with only one option for the cf' do


### PR DESCRIPTION
WP [#26403](https://community.openproject.com/projects/openproject/work_packages/26403)

Technically one could of course just change the custom field's cache key.
For this we would need to perform a SQL query to check on the custom options every time the cache key is used, however. Which is a number of times for each custom field per request.

So I opted for this approach to just touch the custom field upon changes in the custom options in the one spot where a user can change them.