### PR TITLE
[26145] Page size increased when opening comment field in Safari

### DIFF
--- a/app/assets/stylesheets/layout/_accessibility.sass
+++ b/app/assets/stylesheets/layout/_accessibility.sass
@@ -29,7 +29,7 @@
 .hidden-for-sighted
   position: absolute
   left: -10000px
-  top: auto
+  top: 0
   width: 1px
   height: 1px
   overflow: hidden


### PR DESCRIPTION
Safari cannot really handle `top: auto`. Thus in this case the hidden label is positioned below the comment field. The causes the scrolling behavior.

https://community.openproject.com/projects/openproject/work_packages/26145/activity