### PR TITLE
[26456] Use Dragula for CF drag&drop

### DIFF
--- a/app/assets/javascripts/custom-fields.js
+++ b/app/assets/javascripts/custom-fields.js
@@ -187,6 +187,7 @@
     var value = dup.find(".custom-option-value input");
 
     value.attr("name", "custom_field[custom_options_attributes][" + count + "][value]");
+    value.attr("id", "custom_field_custom_options_attributes_" + count + "_value");
     value.val("");
 
     var defaultValue = dup.find(".custom-option-default-value");
@@ -251,42 +252,28 @@
     $(".custom-option-default-value").change(uncheckOtherDefaults);
     $('#custom_field_multi_value').change(checkOnlyOne);
 
-    // prevent draggable interfering with the user's interaction with the input
-    // e.g. c&p
-    $(".custom-option-row input").focus(function() {
-      $(this).closest('.custom-option-row').attr('draggable', false);
+    // Make custom fields draggable
+    var container = document.getElementById('custom-field-dragula-container');
+    dragula([container], {
+      isContainer: function (el) {
+        return false;
+      },
+      moves: function (el, source, handle, sibling) {
+        return $(handle).hasClass('dragula-handle');
+      },
+      accepts: function (el, target, source, sibling) {
+        return true;
+      },
+      invalid: function (el, handle) {
+        return false;
+      },
+      direction: 'vertical',
+      copy: false,
+      copySortSource: false,
+      revertOnSpill: true,
+      removeOnSpill: false,
+      mirrorContainer: container,
+      ignoreInputTextSelection: true
     });
-
-    $(".custom-option-row input").blur(function() {
-      $(this).closest('.custom-option-row').attr('draggable', true);
-    });
-
   });
-
-  window.CustomFields = {
-    allowDrop: function(event) {
-      if ($(event.target).hasClass("custom-option-value-row")) {
-        event.preventDefault();
-      }
-    },
-    drag: function(event) {
-      event.dataTransfer.setData("text", event.target.id);
-    },
-    drop: function(event) {
-      var id = event.dataTransfer.getData("text");
-      var from = $(document.getElementById(id));
-      var to = $(event.target).closest("tr.custom-option-row");
-
-      if (from && to) {
-        var fromIndex = from.parent().children().index(from);
-        var toIndex = from.parent().children().index(to);
-
-        if (fromIndex < toIndex) {
-          to.after(from);
-        } else {
-          to.before(from);
-        }
-      }
-    }
-  };
 }(window, jQuery));

--- a/app/assets/stylesheets/vendor/_dragula.sass
+++ b/app/assets/stylesheets/vendor/_dragula.sass
@@ -20,3 +20,5 @@
   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)"
   filter: alpha(opacity=20)
 
+.dragula-handle
+  cursor: pointer

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -75,53 +75,49 @@ See doc/COPYRIGHT.rdoc for more details.
         </tr>
       </thead>
 
-      <% custom_field.custom_options.each_with_index do |custom_option, i| %>
-        <%= f.fields_for :custom_options, custom_option do |co_f| %>
-          <tr
-            draggable="true"
-            class="custom-option-row -draggable"
-            ondrop="CustomFields.drop(event)"
-            ondragstart="CustomFields.drag(event)"
-            ondragover="CustomFields.allowDrop(event)"
-          >
-            <td>
-              <span class="icon icon-table icon-toggle"></span>
-              <%= co_f.hidden_field :id, class: 'custom-option-id' %>
-              <%= co_f.text_field :value,
-                                  container_class: 'custom-option-value',
+      <tbody id="custom-field-dragula-container">
+        <% custom_field.custom_options.each_with_index do |custom_option, i| %>
+          <%= f.fields_for :custom_options, custom_option do |co_f| %>
+            <tr class="dragula-element custom-option-row">
+              <td>
+                <span class="dragula-handle icon icon-table icon-toggle"></span>
+                <%= co_f.hidden_field :id, class: 'custom-option-id' %>
+                <%= co_f.text_field :value,
+                                    container_class: 'custom-option-value',
+                                    no_label: true %>
+              </td>
+              <td>
+                <%= co_f.check_box :default_value,
+                                  container_class: 'custom-option-default-value',
                                   no_label: true %>
-            </td>
-            <td>
-              <%= co_f.check_box :default_value,
-                                 container_class: 'custom-option-default-value',
-                                 no_label: true %>
-            </td>
-            <td>
-              <span class="reorder-icons">
-                <a title="<%= t(:label_sort_highest) %>" rel="nofollow" href="#" class="sort-up-custom-option">
-                  <%= op_icon('icon-context icon-sort-up icon-small') %>
-                </a>
-                <a title="<%= t(:label_sort_higher) %>" rel="nofollow" href="#" class="move-up-custom-option">
-                  <%= op_icon('icon-context icon-arrow-up2 icon-small') %>
-                </a>
-                <a title="<%= t(:label_sort_lower) %>" rel="nofollow" href="#" class="move-down-custom-option">
-                  <%= op_icon('icon-context icon-arrow-down2 icon-small') %>
-                </a>
-                <a title="<%= t(:label_sort_lowest) %>" rel="nofollow" href="#" class="sort-down-custom-option">
-                  <%= op_icon('icon-context icon-sort-down icon-small') %>
-                </a>
-              </span>
-            </td>
-            <td>
-              <%= link_to t(:button_delete),
-                  delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
-                  method: :delete,
-                  data: { confirm: t(:'custom_fields.confirm_destroy_option') },
-                  class: 'icon icon-delete delete-custom-option' %>
-            </td>
-          </tr>
+              </td>
+              <td>
+                <span class="reorder-icons">
+                  <a title="<%= t(:label_sort_highest) %>" rel="nofollow" href="#" class="sort-up-custom-option">
+                    <%= op_icon('icon-context icon-sort-up icon-small') %>
+                  </a>
+                  <a title="<%= t(:label_sort_higher) %>" rel="nofollow" href="#" class="move-up-custom-option">
+                    <%= op_icon('icon-context icon-arrow-up2 icon-small') %>
+                  </a>
+                  <a title="<%= t(:label_sort_lower) %>" rel="nofollow" href="#" class="move-down-custom-option">
+                    <%= op_icon('icon-context icon-arrow-down2 icon-small') %>
+                  </a>
+                  <a title="<%= t(:label_sort_lowest) %>" rel="nofollow" href="#" class="sort-down-custom-option">
+                    <%= op_icon('icon-context icon-sort-down icon-small') %>
+                  </a>
+                </span>
+              </td>
+              <td>
+                <%= link_to t(:button_delete),
+                    delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
+                    method: :delete,
+                    data: { confirm: t(:'custom_fields.confirm_destroy_option') },
+                    class: 'icon icon-delete delete-custom-option' %>
+              </td>
+            </tr>
+          <% end %>
         <% end %>
-      <% end %>
+      </tbody>
     </table>
 
   </div>

--- a/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
@@ -1,0 +1,123 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Multi-value custom fields creation', type: :feature, js: true do
+  let(:admin)  { FactoryGirl.create(:admin) }
+
+  def drag_and_drop(handle, to)
+    scroll_to_element(handle)
+    page
+      .driver
+      .browser
+      .action
+      .move_to(handle.native)
+      .click_and_hold(handle.native)
+      .perform
+
+    scroll_to_element(to)
+    page
+      .driver
+      .browser
+      .action
+      .move_to(to.native)
+      .release
+      .perform
+  end
+
+  before do
+    login_as(admin)
+    visit custom_fields_path
+  end
+
+  it 'can create and reorder custom field list values' do
+    # Create CF
+    click_on 'Create a new custom field'
+
+    fill_in 'custom_field_name', with: 'My List CF'
+    select 'List', from: 'custom_field_field_format'
+
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_0_value')
+    fill_in 'custom_field_custom_options_attributes_0_value', with: 'A'
+
+    # Add new row
+    find('#add-custom-option').click
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_1_value')
+    fill_in 'custom_field_custom_options_attributes_1_value', with: 'B'
+
+    # Add new row
+    find('#add-custom-option').click
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_2_value')
+    fill_in 'custom_field_custom_options_attributes_2_value', with: 'C'
+
+    click_on 'Save'
+
+    # Edit again
+    page.find('a', text: 'My List CF').click
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_0_value[value=A]')
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_1_value[value=B]')
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_2_value[value=C]')
+
+    # Expect correct values
+    cf = CustomField.last
+    expect(cf.name).to eq('My List CF')
+    expect(cf.possible_values.map(&:value)).to eq %w(A B C)
+
+    # Drag and drop
+
+    # We need to hack a target for where to drag the row to
+    page.evaluate_script <<-JS
+      jQuery('#custom-field-dragula-container')
+        .append('<tr class="__drag_and_drop_end_of_list"><td colspan="4" style="height: 100px"></td></tr>')
+    JS
+
+    sleep 1
+
+    rows = page.all('tr.custom-option-row')
+    expect(rows.length).to eq(3)
+    drag_and_drop rows[0].find('.dragula-handle'), page.find('.__drag_and_drop_end_of_list')
+
+    sleep 1
+
+    page.evaluate_script <<-JS
+      jQuery('.__drag_and_drop_end_of_list').remove()
+    JS
+
+    click_on 'Save'
+
+    # Edit again
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_0_value[value=B]')
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_1_value[value=C]')
+    expect(page).to have_selector('input#custom_field_custom_options_attributes_2_value[value=A]')
+
+    cf.reload
+    expect(cf.name).to eq('My List CF')
+    expect(cf.possible_values.map(&:value)).to eq %w(B C A)
+  end
+end


### PR DESCRIPTION
using native ondrag/ondrop is a pain because it doesn't properly handle
drags on the inputs and a buggy fix for this caused CFs drag&drop to
fail.

We already ship with dragula so we can simply use that instead to make
our lives easier.

Also adds a spec to test the drag&drop behavior.

https://community.openproject.com/wp/26456