### PR TITLE
[26361] Fix anchor links broken by base tag

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -35,7 +35,6 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= display_meta_tags site: Setting.app_title, title: html_title %>
 
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
-    <base href="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>/" />
     <% if @project %>
     <meta name="current_project"
           data-project-name="<%= h @project.name %>"

--- a/frontend/app/components/routing/ui-router.config.ts
+++ b/frontend/app/components/routing/ui-router.config.ts
@@ -78,9 +78,14 @@ openprojectModule
            $urlMatcherFactoryProvider:ng.ui.IUrlMatcherFactory) => {
     $urlMatcherFactoryProvider.strictMode(false);
 
+    // Prepend the baseurl to the route to avoid using a base tag
+    // For more information, see
+    // https://github.com/angular/angular.js/issues/5519
+    // https://github.com/opf/openproject/pull/5685
+    const baseUrl = (window as any).appBasePath;
     $stateProvider
       .state('work-packages', {
-        url: '/{projects}/{projectPath}/work_packages?query_id&query_props',
+        url: baseUrl + '/{projects}/{projectPath}/work_packages?query_id&query_props',
         abstract: true,
         params: {
           // value: null makes the parameter optional

--- a/frontend/app/init-app.js
+++ b/frontend/app/init-app.js
@@ -56,7 +56,11 @@ opApp
         // Disable debugInfo outside development mode
         $compileProvider.debugInfoEnabled(window.openProject.environment === 'development');
 
-        $locationProvider.html5Mode(true);
+        $locationProvider.html5Mode({
+          enabled: true,
+          requireBase: false
+        });
+
         $httpProvider.defaults.headers.common['X-CSRF-TOKEN'] = jQuery(
             'meta[name=csrf-token]').attr('content');
         $httpProvider.defaults.headers.common['X-Authentication-Scheme'] = 'Session';


### PR DESCRIPTION
We only have the base tag for the ui router URL configuration. We can
instead prepend the relative URL to it, if there is any.

This allows us to keep anchors of the kind `<a href="#anchor">...</a>`.

https://community.openproject.com/wp/26361