### PR TITLE
Use indifferent access to access configuration

### DIFF
--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -43,13 +43,18 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     config = example.metadata[:with_config]
     if config.present?
-      config = aggregate_mocked_configuration(example, config)
+      config = aggregate_mocked_configuration(example, config).with_indifferent_access
 
       allow(OpenProject::Configuration).to receive(:[]).and_call_original
       config.each do |k,v|
         allow(OpenProject::Configuration)
           .to receive(:[])
           .with(k.to_s)
+          .and_return(v)
+
+        allow(OpenProject::Configuration)
+          .to receive(:[])
+          .with(k.to_sym)
           .and_return(v)
       end
     end


### PR DESCRIPTION
The `with_config` helper did not use `with_indifferent_access` that may cause some tests to break.