### PR TITLE
Enable Debian 9 support

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -13,6 +13,12 @@ targets:
       - libsqlite3-dev
     dependencies:
       - libmagickwand-6.q16-2
+  debian-9:
+    build_dependencies:
+      - libmagickwand-dev
+      - libsqlite3-dev
+    dependencies:
+      - libmagickwand-6.q16-3
   ubuntu-14.04:
     <<: *debian7
   ubuntu-16.04:


### PR DESCRIPTION
This will enable debian 9 builds on Packager.io.