### PR TITLE
[25512] More prominent work package status selector (2)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -26,6 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+$status-selector-color: #bc7100
+
 @mixin details-pane--form-field
   @include grid-visible-overflow
   padding: 0
@@ -238,3 +240,15 @@ i
       .attributes-key-value--value-container
         *:focus
           outline: 1px solid $gray
+
+.work-package--single-view
+  display: flex
+  padding-top: 2px
+  .wp-status-button .button
+    margin-bottom: 0
+    background: transparent
+    border: 1px solid $status-selector-color
+    color: $status-selector-color
+  .work-packages--info-row
+    line-height: 1.5rem
+

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -42,8 +42,8 @@ $status-selector-bg-hover-color: #e08600
       line-height: 1
 
 .work-packages--info-row
-  font-size: 0.8rem
-  line-height: 1.1rem
+  font-size: 12px
+  line-height: 16px
   padding: 5px 0
 
 .work-packages--details--title
@@ -70,6 +70,16 @@ $status-selector-bg-hover-color: #e08600
   .inplace-edit--write-value
     textarea
       overflow: hidden
+
+  .work-packages--info-row
+    line-height: 12px
+    padding: 0
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+
+    > *
+      margin-left: 3px
 
 .work-package--single-view
   // Make elements in split and full view span the entire width
@@ -257,9 +267,6 @@ i
 
     .button--text
       margin: 0 5px
-
-  .work-packages--info-row
-    line-height: 16px
 
 .work-packages--new .wp-status-button
   padding: 3px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -251,6 +251,7 @@ i
     background: $status-selector-bg-color
     border: 1px solid $status-selector-color
     color: $status-selector-color
+    white-space: nowrap
 
     .button--text
       margin: 0 10px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -26,8 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$status-selector-color: #f99400
-$status-selector-bg-color: #fef1e2
+$status-selector-bg-color: #f99601
+$status-selector-bg-hover-color: #e08600
 
 @mixin details-pane--form-field
   @include grid-visible-overflow
@@ -247,13 +247,13 @@ i
   .wp-status-button .button
     padding: 5px
     margin-bottom: 0
-    background-color: #f99601
+    background-color: $status-selector-bg-color
     border: none
     color: white
     white-space: nowrap
 
     &:hover
-      background-color: #e08600
+      background-color: $status-selector-bg-hover-color
 
     .button--text
       margin: 0 5px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -26,9 +26,6 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$status-selector-bg-color: #f99601
-$status-selector-bg-hover-color: #e08600
-
 @mixin details-pane--form-field
   @include grid-visible-overflow
   padding: 0
@@ -187,7 +184,7 @@ i
   font-size: 0.9rem
 
   &:before
-    @include varprop(color, $body-font-color)
+    @include varprop(color, body-font-color)
 
 // Special styling for project context area
 .attributes-group.-project-context
@@ -257,16 +254,22 @@ i
   .wp-status-button .button
     padding: 5px
     margin-bottom: 0
-    background-color: $status-selector-bg-color
+    @include varprop(background-color, status-selector-bg-color)
     border: none
     color: white
     white-space: nowrap
 
     &:hover
-      background-color: $status-selector-bg-hover-color
+      @include varprop(background-color, status-selector-bg-hover-color)
 
     .button--text
       margin: 0 5px
+
+  attribute-help-text .help-text--entry
+    line-height: 25px
+    margin: 0 10px 0 -10px
+    .icon:before
+      padding: 0
 
 .work-packages--new .wp-status-button
   padding: 3px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -26,7 +26,8 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-$status-selector-color: #bc7100
+$status-selector-color: #f99400
+$status-selector-bg-color: #fef1e2
 
 @mixin details-pane--form-field
   @include grid-visible-overflow
@@ -245,10 +246,22 @@ i
   display: flex
   padding-top: 2px
   .wp-status-button .button
+    padding: 0
     margin-bottom: 0
-    background: transparent
+    background: $status-selector-bg-color
     border: 1px solid $status-selector-color
     color: $status-selector-color
+
+    .button--text
+      margin: 0 10px
+
+    .wp-status-button--icon-container
+      display: inline-block
+      width: 30px
+      background-color: $status-selector-color
+      color: white
+      line-height: 30px
+
   .work-packages--info-row
-    line-height: 1.5rem
+    line-height: 20px
 

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -244,25 +244,24 @@ i
 
 .work-package--single-view
   display: flex
-  padding-top: 2px
   .wp-status-button .button
-    padding: 0
+    padding: 5px
     margin-bottom: 0
-    background: $status-selector-bg-color
-    border: 1px solid $status-selector-color
-    color: $status-selector-color
+    background-color: #f99601
+    border: none
+    color: white
     white-space: nowrap
 
-    .button--text
-      margin: 0 10px
+    &:hover
+      background-color: #e08600
 
-    .wp-status-button--icon-container
-      display: inline-block
-      width: 30px
-      background-color: $status-selector-color
-      color: white
-      line-height: 30px
+    .button--text
+      margin: 0 5px
 
   .work-packages--info-row
-    line-height: 20px
+    line-height: 16px
 
+.work-packages--new .wp-status-button
+  padding: 3px
+  .button
+    height: 40px

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -132,6 +132,7 @@ en:
     label_contains: "contains"
     label_created_on: "created on"
     label_edit_comment: "Edit this comment"
+    label_edit_status: "Edit the status of the work package"
     label_equals: "is"
     label_expand: "Expand"
     label_expanded: "expanded"

--- a/frontend/app/components/context-menus/has-dropdown-menu/has-dropdown-menu-directive.ts
+++ b/frontend/app/components/context-menus/has-dropdown-menu/has-dropdown-menu-directive.ts
@@ -50,8 +50,8 @@ function hasDropdownMenu(contextMenu:ContextMenuService, FocusHelper:any) {
         });
 
         return contextMenu.activate(menuName, event, locals, {
-          my: 'right top',
-          at: 'right bottom',
+          my: 'left top',
+          at: 'left bottom',
           of: positionRelativeTo ? element.find(positionRelativeTo) : element,
           within: collisionContainer ? angular.element(collisionContainer) : window
         });

--- a/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.html
+++ b/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.html
@@ -2,7 +2,7 @@
      id="types-context-menu">
   <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.types.length === 0 }">
     <li ng-repeat="type in $ctrl.types">
-      <a class="menu-item" ui-sref="{{$ctrl.stateName}}({type: type.id})">
+      <a class="menu-item" ui-sref="{{$ctrl.stateName}}({type: type.id})" href>
         {{ type.name }}
       </a>
     </li>

--- a/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.ts
+++ b/frontend/app/components/context-menus/types-context-menu/types-context-menu.service.ts
@@ -43,7 +43,6 @@ class TypesContextMenuController {
     wpCreate.getEmptyForm(project).then((form:any) => {
       this.types = form.schema.type.allowedValues;
 
-
       this.$timeout(() => {
         // Reposition again now that types are loaded
         this.$scope.$root.$emit('repositionDropdown');

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
@@ -1,4 +1,4 @@
-<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar -overflow-in-view"
+<div class="dropdown dropdown-relative dropdownToolbar -overflow-in-view"
      id="wp-status-context-menu">
   <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.status.length === 0 }">
     <li ng-repeat="status in $ctrl.status">

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
@@ -1,4 +1,4 @@
-<div class="dropdown dropdown-relative dropdownToolbar -overflow-in-view"
+<div class="dropdown dropdownToolbar -overflow-in-view"
      id="wp-status-context-menu">
   <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.status.length === 0 }">
     <li ng-repeat="status in $ctrl.status">

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
@@ -2,7 +2,7 @@
      id="wp-status-context-menu">
   <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.status.length === 0 }">
     <li ng-repeat="status in $ctrl.status">
-      <a class="menu-item" ui-sref="{{$ctrl.stateName}}({status: status.id})">
+      <a class="menu-item" ng-click="updateStatus(status)">
         {{ status.name }}
       </a>
     </li>

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html
@@ -1,0 +1,10 @@
+<div class="dropdown dropdown-relative dropdown-anchor-right dropdownToolbar -overflow-in-view"
+     id="wp-status-context-menu">
+  <ul class="dropdown-menu" ng-class="{'-empty': $ctrl.status.length === 0 }">
+    <li ng-repeat="status in $ctrl.status">
+      <a class="menu-item" ui-sref="{{$ctrl.stateName}}({status: status.id})">
+        {{ status.name }}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
@@ -29,13 +29,15 @@
 import {opWorkPackagesModule} from '../../../angular-modules';
 import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
 import {CollectionResource} from '../../api/api-v3/hal-resources/collection-resource.service';
+import {WorkPackageNotificationService} from '../../wp-edit/wp-notification.service';
 
 class WpStatusContextMenuController {
   public status:CollectionResource[] = [];
 
   constructor(protected $timeout:ng.ITimeoutService,
               protected $scope:ng.IScope,
-              protected wpEditing:WorkPackageEditingService) {
+              protected wpEditing:WorkPackageEditingService,
+              protected wpNotificationsService:WorkPackageNotificationService) {
     const wp = $scope.workPackage;
     var changeset = wpEditing.changesetFor(wp);
     $scope.$ctrl = this;
@@ -52,7 +54,9 @@ class WpStatusContextMenuController {
     this.$scope.updateStatus = function (status:any) {
       changeset.setValue('status', status);
       if(!wp.isNew) {
-        changeset.save();
+        changeset.save().then(() => {
+          wpNotificationsService.showSave(wp);
+        });
       }
     };
   }

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
@@ -37,9 +37,10 @@ class WpStatusContextMenuController {
               protected $scope:ng.IScope,
               protected wpEditing:WorkPackageEditingService) {
     const wp = $scope.workPackage;
+    var changeset = wpEditing.changesetFor(wp);
     $scope.$ctrl = this;
 
-    wpEditing.changesetFor(wp).getForm().then((form:any) => {
+    changeset.getForm().then((form:any) => {
       this.status = form.schema.status.allowedValues;
 
       this.$timeout(() => {
@@ -47,6 +48,11 @@ class WpStatusContextMenuController {
         this.$scope.$root.$emit('repositionDropdown');
       })
     });
+
+    this.$scope.updateStatus = function (status:any) {
+      changeset.setValue('status', status);
+      changeset.save();
+    };
   }
 
   public get stateName() {

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
@@ -51,12 +51,10 @@ class WpStatusContextMenuController {
 
     this.$scope.updateStatus = function (status:any) {
       changeset.setValue('status', status);
-      changeset.save();
+      if(!wp.isNew) {
+        changeset.save();
+      }
     };
-  }
-
-  public get stateName() {
-    return this.$scope.stateName;
   }
 }
 

--- a/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
+++ b/frontend/app/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.ts
@@ -1,0 +1,64 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+import {opWorkPackagesModule} from '../../../angular-modules';
+import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
+import {CollectionResource} from '../../api/api-v3/hal-resources/collection-resource.service';
+
+class WpStatusContextMenuController {
+  public status:CollectionResource[] = [];
+
+  constructor(protected $timeout:ng.ITimeoutService,
+              protected $scope:ng.IScope,
+              protected wpEditing:WorkPackageEditingService) {
+    const wp = $scope.workPackage;
+    $scope.$ctrl = this;
+
+    wpEditing.changesetFor(wp).getForm().then((form:any) => {
+      this.status = form.schema.status.allowedValues;
+
+      this.$timeout(() => {
+        // Reposition again now that status are loaded
+        this.$scope.$root.$emit('repositionDropdown');
+      })
+    });
+  }
+
+  public get stateName() {
+    return this.$scope.stateName;
+  }
+}
+
+function wpStatusContextMenuService(ngContextMenu:any) {
+  return ngContextMenu({
+    templateUrl: '/components/context-menus/wp-status-context-menu/wp-status-context-menu.service.html',
+    controller: WpStatusContextMenuController
+  });
+}
+
+opWorkPackagesModule.factory('WpStatusContextMenu', wpStatusContextMenuService);

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -8,6 +8,7 @@
   <wp-status-button ng-if="!$ctrl.workPackage.isNew"
                     work-package="$ctrl.workPackage"
                     allowed="$ctrl.workPackage.isEditable"></wp-status-button>
+  <attribute-help-text attribute="'status'" attribute-scope="WorkPackage"></attribute-help-text>
 
   <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">
     <span ng-bind="$ctrl.idLabel"/>:

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -5,7 +5,8 @@
                    field-name="'subject'"></wp-edit-field>
   </div>
 
-  <wp-status-button work-package="$ctrl.workPackage"
+  <wp-status-button ng-if="!$ctrl.workPackage.isNew"
+                    work-package="$ctrl.workPackage"
                     allowed="$ctrl.workPackage.isEditable"></wp-status-button>
 
   <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -5,8 +5,7 @@
                    field-name="'subject'"></wp-edit-field>
   </div>
 
-  <wp-status-button state-name="work-packages.show"
-                    work-package="$ctrl.workPackage"
+  <wp-status-button work-package="$ctrl.workPackage"
                     allowed="$ctrl.workPackage.isEditable"></wp-status-button>
 
   <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -5,6 +5,9 @@
                    field-name="'subject'"></wp-edit-field>
   </div>
 
+  <wp-status-button state-name="work-packages.show"
+                    work-package="$ctrl.workPackage"
+                    allowed="true"></wp-status-button>
 
   <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">
     <span ng-bind="$ctrl.idLabel"/>:
@@ -34,29 +37,6 @@
         </div>
       </div>
     </div>
-    </div>
-  </div>
-
-
-  <div class="attributes-group -special-fields">
-    <div class="attributes-group--header">
-      <div class="attributes-group--header-container">
-      </div>
-    </div>
-    <div class="-columns-2">
-      <div class="attributes-key-value"
-           ng-class="{'-span-all-columns': descriptor.spanAll }"
-           ng-repeat="descriptor in $ctrl.specialFields track by descriptor.name">
-        <div class="attributes-key-value--key"
-             wp-replacement-label="descriptor.name">
-          {{ descriptor.label }}
-          <span class="required" ng-if="descriptor.field.required && descriptor.field.writable"> *</span>
-          <attribute-help-text title-text="descriptor.label" attribute="descriptor.name" attribute-scope="WorkPackage"></attribute-help-text>
-        </div>
-        <div class="attributes-key-value--value-container">
-          <wp-edit-field work-package-id="$ctrl.workPackage.id" field-name="descriptor.name"></wp-edit-field>
-        </div>
-      </div>
     </div>
   </div>
 

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -7,7 +7,7 @@
 
   <wp-status-button state-name="work-packages.show"
                     work-package="$ctrl.workPackage"
-                    allowed="true"></wp-status-button>
+                    allowed="$ctrl.workPackage.isEditable"></wp-status-button>
 
   <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">
     <span ng-bind="$ctrl.idLabel"/>:

--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.ts
@@ -60,8 +60,6 @@ export class WorkPackageSingleViewController {
 
   // Grouped fields returned from API
   public groupedFields:GroupDescriptor[] = [];
-  // Special fields (project, type)
-  public specialFields:FieldDescriptor[] = [];
   public projectContext:{
     matches:boolean,
     href:string|null,
@@ -96,13 +94,6 @@ export class WorkPackageSingleViewController {
       .subscribe((resource:WorkPackageResourceInterface) => {
         // Prepare the fields that are required always
         const isNew = this.workPackage.isNew;
-
-        // Status selector is separated in the create form
-        if (isNew) {
-          this.specialFields = [];
-        } else {
-          this.specialFields = this.getFields(resource, ['status']);
-        }
 
         if (!resource.project) {
           this.projectContext = { matches: false, href: null };

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
@@ -27,6 +27,7 @@
 // ++
 
 import {wpButtonsModule} from '../../../angular-modules';
+import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
 import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 
 export default class WorkPackageStatusButtonController {
@@ -34,7 +35,8 @@ export default class WorkPackageStatusButtonController {
   public text:any;
   public allowed:boolean;
 
-  constructor(protected I18n:op.I18n) {
+  constructor(protected I18n:op.I18n,
+              protected wpEditing:WorkPackageEditingService) {
     this.text = {
       explanation: I18n.t('js.label_edit_status')
     };
@@ -45,7 +47,13 @@ export default class WorkPackageStatusButtonController {
   }
 
   public isDisabled() {
-    return !this.allowed;
+    let changeset = this.wpEditing.changesetFor(this.workPackage);
+    return !this.allowed || changeset.inFlight;
+  }
+
+  public get getStatus() {
+    let changeset = this.wpEditing.changesetFor(this.workPackage);
+    return changeset.value('status');
   }
 }
 

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
@@ -27,6 +27,7 @@
 // ++
 
 import {wpButtonsModule} from '../../../angular-modules';
+import {WorkPackageResourceInterface} from '../../api/api-v3/hal-resources/work-package-resource.service';
 
 export default class WorkPackageStatusButtonController {
   public workPackage:WorkPackageResourceInterface;

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
@@ -33,7 +33,6 @@ export default class WorkPackageStatusButtonController {
   public workPackage:WorkPackageResourceInterface;
   public text:any;
   public allowed:boolean;
-  public stateName:string;
 
   constructor(protected I18n:op.I18n) {
     this.text = {

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.controller.ts
@@ -1,0 +1,52 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {wpButtonsModule} from '../../../angular-modules';
+
+export default class WorkPackageStatusButtonController {
+  public workPackage:WorkPackageResourceInterface;
+  public text:any;
+  public allowed:boolean;
+  public stateName:string;
+
+  constructor(protected I18n:op.I18n) {
+    this.text = {
+      explanation: I18n.t('js.label_edit_status')
+    };
+  }
+
+  public $onInit() {
+    // Created for interface compliance
+  }
+
+  public isDisabled() {
+    return !this.allowed;
+  }
+}
+
+wpButtonsModule.controller('WorkPackageStatusButtonController', WorkPackageStatusButtonController);

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
@@ -8,7 +8,7 @@
           aria-label="{{ ::$ctrl.text.explanation }}">
 
     <span class="button--text"
-          aria-hidden="true">{{$ctrl.workPackage.status.name}}</span>
+          aria-hidden="true">{{$ctrl.getStatus.name}}</span>
     <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
   </button>
 </div>

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
@@ -9,6 +9,8 @@
 
     <span class="button--text"
           aria-hidden="true">TestStatusText</span>
-    <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+    <div class="wp-status-button--icon-container">
+      <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+    </div>
   </button>
 </div>

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
@@ -1,0 +1,14 @@
+<div class="wp-status-button">
+  <button class="button"
+          has-dropdown-menu
+          target="WpStatusContextMenu"
+          ng-init="workPackage = $ctrl.workPackage; stateName = $ctrl.stateName"
+          locals="workPackage, stateName"
+          ng-disabled="$ctrl.isDisabled()"
+          aria-label="{{ ::$ctrl.text.explanation }}">
+
+    <span class="button--text"
+          aria-hidden="true">TestStatusText</span>
+    <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+  </button>
+</div>

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
@@ -2,15 +2,13 @@
   <button class="button"
           has-dropdown-menu
           target="WpStatusContextMenu"
-          ng-init="workPackage = $ctrl.workPackage; stateName = $ctrl.stateName"
-          locals="workPackage, stateName"
+          ng-init="workPackage = $ctrl.workPackage"
+          locals="workPackage"
           ng-disabled="$ctrl.isDisabled()"
           aria-label="{{ ::$ctrl.text.explanation }}">
 
     <span class="button--text"
           aria-hidden="true">{{$ctrl.workPackage.status.name}}</span>
-    <div class="wp-status-button--icon-container">
-      <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
-    </div>
+    <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
   </button>
 </div>

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.html
@@ -8,7 +8,7 @@
           aria-label="{{ ::$ctrl.text.explanation }}">
 
     <span class="button--text"
-          aria-hidden="true">TestStatusText</span>
+          aria-hidden="true">{{$ctrl.workPackage.status.name}}</span>
     <div class="wp-status-button--icon-container">
       <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
     </div>

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.ts
@@ -1,0 +1,48 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {wpButtonsModule} from '../../../angular-modules';
+
+function wpCreateButton() {
+  return {
+    restrict: 'E',
+    templateUrl: '/components/wp-buttons/wp-status-button/wp-status-button.directive.html',
+
+    scope: {
+      allowed: '=',
+      workPackage: '=',
+      stateName: '@'
+    },
+
+    bindToController: true,
+    controllerAs: '$ctrl',
+    controller: 'WorkPackageStatusButtonController'
+  }
+}
+
+wpButtonsModule.directive('wpStatusButton', wpCreateButton);

--- a/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.ts
+++ b/frontend/app/components/wp-buttons/wp-status-button/wp-status-button.directive.ts
@@ -35,8 +35,7 @@ function wpCreateButton() {
 
     scope: {
       allowed: '=',
-      workPackage: '=',
-      stateName: '@'
+      workPackage: '='
     },
 
     bindToController: true,

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -216,7 +216,9 @@ module OpenProject
       'timeline--header-border-color'                        => '#aaaaaa',
       'timeline--grid-color'                                 => '#dddddd',
       'timeline--separator'                                  => '3px solid #E7E7E7',
-      'table-timeline--row-height'                           => '41px'
+      'table-timeline--row-height'                           => '41px',
+      'status-selector-bg-color'                             => '#F99601',
+      'status-selector-bg-hover-color'                       => '#E08600'
     }.freeze
 
     # Regular expression for references of other variables.

--- a/spec/features/work_package_show_spec.rb
+++ b/spec/features/work_package_show_spec.rb
@@ -48,10 +48,10 @@ RSpec.feature 'Work package show page', selenium: true do
 
     wp_page.visit!
 
-    wp_page.expect_attributes Type: work_package.type.name,
-                              Status: work_package.status.name,
-                              Priority: work_package.priority.name,
-                              Assignee: work_package.assigned_to.name,
-                              Responsible: work_package.responsible.name
+    wp_page.expect_attributes type: work_package.type.name,
+                              status: work_package.status.name,
+                              priority: work_package.priority.name,
+                              assignee: work_package.assigned_to.name,
+                              responsible: work_package.responsible.name
   end
 end

--- a/spec/features/work_packages/attribute_help_texts_spec.rb
+++ b/spec/features/work_packages/attribute_help_texts_spec.rb
@@ -52,7 +52,7 @@ describe 'Work package attribute help texts', type: :feature, js: true do
 
   shared_examples 'allows to view help texts' do
     it 'shows an indicator for whatever help text exists' do
-      expect(page).to have_selector('.attributes-key-value--key .help-text--for-status')
+      expect(page).to have_selector('.work-package--single-view .help-text--for-status')
 
       # Open help text modal
       modal.open!

--- a/spec/support/pages/abstract_work_package.rb
+++ b/spec/support/pages/abstract_work_package.rb
@@ -89,8 +89,11 @@ module Pages
     def expect_attributes(attribute_expectations)
       attribute_expectations.each do |label_name, value|
         label = label_name.to_s
-
-        expect(page).to have_selector(".wp-edit-field.#{label.camelize(:lower)}", text: value)
+        if label == 'status'
+          expect(page).to have_selector(".wp-status-button .button", text: value)
+        else
+          expect(page).to have_selector(".wp-edit-field.#{label.camelize(:lower)}", text: value)
+        end
       end
     end
 
@@ -156,6 +159,8 @@ module Pages
         end
       elsif key == :description
         WorkPackageTextAreaField.new page, key
+      elsif key == :status
+        WorkPackageStatusField.new page
       else
         WorkPackageField.new page, key
       end

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -147,7 +147,6 @@ class WorkPackageField
            'responsible',
            'priority',
            'project',
-           'status',
            'type',
            'version',
            'category'

--- a/spec/support/work_packages/work_package_status_field.rb
+++ b/spec/support/work_packages/work_package_status_field.rb
@@ -1,0 +1,57 @@
+require_relative './work_package_field'
+
+class WorkPackageStatusField < WorkPackageField
+
+  def initialize(context)
+    @context = context
+    @selector = ".wp-status-button"
+  end
+
+  def input_selector
+    '#wp-status-context-menu'
+  end
+
+  def input_element
+    @context.find "#{input_selector}"
+  end
+
+  def display_element
+    @context.find "#{@selector} .button"
+  end
+
+  def activate!
+    retry_block do
+      unless active?
+        scroll_to_and_click(display_element)
+      end
+    end
+  end
+  alias :activate_edition :activate!
+
+  def update(value, save: true, expect_failure: false)
+    retry_block do
+      activate_edition
+      set_value value
+
+      expect_state! open: expect_failure
+    end
+  end
+
+  def set_value(content)
+    input_element.find('a', text: content).click
+  end
+
+  def active?
+    @context.has_selector? "#{input_selector}", wait: 1
+  end
+  alias :editing? :active?
+
+  def expect_active!
+    expect(@context).to have_selector("#{input_selector}", wait: 10),
+          "Expected context menu for status."
+  end
+
+  def expect_inactive!
+    expect(@context).to have_no_selector("#{input_selector}")
+  end
+end


### PR DESCRIPTION
This makes the status selector more prominent. 

### Things to do

- [x] Apply new styling.
  - [x] The status selector shall be on the left of the info row.
  - [x] The label has been removed.
- [x] When clicking on the button a dropdown with possible status shall be shown.
- [x] Keep functionality (when changing the status it shall be stored)
- [x] Handle permissions correctly.
- [x] Take care of all forms (split vs full, create vs show) 
- [x] Fix broken tests

* (Correct focus handling for accessibility (see WP create button) )



https://community.openproject.com/projects/openproject/work_packages/25512/activity