### PR TITLE
hack change event not being fired in chrome on wp multi select

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.directive.html
@@ -34,6 +34,7 @@
     ng-focus="vm.handleUserFocus()"
     ng-disabled="vm.field.inFlight"
     ng-attr-id="{{vm.htmlId}}"
+    ng-click="vm.field.triggerChangeEvent($event)"
     multiple=""
     size=5
   >

--- a/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-multi-select-field.module.ts
@@ -39,11 +39,12 @@ export class MultiSelectEditField extends EditField {
 
   // Dependencies
   public I18n:op.I18n;
+  public $timeout:ng.ITimeoutService;
 
   public currentValueInvalid:boolean = false;
 
   protected initialize() {
-    $injectFields(this, 'I18n');
+    $injectFields(this, 'I18n', '$timeout');
     this.isMultiselect = this.isValueMulti();
 
     this.text = {
@@ -98,7 +99,14 @@ export class MultiSelectEditField extends EditField {
 
   public toggleMultiselect() {
     this.isMultiselect = !this.isMultiselect;
-  };
+  }
+
+  // HACK: Manually trigger the change event.
+  // This is necessary because of some unkown interaction between the field and having the wp split view open when in chrome.
+  // https://community.openproject.com/projects/openproject/work_packages/26611
+  public triggerChangeEvent(event:MouseEvent) {
+    this.$timeout(() => angular.element(event.target).trigger('change'));
+  }
 
   private setValues(availableValues:any[], sortValuesByName:boolean = false) {
     if (sortValuesByName) {


### PR DESCRIPTION
In chrome the change event is for unknown reasons not fired when the split view is open (or has been opened before moving to the full screen). This hack circumvents the problem by always firing a change event when the user clicks inside the select

https://community.openproject.com/projects/openproject/work_packages/26611