### PR TITLE
Adding a spec to reproduce the bug

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -301,6 +301,7 @@ describe Project, type: :model do
 
   describe '#visible' do
     let!(:public_project) {
+      Role.non_member
       FactoryGirl.create(:project, is_public: true)
     }
     it 'shows public projects' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -298,4 +298,15 @@ describe Project, type: :model do
       expect(project.allowed_parent?(other_project)).to be_falsey
     end
   end
+
+  describe '#visible' do
+    let!(:public_project) {
+      FactoryGirl.create(:project, is_public: true)
+    }
+    it 'shows public projects' do
+      public_project
+      allow(User).to receive(:current).and_return(user)
+      expect(Project.all.visible).to include(public_project)
+    end
+  end
 end


### PR DESCRIPTION
@ulferts Could you please have a look into this?

Apparently the resulting query joins ```assigned_roles.builtin``` with a truthy condition. I believe that this is simply wrong.

```
SELECT DISTINCT "projects".* FROM "projects" 
LEFT OUTER JOIN "members" 
  ON "projects"."id" = "members"."project_id" 
  AND "members"."user_id" = 1 
  AND "projects"."status" = 1
LEFT OUTER JOIN "member_roles" 
  ON "members"."id" = "member_roles"."member_id" 
LEFT OUTER JOIN "roles" "assigned_roles" 
  ON 1 = 1 
  AND "projects"."status" = 1 
  AND 
    ("assigned_roles"."id" = "member_roles"."role_id" 
    OR "projects"."is_public" = 't' 
    AND "assigned_roles"."builtin" = 1 
    AND "member_roles"."id" IS NULL) 
WHERE ("assigned_roles"."id" IS NOT NULL)
```