### PR TITLE
verify authenticity of stage complete calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,7 @@ class ApplicationController < ActionController::Base
   include Redmine::I18n
   include HookHelper
   include ::OpenProject::Authentication::SessionExpiry
+  include AdditionalUrlHelpers
 
   layout 'base'
 

--- a/app/controllers/concerns/authentication_stages.rb
+++ b/app/controllers/concerns/authentication_stages.rb
@@ -4,18 +4,28 @@ module Concerns
       stage = session[:authentication_stages].first
 
       if stage.to_s == params[:stage]
-        session[:authentication_stages] = session[:authentication_stages].drop(1)
+        if params[:secret] == stage_secrets[stage]
+          session[:authentication_stages] = session[:authentication_stages].drop(1)
 
-        successful_authentication User.find(session[:authenticated_user_id]), reset_stages: false
+          successful_authentication User.find(session[:authenticated_user_id]), reset_stages: false
+        else
+          flash[:error] = I18n.t :notice_auth_stage_verification_error, stage: stage
+
+          redirect_to signin_path
+        end
       else
-        flash[:error] = "Expected to finish authentication stage '#{stage}', but '#{params[:stage]}' returned."
+        flash[:error] = I18n.t(
+          :notice_auth_stage_wrong_stage,
+          expected: stage,
+          actual: params[:stage]
+        )
 
         redirect_to signin_path
       end
     end
 
     def stage_failure
-      flash[:error] = flash[:error] || "Authentication stage '#{params[:stage]}' failed."
+      flash[:error] = flash[:error] || I18n.t(:notice_auth_stage_error, stage: params[:stage])
 
       redirect_to signin_path
     end
@@ -24,22 +34,42 @@ module Concerns
 
     def authentication_stages(after_activation: false, reset: true)
       if !OpenProject::Authentication::Stage.stages.empty?
-        session.delete :authentication_stages if reset
+        session.delete [:authentication_stages, :stage_secrets] if reset
 
         if session.include?(:authentication_stages)
-          OpenProject::Authentication::Stage.find_all session[:authentication_stages]
+          lookup_authentication_stages
         else
-          stages = OpenProject::Authentication::Stage
-            .stages
-            .select { |s| s.run_after_activation? || !after_activation }
-
-          session[:authentication_stages] = stages.map(&:identifier)
-
-          stages
+          init_authentication_stages after_activation: after_activation
         end
       else
         []
       end
+    end
+
+    def lookup_authentication_stages
+      OpenProject::Authentication::Stage.find_all session[:authentication_stages]
+    end
+
+    def init_authentication_stages(after_activation:)
+      stages = OpenProject::Authentication::Stage
+        .stages
+        .select { |s| s.active? }
+        .select { |s| s.run_after_activation? || !after_activation }
+
+      session[:authentication_stages] = stages.map(&:identifier)
+      session[:stage_secrets] = session[:authentication_stages]
+        .map { |ident| [ident, stage_secret(ident)] }
+        .to_h
+
+      stages
+    end
+
+    def stage_secrets
+      Hash(session[:stage_secrets])
+    end
+
+    def stage_secret(ident)
+      SecureRandom.hex(16)
     end
   end
 end

--- a/app/helpers/additional_url_helpers.rb
+++ b/app/helpers/additional_url_helpers.rb
@@ -1,0 +1,3 @@
+module AdditionalUrlHelpers
+  include AuthenticationStagePathHelper
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,6 +38,7 @@ module ApplicationHelper
   include Redmine::I18n
   include HookHelper
   include IconsHelper
+  include AdditionalUrlHelpers
 
   extend Forwardable
   def_delegators :wiki_helper, :wikitoolbar_for, :heads_for_wiki_formatter

--- a/app/helpers/authentication_stage_path_helper.rb
+++ b/app/helpers/authentication_stage_path_helper.rb
@@ -29,11 +29,11 @@
 #++
 
 module AuthenticationStagePathHelper
-  def authenticate_stage_complete_path(identifier)
+  def authentication_stage_complete_path(identifier)
     OpenProject::Authentication::Stage.complete_path identifier, session: session
   end
 
-  def authenticate_stage_failure_path(identifier)
+  def authentication_stage_failure_path(identifier)
     OpenProject::Authentication::Stage.failure_path identifier
   end
 end

--- a/app/helpers/authentication_stage_path_helper.rb
+++ b/app/helpers/authentication_stage_path_helper.rb
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program::Type.translated_work_package_form_attributes; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module AuthenticationStagePathHelper
+  def authenticate_stage_complete_path(identifier)
+    OpenProject::Authentication::Stage.complete_path identifier, session: session
+  end
+
+  def authenticate_stage_failure_path(identifier)
+    OpenProject::Authentication::Stage.failure_path identifier
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1599,6 +1599,9 @@ en:
   notice_account_wrong_password: "Wrong password"
   notice_account_registered_and_logged_in: "Welcome, your account has been activated. You are logged in now."
   notice_activation_failed: The account could not be activated.
+  notice_auth_stage_verification_error: "Could not verify stage '%{stage}'."
+  notice_auth_stage_wrong_stage: "Expected to finish authentication stage '%{expected}', but '%{actual}' returned."
+  notice_auth_stage_error: "Authentication stage '%{stage}' failed."
   notice_can_t_change_password: "This account uses an external authentication source. Impossible to change the password."
   notice_custom_options_deleted: "Option '%{option_value}' and its %{num_deleted} occurrences were deleted."
   notice_email_error: "An error occurred while sending mail (%{value})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,8 +58,8 @@ OpenProject::Application.routes.draw do
 
     get '/sso', action: 'auth_source_sso_failed', as: 'sso_failure'
 
-    get '/login/:stage/success', action: 'stage_success', as: 'stage_success'
     get '/login/:stage/failure', action: 'stage_failure', as: 'stage_failure'
+    get '/login/:stage/:secret', action: 'stage_success', as: 'stage_success'
   end
 
   namespace :api do


### PR DESCRIPTION
Also adds path helpers to controllers and views for the finish paths:

* `authentication_stage_complete_path :identifier`
* `authentication_stage_failure_path :identifier`

Moreover it adds a new option for stages to decide whether they are active at runtime. For instance:

```
OpenProject::Authentication::Stage.register :2fa, '/2fa/', active: -> { Setting.2fa_enabled? }
```