### PR TITLE
[26672] Hide help text for status in create mode

### DIFF
--- a/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
+++ b/frontend/app/components/work-packages/wp-single-view/wp-single-view.directive.html
@@ -9,7 +9,7 @@
     <wp-status-button ng-if="!$ctrl.workPackage.isNew"
                       work-package="$ctrl.workPackage"
                       allowed="$ctrl.workPackage.isEditable"></wp-status-button>
-    <attribute-help-text attribute="'status'" attribute-scope="WorkPackage"></attribute-help-text>
+    <attribute-help-text attribute="'status'" attribute-scope="WorkPackage" ng-if="!$ctrl.workPackage.isNew"></attribute-help-text>
 
     <div class="work-packages--info-row" ng-if="!$ctrl.workPackage.isNew">
       <span ng-bind="$ctrl.idLabel"/>:


### PR DESCRIPTION
Hide the help attribute for the status in the create mode.

The actual fix has been made in the scope of #6017 and #6016 .

https://community.openproject.com/projects/openproject/work_packages/26672/activity