### PR TITLE
editActionsBar never calls onSave()

### DIFF
--- a/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
+++ b/frontend/app/components/common/edit-actions-bar/edit-actions-bar.directive.ts
@@ -53,6 +53,7 @@ export class EditActionsBarController {
       .saveWorkPackage()
       .finally(() => {
         this.saving = false;
+        this.onSave();
       });
   }
 


### PR DESCRIPTION
editActionsBar have scope variable onSave but never calls it. Therefore if plugin author needs to do something after save, he has to copy whole directive code to his plugin and add a trivial change.

https://community.openproject.com/projects/openproject/work_packages/26683/activity