### PR TITLE
[26691] Avoid find(ids) in eager loader

### DIFF
--- a/docs/installation/packaged/3-customization.md
+++ b/docs/installation/packaged/3-customization.md
@@ -21,8 +21,12 @@ If you have a plugin you wish to add to your packaged OpenProject installation,
 create a separate Gemfile with the Gem dependencies, such as the following:
 
 ```
-gem 'openproject-emoji', git: 'https://github.com/tessi/openproject-emoji.git', :branch => 'op-5-stable'
+group :opf_plugins do
+  gem 'openproject-emoji', git: 'https://github.com/tessi/openproject-emoji.git', :branch => 'op-5-stable'
+end
 ```
+
+The `group :opf_plugins` is generally recommended, but only required for plugins with custom frontend code that is picked up by webpack and output into their respective bundles.
 
 We suggest to store the Gemfile under `/etc/openproject/Gemfile.custom`, but
 the choice is up to you, just make sure the `openproject` user is able to read

--- a/lib/api/v3/work_packages/work_package_collection_eager_loading.rb
+++ b/lib/api/v3/work_packages/work_package_collection_eager_loading.rb
@@ -76,7 +76,7 @@ module API
 
           ids_of_values = cvs.map(&:value).select { |v| v =~ /\A\d+\z/ }
 
-          values_by_id = scope.find(ids_of_values).group_by(&:id)
+          values_by_id = scope.where(id: ids_of_values).group_by(&:id)
 
           cvs.each do |cv|
             next unless values_by_id[cv.value.to_i]


### PR DESCRIPTION
The `WorkPackageCollectionEagerLoading` uses eager loading for eager loading CF values
that MAY not exist anymore. This results in a faulty query when hitting one of these entries.

```
E, [2017-11-29T17:25:21.847832 #14241] ERROR -- :   Grape rescuing from error: API::Errors::NotFound

  Original error: #<ActiveRecord::RecordNotFound: Couldn't find Version with 'id'=35>

  Stacktrace:

    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/finder_methods.rb:353:in `raise_record_not_found_exception!'
    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/finder_methods.rb:479:in `find_one'
    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/finder_methods.rb:458:in `find_with_ids'
    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/relation/finder_methods.rb:66:in `find'
    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/querying.rb:3:in `find'
    /opt/openproject/vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/core.rb:151:in `find'
    /opt/openproject/lib/api/v3/work_packages/work_package_collection_representer.rb:228:in `eager_load_custom_values'
    /opt/openproject/lib/api/v3/work_packages/work_package_collection_representer.rb:216:in `eager_load_version_custom_values'
    /opt/openproject/lib/api/v3/work_packages/work_package_collection_representer.rb:197:in `full_work_packages'
    /opt/openproject/lib/api/v3/work_packages/work_package_collection_representer.rb:72:in `initialize'
    /opt/openproject/app/services/api/v3/work_package_collection_from_query_service.rb:125:in `new'
    /opt/openproject/app/services/api/v3/work_package_collection_from_query_service.rb:125:in `collection_representer'
    /opt/openproject/app/services/api/v3/work_package_collection_from_query_service.rb:57:in `results_to_representer'
    /opt/openproject/app/services/api/v3/work_package_collection_from_query_service.rb:46:in `call'
    /opt/openproject/lib/api/v3/queries/helpers/query_representer_response.rb:37:in `query_representer_response'
    /opt/openproject/lib/api/v3/queries/queries_api.rb:91:in `block (3 levels) in <class:QueriesAPI>'
```

https://community.openproject.com/wp/26691