### PR TITLE
[26424] Copy custom_values of project as the association it is

### DIFF
--- a/app/models/project/copy.rb
+++ b/app/models/project/copy.rb
@@ -36,7 +36,7 @@ module Project::Copy
     base.not_to_copy ['id', 'created_on', 'updated_on', 'name', 'identifier', 'status', 'lft', 'rgt']
 
     # specify the order of associations to copy
-    base.copy_precedence ['members', 'versions', 'categories', 'work_packages', 'wiki']
+    base.copy_precedence ['members', 'versions', 'categories', 'work_packages', 'wiki', 'custom_values']
   end
 
   module CopyMethods
@@ -45,7 +45,6 @@ module Project::Copy
       with_model(project) do |project|
         self.enabled_module_names = project.enabled_module_names
         self.types = project.types
-        self.custom_values = project.custom_values.map(&:clone)
         self.work_package_custom_fields = project.work_package_custom_fields
       end
       return self
@@ -58,6 +57,11 @@ module Project::Copy
     end
 
     private
+
+    # Copies custom values from +project+
+    def copy_custom_values(project, selected_copies = [])
+      self.custom_values = project.custom_values.map(&:dup)
+    end
 
     # Copies wiki from +project+
     def copy_wiki(project, selected_copies = [])

--- a/app/views/copy_projects/copy_from_settings.html.erb
+++ b/app/views/copy_projects/copy_from_settings.html.erb
@@ -38,7 +38,8 @@ See doc/COPYRIGHT.rdoc for more details.
                                                  render_advanced: true,
                                                  render_types: false,
                                                  render_modules: false,
-                                                 render_custom_fields: false
+                                                 render_custom_fields: false,
+                                                 no_error_messages: true
                                                } %>
 
   <%= render partial: "copy_projects/copy_settings/copy_associations", locals: { project: @project } %>

--- a/app/views/copy_projects/copy_settings/_copy_associations.html.erb
+++ b/app/views/copy_projects/copy_settings/_copy_associations.html.erb
@@ -31,6 +31,9 @@ See doc/COPYRIGHT.rdoc for more details.
   <legend class="form--fieldset-legend"><%= l(:button_copy) %></legend>
 
   <%= render partial: "copy_projects/copy_settings/block_checkbox",
+             locals: { name: "custom_values", checked: true, label: l('copy_project.project_custom_fields'),
+                       count: project.custom_values.count } %>
+  <%= render partial: "copy_projects/copy_settings/block_checkbox",
              locals: { name: "queries", checked: true, label: l(:label_query_plural),
                           count: project.queries.count } %>
   <%= render partial: "copy_projects/copy_settings/block_checkbox",

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= error_messages_for project %>
+<%= error_messages_for project unless local_assigns[:no_error_messages] %>
 
 <!--[form:project]-->
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,6 +707,7 @@ en:
     failed: "Cannot copy project %{source_project_name}"
     succeeded: "Created project %{target_project_name}"
     errors: "Error"
+    project_custom_fields: 'Custom fields on project'
     text:
       failed: "Could not copy project \"%{source_project_name}\" to project \"%{target_project_name}\"."
       succeeded: "Copied project \"%{source_project_name}\" to \"%{target_project_name}\"."


### PR DESCRIPTION
The custom values of a project were copied inocrrectly:

1. They were copied in #copy_attributes, where not all required vlaues
for the CV may exist (e.g., user CF => members copied)

2. They were copied with clone(), not dup(), thus the original project
lost their CFs.

https://community.openproject.com/wp/26424