### PR TITLE
Fix invitation wording for resend invitation

### DIFF
--- a/app/views/users/_toolbar.html.erb
+++ b/app/views/users/_toolbar.html.erb
@@ -35,7 +35,7 @@ See doc/COPYRIGHT.rdoc for more details.
                             method: :post) do |_form| %>
           <button class="button" title="<%= t(:tooltip_resend_invitation) %>">
             <%= op_icon('button--icon icon-mail1') %>
-            <span class="button--text"><%= t(:label_resend_invitation) %></span>
+            <span class="button--text"><%= t(:label_send_invitation) %></span>
           </button>
         <% end %>
       </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1066,7 +1066,7 @@ en:
   label_select_main_menu_item: Select new main menu item
   label_select_project: "Select a project"
   label_required_disk_storage: "Required disk storage"
-  label_resend_invitation: Resend invitation
+  label_send_invitation: Send invitation
   label_change_plural: "Changes"
   label_change_properties: "Change properties"
   label_change_status: "Change status"
@@ -1631,7 +1631,7 @@ en:
   notice_unable_delete_time_entry: "Unable to delete time log entry."
   notice_unable_delete_version: "Unable to delete version."
   notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
-  notice_user_invitation_resent: Another invitation has been sent to %{email}.
+  notice_user_invitation_resent: An invitation has been sent to %{email}.
   present_access_key_value: "Your %{key_name} is: %{value}"
   notice_automatic_set_of_standard_type: "Set standard type automatically."
   notice_logged_out: "You have been logged out."

--- a/spec/features/users/resend_invitation_spec.rb
+++ b/spec/features/users/resend_invitation_spec.rb
@@ -39,8 +39,8 @@ feature 'resend invitation', type: :feature do
   end
 
   scenario 'admin resends the invitation' do
-    click_on 'Resend invitation'
+    click_on I18n.t(:label_send_invitation)
 
-    expect(page).to have_text 'Another invitation has been sent to holly@openproject.com.'
+    expect(page).to have_text 'An invitation has been sent to holly@openproject.com.'
   end
 end

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -73,7 +73,7 @@ describe 'users/edit', type: :view do
       end
 
       it 'renders the resend invitation button' do
-        expect(rendered).to include I18n.t(:label_resend_invitation)
+        expect(rendered).to include I18n.t(:label_send_invitation)
       end
     end
 
@@ -86,7 +86,7 @@ describe 'users/edit', type: :view do
       end
 
       it 'does not render the resend invitation button' do
-        expect(rendered).not_to include I18n.t(:label_resend_invitation)
+        expect(rendered).not_to include I18n.t(:label_send_invitation)
       end
     end
   end
@@ -103,7 +103,7 @@ describe 'users/edit', type: :view do
     end
 
     it 'also renders the resend invitation button' do
-      expect(rendered).to include I18n.t(:label_resend_invitation)
+      expect(rendered).to include I18n.t(:label_send_invitation)
     end
   end
 


### PR DESCRIPTION
On initial registration, no invitation is sent, thus the 'resend'
invitation button is confusing.