### PR TITLE
[26707] Hide info icon on mobile pages

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/context-link-icon-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/context-link-icon-builder.ts
@@ -36,7 +36,7 @@ export class ContextLinkIconBuilder {
       ''
     );
 
-    detailsLink.classList.add(detailsLinkClassName, contextColumnIcon);
+    detailsLink.classList.add(detailsLinkClassName, contextColumnIcon, 'hidden-for-mobile');
     detailsLink.appendChild(opIconElement('icon', 'icon-info2'));
 
     // Enter the context menu arrow


### PR DESCRIPTION
To avoid a split screen on too small mobile devices, the icon is now hidden.

https://community.openproject.com/projects/openproject/work_packages/26707/activity