### PR TITLE
[Fix] WP subject edit field is misaligned on mobile

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -122,7 +122,7 @@ body:not(.accessibility-mode) .breadcrumb .breadcrumb-project-element
   wp-breadcrumb
     margin-top: 40px
   .wp-breadcrumb
-    margin: 10px 0 0 0
+    margin: 10px 0 0 0 !important
     ul.breadcrumb
       line-height: 1.25
       li

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -210,11 +210,6 @@ body.controller-work_packages.full-create
       line-height: 34px
 
     .work-packages--subject-element
-      &.work-packages--details--subject
-        .work-packages--details--subject.-active
-          @media only screen and (max-width: 679px)
-            margin-top: 8px
-
       .wp-inline-edit--field
         height: 34px
 


### PR DESCRIPTION
#### Before
![bildschirmfoto 2017-12-01 um 15 44 08](https://user-images.githubusercontent.com/7457313/33487761-9a37b136-d6ae-11e7-8a1a-568e7f70dbd0.png)
Before

#### After
![bildschirmfoto 2017-12-01 um 15 43 07](https://user-images.githubusercontent.com/7457313/33487771-a31ac928-d6ae-11e7-8ee8-e64794cd07b2.png)
