### PR TITLE
hack availability of wp id filter

### DIFF
--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -271,7 +271,11 @@ module API
         end
 
         def filters
-          represented.filters.map do |filter|
+          # HACK: we currently cannot display the id filter as there could potentially
+          # be too many candidates for the filter to be displayed.
+          # But as it is practical to have the id filter we allow users to type ids into the url. In such
+          # cases, the filter will be applied but it is not displayed as applied.
+          represented.filters.reject { |f| f.name == :id }.map do |filter|
             ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter
               .new(filter)
           end


### PR DESCRIPTION
The id filter is currently implemented as a stub. It is usable from the wp api but using it via the query api and by that via the front end fails intentionally as we currenlty have no solution to display the potentiall filter values efficiently. As there could be thousands of possible values, this problem is quite hard.

This hack circumvents the problem by not showing the filter in the query representer.

The filter is applied but the user will not be informed of the existence of the filter or its values.

As this is more of an easter egg, this is probably ok for now.

This would allow use cases as described on [community](https://community.openproject.com/projects/openproject/work_packages/26450).