### PR TITLE
Fix/circular dependency error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'friendly_id', '~> 5.2.1'
 gem 'acts_as_list', '~> 0.9.9'
 gem 'acts_as_tree', '~> 2.7.0'
 gem 'awesome_nested_set', '~> 3.1.3'
-gem 'typed_dag', '~> 1.0.0'
+gem 'typed_dag', '~> 1.0.1'
 
 gem 'color-tools', '~> 1.3.0', require: 'color'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,7 +577,7 @@ GEM
     tilt (2.0.7)
     timecop (0.9.1)
     ttfunk (1.5.0)
-    typed_dag (1.0.0)
+    typed_dag (1.0.1)
       rails (>= 5.0.4)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -730,7 +730,7 @@ DEPENDENCIES
   thin (~> 1.7.2)
   timecop (~> 0.9.0)
   transactional_lock!
-  typed_dag (~> 1.0.0)
+  typed_dag (~> 1.0.1)
   tzinfo-data (~> 1.2017.2)
   unicorn
   unicorn-worker-killer

--- a/app/contracts/users/create_contract.rb
+++ b/app/contracts/users/create_contract.rb
@@ -39,12 +39,8 @@ module Users
       end
     end
 
-    def validate
-      user_allowed_to_add
-      authentication_defined
-
-      super
-    end
+    validate :user_allowed_to_add
+    validate :authentication_defined
 
     private
 

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -119,7 +119,7 @@ class Relation < ActiveRecord::Base
   end
 
   def self.hierarchy_or_follows
-    with_type_colums_0(WorkPackage._dag_options.type_columns - %i(hierarchy follows))
+    with_type_columns_0(WorkPackage._dag_options.type_columns - %i(hierarchy follows))
       .non_reflexive
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -486,6 +486,8 @@ en:
               inexistent: "There is no custom field for the filter."
               invalid: "The custom field is not valid in the given context."
         relation:
+          typed_dag:
+            circular_dependency: "The relationship creates a circle of relationships."
           attributes:
             to:
               error_not_found: "work package in `to` position not found or not visible"

--- a/db/migrate/20170829095701_generate_wp_closure.rb
+++ b/db/migrate/20170829095701_generate_wp_closure.rb
@@ -36,8 +36,6 @@ class GenerateWpClosure < ActiveRecord::Migration[5.0]
 
     insert_hierarchy_relation_for_parent
 
-    insert_reflexive_relations
-
     WorkPackage.rebuild_dag!
 
     relation_types.each do |column|
@@ -196,15 +194,6 @@ class GenerateWpClosure < ActiveRecord::Migration[5.0]
       FROM work_packages w1
       JOIN work_packages w2
       ON w1.id = w2.parent_id
-    SQL
-  end
-
-  def insert_reflexive_relations
-    ActiveRecord::Base.connection.execute <<-SQL
-      INSERT INTO relations
-        (from_id, to_id)
-      SELECT id, id
-      FROM work_packages
     SQL
   end
 


### PR DESCRIPTION
The [migration](https://github.com/opf/openproject/blob/6fdd122534437d7bf6c19bae89c9601b90a4957b/db/migrate/20170829095701_generate_wp_closure.rb) used to create reflexive relations (meaning relations where to and from are identical) only to have them removed right away by typed_dag's `.rebuild_dag!` method. 

The reflexive relations are important for building the transitive relationships. Only when those exist, will the transitive relationships be build correctly. And the transitive relationships are required to correctly identify circular dependencies. 

By that, it fixes https://community.openproject.com/projects/openproject/work_packages/26694 by providing an error message.

By completely moving rebuilding reflexive relationships into the typed_dag method using `.typed_dag!` in production settings should yield the correct results again. We actually have the chance to test just that as the instances on edge will now all require us to run the method :)