### PR TITLE
Enable rails generators out of the box

### DIFF
--- a/Gemspec
+++ b/Gemspec
@@ -1,1 +1,0 @@
-../plugins/openproject-xx_test

--- a/Gemspec
+++ b/Gemspec
@@ -1,0 +1,1 @@
+../plugins/openproject-xx_test

--- a/lib/generators/open_project/plugin/plugin_generator.rb
+++ b/lib/generators/open_project/plugin/plugin_generator.rb
@@ -36,6 +36,7 @@ class OpenProject::PluginGenerator < Rails::Generators::Base
   def generate_plugin
     plugin_dir
     lib_dir
+    bin_dir
   end
 
   def full_name
@@ -68,6 +69,16 @@ class OpenProject::PluginGenerator < Rails::Generators::Base
   def lib_dir
     @lib_dir ||= begin
       directory('lib', lib_path)
+    end
+  end
+
+  def bin_path
+    "#{plugin_path}/bin"
+  end
+
+  def bin_dir
+    @bin_dir ||= begin
+      directory('bin', bin_path)
     end
   end
 end

--- a/lib/generators/open_project/plugin/templates/Gemfile
+++ b/lib/generators/open_project/plugin/templates/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/lib/generators/open_project/plugin/templates/bin/rails.tt
+++ b/lib/generators/open_project/plugin/templates/bin/rails.tt
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/open_project/<%= plugin_name %>/engine', __FILE__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+##
+# This is not ideal but better than nothing.
+if ENV['OPENPROJECT_ROOT']
+  # /Users/mkahl/dev/openproject/release/lib
+  path = Pathname(ENV["OPENPROJECT_ROOT"]).join("lib")
+  $LOAD_PATH.unshift(path.to_s)
+else
+  puts
+  puts "Error: please define OPENPROJECT_ROOT pointing to your OpenProject core's root directory"
+  puts
+  Kernel.exit(1)
+end
+
+require 'rails/all'
+require 'rails/engine/commands'


### PR DESCRIPTION
Add bin/rails and Gemfile to generated plugin.
This enables use of rails generators in the generated plugin
right after including it into OP's Gemfile.plugins and setting OPENPROJECT_ROOT environment variable.
https://community.openproject.com/work_packages/26719/activity