### PR TITLE
Fix/parent scheduling

### DIFF
--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -182,8 +182,8 @@ class WorkPackages::ScheduleDependency
     end
 
     def ancestors_from_preloaded(work_package)
-      if work_package.parent_relation
-        parent = known_work_packages.detect { |c| work_package.parent_relation.from_id == c.id }
+      if work_package.parent_id
+        parent = known_work_packages.detect { |c| work_package.parent_id == c.id }
 
         if parent
           [parent] + ancestors_from_preloaded(parent)
@@ -192,7 +192,7 @@ class WorkPackages::ScheduleDependency
     end
 
     def descendants_from_preloaded(work_package)
-      children = known_work_packages.select { |c| c.parent_relation && c.parent_relation.from_id == work_package.id }
+      children = known_work_packages.select { |c| c.parent_id == work_package.id }
 
       children + children.map { |child| descendants_from_preloaded(child) }.flatten
     end

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -142,8 +142,10 @@ class WorkPackages::SetScheduleService
   end
 
   def reschedule_to_date(scheduled, date)
-    scheduled.due_date = date + scheduled.duration - 1
-    scheduled.start_date = date
+    new_start_date = [scheduled.start_date, date].compact.max
+
+    scheduled.due_date = new_start_date + scheduled.duration - 1
+    scheduled.start_date = new_start_date
   end
 
   def reschedule_by_delta(scheduled, delta, min_start_date)

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -43,7 +43,7 @@ class WorkPackages::SetScheduleService
                 []
               end
 
-    if (%i(start_date due_date) & attributes).any?
+    if (%i(start_date due_date parent parent_id) & attributes).any?
       altered += schedule_following
     end
 

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -67,6 +67,23 @@ describe WorkPackages::SetScheduleService do
     work_package
   end
 
+  def stub_follower_child(parent, start, due)
+    child = stub_follower(start,
+                          due,
+                          {})
+
+    relation = FactoryGirl.build_stubbed(:hierarchy_relation,
+                                         from: parent,
+                                         to: child)
+
+    allow(child)
+      .to receive(:parent_relation)
+            .and_return relation
+
+    child
+  end
+
+
   let(:follower1_start_date) { Date.today + 1.day }
   let(:follower1_due_date) { Date.today + 3.day }
   let(:follower1_delay) { 0 }
@@ -608,21 +625,7 @@ describe WorkPackages::SetScheduleService do
     let(:child_start_date) { follower1_start_date }
     let(:child_due_date) { follower1_due_date }
 
-    let(:child_work_package) do
-      child = stub_follower(child_start_date,
-                            child_due_date,
-                            {})
-
-      relation = FactoryGirl.build_stubbed(:hierarchy_relation,
-                                           from: following_work_package1,
-                                           to: child)
-
-      allow(child)
-        .to receive(:parent_relation)
-        .and_return relation
-
-      child
-    end
+    let(:child_work_package) { stub_follower_child(following_work_package1, child_start_date, child_due_date) }
 
     let(:following) do
       {
@@ -647,6 +650,107 @@ describe WorkPackages::SetScheduleService do
         let(:expected) do
           { following_work_package1 => [Date.today + 6.days, Date.today + 8.days],
             child_work_package => [Date.today + 6.days, Date.today + 8.days] }
+        end
+      end
+    end
+  end
+
+  context 'with a single successor having two children' do
+    let(:follower1_start_date) { work_package_due_date + 1.day }
+    let(:follower1_due_date) { work_package_due_date + 10.days }
+    let(:child1_start_date) { follower1_start_date }
+    let(:child1_due_date) { follower1_start_date + 3.days }
+    let(:child2_start_date) { follower1_start_date + 8.days }
+    let(:child2_due_date) { follower1_due_date }
+
+    let(:child1_work_package) { stub_follower_child(following_work_package1, child1_start_date, child1_due_date)}
+    let(:child2_work_package) { stub_follower_child(following_work_package1, child2_start_date, child2_due_date)}
+
+    let(:following) do
+      {
+        [work_package] => [following_work_package1,
+                           child1_work_package,
+                           child2_work_package],
+        [following_work_package1,
+         child1_work_package,
+         child2_work_package] => []
+      }
+    end
+
+    before do
+      following_work_package1
+      child1_work_package
+      child2_work_package
+    end
+
+    context 'unchanged dates (e.g. when creating a follows relation) and successor starting 1 day after scheduled' do
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [follower1_start_date, follower1_due_date],
+            child1_work_package => [child1_start_date, child1_due_date],
+            child2_work_package => [child2_start_date, child2_due_date] }
+        end
+        let(:unchanged) do
+          [following_work_package1, child1_work_package, child2_work_package]
+        end
+      end
+    end
+
+    context 'unchanged dates (e.g. when creating a follows relation) and successor starting 3 days after scheduled' do
+      let(:follower1_start_date) { work_package_due_date + 3.days }
+      let(:follower1_due_date) { follower1_start_date + 10.days }
+      let(:child1_start_date) { follower1_start_date }
+      let(:child1_due_date) { follower1_start_date + 6.days }
+      let(:child2_start_date) { follower1_start_date + 8.days }
+      let(:child2_due_date) { follower1_due_date }
+
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [follower1_start_date, follower1_due_date],
+            child1_work_package => [child1_start_date, child1_due_date],
+            child2_work_package => [child2_start_date, child2_due_date] }
+        end
+        let(:unchanged) do
+          [following_work_package1, child1_work_package, child2_work_package]
+        end
+      end
+    end
+
+    context 'unchanged dates (e.g. when creating a follows relation) and successor\'s first child' do
+      let(:follower1_start_date) { work_package_due_date - 3.days }
+      let(:follower1_due_date) { work_package_due_date + 10.days }
+      let(:child1_start_date) { follower1_start_date }
+      let(:child1_due_date) { follower1_start_date + 6.days }
+      let(:child2_start_date) { follower1_start_date + 8.days }
+      let(:child2_due_date) { follower1_due_date }
+
+      # following parent is reduced in length as the children allow to be executed at the same time
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [work_package_due_date + 1.day, follower1_due_date],
+            child1_work_package => [work_package_due_date + 1.day, follower1_start_date + 10.days],
+            child2_work_package => [child2_start_date, child2_due_date] }
+        end
+        let(:unchanged) do
+          [child2_work_package]
+        end
+      end
+    end
+
+    context 'unchanged dates (e.g. when creating a follows relation) and successor\s children need to be rescheduled' do
+      let(:follower1_start_date) { work_package_due_date - 8.days }
+      let(:follower1_due_date) { work_package_due_date + 10.days }
+      let(:child1_start_date) { follower1_start_date }
+      let(:child1_due_date) { follower1_start_date + 4.days }
+      let(:child2_start_date) { follower1_start_date + 6.days }
+      let(:child2_due_date) { follower1_due_date }
+
+      # following parent is reduced in length and children are rescheduled
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [work_package_due_date + 1.day, follower1_start_date + 21.days],
+            child1_work_package => [work_package_due_date + 1.day, child1_due_date + 9.days],
+            child2_work_package => [work_package_due_date + 1.day, follower1_start_date + 21.days] }
         end
       end
     end


### PR DESCRIPTION
* Updates the new parent's start and due date when parent_id is set
* Updates the former parent's start and due date when parent_id is changed
* does not reschedule work packages that come into a follows relation (direct or indirect, e.g. as children of a following parent) if their start is after the minimum start date https://community.openproject.com/projects/openproject/work_packages/26718