### PR TITLE
[26692] Width of work packages columns changes in FF57 while inline editing

### DIFF
--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -73,7 +73,9 @@ export class TableRowEditContext implements WorkPackageEditContext {
     // Forcibly set the width since the edit field may otherwise
     // be given more width
     const td = this.findCell(fieldName);
-    td.css('width', td.css('width'));
+    const width = td.css('width');
+    td.css('max-width', width);
+    td.css('width', width);
 
     // Create a field handler for the newly active field
     const fieldHandler = new WorkPackageEditFieldHandler(
@@ -113,6 +115,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
 
     if (cell.length) {
       this.findCell(fieldName).css('width', '');
+      this.findCell(fieldName).css('max-width', '');
       this.cellBuilder.refresh(cell[0], workPackage, fieldName);
 
       if (focus) {


### PR DESCRIPTION
In the WP table we have a `max-width` for table cells. Normally widths cannot be set to inline or table elements. This case is handled differently by each browser. Chrome for example ignores it more or less. FF is the only one who supports this at  least partially (https://developer.mozilla.org/en-US/docs/Web/CSS/max-width). That is why the cells shrinks in edit mode. 
So to avoid this we have to override the `max-width` attribute just like we do it with the `width`. 

https://community.openproject.com/projects/openproject/work_packages/26692/activity