### PR TITLE
[26740] Trigger resize event in timeline

### DIFF
--- a/frontend/app/components/wp-resizer/wp-resizer.directive.ts
+++ b/frontend/app/components/wp-resizer/wp-resizer.directive.ts
@@ -32,6 +32,7 @@ export class WorkPackageResizerController {
   private elementFlex:number;
   private oldPosition:number;
   private mouseMoveHandler:any;
+  public resizeEvent: string;
   public elementClass: string;
   public localStorageKey: string;
 
@@ -91,7 +92,13 @@ export class WorkPackageResizerController {
     // When the mouseup is outside the container these values will differ
     // which will cause problems at the next movement start
     let localStorageValue = localStorage.getItem(this.localStorageKey);
-    if(localStorageValue) { this.elementFlex = parseInt(localStorageValue, 10) };
+    if (localStorageValue) {
+      this.elementFlex = parseInt(localStorageValue, 10);
+    }
+
+    // Send a event that we resized this element
+    const event = new Event(this.resizeEvent);
+    window.dispatchEvent(event);
   }
 
   private resizeElement(element:HTMLElement, e:MouseEvent) {
@@ -124,6 +131,7 @@ function wpResizer():any {
     templateUrl: '/components/wp-resizer/wp-resizer.directive.html',
     scope: {
       elementClass: '=',
+      resizeEvent: '@',
       localStorageKey: '='
     },
 

--- a/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -122,6 +122,9 @@ export class WorkPackageTimelineTableController {
     // Refresh on changes to work packages
     this.updateOnWorkPackageChanges();
 
+    // Refresh on window resize events
+    window.addEventListener('wp-resize.timeline', this.debouncedRefresh.bind(this));
+
     // Refresh timeline view after table rendered
     this.states.table.rendered.values$()
       .takeUntil(this.states.table.stopAllSubscriptions)

--- a/frontend/app/components/wp-table/wp-table.directive.html
+++ b/frontend/app/components/wp-table/wp-table.directive.html
@@ -64,7 +64,7 @@
   </div>
 
   <div class="work-packages--tabletimeline--timeline--resizer hidden-for-mobile hide-when-print">
-    <wp-resizer element-class="'work-packages-tabletimeline--timeline-side'" local-storage-key="'openProject-timelineFlexBasis'"></wp-resizer>
+    <wp-resizer element-class="'work-packages-tabletimeline--timeline-side'" resize-event="wp-resize.timeline" local-storage-key="'openProject-timelineFlexBasis'"></wp-resizer>
   </div>
 
   <div class="work-packages-tabletimeline--timeline-side">


### PR DESCRIPTION
Triggers a refresh of the timeline _after_ the resize has completed. Note: That means that the whitespace will still happen when resizing.

This has the nice side effect of updating the autozoom when we resize the timeline.

![resize](https://user-images.githubusercontent.com/459462/33767021-4eed7a72-dc20-11e7-97cc-80efab652a87.gif)


https://community.openproject.com/wp/26740