### PR TITLE
escape html content by default

### DIFF
--- a/app/cells/rails_cell.rb
+++ b/app/cells/rails_cell.rb
@@ -32,4 +32,10 @@ class RailsCell < Cell::ViewModel
   def form_authenticity_token(*args)
     controller.send(:form_authenticity_token, *args)
   end
+
+  # override cell-erb's behaviour to not escape
+  # https://github.com/trailblazer/cells-erb/tree/v0.1.0#html-escaping
+  def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+    super
+  end
 end


### PR DESCRIPTION
Turns:

![image](https://user-images.githubusercontent.com/617519/33892330-d2b8e8ce-df58-11e7-96e4-525f085bc8ad.png)

into:

![image](https://user-images.githubusercontent.com/617519/33892411-f6ea7690-df58-11e7-8fec-773875d93d05.png)


