### PR TITLE
blacklist RelationColumn on export

### DIFF
--- a/app/models/work_package/exporter/base.rb
+++ b/app/models/work_package/exporter/base.rb
@@ -50,10 +50,8 @@ class WorkPackage::Exporter::Base
   end
 
   def valid_export_columns
-    query.columns.select do |c|
-      c.is_a?(Queries::WorkPackages::Columns::WorkPackageColumn) ||
-        c.is_a?(Queries::WorkPackages::Columns::PropertyColumn) ||
-        c.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn)
+    query.columns.reject do |c|
+      c.is_a?(Queries::WorkPackages::Columns::RelationColumn)
     end
   end
 


### PR DESCRIPTION
That way, plugins can easily add additional columns while the exporters are safe from trying to export relation columns

https://community.openproject.com/projects/openproject/work_packages/26773