### PR TITLE
[26763] Fix merging relations state when is empty

### DIFF
--- a/frontend/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations.service.ts
@@ -127,7 +127,11 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
       this.multiState.get(wpId).doModify((value:RelationsStateValue) => {
         value[relation.id] = relation;
         return value;
-      }, () => { return {}; });
+      }, () => {
+        let value:RelationsStateValue = {};
+        value[relation.id] = relation;
+        return value;
+      });
     });
   }
 


### PR DESCRIPTION
The `InputState#or` callback is called when the InputState for the
reflexive relation state has no value.

That means that new relations aren't merged into that state.

https://community.openproject.com/wp/26763