### PR TITLE
always return a custom value if it is available in the customizable

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -103,17 +103,15 @@ See doc/COPYRIGHT.rdoc for more details.
               <td><%= checked_image project.is_public? %></td>
               <% if EnterpriseToken.allows_to?(:custom_fields_in_projects_list) %>
                 <% @custom_fields.each do |custom_field| %>
-                  <% if project.custom_value_for(custom_field).present? %>
-                    <td class="format-<%= custom_field.field_format %>">
-                      <% if custom_field.field_format == 'text' %>
-                        <%= shorten_text(project.custom_value_for(custom_field).formatted_value, 20) %>
-                      <% else %>
-                        <%= project.custom_value_for(custom_field).formatted_value %>
-                      <% end %>
-                    </td>
-                  <% else %>
-                    <td></td>
-                  <% end %>
+                  <td class="format-<%= custom_field.field_format %>">
+                    <% custom_value = project.custom_value_for(custom_field).formatted_value %>
+
+                    <% if custom_field.field_format == 'text' %>
+                      <%= shorten_text(custom_value, 20) %>
+                    <% else %>
+                      <%= custom_value %>
+                    <% end %>
+                  </td>
                 <% end %>
               <% end %>
               <% if User.current.admin? %>

--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -156,7 +156,7 @@ module Redmine
 
         def custom_value_for(c)
           field_id = (c.is_a?(CustomField) ? c.id : c.to_i)
-          values = custom_values.select { |v| v.custom_field_id == field_id }
+          values = custom_field_values.select { |v| v.custom_field_id == field_id }
 
           if values.size > 1
             values.sort_by { |v| v.id.to_i } # need to cope with nil

--- a/spec/models/project/customizable_spec.rb
+++ b/spec/models/project/customizable_spec.rb
@@ -1,0 +1,93 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Project, 'customizable', type: :model do
+  let(:project) { FactoryGirl.build_stubbed(:project) }
+  let(:stub_available_custom_fields) do
+    custom_fields_stub = double('custom fields stub')
+    allow(CustomField)
+      .to receive(:where)
+      .with(type: "ProjectCustomField")
+      .and_return(custom_fields_stub)
+
+    allow(custom_fields_stub)
+      .to receive(:order)
+      .with(:position)
+      .and_return(available_custom_fields)
+  end
+
+  before do
+    stub_available_custom_fields
+  end
+
+  describe 'custom_value_for' do
+    subject { project.custom_value_for(custom_field) }
+
+    context 'for a boolean custom field' do
+      let(:custom_field) { FactoryGirl.build_stubbed(:bool_project_custom_field) }
+      let(:available_custom_fields) { [custom_field] }
+
+      context 'with no value set' do
+        it 'returns a custom value' do
+          expect(subject)
+            .to be_present
+        end
+
+        it 'is unpersisted' do
+          expect(subject)
+            .to be_new_record
+        end
+
+        it 'has nil as its value' do
+          expect(subject.value)
+            .to be_nil
+        end
+      end
+
+      context 'with a value set' do
+        let(:custom_value) do
+          FactoryGirl.build_stubbed(:custom_value,
+                                    custom_field: custom_field,
+                                    value: true)
+        end
+        before do
+          allow(project)
+            .to receive(:custom_values)
+            .and_return([custom_value])
+        end
+
+        it 'returns the custom value' do
+          expect(subject)
+            .to eql custom_value
+        end
+      end
+    end
+  end
+end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -32,18 +32,18 @@ describe WorkPackage, type: :model do
   describe '#custom_fields' do
     let(:type) { FactoryGirl.create(:type_standard) }
     let(:project) { FactoryGirl.create(:project, types: [type]) }
-    let(:work_package) {
+    let(:work_package) do
       FactoryGirl.build(:work_package,
                         project: project,
                         type: type)
-    }
-    let (:custom_field) {
+    end
+    let (:custom_field) do
       FactoryGirl.create(:work_package_custom_field,
                          name: 'Database',
                          field_format: 'list',
-                         possible_values: ['MySQL', 'PostgreSQL', 'Oracle'],
+                         possible_values: %w(MySQL PostgreSQL Oracle),
                          is_required: true)
-    }
+    end
 
     shared_context 'project with required custom field' do
       before do
@@ -84,12 +84,12 @@ describe WorkPackage, type: :model do
             end
 
             describe 'error message' do
-              before do work_package.save end
+              before { work_package.save }
 
               subject { work_package.errors[custom_field_key] }
 
               it {
-                is_expected.to include(I18n.translate("activerecord.errors.messages.#{error_key}"))
+                is_expected.to include(I18n.t("activerecord.errors.messages.#{error_key}"))
               }
             end
 
@@ -137,7 +137,7 @@ describe WorkPackage, type: :model do
         end
 
         context 'full error message' do
-          before do change_custom_field_value(work_package, 'SQLServer') end
+          before { change_custom_field_value(work_package, 'SQLServer') }
 
           subject { work_package.errors.full_messages.first }
 
@@ -148,7 +148,7 @@ describe WorkPackage, type: :model do
       end
 
       describe 'valid value given' do
-        before do change_custom_field_value(work_package, 'PostgreSQL') end
+        before { change_custom_field_value(work_package, 'PostgreSQL') }
 
         context 'errors' do
           subject { work_package.errors[:custom_values] }
@@ -184,10 +184,10 @@ describe WorkPackage, type: :model do
 
     describe 'work package type change' do
       let (:custom_field_2) { FactoryGirl.create(:work_package_custom_field) }
-      let(:type_feature) {
+      let(:type_feature) do
         FactoryGirl.create(:type_feature,
                            custom_fields: [custom_field_2])
-      }
+      end
 
       before do
         project.work_package_custom_fields << custom_field_2
@@ -215,11 +215,11 @@ describe WorkPackage, type: :model do
       end
 
       context 'w/o initial type' do
-        let(:work_package_without_type) {
+        let(:work_package_without_type) do
           FactoryGirl.build_stubbed(:work_package,
                                     project: project,
                                     type: type)
-        }
+        end
 
         describe 'pre-condition' do
           subject { work_package_without_type.custom_field_values }
@@ -228,7 +228,7 @@ describe WorkPackage, type: :model do
         end
 
         context 'with assigning type' do
-          before do work_package_without_type.type = type_feature end
+          before { work_package_without_type.type = type_feature }
 
           subject { work_package_without_type.custom_field_values }
 
@@ -259,21 +259,21 @@ describe WorkPackage, type: :model do
 
     describe "custom field type 'text'" do
       let(:value) { 'text' * 1024 }
-      let(:custom_field) {
+      let(:custom_field) do
         FactoryGirl.create(:work_package_custom_field,
                            name: 'Test Text',
                            field_format: 'text',
                            is_required: true)
-      }
+      end
 
       include_context 'project with required custom field'
 
       it_behaves_like 'work package with required custom field'
 
       describe 'value' do
-        let(:relevant_journal) {
+        let(:relevant_journal) do
           work_package.journals.find { |j| j.customizable_journals.size > 0 }
-        }
+        end
         subject { relevant_journal.customizable_journals.first.value }
 
         before do
@@ -303,7 +303,7 @@ describe WorkPackage, type: :model do
         expect(work_package.valid?).to be_falsey
 
         expect(work_package.errors.full_messages.first)
-          .to eq ('PIN is too long (maximum is 4 characters).')
+          .to eq 'PIN is too long (maximum is 4 characters).'
       end
     end
   end


### PR DESCRIPTION
That way, project custom fields, which are added after a project has already been created will have the chance to have their default values displayed (e.g. "No" for bool)

https://community.openproject.com/projects/openproject/work_packages/26782