### PR TITLE
[26796] Fix previewing work packages with ### in new pages

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -387,7 +387,13 @@ class WikiController < ApplicationController
     return render_403 unless page.nil? || editable?(page)
 
     attachments = page && page.attachments
-    previewed = page && page.content
+    previewed =
+      if page
+        page.content
+      else
+        build_wiki_page_and_content
+        @content
+      end
 
     text = { WikiPage.human_attribute_name(:content) => params[:content][:text] }
 


### PR DESCRIPTION
The content was nil, resulting in the work package ### check failing.

https://community.openproject.com/wp/26796