### PR TITLE
[26759] On mobile scroll bar of page covers up scrollbar of split screen 

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -177,3 +177,7 @@
         flex-grow: 0
     .work-packages-full-view--split-container
       border-top: none
+
+  body.controller-work_packages.action-details
+    .work-packages-split-view--details-side
+      overflow-x: auto


### PR DESCRIPTION
Allow horizontal scrolling in WP split screen on mobile. 

https://community.openproject.com/projects/openproject/work_packages/26759/activity