### PR TITLE
[26436] Reduce doubled implementations of drop downs

### DIFF
--- a/app/assets/javascripts/action_menu.js
+++ b/app/assets/javascripts/action_menu.js
@@ -34,7 +34,7 @@
       <li><a>Menu item text</a></li>
       <li class="drop-down">
         <a class="icon icon-more" href="javascript:">More functions</a>
-        <ul style="display:none;" class="legacy-actions-more">
+        <ul style="display:none;" class="menu-drop-down-container">
           <li><a>Menu item text</a></li>
         </ul>
       </li>

--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -116,12 +116,12 @@
       var menu_start_position;
       if (this.menu_container.next().get(0) != undefined && (this.menu_container.next().get(0).tagName == 'H2')){
         menu_start_position = this.menu_container.next().innerHeight() + this.menu_container.next().position().top;
-        this.menu_container.find("ul.legacy-actions-more").css({ top: menu_start_position });
+        this.menu_container.find("ul.menu-drop-down-container").css({ top: menu_start_position });
       }
       else if(this.menu_container.next().hasClass("wiki-content") && this.menu_container.next().children().next().first().get(0) != undefined && this.menu_container.next().children().next().first().get(0).tagName == 'H1'){
         var wiki_heading = this.menu_container.next().children().next().first();
         menu_start_position = wiki_heading.innerHeight() + wiki_heading.position().top;
-        this.menu_container.find("ul.legacy-actions-more").css({ top: menu_start_position });
+        this.menu_container.find("ul.menu-drop-down-container").css({ top: menu_start_position });
       }
     },
 

--- a/app/assets/stylesheets/content/_action_menu_main.sass
+++ b/app/assets/stylesheets/content/_action_menu_main.sass
@@ -61,10 +61,6 @@
       display: none
       position: absolute
 
-hr
-  .legacy-actions-more > &
-    margin: 10px 0
-
 .icon-action-menu
   @include icon-action-menu-rules
 .icon-sub-menu

--- a/app/assets/stylesheets/content/_legacy_actions.sass
+++ b/app/assets/stylesheets/content/_legacy_actions.sass
@@ -54,18 +54,6 @@ ul.legacy-actions-specific,
 p.subtitle + ul.legacy-actions-specific
   @include legacy-actions-defaults(-57px)
 
-#lower-title-bar ul.legacy-actions-specific
-  @include legacy-actions-defaults
-  padding-top: 10px
-
-#lower-title-bar ul.legacy-actions-more
-  bottom: 0
-  right: 0
-  margin-bottom: 25px
-  top: auto
-  > li.drop-down
-    position: relative
-
 .message-reply-menu
   @include contextual(-60px)
   > .button

--- a/app/assets/stylesheets/content/_projects_list.sass
+++ b/app/assets/stylesheets/content/_projects_list.sass
@@ -117,7 +117,7 @@ form.project-filters
       .project-actions
         display: inline-block
         margin: 0
-        .dropdown-menu
+        .menu-drop-down-container
           text-align: left
     .archived
       color: $gray-dark

--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -26,40 +26,24 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-// Styles taken from jquery-dropdown plugin:
-// https://github.com/plapier/jquery-dropdown
-// (dual MIT/GPL-Licensed)
+// --------------------------------------------------------
+// At the moment we have basically two different class sets for dropdowns.
+// '.dropdown' is used for all menus within the WP context
+//  --> (contextMenus (createButton, statusButton, tableContextMenu), wpToolbarSettingsButton))
+// '.drop-down' is used for the rest
+//  --> top menu and all other toolbar settings menus (e.g. wiki)
+// --------------------------------------------------------
 
 
-.dropdown.dropdownToolbar
-  margin: 10px 0 0 0
-
-#column-context-menu .menu
-  margin: 0
-
-.dropdown
-  // Will be overridden by the js code but having this here will prevent the
-  // dropdown to displayed in the upper right corner until the js sets the
-  // position explicitly.
-  visibility: hidden
-
-  // Avoid a context menu that MAY get too large for the screen
-  // to exceed it, but rather limit its height to the view port.
-  &.-overflow-in-view
-    max-height: 100vh
-    overflow: auto
-
+// ---------------------------- SHARED styles --------------------------------
 .dropdown,
-.toolbar .legacy-actions-more
+.drop-down .menu-drop-down-container
   position: absolute
   z-index: 9999999
 
-.toolbar .legacy-actions-more
-  right: 0
-
 .dropdown .dropdown-menu,
 .dropdown .dropdown-panel,
-.toolbar .legacy-actions-more
+.drop-down .menu-drop-down-container
   min-width: 200px
   list-style: none
   background: #FFF
@@ -71,51 +55,8 @@
   padding: 3px 0
   margin: 0
 
-.dropdown-menu.-empty
-  visibility: hidden
-
-.dropdown .dropdown-panel
-  padding: 10px
-
-.dropdown.dropdown-tip
-  margin-top: 8px
-
-.dropdown.dropdown-tip:before
-  position: absolute
-  top: -6px
-  left: 9px
-  content: ''
-  border-left: 7px solid transparent
-  border-right: 7px solid transparent
-  border-bottom: 7px solid #CCC
-  border-bottom-color: rgba(0, 0, 0, 0.2)
-  display: inline-block
-
-.dropdown.dropdown-tip.dropdown-anchor-right:before
-  left: auto
-  right: 9px
-
-.dropdown.dropdown-tip:after
-  position: absolute
-  top: -5px
-  left: 10px
-  content: ''
-  border-left: 6px solid transparent
-  border-right: 6px solid transparent
-  border-bottom: 6px solid #FFF
-  display: inline-block
-
-.dropdown.dropdown-tip.dropdown-anchor-right:after
-  left: auto
-  right: 10px
-
-.dropdown.dropdown-scroll .dropdown-menu,
-.dropdown.dropdown-scroll .dropdown-panel
-  max-height: 358px
-  overflow: auto
-
 .dropdown .dropdown-menu,
-.toolbar .legacy-actions-more
+.drop-down .menu-drop-down-container
   LI
     list-style: none
     padding: 0
@@ -123,7 +64,7 @@
     line-height: 20px
 
 .dropdown .dropdown-menu,
-.toolbar .legacy-actions-more
+.drop-down .menu-drop-down-container
   LI > A,
   LABEL,
   .menu-item
@@ -149,6 +90,40 @@
   LI > A.inactive
     color: #999999
 
+
+
+// ---------------------------- .DROPDOWN styles --------------------------------
+
+// Styles taken from jquery-dropdown plugin:
+// https://github.com/plapier/jquery-dropdown
+// (dual MIT/GPL-Licensed)
+
+#column-context-menu .menu
+  margin: 0
+
+.dropdown
+  // Will be overridden by the js code but having this here will prevent the
+  // dropdown to displayed in the upper right corner until the js sets the
+  // position explicitly.
+  visibility: hidden
+
+  // Avoid a context menu that MAY get too large for the screen
+  // to exceed it, but rather limit its height to the view port.
+  &.-overflow-in-view
+    max-height: 100vh
+    overflow: auto
+
+.dropdown-menu.-empty
+  visibility: hidden
+
+.dropdown .dropdown-panel
+  padding: 10px
+
+.dropdown.dropdown-scroll .dropdown-menu,
+.dropdown.dropdown-scroll .dropdown-panel
+  max-height: 358px
+  overflow: auto
+
 .dropdown LI > A.dropdown-menu-hasicons
   display: block
   @include varprop(color, context-menu-unselected-font-color)
@@ -171,3 +146,29 @@
 // extended styles
 .wp-create-button li
   float: none !important
+
+
+
+// ---------------------------- .DROP-DOWN styles --------------------------------
+.drop-down
+  list-style-type: none
+  select
+    width: 100%
+
+.drop-down .button--dropdown-indicator
+  &:before
+    @include icon-font-common
+    font-size: 10px
+    padding: 0 0 0 9px
+    @extend .icon-pulldown:before
+
+.drop-down .menu-drop-down-container
+  right: 0
+  display: none
+  height: auto
+  li
+    white-space: nowrap
+    list-style-type: none
+    a
+      height: 32px
+      text-decoration: none

--- a/app/assets/stylesheets/layout/_drop_down_mobile.sass
+++ b/app/assets/stylesheets/layout/_drop_down_mobile.sass
@@ -32,7 +32,7 @@
 
 @include breakpoint(680px down)
   .dropdown .dropdown-menu,
-  .toolbar .legacy-actions-more
+  .drop-down .menu-drop-down-container
     LI > A,
     LABEL
       padding: 8px 13px 8px 10px

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -197,10 +197,6 @@
   span.filter-selection
     @include query-select-dropdown-filter-select($primary-color)
 
-  .dropdown-scrollable
-    overflow-y: auto
-    max-height: 500px
-
 /** Allow select2 to display correctly in the toolbar */
 .toolbar .select2-container
   padding: 0

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -58,14 +58,14 @@
     color: $header-search-field-font-color
   :-moz-placeholder
     color: $header-search-field-font-color
-  ul
+  .menu_root
     margin: 0
     padding: 0
     float: left
     height: $header-height
     border-top: 0
     position: relative
-  li
+  li.drop-down
     float: left
     list-style-type: none
     white-space: nowrap
@@ -78,49 +78,27 @@
       zoom: 1
       @include varprop(color, header-item-font-color)
       @include varprop(font-size, header-item-font-size)
-      font-weight: normal
       text-decoration: none
-      padding: 0 15px 0 15px
+      padding: 0 15px
 
     > a:hover
       @include varprop(background, header-item-bg-hover-color)
       @include varprop(color, header-item-font-hover-color)
 
     > ul
-      top: $header-height + $header-border-bottom-width
-      display: none
-      position: absolute
-      height: auto
       min-width: 270px
-      left: -1px
-      z-index: 20
+      padding: 6px 0
       border: 2px solid $header-drop-down-border-color
       border-top: 0
       background-color: $header-drop-down-bg-color
       li
         float: none
-        white-space: nowrap
-        a
-          height: 32px
-          line-height: 32px
-          font-size: 1rem
     > ul.drop-down--projects
       min-width: 400px
-  li.open > a
-    position: relative
-    top: 0
-    z-index: 21
+      left: 0
+      box-shadow: none
 
   li.drop-down
-    select
-      width: 100%
-
-    .button--dropdown-indicator
-      &:before
-        @include icon-font-common
-        font-size: 10px
-        padding: 0 0 0 9px
-        @extend .icon-pulldown:before
     &:hover
       @include varprop(background-color, header-item-bg-hover-color)
       > a
@@ -142,13 +120,9 @@
     li
       > a
         color: $header-drop-down-item-font-color
-        padding: 0 15px
         &:hover
           @include varprop(background, drop-down-hover-bg-color)
           @include varprop(color, drop-down-hover-font-color)
-
-    > ul
-      padding: 6px 0
 
   li.last-child > ul,
   .drop-down--help,
@@ -258,8 +232,6 @@ input.top-menu-search--input
   padding-top: 0
   .top-menu-items-right
     float: right
-#top-menu.open
-  z-index: 5
 
 #select2-drop.project-search-results
   margin: 0 0 0 -2px
@@ -344,7 +316,7 @@ input.top-menu-search--input
 #account-nav-right
   .drop-down.last-child
     .avatar
-      // To accommodate the padding of the help icon which exisits because of the circle
+      // To accommodate the padding of the help icon which exists because of the circle
       margin-top: -5px
   .icon-help:before
     border-width: 2px

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -54,10 +54,6 @@
 
       .button
         margin-right: 0
-    ul,
-    li > a
-      height: $header-height-mobile
-      line-height: $header-height-mobile
     li > a:before
       font-size: 1.25rem !important
       vertical-align: text-bottom

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -77,7 +77,6 @@ body.controller-work_packages.full-create
         top: 100% !important
         right: 0px !important
         left: auto !important
-        margin-top: 0
 
         ul li
           float: none

--- a/app/assets/stylesheets/openproject/_legacy.sass
+++ b/app/assets/stylesheets/openproject/_legacy.sass
@@ -450,12 +450,6 @@ label
 #query_form_content
   padding-top: 10px
 
-#lower-title-bar
-  div.contextual
-    margin-top: -8px
-  margin-top: 30px
-  margin-left: 10px
-
 #watchers .contextual
   margin-top: 0
 

--- a/app/views/layouts/_action_menu_base.html.erb
+++ b/app/views/layouts/_action_menu_base.html.erb
@@ -45,7 +45,7 @@ See doc/COPYRIGHT.rdoc for more details.
             <span class="button--text"><%= l(:label_more) %></span>
             <%= op_icon('button--dropdown-indicator') %>
           </a>
-          <ul class="legacy-actions-more" style="display:none;">
+          <ul class="menu-drop-down-container" style="display:none;">
             <%= content_for :action_menu_more %>
           </ul>
         </li>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -122,13 +122,10 @@ See doc/COPYRIGHT.rdoc for more details.
               <td class="buttons">
                 <% items = project_more_menu_items(project) %>
                 <% if items.any?  %>
-                  <%# toolbar and legacy-actions-more are only for styling purposes.
-                      Because of multiple diverging implementations of dropdowns the
-                      normal dropdown classes cannot be used any more without making special rules %>
-                  <ul class="toolbar project-actions">
+                  <ul class="project-actions">
                     <li aria-haspopup="true" title="<%= t(:label_open_menu) %>" class="drop-down">
                       <a class="icon icon-show-more-horizontal context-menu--icon" title="<%= t(:label_open_menu) %>" href></a>
-                      <ul style="display:none;" class="legacy-actions-more dropdown-menu">
+                      <ul style="display:none;" class="menu-drop-down-container">
                         <% items.each do |item| %>
                           <li>
                             <%= link_to(*item) %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -74,7 +74,7 @@ See doc/COPYRIGHT.rdoc for more details.
       <span class="button--text"><%= t(:label_more) %></span>
       <%= op_icon('button--dropdown-indicator') %>
     </a>
-    <ul style="display:none;" class="legacy-actions-more">
+    <ul style="display:none;" class="menu-drop-down-container">
       <% if @editable %>
         <%= li_unless_nil(link_to_if_authorized(l(:button_lock), {action: 'protect', id: @page, protected: 1}, method: :post, class: 'icon-context icon-locked')) if !@page.protected? %>
         <%= li_unless_nil(link_to_if_authorized(l(:button_unlock), {action: 'protect', id: @page, protected: 0}, method: :post, class: 'icon-context icon-unlocked')) if @page.protected? %>

--- a/features/projects/archive.feature
+++ b/features/projects/archive.feature
@@ -43,7 +43,7 @@ Feature: Navigating to reports page
     And I should see "Projects"
     And I hover over "tbody > tr:nth-of-type(1)"
     And I click on "Open menu" within "tbody > tr:nth-of-type(1)"
-    And I click on "Archive" within ".dropdown-menu"
+    And I click on "Archive" within ".menu-drop-down-container"
     And I confirm popups
     Then I should be on the projects page
     And I should not see "ParentProject"
@@ -58,7 +58,7 @@ Feature: Navigating to reports page
     And I click on "Filter"
     And I hover over "tbody > tr:nth-of-type(1)"
     And I click on "Open menu" within "tbody > tr:nth-of-type(1)"
-    And I click on "Unarchive" within ".dropdown-menu"
+    And I click on "Unarchive" within ".menu-drop-down-container"
     Then I should be on the projects page
     And I should see "ParentProject"
     When I go to the page of the project called "ParentProject"


### PR DESCRIPTION
This PR tries to reduce the amount of different implementations we currently have for dropdowns.

Right now there are two class sets left:

1. `.drop-down` (Therefore the class `legacy-actions-more` has been removed. It was used for `More`-menus like in the wiki. Now these menus use the same implementation as the dropdowns in the top menu. These styles are collected in `drop_down.sass` instead of `top_menu.sass`)
2. `.dopdown` (Applied on all dropdowns within the WP context)

https://community.openproject.com/projects/openproject/work_packages/26436/activity