### PR TITLE
[26777] [Accessibility] Contrast of WP status button too low

### DIFF
--- a/app/assets/stylesheets/openproject/_accessibility.sass
+++ b/app/assets/stylesheets/openproject/_accessibility.sass
@@ -134,3 +134,7 @@ body.accessibility-mode
     width: calc(100% - 6px)
     padding: 0
     margin: 3px
+
+  .wp-status-button .button
+    @include varprop(color, body-font-color)
+    font-weight: bold


### PR DESCRIPTION
Change font color in accessibility mode to increase contrast ratio.

https://community.openproject.com/projects/openproject/work_packages/26777/activity