### PR TITLE
allow creating follows relations among siblings

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -155,6 +155,19 @@ class Relation < ActiveRecord::Base
       .hierarchy_or_reflexive
   end
 
+  def self.tree_of(work_package)
+    root_id = to_root(work_package)
+              .select(:from_id)
+
+    hierarchy
+      .where(from_id: root_id)
+  end
+
+  def self.sibling_of(work_package)
+    hierarchy
+      .where(from_id: work_package.parent_id)
+  end
+
   def relation_type=(type)
     attribute_will_change!('relation_type') if relation_type != type
     @relation_type = type

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -69,6 +69,18 @@ describe  'API v3 Relation resource', type: :request, content_type: :json do
   end
 
   describe "creating a relation" do
+    shared_examples_for 'creates the relation' do
+      it 'creates the relation correctly' do
+        rel = ::API::V3::Relations::RelationPayloadRepresenter.new(Relation.new, current_user: user).from_json last_response.body
+
+        expect(rel.from).to eq from
+        expect(rel.to).to eq to
+        expect(rel.relation_type).to eq type
+        expect(rel.description).to eq description
+        expect(rel.delay).to eq delay
+      end
+    end
+
     let(:setup) {}
     before do
       # reflexive relations
@@ -89,15 +101,7 @@ describe  'API v3 Relation resource', type: :request, content_type: :json do
       expect(Relation.count).to eq 3
     end
 
-    it 'should have created the relation correctly' do
-      rel = ::API::V3::Relations::RelationPayloadRepresenter.new(Relation.new, current_user: user).from_json last_response.body
-
-      expect(rel.from).to eq from
-      expect(rel.to).to eq to
-      expect(rel.relation_type).to eq type
-      expect(rel.description).to eq description
-      expect(rel.delay).to eq delay
-    end
+    it_behaves_like 'creates the relation'
 
     context 'relation that would create a circular scheduling dependency' do
       let(:from_child) do
@@ -126,6 +130,27 @@ describe  'API v3 Relation resource', type: :request, content_type: :json do
           .to be_json_eql(I18n.t(:'activerecord.errors.messages.circular_dependency').to_json)
           .at_path('message')
       end
+    end
+
+    context 'follows relation within siblings' do
+      let(:sibling) do
+        FactoryGirl.create(:work_package)
+      end
+      let(:parent) do
+        wp = FactoryGirl.create(:work_package)
+
+        wp.children = [sibling, from, to]
+      end
+      let(:existing_follows) do
+        FactoryGirl.create(:relation, relation_type: 'follows', from: to, to: sibling)
+      end
+
+      let(:setup) do
+        parent
+        existing_follows
+      end
+
+      it_behaves_like 'creates the relation'
     end
   end
 


### PR DESCRIPTION
Fixes the validation check that is preventing circular scheduling relationships crossing hierarchies to allow follows relationships among siblings.

https://community.openproject.com/projects/openproject/work_packages/26821