### PR TITLE
remove unused sortable join

### DIFF
--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -34,7 +34,6 @@ class Queries::Columns::Base
               :association
 
   attr_accessor :name,
-                :sortable_join,
                 :summable,
                 :default_order
 
@@ -44,7 +43,6 @@ class Queries::Columns::Base
     self.name = name
 
     %i(sortable
-       sortable_join
        groupable
        summable
        association

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -57,27 +57,7 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
       association: 'ancestors_relations',
       default_order: 'asc',
       sortable: ["COALESCE(#{Relation.table_name}.from_id, #{WorkPackage.table_name}.id)",
-                 "COALESCE(#{Relation.table_name}.hierarchy, 0)"],
-      sortable_join: <<-SQL
-        LEFT OUTER JOIN (
-          SELECT
-            r1.from_id,
-            r1.to_id,
-            r1.hierarchy
-        FROM relations r1
-        LEFT OUTER JOIN relations r2
-          ON
-            r1.to_id = r2.to_id
-            AND r1.hierarchy < r2.hierarchy
-            AND r1.relates = 0
-            AND r1.duplicates = 0
-            AND r1.follows = 0
-            AND r1.blocks = 0
-            AND r1.includes = 0
-            AND r1.requires = 0
-          WHERE r2.id IS NULL) depth_relations
-        ON depth_relations.to_id = work_packages.id
-      SQL
+                 "COALESCE(#{Relation.table_name}.hierarchy, 0)"]
     },
     status: {
       association: 'status',

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -75,7 +75,6 @@ class ::Query::Results
       .where(query.statement)
       .where(options[:conditions])
       .includes(all_includes)
-      .joins(all_joins)
       .order(order_option)
       .references(:projects)
   end
@@ -142,10 +141,6 @@ class ::Query::Results
     (%i(status project) +
       includes_for_columns(include_columns) +
       (options[:include] || [])).uniq
-  end
-
-  def all_joins
-    query.sort_criteria_columns.map { |column, _direction| column.sortable_join }.compact
   end
 
   def includes_for_columns(column_names)


### PR DESCRIPTION
As the sortable statements are referring to `relations`, joining a subselect called `depth_relations` has no effect and as such can be removed.