### PR TITLE
squash transitive relations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'friendly_id', '~> 5.2.1'
 gem 'acts_as_list', '~> 0.9.9'
 gem 'acts_as_tree', '~> 2.7.0'
 gem 'awesome_nested_set', '~> 3.1.3'
-gem 'typed_dag', '~> 1.0.1'
+gem 'typed_dag', '~> 2.0.0'
 
 gem 'color-tools', '~> 1.3.0', require: 'color'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,7 +574,7 @@ GEM
     tilt (2.0.7)
     timecop (0.9.1)
     ttfunk (1.5.0)
-    typed_dag (1.0.1)
+    typed_dag (2.0.0)
       rails (>= 5.0.4)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -725,7 +725,7 @@ DEPENDENCIES
   thin (~> 1.7.2)
   timecop (~> 0.9.0)
   transactional_lock!
-  typed_dag (~> 1.0.1)
+  typed_dag (~> 2.0.0)
   tzinfo-data (~> 1.2017.2)
   unicorn
   unicorn-worker-killer

--- a/db/migrate/20180105130053_rebuild_dag.rb
+++ b/db/migrate/20180105130053_rebuild_dag.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class RebuildDag < ActiveRecord::Migration[5.0]
+  def up
+    add_column :relations, :count, :integer, default: 0, null: false
+
+    set_count_to_1
+
+    if index_exists?(:relations, relation_types)
+      remove_index :relations, relation_types
+    end
+
+    truncate_closure_entries
+
+    add_index :relations,
+              %i(from_id to_id hierarchy relates duplicates blocks follows includes requires),
+              name: 'index_relations_on_type_columns',
+              unique: true
+
+    WorkPackage.rebuild_dag!
+
+    # supports finding relations that are to be deleted
+    add_index :relations, :count, where: 'count = 0'
+  end
+
+  def down
+    remove_column :relations, :count
+
+    truncate_closure_entries
+  end
+
+  private
+
+  def set_count_to_1
+    ActiveRecord::Base.connection.execute <<-SQL
+      UPDATE
+        relations
+      SET
+        count = 1
+    SQL
+  end
+
+  def truncate_closure_entries
+    ActiveRecord::Base.connection.execute <<-SQL
+      DELETE FROM relations
+      WHERE (#{relation_types.join(' + ')} > 1)
+      OR (#{relation_types.join(' + ')} = 0)
+    SQL
+  end
+
+  def relation_types
+    %i(hierarchy relates duplicates blocks follows includes requires)
+  end
+end

--- a/db/migrate/20180108132929_vacuum_relations.rb
+++ b/db/migrate/20180108132929_vacuum_relations.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class VacuumRelations < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def up
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      connection.execute 'vacuum relations'
+    end
+  end
+end

--- a/docs/installation/system-requirements.md
+++ b/docs/installation/system-requirements.md
@@ -32,7 +32,7 @@ provide any official support for them.
 * __Application server:__ [Phusion Passenger](https://www.phusionpassenger.com/)
   or [Unicorn](http://unicorn.bogomips.org/)
 * __Database:__ [MySQL](https://www.mysql.com/) Version >= 5.6
-  or [PostgreSQL](http://www.postgresql.org/) Version >= 9.1
+  or [PostgreSQL](http://www.postgresql.org/) Version >= 9.5
 
 Please be aware that the dependencies listed above also have a lot of
 dependencies themselves.


### PR DESCRIPTION
Squashes transitive edges having the same from_id, to_id and hops for each relation type into a single edge with a counter. 

This drastically reduces the number of transitive edges in cases where a lot of alternative routes exist on deeply nested dags.
  
https://community.openproject.com/projects/openproject/work_packages/26861