### PR TITLE
[26803] Subject in breadcrumb truncated even though there is enough space

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -99,7 +99,7 @@ ul.breadcrumb
     height: initial
     li
       line-height: 20px
-      max-width: 250px
+      max-width: 420px
       overflow: hidden
       text-overflow: ellipsis
       &:first-child


### PR DESCRIPTION
Increase width of breadcrumb elements. Thus when the split screen is at the smallest possible width, there is no space wasted.

https://community.openproject.com/projects/openproject/work_packages/26803/activity